### PR TITLE
HDDS-4330. Bootstrap new OM node

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2228,6 +2228,15 @@
       client ozone manager protocol.
     </description>
   </property>
+  <property>
+    <name>ozone.om.security.admin.protocol.acl</name>
+    <value>*</value>
+    <tag>SECURITY</tag>
+    <description>
+      Comma separated list of users and groups allowed to access ozone
+      manager admin protocol.
+    </description>
+  </property>
 
   <property>
     <name>hdds.datanode.http.auth.kerberos.principal</name>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/NodeDetails.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/NodeDetails.java
@@ -28,20 +28,39 @@ import java.net.InetSocketAddress;
 public abstract class NodeDetails {
   private String serviceId;
   private String nodeId;
-  private InetSocketAddress rpcAddress;
+  private String hostAddress;
+  private int rpcPort;
   private int ratisPort;
   private String httpAddress;
   private String httpsAddress;
+
+  private InetSocketAddress rpcAddress;
 
   /**
    * Constructs NodeDetails object.
    */
   public NodeDetails(String serviceId, String nodeId,
-                        InetSocketAddress rpcAddr, int ratisPort,
-                        String httpAddress, String httpsAddress) {
+      InetSocketAddress rpcAddress, int ratisPort,
+      String httpAddress, String httpsAddress) {
     this.serviceId = serviceId;
     this.nodeId = nodeId;
-    this.rpcAddress = rpcAddr;
+    this.rpcAddress = rpcAddress;
+    this.hostAddress = rpcAddress.getHostName();
+    this.rpcPort = rpcAddress.getPort();
+    this.ratisPort = ratisPort;
+    this.httpAddress = httpAddress;
+    this.httpsAddress = httpsAddress;
+  }
+
+  /**
+   * Constructs NodeDetails object.
+   */
+  public NodeDetails(String serviceId, String nodeId, String hostAddr,
+      int rpcPort, int ratisPort, String httpAddress, String httpsAddress) {
+    this.serviceId = serviceId;
+    this.nodeId = nodeId;
+    this.hostAddress = hostAddr;
+    this.rpcPort = rpcPort;
     this.ratisPort = ratisPort;
     this.httpAddress = httpAddress;
     this.httpsAddress = httpsAddress;
@@ -56,19 +75,26 @@ public abstract class NodeDetails {
   }
 
   public InetSocketAddress getRpcAddress() {
+    if (rpcAddress == null) {
+      rpcAddress = NetUtils.createSocketAddr(hostAddress, rpcPort);
+    }
     return rpcAddress;
   }
 
   public boolean isHostUnresolved() {
-    return rpcAddress.isUnresolved();
+    return getRpcAddress().isUnresolved();
   }
 
   public InetAddress getInetAddress() {
-    return rpcAddress.getAddress();
+    return getRpcAddress().getAddress();
   }
 
   public String getHostName() {
-    return rpcAddress.getHostName();
+    return getRpcAddress().getHostName();
+  }
+
+  public String getHostAddress() {
+    return hostAddress;
   }
 
   public String getRatisHostPortStr() {
@@ -93,7 +119,7 @@ public abstract class NodeDetails {
   }
 
   public String getRpcAddressString() {
-    return NetUtils.getHostPortString(rpcAddress);
+    return NetUtils.getHostPortString(getRpcAddress());
   }
 
   public String getHttpAddress() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/NodeDetails.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/NodeDetails.java
@@ -45,8 +45,10 @@ public abstract class NodeDetails {
     this.serviceId = serviceId;
     this.nodeId = nodeId;
     this.rpcAddress = rpcAddress;
-    this.hostAddress = rpcAddress.getHostName();
-    this.rpcPort = rpcAddress.getPort();
+    if (rpcAddress != null) {
+      this.hostAddress = rpcAddress.getHostName();
+      this.rpcPort = rpcAddress.getPort();
+    }
     this.ratisPort = ratisPort;
     this.httpAddress = httpAddress;
     this.httpsAddress = httpsAddress;

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -72,6 +72,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>hdds-server-framework</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -221,6 +221,13 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL =
       "ozone.om.security.client.protocol.acl";
 
+  // Comma separated acls (users, groups) allowing clients accessing
+  // OM admin protocol.
+  // When hadoop.security.authorization is true, this needs to be set in
+  // hadoop-policy.xml, "*" allows all users/groups to access.
+  public static final String OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL =
+      "ozone.om.security.admin.protocol.acl";
+
   public static final String OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_KEY =
           "ozone.om.keyname.character.check.enabled";
   public static final boolean OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
-import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import org.apache.ratis.protocol.exceptions.StateMachineException;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMNodeDetails.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMNodeDetails.java
@@ -15,17 +15,23 @@
  * the License.
  */
 
-package org.apache.hadoop.ozone.om.ha;
+package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.hdds.NodeDetails;
 
 import java.net.InetSocketAddress;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_KEY;
 
 /**
  * This class stores OM node details.
@@ -40,6 +46,16 @@ public final class OMNodeDetails extends NodeDetails {
       InetSocketAddress rpcAddr, int rpcPort, int ratisPort,
       String httpAddress, String httpsAddress) {
     super(serviceId, nodeId, rpcAddr, ratisPort, httpAddress, httpsAddress);
+    this.rpcPort = rpcPort;
+  }
+
+  /**
+   * Constructs OMNodeDetails object.
+   */
+  private OMNodeDetails(String serviceId, String nodeId, String hostAddr,
+      int rpcPort, int ratisPort, String httpAddress, String httpsAddress) {
+    super(serviceId, nodeId, hostAddr, rpcPort, ratisPort, httpAddress,
+        httpsAddress);
     this.rpcPort = rpcPort;
   }
 
@@ -66,15 +82,32 @@ public final class OMNodeDetails extends NodeDetails {
   public static class Builder {
     private String omServiceId;
     private String omNodeId;
+    private String hostAddress;
     private InetSocketAddress rpcAddress;
     private int rpcPort;
     private int ratisPort;
     private String httpAddr;
     private String httpsAddr;
 
+    public Builder setHostAddress(String hostName) {
+      this.hostAddress = hostName;
+      return this;
+    }
+
     public Builder setRpcAddress(InetSocketAddress rpcAddr) {
       this.rpcAddress = rpcAddr;
       this.rpcPort = rpcAddress.getPort();
+      return this;
+    }
+
+    public Builder setRatisAddress(InetSocketAddress ratisAddr) {
+      this.hostAddress = ratisAddr.getHostName();
+      this.ratisPort = ratisAddr.getPort();
+      return this;
+    }
+
+    public Builder setRpcPort(int port) {
+      this.rpcPort = port;
       return this;
     }
 
@@ -104,13 +137,18 @@ public final class OMNodeDetails extends NodeDetails {
     }
 
     public OMNodeDetails build() {
-      return new OMNodeDetails(omServiceId, omNodeId, rpcAddress, rpcPort,
-          ratisPort, httpAddr, httpsAddr);
+      if (rpcAddress != null) {
+        return new OMNodeDetails(omServiceId, omNodeId, rpcAddress, rpcPort,
+            ratisPort, httpAddr, httpsAddr);
+      } else {
+        return new OMNodeDetails(omServiceId, omNodeId, hostAddress, rpcPort,
+            ratisPort, httpAddr, httpsAddr);
+      }
     }
   }
 
-  public String getOMDBCheckpointEnpointUrl(HttpConfig.Policy httpPolicy) {
-    if (httpPolicy.isHttpEnabled()) {
+  public String getOMDBCheckpointEnpointUrl(boolean isHttpPolicy) {
+    if (isHttpPolicy) {
       if (StringUtils.isNotEmpty(getHttpAddress())) {
         return "http://" + getHttpAddress() +
             OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT +
@@ -124,5 +162,41 @@ public final class OMNodeDetails extends NodeDetails {
       }
     }
     return null;
+  }
+
+  public static OMNodeDetails getOMNodeDetailsFromConf(OzoneConfiguration conf,
+      String omServiceId, String omNodeId) {
+    String rpcAddrKey = ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
+        omServiceId, omNodeId);
+    String rpcAddrStr = OmUtils.getOmRpcAddress(conf, rpcAddrKey);
+    if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
+      return null;
+    }
+
+    String ratisPortKey = ConfUtils.addKeySuffixes(OZONE_OM_RATIS_PORT_KEY,
+        omServiceId, omNodeId);
+    int ratisPort = conf.getInt(ratisPortKey, OZONE_OM_RATIS_PORT_DEFAULT);
+
+    InetSocketAddress omRpcAddress = null;
+    try {
+      omRpcAddress = NetUtils.createSocketAddr(rpcAddrStr);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Couldn't create socket address" +
+          " for OM " + omNodeId + " at " + rpcAddrStr, e);
+    }
+
+    String httpAddr = OmUtils.getHttpAddressForOMPeerNode(conf,
+        omServiceId, omNodeId, omRpcAddress.getHostName());
+    String httpsAddr = OmUtils.getHttpsAddressForOMPeerNode(conf,
+        omServiceId, omNodeId, omRpcAddress.getHostName());
+
+    return new OMNodeDetails.Builder()
+        .setOMNodeId(omNodeId)
+        .setRpcAddress(omRpcAddress)
+        .setRatisPort(ratisPort)
+        .setHttpAddress(httpAddr)
+        .setHttpsAddress(httpsAddr)
+        .setOMServiceId(omServiceId)
+        .build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
@@ -19,11 +19,18 @@ package org.apache.hadoop.ozone.om.protocol;
 
 import java.io.Closeable;
 import java.io.IOException;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
+import org.apache.hadoop.security.KerberosInfo;
+import org.apache.hadoop.security.token.TokenInfo;
 
 /**
  * Protocol for inter OM communication.
  */
+@KerberosInfo(
+    serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)
+@TokenInfo(OzoneDelegationTokenSelector.class)
 public interface OMInterServiceProtocol extends Closeable {
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
@@ -21,9 +21,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
-import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 import org.apache.hadoop.security.KerberosInfo;
-import org.apache.hadoop.security.token.TokenInfo;
 
 /**
  * Protocol for inter OM communication.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.security.token.TokenInfo;
  */
 @KerberosInfo(
     serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)
-@TokenInfo(OzoneDelegationTokenSelector.class)
 public interface OMInterServiceProtocol extends Closeable {
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMInterServiceProtocol.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.protocol;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+
+/**
+ * Protocol for inter OM communication.
+ */
+public interface OMInterServiceProtocol extends Closeable {
+
+  /**
+   * Bootstrap OM by adding to existing OM Ratis ring.
+   */
+  void bootstrap(OMNodeDetails newOMNode) throws IOException;
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
@@ -64,7 +64,7 @@ public class Hadoop3OmTransport implements OmTransport {
         ProtobufRpcEngine.class);
 
     this.omFailoverProxyProvider = new OMFailoverProxyProvider(conf, ugi,
-        omServiceId);
+        omServiceId, OzoneManagerProtocolPB.class);
 
     int maxFailovers = conf.getInt(
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapErrorCode;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.ErrorCode;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,14 +90,14 @@ public class OMInterServiceProtocolClientSideImpl implements
       OMNotLeaderException notLeaderException =
           OMFailoverProxyProvider.getNotLeaderException(e);
       if (notLeaderException != null) {
-        throwException(BootstrapErrorCode.LEADER_UNDETERMINED,
+        throwException(ErrorCode.LEADER_UNDETERMINED,
             notLeaderException.getMessage());
       }
 
       OMLeaderNotReadyException leaderNotReadyException =
           OMFailoverProxyProvider.getLeaderNotReadyException(e);
       if (leaderNotReadyException != null) {
-        throwException(BootstrapErrorCode.LEADER_NOT_READY,
+        throwException(ErrorCode.LEADER_NOT_READY,
             leaderNotReadyException.getMessage());
       }
       throw ProtobufHelper.getRemoteException(e);
@@ -108,7 +108,7 @@ public class OMInterServiceProtocolClientSideImpl implements
     }
   }
 
-  private void throwException(BootstrapErrorCode errorCode, String errorMsg)
+  private void throwException(ErrorCode errorCode, String errorMsg)
       throws IOException {
     throw new IOException("Failed to Bootstrap OM. Error Code: " + errorCode +
         ", Error Message: " + errorMsg);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.protocolPB;
+
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.io.retry.RetryProxy;
+import org.apache.hadoop.ipc.ProtobufHelper;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
+import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapErrorCode;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Protocol implementation for Inter OM communication
+ */
+public class OMInterServiceProtocolClientSideImpl implements
+    OMInterServiceProtocol {
+
+  /**
+   * RpcController is not used and hence is set to null.
+   */
+  private static final RpcController NULL_RPC_CONTROLLER = null;
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMInterServiceProtocolClientSideImpl.class);
+
+  private final OMFailoverProxyProvider omFailoverProxyProvider;
+
+  private final OMInterServiceProtocolPB rpcProxy;
+
+  public OMInterServiceProtocolClientSideImpl(ConfigurationSource conf,
+      UserGroupInformation ugi, String omServiceId) throws IOException {
+
+    RPC.setProtocolEngine(OzoneConfiguration.of(conf),
+        OMInterServiceProtocolPB.class, ProtobufRpcEngine.class);
+
+    this.omFailoverProxyProvider = new OMFailoverProxyProvider(conf, ugi,
+        omServiceId, OMInterServiceProtocolPB.class);
+
+    int maxFailovers = conf.getInt(
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT);
+
+    this.rpcProxy = (OMInterServiceProtocolPB) RetryProxy.create(
+        OMInterServiceProtocolPB.class, omFailoverProxyProvider,
+        omFailoverProxyProvider.getRetryPolicy(maxFailovers));
+  }
+
+  @Override
+  public void bootstrap(OMNodeDetails newOMNode) throws IOException {
+    BootstrapOMRequest bootstrapOMRequest = BootstrapOMRequest.newBuilder()
+        .setNodeId(newOMNode.getNodeId())
+        .setHostAddress(newOMNode.getHostAddress())
+        .setRatisPort(newOMNode.getRatisPort())
+        .build();
+
+    BootstrapOMResponse response;
+    try {
+      response = rpcProxy.bootstrap(NULL_RPC_CONTROLLER, bootstrapOMRequest);
+    } catch (ServiceException e) {
+      OMNotLeaderException notLeaderException =
+          OMFailoverProxyProvider.getNotLeaderException(e);
+      if (notLeaderException != null) {
+        throwException(BootstrapErrorCode.LEADER_UNDETERMINED,
+            notLeaderException.getMessage());
+      }
+
+      OMLeaderNotReadyException leaderNotReadyException =
+          OMFailoverProxyProvider.getLeaderNotReadyException(e);
+      if (leaderNotReadyException != null) {
+        throwException(BootstrapErrorCode.LEADER_NOT_READY,
+            leaderNotReadyException.getMessage());
+      }
+      throw ProtobufHelper.getRemoteException(e);
+    }
+
+    if (!response.getSuccess()) {
+      throwException(response.getErrorCode(), response.getErrorMsg());
+    }
+  }
+
+  private void throwException(BootstrapErrorCode errorCode, String errorMsg)
+      throws IOException {
+    throw new IOException("Failed to Bootstrap OM. Error Code: " + errorCode +
+        ", Error Message: " + errorMsg);
+  }
+
+  @Override
+  public void close() throws IOException {
+    omFailoverProxyProvider.close();
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolClientSideImpl.java
@@ -40,7 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Protocol implementation for Inter OM communication
+ * Protocol implementation for Inter OM communication.
  */
 public class OMInterServiceProtocolClientSideImpl implements
     OMInterServiceProtocol {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
     protocolVersion = 1)
 @KerberosInfo(
     serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)
-@TokenInfo(OzoneDelegationTokenSelector.class)
 @InterfaceAudience.Private
 public interface OMInterServiceProtocolPB
     extends OzoneManagerInterService.BlockingInterface {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.ipc.ProtocolInfo;
 import org.apache.hadoop.ozone.protocol.proto
     .OzoneManagerInterServiceProtocolProtos.OzoneManagerInterService;
 import org.apache.hadoop.security.KerberosInfo;
-import org.apache.hadoop.security.token.TokenInfo;
-import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 
 /**
  * Protocol used for communication between OMs.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMInterServiceProtocolPB.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.protocolPB;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ipc.ProtocolInfo;
+import org.apache.hadoop.ozone.protocol.proto
+    .OzoneManagerInterServiceProtocolProtos.OzoneManagerInterService;
+import org.apache.hadoop.security.KerberosInfo;
+import org.apache.hadoop.security.token.TokenInfo;
+import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
+
+/**
+ * Protocol used for communication between OMs.
+ */
+@ProtocolInfo(protocolName =
+    "org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol",
+    protocolVersion = 1)
+@KerberosInfo(
+    serverPrincipal = OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY)
+@TokenInfo(OzoneDelegationTokenSelector.class)
+@InterfaceAudience.Private
+public interface OMInterServiceProtocolPB
+    extends OzoneManagerInterService.BlockingInterface {
+}

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/ha/TestOMFailoverProxyProvider.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.Before;
@@ -68,7 +69,8 @@ public class TestOMFailoverProxyProvider {
     config.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
         allNodeIds.toString());
     provider = new OMFailoverProxyProvider(config,
-        UserGroupInformation.getCurrentUser(), OM_SERVICE_ID);
+        UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+        OzoneManagerProtocolPB.class);
   }
 
   /**
@@ -184,7 +186,8 @@ public class TestOMFailoverProxyProvider {
     ozoneConf.set(ConfUtils.addKeySuffixes(OZONE_OM_NODES_KEY, OM_SERVICE_ID),
         allNodeIds.toString());
     OMFailoverProxyProvider prov = new OMFailoverProxyProvider(ozoneConf,
-        UserGroupInformation.getCurrentUser(), OM_SERVICE_ID);
+        UserGroupInformation.getCurrentUser(), OM_SERVICE_ID,
+        OzoneManagerProtocolPB.class);
 
     Text dtService = prov.getCurrentProxyDelegationToken();
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -103,8 +103,10 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
   public MiniOzoneChaosCluster(OzoneConfiguration conf,
       List<OzoneManager> ozoneManagers, List<StorageContainerManager> scms,
       List<HddsDatanodeService> hddsDatanodes, String omServiceID,
-      String scmServiceId, Set<Class<? extends Failures>> clazzes) {
-    super(conf, ozoneManagers, scms, hddsDatanodes, omServiceID, scmServiceId);
+      String scmServiceId, String clusterPath,
+      Set<Class<? extends Failures>> clazzes) {
+    super(conf, ozoneManagers, scms, hddsDatanodes, omServiceID, scmServiceId,
+        clusterPath);
     this.numDatanodes = getHddsDatanodes().size();
     this.numOzoneManagers = ozoneManagers.size();
     this.numStorageContainerManagers = scms.size();
@@ -327,7 +329,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
 
       MiniOzoneChaosCluster cluster =
           new MiniOzoneChaosCluster(conf, omList, scmList, hddsDatanodes,
-              omServiceId, scmServiceId, clazzes);
+              omServiceId, scmServiceId, path, clazzes);
 
       if (startDataNodes) {
         cluster.startHddsDatanodes();

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -100,6 +100,7 @@ public class MiniOzoneChaosCluster extends MiniOzoneHAClusterImpl {
     }
   }
 
+  @SuppressWarnings("parameternumber")
   public MiniOzoneChaosCluster(OzoneConfiguration conf,
       List<OzoneManager> ozoneManagers, List<StorageContainerManager> scms,
       List<HddsDatanodeService> hddsDatanodes, String omServiceID,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -76,6 +76,11 @@ public interface MiniOzoneCluster {
   OzoneConfiguration getConf();
 
   /**
+   * Set the configuration for the MiniOzoneCluster.
+   */
+  void setConf(OzoneConfiguration newConf);
+
+  /**
    * Waits for the cluster to be ready, this call blocks till all the
    * configured {@link HddsDatanodeService} registers with
    * {@link StorageContainerManager}.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -110,7 +110,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   private static final Logger LOG =
       LoggerFactory.getLogger(MiniOzoneClusterImpl.class);
 
-  private final OzoneConfiguration conf;
+  private OzoneConfiguration conf;
   private StorageContainerManager scm;
   private OzoneManager ozoneManager;
   private final List<HddsDatanodeService> hddsDatanodes;
@@ -187,6 +187,11 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   @Override
   public OzoneConfiguration getConf() {
     return conf;
+  }
+
+  @Override
+  public void setConf(OzoneConfiguration newConf) {
+    this.conf = newConf;
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -73,8 +73,8 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   private int waitForClusterToBeReadyTimeout = 120000; // 2 min
 
   private static final Random RANDOM = new Random();
-  private static final int RATIS_RPC_TIMEOUT = 1000; // 10 second
-  public static final int NODE_FAILURE_TIMEOUT = 2000; // 20 seconds
+  private static final int RATIS_RPC_TIMEOUT = 1000; // 1 second
+  private static final int NODE_FAILURE_TIMEOUT = 2000; // 2 seconds
 
   /**
    * Creates a new MiniOzoneCluster.
@@ -365,7 +365,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         numOfActiveOMs = numOfOMs;
       }
 
-      // If num of OMs it not set, set it to 1.
+      // If num of SCMs it not set, set it to 1.
       if (numOfSCMs == 0) {
         numOfSCMs = 1;
       }
@@ -703,12 +703,6 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             omNodeId, basePort);
 
         om = bootstrapNewOM(omNodeId);
-
-        // Get the CertClient from an existing OM and set for new OM
-        if (omhaService.getServiceByIndex(0).getCertificateClient() != null) {
-          om.setCertClient(
-              omhaService.getServiceByIndex(0).getCertificateClient());
-        }
 
         LOG.info("Bootstrapped OzoneManager {} RPC server at {}", omNodeId,
             om.getOmRpcServerAddr());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -68,11 +68,13 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   private final OMHAService omhaService;
   private final SCMHAService scmhaService;
 
+  private final String clusterMetaPath;
+
   private int waitForClusterToBeReadyTimeout = 120000; // 2 min
 
   private static final Random RANDOM = new Random();
-  private static final int RATIS_RPC_TIMEOUT = 1000; // 1 second
-  public static final int NODE_FAILURE_TIMEOUT = 2000; // 2 seconds
+  private static final int RATIS_RPC_TIMEOUT = 1000; // 10 second
+  public static final int NODE_FAILURE_TIMEOUT = 2000; // 20 seconds
 
   /**
    * Creates a new MiniOzoneCluster.
@@ -89,12 +91,14 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       List<HddsDatanodeService> hddsDatanodes,
       String omServiceId,
       String scmServiceId,
+      String clusterPath,
       ReconServer reconServer) {
     super(conf, hddsDatanodes, reconServer);
     omhaService =
         new OMHAService(activeOMList, inactiveOMList, omServiceId);
     scmhaService =
         new SCMHAService(activeSCMList, inactiveSCMList, scmServiceId);
+    this.clusterMetaPath = clusterPath;
   }
 
   /**
@@ -107,9 +111,10 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       List<StorageContainerManager> scmList,
       List<HddsDatanodeService> hddsDatanodes,
       String omServiceId,
-      String scmServiceId) {
+      String scmServiceId,
+      String clusterPath) {
     this(conf, omList, null, scmList, null, hddsDatanodes,
-        omServiceId, scmServiceId, null);
+        omServiceId, scmServiceId, clusterPath, null);
   }
 
   @Override
@@ -181,7 +186,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
    */
   public OzoneManager getOMLeader() {
     OzoneManager res = null;
-    for (OzoneManager ozoneManager : this.omhaService.getServices()) {
+    for (OzoneManager ozoneManager : this.omhaService.getActiveServices()) {
       if (ozoneManager.isLeaderReady()) {
         if (res != null) {
           // Found more than one leader
@@ -239,7 +244,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     LOG.info("Shutting down StorageContainerManager " + scm.getScmId());
 
     scm.stop();
-    scmhaService.removeInstance(scm);
+    scmhaService.deactivate(scm);
   }
 
   public void restartStorageContainerManager(
@@ -251,7 +256,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     shutdownStorageContainerManager(scm);
     scm.join();
     scm = TestUtils.getScmSimple(scmConf);
-    scmhaService.addInstance(scm);
+    scmhaService.activate(scm);
     scm.start();
     if (waitForSCM) {
       waitForClusterToBeReady();
@@ -305,13 +310,17 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   }
 
   public void stopOzoneManager(int index) {
-    omhaService.getServices().get(index).stop();
-    omhaService.getServices().get(index).join();
+    OzoneManager om = omhaService.getServices().get(index);
+    om.stop();
+    om.join();
+    omhaService.deactivate(om);
   }
 
   public void stopOzoneManager(String omNodeId) {
-    omhaService.getServiceById(omNodeId).stop();
-    omhaService.getServiceById(omNodeId).join();
+    OzoneManager om = omhaService.getServiceById(omNodeId);
+    om.stop();
+    om.join();
+    omhaService.deactivate(om);
   }
 
   /**
@@ -356,7 +365,12 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         numOfActiveOMs = numOfOMs;
       }
 
-      // If num of ActiveOMs is not set, set it to numOfOMs.
+      // If num of OMs it not set, set it to 1.
+      if (numOfSCMs == 0) {
+        numOfSCMs = 1;
+      }
+
+      // If num of ActiveSCMs is not set, set it to numOfSCMs.
       if (numOfActiveSCMs == ACTIVE_SCMS_NOT_SET) {
         numOfActiveSCMs = numOfSCMs;
       }
@@ -383,7 +397,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
       MiniOzoneHAClusterImpl cluster = new MiniOzoneHAClusterImpl(conf,
           activeOMs, inactiveOMs, activeSCMs, inactiveSCMs,
-          hddsDatanodes, omServiceId, scmServiceId, reconServer);
+          hddsDatanodes, omServiceId, scmServiceId, path, reconServer);
 
       if (startDataNodes) {
         cluster.startHddsDatanodes();
@@ -430,7 +444,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       List<OzoneManager> omList = Lists.newArrayList();
 
       int retryCount = 0;
-      int basePort = 10000;
+      int basePort;
 
       while (true) {
         try {
@@ -466,7 +480,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             if (i <= numOfActiveOMs) {
               om.start();
               activeOMs.add(om);
-              LOG.info("Started OzoneManager RPC server at {}",
+              LOG.info("Started OzoneManager {} RPC server at {}", nodeId,
                   om.getOmRpcServerAddr());
             } else {
               inactiveOMs.add(om);
@@ -642,13 +656,14 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       conf.set(OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID, omServiceId);
       String omNodesKey = ConfUtils.addKeySuffixes(
           OMConfigKeys.OZONE_OM_NODES_KEY, omServiceId);
-      StringBuilder omNodesKeyValue = new StringBuilder();
+      List<String> omNodeIds = new ArrayList<>();
 
       int port = basePort;
 
       for (int i = 1; i <= numOfOMs; i++, port+=6) {
         String omNodeId = OM_NODE_ID_PREFIX + i;
-        omNodesKeyValue.append(",").append(omNodeId);
+        omNodeIds.add(omNodeId);
+
         String omAddrKey = ConfUtils.addKeySuffixes(
             OMConfigKeys.OZONE_OM_ADDRESS_KEY, omServiceId, omNodeId);
         String omHttpAddrKey = ConfUtils.addKeySuffixes(
@@ -664,8 +679,161 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         conf.setInt(omRatisPortKey, port + 4);
       }
 
-      conf.set(omNodesKey, omNodesKeyValue.substring(1));
+      conf.set(omNodesKey, String.join(",", omNodeIds));
     }
+  }
+
+  /**
+   * Bootstrap new OM and add to existing OM HA service ring.
+   * @return new OM nodeId
+   */
+  public void bootstrapOzoneManager(String omNodeId) throws Exception {
+
+    int basePort;
+    int retryCount = 0;
+
+    OzoneManager om = null;
+
+    long leaderSnapshotIndex = getOMLeader().getRatisSnapshotIndex();
+
+    while (true) {
+      try {
+        basePort = 10000 + RANDOM.nextInt(1000) * 4;
+        OzoneConfiguration newConf = addNewOMToConfig(getOMServiceId(),
+            omNodeId, basePort);
+
+        om = bootstrapNewOM(omNodeId);
+
+        // Get the CertClient from an existing OM and set for new OM
+        if (omhaService.getServiceByIndex(0).getCertificateClient() != null) {
+          om.setCertClient(
+              omhaService.getServiceByIndex(0).getCertificateClient());
+        }
+
+        LOG.info("Bootstrapped OzoneManager {} RPC server at {}", omNodeId,
+            om.getOmRpcServerAddr());
+
+        // Add new OMs to cluster's in memory map and update existing OMs conf.
+        setConf(newConf);
+
+        omhaService.addInstance(om, true);
+        break;
+      } catch (IOException e) {
+        // Existing OM config could have been updated with new conf. Reset it.
+        for (OzoneManager existingOM : omhaService.getServices()) {
+          existingOM.setConfiguration(getConf());
+        }
+        if (e instanceof BindException ||
+            e.getCause() instanceof BindException) {
+          if (om != null) {
+            om.stop();
+            om.join();
+            LOG.info("Stopping OzoneManager server at {}",
+                om.getOmRpcServerAddr());
+          }
+          ++retryCount;
+          LOG.info("MiniOzoneHACluster port conflicts, retried {} times",
+              retryCount);
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    waitForBootstrappedNodeToBeReady(om, leaderSnapshotIndex);
+    waitForConfigUpdateOnAllOMs(omNodeId);
+  }
+
+  /**
+   * Set the configs for new OMs.
+   */
+  private OzoneConfiguration addNewOMToConfig(String omServiceId,
+      String omNodeId, int basePort) {
+    OzoneConfiguration newConf = getConf();
+    String omNodesKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_NODES_KEY, omServiceId);
+    StringBuilder omNodesKeyValue = new StringBuilder();
+    omNodesKeyValue.append(newConf.get(omNodesKey))
+        .append(",").append(omNodeId);
+
+    String omAddrKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_ADDRESS_KEY, omServiceId, omNodeId);
+    String omHttpAddrKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, omServiceId, omNodeId);
+    String omHttpsAddrKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, omServiceId, omNodeId);
+    String omRatisPortKey = ConfUtils.addKeySuffixes(
+        OMConfigKeys.OZONE_OM_RATIS_PORT_KEY, omServiceId, omNodeId);
+
+    newConf.set(omAddrKey, "127.0.0.1:" + basePort);
+    newConf.set(omHttpAddrKey, "127.0.0.1:" + (basePort + 2));
+    newConf.set(omHttpsAddrKey, "127.0.0.1:" + (basePort + 3));
+    newConf.setInt(omRatisPortKey, basePort + 4);
+
+    newConf.set(omNodesKey, omNodesKeyValue.toString());
+
+    return newConf;
+  }
+
+  /**
+   * Start a new OM in Bootstrap mode. Configs for the new OM must already be
+   * set.
+   */
+  private OzoneManager bootstrapNewOM(String nodeId)
+      throws IOException, AuthenticationException {
+    OzoneConfiguration config = new OzoneConfiguration(getConf());
+    config.set(OMConfigKeys.OZONE_OM_NODE_ID_KEY, nodeId);
+    // Set the OM rpc and http(s) address to null so that the cluster picks
+    // up the address set with service ID and node ID
+    config.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY, "");
+    config.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "");
+    config.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "");
+
+    // Set metadata/DB dir base path
+    String metaDirPath = clusterMetaPath + "/" + nodeId;
+    config.set(OZONE_METADATA_DIRS, metaDirPath);
+
+    // Update existing OMs config
+    for (OzoneManager existingOM : omhaService.getServices()) {
+      existingOM.setConfiguration(config);
+    }
+
+    OzoneManager.omInit(config);
+    OzoneManager om = OzoneManager.createOm(config,
+        OzoneManager.StartupOption.BOOTSTRAP);
+    om.start();
+    return om;
+
+  }
+
+  /**
+   * Wait for AddOM command to execute on all OMs.
+   */
+  private void waitForBootstrappedNodeToBeReady(OzoneManager newOM,
+      long leaderSnapshotIndex) throws Exception {
+    // Wait for bootstrapped nodes to catch up with others
+    GenericTestUtils.waitFor(() -> {
+      try {
+        if (newOM.getRatisSnapshotIndex() >= leaderSnapshotIndex) {
+          return true;
+        }
+      } catch (IOException e) {
+        return false;
+      }
+      return false;
+    }, 1000, waitForClusterToBeReadyTimeout);
+  }
+
+  private void waitForConfigUpdateOnAllOMs(String newOMNodeId)
+      throws Exception {
+    GenericTestUtils.waitFor(() -> {
+      for (OzoneManager om : omhaService.getActiveServices()) {
+        if (!om.doesPeerExist(newOMNodeId)) {
+          return false;
+        }
+      }
+      return true;
+    }, 1000, waitForClusterToBeReadyTimeout);
   }
 
   /**
@@ -683,11 +851,15 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     private List<Type> activeServices;
     private List<Type> inactiveServices;
 
+    // Function to extract the Id from service
+    Function<Type, String> serviceIdProvider;
+
     MiniOzoneHAService(String name, List<Type> activeList,
                        List<Type> inactiveList, String serviceId,
                        Function<Type, String> idProvider) {
       this.serviceName = name;
       this.serviceMap = Maps.newHashMap();
+      this.serviceIdProvider = idProvider;
       if (activeList != null) {
         for (Type service : activeList) {
           this.serviceMap.put(idProvider.apply(service), service);
@@ -717,12 +889,30 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
       return services;
     }
 
+    public List<Type> getActiveServices() {
+      return activeServices;
+    }
+
     public boolean removeInstance(Type t) {
       return services.remove(t);
     }
 
-    public boolean addInstance(Type t) {
-      return services.add(t);
+    public void addInstance(Type t, boolean isActive) {
+      services.add(t);
+      serviceMap.put(serviceIdProvider.apply(t), t);
+      if (isActive) {
+        activeServices.add(t);
+      }
+    }
+
+    public void activate(Type t) {
+      activeServices.add(t);
+      inactiveServices.remove(t);
+    }
+
+    public void deactivate(Type t) {
+      activeServices.remove(t);
+      inactiveServices.add(t);
     }
 
     public boolean isServiceActive(String id) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -725,12 +725,6 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
         }
         if (e instanceof BindException ||
             e.getCause() instanceof BindException) {
-          if (om != null) {
-            om.stop();
-            om.join();
-            LOG.info("Stopping OzoneManager server at {}",
-                om.getOmRpcServerAddr());
-          }
           ++retryCount;
           LOG.info("MiniOzoneHACluster port conflicts, retried {} times",
               retryCount);
@@ -852,7 +846,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     private List<Type> inactiveServices;
 
     // Function to extract the Id from service
-    Function<Type, String> serviceIdProvider;
+    private Function<Type, String> serviceIdProvider;
 
     MiniOzoneHAService(String name, List<Type> activeList,
                        List<Type> inactiveList, String serviceId,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -815,14 +815,17 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
 
   private void waitForConfigUpdateOnAllOMs(String newOMNodeId)
       throws Exception {
-    OzoneManagerRatisServer newOMRatisServer =
-        omhaService.getServiceById(newOMNodeId).getOmRatisServer();
+    OzoneManager newOMNode = omhaService.getServiceById(newOMNodeId);
+    OzoneManagerRatisServer newOMRatisServer = newOMNode.getOmRatisServer();
     GenericTestUtils.waitFor(() -> {
       // Each existing active OM should contain the new OM in its peerList.
-      // Also, the new OM should contain each existing active OM in it's
-      // RatisServer peerList.
+      // Also, the new OM should contain each existing active OM in it's OM
+      // peer list and RatisServer peerList.
       for (OzoneManager om : omhaService.getActiveServices()) {
         if (!om.doesPeerExist(newOMNodeId)) {
+          return false;
+        }
+        if (!newOMNode.doesPeerExist(om.getOMNodeId())) {
           return false;
         }
         if (!newOMRatisServer.doesPeerExist(om.getOMNodeId())) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneOMHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneOMHAClusterImpl.java
@@ -50,9 +50,10 @@ public final class MiniOzoneOMHAClusterImpl extends MiniOzoneHAClusterImpl {
       StorageContainerManager scm,
       List<HddsDatanodeService> hddsDatanodes,
       String omServiceId,
+      String metaPath,
       ReconServer reconServer) {
     super(conf, activeOMList, inactiveOMList, Collections.singletonList(scm),
-        null, hddsDatanodes, omServiceId, null, reconServer);
+        null, hddsDatanodes, omServiceId, null, metaPath, reconServer);
   }
 
   /**
@@ -104,7 +105,7 @@ public final class MiniOzoneOMHAClusterImpl extends MiniOzoneHAClusterImpl {
 
       MiniOzoneClusterImpl cluster = new MiniOzoneOMHAClusterImpl(conf,
           getActiveOMs(), getInactiveOMs(), scm, hddsDatanodes,
-          omServiceId, reconServer);
+          omServiceId, path, reconServer);
 
       if (startDataNodes) {
         cluster.startHddsDatanodes();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
-import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -48,6 +48,9 @@ import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
 
+/**
+ * Test for OM bootstrap process.
+ */
 public class TestOzoneManagerBootstrap {
 
   @Rule
@@ -122,14 +125,11 @@ public class TestOzoneManagerBootstrap {
     }
 
     OzoneManager newOM = cluster.getOzoneManager(nodeId);
-    GenericTestUtils.waitFor(new Supplier<Boolean>() {
-      @Override
-      public Boolean get() {
-        try {
-          return newOM.getRatisSnapshotIndex() >= lastTransactionIndex;
-        } catch (IOException e) {
-          return false;
-        }
+    GenericTestUtils.waitFor((Supplier<Boolean>) () -> {
+      try {
+        return newOM.getRatisSnapshotIndex() >= lastTransactionIndex;
+      } catch (IOException e) {
+        return false;
       }
     }, 100, 100000);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
@@ -1,0 +1,212 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.base.Supplier;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdfs.server.common.Storage;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
+import org.apache.hadoop.test.GenericTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
+
+public class TestOzoneManagerBootstrap {
+
+  @Rule
+  public ExpectedException exception = ExpectedException.none();
+
+  @Rule
+  public Timeout timeout = new Timeout(500_000);
+
+  private MiniOzoneHAClusterImpl cluster = null;
+  private ObjectStore objectStore;
+  private OzoneConfiguration conf;
+  private final String clusterId = UUID.randomUUID().toString();
+  private final String scmId = UUID.randomUUID().toString();
+  private final String omServiceId = "om-bootstrap";
+
+  private static final int NUM_INITIAL_OMS = 3;
+
+  private static final String VOLUME_NAME;
+  private static final String BUCKET_NAME;
+
+  private long lastTransactionIndex;
+
+  static {
+    VOLUME_NAME = "volume" + RandomStringUtils.randomNumeric(5);
+    BUCKET_NAME = "bucket" + RandomStringUtils.randomNumeric(5);
+  }
+
+  private void setupCluster() throws Exception {
+    setupCluster(NUM_INITIAL_OMS);
+  }
+
+  private void setupCluster(int numInitialOMs) throws Exception {
+    conf = new OzoneConfiguration();
+    cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newHABuilder(conf)
+        .setClusterId(clusterId)
+        .setScmId(scmId)
+        .setSCMServiceId(SCM_DUMMY_SERVICE_ID)
+        .setOMServiceId(omServiceId)
+        .setNumOfOzoneManagers(numInitialOMs)
+        .build();
+    cluster.waitForClusterToBeReady();
+    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
+        .getObjectStore();
+
+    // Perform some transactions
+    objectStore.createVolume(VOLUME_NAME);
+    OzoneVolume volume = objectStore.getVolume(VOLUME_NAME);
+    volume.createBucket(BUCKET_NAME);
+    OzoneBucket bucket = volume.getBucket(BUCKET_NAME);
+    createKey(bucket);
+
+    lastTransactionIndex = cluster.getOMLeader().getRatisSnapshotIndex();
+  }
+
+  @After
+  public void shutdown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  private void assertNewOMExistsInPeerList(String nodeId) throws Exception {
+    for (OzoneManager om : cluster.getOzoneManagersList()) {
+      Assert.assertTrue("New OM node " + nodeId + " not present in Peer list " +
+              "of OM " + om.getOMNodeId(), om.doesPeerExist(nodeId));
+    }
+    OzoneManager newOM = cluster.getOzoneManager(nodeId);
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        try {
+          return newOM.getRatisSnapshotIndex() >= lastTransactionIndex;
+        } catch (IOException e) {
+          return false;
+        }
+      }
+    }, 100, 10000);
+
+    // Check Ratis Dir for log files
+    File[] logFiles = getRatisLogFiles(newOM);
+    Assert.assertTrue("There are no ratis logs in new OM ",
+        logFiles.length > 0);
+  }
+
+  private File[] getRatisLogFiles(OzoneManager om) {
+    OzoneManagerRatisServer newOMRatisServer = om.getOmRatisServer();
+    File ratisDir = new File(newOMRatisServer.getRatisStorageDir(),
+        newOMRatisServer.getRaftGroupId().getUuid().toString());
+    File ratisLogDir = new File(ratisDir, Storage.STORAGE_DIR_CURRENT);
+    return ratisLogDir.listFiles(new FileFilter() {
+      @Override
+      public boolean accept(File pathname) {
+        return pathname.getName().startsWith("log");
+      }
+    });
+  }
+
+  private List<String> testBootstrapOMs(int numNewOMs) throws Exception {
+    List<String> newOMNodeIds = new ArrayList<>(numNewOMs);
+    for (int i = 1; i <= numNewOMs; i++) {
+      String nodeId =  "omNode-bootstrap-" + i;
+      cluster.bootstrapOzoneManager(nodeId);
+      assertNewOMExistsInPeerList(nodeId);
+      newOMNodeIds.add(nodeId);
+    }
+    return newOMNodeIds;
+  }
+
+  /**
+   * Add 1 new OM to cluster.
+   * @throws Exception
+   */
+  @Test
+  public void testBootstrapOneNewOM() throws Exception {
+    setupCluster();
+    testBootstrapOMs(1);
+  }
+
+  /**
+   * Add 2 new OMs to cluster.
+   * @throws Exception
+   */
+  @Test
+  public void testBootstrapTwoNewOMs() throws Exception {
+    setupCluster();
+    testBootstrapOMs(2);
+  }
+
+  /**
+   * Add 2 new OMs to a 1 node OM cluster. Verify that one of the new OMs
+   * must becomes the leader by stopping the old OM.
+   */
+  @Test
+  public void testLeaderChangeToNewOM() throws Exception {
+    setupCluster(1);
+    OzoneManager oldOM = cluster.getOzoneManager();
+    List<String> newOMNodeIds = testBootstrapOMs(2);
+
+    // Stop old OM
+    cluster.stopOzoneManager(oldOM.getOMNodeId());
+
+    // Wait for Leader Election timeout
+    Thread.sleep(OZONE_OM_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT
+        .toLong(TimeUnit.MILLISECONDS) * 3);
+
+    // Verify that one of the new OMs is the leader
+    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
+    OzoneManager omLeader = cluster.getOMLeader();
+
+    Assert.assertTrue("New Bootstrapped OM not elected Leader even though " +
+        "other OMs are down", newOMNodeIds.contains(omLeader.getOMNodeId()));
+
+    // Perform some read and write operations with new OM leader
+    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
+        .getObjectStore();
+    OzoneVolume volume = objectStore.getVolume(VOLUME_NAME);
+    OzoneBucket bucket = volume.getBucket(BUCKET_NAME);
+    String key = createKey(bucket);
+
+    Assert.assertNotNull(bucket.getKey(key));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
@@ -18,10 +18,8 @@
 
 package org.apache.hadoop.ozone.om;
 
-import com.google.common.base.Supplier;
 import java.io.File;
 import java.io.FileFilter;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerBootstrap.java
@@ -61,10 +61,10 @@ public class TestOzoneManagerBootstrap {
   private OzoneConfiguration conf;
   private final String clusterId = UUID.randomUUID().toString();
   private final String scmId = UUID.randomUUID().toString();
-  private final String omServiceId = "om-bootstrap";
 
   private static final int NUM_INITIAL_OMS = 3;
 
+  private static final String OM_SERVICE_ID = "om-bootstrap";
   private static final String VOLUME_NAME;
   private static final String BUCKET_NAME;
 
@@ -85,11 +85,11 @@ public class TestOzoneManagerBootstrap {
         .setClusterId(clusterId)
         .setScmId(scmId)
         .setSCMServiceId(SCM_DUMMY_SERVICE_ID)
-        .setOMServiceId(omServiceId)
+        .setOMServiceId(OM_SERVICE_ID)
         .setNumOfOzoneManagers(numInitialOMs)
         .build();
     cluster.waitForClusterToBeReady();
-    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
+    objectStore = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf)
         .getObjectStore();
 
     // Perform some transactions
@@ -201,7 +201,7 @@ public class TestOzoneManagerBootstrap {
         "other OMs are down", newOMNodeIds.contains(omLeader.getOMNodeId()));
 
     // Perform some read and write operations with new OM leader
-    objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
+    objectStore = OzoneClientFactory.getRpcClient(OM_SERVICE_ID, conf)
         .getObjectStore();
     OzoneVolume volume = objectStore.getVolume(VOLUME_NAME);
     OzoneBucket bucket = volume.getBucket(BUCKET_NAME);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.ozone.test.GenericTestUtils;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -73,6 +73,7 @@ public abstract class TestOzoneManagerHA {
   private OzoneConfiguration conf;
   private String clusterId;
   private String scmId;
+  private String omId;
   private String omServiceId;
   private static int numOfOMs = 3;
   private static final int LOG_PURGE_GAP = 50;
@@ -137,6 +138,7 @@ public abstract class TestOzoneManagerHA {
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
     omServiceId = "om-service-test1";
+    omId = UUID.randomUUID().toString();
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.set(OzoneConfigKeys.OZONE_ADMINISTRATORS,
         OZONE_ADMINISTRATORS_WILDCARD);
@@ -168,6 +170,7 @@ public abstract class TestOzoneManagerHA {
         .setClusterId(clusterId)
         .setScmId(scmId)
         .setOMServiceId(omServiceId)
+        .setOmId(omId)
         .setNumOfOzoneManagers(numOfOMs)
         .build();
     cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/interface-client/src/main/proto/OmInterServiceProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmInterServiceProtocol.proto
@@ -42,11 +42,11 @@ message BootstrapOMRequest {
 
 message BootstrapOMResponse {
     required bool success = 1;
-    optional BootstrapErrorCode errorCode = 2;
+    optional ErrorCode errorCode = 2;
     optional string errorMsg = 3;
 }
 
-enum BootstrapErrorCode {
+enum ErrorCode {
     RATIS_NOT_ENABLED = 1;
     LEADER_UNDETERMINED = 2;
     LEADER_NOT_READY = 3;

--- a/hadoop-ozone/interface-client/src/main/proto/OmInterServiceProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmInterServiceProtocol.proto
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * These .proto interfaces are private and unstable.
+ * Please see http://wiki.apache.org/hadoop/Compatibility
+ * for what changes are allowed for a *unstable* .proto interface.
+ */
+
+syntax = "proto2";
+option java_package = "org.apache.hadoop.ozone.protocol.proto";
+option java_outer_classname = "OzoneManagerInterServiceProtocolProtos";
+option java_generic_services = true;
+option java_generate_equals_and_hash = true;
+package hadoop.ozone;
+
+/**
+This file contains the protocol for communication between Ozone Managers in
+an HA setup.
+*/
+
+message BootstrapOMRequest {
+    required string nodeId = 1;
+    required string hostAddress = 2;
+    required uint32 ratisPort = 3;
+}
+
+message BootstrapOMResponse {
+    required bool success = 1;
+    optional BootstrapErrorCode errorCode = 2;
+    optional string errorMsg = 3;
+}
+
+enum BootstrapErrorCode {
+    RATIS_NOT_ENABLED = 1;
+    LEADER_UNDETERMINED = 2;
+    LEADER_NOT_READY = 3;
+    RATIS_BOOTSTRAP_ERROR = 4;
+    UNDEFINED_ERROR = 5;
+}
+
+/**
+ The OM service for OM-OM communication.
+*/
+service OzoneManagerInterService {
+    // RPC request from new OM to existing OM ring to bootstrap itself
+    rpc bootstrap(BootstrapOMRequest)
+    returns(BootstrapOMResponse);
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMPolicyProvider.java
@@ -21,12 +21,14 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.annotation.InterfaceStability.Unstable;
+import org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.security.authorize.PolicyProvider;
 import org.apache.hadoop.security.authorize.Service;
 
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys
     .OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL;
 
@@ -56,6 +58,8 @@ public final class OMPolicyProvider extends PolicyProvider {
       new Service[]{
           new Service(OZONE_OM_SECURITY_CLIENT_PROTOCOL_ACL,
               OzoneManagerProtocol.class),
+          new Service(OZONE_OM_SECURITY_ADMIN_PROTOCOL_ACL,
+              OMInterServiceProtocol.class)
       };
 
   @SuppressFBWarnings("EI_EXPOSE_REP")

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -30,6 +30,8 @@ public interface OMStarterInterface {
       AuthenticationException;
   boolean init(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
+  void bootstrap(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
   void startAndCancelPrepare(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -253,7 +253,6 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_L
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.OzoneManagerInterService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService.newReflectiveBlockingService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.server.protocol.TermIndex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -364,6 +364,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private OzoneManagerPrepareState prepareState;
 
+  /**
+   * OM Startup mode.
+   */
   public enum StartupOption {
     REGUALR,
     BOOTSTRAP

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -97,6 +97,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
@@ -111,7 +112,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMHANodeDetails;
-import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -133,7 +134,10 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocol.OMInterServiceProtocol;
+import org.apache.hadoop.ozone.om.protocolPB.OMInterServiceProtocolClientSideImpl;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.protocolPB.OMInterServiceProtocolPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.common.ha.ratis.RatisSnapshotInfo;
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
@@ -150,6 +154,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
+import org.apache.hadoop.ozone.protocolPB.OMInterServiceProtocolServerSideImpl;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
 import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
@@ -246,12 +251,12 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.OzoneManagerInterService;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneManagerService.newReflectiveBlockingService;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
-
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.server.protocol.TermIndex;
-import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
 import org.apache.ratis.util.LifeCycle;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -263,7 +268,8 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.LimitedPrivate({"HDFS", "CBLOCK", "OZONE", "HBASE"})
 public final class OzoneManager extends ServiceRuntimeInfoImpl
-    implements OzoneManagerProtocol, OMMXBean, Auditor {
+    implements OzoneManagerProtocol, OMInterServiceProtocol,
+    OMMXBean, Auditor {
   public static final Logger LOG =
       LoggerFactory.getLogger(OzoneManager.class);
 
@@ -280,7 +286,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private List<String> caCertPemList = new ArrayList<>();
   private static boolean testSecureOmFlag = false;
   private final Text omRpcAddressTxt;
-  private final OzoneConfiguration configuration;
+  private OzoneConfiguration configuration;
   private RPC.Server omRpcServer;
   private InetSocketAddress omRpcAddress;
   private String omId;
@@ -358,11 +364,19 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private OzoneManagerPrepareState prepareState;
 
+  public enum StartupOption {
+    REGUALR,
+    BOOTSTRAP
+  }
+
   private enum State {
     INITIALIZED,
+    BOOTSTRAPPING,
     RUNNING,
     STOPPED
   }
+
+  private boolean isBootstrapping = false;
 
   // Used in MiniOzoneCluster testing
   private State omState;
@@ -371,11 +385,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static final int MSECS_PER_MINUTE = 60 * 1000;
 
   @SuppressWarnings("methodlength")
-  private OzoneManager(OzoneConfiguration conf) throws IOException,
-      AuthenticationException {
+  private OzoneManager(OzoneConfiguration conf, StartupOption startupOption)
+      throws IOException, AuthenticationException {
     super(OzoneVersionInfo.OZONE_VERSION_INFO);
     Preconditions.checkNotNull(conf);
-    configuration = conf;
+    setConfiguration(conf);
     // Load HA related configurations
     OMHANodeDetails omhaNodeDetails =
         OMHANodeDetails.loadOMHAConfig(configuration);
@@ -388,6 +402,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     versionManager = new OMLayoutVersionManager(omStorage.getLayoutVersion());
     upgradeFinalizer = new OMUpgradeFinalizer(versionManager);
+
+    exitManager = new ExitManager();
+
+    // In case of single OM Node Service there will be no OM Node ID
+    // specified, set it to value from om storage
+    if (this.omNodeDetails.getNodeId() == null) {
+      this.omNodeDetails = OMHANodeDetails.getOMNodeDetails(conf,
+          omNodeDetails.getServiceId(),
+          omStorage.getOmId(), omNodeDetails.getRpcAddress(),
+          omNodeDetails.getRatisPort());
+    }
 
     loginOMUserIfSecurityEnabled(conf);
 
@@ -478,40 +503,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // Create special volume s3v which is required for S3G.
     addS3GVolumeToDB();
 
-    this.omRatisSnapshotInfo = new RatisSnapshotInfo();
-
-    if (isRatisEnabled) {
-      // Create Ratis storage dir
-      String omRatisDirectory =
-          OzoneManagerRatisServer.getOMRatisDirectory(configuration);
-      if (omRatisDirectory == null || omRatisDirectory.isEmpty()) {
-        throw new IllegalArgumentException(HddsConfigKeys.OZONE_METADATA_DIRS +
-            " must be defined.");
-      }
-      OmUtils.createOMDir(omRatisDirectory);
-
-      // Create Ratis snapshot dir
-      omRatisSnapshotDir = OmUtils.createOMDir(
-          OzoneManagerRatisServer.getOMRatisSnapshotDirectory(configuration));
-
-      // Before starting ratis server, check if previous installation has
-      // snapshot directory in Ratis storage directory. if yes, move it to
-      // new snapshot directory.
-
-      File snapshotDir = new File(omRatisDirectory, OM_RATIS_SNAPSHOT_DIR);
-
-      if (snapshotDir.isDirectory()) {
-        FileUtils.moveDirectory(snapshotDir.toPath(),
-            omRatisSnapshotDir.toPath());
-      }
-
-      if (peerNodes != null && !peerNodes.isEmpty()) {
-        this.omSnapshotProvider = new OzoneManagerSnapshotProvider(
-            configuration, omRatisSnapshotDir, peerNodes);
-      }
+    if (startupOption == StartupOption.BOOTSTRAP) {
+      isBootstrapping = true;
     }
 
-    initializeRatisServer();
+    this.omRatisSnapshotInfo = new RatisSnapshotInfo();
+
+    initializeRatisDirs(conf);
+    initializeRatisServer(isBootstrapping);
 
     metrics = OMMetrics.create();
     omClientProtocolMetrics = ProtocolMessageMetrics
@@ -529,6 +528,24 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ShutdownHookManager.get().addShutdownHook(shutdownHook,
         SHUTDOWN_HOOK_PRIORITY);
     omState = State.INITIALIZED;
+  }
+
+  /**
+   * Constructs OM instance based on the configuration.
+   *
+   * @param conf OzoneConfiguration
+   * @return OM instance
+   * @throws IOException, AuthenticationException in case OM instance
+   *                      creation fails.
+   */
+  public static OzoneManager createOm(OzoneConfiguration conf)
+      throws IOException, AuthenticationException {
+    return new OzoneManager(conf, StartupOption.REGUALR);
+  }
+
+  public static OzoneManager createOm(OzoneConfiguration conf,
+      StartupOption startupOption) throws IOException, AuthenticationException {
+    return new OzoneManager(conf, startupOption);
   }
 
   private void logVersionMismatch(OzoneConfiguration conf, ScmInfo scmInfo) {
@@ -690,6 +707,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public void close() throws IOException {
     stop();
+  }
+
+  public void shutdown(Exception ex) throws IOException {
+    if (omState != State.STOPPED) {
+      stop();
+      exitManager.exitSystem(1, ex.getLocalizedMessage(), ex, LOG);
+    }
   }
 
   /**
@@ -901,22 +925,57 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Starts an RPC server, if configured.
+   * Creates a new instance of rpc server. If an earlier instance is already
+   * running then returns the same.
+   */
+  private RPC.Server getRpcServer(OzoneConfiguration conf) throws IOException {
+    if (isOmRpcServerRunning) {
+      return omRpcServer;
+    }
+
+    InetSocketAddress omNodeRpcAddr = OmUtils.getOmAddress(conf);
+
+    final int handlerCount = conf.getInt(OZONE_OM_HANDLER_COUNT_KEY,
+        OZONE_OM_HANDLER_COUNT_DEFAULT);
+    RPC.setProtocolEngine(configuration, OzoneManagerProtocolPB.class,
+        ProtobufRpcEngine.class);
+
+    this.omServerProtocol = new OzoneManagerProtocolServerSideTranslatorPB(
+        this, omRatisServer, omClientProtocolMetrics, isRatisEnabled,
+        getLastTrxnIndexForNonRatis());
+    BlockingService omService =
+        OzoneManagerService.newReflectiveBlockingService(omServerProtocol);
+
+    OMInterServiceProtocolServerSideImpl omInterServerProtocol =
+        new OMInterServiceProtocolServerSideImpl(omRatisServer,
+            isRatisEnabled);
+    BlockingService omInterService =
+        OzoneManagerInterService.newReflectiveBlockingService(
+            omInterServerProtocol);
+
+    return startRpcServer(configuration, omNodeRpcAddr, omService,
+        omInterService, handlerCount);
+  }
+
+  /**
    *
-   * @param conf         configuration
-   * @param addr         configured address of RPC server
-   * @param protocol     RPC protocol provided by RPC server
-   * @param instance     RPC protocol implementation instance
+   * @param conf configuration
+   * @param addr configured address of RPC server
+   * @param clientProtocolService RPC protocol for client communication
+   *                              (OzoneManagerProtocolPB impl)
+   * @param interOMProtocolService RPC protocol for inter OM communication
+   *                               (OMInterServiceProtocolPB impl)
    * @param handlerCount RPC server handler count
    * @return RPC server
    * @throws IOException if there is an I/O error while creating RPC server
    */
   private RPC.Server startRpcServer(OzoneConfiguration conf,
-      InetSocketAddress addr, Class<?> protocol, BlockingService instance,
-      int handlerCount) throws IOException {
+      InetSocketAddress addr, BlockingService clientProtocolService,
+      BlockingService interOMProtocolService, int handlerCount)
+      throws IOException {
     RPC.Server rpcServer = new RPC.Builder(conf)
-        .setProtocol(protocol)
-        .setInstance(instance)
+        .setProtocol(OzoneManagerProtocolPB.class)
+        .setInstance(clientProtocolService)
         .setBindAddress(addr.getHostString())
         .setPort(addr.getPort())
         .setNumHandlers(handlerCount)
@@ -924,7 +983,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setSecretManager(delegationTokenMgr)
         .build();
 
-    HddsServerUtil.addPBProtocol(conf, protocol, instance, rpcServer);
+    HddsServerUtil.addPBProtocol(conf, OMInterServiceProtocolPB.class,
+        interOMProtocolService, rpcServer);
 
     if (conf.getBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION,
         false)) {
@@ -939,19 +999,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   private static boolean isOzoneSecurityEnabled() {
     return securityEnabled;
-  }
-
-  /**
-   * Constructs OM instance based on the configuration.
-   *
-   * @param conf OzoneConfiguration
-   * @return OM instance
-   * @throws IOException, AuthenticationException in case OM instance
-   *                      creation fails.
-   */
-  public static OzoneManager createOm(OzoneConfiguration conf)
-      throws IOException, AuthenticationException {
-    return new OzoneManager(conf);
   }
 
   /**
@@ -1064,6 +1111,39 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       LOG.error("OM security initialization failed. Init response: {}",
           response);
       throw new RuntimeException("OM security initialization failed.");
+    }
+  }
+
+  private void initializeRatisDirs(OzoneConfiguration conf) throws IOException {
+    if (isRatisEnabled) {
+      // Create Ratis storage dir
+      String omRatisDirectory =
+          OzoneManagerRatisUtils.getOMRatisDirectory(conf);
+      if (omRatisDirectory == null || omRatisDirectory.isEmpty()) {
+        throw new IllegalArgumentException(HddsConfigKeys.OZONE_METADATA_DIRS +
+            " must be defined.");
+      }
+      OmUtils.createOMDir(omRatisDirectory);
+
+      // Create Ratis snapshot dir
+      omRatisSnapshotDir = OmUtils.createOMDir(
+          OzoneManagerRatisUtils.getOMRatisSnapshotDirectory(conf));
+
+      // Before starting ratis server, check if previous installation has
+      // snapshot directory in Ratis storage directory. if yes, move it to
+      // new snapshot directory.
+
+      File snapshotDir = new File(omRatisDirectory, OM_RATIS_SNAPSHOT_DIR);
+
+      if (snapshotDir.isDirectory()) {
+        FileUtils.moveDirectory(snapshotDir.toPath(),
+            omRatisSnapshotDir.toPath());
+      }
+
+      if (peerNodes != null && !peerNodes.isEmpty()) {
+        this.omSnapshotProvider = new OzoneManagerSnapshotProvider(
+            configuration, omRatisSnapshotDir, peerNodes);
+      }
     }
   }
 
@@ -1223,6 +1303,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     startJVMPauseMonitor();
     setStartTime();
 
+    if (isBootstrapping) {
+      omState = State.BOOTSTRAPPING;
+      bootstrap(omNodeDetails);
+    }
+
     omState = State.RUNNING;
   }
 
@@ -1261,7 +1346,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     metricsTimer = new Timer();
     metricsTimer.schedule(scheduleOMMetricsWriteTask, 0, period);
 
-    initializeRatisServer();
+    initializeRatisServer(false);
     if (omRatisServer != null) {
       omRatisServer.start();
     }
@@ -1286,6 +1371,76 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     omState = State.RUNNING;
   }
 
+  @Override
+  public void bootstrap(OMNodeDetails newOMNode) throws IOException {
+    // Create InterOmServiceProtocol client to send request to other OMs
+    if (isRatisEnabled) {
+      try (OMInterServiceProtocolClientSideImpl omInterServiceProtocol =
+               new OMInterServiceProtocolClientSideImpl(configuration,
+                   getRemoteUser(), getOMServiceId())) {
+
+        omInterServiceProtocol.bootstrap(omNodeDetails);
+
+        LOG.info("Successfully bootstrapped OM {} and joined the Ratis group " +
+            "{}", getOMNodeId(), omRatisServer.getRaftGroup());
+      }
+    } else {
+      throw new IOException("OzoneManager can be bootstrapped only when ratis" +
+          " is enabled and there is atleast one OzoneManager to bootstrap" +
+          " from.");
+    }
+  }
+
+  /**
+   * Add a new OM Node to the HA cluster. This call comes from OMRatisServer
+   * after a SetConfiguration request has been successfully executed by the
+   * Ratis server.
+   */
+  public void addOMNodeToPeers(String newOMNodeId) {
+    OMNodeDetails newOMNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
+        getConfiguration(), getOMServiceId(), newOMNodeId);
+    if (newOMNodeDetails == null) {
+      // Load new configuration object to read in new peer information
+      setConfiguration(new OzoneConfiguration());
+      newOMNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
+          getConfiguration(), getOMServiceId(), newOMNodeId);
+
+      if (newOMNodeDetails == null) {
+        // If new node information is not present in the newly loaded
+        // configuration also, throw an exception
+        throw new OzoneIllegalArgumentException("There is no OM configuration "
+            + "for node ID " + newOMNodeId + " in ozone-site.xml.");
+      }
+    }
+
+    peerNodes.add(newOMNodeDetails);
+    if (omSnapshotProvider == null) {
+      omSnapshotProvider = new OzoneManagerSnapshotProvider(
+          configuration, omRatisSnapshotDir, peerNodes);
+    } else {
+      omSnapshotProvider.addNewPeerNode(newOMNodeDetails);
+    }
+    omRatisServer.addRaftPeer(newOMNodeDetails);
+  }
+
+  /**
+   * Check if the input nodeId exists in the peers list.
+   * @return true if the nodeId is self or it exists in peer node list,
+   *         false otherwsie.
+   */
+  public boolean doesPeerExist(String omNodeId) {
+    if (getOMNodeId().equals(omNodeId)) {
+      return true;
+    }
+    if (peerNodes != null && !peerNodes.isEmpty()) {
+      for (OMNodeDetails peerNode : peerNodes) {
+        if (peerNode.getNodeId().contains(omNodeId)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 
   /**
    * Starts a Trash Emptier thread that does an fs.trashRoots and performs
@@ -1325,35 +1480,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Creates a new instance of rpc server. If an earlier instance is already
-   * running then returns the same.
-   */
-  private RPC.Server getRpcServer(OzoneConfiguration conf) throws IOException {
-    if (isOmRpcServerRunning) {
-      return omRpcServer;
-    }
-
-    InetSocketAddress omNodeRpcAddr = OmUtils.getOmAddress(conf);
-
-    final int handlerCount = conf.getInt(OZONE_OM_HANDLER_COUNT_KEY,
-        OZONE_OM_HANDLER_COUNT_DEFAULT);
-    RPC.setProtocolEngine(configuration, OzoneManagerProtocolPB.class,
-        ProtobufRpcEngine.class);
-    this.omServerProtocol = new OzoneManagerProtocolServerSideTranslatorPB(
-        this, omRatisServer, omClientProtocolMetrics, isRatisEnabled,
-        getLastTrxnIndexForNonRatis());
-
-    BlockingService omService = newReflectiveBlockingService(omServerProtocol);
-
-    return startRpcServer(configuration, omNodeRpcAddr,
-        OzoneManagerProtocolPB.class, omService,
-        handlerCount);
-  }
-
-  /**
    * Creates an instance of ratis server.
    */
-  private void initializeRatisServer() throws IOException {
+  /**
+   * Creates an instance of ratis server.
+   * @param shouldBootstrap If OM is started in Bootstrap mode, then Ratis
+   *                        server will be initialized without adding self to
+   *                        Ratis group
+   * @throws IOException
+   */
+  private void initializeRatisServer(boolean shouldBootstrap)
+      throws IOException {
     if (isRatisEnabled) {
       if (omRatisServer == null) {
         // This needs to be done before initializing Ratis.
@@ -1361,7 +1498,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             registerRatisMetricReporters(ratisMetricsMap);
         omRatisServer = OzoneManagerRatisServer.newOMRatisServer(
             configuration, this, omNodeDetails, peerNodes,
-            secConfig, certClient);
+            secConfig, certClient, shouldBootstrap);
       }
       LOG.info("OzoneManager Ratis server initialized at port {}",
           omRatisServer.getServerPort());
@@ -1422,7 +1559,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Stop service.
    */
   public void stop() {
+    LOG.info("Stopping Ozone Manager");
     try {
+      omState = State.STOPPED;
       // Cancel the metrics timer and set to null.
       if (metricsTimer != null) {
         metricsTimer.cancel();
@@ -3546,7 +3685,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       } catch (IOException ex) {
         String errorMsg = "Failed to reset to original DB. OM is in an " +
             "inconsistent state.";
-        ExitUtils.terminate(1, errorMsg, ex, LOG);
+        exitManager.exitSystem(1, errorMsg, ex, LOG);
       }
       throw e;
     }
@@ -3592,6 +3731,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   public OzoneConfiguration getConfiguration() {
     return configuration;
+  }
+
+  @VisibleForTesting
+  public void setConfiguration(OzoneConfiguration conf) {
+    this.configuration = conf;
   }
 
   public static void setTestSecureOmFlag(boolean testSecureOmFlag) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -124,6 +124,26 @@ public class OzoneManagerStarter extends GenericCli {
   }
 
   /**
+   * This function implements a sub-command to allow the OM to be bootstrapped
+   * initialized from the command line. After OM is initialized, it will
+   * contact the leader OM to add itself to the ring. Once the leader OM
+   * responds back affirmatively, bootstrap step is complete and the OM is
+   * functional.
+   */
+  @CommandLine.Command(name = "--bootstrap",
+      customSynopsis = "ozone om [global options] --bootstrap",
+      hidden = false,
+      description = "Initialize if not already initialized and Bootstrap " +
+          "the Ozone Manager",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void bootstrapOM()
+      throws Exception {
+    commonInit();
+    receiver.bootstrap(conf);
+  }
+
+  /**
    * This function should be called by each command to ensure the configuration
    * is set and print the startup banner message.
    */
@@ -163,6 +183,21 @@ public class OzoneManagerStarter extends GenericCli {
     public boolean init(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
       return OzoneManager.omInit(conf);
+    }
+
+    @Override
+    public void bootstrap(OzoneConfiguration conf)
+        throws IOException, AuthenticationException {
+      // Initialize the Ozone Manager, if not already initialized.
+      boolean initialize = OzoneManager.omInit(conf);
+      if (!initialize) {
+        throw new IOException("OM Init failed.");
+      }
+      // Bootstrap the OM
+      OzoneManager om = OzoneManager.createOm(conf,
+          OzoneManager.StartupOption.BOOTSTRAP);
+      om.start();
+      om.join();
     }
 
     @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.ozone.om.ha;
 
 import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OmUtils;
@@ -72,8 +74,12 @@ public class OMHANodeDetails {
     return localNodeDetails;
   }
 
-  public List< OMNodeDetails > getPeerNodeDetails() {
-    return peerNodeDetails;
+  public Map<String, OMNodeDetails> getPeerNodesMap() {
+    Map<String, OMNodeDetails> peerNodesMap = new HashMap<>();
+    for (OMNodeDetails peeNode : peerNodeDetails) {
+      peerNodesMap.put(peeNode.getNodeId(), peeNode);
+    }
+    return peerNodesMap;
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -30,6 +30,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -689,6 +690,21 @@ public final class OzoneManagerRatisServer {
           "whether it's leader. ", ioe);
     }
     return RaftServerStatus.NOT_LEADER;
+  }
+
+  @VisibleForTesting
+  public List<String> getCurrentPeersFromRaftConf() {
+    try {
+      Collection<RaftPeer> currentPeers =
+          server.getDivision(raftGroupId).getRaftConf().getCurrentPeers();
+      List<String> currentPeerList = new ArrayList<>();
+      currentPeers.forEach(e -> currentPeerList.add(e.getId().toString()));
+      return currentPeerList;
+    } catch (IOException e) {
+      // In this case we return not a leader.
+      LOG.error("Failed to get RaftServer information. ", e);
+    }
+    return null;
   }
 
   public int getServerPort() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -151,7 +151,7 @@ public final class OzoneManagerRatisServer {
       LOG.info("OM started in Bootstrap mode. Instantiating OM Ratis server " +
           "with groupID: {}", raftGroupIdStr);
     } else {
-     StringBuilder raftPeersStr = new StringBuilder();
+      StringBuilder raftPeersStr = new StringBuilder();
       for (RaftPeer peer : peers) {
         raftPeersStr.append(", ").append(peer.getAddress());
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -692,8 +692,12 @@ public final class OzoneManagerRatisServer {
     return RaftServerStatus.NOT_LEADER;
   }
 
+  /**
+   * Get list of peer NodeIds from Ratis.
+   * @return List of Peer NodeId's.
+   */
   @VisibleForTesting
-  public List<String> getCurrentPeersFromRaftConf() {
+  public List<String> getCurrentPeersFromRaftConf() throws IOException {
     try {
       Collection<RaftPeer> currentPeers =
           server.getDivision(raftGroupId).getRaftConf().getCurrentPeers();
@@ -702,9 +706,8 @@ public final class OzoneManagerRatisServer {
       return currentPeerList;
     } catch (IOException e) {
       // In this case we return not a leader.
-      LOG.error("Failed to get RaftServer information. ", e);
+      throw new IOException("Failed to get peer information from Ratis.", e);
     }
-    return null;
   }
 
   public int getServerPort() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -175,7 +175,7 @@ public final class OzoneManagerRatisServer {
    */
   public static OzoneManagerRatisServer newOMRatisServer(
       ConfigurationSource ozoneConf, OzoneManager omProtocol,
-      OMNodeDetails omNodeDetails, List<OMNodeDetails> peerNodes,
+      OMNodeDetails omNodeDetails, Map<String, OMNodeDetails> peerNodes,
       SecurityConfig secConfig, CertificateClient certClient,
       boolean isBootstrapping) throws IOException {
 
@@ -201,18 +201,19 @@ public final class OzoneManagerRatisServer {
       // On regular startup, add all OMs to Ratis ring
       raftPeers.add(localRaftPeer);
 
-      for (OMNodeDetails peerInfo : peerNodes) {
-        String peerNodeId = peerInfo.getNodeId();
+      for (Map.Entry<String, OMNodeDetails> peerInfo : peerNodes.entrySet()) {
+        String peerNodeId = peerInfo.getKey();
+        OMNodeDetails peerNode = peerInfo.getValue();
         RaftPeerId raftPeerId = RaftPeerId.valueOf(peerNodeId);
         RaftPeer raftPeer;
-        if (peerInfo.isHostUnresolved()) {
+        if (peerNode.isHostUnresolved()) {
           raftPeer = RaftPeer.newBuilder()
               .setId(raftPeerId)
-              .setAddress(peerInfo.getRatisHostPortStr())
+              .setAddress(peerNode.getRatisHostPortStr())
               .build();
         } else {
           InetSocketAddress peerRatisAddr = new InetSocketAddress(
-              peerInfo.getInetAddress(), peerInfo.getRatisPort());
+              peerNode.getInetAddress(), peerNode.getRatisPort());
           raftPeer = RaftPeer.newBuilder()
               .setId(raftPeerId)
               .setAddress(peerRatisAddr)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -350,9 +350,6 @@ public final class OzoneManagerRatisServer {
    */
   @VisibleForTesting
   public boolean doesPeerExist(String peerId) {
-    if (peerId.equals(raftPeerId.toString())) {
-      return true;
-    }
     for (RaftPeer raftPeer : raftPeers) {
       if (raftPeer.getId().toString().equals(peerId)) {
         return true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -187,16 +187,13 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
         newRaftConfiguration.getPeersList();
     LOG.info("Received Configuration change notification from Ratis. New Peer" +
         " list:\n{}", newPeers);
+
+    List<String> newPeerIds = new ArrayList<>();
     for (RaftProtos.RaftPeerProto raftPeerProto : newPeers) {
-      String omNodeId = RaftPeerId.valueOf(raftPeerProto.getId()).toString();
-      if (!ozoneManager.doesPeerExist(omNodeId)) {
-        LOG.info("Adding new OM {} to the Peer list.", omNodeId);
-        ozoneManager.addOMNodeToPeers(omNodeId);
-      } else {
-        LOG.debug("Not adding OM {} to cluster as it is already present in " +
-            "peer list.", omNodeId);
-      }
+      newPeerIds.add(RaftPeerId.valueOf(raftPeerProto.getId()).toString());
     }
+    // Check and update the peer list in OzoneManager
+    ozoneManager.updatePeerList(newPeerIds);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -183,13 +183,14 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   @Override
   public void notifyConfigurationChanged(long term, long index,
       RaftProtos.RaftConfigurationProto newRaftConfiguration) {
-    List<RaftProtos.RaftPeerProto> newPeers = newRaftConfiguration.getPeersList();
+    List<RaftProtos.RaftPeerProto> newPeers =
+        newRaftConfiguration.getPeersList();
     LOG.info("Received Configuration change notification from Ratis. New Peer" +
         " list:\n{}", newPeers);
     for (RaftProtos.RaftPeerProto raftPeerProto : newPeers) {
       String omNodeId = RaftPeerId.valueOf(raftPeerProto.getId()).toString();
       if (!ozoneManager.doesPeerExist(omNodeId)) {
-        LOG.info("Adding new OM {} to the cluster.", omNodeId);
+        LOG.info("Adding new OM {} to the Peer list.", omNodeId);
         ozoneManager.addOMNodeToPeers(omNodeId);
       } else {
         LOG.debug("Not adding OM {} to cluster as it is already present in " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -380,6 +380,9 @@ public final class OzoneManagerRatisUtils {
     return storageDir;
   }
 
+  /**
+   * Get the local directory where ratis snapshots will be stored.
+   */
   public static String getOMRatisSnapshotDirectory(ConfigurationSource conf) {
     String snapshotDir = conf.get(OZONE_OM_RATIS_SNAPSHOT_DIR);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
-import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 
 import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -120,7 +120,7 @@ public class OzoneManagerSnapshotProvider {
     File targetFile = new File(snapshotFileName + ".tar.gz");
 
     String omCheckpointUrl = peerNodesMap.get(leaderOMNodeID)
-        .getOMDBCheckpointEnpointUrl(httpPolicy);
+        .getOMDBCheckpointEnpointUrl(httpPolicy.isHttpEnabled());
 
     LOG.info("Downloading latest checkpoint from Leader OM {}. Checkpoint " +
         "URL: {}", leaderOMNodeID, omCheckpointUrl);
@@ -158,5 +158,12 @@ public class OzoneManagerSnapshotProvider {
     if (connectionFactory != null) {
       connectionFactory.destroy();
     }
+  }
+
+  /**
+   * When a new OM is bootstrapped, add it to the peerNode map.
+   */
+  public void addNewPeerNode(OMNodeDetails newOMNode) {
+    peerNodesMap.put(newOMNode.getNodeId(), newOMNode);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -26,7 +26,6 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -72,15 +72,13 @@ public class OzoneManagerSnapshotProvider {
   private static final String OM_SNAPSHOT_DB = "om.snapshot.db";
 
   public OzoneManagerSnapshotProvider(MutableConfigurationSource conf,
-      File omRatisSnapshotDir, List<OMNodeDetails> peerNodes) {
+      File omRatisSnapshotDir, Map<String, OMNodeDetails> peerNodeDetails) {
 
     LOG.info("Initializing OM Snapshot Provider");
     this.omSnapshotDir = omRatisSnapshotDir;
 
     this.peerNodesMap = new HashMap<>();
-    for (OMNodeDetails peerNode : peerNodes) {
-      this.peerNodesMap.put(peerNode.getNodeId(), peerNode);
-    }
+    peerNodesMap.putAll(peerNodeDetails);
 
     this.httpPolicy = HttpConfig.getHttpPolicy(conf);
     this.spnegoEnabled = conf.get(OZONE_OM_HTTP_AUTH_TYPE, "simple")

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMInterServiceProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapErrorCode;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.ErrorCode;
 
 public class OMInterServiceProtocolServerSideImpl implements
     OMInterServiceProtocolPB {
@@ -49,7 +49,7 @@ public class OMInterServiceProtocolServerSideImpl implements
     if (!isRatisEnabled) {
       return BootstrapOMResponse.newBuilder()
           .setSuccess(false)
-          .setErrorCode(BootstrapErrorCode.RATIS_NOT_ENABLED)
+          .setErrorCode(ErrorCode.RATIS_NOT_ENABLED)
           .setErrorMsg("New OM node cannot be bootstrapped as Ratis " +
               "is not enabled on existing OM")
           .build();
@@ -68,7 +68,7 @@ public class OMInterServiceProtocolServerSideImpl implements
     } catch (IOException ex) {
       return BootstrapOMResponse.newBuilder()
           .setSuccess(false)
-          .setErrorCode(BootstrapErrorCode.RATIS_BOOTSTRAP_ERROR)
+          .setErrorCode(ErrorCode.RATIS_BOOTSTRAP_ERROR)
           .setErrorMsg(ex.getMessage())
           .build();
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
@@ -28,6 +28,11 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolPr
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.ErrorCode;
 
+/**
+ * This class is the server-side translator that forwards requests received on
+ * {@link OMInterServiceProtocolPB}
+ * to the OzoneManagerInterService server implementation.
+ */
 public class OMInterServiceProtocolServerSideImpl implements
     OMInterServiceProtocolPB {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
@@ -1,0 +1,73 @@
+package org.apache.hadoop.ozone.protocolPB;
+
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.om.protocolPB.OMInterServiceProtocolPB;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapErrorCode;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class OMInterServiceProtocolServerSideImpl implements
+    OMInterServiceProtocolPB {
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      OMInterServiceProtocolServerSideImpl.class);
+
+  private final OzoneManagerRatisServer omRatisServer;
+  private final boolean isRatisEnabled;
+
+  public OMInterServiceProtocolServerSideImpl(
+      OzoneManagerRatisServer ratisServer, boolean enableRatis) {
+    this.omRatisServer = ratisServer;
+    this.isRatisEnabled = enableRatis;
+  }
+
+  @Override
+  public BootstrapOMResponse bootstrap(RpcController controller,
+      BootstrapOMRequest request) throws ServiceException {
+    if (request == null) {
+      return null;
+    }
+    if (!isRatisEnabled) {
+      return BootstrapOMResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorCode(BootstrapErrorCode.RATIS_NOT_ENABLED)
+          .setErrorMsg("New OM node cannot be bootstrapped as Ratis " +
+              "is not enabled on existing OM")
+          .build();
+    }
+
+    checkLeaderStatus();
+
+    OMNodeDetails newOmNode = new OMNodeDetails.Builder()
+        .setOMNodeId(request.getNodeId())
+        .setHostAddress(request.getHostAddress())
+        .setRatisPort(request.getRatisPort())
+        .build();
+
+    try {
+      omRatisServer.addOMToRatisRing(newOmNode);
+    } catch (IOException ex) {
+      return BootstrapOMResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorCode(BootstrapErrorCode.RATIS_BOOTSTRAP_ERROR)
+          .setErrorMsg(ex.getMessage())
+          .build();
+    }
+
+    return BootstrapOMResponse.newBuilder()
+        .setSuccess(true)
+        .build();
+  }
+
+  private void checkLeaderStatus() throws ServiceException {
+    OzoneManagerRatisUtils.checkLeaderStatus(omRatisServer.checkLeaderStatus(),
+        omRatisServer.getRaftPeerId());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMInterServiceProtocolServerSideImpl.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package org.apache.hadoop.ozone.protocolPB;
 
 import com.google.protobuf.RpcController;
@@ -10,14 +27,9 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapErrorCode;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerInterServiceProtocolProtos.BootstrapOMResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class OMInterServiceProtocolServerSideImpl implements
     OMInterServiceProtocolPB {
-
-  private static final Logger LOG = LoggerFactory.getLogger(
-      OMInterServiceProtocolServerSideImpl.class);
 
   private final OzoneManagerRatisServer omRatisServer;
   private final boolean isRatisEnabled;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -41,13 +41,9 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
-import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
-import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER;
 
 /**
  * This class is the server-side translator that forwards requests received on

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -16,6 +16,8 @@
  */
 package org.apache.hadoop.ozone.protocolPB;
 
+import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.LEADER_AND_READY;
+import static org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus.NOT_LEADER;
 import static org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils.createClientRequest;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.PrepareStatus;
 
@@ -28,6 +30,8 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -41,6 +45,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
+import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -178,6 +178,12 @@ public class TestOzoneManagerStarter {
     }
 
     @Override
+    public void bootstrap(OzoneConfiguration conf) throws IOException,
+        AuthenticationException {
+      //TODO: Add test for bootstrap
+    }
+
+    @Override
     public void startAndCancelPrepare(OzoneConfiguration conf)
         throws IOException, AuthenticationException {
       startAndCancelPrepareCalled = true;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/failover/TestOMFailovers.java
@@ -118,7 +118,7 @@ public class TestOMFailovers {
 
     private MockFailoverProxyProvider(ConfigurationSource configuration)
         throws IOException {
-      super(configuration, null, null);
+      super(configuration, null, null, OzoneManagerProtocolPB.class);
     }
 
     @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.ha.ratis.RatisSnapshotInfo;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -115,7 +115,7 @@ public class TestOzoneManagerRatisServer {
     secConfig = new SecurityConfig(conf);
     certClient = new OMCertificateClient(secConfig);
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-      omNodeDetails, Collections.emptyList(), secConfig, certClient);
+      omNodeDetails, Collections.emptyList(), secConfig, certClient, false);
     omRatisServer.start();
   }
 
@@ -155,7 +155,7 @@ public class TestOzoneManagerRatisServer {
 
     // Start new Ratis server. It should pick up and load the new SnapshotInfo
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-        omNodeDetails, Collections.emptyList(), secConfig, certClient);
+        omNodeDetails, Collections.emptyList(), secConfig, certClient, false);
     omRatisServer.start();
     TermIndex lastAppliedTermIndex =
         omRatisServer.getLastAppliedTermIndex();
@@ -225,7 +225,7 @@ public class TestOzoneManagerRatisServer {
     omRatisServer.stop();
     OzoneManagerRatisServer newOmRatisServer = OzoneManagerRatisServer
         .newOMRatisServer(newConf, ozoneManager, nodeDetails,
-            Collections.emptyList(), secConfig, certClient);
+            Collections.emptyList(), secConfig, certClient, false);
     newOmRatisServer.start();
 
     UUID uuid = UUID.nameUUIDFromBytes(customOmServiceId.getBytes(UTF_8));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -115,7 +115,7 @@ public class TestOzoneManagerRatisServer {
     secConfig = new SecurityConfig(conf);
     certClient = new OMCertificateClient(secConfig);
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-      omNodeDetails, Collections.emptyList(), secConfig, certClient, false);
+      omNodeDetails, Collections.emptyMap(), secConfig, certClient, false);
     omRatisServer.start();
   }
 
@@ -155,7 +155,7 @@ public class TestOzoneManagerRatisServer {
 
     // Start new Ratis server. It should pick up and load the new SnapshotInfo
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-        omNodeDetails, Collections.emptyList(), secConfig, certClient, false);
+        omNodeDetails, Collections.emptyMap(), secConfig, certClient, false);
     omRatisServer.start();
     TermIndex lastAppliedTermIndex =
         omRatisServer.getLastAppliedTermIndex();
@@ -225,7 +225,7 @@ public class TestOzoneManagerRatisServer {
     omRatisServer.stop();
     OzoneManagerRatisServer newOmRatisServer = OzoneManagerRatisServer
         .newOMRatisServer(newConf, ozoneManager, nodeDetails,
-            Collections.emptyList(), secConfig, certClient, false);
+            Collections.emptyMap(), secConfig, certClient, false);
     newOmRatisServer.start();
 
     UUID uuid = UUID.nameUUIDFromBytes(customOmServiceId.getBytes(UTF_8));

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
@@ -57,7 +57,7 @@ public class Hadoop27RpcTransport implements OmTransport {
         ProtobufRpcEngine.class);
 
     this.omFailoverProxyProvider = new OMFailoverProxyProvider(conf, ugi,
-        omServiceId);
+        omServiceId, OzoneManagerProtocolPB.class);
 
     int maxFailovers = conf.getInt(
         OzoneConfigKeys.OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a ratis enabled OM cluster, add support to bootstrap a new OM node and add it to OM ratis ring. 

First step would be to update the ozone-site.xml with the configs (nodeId, address, ports etc.) for the new OM. 
The new node(s) should be started in BOOTSTRAP mode using the following command. This command will also initialize the OM. Hence, no need to run om init command before this command.
`ozone om --bootstrap`
When this command is run, it starts the OM in bootstrap mode. The new OM starts up its Ratis server and sends a request to existing OMs to perform a SetConfiguration operation. After the SetConfiguration operation is successful, the new OM is bootstrapped and part of the OM Ratis ring.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4330

## How was this patch tested?

Added unit tests