### PR TITLE
HDDS-4375. OM changes the block length when receives truncate request

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -546,6 +546,16 @@ public class OzoneBucket extends WithMetadata {
   }
 
   /**
+   * Truncates key in the bucket.
+   * @param key Name of the key to be truncated.
+   * @param newLength New length of the key after truncate.
+   * @throws IOException
+   */
+  public void truncateKey(String key, long newLength) throws IOException {
+    proxy.truncateKey(volumeName, name, key, newLength);
+  }
+
+  /**
    * Deletes the given list of keys from the bucket.
    * @param keyList List of the key name to be deleted.
    * @throws IOException

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -295,6 +295,17 @@ public interface ClientProtocol {
       throws IOException;
 
   /**
+   * Truncates an existing key.
+   * @param volumeName Name of the Volume
+   * @param bucketName Name of the Bucket
+   * @param keyName Name of the Key
+   * @param newLength New length of the key after truncate.
+   * @throws IOException
+   */
+  void truncateKey(String volumeName, String bucketName, String keyName,
+      long newLength) throws IOException;
+
+  /**
    * Deletes keys through the list.
    * @param volumeName Name of the Volume
    * @param bucketName Name of the Bucket

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -794,6 +794,22 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public void truncateKey(
+      String volumeName, String bucketName, String keyName, long newLength)
+      throws IOException {
+    verifyVolumeName(volumeName);
+    verifyBucketName(bucketName);
+    Preconditions.checkNotNull(keyName);
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setNewLength(newLength)
+        .build();
+    ozoneManagerClient.truncateKey(keyArgs);
+  }
+
+  @Override
   public void deleteKeys(
           String volumeName, String bucketName, List<String> keyNameList)
           throws IOException {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -272,6 +272,7 @@ public final class OmUtils {
     case PurgeKeys:
     case RecoverTrash:
     case DeleteOpenKeys:
+    case TruncateKey:
       return false;
     default:
       LOG.error("CmdType {} is not categorized as readOnly or not.", cmdType);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -31,6 +31,7 @@ public enum OMAction implements AuditAction {
   DELETE_VOLUME,
   DELETE_BUCKET,
   DELETE_KEY,
+  TRUNCATE_KEY,
   RENAME_KEY,
   RENAME_KEYS,
   SET_OWNER,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -231,7 +231,9 @@ public class OMException extends IOException {
 
     PARTIAL_RENAME,
 
-    QUOTA_EXCEEDED
+    QUOTA_EXCEEDED,
+
+    INVALID_TRUNCATE_NEW_LENGTH
 
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -48,6 +48,7 @@ public final class OmKeyArgs implements Auditable {
   private boolean refreshPipeline;
   private boolean sortDatanodesInPipeline;
   private List<OzoneAcl> acls;
+  private long newLength;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -55,7 +56,7 @@ public final class OmKeyArgs implements Auditable {
       List<OmKeyLocationInfo> locationInfoList, boolean isMultipart,
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
-      List<OzoneAcl> acls, boolean sortDatanode) {
+      List<OzoneAcl> acls, boolean sortDatanode, long newLength) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -70,6 +71,7 @@ public final class OmKeyArgs implements Auditable {
     this.refreshPipeline = refreshPipeline;
     this.acls = acls;
     this.sortDatanodesInPipeline = sortDatanode;
+    this.newLength = newLength;
   }
 
   public boolean getIsMultipartKey() {
@@ -140,6 +142,10 @@ public final class OmKeyArgs implements Auditable {
     return sortDatanodesInPipeline;
   }
 
+  public long getNewLength() {
+    return newLength;
+  }
+
   @Override
   public Map<String, String> toAuditMap() {
     Map<String, String> auditMap = new LinkedHashMap<>();
@@ -198,6 +204,7 @@ public final class OmKeyArgs implements Auditable {
     private boolean refreshPipeline;
     private boolean sortDatanodesInPipeline;
     private List<OzoneAcl> acls;
+    private long newLength;
 
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
@@ -274,11 +281,16 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
+    public Builder setNewLength(long len) {
+      this.newLength = len;
+      return this;
+    }
+
     public OmKeyArgs build() {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize, type,
           factor, locationInfoList, isMultipartKey, multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline);
+          sortDatanodesInPipeline, newLength);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -247,6 +247,14 @@ public interface OzoneManagerProtocol
   void deleteKeys(OmDeleteKeys deleteKeys) throws IOException;
 
   /**
+   * Truncates an existing key.
+   *
+   * @param args the args of the key.
+   * @throws IOException
+   */
+  void truncateKey(OmKeyArgs args) throws IOException;
+
+  /**
    * Deletes an existing empty bucket from volume.
    * @param volume - Name of the volume.
    * @param bucket - Name of the bucket.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -134,6 +134,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclR
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetBucketPropertyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.SetVolumePropertyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TruncateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.VolumeInfo;
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
@@ -773,6 +774,30 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     handleError(submitRequest(omRequest));
 
+  }
+
+  /**
+   * Truncates an existing key.
+   *
+   * @param args the args of the key.
+   * @throws IOException
+   */
+  @Override
+  public void truncateKey(OmKeyArgs args) throws IOException {
+    TruncateKeyRequest.Builder req = TruncateKeyRequest.newBuilder();
+    KeyArgs keyArgs = KeyArgs.newBuilder()
+        .setVolumeName(args.getVolumeName())
+        .setBucketName(args.getBucketName())
+        .setKeyName(args.getKeyName())
+        .setNewLength(args.getNewLength())
+        .build();
+    req.setKeyArgs(keyArgs);
+
+    OMRequest omRequest = createOMRequest(Type.TruncateKey)
+        .setTruncateKeyRequest(req)
+        .build();
+
+    handleError(submitRequest(omRequest));
   }
 
   /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -62,6 +62,7 @@ enum Type {
   DeleteKeys = 38;
   RenameKeys = 39;
   DeleteOpenKeys = 40;
+  TruncateKey = 41;
 
   InitiateMultiPartUpload = 45;
   CommitMultiPartUpload = 46;
@@ -130,6 +131,7 @@ message OMRequest {
   optional DeleteKeysRequest                deleteKeysRequest              = 38;
   optional RenameKeysRequest                renameKeysRequest              = 39;
   optional DeleteOpenKeysRequest            deleteOpenKeysRequest          = 40;
+  optional TruncateKeyRequest               truncateKeyRequest             = 41;
 
   optional MultipartInfoInitiateRequest     initiateMultiPartUploadRequest = 45;
   optional MultipartCommitUploadPartRequest commitMultiPartUploadRequest   = 46;
@@ -203,6 +205,7 @@ message OMResponse {
   optional AllocateBlockResponse             allocateBlockResponse         = 37;
   optional DeleteKeysResponse                deleteKeysResponse            = 38;
   optional RenameKeysResponse                renameKeysResponse            = 39;
+  optional TruncateKeyResponse               truncateKeyResponse           = 40;
 
   optional MultipartInfoInitiateResponse   initiateMultiPartUploadResponse = 45;
   optional MultipartCommitUploadPartResponse commitMultiPartUploadResponse = 46;
@@ -317,6 +320,8 @@ enum Status {
     PARTIAL_RENAME = 65;
 
     QUOTA_EXCEEDED = 66;
+
+    INVALID_TRUNCATE_NEW_LENGTH = 67;
 
 }
 
@@ -725,6 +730,7 @@ message KeyArgs {
 
     // This will be set by leader OM in HA and update the original request.
     optional FileEncryptionInfoProto fileEncryptionInfo = 15;
+    optional uint64 newLength = 16;
 }
 
 message KeyLocation {
@@ -889,6 +895,14 @@ message RenameKeyResponse{
 
 message DeleteKeyRequest {
     required KeyArgs keyArgs = 1;
+}
+
+message TruncateKeyRequest {
+    required KeyArgs keyArgs = 1;
+}
+
+message TruncateKeyResponse {
+
 }
 
 message DeleteKeysRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -56,6 +56,7 @@ public class OMMetrics {
   private @Metric MutableCounterLong numKeyLookup;
   private @Metric MutableCounterLong numKeyRenames;
   private @Metric MutableCounterLong numKeyDeletes;
+  private @Metric MutableCounterLong numKeyTruncates;
   private @Metric MutableCounterLong numBucketLists;
   private @Metric MutableCounterLong numKeyLists;
   private @Metric MutableCounterLong numTrashKeyLists;
@@ -91,6 +92,7 @@ public class OMMetrics {
   private @Metric MutableCounterLong numKeyLookupFails;
   private @Metric MutableCounterLong numKeyRenameFails;
   private @Metric MutableCounterLong numKeyDeleteFails;
+  private @Metric MutableCounterLong numKeyTruncateFails;
   private @Metric MutableCounterLong numBucketListFails;
   private @Metric MutableCounterLong numKeyListFails;
   private @Metric MutableCounterLong numTrashKeyListFails;
@@ -491,6 +493,15 @@ public class OMMetrics {
     numKeyDeletes.incr();
   }
 
+  public void incNumKeyTruncates() {
+    numKeyOps.incr();
+    numKeyTruncates.incr();
+  }
+
+  public void incNumKeyTruncateFails() {
+    numKeyTruncateFails.incr();
+  }
+
   public void incNumKeyCommits() {
     numKeyOps.incr();
     numKeyCommits.incr();
@@ -711,8 +722,18 @@ public class OMMetrics {
   }
 
   @VisibleForTesting
+  public long getNumKeyTruncates() {
+    return numKeyTruncates.value();
+  }
+
+  @VisibleForTesting
   public long getNumKeyDeletesFails() {
     return numKeyDeleteFails.value();
+  }
+
+  @VisibleForTesting
+  public long getNumKeyTruncatesFails() {
+    return numKeyTruncateFails.value();
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2300,6 +2300,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
+   * Truncates an existing key.
+   *
+   * @param args - attributes of the key.
+   * @throws IOException
+   */
+  @Override
+  public void truncateKey(OmKeyArgs args) throws IOException {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented. As truncate requests use a new approach");
+  }
+
+  /**
    * Deletes an existing key.
    *
    * @param deleteKeys - List of keys to be deleted from volume and a bucket.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyPurgeRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyRenameRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeysRenameRequest;
 import org.apache.hadoop.ozone.om.request.key.OMTrashRecoverRequest;
+import org.apache.hadoop.ozone.om.request.key.OMKeyTruncateRequest;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequest;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequest;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequest;
@@ -160,6 +161,8 @@ public final class OzoneManagerRatisUtils {
       return new S3GetSecretRequest(omRequest);
     case RecoverTrash:
       return new OMTrashRecoverRequest(omRequest);
+    case TruncateKey:
+      return new OMKeyTruncateRequest(omRequest);
     default:
       throw new IllegalStateException("Unrecognized write command " +
           "type request" + cmdType);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyTruncateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyTruncateRequest.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.key.OMKeyTruncateResponse;
+import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
+import org.apache.hadoop.ozone.security.acl.OzoneObj;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TruncateKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TruncateKeyResponse;
+import org.apache.hadoop.util.Time;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_TRUNCATE_NEW_LENGTH;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+
+/**
+ * Handles TruncateKey request.
+ */
+public class OMKeyTruncateRequest extends OMKeyRequest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMKeyTruncateRequest.class);
+
+  public OMKeyTruncateRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    TruncateKeyRequest truncateKeyRequest =
+        getOmRequest().getTruncateKeyRequest();
+    Preconditions.checkNotNull(truncateKeyRequest);
+
+    OzoneManagerProtocolProtos.KeyArgs keyArgs =
+        truncateKeyRequest.getKeyArgs();
+
+    OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
+        keyArgs.toBuilder().setModificationTime(Time.now())
+            .setKeyName(validateAndNormalizeKey(
+                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
+
+    return getOmRequest().toBuilder()
+        .setTruncateKeyRequest(truncateKeyRequest.toBuilder()
+            .setKeyArgs(newKeyArgs)).setUserInfo(getUserInfo()).build();
+  }
+
+  @Override
+  @SuppressWarnings("methodlength")
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
+    TruncateKeyRequest truncateKeyRequest =
+        getOmRequest().getTruncateKeyRequest();
+    OzoneManagerProtocolProtos.KeyArgs keyArgs =
+        truncateKeyRequest.getKeyArgs();
+    Map<String, String> auditMap = buildKeyArgsAuditMap(keyArgs);
+
+    String volumeName = keyArgs.getVolumeName();
+    String bucketName = keyArgs.getBucketName();
+    String keyName = keyArgs.getKeyName();
+    long newLength = keyArgs.getNewLength();
+
+    OMMetrics omMetrics = ozoneManager.getMetrics();
+    omMetrics.incNumKeyTruncates();
+
+    AuditLogger auditLogger = ozoneManager.getAuditLogger();
+
+    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
+        getOmRequest());
+
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    boolean acquiredLock = false;
+    OMClientResponse omClientResponse = null;
+    IOException exception = null;
+    Result result = null;
+    OmVolumeArgs omVolumeArgs = null;
+    OmBucketInfo omBucketInfo = null;
+    try {
+      keyArgs = resolveBucketLink(ozoneManager, keyArgs, auditMap);
+      volumeName = keyArgs.getVolumeName();
+      bucketName = keyArgs.getBucketName();
+
+      // check Acls to see if user has access to perform truncate operation on
+      // the key
+      checkKeyAcls(ozoneManager, volumeName, bucketName, keyName,
+          IAccessAuthorizer.ACLType.WRITE, OzoneObj.ResourceType.KEY);
+
+      acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
+          volumeName, bucketName);
+
+      // Validate bucket and volume exists or not.
+      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      // Check if the key exists
+      String objectKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+          keyName);
+
+      // keyName should exist
+      OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(objectKey);
+      if (omKeyInfo == null) {
+        throw new OMException("Key not found " + keyName, KEY_NOT_FOUND);
+      }
+
+      // newLength should be less than the existed length
+      if (newLength >= omKeyInfo.getDataSize()) {
+        throw new OMException("Invalid truncate new length " + keyName,
+            INVALID_TRUNCATE_NEW_LENGTH);
+      }
+
+      omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
+      List<OmKeyLocationInfo> locationInfos =
+          omKeyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
+
+      omKeyInfo.addNewVersion(new ArrayList<>(), true);
+
+      List<OmKeyLocationInfo> newLocationInfos = new ArrayList<>();
+      long len = 0;
+      for (OmKeyLocationInfo locationInfo : locationInfos) {
+        long blockLen = locationInfo.getLength();
+        if (len + blockLen > newLength) {
+          blockLen = newLength - len;
+        }
+
+        newLocationInfos.add(new OmKeyLocationInfo.Builder()
+              .setPipeline(locationInfo.getPipeline())
+              .setBlockID(locationInfo.getBlockID())
+              .setLength(blockLen)
+              .setOffset(locationInfo.getOffset())
+              .setToken(locationInfo.getToken())
+              .build());
+
+        len += locationInfo.getLength();
+        if (len >= newLength) {
+          break;
+        }
+      }
+
+      long quotaReleased = omKeyInfo.getDataSize() - newLength;
+
+      omKeyInfo.appendNewBlocks(newLocationInfos, true);
+      omKeyInfo.setDataSize(newLength);
+
+      // Add to cache and override the existed entry
+      Table<String, OmKeyInfo> keyTable = omMetadataManager.getKeyTable();
+
+      keyTable.addCacheEntry(new CacheKey<>(objectKey),
+          new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
+
+      omVolumeArgs = getVolumeInfo(omMetadataManager, volumeName);
+      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+
+      // update usedBytes atomically.
+      omVolumeArgs.getUsedBytes().add(-quotaReleased);
+      omBucketInfo.getUsedBytes().add(-quotaReleased);
+
+      omClientResponse = new OMKeyTruncateResponse(omResponse
+          .setTruncateKeyResponse(TruncateKeyResponse.newBuilder()).build(),
+          omKeyInfo, omVolumeArgs, omBucketInfo);
+
+      result = Result.SUCCESS;
+    } catch (IOException ex) {
+      result = Result.FAILURE;
+      exception = ex;
+      omClientResponse = new OMKeyTruncateResponse(createErrorOMResponse(
+          omResponse, exception));
+    } finally {
+      addResponseToDoubleBuffer(trxnLogIndex, omClientResponse,
+            omDoubleBufferHelper);
+      if (acquiredLock) {
+        omMetadataManager.getLock().releaseWriteLock(BUCKET_LOCK, volumeName,
+            bucketName);
+      }
+    }
+
+    auditLog(auditLogger, buildAuditMessage(OMAction.TRUNCATE_KEY, auditMap,
+        exception, getOmRequest().getUserInfo()));
+
+    switch (result) {
+    case SUCCESS:
+      LOG.debug("Truncate Key is successfully completed for" +
+          "volume:{} bucket:{} key:{}. ",
+          volumeName, bucketName, keyName);
+      break;
+    case FAILURE:
+      ozoneManager.getMetrics().incNumKeyTruncateFails();
+      LOG.error("Truncate key failed for volume:{} bucket:{} key: {}.",
+          volumeName, bucketName, keyName);
+      break;
+    default:
+      LOG.error("Unrecognized Result for OMKeyRenameRequest: {}",
+          truncateKeyRequest);
+    }
+    return omClientResponse;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyTruncateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyTruncateResponse.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.key;
+
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMResponse;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+
+/**
+ * Response for TruncateKey request.
+ */
+@CleanupTableInfo(cleanupTables = {KEY_TABLE})
+public class OMKeyTruncateResponse extends OMClientResponse {
+
+  private OmKeyInfo omKeyInfo;
+  private OmVolumeArgs omVolumeArgs;
+  private OmBucketInfo omBucketInfo;
+
+  public OMKeyTruncateResponse(@Nonnull OMResponse omResponse,
+      @Nonnull OmKeyInfo omKeyInfo, @Nonnull OmVolumeArgs omVolumeArgs,
+      @Nonnull OmBucketInfo omBucketInfo) {
+    super(omResponse);
+    this.omKeyInfo = omKeyInfo;
+    this.omVolumeArgs = omVolumeArgs;
+    this.omBucketInfo = omBucketInfo;
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMKeyTruncateResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+
+    // For OmResponse with failure, this should do nothing. This method is
+    // not called in failure scenario in OM code.
+    String ozoneKey = omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
+        omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
+
+    // RocksDB.put can overwrite the duplicated key, so we do not need
+    // RocksDB.delete before RocksDB.put. But if we use other DB,
+    // maybe DB.put can not support overwrite, so before DB.put,
+    // we delete the existed key.
+    omMetadataManager.getKeyTable().deleteWithBatch(batchOperation, ozoneKey);
+    omMetadataManager.getKeyTable().putWithBatch(
+        batchOperation, ozoneKey, omKeyInfo);
+
+    // update volume usedBytes.
+    omMetadataManager.getVolumeTable().putWithBatch(batchOperation,
+        omMetadataManager.getVolumeKey(omVolumeArgs.getVolume()),
+        omVolumeArgs);
+    // update bucket usedBytes.
+    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
+        omMetadataManager.getBucketKey(omVolumeArgs.getVolume(),
+            omBucketInfo.getBucketName()), omBucketInfo);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -73,9 +73,17 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
  * Helper class to test OMClientRequest classes.
  */
 public final class TestOMRequestUtils {
+  private static final long DATA_SIZE = 1000L;
 
   private TestOMRequestUtils() {
     //Do nothing
+  }
+
+  /**
+   * Get data size of the key.
+   */
+  public static long getDataSize() {
+    return DATA_SIZE;
   }
 
   /**
@@ -264,7 +272,7 @@ public final class TestOMRequestUtils {
             new OmKeyLocationInfoGroup(0, new ArrayList<>())))
         .setCreationTime(creationTime)
         .setModificationTime(Time.now())
-        .setDataSize(1000L)
+        .setDataSize(getDataSize())
         .setReplicationType(replicationType)
         .setReplicationFactor(replicationFactor)
         .setObjectID(objectID)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -90,6 +90,8 @@ public class TestOMKeyRequest {
   protected long scmBlockSize = 1000L;
   protected long dataSize;
 
+  protected long truncateNewLength = 10;
+
   // Just setting ozoneManagerDoubleBuffer which does nothing.
   protected OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
       ((response, transactionIndex) -> {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyTruncateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyTruncateRequest.java
@@ -1,0 +1,209 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import java.util.UUID;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .TruncateKeyRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
+    .KeyArgs;
+
+/**
+ * Tests OmKeyTruncate request.
+ */
+public class TestOMKeyTruncateRequest extends TestOMKeyRequest {
+
+  @Test
+  public void testPreExecute() throws Exception {
+    doPreExecute(createTruncateKeyRequest(truncateNewLength));
+  }
+
+  @Test
+  public void testValidateAndUpdateCache() throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createTruncateKeyRequest(truncateNewLength));
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(modifiedOmRequest);
+
+    // Add volume, bucket and key entries to OM DB.
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, omMetadataManager);
+
+    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+
+    OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+
+    // As we added manually to key table.
+    Assert.assertNotNull(omKeyInfo);
+
+    OMClientResponse omClientResponse =
+        omKeyTruncateRequest.validateAndUpdateCache(ozoneManager,
+        100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+    // Now after calling validateAndUpdateCache, it should be deleted.
+
+    omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+
+    Assert.assertEquals(omKeyInfo.getDataSize(), truncateNewLength);
+    Assert.assertEquals(omKeyInfo.getKeyLocationVersions().size(), 2);
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithKeyNotFound() throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createTruncateKeyRequest(truncateNewLength));
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(modifiedOmRequest);
+
+    // Add only volume and bucket entry to DB.
+    // In actual implementation we don't check for bucket/volume exists
+    // during truncate key.
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    OMClientResponse omClientResponse =
+        omKeyTruncateRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createTruncateKeyRequest(truncateNewLength));
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(modifiedOmRequest);
+
+    OMClientResponse omClientResponse =
+        omKeyTruncateRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createTruncateKeyRequest(truncateNewLength));
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(modifiedOmRequest);
+
+    TestOMRequestUtils.addVolumeToDB(volumeName, omMetadataManager);
+
+    OMClientResponse omClientResponse =
+        omKeyTruncateRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  @Test
+  public void testValidateAndUpdateCacheWithInvalidNewLength()
+      throws Exception {
+    OMRequest modifiedOmRequest =
+        doPreExecute(createTruncateKeyRequest(
+            TestOMRequestUtils.getDataSize() + 10));
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(modifiedOmRequest);
+
+    // Add volume, bucket and key entries to OM DB.
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager);
+
+    TestOMRequestUtils.addKeyToTable(false, volumeName, bucketName, keyName,
+        clientID, replicationType, replicationFactor, omMetadataManager);
+
+    String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+
+    OmKeyInfo omKeyInfo = omMetadataManager.getKeyTable().get(ozoneKey);
+
+    // As we added manually to key table.
+    Assert.assertNotNull(omKeyInfo);
+
+    OMClientResponse omClientResponse =
+        omKeyTruncateRequest.validateAndUpdateCache(ozoneManager,
+            100L, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(
+        OzoneManagerProtocolProtos.Status.INVALID_TRUNCATE_NEW_LENGTH,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  /**
+   * This method calls preExecute and verify the modified request.
+   * @param originalOmRequest
+   * @return OMRequest - modified request returned from preExecute.
+   * @throws Exception
+   */
+  private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
+
+    OMKeyTruncateRequest omKeyTruncateRequest =
+        new OMKeyTruncateRequest(originalOmRequest);
+
+    OMRequest modifiedOmRequest = omKeyTruncateRequest.preExecute(ozoneManager);
+
+    // Will not be equal, as UserInfo will be set.
+    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+
+    return modifiedOmRequest;
+  }
+
+  /**
+   * Create OMRequest which encapsulates TruncateKeyRequest.
+   * @return OMRequest
+   */
+  private OMRequest createTruncateKeyRequest(long length) {
+    KeyArgs keyArgs = KeyArgs.newBuilder().setBucketName(bucketName)
+        .setVolumeName(volumeName).setKeyName(keyName)
+        .setNewLength(length).build();
+
+    TruncateKeyRequest truncateKeyRequest =
+        TruncateKeyRequest.newBuilder().setKeyArgs(keyArgs).build();
+
+    return OMRequest.newBuilder().setTruncateKeyRequest(truncateKeyRequest)
+        .setCmdType(OzoneManagerProtocolProtos.Type.TruncateKey)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. When OM receives truncate(key, newLength),in the keyTable, OM deletes the blocks which are fully truncated, and updates the block length which is partially truncated, then return success to client.

2. Ozone client read key according to the block length got from OM, which has already been implemented. 

3. So, with this PR, Ozone client can read the truncated key with newLength, when the truncate operation returns success.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4375

## How was this patch tested?

new UT and IT
