### PR TITLE
HDDS-4339. Allow AWSSignatureProcessor init when aws signature is absent.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSSignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/AWSSignatureProcessor.java
@@ -129,7 +129,6 @@ public class AWSSignatureProcessor implements SignatureProcessor {
 
 
   private void parse() throws Exception {
-    Preconditions.checkNotNull(v4Header);
 
     StringBuilder strToSign = new StringBuilder();
     // According to AWS sigv4 documentation, authorization header should be
@@ -175,7 +174,6 @@ public class AWSSignatureProcessor implements SignatureProcessor {
 
   @VisibleForTesting
   protected String buildCanonicalRequest() throws OS3Exception {
-    Preconditions.checkNotNull(v4Header);
 
     Iterable<String> parts = split("/", uri);
     List<String> encParts = new ArrayList<>();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -82,7 +82,7 @@ public class OzoneClientProducer {
       if (OzoneSecurityUtil.isSecurityEnabled(config)) {
         LOG.debug("Creating s3 auth info for client.");
         try {
-
+          validateAccessId(awsAccessId);
           OzoneTokenIdentifier identifier = new OzoneTokenIdentifier();
           identifier.setTokenType(S3AUTHINFO);
           identifier.setStrToSign(signatureParser.getStringToSign());
@@ -113,6 +113,13 @@ public class OzoneClientProducer {
     } else {
       // As in HA case, we need to pass om service ID.
       return OzoneClientFactory.getRpcClient(omServiceID, ozoneConfiguration);
+    }
+  }
+
+  // ONLY validate aws access id when needed.
+  private void validateAccessId(String awsAccessId) throws Exception {
+    if (awsAccessId == null || awsAccessId.equals("")) {
+      throw S3_AUTHINFO_CREATION_ERROR;
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -78,16 +78,11 @@ public class OzoneClientProducer {
   private OzoneClient getClient(OzoneConfiguration config) throws IOException {
     try {
       String awsAccessId = signatureParser.getAwsAccessId();
+      validateAccessId(awsAccessId);
+
       UserGroupInformation remoteUser =
           UserGroupInformation.createRemoteUser(awsAccessId);
       if (OzoneSecurityUtil.isSecurityEnabled(config)) {
-        try {
-          validateAccessId(awsAccessId);
-        } catch (OS3Exception ex) {
-          LOG.error("Malformed s3 header.", ex);
-          throw ex;
-        }
-        
         LOG.debug("Creating s3 auth info for client.");
         try {
           OzoneTokenIdentifier identifier = new OzoneTokenIdentifier();
@@ -125,6 +120,7 @@ public class OzoneClientProducer {
   // ONLY validate aws access id when needed.
   private void validateAccessId(String awsAccessId) throws Exception {
     if (awsAccessId == null || awsAccessId.equals("")) {
+      LOG.error("Malformed s3 header. awsAccessID: ", awsAccessId);
       throw MALFORMED_HEADER;
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.security.PrivilegedExceptionAction;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
@@ -81,6 +82,10 @@ public class OzoneClientProducer {
       throws OS3Exception {
     OzoneClient ozoneClient = null;
     try {
+      // Check if any error occurred during creation of signatureProcessor.
+      if (signatureParser.getException() != null) {
+        throw signatureParser.getException();
+      }
       String awsAccessId = signatureParser.getAwsAccessId();
       validateAccessId(awsAccessId);
 
@@ -143,5 +148,10 @@ public class OzoneClientProducer {
 
   public void setOzoneConfiguration(OzoneConfiguration config) {
     this.ozoneConfiguration = config;
+  }
+
+  @VisibleForTesting
+  public void setSignatureParser(SignatureProcessor signatureParser) {
+    this.signatureParser = signatureParser;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/SignatureProcessor.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/SignatureProcessor.java
@@ -61,4 +61,6 @@ public interface SignatureProcessor {
   String getSignature();
 
   String getAwsAccessId();
+
+  Exception getException();
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_SERVER_ERROR;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_NOT_SATISFIABLE;
 
 /**
@@ -99,6 +100,10 @@ public final class S3ErrorTable {
       "EntityTooSmall", "Your proposed upload is smaller than the minimum " +
       "allowed object size. Each part must be at least 5 MB in size, except " +
       "the last part.", HTTP_BAD_REQUEST);
+
+  public static final OS3Exception INTERNAL_ERROR = new OS3Exception(
+      "InternalError", "We encountered an internal error. Please try again.",
+      HTTP_SERVER_ERROR);
 
 
   /**

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -74,6 +74,11 @@ public class TestBucketPut {
       public String getAwsAccessId() {
         return OzoneConsts.OZONE;
       }
+
+      @Override
+      public Exception getException() {
+        return null;
+      }
     });
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -69,6 +69,11 @@ public class TestRootList {
       public String getAwsAccessId() {
         return OzoneConsts.OZONE;
       }
+
+      @Override
+      public Exception getException() {
+        return null;
+      }
     });
     // List operation should succeed even there is no bucket.
     ListBucketResponse response =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Skip aws signature retrieval in AWSSignatureProcessor. It was causing NPE when signature is absent in header.

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4339

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
UT
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
