### PR TITLE
HDDS-4399. Safe mode rule for piplelines should only consider open pipelines.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
@@ -41,8 +41,7 @@ public class PipelineCodec implements Codec<Pipeline> {
   public Pipeline fromPersistedFormat(byte[] rawData) throws IOException {
     HddsProtos.Pipeline.Builder pipelineBuilder = HddsProtos.Pipeline
         .newBuilder(HddsProtos.Pipeline.PARSER.parseFrom(rawData));
-    Pipeline pipeline = Pipeline.getFromProtobuf(pipelineBuilder.setState(
-        HddsProtos.PipelineState.PIPELINE_ALLOCATED).build());
+    Pipeline pipeline = Pipeline.getFromProtobuf(pipelineBuilder.build());
     // When SCM is restarted, set Creation time with current time.
     pipeline.setCreationTimestamp(Instant.now());
     Preconditions.checkNotNull(pipeline);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -114,9 +114,11 @@ public class PipelineReportHandler implements
       }
       if (pipeline.isHealthy()) {
         pipelineManager.openPipeline(pipelineID);
-        if (pipelineAvailabilityCheck && scmSafeModeManager.getInSafeMode()) {
-          publisher.fireEvent(SCMEvents.OPEN_PIPELINE, pipeline);
-        }
+      }
+    }
+    if (pipeline.isHealthy()) {
+      if (pipelineAvailabilityCheck && scmSafeModeManager.getInSafeMode()) {
+        publisher.fireEvent(SCMEvents.OPEN_PIPELINE, pipeline);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -78,7 +78,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
     // We want to wait for RATIS THREE factor write pipelines
     int pipelineCount = pipelineManager.getPipelines(
         HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.THREE,
-        Pipeline.PipelineState.ALLOCATED).size();
+        Pipeline.PipelineState.OPEN).size();
 
     // This value will be zero when pipeline count is 0.
     // On a fresh installed cluster, there will be zero pipelines in the SCM
@@ -118,7 +118,6 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
     Preconditions.checkNotNull(pipeline);
     if (pipeline.getType() == HddsProtos.ReplicationType.RATIS &&
         pipeline.getFactor() == HddsProtos.ReplicationFactor.THREE &&
-        pipeline.isHealthy() &&
         !processedPipelineIDs.contains(pipeline.getId())) {
       getSafeModeMetrics().incCurrentHealthyPipelinesCount();
       currentHealthyPipelineCount++;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -131,6 +131,7 @@ public class TestSCMPipelineManager {
       Pipeline pipeline = pipelineManager
           .createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline.getId());
       pipelines.add(pipeline);
     }
     pipelineManager.close();
@@ -146,7 +147,8 @@ public class TestSCMPipelineManager {
     pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
         mockRatisProvider);
     for (Pipeline p : pipelines) {
-      pipelineManager.openPipeline(p.getId());
+      // After reload, pipelines should be in open state
+      Assert.assertTrue(pipelineManager.getPipeline(p.getId()).isOpen());
     }
     List<Pipeline> pipelineList =
         pipelineManager.getPipelines(HddsProtos.ReplicationType.RATIS);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -128,12 +128,15 @@ public class TestHealthyPipelineSafeModeRule {
       Pipeline pipeline1 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline3.getId());
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
           config, containers, pipelineManager, eventQueue);
@@ -204,12 +207,15 @@ public class TestHealthyPipelineSafeModeRule {
       Pipeline pipeline1 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.ONE);
+      pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
           pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
               HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline3.getId());
 
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -18,21 +18,24 @@
 package org.apache.hadoop.hdds.scm.safemode;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
-import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
+import org.apache.hadoop.hdds.scm.pipeline.*;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.test.GenericTestUtils;
 
