### PR TITLE
HDDS-4255. Remove unused Ant and Jdiff dependency versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- number of threads/forks to use when running tests in parallel, see parallel-tests profile -->
     <testsThreadCount>4</testsThreadCount>
 
-    <!-- These 2 versions are defined here because they are used -->
-    <!-- JDIFF generation from embedded ant in the antrun plugin -->
-    <jdiff.version>1.0.9</jdiff.version>
-    <!-- Version number for xerces used by JDiff -->
-    <xerces.jdiff.version>2.11.0</xerces.jdiff.version>
-
     <commons-daemon.version>1.0.13</commons-daemon.version>
 
     <test.build.dir>${project.build.directory}/test-dir</test.build.dir>
@@ -261,11 +255,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>4.4.0</version>
-      </dependency>
-      <dependency>
-        <groupId>jdiff</groupId>
-        <artifactId>jdiff</artifactId>
-        <version>${jdiff.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -1290,11 +1279,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>net.sf.kosmosfs</groupId>
         <artifactId>kfs</artifactId>
         <version>0.3</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.ant</groupId>
-        <artifactId>ant</artifactId>
-        <version>1.8.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.re2j</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Versions of Ant and JDiff are not used in ozone project, but we have some version declaration (inherited from the Hadoo parent pom which was used as a base for the main pom.xml).

As the (unused) ANT version has security issues, I would remove them to avoid any confusion

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4255

## How was this patch tested?

Clean build + `rg org.apache.ant pom.xml`