### PR TITLE
HDDS-4222: [OzoneFS optimization] Provide a mechanism for efficient path lookup

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2523,7 +2523,7 @@
   </property>
 
   <property>
-    <name>ozone.om.metadata.cache.directory</name>
+    <name>ozone.om.metadata.cache.directory.policy</name>
     <tag>OZONE, OM</tag>
     <value>DIR_LRU</value>
     <description>Configure the cache policy to provide caching of the

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2536,7 +2536,7 @@
   <property>
     <name>ozone.om.metadata.cache.directory.init.capacity</name>
     <tag>OZONE, OM</tag>
-    <value>DIR_LRU</value>
+    <value>100000</value>
     <description>Configure the minimum total size for directory cache.
     </description>
   </property>
@@ -2544,7 +2544,7 @@
   <property>
     <name>ozone.om.metadata.cache.directory.max.capacity</name>
     <tag>OZONE, OM</tag>
-    <value>DIR_LRU</value>
+    <value>5000000</value>
     <description>Specifies the maximum number of entries the cache may
       contain in the directory cache.
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2521,4 +2521,32 @@
       filesystem semantics.
     </description>
   </property>
+
+  <property>
+    <name>ozone.om.metadata.cache.directory</name>
+    <tag>OZONE, OM</tag>
+    <value>DIR_LRU</value>
+    <description>Configure the cache policy to provide caching of the
+      directories for faster traversal of path components. Available values
+      are DIR_LRU and DIR_NOCACHE. As name says, DIR_LRU uses least recently
+      used eviction mechanism and DIR_NOCACHE has no caching.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.om.metadata.cache.directory.init.capacity</name>
+    <tag>OZONE, OM</tag>
+    <value>DIR_LRU</value>
+    <description>Configure the minimum total size for directory cache.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.om.metadata.cache.directory.max.capacity</name>
+    <tag>OZONE, OM</tag>
+    <value>DIR_LRU</value>
+    <description>Specifies the maximum number of entries the cache may
+      contain in the directory cache.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -246,4 +246,15 @@ public final class OMConfigKeys {
       "ozone.om.enable.filesystem.paths";
   public static final boolean OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT =
       false;
+
+  public static final String OZONE_OM_CACHE_DIR_POLICY =
+          "ozone.om.metadata.cache.directory";
+  public static final String OZONE_OM_CACHE_DIR_DEFAULT = "DIR_LRU";
+  public static final String OZONE_OM_CACHE_DIR_INIT_CAPACITY =
+          "ozone.om.metadata.cache.directory.init.capacity";
+  public static final int OZONE_OM_CACHE_DIR_INIT_CAPACITY_DEFAULT = 100000;
+  public static final String OZONE_OM_CACHE_DIR_MAX_CAPACITY =
+          "ozone.om.metadata.cache.directory.max.capacity";
+  public static final long OZONE_OM_CACHE_DIR_MAX_CAPACITY_DEFAULT = 5000000;
+
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -249,7 +249,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_OM_CACHE_DIR_POLICY =
           "ozone.om.metadata.cache.directory.policy";
-  public static final String OZONE_OM_CACHE_DIR_DEFAULT = "DIR_LRU";
+  public static final String OZONE_OM_CACHE_DIR_POLICY_DEFAULT = "DIR_LRU";
   public static final String OZONE_OM_CACHE_DIR_INIT_CAPACITY =
           "ozone.om.metadata.cache.directory.init.capacity";
   public static final int OZONE_OM_CACHE_DIR_INIT_CAPACITY_DEFAULT = 100000;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -248,7 +248,7 @@ public final class OMConfigKeys {
       false;
 
   public static final String OZONE_OM_CACHE_DIR_POLICY =
-          "ozone.om.metadata.cache.directory";
+          "ozone.om.metadata.cache.directory.policy";
   public static final String OZONE_OM_CACHE_DIR_DEFAULT = "DIR_LRU";
   public static final String OZONE_OM_CACHE_DIR_INIT_CAPACITY =
           "ozone.om.metadata.cache.directory.init.capacity";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -389,5 +389,5 @@ public interface OMMetadataManager {
    *
    * @return OMCacheManager.
    */
-  public OMCacheManager getOMCacheManager();
+  OMCacheManager getOMCacheManager();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.common.BlockGroup;
+import org.apache.hadoop.ozone.om.cache.OMCacheManager;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -382,4 +383,11 @@ public interface OMMetadataManager {
    * @return table names in OM DB.
    */
   Set<String> listTableNames();
+
+  /**
+   * Returns the CacheManager used to keep cache entities.
+   *
+   * @return OMCacheManager.
+   */
+  public OMCacheManager getOMCacheManager();
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
+import org.apache.hadoop.ozone.om.cache.OMCacheManager;
 import org.apache.hadoop.ozone.om.codec.OMTransactionInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmBucketInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmKeyInfoCodec;
@@ -163,6 +164,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private boolean ignorePipelineinKey;
 
   private Map<String, Table> tableMap = new HashMap<>();
+
+  private OMCacheManager omCacheManager;
 
   public OmMetadataManagerImpl(OzoneConfiguration conf) throws IOException {
 
@@ -291,6 +294,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       this.store = loadDB(configuration, metaDir);
 
       initializeOmTables();
+
+      omCacheManager = new OMCacheManager(configuration);
     }
   }
 
@@ -1132,6 +1137,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Set<String> listTableNames() {
     return tableMap.keySet();
+  }
+
+  @Override
+  public OMCacheManager getOMCacheManager() {
+    return omCacheManager;
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheEntity.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheEntity.java
@@ -38,7 +38,7 @@ public enum CacheEntity {
 
   public static CacheEntity getEntity(String entityStr) {
     for (CacheEntity entity : CacheEntity.values()) {
-      if (entityStr.equalsIgnoreCase(entity.getName())) {
+      if (entity.getName().equalsIgnoreCase(entityStr)) {
         return entity;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheEntity.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheEntity.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+/**
+ * Entities that are to be cached.
+ */
+public enum CacheEntity {
+
+  DIR("directory");
+  // This is extendable and one can add more entities for
+  // caching based on demand. For example, define new entities like FILE
+  // ("file"), LISTING("listing") cache etc.
+
+  CacheEntity(String entity) {
+    this.entityName = entity;
+  }
+
+  private String entityName;
+
+  public String getName() {
+    return entityName;
+  }
+
+  public static CacheEntity getEntity(String entityStr) {
+    for (CacheEntity entity : CacheEntity.values()) {
+      if (entityStr.equalsIgnoreCase(entity.getName())) {
+        return entity;
+      }
+    }
+    // no default
+    return null;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CachePolicy.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CachePolicy.java
@@ -1,5 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.ozone.om.cache;
-
 
 /**
  * Type like : LRU, LRU2(multi-level), MFU etc..

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CachePolicy.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CachePolicy.java
@@ -1,0 +1,32 @@
+package org.apache.hadoop.ozone.om.cache;
+
+
+/**
+ * Type like : LRU, LRU2(multi-level), MFU etc..
+ */
+public enum CachePolicy {
+
+  DIR_LRU("DIR_LRU"),
+
+  DIR_NOCACHE("DIR_NOCACHE"); // disable dir cache
+
+  CachePolicy(String cachePolicy) {
+    this.policy = cachePolicy;
+  }
+
+  private String policy;
+
+  public String getPolicy() {
+    return policy;
+  }
+
+  public static CachePolicy getPolicy(String policyStr) {
+    for (CachePolicy policy : CachePolicy.values()) {
+      if (policyStr.equalsIgnoreCase(policy.getPolicy())) {
+        return policy;
+      }
+    }
+    // defaulting to NO_CACHE
+    return DIR_NOCACHE;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheStore.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+/**
+ * Cache used for traversing path components from parent node to the leaf node.
+ * <p>
+ * Basically, its a write-through cache and ensures that no-stale entries in
+ * the cache.
+ * <p>
+ * TODO: can define specific 'CacheLoader' to handle the OM restart and
+ *       define cache loading strategies. It can be NullLoader, LazyLoader,
+ *       LevelLoader etc.
+ *
+ * @param <CACHEKEY>
+ * @param <CACHEVALUE>
+ */
+public interface CacheStore<CACHEKEY extends OMCacheKey,
+        CACHEVALUE extends OMCacheValue> {
+
+  /**
+   * Add an entry to the cache, if the key already exists it overrides.
+   *
+   * @param key
+   * @param value
+   */
+  void put(CACHEKEY key, CACHEVALUE value);
+
+  /**
+   * Returns value for the given key if it exists, otherwise return
+   * null.
+   *
+   * @param key
+   * @return CACHEVALUE
+   */
+  CACHEVALUE get(CACHEKEY key);
+
+  /**
+   * Removes a key from the cache.
+   *
+   * @param key the key to remove
+   */
+  void remove(CACHEKEY key);
+
+  /**
+   * Returns total size of the cache.
+   *
+   * @return cache size
+   */
+  long size();
+
+  /**
+   * Returns cache policy.
+   *
+   * @return CachePolicy
+   */
+  CachePolicy getCachePolicy();
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/CacheStore.java
@@ -26,6 +26,8 @@ package org.apache.hadoop.ozone.om.cache;
  *       define cache loading strategies. It can be NullLoader, LazyLoader,
  *       LevelLoader etc.
  *
+ * TODO: Add cache metrics interface - occupancy, hit, miss, evictions etc
+ *
  * @param <CACHEKEY>
  * @param <CACHEVALUE>
  */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryLRUCacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryLRUCacheStore.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Directory LRUCache: cache directories based on LRU (Least Recently Used)
+ * cache eviction strategy, wherein if the cache size has reached the maximum
+ * allocated capacity, the least recently used objects in the cache will be
+ * evicted.
+ * <p>
+ * TODO: Add cache metrics - occupancy, hit, miss, evictions etc
+ */
+public class DirectoryLRUCacheStore implements CacheStore {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(DirectoryLRUCacheStore.class);
+
+  // Initialises Guava based LRU cache.
+  private Cache<OMCacheKey, OMCacheValue> mCache;
+
+  /**
+   * @param configuration ozone config
+   */
+  public DirectoryLRUCacheStore(OzoneConfiguration configuration) {
+    LOG.info("Initializing DirectoryLRUCacheStore..");
+    // defaulting to 1000,00
+    int initSize = configuration.getInt(
+            OMConfigKeys.OZONE_OM_CACHE_DIR_INIT_CAPACITY,
+            OMConfigKeys.OZONE_OM_CACHE_DIR_INIT_CAPACITY_DEFAULT);
+    // defaulting to 5000,000
+    long maxSize = configuration.getLong(
+            OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY,
+            OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY_DEFAULT);
+    LOG.info("Configured {} with {}",
+            OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY, maxSize);
+    mCache = CacheBuilder.newBuilder()
+            .initialCapacity(initSize)
+            .maximumSize(maxSize)
+            .build();
+  }
+
+  @Override
+  public void put(OMCacheKey key, OMCacheValue value) {
+    mCache.put(key, value);
+  }
+
+  @Override
+  public OMCacheValue get(OMCacheKey key) {
+    return mCache.getIfPresent(key);
+  }
+
+  @Override
+  public void remove(OMCacheKey key) {
+    mCache.invalidate(key);
+  }
+
+  @Override
+  public long size() {
+    return mCache.size();
+  }
+
+  @Override
+  public CachePolicy getCachePolicy() {
+    return CachePolicy.DIR_LRU;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryLRUCacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryLRUCacheStore.java
@@ -52,8 +52,10 @@ public class DirectoryLRUCacheStore implements CacheStore {
     long maxSize = configuration.getLong(
             OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY,
             OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY_DEFAULT);
-    LOG.info("Configured {} with {}",
+    LOG.info("Configured {} = {} and {} = {}",
+            OMConfigKeys.OZONE_OM_CACHE_DIR_INIT_CAPACITY, initSize,
             OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY, maxSize);
+
     mCache = CacheBuilder.newBuilder()
             .initialCapacity(initSize)
             .maximumSize(maxSize)
@@ -62,17 +64,24 @@ public class DirectoryLRUCacheStore implements CacheStore {
 
   @Override
   public void put(OMCacheKey key, OMCacheValue value) {
-    mCache.put(key, value);
+    if (key != null && value != null) {
+      mCache.put(key, value);
+    }
   }
 
   @Override
   public OMCacheValue get(OMCacheKey key) {
-    return mCache.getIfPresent(key);
+    if (key != null) {
+      return mCache.getIfPresent(key);
+    }
+    return null;
   }
 
   @Override
   public void remove(OMCacheKey key) {
-    mCache.invalidate(key);
+    if (key != null) {
+      mCache.invalidate(key);
+    }
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
@@ -19,6 +19,9 @@ package org.apache.hadoop.ozone.om.cache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Not caching directories and used to disable caching.
+ */
 public class DirectoryNullCacheStore implements CacheStore {
 
   private static final Logger LOG =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
@@ -57,3 +57,4 @@ public class DirectoryNullCacheStore implements CacheStore {
     return CachePolicy.DIR_NOCACHE;
   }
 }
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/DirectoryNullCacheStore.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DirectoryNullCacheStore implements CacheStore {
+
+  private static final Logger LOG =
+          LoggerFactory.getLogger(DirectoryNullCacheStore.class);
+
+  DirectoryNullCacheStore() {
+    LOG.info("Initializing DirectoryNullCacheStore..");
+  }
+
+  @Override
+  public void put(OMCacheKey key, OMCacheValue value) {
+    // Nothing to do
+  }
+
+  @Override
+  public OMCacheValue get(OMCacheKey key) {
+    // Nothing to do
+    return null;
+  }
+
+  @Override
+  public void remove(OMCacheKey key) {
+    // Nothing to do;
+  }
+
+  @Override
+  public long size() {
+    return 0;
+  }
+
+  @Override
+  public CachePolicy getCachePolicy() {
+    return CachePolicy.DIR_NOCACHE;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheKey.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheKey.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.cache;
+
+import java.util.Objects;
+
+/**
+ * CacheKey for an entity.
+ * @param <KEY>
+ */
+public class OMCacheKey<KEY> implements Comparable<KEY> {
+
+  // Format <parentID/keyName>.
+  // For example, user defined path "/vol1/buck1/a" the key will be "512/a", where
+  // 512 is bucketID.
+  private final KEY key;
+
+  public OMCacheKey(KEY key) {
+    Objects.requireNonNull(key, "Key Should not be null in CacheKey");
+    this.key = key;
+  }
+
+  public KEY getCacheKey() {
+    return key;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    OMCacheKey<?> cacheKey = (OMCacheKey<?>) o;
+    return Objects.equals(key, cacheKey.key);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(key);
+  }
+
+  @Override
+  public int compareTo(Object o) {
+    if (Objects.equals(key, ((OMCacheKey<?>) o).key)) {
+      return 0;
+    } else {
+      return key.toString().compareTo((((OMCacheKey<?>) o).key).toString());
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheKey.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheKey.java
@@ -15,7 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.hadoop.ozone.om.cache;
 
 import java.util.Objects;
@@ -27,8 +26,8 @@ import java.util.Objects;
 public class OMCacheKey<KEY> implements Comparable<KEY> {
 
   // Format <parentID/keyName>.
-  // For example, user defined path "/vol1/buck1/a" the key will be "512/a", where
-  // 512 is bucketID.
+  // For example, user defined path "/vol1/buck1/a" the key will be "512/a",
+  // where 512 is bucketID.
   private final KEY key;
 
   public OMCacheKey(KEY key) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
@@ -34,7 +34,7 @@ public class OMCacheManager {
     // Defaulting to DIR_LRU cache policy.
     dirCache = OMMetadataCacheFactory.getCache(
             OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
-            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, config);
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT, config);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
@@ -37,7 +37,13 @@ public class OMCacheManager {
             OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, config);
   }
 
+  /**
+   * Returns directory cache store instance.
+   *
+   * @return
+   */
   public CacheStore getDirCache() {
     return dirCache;
   }
 }
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheManager.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+
+import java.io.IOException;
+
+/**
+ * Manages cache to do a faster path look ups. OM will traverse each path
+ * components in the path from parent to the child leaf node.
+ */
+public class OMCacheManager {
+
+  private final CacheStore dirCache;
+
+  public OMCacheManager(OzoneConfiguration config) throws IOException {
+    // Defaulting to DIR_LRU cache policy.
+    dirCache = OMMetadataCacheFactory.getCache(
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, config);
+  }
+
+  public CacheStore getDirCache() {
+    return dirCache;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheValue.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheValue.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.cache;
+
+import com.google.common.base.Optional;
+
+/**
+ * CacheValue for an entity.
+ * @param <VALUE>
+ */
+public class OMCacheValue<VALUE> {
+
+  private VALUE value;
+
+  public OMCacheValue(VALUE value) {
+    this.value = value;
+  }
+
+  public VALUE getCacheValue() {
+    return value;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheValue.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMCacheValue.java
@@ -15,10 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.hadoop.ozone.om.cache;
-
-import com.google.common.base.Optional;
 
 /**
  * CacheValue for an entity.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheFactory.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheFactory.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Provides different caching policies for cache entities. This can be
+ * extended by adding more entities and their caching policies into it.
+ * <p>
+ * For example, for the directory cache user has to configure following
+ * property with cache type. OM will creates specific cache store for the
+ * directory based on the configured cache policy.
+ * ozone.om.metadata.cache.directory = DIR_LRU
+ * <p>
+ * One can add new directory policy to OM by defining new cache type say
+ * "DIR_LFU" and implements new CacheStore as DirectoryLFUCacheStore.
+ * <p>
+ * One can add new entity to OM, let's say file to be cached by configuring the
+ * property like below and implement specific provider to instantiate the
+ * fileCacheStore.
+ * ozone.om.metadata.cache.file = FILE_LRU
+ */
+public final class OMMetadataCacheFactory {
+  private static final Logger LOG =
+          LoggerFactory.getLogger(OMMetadataCacheFactory.class);
+
+  /**
+   * Private constructor, class is not meant to be initialized.
+   */
+  private OMMetadataCacheFactory() {
+  }
+
+  public static CacheStore getCache(String configuredCachePolicy,
+                                    String defaultValue,
+                                    OzoneConfiguration config) {
+    String cachePolicy = config.get(configuredCachePolicy, defaultValue);
+    LOG.info("Configured {} with {}", configuredCachePolicy, cachePolicy);
+    CacheEntity entity = getCacheEntity(configuredCachePolicy);
+
+    switch (entity) {
+      case DIR:
+        OMMetadataCacheProvider provider = new OMDirectoryCacheProvider(config,
+                cachePolicy);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("CacheStore initialized with {}:" + provider.getEntity());
+        }
+        return provider.getCache();
+      default:
+        return null;
+    }
+  }
+
+  private static CacheEntity getCacheEntity(String configuredCachePolicy) {
+    // entityname present at the end of configuration name. Here, the
+    // logic is to get the last part separated by '.' character.
+    // For example, in configuration "ozone.om.metadata.cache.directory", the
+    // last part is 'directory' and this represents the entity name.
+    // In future, one can add new entity by providing new configuration like,
+    // "ozone.om.metadata.cache.file" and this represents the FILE cache entity.
+    String entity = configuredCachePolicy
+            .substring(configuredCachePolicy.lastIndexOf('.') + 1);
+    return CacheEntity.getEntity(entity);
+  }
+
+  /**
+   * Directory Cache provider which will initialise cache store based on the
+   * configured cache policy. For any invalid cache policy argument it will
+   * return NO_CACHE.
+   */
+  private static class OMDirectoryCacheProvider
+          implements OMMetadataCacheProvider {
+
+    private OzoneConfiguration config;
+    private CacheStore dirCache;
+
+    OMDirectoryCacheProvider(OzoneConfiguration configuration,
+                             String cacheType) {
+      this.config = configuration;
+      this.dirCache = getCacheStore(cacheType);
+    }
+
+    @Override
+    public CacheStore getCache() {
+      return dirCache;
+    }
+
+    private CacheStore getCacheStore(String cachePolicy) {
+      CachePolicy policy = CachePolicy.getPolicy(cachePolicy);
+      switch (policy) {
+        case DIR_LRU:
+          return new DirectoryLRUCacheStore(config);
+        case DIR_NOCACHE: // testing purpose
+        default:
+          return new DirectoryNullCacheStore();
+      }
+    }
+
+    @Override
+    public CacheEntity getEntity() {
+      return CacheEntity.DIR;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheFactory.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheFactory.java
@@ -55,15 +55,15 @@ public final class OMMetadataCacheFactory {
     CacheEntity entity = getCacheEntity(configuredCachePolicy);
 
     switch (entity) {
-      case DIR:
-        OMMetadataCacheProvider provider = new OMDirectoryCacheProvider(config,
-                cachePolicy);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("CacheStore initialized with {}:" + provider.getEntity());
-        }
-        return provider.getCache();
-      default:
-        return null;
+    case DIR:
+      OMMetadataCacheProvider provider = new OMDirectoryCacheProvider(config,
+              cachePolicy);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("CacheStore initialized with {}:" + provider.getEntity());
+      }
+      return provider.getCache();
+    default:
+      return null;
     }
   }
 
@@ -104,11 +104,11 @@ public final class OMMetadataCacheFactory {
     private CacheStore getCacheStore(String cachePolicy) {
       CachePolicy policy = CachePolicy.getPolicy(cachePolicy);
       switch (policy) {
-        case DIR_LRU:
-          return new DirectoryLRUCacheStore(config);
-        case DIR_NOCACHE: // testing purpose
-        default:
-          return new DirectoryNullCacheStore();
+      case DIR_LRU:
+        return new DirectoryLRUCacheStore(config);
+      case DIR_NOCACHE: // disable cache
+      default:
+        return new DirectoryNullCacheStore();
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/OMMetadataCacheProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+/**
+ * Interface defines metadata cache provider which will return a specific cache
+ * store to OM.
+ */
+public interface OMMetadataCacheProvider {
+
+  /**
+   * Returns cache store.
+   *
+   * @return CacheStore reference.
+   */
+  CacheStore getCache();
+
+  /**
+   * Returns the cache entity.
+   *
+   * @return CacheEntity
+   */
+  CacheEntity getEntity();
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/package-info.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/package-info.java
@@ -21,3 +21,4 @@ package org.apache.hadoop.ozone.om.cache;
 /**
  * This package contains classes related to OM Metadata cache.
  */
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/package-info.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/cache/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.cache;
+
+/**
+ * This package contains classes related to OM Metadata cache.
+ */

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
@@ -62,7 +62,7 @@ public class TestOMMetadataCache {
             CachePolicy.DIR_NOCACHE.getPolicy());
     CacheStore dirCacheStore = OMMetadataCacheFactory.getCache(
             OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
-            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT, conf);
     Assert.assertEquals("Cache Policy mismatches!", CachePolicy.DIR_NOCACHE,
             dirCacheStore.getCachePolicy());
 
@@ -70,16 +70,16 @@ public class TestOMMetadataCache {
     conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY, "InvalidCachePolicy");
     dirCacheStore = OMMetadataCacheFactory.getCache(
             OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
-            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT, conf);
     Assert.assertEquals("Expected NullCache for an invalid CachePolicy",
             CachePolicy.DIR_NOCACHE, dirCacheStore.getCachePolicy());
 
     //3. Directory LRU cache policy
     conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
-            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT);
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT);
     dirCacheStore = OMMetadataCacheFactory.getCache(
             OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
-            OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+            OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT, conf);
     Assert.assertEquals("Cache Type mismatches!", CachePolicy.DIR_LRU,
             dirCacheStore.getCachePolicy());
   }
@@ -167,7 +167,8 @@ public class TestOMMetadataCache {
   }
 
   @Test
-  public void testNullKeysAndValuesToLRUCacheDirectoryPolicy() throws IOException {
+  public void testNullKeysAndValuesToLRUCacheDirectoryPolicy()
+          throws IOException {
     conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
             CachePolicy.DIR_LRU.getPolicy());
     conf.setInt(OMConfigKeys.OZONE_OM_CACHE_DIR_INIT_CAPACITY, 1);
@@ -255,7 +256,7 @@ public class TestOMMetadataCache {
   }
 
   @Test
-  public void testInvalidCacheDirectoryPolicyConfigurationName() throws IOException {
+  public void testInvalidCacheDirectoryPolicyConfigurationName() {
     File testDir = GenericTestUtils.getRandomizedTestDir();
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
             testDir.toString());
@@ -267,7 +268,7 @@ public class TestOMMetadataCache {
 
     try {
       OMMetadataCacheFactory.getCache(propertyName,
-              OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+              OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY_DEFAULT, conf);
       fail("An invalid property name should cause an IllegalArgumentException");
     } catch (Exception e) {
       assertTrue(e instanceof IllegalArgumentException);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
@@ -192,6 +192,7 @@ public class TestOMMetadataCache {
             testDir.toString());
 
     //1. Verify default dir cache policy. Defaulting to DIR_LRU
+    conf.unset(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY);
     Assert.assertNull("Unexpected CachePolicy, it should be null!",
             conf.get(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY));
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/TestOMMetadataCache.java
@@ -1,0 +1,203 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Testing OMMetadata cache provider class.
+ */
+public class TestOMMetadataCache {
+
+  private OzoneConfiguration conf;
+  private OMMetadataManager omMetadataManager;
+
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = new Timeout(100000);
+
+  @Before
+  public void setup() {
+    //initialize config
+    conf = new OzoneConfiguration();
+  }
+
+  @Test
+  public void testVerifyDirCachePolicies() {
+    //1. Verify disabling cache
+    conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+            CachePolicy.DIR_NOCACHE.getPolicy());
+    CacheStore dirCacheStore =
+            OMMetadataCacheFactory.getCache(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+                    OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+    Assert.assertEquals("Cache Policy mismatches!", CachePolicy.DIR_NOCACHE,
+            dirCacheStore.getCachePolicy());
+
+    //2. Invalid cache policy
+    conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY, "InvalidCachePolicy");
+    dirCacheStore =
+            OMMetadataCacheFactory.getCache(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+                    OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+    Assert.assertEquals("Expected NullCache for an invalid CachePolicy",
+            CachePolicy.DIR_NOCACHE, dirCacheStore.getCachePolicy());
+
+    //3. Directory LRU cache policy
+    conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY, OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT);
+    dirCacheStore =
+            OMMetadataCacheFactory.getCache(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+                    OMConfigKeys.OZONE_OM_CACHE_DIR_DEFAULT, conf);
+    Assert.assertEquals("Cache Type mismatches!", CachePolicy.DIR_LRU,
+            dirCacheStore.getCachePolicy());
+  }
+
+  @Test
+  public void testLRUCacheDirectoryPolicy() throws IOException {
+    conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+            CachePolicy.DIR_LRU.getPolicy());
+    conf.setInt(OMConfigKeys.OZONE_OM_CACHE_DIR_INIT_CAPACITY, 1);
+    conf.setLong(OMConfigKeys.OZONE_OM_CACHE_DIR_MAX_CAPACITY, 2);
+
+    File testDir = GenericTestUtils.getRandomizedTestDir();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+            testDir.toString());
+
+    omMetadataManager = new OmMetadataManagerImpl(conf);
+    CacheStore dirCacheStore =
+            omMetadataManager.getOMCacheManager().getDirCache();
+    Assert.assertEquals("CachePolicy Mismatches!", CachePolicy.DIR_LRU,
+            dirCacheStore.getCachePolicy());
+
+    OMCacheKey<String> dirA = new OMCacheKey<>("512/a");
+    OMCacheValue<Long> dirA_ID = new OMCacheValue<>(1025L);
+    OMCacheKey<String> dirB = new OMCacheKey<>(dirA_ID + "/b");
+    OMCacheValue<Long> dirB_ID = new OMCacheValue<>(1026L);
+    dirCacheStore.put(dirA, dirA_ID);
+    dirCacheStore.put(dirB, dirB_ID);
+    // Step1. Cached Entries => {a, b}
+    Assert.assertEquals("Unexpected Cache Value",
+            dirA_ID.getCacheValue(), dirCacheStore.get(dirA).getCacheValue());
+    Assert.assertEquals("Unexpected Cache Value",
+            dirB_ID.getCacheValue(), dirCacheStore.get(dirB).getCacheValue());
+
+    // Step2. Verify eviction
+    // Cached Entries {frontEntry, rearEntry} => {c, b}
+    OMCacheKey<String> dirC = new OMCacheKey<>(dirB_ID + "/c");
+    OMCacheValue<Long> dirC_ID = new OMCacheValue<>(1027L);
+    dirCacheStore.put(dirC, dirC_ID);
+    Assert.assertEquals("Unexpected Cache Value",
+            dirC_ID.getCacheValue(), dirCacheStore.get(dirC).getCacheValue());
+    Assert.assertNull("Unexpected Cache Value", dirCacheStore.get(dirA));
+
+    // Step3. Adding 'a' again. Now 'b' will be evicted.
+    dirCacheStore.put(dirA, dirA_ID);
+    // Cached Entries {frontEntry, rearEntry} => {a, c}
+    Assert.assertEquals("Unexpected Cache Value",
+            dirA_ID.getCacheValue(), dirCacheStore.get(dirA).getCacheValue());
+    Assert.assertNull("Unexpected Cache Value", dirCacheStore.get(dirB));
+
+    // Step4. Cached Entries {frontEntry, rearEntry} => {c, a}
+    // Access 'c' so that the recently used entry will be 'c'. Now the entry
+    // eligible for eviction will be 'a'.
+    Assert.assertEquals("Unexpected Cache Value",
+            dirC_ID.getCacheValue(), dirCacheStore.get(dirC).getCacheValue());
+
+    // Step4. Recently accessed entry will be retained.
+    dirCacheStore.put(dirB, dirB_ID);
+    // Cached Entries {frontEntry, rearEntry} => {b, c}
+    Assert.assertEquals("Unexpected Cache Value",
+            dirB_ID.getCacheValue(), dirCacheStore.get(dirB).getCacheValue());
+    Assert.assertEquals("Unexpected Cache Value",
+            dirC_ID.getCacheValue(), dirCacheStore.get(dirC).getCacheValue());
+    Assert.assertNull("Unexpected Cache Value", dirCacheStore.get(dirA));
+
+    // Step5. Add duplicate entries shouldn't make any eviction.
+    dirCacheStore.put(dirB, dirB_ID);
+    Assert.assertEquals("Unexpected Cache Value",
+            dirB_ID.getCacheValue(), dirCacheStore.get(dirB).getCacheValue());
+    Assert.assertEquals("Unexpected Cache Value",
+            dirC_ID.getCacheValue(), dirCacheStore.get(dirC).getCacheValue());
+    Assert.assertEquals("Incorrect cache size", 2, dirCacheStore.size());
+
+    // Step6. Verify entry removal. Remove recently accessed entry.
+    dirCacheStore.remove(dirC);
+    // duplicate removal shouldn't cause any issues
+    dirCacheStore.remove(dirC);
+    Assert.assertEquals("Unexpected Cache Value",
+            dirB_ID.getCacheValue(), dirCacheStore.get(dirB).getCacheValue());
+    Assert.assertNull("Unexpected Cache Value", dirCacheStore.get(dirC));
+    Assert.assertEquals("Incorrect cache size", 1, dirCacheStore.size());
+
+    // Step7. Make it empty
+    dirCacheStore.remove(dirB);
+    Assert.assertEquals("Incorrect cache size", 0, dirCacheStore.size());
+  }
+
+  @Test
+  public void testNullCacheDirectoryPolicy() throws IOException {
+    conf.set(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY,
+            CachePolicy.DIR_NOCACHE.getPolicy());
+
+    File testDir = GenericTestUtils.getRandomizedTestDir();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+            testDir.toString());
+
+    omMetadataManager = new OmMetadataManagerImpl(conf);
+    CacheStore dirCacheStore =
+            omMetadataManager.getOMCacheManager().getDirCache();
+    Assert.assertEquals("CachePolicy Mismatches!", CachePolicy.DIR_NOCACHE,
+            dirCacheStore.getCachePolicy());
+
+    // Verify caching
+    OMCacheKey<String> dirA = new OMCacheKey<>("512/a");
+    OMCacheValue<Long> dirA_ID = new OMCacheValue<>(1025L);
+    dirCacheStore.put(dirA, dirA_ID);
+    Assert.assertNull("Unexpected Cache Value", dirCacheStore.get(dirA));
+  }
+
+  @Test
+  public void testDefaultCacheDirectoryPolicy() throws IOException {
+    File testDir = GenericTestUtils.getRandomizedTestDir();
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+            testDir.toString());
+
+    //1. Verify default dir cache policy. Defaulting to DIR_LRU
+    Assert.assertNull("Unexpected CachePolicy, it should be null!",
+            conf.get(OMConfigKeys.OZONE_OM_CACHE_DIR_POLICY));
+
+    omMetadataManager = new OmMetadataManagerImpl(conf);
+    CacheStore dirCacheStore =
+            omMetadataManager.getOMCacheManager().getDirCache();
+    Assert.assertEquals("CachePolicy Mismatches!", CachePolicy.DIR_LRU,
+            dirCacheStore.getCachePolicy());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/package-info.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/package-info.java
@@ -19,3 +19,4 @@ package org.apache.hadoop.ozone.om.cache;
 /**
  * Unit tests for metadata cache in OM.
  */
+

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/package-info.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/cache/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.cache;
+/**
+ * Unit tests for metadata cache in OM.
+ */


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the new file system HDDS-2939 like semantics design it requires multiple DB lookups to traverse the path component in top-down fashion. This patch provides a metadata caching service to cache directories for faster lookup. This patch is developed as an independent module and needs to be integrated once HDDS-2949 is pushed in.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2949

## How was this patch tested?

Added unit test cases to verify cache init and other ops.
