### PR TITLE
HDDS-4366. SCM deletion service should delete configured number of blocks every interval.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -74,6 +74,18 @@ public class ScmConfig {
   )
   private String pipelineChoosePolicyName;
 
+  @Config(key = "block.deletion.per-interval.max",
+      type = ConfigType.INT,
+      defaultValue = "10000",
+      tags = { ConfigTag.SCM, ConfigTag.DELETION},
+      description =
+          "Maximum number of blocks which SCM processes during an interval. "
+              + "If SCM has 100000 blocks which need to be deleted and the "
+              + "configuration is 5000 then it would only send 5000 blocks "
+              + "for deletion to the datanodes."
+  )
+  private int blockDeletionLimit;
+
   public void setKerberosPrincipal(String kerberosPrincipal) {
     this.principal = kerberosPrincipal;
   }
@@ -91,6 +103,10 @@ public class ScmConfig {
     this.pipelineChoosePolicyName = pipelineChoosePolicyName;
   }
 
+  public void setBlockDeletionLimit(int blockDeletionLimit) {
+    this.blockDeletionLimit = blockDeletionLimit;
+  }
+
   public String getKerberosPrincipal() {
     return this.principal;
   }
@@ -105,6 +121,10 @@ public class ScmConfig {
 
   public String getPipelineChoosePolicyName() {
     return pipelineChoosePolicyName;
+  }
+
+  public int getBlockDeletionLimit() {
+    return blockDeletionLimit;
   }
 
   /**

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigTag.java
@@ -42,5 +42,6 @@ public enum ConfigTag {
   STANDALONE,
   S3GATEWAY,
   DATANODE,
-  RECON
+  RECON,
+  DELETION
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DatanodeDeletedBlockTransactions.java
@@ -16,121 +16,65 @@
  */
 package org.apache.hadoop.hdds.scm.block;
 
-import com.google.common.collect.ArrayListMultimap;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 
-import java.io.IOException;
-import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
 /**
  * A wrapper class to hold info about datanode and all deleted block
  * transactions that will be sent to this datanode.
  */
-public class DatanodeDeletedBlockTransactions {
-  private int nodeNum;
-  // The throttle size for each datanode.
-  private int maximumAllowedTXNum;
-  // Current counter of inserted TX.
-  private int currentTXNum;
-  private ContainerManager containerManager;
+class DatanodeDeletedBlockTransactions {
   // A list of TXs mapped to a certain datanode ID.
-  private final ArrayListMultimap<UUID, DeletedBlocksTransaction>
-      transactions;
+  private final Map<UUID, List<DeletedBlocksTransaction>> transactions =
+      new HashMap<>();
+  // counts blocks deleted across datanodes. Blocks deleted will be counted
+  // for all the replicas and may not be unique.
+  private int blocksDeleted = 0;
+  private final Map<Long, Long> containerIdToTxnId = new HashMap<>();
 
-  DatanodeDeletedBlockTransactions(ContainerManager containerManager,
-      int maximumAllowedTXNum, int nodeNum) {
-    this.transactions = ArrayListMultimap.create();
-    this.containerManager = containerManager;
-    this.maximumAllowedTXNum = maximumAllowedTXNum;
-    this.nodeNum = nodeNum;
+  DatanodeDeletedBlockTransactions() {
   }
 
-  public boolean addTransaction(DeletedBlocksTransaction tx,
-      Set<UUID> dnsWithTransactionCommitted) {
-    try {
-      boolean success = false;
-      final ContainerID id = ContainerID.valueof(tx.getContainerID());
-      final ContainerInfo container = containerManager.getContainer(id);
-      final Set<ContainerReplica> replicas = containerManager
-          .getContainerReplicas(id);
-      if (!container.isOpen()) {
-        for (ContainerReplica replica : replicas) {
-          UUID dnID = replica.getDatanodeDetails().getUuid();
-          if (dnsWithTransactionCommitted == null ||
-              !dnsWithTransactionCommitted.contains(dnID)) {
-            // Transaction need not be sent to dns which have
-            // already committed it
-            success = addTransactionToDN(dnID, tx);
-          }
-        }
-      }
-      return success;
-    } catch (IOException e) {
-      SCMBlockDeletingService.LOG.warn("Got container info error.", e);
-      return false;
+  void addTransactionToDN(UUID dnID, DeletedBlocksTransaction tx) {
+    transactions.computeIfAbsent(dnID, k -> new LinkedList<>()).add(tx);
+    containerIdToTxnId.put(tx.getContainerID(), tx.getTxID());
+    blocksDeleted += tx.getLocalIDCount();
+    if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
+      SCMBlockDeletingService.LOG
+          .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
     }
   }
 
-  private boolean addTransactionToDN(UUID dnID, DeletedBlocksTransaction tx) {
-    List<DeletedBlocksTransaction> txs = transactions.get(dnID);
-    if (txs == null || txs.size() < maximumAllowedTXNum) {
-      currentTXNum++;
-      if (txs == null) {
-        transactions.put(dnID, tx);
-      } else {
-        txs.add(tx);
-      }
-      if (SCMBlockDeletingService.LOG.isDebugEnabled()) {
-        SCMBlockDeletingService.LOG
-            .debug("Transaction added: {} <- TX({})", dnID, tx.getTxID());
-      }
-      return true;
-    }
-    return false;
+  Map<UUID, List<DeletedBlocksTransaction>> getDatanodeTransactionMap() {
+    return transactions;
   }
 
-  Set<UUID> getDatanodeIDs() {
-    return transactions.keySet();
+  Map<Long, Long> getContainerIdToTxnIdMap() {
+    return containerIdToTxnId;
+  }
+
+  int getBlocksDeleted() {
+    return blocksDeleted;
+  }
+
+  List<String> getTransactionIDList(UUID dnId) {
+    return Optional.ofNullable(transactions.get(dnId))
+        .orElse(new LinkedList<>())
+        .stream()
+        .map(DeletedBlocksTransaction::getTxID)
+        .map(String::valueOf)
+        .collect(Collectors.toList());
   }
 
   boolean isEmpty() {
     return transactions.isEmpty();
-  }
-
-  boolean hasTransactions(UUID dnId) {
-    return transactions.containsKey(dnId) &&
-        !transactions.get(dnId).isEmpty();
-  }
-
-  List<DeletedBlocksTransaction> getDatanodeTransactions(UUID dnId) {
-    return transactions.get(dnId);
-  }
-
-  List<String> getTransactionIDList(UUID dnId) {
-    if (hasTransactions(dnId)) {
-      return transactions.get(dnId).stream()
-          .map(DeletedBlocksTransaction::getTxID).map(String::valueOf)
-          .collect(Collectors.toList());
-    } else {
-      return Collections.emptyList();
-    }
-  }
-
-  boolean isFull() {
-    return currentTXNum >= maximumAllowedTXNum * nodeNum;
-  }
-
-  int getTXNum() {
-    return currentTXNum;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -41,11 +41,11 @@ public interface DeletedBlockLog extends Closeable {
    * Scan entire log once and returns TXs to DatanodeDeletedBlockTransactions.
    * Once DatanodeDeletedBlockTransactions is full, the scan behavior will
    * stop.
-   * @param transactions a list of TXs will be set into.
+   * @param blockDeletionLimit Maximum number of blocks to fetch
    * @return Mapping from containerId to latest transactionId for the container.
    * @throws IOException
    */
-  Map<Long, Long> getTransactions(DatanodeDeletedBlockTransactions transactions)
+  DatanodeDeletedBlockTransactions getTransactions(int blockDeletionLimit)
       throws IOException;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -200,7 +200,7 @@ public class DeletedBlockLogImpl
             LOG.debug("Transaction txId={} commit by dnId={} for containerID={}"
                     + " failed. Corresponding entry not found.", txID, dnID,
                 containerId);
-            return;
+            continue;
           }
 
           dnsWithCommittedTxn.add(dnID);
@@ -323,31 +323,54 @@ public class DeletedBlockLogImpl
   public void close() throws IOException {
   }
 
-  @Override
-  public Map<Long, Long> getTransactions(
-      DatanodeDeletedBlockTransactions transactions) throws IOException {
-    lock.lock();
+  private void getTransaction(DeletedBlocksTransaction tx,
+      DatanodeDeletedBlockTransactions transactions) {
     try {
-      Map<Long, Long> deleteTransactionMap = new HashMap<>();
-      try (TableIterator<Long,
-          ? extends Table.KeyValue<Long, DeletedBlocksTransaction>> iter =
-               scmMetadataStore.getDeletedBlocksTXTable().iterator()) {
-        while (iter.hasNext()) {
-          Table.KeyValue<Long, DeletedBlocksTransaction> keyValue =
-              iter.next();
-          DeletedBlocksTransaction block = keyValue.getValue();
-          if (block.getCount() > -1 && block.getCount() <= maxRetry) {
-            if (transactions.addTransaction(block,
-                transactionToDNsCommitMap.get(block.getTxID()))) {
-              deleteTransactionMap.put(block.getContainerID(),
-                  block.getTxID());
-              transactionToDNsCommitMap
-                  .putIfAbsent(block.getTxID(), new LinkedHashSet<>());
-            }
+      final ContainerID id = ContainerID.valueof(tx.getContainerID());
+      if (!containerManager.getContainer(id).isOpen()) {
+        Set<ContainerReplica> replicas = containerManager
+            .getContainerReplicas(ContainerID.valueof(tx.getContainerID()));
+        for (ContainerReplica replica : replicas) {
+          UUID dnID = replica.getDatanodeDetails().getUuid();
+          Set<UUID> dnsWithTransactionCommitted =
+              transactionToDNsCommitMap.get(tx.getTxID());
+          if (dnsWithTransactionCommitted == null
+              || !dnsWithTransactionCommitted.contains(dnID)) {
+            // Transaction need not be sent to dns which have
+            // already committed it
+            transactions.addTransactionToDN(dnID, tx);
           }
         }
       }
-      return deleteTransactionMap;
+    } catch (IOException e) {
+      LOG.warn("Got container info error.", e);
+    }
+  }
+
+  @Override
+  public DatanodeDeletedBlockTransactions getTransactions(
+      int blockDeletionLimit) throws IOException {
+    lock.lock();
+    try {
+      DatanodeDeletedBlockTransactions transactions =
+          new DatanodeDeletedBlockTransactions();
+      try (TableIterator<Long,
+          ? extends Table.KeyValue<Long, DeletedBlocksTransaction>> iter =
+               scmMetadataStore.getDeletedBlocksTXTable().iterator()) {
+        int numBlocksAdded = 0;
+        while (iter.hasNext() && numBlocksAdded < blockDeletionLimit) {
+          Table.KeyValue<Long, DeletedBlocksTransaction> keyValue =
+              iter.next();
+          DeletedBlocksTransaction txn = keyValue.getValue();
+          if (txn.getCount() > -1 && txn.getCount() <= maxRetry) {
+            numBlocksAdded += txn.getLocalIDCount();
+            getTransaction(txn, transactions);
+            transactionToDNsCommitMap
+                .putIfAbsent(txn.getTxID(), new LinkedHashSet<>());
+          }
+        }
+      }
+      return transactions;
     } finally {
       lock.unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.block;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -40,8 +41,6 @@ import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL_DEFAULT;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,24 +56,12 @@ public class SCMBlockDeletingService extends BackgroundService {
   public static final Logger LOG =
       LoggerFactory.getLogger(SCMBlockDeletingService.class);
 
-  // ThreadPoolSize=2, 1 for scheduler and the other for the scanner.
-  private final static int BLOCK_DELETING_SERVICE_CORE_POOL_SIZE = 2;
+  private final static int BLOCK_DELETING_SERVICE_CORE_POOL_SIZE = 1;
   private final DeletedBlockLog deletedBlockLog;
   private final ContainerManager containerManager;
   private final NodeManager nodeManager;
   private final EventPublisher eventPublisher;
 
-  // Block delete limit size is dynamically calculated based on container
-  // delete limit size (ozone.block.deleting.container.limit.per.interval)
-  // that configured for datanode. To ensure DN not wait for
-  // delete commands, we use this value multiply by a factor 2 as the final
-  // limit TX size for each node.
-  // Currently we implement a throttle algorithm that throttling delete blocks
-  // for each datanode. Each node is limited by the calculation size. Firstly
-  // current node info is fetched from nodemanager, then scan entire delLog
-  // from the beginning to end. If one node reaches maximum value, its records
-  // will be skipped. If not, keep scanning until it reaches maximum value.
-  // Once all node are full, the scan behavior will stop.
   private int blockDeleteLimitSize;
 
   public SCMBlockDeletingService(DeletedBlockLog deletedBlockLog,
@@ -88,14 +75,10 @@ public class SCMBlockDeletingService extends BackgroundService {
     this.nodeManager = nodeManager;
     this.eventPublisher = eventPublisher;
 
-    int containerLimit = conf.getInt(
-        OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL,
-        OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL_DEFAULT);
-    Preconditions.checkArgument(containerLimit > 0,
-        "Container limit size should be " + "positive.");
-    // Use container limit value multiply by a factor 2 to ensure DN
-    // not wait for orders.
-    this.blockDeleteLimitSize = containerLimit * 2;
+    blockDeleteLimitSize =
+        conf.getObject(ScmConfig.class).getBlockDeletionLimit();
+    Preconditions.checkArgument(blockDeleteLimitSize > 0,
+        "Block deletion limit should be " + "positive.");
   }
 
   @Override
@@ -105,16 +88,18 @@ public class SCMBlockDeletingService extends BackgroundService {
     return queue;
   }
 
-  public void handlePendingDeletes(PendingDeleteStatusList deletionStatusList) {
+  void handlePendingDeletes(PendingDeleteStatusList deletionStatusList) {
     DatanodeDetails dnDetails = deletionStatusList.getDatanodeDetails();
     for (PendingDeleteStatusList.PendingDeleteStatus deletionStatus :
         deletionStatusList.getPendingDeleteStatuses()) {
-      LOG.debug(
-          "Block deletion txnID lagging in datanode {} for containerID {}."
-              + " Datanode delete txnID: {}, SCM txnID: {}",
-          dnDetails.getUuid(), deletionStatus.getContainerId(),
-          deletionStatus.getDnDeleteTransactionId(),
-          deletionStatus.getScmDeleteTransactionId());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+            "Block deletion txnID lagging in datanode {} for containerID {}."
+                + " Datanode delete txnID: {}, SCM txnID: {}",
+            dnDetails.getUuid(), deletionStatus.getContainerId(),
+            deletionStatus.getDnDeleteTransactionId(),
+            deletionStatus.getScmDeleteTransactionId());
+      }
     }
   }
 
@@ -127,19 +112,54 @@ public class SCMBlockDeletingService extends BackgroundService {
 
     @Override
     public EmptyTaskResult call() throws Exception {
-      int dnTxCount = 0;
       long startTime = Time.monotonicNow();
       // Scan SCM DB in HB interval and collect a throttled list of
       // to delete blocks.
-      LOG.debug("Running DeletedBlockTransactionScanner");
-      DatanodeDeletedBlockTransactions transactions = null;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Running DeletedBlockTransactionScanner");
+      }
+
       List<DatanodeDetails> datanodes = nodeManager.getNodes(NodeState.HEALTHY);
-      Map<Long, Long> transactionMap = null;
       if (datanodes != null) {
-        transactions = new DatanodeDeletedBlockTransactions(containerManager,
-            blockDeleteLimitSize, datanodes.size());
         try {
-          transactionMap = deletedBlockLog.getTransactions(transactions);
+          DatanodeDeletedBlockTransactions transactions =
+              deletedBlockLog.getTransactions(blockDeleteLimitSize);
+          Map<Long, Long> containerIdToMaxTxnId =
+              transactions.getContainerIdToTxnIdMap();
+
+          if (transactions.isEmpty()) {
+            return EmptyTaskResult.newResult();
+          }
+
+          for (Map.Entry<UUID, List<DeletedBlocksTransaction>> entry :
+              transactions.getDatanodeTransactionMap().entrySet()) {
+            UUID dnId = entry.getKey();
+            List<DeletedBlocksTransaction> dnTXs = entry.getValue();
+            if (!dnTXs.isEmpty()) {
+              // TODO commandQueue needs a cap.
+              // We should stop caching new commands if num of un-processed
+              // command is bigger than a limit, e.g 50. In case datanode goes
+              // offline for sometime, the cached commands be flooded.
+              eventPublisher.fireEvent(SCMEvents.RETRIABLE_DATANODE_COMMAND,
+                  new CommandForDatanode<>(dnId,
+                      new DeleteBlocksCommand(dnTXs)));
+              if (LOG.isDebugEnabled()) {
+                LOG.debug(
+                    "Added delete block command for datanode {} in the queue,"
+                        + " number of delete block transactions: {}{}", dnId,
+                    dnTXs.size(), LOG.isTraceEnabled() ?
+                        ", TxID list: " + String.join(",",
+                            transactions.getTransactionIDList(dnId)) : "");
+              }
+            }
+          }
+
+          containerManager.updateDeleteTransactionId(containerIdToMaxTxnId);
+          LOG.info("Totally added {} blocks to be deleted for"
+                  + " {} datanodes, task elapsed time: {}ms",
+              transactions.getBlocksDeleted(),
+              transactions.getDatanodeTransactionMap().size(),
+              Time.monotonicNow() - startTime);
         } catch (IOException e) {
           // We may tolerant a number of failures for sometime
           // but if it continues to fail, at some point we need to raise
@@ -147,42 +167,10 @@ public class SCMBlockDeletingService extends BackgroundService {
           // continues to retry the scanning.
           LOG.error("Failed to get block deletion transactions from delTX log",
               e);
+          return EmptyTaskResult.newResult();
         }
-        LOG.debug("Scanned deleted blocks log and got {} delTX to process.",
-            transactions.getTXNum());
       }
 
-      if (transactions != null && !transactions.isEmpty()) {
-        for (UUID dnId : transactions.getDatanodeIDs()) {
-          List<DeletedBlocksTransaction> dnTXs = transactions
-              .getDatanodeTransactions(dnId);
-          if (dnTXs != null && !dnTXs.isEmpty()) {
-            dnTxCount += dnTXs.size();
-            // TODO commandQueue needs a cap.
-            // We should stop caching new commands if num of un-processed
-            // command is bigger than a limit, e.g 50. In case datanode goes
-            // offline for sometime, the cached commands be flooded.
-            eventPublisher.fireEvent(SCMEvents.RETRIABLE_DATANODE_COMMAND,
-                new CommandForDatanode<>(dnId, new DeleteBlocksCommand(dnTXs)));
-            if (LOG.isDebugEnabled()) {
-              LOG.debug(
-                  "Added delete block command for datanode {} in the queue," +
-                      " number of delete block transactions: {}, TxID list: {}",
-                  dnId, dnTXs.size(), String.join(",",
-                      transactions.getTransactionIDList(dnId)));
-            }
-          }
-        }
-        containerManager.updateDeleteTransactionId(transactionMap);
-      }
-
-      if (dnTxCount > 0) {
-        LOG.info(
-            "Totally added {} delete blocks command for"
-                + " {} datanodes, task elapsed time: {}ms",
-            dnTxCount, transactions.getDatanodeIDs().size(),
-            Time.monotonicNow() - startTime);
-      }
 
       return EmptyTaskResult.newResult();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -161,7 +161,7 @@ public class SCMBlockDeletingService extends BackgroundService {
               transactions.getDatanodeTransactionMap().size(),
               Time.monotonicNow() - startTime);
         } catch (IOException e) {
-          // We may tolerant a number of failures for sometime
+          // We may tolerate a number of failures for sometime
           // but if it continues to fail, at some point we need to raise
           // an exception and probably fail the SCM ? At present, it simply
           // continues to retry the scanning.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine.commandhandler;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -96,6 +97,7 @@ public class TestBlockDeletion {
   private static OzoneManager om = null;
   private static Set<Long> containerIdsWithDeletedBlocks;
   private static long maxTransactionId = 0;
+  private static File baseDir;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -106,7 +108,7 @@ public class TestBlockDeletion {
 
     String path =
         GenericTestUtils.getTempPath(TestBlockDeletion.class.getSimpleName());
-    File baseDir = new File(path);
+    baseDir = new File(path);
     baseDir.mkdirs();
 
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,
@@ -137,10 +139,11 @@ public class TestBlockDeletion {
   }
 
   @AfterClass
-  public static void cleanup() {
+  public static void cleanup() throws IOException {
     if (cluster != null) {
       cluster.shutdown();
     }
+    FileUtils.deleteDirectory(baseDir);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM service currently uses datanode's configuration to determine the number of blocks to delete every interval. It should have its own congifuration for maximum number of blocks to delete in every interval.
Further it currently scans the entire DB to fetch block deletion transactions. This can be avoided with this approach. With this patch service would always fetch configured number of blocks from the db.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4366

## How was this patch tested?

Existing UT
