### PR TITLE
HDDS-4315. Use Epoch to generate unique ObjectIDs

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/ExitManager.java
@@ -28,6 +28,6 @@ public class ExitManager {
 
   public void exitSystem(int status, String message, Throwable throwable,
       Logger log) {
-    ExitUtils.terminate(1, message, throwable, log);
+    ExitUtils.terminate(status, message, throwable, log);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -111,6 +112,7 @@ import static org.apache.hadoop.hdds.StringUtils.string2Bytes;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.client.ReplicationType.STAND_ALONE;
+import static org.apache.hadoop.ozone.OmUtils.MAX_TRXN_ID;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
@@ -254,8 +256,9 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertEquals(ozoneVolume.getName(), s3VolumeName);
     OMMetadataManager omMetadataManager =
         cluster.getOzoneManager().getMetadataManager();
-    long transactionID = Long.MAX_VALUE -1 >> 8;
-    long objectID = transactionID << 8;
+    long transactionID = MAX_TRXN_ID + 1;
+    long objectID = OmUtils.addEpochToObjectId(omMetadataManager.getOmEpoch(),
+        transactionID);
     OmVolumeArgs omVolumeArgs =
         cluster.getOzoneManager().getMetadataManager().getVolumeTable().get(
             omMetadataManager.getVolumeKey(s3VolumeName));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -257,7 +257,7 @@ public abstract class TestOzoneRpcClientAbstract {
     OMMetadataManager omMetadataManager =
         cluster.getOzoneManager().getMetadataManager();
     long transactionID = MAX_TRXN_ID + 1;
-    long objectID = OmUtils.addEpochToObjectId(omMetadataManager.getOmEpoch(),
+    long objectID = OmUtils.addEpochToTxId(omMetadataManager.getOmEpoch(),
         transactionID);
     OmVolumeArgs omVolumeArgs =
         cluster.getOzoneManager().getMetadataManager().getVolumeTable().get(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRestart.java
@@ -26,17 +26,27 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.commons.lang3.RandomStringUtils;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT;
+import static org.apache.hadoop.ozone.OmUtils.EPOCH_ID_SHIFT;
+import static org.apache.hadoop.ozone.OmUtils.EPOCH_WHEN_RATIS_NOT_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
@@ -104,7 +114,6 @@ public class TestOzoneManagerRestart {
     String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
 
     OzoneClient client = cluster.getClient();
-
     ObjectStore objectStore = client.getObjectStore();
 
     objectStore.createVolume(volumeName);
@@ -209,5 +218,94 @@ public class TestOzoneManagerRestart {
         ReplicationType.RATIS));
   }
 
+  @Test
+  public void testUniqueTrxnIndexOnOMRestart() throws Exception {
+    // When OM is restarted, the transaction index for requests should not
+    // start from 0. It should incrementally increase from the last
+    // transaction index which was stored in DB before restart.
 
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    String bucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    String keyName = "key" + RandomStringUtils.randomNumeric(5);
+
+    OzoneManager om = cluster.getOzoneManager();
+    OzoneClient client = cluster.getClient();
+    ObjectStore objectStore = client.getObjectStore();
+
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    OzoneManagerProtocolClientSideTranslatorPB omClient =
+        new OzoneManagerProtocolClientSideTranslatorPB(
+            OmTransportFactory.create(conf, ugi, null),
+            RandomStringUtils.randomAscii(5));
+
+    objectStore.createVolume(volumeName);
+
+    // Verify that the last transactionIndex stored in DB after volume
+    // creation equals the transaction index corresponding to volume's
+    // objectID. Also, the volume transaction index should be 1 as this is
+    // the first transaction in this cluster.
+    OmVolumeArgs volumeInfo = omClient.getVolumeInfo(volumeName);
+    long volumeTrxnIndex = OmUtils.getTxIdFromObjectId(
+        volumeInfo.getObjectID());
+    Assert.assertEquals(1, volumeTrxnIndex);
+    Assert.assertEquals(volumeTrxnIndex, om.getLastTrxnIndexForNonRatis());
+
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
+    ozoneVolume.createBucket(bucketName);
+
+    // Verify last transactionIndex is updated after bucket creation
+    OmBucketInfo bucketInfo = omClient.getBucketInfo(volumeName, bucketName);
+    long bucketTrxnIndex = OmUtils.getTxIdFromObjectId(
+        bucketInfo.getObjectID());
+    Assert.assertEquals(2, bucketTrxnIndex);
+    Assert.assertEquals(bucketTrxnIndex, om.getLastTrxnIndexForNonRatis());
+
+    // Restart the OM and create new object
+    cluster.restartOzoneManager();
+
+    String data = "random data";
+    OzoneOutputStream ozoneOutputStream = ozoneVolume.getBucket(bucketName)
+        .createKey(keyName, data.length(), ReplicationType.RATIS,
+            ReplicationFactor.ONE, new HashMap<>());
+    ozoneOutputStream.write(data.getBytes(), 0, data.length());
+    ozoneOutputStream.close();
+
+    // Verify last transactionIndex is updated after key creation and the
+    // transaction index after restart is incremented from the last
+    // transaction index before restart.
+    OmKeyInfo omKeyInfo = omClient.lookupKey(new OmKeyArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setRefreshPipeline(true).build());
+    long keyTrxnIndex = OmUtils.getTxIdFromObjectId(
+        omKeyInfo.getObjectID());
+    Assert.assertEquals(3, keyTrxnIndex);
+    // Key commit is a separate transaction. Hence, the last trxn index in DB
+    // should be 1 more than KeyTrxnIndex
+    Assert.assertEquals(4, om.getLastTrxnIndexForNonRatis());
+  }
+
+  @Test
+  public void testEpochIntegrationInObjectID() throws Exception {
+    // Create a volume and check the objectID has the epoch as
+    // EPOCH_FOR_RATIS_NOT_ENABLED in the first 2 bits.
+
+    OzoneClient client = cluster.getClient();
+    ObjectStore objectStore = client.getObjectStore();
+
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+    objectStore.createVolume(volumeName);
+
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    OzoneManagerProtocolClientSideTranslatorPB omClient =
+        new OzoneManagerProtocolClientSideTranslatorPB(
+        OmTransportFactory.create(conf, ugi, null),
+        RandomStringUtils.randomAscii(5));
+
+    long volObjId = omClient.getVolumeInfo(volumeName).getObjectID();
+    long epochInVolObjId = volObjId >> EPOCH_ID_SHIFT;
+
+    Assert.assertEquals(EPOCH_WHEN_RATIS_NOT_ENABLED, epochInVolObjId);
+  }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -73,6 +73,11 @@ public interface OMMetadataManager {
   OzoneManagerLock getLock();
 
   /**
+   * Returns the epoch associated with current OM process.
+   */
+  long getOmEpoch();
+
+  /**
    * Given a volume return the corresponding DB key.
    *
    * @param volume - Volume name

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -75,7 +75,7 @@ public interface OMMetadataManager {
   /**
    * Returns the epoch associated with current OM process.
    */
-  int getOmEpoch();
+  long getOmEpoch();
 
   /**
    * Given a volume return the corresponding DB key.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -75,7 +75,7 @@ public interface OMMetadataManager {
   /**
    * Returns the epoch associated with current OM process.
    */
-  long getOmEpoch();
+  int getOmEpoch();
 
   /**
    * Given a volume return the corresponding DB key.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/ratis/OMTransactionInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/ratis/OMTransactionInfo.java
@@ -34,8 +34,12 @@ import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_SPLIT_KEY;
  */
 public final class OMTransactionInfo {
 
+  // Term associated with Ratis Log index in Ratis enabled cluster. In
+  // non-Ratis cluster, term is set to -1.
   private long term; // term associated with the ratis log index.
-  // Transaction index corresponds to ratis log index
+  // Ratis Log index in Ratis enabled cluster or the unique transaction
+  // index {@link OzoneManagerServerSideTransalatorPB#transactionIndex} in
+  // non-Ratis cluster
   private long transactionIndex;
 
   private OMTransactionInfo(String transactionInfo) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -170,7 +170,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   // non-ratis OM clusters will be binary 01 (= decimal 1)  and for ratis
   // enabled OM cluster will be binary 10 (= decimal 2). This epoch is added
   // to ensure uniqueness of objectIDs.
-  private final int omEpoch;
+  private final long omEpoch;
 
   private Map<String, Table> tableMap = new HashMap<>();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.codec.OMTransactionInfoCodec;
@@ -162,6 +163,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private boolean isRatisEnabled;
   private boolean ignorePipelineinKey;
 
+  private final int omEpoch;
+
   private Map<String, Table> tableMap = new HashMap<>();
 
   public OmMetadataManagerImpl(OzoneConfiguration conf) throws IOException {
@@ -176,6 +179,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     isRatisEnabled = conf.getBoolean(
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_DEFAULT);
+    this.omEpoch = OmUtils.getOMEpoch(isRatisEnabled);
     // For test purpose only
     ignorePipelineinKey = conf.getBoolean(
         "ozone.om.ignore.pipeline", Boolean.TRUE);
@@ -189,6 +193,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     this.lock = new OzoneManagerLock(new OzoneConfiguration());
     this.openKeyExpireThresholdMS =
         OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS_DEFAULT;
+    this.omEpoch = 0;
   }
 
   @Override
@@ -234,7 +239,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public Table<String, OmMultipartKeyInfo> getMultipartInfoTable() {
     return multipartInfoTable;
   }
-
 
   private void checkTableStatus(Table table, String name) throws IOException {
     String logMessage = "Unable to get a reference to %s table. Cannot " +
@@ -496,6 +500,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public org.apache.hadoop.ozone.om.lock.OzoneManagerLock getLock() {
     return lock;
+  }
+
+  @Override
+  public long getOmEpoch() {
+    return omEpoch;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -163,6 +163,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private boolean isRatisEnabled;
   private boolean ignorePipelineinKey;
 
+  // Epoch is used to generate the objectIDs. The most significant 2 bits of
+  // objectIDs is set to this epoch. For clusters before HDDS-4315 there is
+  // no epoch as such. But it can be safely assumed that the most significant
+  // 2 bits of the objectID will be 00. From HDDS-4315 onwards, the Epoch for
+  // non-ratis OM clusters will be binary 01 (= decimal 1)  and for ratis
+  // enabled OM cluster will be binary 10 (= decimal 2). This epoch is added
+  // to ensure uniqueness of objectIDs.
   private final int omEpoch;
 
   private Map<String, Table> tableMap = new HashMap<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1285,7 +1285,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public long getObjectIdFromTxId(long trxnId) {
-    return OmUtils.getObjectIdFromTxId((long) metadataManager.getOmEpoch(),
+    return OmUtils.getObjectIdFromTxId(metadataManager.getOmEpoch(),
         trxnId);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/PrefixManagerImpl.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone.om;
 
 import com.google.common.base.Strings;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -315,7 +316,8 @@ public class PrefixManagerImpl implements PrefixManager {
           new OmPrefixInfo.Builder()
           .setName(ozoneObj.getPath());
       if (transactionLogIndex > 0) {
-        prefixInfoBuilder.setObjectID(transactionLogIndex);
+        prefixInfoBuilder.setObjectID(OmUtils.getObjectIdFromTxId(
+            metadataManager.getOmEpoch(), transactionLogIndex));
         prefixInfoBuilder.setUpdateID(transactionLogIndex);
       }
       prefixInfo = prefixInfoBuilder.build();
@@ -365,7 +367,8 @@ public class PrefixManagerImpl implements PrefixManager {
           new OmPrefixInfo.Builder()
               .setName(ozoneObj.getPath());
       if (transactionLogIndex > 0) {
-        prefixInfoBuilder.setObjectID(transactionLogIndex);
+        prefixInfoBuilder.setObjectID(OmUtils.getObjectIdFromTxId(
+            metadataManager.getOmEpoch(), transactionLogIndex));
         prefixInfoBuilder.setUpdateID(transactionLogIndex);
       }
       prefixInfo = prefixInfoBuilder.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -199,13 +198,12 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
       // Add objectID and updateID
       omBucketInfo.setObjectID(
-          OMFileRequest.getObjIDFromTxId(transactionLogIndex));
+          ozoneManager.getObjectIdFromTxId(transactionLogIndex));
       omBucketInfo.setUpdateID(transactionLogIndex,
           ozoneManager.isRatisEnabled());
 
       // Add default acls from volume.
       addDefaultAcls(omBucketInfo, omVolumeArgs);
-
 
       // Update table cache.
       metadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OzoneAcl;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
@@ -82,6 +81,11 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateRequest.class);
+
+  // The maximum number of directories which can be created through a single
+  // transaction (recursive directory creations) is 2^8 - 1 as only 8
+  // bits are set aside for this in ObjectID.
+  private static final long MAX_NUM_OF_RECURSIVE_DIRS = 255;
 
   /**
    * Stores the result of request execution in
@@ -185,7 +189,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       } else if (omDirectoryResult == DIRECTORY_EXISTS_IN_GIVENPATH ||
           omDirectoryResult == NONE) {
         List<String> missingParents = omPathInfo.getMissingParents();
-        long baseObjId = OMFileRequest.getObjIDFromTxId(trxnLogIndex);
+        long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
         List<OzoneAcl> inheritAcls = omPathInfo.getAcls();
 
         dirKeyInfo = createDirectoryKeyInfoWithACL(keyName,
@@ -246,11 +250,12 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
     List<OmKeyInfo> missingParentInfos = new ArrayList<>();
 
-    ImmutablePair<Long, Long> objIdRange = OMFileRequest
-        .getObjIdRangeFromTxId(trxnLogIndex);
-    long baseObjId = objIdRange.getLeft();
-    long maxObjId = objIdRange.getRight();
-    long maxLevels = maxObjId - baseObjId;
+    // The base id is left shifted by 8 bits for creating space to
+    // create (2^8 - 1) object ids in every request.
+    // maxObjId represents the largest object id allocation possible inside
+    // the transaction.
+    long baseObjId = ozoneManager.getObjectIdFromTxId(trxnLogIndex);
+    long maxObjId = baseObjId + MAX_NUM_OF_RECURSIVE_DIRS;
     long objectCount = 1; // baseObjID is used by the leaf directory
 
     String volumeName = keyArgs.getVolumeName();
@@ -261,8 +266,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       long nextObjId = baseObjId + objectCount;
       if (nextObjId > maxObjId) {
         throw new OMException("Too many directories in path. Exceeds limit of "
-            + maxLevels + ". Unable to create directory: " + keyName
-            + " in volume/bucket: " + volumeName + "/" + bucketName,
+            + MAX_NUM_OF_RECURSIVE_DIRS + ". Unable to create directory: "
+            + keyName + " in volume/bucket: " + volumeName + "/" + bucketName,
             INVALID_KEY_NAME);
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -260,6 +260,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),
           ozoneManager.getPrefixManager(), bucketInfo, trxnLogIndex,
+          ozoneManager.getObjectIdFromTxId(trxnLogIndex),
           ozoneManager.isRatisEnabled());
 
       long openVersion = omKeyInfo.getLatestVersionLocations().getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -24,8 +24,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -44,7 +44,6 @@ public final class OMFileRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMFileRequest.class);
-  private static final long TRANSACTION_ID_SHIFT = 8;
 
   private OMFileRequest() {
   }
@@ -127,33 +126,6 @@ public final class OMFileRequest {
         + keyName + ":" + result);
     // Found no files/ directories in the given path.
     return new OMPathInfo(missing, OMDirectoryResult.NONE, inheritAcls);
-  }
-
-  /**
-   * Get the valid base object id given the transaction id.
-   * @param id of the transaction
-   * @return base object id allocated against the transaction
-   */
-  public static long getObjIDFromTxId(long id) {
-    return id << TRANSACTION_ID_SHIFT;
-  }
-
-  /**
-   * Generate the valid object id range for the transaction id.
-   * The transaction id is left shifted by 8 bits -
-   * creating space to create (2^8 - 1) object ids in every request.
-   * maxId (right element of Immutable pair) represents the largest
-   * object id allocation possible inside the transaction.
-   * @param id
-   * @return object id range
-   */
-  public static ImmutablePair<Long, Long> getObjIdRangeFromTxId(long id) {
-    long baseId = getObjIDFromTxId(id);
-    // 1 less than the baseId for the next transaction
-    long maxAvailableId = getObjIDFromTxId(id+1) - 1;
-    Preconditions.checkState(maxAvailableId >= baseId,
-        "max available id must be atleast equal to the base id.");
-    return new ImmutablePair<>(baseId, maxAvailableId);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -273,6 +273,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
           keyArgs.getDataSize(), locations, getFileEncryptionInfo(keyArgs),
           ozoneManager.getPrefixManager(), bucketInfo, trxnLogIndex,
+          ozoneManager.getObjectIdFromTxId(trxnLogIndex),
           ozoneManager.isRatisEnabled());
 
       long openVersion = omKeyInfo.getLatestVersionLocations().getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -250,9 +249,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nullable FileEncryptionInfo encInfo,
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
-        long transactionLogIndex) {
-    long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
-
+      long transactionLogIndex, long objectID) {
     return new OmKeyInfo.Builder()
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
@@ -323,12 +320,14 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nullable FileEncryptionInfo encInfo,
       @Nonnull PrefixManager prefixManager,
       @Nullable OmBucketInfo omBucketInfo,
-      long transactionLogIndex, boolean isRatisEnabled)
+      long transactionLogIndex,
+      @Nonnull long objectID,
+      boolean isRatisEnabled)
       throws IOException {
     if (keyArgs.getIsMultipartKey()) {
       return prepareMultipartKeyInfo(omMetadataManager, keyArgs,
           size, locations, encInfo, prefixManager, omBucketInfo,
-          transactionLogIndex);
+          transactionLogIndex, objectID);
       //TODO args.getMetadata
     }
     if (dbKeyInfo != null) {
@@ -350,7 +349,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // Blocks will be appended as version 0.
     return createKeyInfo(keyArgs, locations, keyArgs.getFactor(),
         keyArgs.getType(), keyArgs.getDataSize(), encInfo, prefixManager,
-        omBucketInfo, transactionLogIndex);
+        omBucketInfo, transactionLogIndex, objectID);
   }
 
   /**
@@ -365,7 +364,8 @@ public abstract class OMKeyRequest extends OMClientRequest {
       @Nonnull KeyArgs args, long size,
       @Nonnull List<OmKeyLocationInfo> locations,
       FileEncryptionInfo encInfo,  @Nonnull PrefixManager prefixManager,
-      @Nullable OmBucketInfo omBucketInfo, @Nonnull long transactionLogIndex)
+      @Nullable OmBucketInfo omBucketInfo, @Nonnull long transactionLogIndex,
+      @Nonnull long objectId)
       throws IOException {
     HddsProtos.ReplicationFactor factor;
     HddsProtos.ReplicationType type;
@@ -394,7 +394,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     // For this upload part we don't need to check in KeyTable. As this
     // is not an actual key, it is a part of the key.
     return createKeyInfo(args, locations, factor, type, size, encInfo,
-        prefixManager, omBucketInfo, transactionLogIndex);
+        prefixManager, omBucketInfo, transactionLogIndex, objectId);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -117,7 +116,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
     OmMultipartKeyInfo multipartKeyInfo = null;
     OmKeyInfo omKeyInfo = null;
     Result result = null;
-    long objectID = OMFileRequest.getObjIDFromTxId(transactionLogIndex);
+    long objectID = ozoneManager.getObjectIdFromTxId(transactionLogIndex);
 
     OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
         getOmRequest());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeCreateRequest.java
@@ -27,7 +27,6 @@ import com.google.common.base.Preconditions;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -125,7 +124,7 @@ public class OMVolumeCreateRequest extends OMVolumeRequest {
       // The Object ID will never change, but update
       // ID will be set to transactionID each time we update the object.
       omVolumeArgs.setObjectID(
-          OMFileRequest.getObjIDFromTxId(transactionLogIndex));
+          ozoneManager.getObjectIdFromTxId(transactionLogIndex));
       omVolumeArgs.setUpdateID(transactionLogIndex,
           ozoneManager.isRatisEnabled());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -58,7 +58,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
   private final boolean isRatisEnabled;
   private final OzoneManager ozoneManager;
   private final OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
-  private final AtomicLong transactionIndex = new AtomicLong(0L);
+  private final AtomicLong transactionIndex;
   private final OzoneProtocolMessageDispatcher<OMRequest, OMResponse,
       ProtocolMessageEnum> dispatcher;
 
@@ -71,9 +71,14 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       OzoneManager impl,
       OzoneManagerRatisServer ratisServer,
       ProtocolMessageMetrics<ProtocolMessageEnum> metrics,
-      boolean enableRatis) {
+      boolean enableRatis,
+      long lastTransactionIndexForNonRatis) {
     this.ozoneManager = impl;
     this.isRatisEnabled = enableRatis;
+    // Update the transactionIndex with the last TransactionIndex read from DB.
+    // New requests should have transactionIndex incremented from this index
+    // onwards to ensure unique objectIDs.
+    this.transactionIndex = new AtomicLong(lastTransactionIndexForNonRatis);
 
     if (isRatisEnabled) {
       // In case of ratis is enabled, handler in ServerSideTransaltorPB is used

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeCreateRequest.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.request.volume;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.volume.OMVolumeCreateResponse;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -64,7 +63,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
     String adminName = "user1";
     String ownerName = "user1";
     long txLogIndex = 1;
-    long expectedObjId = OMFileRequest.getObjIDFromTxId(txLogIndex);
+    long expectedObjId = ozoneManager.getObjectIdFromTxId(txLogIndex);
 
     OMRequest originalRequest = createVolumeRequest(volumeName, adminName,
         ownerName);
@@ -115,7 +114,7 @@ public class TestOMVolumeCreateRequest extends TestOMVolumeRequest {
 
     omVolumeCreateRequest = new OMVolumeCreateRequest(modifiedRequest);
     long txLogIndex = 2;
-    long expectedObjId = OMFileRequest.getObjIDFromTxId(txLogIndex);
+    long expectedObjId = ozoneManager.getObjectIdFromTxId(txLogIndex);
 
     OMClientResponse omClientResponse =
         omVolumeCreateRequest.validateAndUpdateCache(ozoneManager, txLogIndex,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a non-Ratis OM, the transaction index used to generate ObjectID is reset on OM restart. This can lead to duplicate ObjectIDs when the OM is restarted. ObjectIDs should be unique. 
For HDDS-2939 and NFS are some of the features which depend on ObjectIds being unique.

~~This Jira aims to introduce an epoch number in OM which is incremented on OM restarts. The epoch is persisted on disk. This epoch will be used to set the first 16 bits of the objectID to ensure that objectIDs are unique even after OM restart.
The highest epoch number is reserved for transactions coming through ratis. This will take care of the scenario where OM ratis is enabled on an existing cluster.~~

To ensure that objectIDs are unique across restarts in non-ratis OM cluster, the transaction index should be updated in DB on every flush to DB. This can be done in a similar fashion to what is being done for ratis enabled cluster today. TransactionInfo table is updated with transaction index as part of every batch write operation to DB.

Also, and epoch number is introduced to ensure that objectIDs do not clash with older clusters in which this fix does not exist. From the 64 bits of ObjectID (long variable), 2 bits are reserved for epoch and 8 bits for recursive directory creation, if required. The most significant 2 bits of objectIDs is set to epoch. For clusters before HDDS-4315 there is no epoch as such. But it can be safely assumed that the most significant 2 bits of the objectID will be 00 (as it unlikely to reach trxn index > 2^62 in an existing cluster). From HDDS-4315 onwards, the Epoch for non-ratis OM clusters will be binary 01 (= decimal 1) and for ratis enabled OM cluster will be binary 10 (= decimal 2).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4315

## How was this patch tested?

Added unit tests.