### PR TITLE
HDDS-4363. Add metric to track the number of RocksDB open/close operations.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Striped;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -33,6 +34,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaOneImpl;
 import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
+import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,7 @@ public final class ContainerCache extends LRUMap {
   private static ContainerCache cache;
   private static final float LOAD_FACTOR = 0.75f;
   private final Striped<Lock> rocksDBLock;
+  private final ContainerCacheMetrics metrics;
   /**
    * Constructs a cache that holds DBHandle references.
    */
@@ -53,6 +56,12 @@ public final class ContainerCache extends LRUMap {
       scanUntilRemovable) {
     super(maxSize, loadFactor, scanUntilRemovable);
     rocksDBLock = Striped.lazyWeakLock(stripes);
+    metrics = ContainerCacheMetrics.create();
+  }
+
+  @VisibleForTesting
+  public ContainerCacheMetrics getMetrics() {
+    return this.metrics;
   }
 
   /**
@@ -86,7 +95,7 @@ public final class ContainerCache extends LRUMap {
       while (iterator.hasNext()) {
         iterator.next();
         ReferenceCountedDB db = (ReferenceCountedDB) iterator.getValue();
-        Preconditions.checkArgument(db.cleanup(), "refCount:",
+        Preconditions.checkArgument(cleanupDb(db), "refCount:",
             db.getReferenceCount());
       }
       // reset the cache
@@ -104,7 +113,8 @@ public final class ContainerCache extends LRUMap {
     ReferenceCountedDB db = (ReferenceCountedDB) entry.getValue();
     lock.lock();
     try {
-      return db.cleanup();
+      metrics.incNumCacheEvictions();
+      return cleanupDb(db);
     } finally {
       lock.unlock();
     }
@@ -130,19 +140,24 @@ public final class ContainerCache extends LRUMap {
     ReferenceCountedDB db;
     Lock containerLock = rocksDBLock.get(containerDBPath);
     containerLock.lock();
+    metrics.incNumDbGetOps();
     try {
       lock.lock();
       try {
         db = (ReferenceCountedDB) this.get(containerDBPath);
         if (db != null) {
+          metrics.incNumCacheHits();
           db.incrementReference();
           return db;
+        } else {
+          metrics.incNumCacheMisses();
         }
       } finally {
         lock.unlock();
       }
 
       try {
+        long start = Time.monotonicNow();
         DatanodeStore store;
 
         if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
@@ -157,6 +172,7 @@ public final class ContainerCache extends LRUMap {
         }
 
         db = new ReferenceCountedDB(store, containerDBPath);
+        metrics.incDbOpenLatency(Time.monotonicNow() - start);
       } catch (Exception e) {
         LOG.error("Error opening DB. Container:{} ContainerPath:{}",
             containerID, containerDBPath, e);
@@ -171,7 +187,7 @@ public final class ContainerCache extends LRUMap {
           // increment the reference before returning the object
           currentDB.incrementReference();
           // clean the db created in previous step
-          db.cleanup();
+          cleanupDb(db);
           return currentDB;
         } else {
           this.put(containerDBPath, db);
@@ -197,13 +213,22 @@ public final class ContainerCache extends LRUMap {
     try {
       ReferenceCountedDB db = (ReferenceCountedDB)this.get(containerDBPath);
       if (db != null) {
-        Preconditions.checkArgument(db.cleanup(), "refCount:",
+        Preconditions.checkArgument(cleanupDb(db), "refCount:",
             db.getReferenceCount());
       }
       this.remove(containerDBPath);
     } finally {
       lock.unlock();
     }
+  }
+
+  private boolean cleanupDb(ReferenceCountedDB db) {
+    long time = Time.monotonicNow();
+    boolean ret = db.cleanup();
+    if (ret) {
+      metrics.incDbCloseLatency(Time.monotonicNow() - time);
+    }
+    return ret;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -48,7 +48,7 @@ public final class ContainerCache extends LRUMap {
   private static ContainerCache cache;
   private static final float LOAD_FACTOR = 0.75f;
   private final Striped<Lock> rocksDBLock;
-  private final ContainerCacheMetrics metrics;
+  private static ContainerCacheMetrics metrics;
   /**
    * Constructs a cache that holds DBHandle references.
    */
@@ -56,12 +56,11 @@ public final class ContainerCache extends LRUMap {
       scanUntilRemovable) {
     super(maxSize, loadFactor, scanUntilRemovable);
     rocksDBLock = Striped.lazyWeakLock(stripes);
-    metrics = ContainerCacheMetrics.create();
   }
 
   @VisibleForTesting
   public ContainerCacheMetrics getMetrics() {
-    return this.metrics;
+    return metrics;
   }
 
   /**
@@ -80,6 +79,7 @@ public final class ContainerCache extends LRUMap {
           OzoneConfigKeys.OZONE_CONTAINER_CACHE_LOCK_STRIPES,
           OzoneConfigKeys.OZONE_CONTAINER_CACHE_LOCK_STRIPES_DEFAULT);
       cache = new ContainerCache(cacheSize, stripes, LOAD_FACTOR, true);
+      metrics = ContainerCacheMetrics.create();
     }
     return cache;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.metrics2.lib.MutableRate;
 /**
  * Metrics for the usage of ContainerDB.
  */
-public class ContainerCacheMetrics {
+public final class ContainerCacheMetrics {
 
   private final String name;
   private final MetricsSystem ms;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.utils;
+
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+import org.apache.hadoop.metrics2.lib.MutableRate;
+
+/**
+ * Metrics for the usage of ContainerDB.
+ */
+public class ContainerCacheMetrics {
+
+  private final String name;
+  private final MetricsSystem ms;
+
+  @Metric("Rate to measure the db open latency")
+  private MutableRate dbOpenLatency;
+
+  @Metric("Rate to measure the db close latency")
+  private MutableRate dbCloseLatency;
+
+  @Metric("Number of Container Cache Hits")
+  private MutableCounterLong numCacheHits;
+
+  @Metric("Number of Container Cache Misses")
+  private MutableCounterLong numCacheMisses;
+
+  @Metric("Number of DB.get Ops")
+  private MutableCounterLong numDbGetOps;
+
+  @Metric("Number of DB.remove Ops")
+  private MutableCounterLong numDbRemoveOps;
+
+  @Metric("Number of Container Cache Evictions")
+  private MutableCounterLong numCacheEvictions;
+
+  private ContainerCacheMetrics(String name, MetricsSystem ms) {
+    this.name = name;
+    this.ms = ms;
+  }
+
+  public static ContainerCacheMetrics create() {
+    MetricsSystem ms = DefaultMetricsSystem.instance();
+    String name = "ContainerCacheMetrics";
+
+    return ms.register(name, "null", new ContainerCacheMetrics(name, ms));
+  }
+
+  public void incNumDbGetOps() {
+    numDbGetOps.incr();
+  }
+
+  public void incNumDbRemoveOps() {
+    numDbRemoveOps.incr();
+  }
+
+  public void incNumCacheMisses() {
+    numCacheMisses.incr();
+  }
+
+  public void incNumCacheHits() {
+    numCacheHits.incr();
+  }
+
+  public void incNumCacheEvictions() {
+    numCacheEvictions.incr();
+  }
+
+  public void incDbCloseLatency(long millis) {
+    dbCloseLatency.add(millis);
+  }
+
+  public void incDbOpenLatency(long millis) {
+    dbOpenLatency.add(millis);
+  }
+
+  public long getNumDbGetOps() {
+    return numDbGetOps.value();
+  }
+
+  public long getNumDbRemoveOps() {
+    return numDbRemoveOps.value();
+  }
+
+  public long getNumCacheMisses() {
+    return numCacheMisses.value();
+  }
+
+  public long getNumCacheHits() {
+    return numCacheHits.value();
+  }
+
+  public long getNumCacheEvictions() {
+    return numCacheEvictions.value();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
While benchmarking Ozone performance, it was realized RocksDB open/close operations have impact on performance.
Adding metrics on these operations will help understand DataNode performance problems.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4363

## How was this patch tested?
Modified TestContainerCache