@@ -52,6 +55,7 @@ public class TestOneReplicaPipelineSafeModeRule {
   private OneReplicaPipelineSafeModeRule rule;
   private SCMPipelineManager pipelineManager;
   private EventQueue eventQueue;
+  private MockNodeManager mockNodeManager;
 
   private void setup(int nodes, int pipelineFactorThreeCount,
       int pipelineFactorOneCount) throws Exception {
@@ -65,7 +69,7 @@ public class TestOneReplicaPipelineSafeModeRule {
 
     List<ContainerInfo> containers = new ArrayList<>();
     containers.addAll(HddsTestUtils.getContainerInfo(1));
-    MockNodeManager mockNodeManager = new MockNodeManager(true, nodes);
+    mockNodeManager = new MockNodeManager(true, nodes);
 
     eventQueue = new EventQueue();
 
@@ -112,9 +116,7 @@ public class TestOneReplicaPipelineSafeModeRule {
             LoggerFactory.getLogger(SCMSafeModeManager.class));
 
     List<Pipeline> pipelines = pipelineManager.getPipelines();
-    for (int i = 0; i < pipelineFactorThreeCount -1; i++) {
-      firePipelineEvent(pipelines.get(i));
-    }
+    firePipelineEvent(pipelines.subList(0, pipelineFactorThreeCount -1));
 
     // As 90% of 7 with ceil is 7, if we send 6 pipeline reports, rule
     // validate should be still false.
@@ -125,7 +127,8 @@ public class TestOneReplicaPipelineSafeModeRule {
     Assert.assertFalse(rule.validate());
 
     //Fire last pipeline event from datanode.
-    firePipelineEvent(pipelines.get(pipelineFactorThreeCount - 1));
+    firePipelineEvent(pipelines.subList(pipelineFactorThreeCount -1,
+            pipelineFactorThreeCount));
 
     GenericTestUtils.waitFor(() -> rule.validate(), 1000, 5000);
   }
@@ -150,10 +153,7 @@ public class TestOneReplicaPipelineSafeModeRule {
     List<Pipeline> pipelines =
         pipelineManager.getPipelines(HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.ONE);
-    for (int i = 0; i < pipelineCountOne; i++) {
-      firePipelineEvent(pipelines.get(i));
-    }
-
+    firePipelineEvent(pipelines);
     GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
         "reported count is 0"), 1000, 5000);
 
@@ -163,15 +163,14 @@ public class TestOneReplicaPipelineSafeModeRule {
     pipelines =
         pipelineManager.getPipelines(HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.THREE);
-    for (int i = 0; i < pipelineCountThree - 1; i++) {
-      firePipelineEvent(pipelines.get(i));
-    }
+    firePipelineEvent(pipelines.subList(0, pipelineCountThree -1));
 
     GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
         "reported count is 6"), 1000, 5000);
 
     //Fire last pipeline event from datanode.
-    firePipelineEvent(pipelines.get(pipelineCountThree - 1));
+    firePipelineEvent(pipelines.subList(pipelineCountThree -1,
+            pipelineCountThree));
 
     GenericTestUtils.waitFor(() -> rule.validate(), 1000, 5000);
   }
@@ -179,12 +178,45 @@ public class TestOneReplicaPipelineSafeModeRule {
   private void createPipelines(int count,
       HddsProtos.ReplicationFactor factor) throws Exception {
     for (int i = 0; i < count; i++) {
-      pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
-          factor);
+      Pipeline pipeline = pipelineManager.createPipeline(
+              HddsProtos.ReplicationType.RATIS, factor);
+      pipelineManager.openPipeline(pipeline.getId());
+
     }
   }
 
