### PR TITLE
HDDS-4313. Create thread-local instance of FileSystem in HadoopFsGenerator

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -162,11 +162,20 @@ public class BaseFreonGenerator {
 
       //in case of an other failed test, we shouldn't execute more tasks.
       if (counter >= testNo || (!failAtEnd && failureCounter.get() > 0)) {
-        return;
+        break;
       }
 
       tryNextTask(provider, counter);
     }
+
+    taskLoopCompleted();
+  }
+
+  /**
+   * Provides a way to clean up per-thread resources.
+   */
+  protected void taskLoopCompleted() {
+    // no-op
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Create a separate instance of `FileSystem` in `HadoopFsGenerator` for each test thread.
2. Move directory creation to test setup.  Previously `mkdirs()` resulted in an extra RPC for each file.
3. Provide a hook method in `BaseFreonGenerator` for thread-specific cleanup.

https://issues.apache.org/jira/browse/HDDS-4313

## How was this patch tested?

```
ozone freon ockg -n1 -t1 -p warmup
ozone freon dfsg -n10000 -t10
```

```
/opt/profiler/profiler.sh -e lock -d 60 -o svg -f dfsg-lock.svg $(ps aux | grep 'proc_freo[n]' | awk '{ print $2 }')
```