### PR TITLE
HDDS-3843. Throw the specific exception other than NPE.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/header/AuthorizationHeaderV4.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.s3.header;
 
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.apache.commons.codec.DecoderException;
 import org.apache.commons.codec.binary.Hex;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
@@ -65,7 +64,9 @@ public class AuthorizationHeaderV4 {
    * @param header
    */
   public AuthorizationHeaderV4(String header) throws OS3Exception {
-    Preconditions.checkNotNull(header);
+    if (header == null) {
+      throw MALFORMED_HEADER;
+    }
     this.authHeader = header;
     parseAuthHeader();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

NPE shouldn't appear in the log.

## What is the link to the Apache JIRA
HDDS-3843

## How was this patch tested?

Start a s3g without enable the security.

Start a goofys without Authorization related setting.

ls the dir within the mount point, the NPE will appear. 