-  private void firePipelineEvent(Pipeline pipeline) {
-    eventQueue.fireEvent(SCMEvents.OPEN_PIPELINE, pipeline);
+  private void firePipelineEvent(List<Pipeline> pipelines) {
+    Map<DatanodeDetails, PipelineReportsProto.Builder>
+            reportMap = new HashMap<>();
+    for (Pipeline pipeline : pipelines) {
+      for (DatanodeDetails dn : pipeline.getNodes()) {
+        reportMap.putIfAbsent(dn, PipelineReportsProto.newBuilder());
+      }
+    }
+    for (DatanodeDetails dn : reportMap.keySet()) {
+      List<PipelineReport> reports = new ArrayList<>();
+      for (PipelineID pipeline : mockNodeManager.
+              getNode2PipelineMap().getPipelines(dn.getUuid())) {
+        try {
+          if (!pipelines.contains(pipelineManager.getPipeline(pipeline))) {
+            continue;
+          }
+        } catch (PipelineNotFoundException pnfe) {
+          continue;
+        }
+        HddsProtos.PipelineID pipelineID = pipeline.getProtobuf();
+        reports.add(PipelineReport.newBuilder()
+                .setPipelineID(pipelineID)
+                .setIsLeader(false)
+                .setBytesWritten(0)
+                .build());
+      }
+      PipelineReportsProto.Builder pipelineReportsProto =
+              PipelineReportsProto.newBuilder();
+      pipelineReportsProto.addAllPipelineReport(reports);
+      eventQueue.fireEvent(SCMEvents.PIPELINE_REPORT, new
+              SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode(dn,
+              pipelineReportsProto.build()));
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -207,7 +207,7 @@ public class TestOneReplicaPipelineSafeModeRule {
         HddsProtos.PipelineID pipelineID = pipeline.getProtobuf();
         reports.add(PipelineReport.newBuilder()
                 .setPipelineID(pipelineID)
-                .setIsLeader(false)
+                .setIsLeader(true)
                 .setBytesWritten(0)
                 .build());
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -459,13 +459,13 @@ public class TestSCMSafeModeManager {
     for (DatanodeDetails dn : pipeline.getNodes()) {
       List<StorageContainerDatanodeProtocolProtos.
               PipelineReport> reports = new ArrayList<>();
-        HddsProtos.PipelineID pipelineID = pipeline.getId().getProtobuf();
-        reports.add(StorageContainerDatanodeProtocolProtos
-                .PipelineReport.newBuilder()
-                .setPipelineID(pipelineID)
-                .setIsLeader(true)
-                .setBytesWritten(0)
-                .build());
+      HddsProtos.PipelineID pipelineID = pipeline.getId().getProtobuf();
+      reports.add(StorageContainerDatanodeProtocolProtos
+              .PipelineReport.newBuilder()
+              .setPipelineID(pipelineID)
+              .setIsLeader(true)
+              .setBytesWritten(0)
+              .build());
       StorageContainerDatanodeProtocolProtos
               .PipelineReportsProto.Builder pipelineReportsProto =
               StorageContainerDatanodeProtocolProtos

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -30,19 +30,18 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
-import org.apache.hadoop.hdds.scm.pipeline.MockRatisPipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineProvider;
-import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager;
+import org.apache.hadoop.hdds.scm.pipeline.*;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -364,8 +363,10 @@ public class TestSCMSafeModeManager {
     pipelineManager.allowPipelineCreation();
 
     for (int i=0; i < pipelineCount; i++) {
-      pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
+      Pipeline pipeline = pipelineManager.
+              createPipeline(HddsProtos.ReplicationType.RATIS,
           HddsProtos.ReplicationFactor.THREE);
+      pipelineManager.openPipeline(pipeline.getId());
     }
 
     for (ContainerInfo container : containers) {
@@ -454,6 +455,27 @@ public class TestSCMSafeModeManager {
     pipelineManager.openPipeline(pipeline.getId());
     queue.fireEvent(SCMEvents.OPEN_PIPELINE,
         pipelineManager.getPipeline(pipeline.getId()));
+
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      List<StorageContainerDatanodeProtocolProtos.
+              PipelineReport> reports = new ArrayList<>();
+        HddsProtos.PipelineID pipelineID = pipeline.getId().getProtobuf();
+        reports.add(StorageContainerDatanodeProtocolProtos
+                .PipelineReport.newBuilder()
+                .setPipelineID(pipelineID)
+                .setIsLeader(true)
+                .setBytesWritten(0)
+                .build());
+      StorageContainerDatanodeProtocolProtos
+              .PipelineReportsProto.Builder pipelineReportsProto =
+              StorageContainerDatanodeProtocolProtos
+                      .PipelineReportsProto.newBuilder();
+      pipelineReportsProto.addAllPipelineReport(reports);
+      queue.fireEvent(SCMEvents.PIPELINE_REPORT, new
+              SCMDatanodeHeartbeatDispatcher
+                      .PipelineReportFromDatanode(dn,
+              pipelineReportsProto.build()));
+    }
   }
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -29,7 +29,9 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto
         .HddsProtos.ReplicationFactor.THREE;
@@ -65,6 +67,8 @@ public class TestSCMRestart {
   @BeforeClass
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1000,
+            TimeUnit.MILLISECONDS);
     int numOfNodes = 4;
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(numOfNodes)
@@ -80,9 +84,11 @@ public class TestSCMRestart {
     ratisPipeline1 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
         RATIS, THREE, "Owner1").getPipelineID());
+    pipelineManager.openPipeline(ratisPipeline1.getId());
     ratisPipeline2 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
         RATIS, ONE, "Owner2").getPipelineID());
+    pipelineManager.openPipeline(ratisPipeline2.getId());
     // At this stage, there should be 2 pipeline one with 1 open container
     // each. Try restarting the SCM and then discover that pipeline are in
     // correct state.


### PR DESCRIPTION


## What changes were proposed in this pull request?
Currently, for safe mode we consider all pipelines existing in DB for safe mode exit criteria. It ma happen that, SCM has the pipelines craeted , but none of the participants datanodes ever created these datanodes. In such cases, SCM fails to come out of safemode as these pipelines are never reported back to SCM.

The idea here is to consider pipelines which are marked open during SCM startup.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4399

## How was this patch tested?
Added unit tests

