### PR TITLE
HDDS-4405. Proxy failover is logging with out trying all OMS.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -214,7 +214,7 @@ public class OMFailoverProxyProvider implements
     try {
       OzoneManagerProtocolPB proxy = createOMProxy(address);
       // Create proxyInfo here, to make it work with all Hadoop versions.
-      proxyInfo = new ProxyInfo<>(proxy, omProxyInfos.toString());
+      proxyInfo = new ProxyInfo<>(proxy, omProxyInfo.toString());
       omProxies.put(nodeId, proxyInfo);
     } catch (IOException ioe) {
       LOG.error("{} Failed to create RPC proxy to OM at {}",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update ProxyInfo with specific OM information which will help in skipping the retry log during the first time fail overs, tilll it finds leader OM.
Skip Retry INFO logging on the first failover from a proxy is broken. This fixes the behavior which is broken by HDDS-4292. For more info refer to this https://github.com/apache/ozone/pull/1531#issuecomment-718857999 link.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4405

## How was this patch tested?

Tested it on the deployed ozone cluster.
