### PR TITLE
HDDS-3988: DN can distinguish SCMCommand from stale leader SCM

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -272,6 +272,9 @@ public class HeartbeatEndpointTask
         DeleteBlocksCommand db = DeleteBlocksCommand
             .getFromProtobuf(
                 commandResponseProto.getDeleteBlocksCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          db.setTerm(commandResponseProto.getTerm());
+        }
         if (!db.blocksTobeDeleted().isEmpty()) {
           if (LOG.isDebugEnabled()) {
             LOG.debug(DeletedContainerBlocksSummary
@@ -285,6 +288,9 @@ public class HeartbeatEndpointTask
         CloseContainerCommand closeContainer =
             CloseContainerCommand.getFromProtobuf(
                 commandResponseProto.getCloseContainerCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          closeContainer.setTerm(commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM container close request for container {}",
               closeContainer.getContainerID());
@@ -295,6 +301,9 @@ public class HeartbeatEndpointTask
         ReplicateContainerCommand replicateContainerCommand =
             ReplicateContainerCommand.getFromProtobuf(
                 commandResponseProto.getReplicateContainerCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          replicateContainerCommand.setTerm(commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM container replicate request for container {}",
               replicateContainerCommand.getContainerID());
@@ -305,6 +314,9 @@ public class HeartbeatEndpointTask
         DeleteContainerCommand deleteContainerCommand =
             DeleteContainerCommand.getFromProtobuf(
                 commandResponseProto.getDeleteContainerCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          deleteContainerCommand.setTerm(commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM delete container request for container {}",
               deleteContainerCommand.getContainerID());
@@ -315,6 +327,9 @@ public class HeartbeatEndpointTask
         CreatePipelineCommand createPipelineCommand =
             CreatePipelineCommand.getFromProtobuf(
                 commandResponseProto.getCreatePipelineCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          createPipelineCommand.setTerm(commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM create pipeline request {}",
               createPipelineCommand.getPipelineID());
@@ -325,6 +340,9 @@ public class HeartbeatEndpointTask
         ClosePipelineCommand closePipelineCommand =
             ClosePipelineCommand.getFromProtobuf(
                 commandResponseProto.getClosePipelineCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          closePipelineCommand.setTerm(commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM close pipeline request {}",
               closePipelineCommand.getPipelineID());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
@@ -30,7 +30,13 @@ import org.apache.hadoop.hdds.server.events.IdentifiableEventPayload;
  */
 public abstract class SCMCommand<T extends GeneratedMessage> implements
     IdentifiableEventPayload {
-  private long id;
+  private final long id;
+
+  // Under HA mode, holds term of underlying RaftServer iff current
+  // SCM is a leader, otherwise, holds term 0.
+  // Notes that, the first elected leader is from term 1, term 0,
+  // as the initial value of currentTerm, is never used under HA mode.
+  private long term = 0;
 
   SCMCommand() {
     this.id = HddsIdFactory.getLongId();
@@ -59,4 +65,18 @@ public abstract class SCMCommand<T extends GeneratedMessage> implements
     return id;
   }
 
+  /**
+   * Get term of this command.
+   * @return term
+   */
+  public long getTerm() {
+    return term;
+  }
+
+  /**
+   * Set term of this command.
+   */
+  public void setTerm(long term) {
+    this.term = term;
+  }
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -303,6 +303,12 @@ message SCMCommandProto {
   optional ReplicateContainerCommandProto replicateContainerCommandProto = 6;
   optional CreatePipelineCommandProto createPipelineCommandProto = 7;
   optional ClosePipelineCommandProto closePipelineCommandProto = 8;
+
+  // Under HA mode, holds term of underlying RaftServer iff current
+  // SCM is a leader, otherwise, holds term 0.
+  // Notes that, the first elected leader is from term 1, term 0,
+  // as the initial value of currentTerm, is never used under HA mode.
+  optional uint64 term = 15;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -22,6 +22,7 @@ import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * SCMHAManager provides HA service for SCM.
@@ -34,9 +35,13 @@ public interface SCMHAManager {
   void start() throws IOException;
 
   /**
-   * Returns true if the current SCM is the leader.
+   * For HA mode, return an Optional that holds term of the
+   * underlying RaftServer iff current SCM is in leader role.
+   * Otherwise, return an empty optional.
+   *
+   * For non-HA mode, return an Optional that holds term 0.
    */
-  boolean isLeader();
+  Optional<Long> isLeader();
 
   /**
    * Returns RatisServer instance associated with the SCM instance.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
@@ -32,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * SCMHAManagerImpl uses Apache Ratis for HA implementation. We will have 2N+1
@@ -70,29 +72,28 @@ public class SCMHAManagerImpl implements SCMHAManager {
    * {@inheritDoc}
    */
   @Override
-  public boolean isLeader() {
+  public Optional<Long> isLeader() {
     if (!SCMHAUtils.isSCMHAEnabled(conf)) {
       // When SCM HA is not enabled, the current SCM is always the leader.
-      return true;
+      return Optional.of((long)0);
     }
     RaftServer server = ratisServer.getServer();
     Preconditions.checkState(server instanceof RaftServerProxy);
-    RaftServerImpl serverImpl = null;
     try {
       // SCM only has one raft group.
-      serverImpl = ((RaftServerProxy) server)
+      RaftServerImpl serverImpl = ((RaftServerProxy) server)
           .getImpl(ratisServer.getRaftGroupId());
       if (serverImpl != null) {
-        // Only when it's sure the current SCM is the leader, otherwise
-        // it should all return false.
-        return serverImpl.isLeader();
+        RaftProtos.RoleInfoProto roleInfoProto = serverImpl.getRoleInfoProto();
+        return roleInfoProto.hasLeaderInfo()
+            ? Optional.of(roleInfoProto.getLeaderInfo().getTerm())
+            : Optional.empty();
       }
     } catch (IOException ioe) {
       LOG.error("Fail to get RaftServer impl and therefore it's not clear " +
           "whether it's leader. ", ioe);
     }
-
-    return false;
+    return Optional.empty();
   }
 
   /**
@@ -104,11 +105,6 @@ public class SCMHAManagerImpl implements SCMHAManager {
   }
 
   private RaftPeerId getPeerIdFromRoleInfo(RaftServerImpl serverImpl) {
-    /*
-      TODO: Fix Me
-              Ratis API has changed.
-              RaftServerImpl#getRoleInfoProto is no more public.
-
     if (serverImpl.isLeader()) {
       return RaftPeerId.getRaftPeerId(
           serverImpl.getRoleInfoProto().getLeaderInfo().toString());
@@ -119,8 +115,6 @@ public class SCMHAManagerImpl implements SCMHAManager {
     } else {
       return null;
     }
-     */
-    return null;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.Collections;
@@ -47,6 +48,7 @@ import org.apache.hadoop.hdds.scm.VersionInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.states.NodeAlreadyExistsException;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -106,13 +108,16 @@ public class SCMNodeManager implements NodeManager {
       new ConcurrentHashMap<>();
   private final int numPipelinesPerMetadataVolume;
   private final int heavyNodeCriteria;
+  private final SCMHAManager scmhaManager;
 
   /**
    * Constructs SCM machine Manager.
    */
   public SCMNodeManager(OzoneConfiguration conf,
-      SCMStorageConfig scmStorageConfig, EventPublisher eventPublisher,
-      NetworkTopology networkTopology) {
+                        SCMStorageConfig scmStorageConfig,
+                        EventPublisher eventPublisher,
+                        NetworkTopology networkTopology,
+                        SCMHAManager scmhaManager) {
     this.nodeStateManager = new NodeStateManager(conf, eventPublisher);
     this.version = VersionInfo.getLatestVersion();
     this.commandQueue = new CommandQueue();
@@ -138,6 +143,14 @@ public class SCMNodeManager implements NodeManager {
             ScmConfigKeys.OZONE_SCM_PIPELINE_PER_METADATA_VOLUME_DEFAULT);
     String dnLimit = conf.get(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT);
     this.heavyNodeCriteria = dnLimit == null ? 0 : Integer.parseInt(dnLimit);
+    this.scmhaManager = scmhaManager;
+  }
+
+  public SCMNodeManager(OzoneConfiguration conf,
+                        SCMStorageConfig scmStorageConfig,
+                        EventPublisher eventPublisher,
+                        NetworkTopology networkTopology) {
+    this(conf, scmStorageConfig, eventPublisher, networkTopology, null);
   }
 
   private void registerMXBean() {
@@ -656,8 +669,57 @@ public class SCMNodeManager implements NodeManager {
   // Since datanode commands are added through event queue, onMessage method
   // should take care of adding commands to command queue.
   // Refactor and remove all the usage of this method and delete this method.
+  /**
+   * Only leader SCM can send SCMCommand to datanode, and needs record its
+   * term in the command so that datanode can distinguish commands from stale
+   * leader SCM by comparing term.
+   *
+   * There are 7 SCMCommands:
+   *    ReregisterCommand
+   *    ClosePipelineCommand
+   *    CreatePipelineCommand
+   *    CloseContainerCommand
+   *    ReplicateContainerCommand
+   *    DeleteContainerCommand
+   *    DeleteBlocksCommand
+   *
+   * They are sent by:
+   *    NodeManager
+   *    PipelineManager
+   *    ContainerManager
+   *    BlockManager
+   *    ReplicationManager and etc.
+   *
+   * Ideally term of SCMCommand should be queried from SCMHAManager::isLeader()
+   * before these managers decide to take an action.
+   *
+   * However till now only several of these managers have been integrated
+   * with HA, thus need NodeManager, as EventHandler for DATANODE_COMMAND,
+   * to play as a safe guard when receiving a SCMCommand:
+   *
+   * - If receive a SCMCommand when underling RaftServer is not leader,
+   *   drop the command.
+   *
+   * - If receive a SCMCommand when underling RaftServer is leader, meanwhile
+   *   term of SCMCommand is 0 (which is the default value of term and will
+   *   not be used under HA mode), log a warning and help set the term.
+   *   Notes that, term queried before putting into command queue may be not
+   *   accurate, since raft term may bump when managers are taking actions.
+   */
   @Override
   public void addDatanodeCommand(UUID dnId, SCMCommand command) {
+    if (scmhaManager != null && command.getTerm() == 0) {
+      Optional<Long> termOpt = scmhaManager.isLeader();
+
+      if (!termOpt.isPresent()) {
+        LOG.warn("Not leader, drop SCMCommand {}.", command);
+        return;
+      }
+
+      LOG.warn("Help set term {} for SCMCommand {}. It is not an accurate " +
+          "way to set term of SCMCommand.", termOpt.get(), command);
+      command.setTerm(termOpt.get());
+    }
     this.commandQueue.addCommand(dnId, command);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -669,43 +669,6 @@ public class SCMNodeManager implements NodeManager {
   // Since datanode commands are added through event queue, onMessage method
   // should take care of adding commands to command queue.
   // Refactor and remove all the usage of this method and delete this method.
-  /**
-   * Only leader SCM can send SCMCommand to datanode, and needs record its
-   * term in the command so that datanode can distinguish commands from stale
-   * leader SCM by comparing term.
-   *
-   * There are 7 SCMCommands:
-   *    ReregisterCommand
-   *    ClosePipelineCommand
-   *    CreatePipelineCommand
-   *    CloseContainerCommand
-   *    ReplicateContainerCommand
-   *    DeleteContainerCommand
-   *    DeleteBlocksCommand
-   *
-   * They are sent by:
-   *    NodeManager
-   *    PipelineManager
-   *    ContainerManager
-   *    BlockManager
-   *    ReplicationManager and etc.
-   *
-   * Ideally term of SCMCommand should be queried from SCMHAManager::isLeader()
-   * before these managers decide to take an action.
-   *
-   * However till now only several of these managers have been integrated
-   * with HA, thus need NodeManager, as EventHandler for DATANODE_COMMAND,
-   * to play as a safe guard when receiving a SCMCommand:
-   *
-   * - If receive a SCMCommand when underling RaftServer is not leader,
-   *   drop the command.
-   *
-   * - If receive a SCMCommand when underling RaftServer is leader, meanwhile
-   *   term of SCMCommand is 0 (which is the default value of term and will
-   *   not be used under HA mode), log a warning and help set the term.
-   *   Notes that, term queried before putting into command queue may be not
-   *   accurate, since raft term may bump when managers are taking actions.
-   */
   @Override
   public void addDatanodeCommand(UUID dnId, SCMCommand command) {
     if (scmhaManager != null && command.getTerm() == 0) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -637,13 +638,15 @@ public final class PipelineManagerV2Impl implements PipelineManager {
   }
 
   /**
-   * Check if scm is current leader.
-   * @throws NotLeaderException when it's not the current leader.
+   * return term of underlying RaftServer if role of SCM is leader.
+   * @throws NotLeaderException when it's not leader.
    */
-  private void checkLeader() throws NotLeaderException {
-    if (!scmhaManager.isLeader()) {
+  private long checkLeader() throws NotLeaderException {
+    Optional<Long> termOpt = scmhaManager.isLeader();
+    if (!termOpt.isPresent()) {
       throw scmhaManager.triggerNotLeaderException();
     }
+    return termOpt.get();
   }
 
   private void setBackgroundPipelineCreator(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -292,6 +292,11 @@ public class SCMDatanodeProtocolServer implements
       throws IOException {
     SCMCommandProto.Builder builder =
         SCMCommandProto.newBuilder();
+
+    // In HA mode, it is the term of current leader SCM.
+    // In non-HA mode, it is the default value 0.
+    builder.setTerm(cmd.getTerm());
+
     switch (cmd.getType()) {
     case reregisterCommand:
       return builder

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -425,7 +425,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       scmNodeManager = configurator.getScmNodeManager();
     } else {
       scmNodeManager = new SCMNodeManager(
-          conf, scmStorageConfig, eventQueue, clusterMap);
+          conf, scmStorageConfig, eventQueue, clusterMap, scmHAManager);
     }
 
     placementMetrics = SCMContainerPlacementMetrics.create();
@@ -1027,7 +1027,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    * @return - if the current scm is the leader.
    */
   public boolean checkLeader() {
-    return scmHAManager.isLeader();
+    return scmHAManager.isLeader().isPresent();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
@@ -79,8 +80,8 @@ public final class MockSCMHAManager implements SCMHAManager {
    * {@inheritDoc}
    */
   @Override
-  public boolean isLeader() {
-    return isLeader;
+  public Optional<Long> isLeader() {
+    return isLeader ? Optional.of((long)0) : Optional.empty();
   }
 
   public void setIsLeader(boolean isLeader) {

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>1.1.0-913f5a4-SNAPSHOT</ratis.version>
+    <ratis.version>1.1.0-4573fb7-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.6.0-SNAPSHOT</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of SCMCommand SCM will also send its current term, which will be used in Datanode to identify if the command was sent by the latest leader SCM.
 
Datanode will maintain the highest term that it has seen and compare it with the term that is received as part of SCMCommand.
If the term in the Datanode and SCMCommand are same, the command is added to the command queue for processing.
If the term in the Datanode is less than the term received in SCMCommand, Datanode will update its term and add the command to the command queue for processing.
If the term in the Datanode is greater than the term received in SCMCommand, Datanode will ignore the command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3988

## How was this patch tested?

CI