### PR TITLE
HDDS-4408: Datanode State Machine Thread should keep alive during the whole lifetime of Datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.ratis.util.ExitUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -410,6 +411,11 @@ public class DatanodeStateMachine implements Closeable {
     stateMachineThread =  new ThreadFactoryBuilder()
         .setDaemon(true)
         .setNameFormat("Datanode State Machine Thread - %d")
+        .setUncaughtExceptionHandler((Thread t, Throwable ex) -> {
+          String message = "Terminate Datanode, encounter uncaught exception"
+              + " in Datanode State Machine Thread";
+          ExitUtils.terminate(1, message, ex, LOG);
+        })
         .build().newThread(startStateMachineTask);
     stateMachineThread.start();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Datanode State Machine Thread should keep alive during the whole lifetime of Datanode, since it periodic generates heartbeat tasks which trigger DN to actively talk with DN. If this thread crashes, DN will become a zombie: although it is alive, heartbeats between itself and SCM are stopped.

In Tencent internal production environment, we got several dead DNs which can never come back without a restart.
 
We found that the thread "Datanode State Machine Thread - 0" does not exist in the output of jstack, thus no HeartbeatEndpointTask will be created,  this DN will soon become dead and can not recover unless being restarted.
 
After checked the .out log, we saw that OOM occurred in thread "Datanode State Machine Thread", which should be responsible for this issue:

```
300010.579: Total time for which application threads were stopped: 3.0848769 seconds, Stopping threads took: 0.0000943 seconds
Exception in thread "Datanode State Machine Thread - 0" java.lang.OutOfMemoryError: Java heap space
300010.579: Application time: 0.0001554 seconds
300010.580: Total time for which application threads were stopped: 0.0015600 seconds, Stopping threads took: 0.0002747 seconds
300010.581: Application time: 0.0004684 seconds
{Heap before GC invocations=13766 (full 11664):
 PSYoungGen total 3441664K, used 3388416K [0x000000072ab00000, 0x0000000800000000, 0x0000000800000000)
 eden space 3388416K, 100% used [0x000000072ab00000,0x00000007f9800000,0x00000007f9800000)
 from space 53248K, 0% used [0x00000007fcc00000,0x00000007fcc00000,0x0000000800000000)
 to space 53248K, 0% used [0x00000007f9800000,0x00000007f9800000,0x00000007fcc00000)
 ParOldGen total 6990848K, used 6990848K [0x0000000580000000, 0x000000072ab00000, 0x000000072ab00000)
 object space 6990848K, 100% used [0x0000000580000000,0x000000072ab00000,0x000000072ab00000)
 Metaspace used 55150K, capacity 57816K, committed 59224K, reserved 1101824K
 class space used 5922K, capacity 6372K, committed 6744K, reserved 1048576K
```

BTW, after running DN for more than a week, we see a lot of "java.lang.OutOfMemoryError: GC overhead limit exceeded" in DN's log. Since we configured a dead Recon, we guess this could be an evidence for HDDS-4404.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4408

## How was this patch tested?

CI