### PR TITLE
HDDS-4413. Container replication should fail in case of import failure.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.container.replication;
 
 import java.io.FileInputStream;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -43,7 +44,7 @@ import org.slf4j.LoggerFactory;
  */
 public class DownloadAndImportReplicator implements ContainerReplicator {
 
-  private static final Logger LOG =
+  public static final Logger LOG =
       LoggerFactory.getLogger(DownloadAndImportReplicator.class);
 
   private final ContainerSet containerSet;
@@ -65,7 +66,8 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
     this.packer = packer;
   }
 
-  public void importContainer(long containerID, Path tarFilePath) {
+  public void importContainer(long containerID, Path tarFilePath)
+      throws IOException {
     try {
       ContainerData originalContainerData;
       try (FileInputStream tempContainerTarStream = new FileInputStream(
@@ -89,6 +91,7 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
       LOG.error(
           "Can't import the downloaded container data id=" + containerID,
           e);
+      throw e;
     } finally {
       try {
         Files.delete(tarFilePath);
@@ -122,7 +125,7 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
       LOG.info("Container {} is replicated successfully", containerID);
       task.setStatus(Status.DONE);
     } catch (Exception e) {
-      LOG.error("Container replication was unsuccessful .", e);
+      LOG.error("Container replication was unsuccessful.", e);
       task.setStatus(Status.FAILED);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -87,11 +87,6 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
         containerSet.addContainer(container);
       }
 
-    } catch (Exception e) {
-      LOG.error(
-          "Can't import the downloaded container data id=" + containerID,
-          e);
-      throw e;
     } finally {
       try {
         Files.delete(tarFilePath);
@@ -125,7 +120,7 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
       LOG.info("Container {} is replicated successfully", containerID);
       task.setStatus(Status.DONE);
     } catch (Exception e) {
-      LOG.error("Container replication was unsuccessful.", e);
+      LOG.error("Container {} replication was unsuccessful.", containerID, e);
       task.setStatus(Status.FAILED);
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -188,7 +188,7 @@ public class TestReplicationSupervisor {
     SimpleContainerDownloader moc =
         Mockito.mock(SimpleContainerDownloader.class);
     CompletableFuture<Path> res = new CompletableFuture<>();
-    res.complete(Paths.get("file:/tmp/file"));
+    res.complete(Paths.get("file:/tmp/no-such-file"));
     Mockito.when(
         moc.getContainerDataFromReplicas(Mockito.anyLong(), Mockito.anyList()))
         .thenReturn(res);
@@ -205,7 +205,7 @@ public class TestReplicationSupervisor {
     Assert.assertEquals(1, supervisor.getReplicationFailureCount());
     Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
     Assert.assertTrue(logCapturer.getOutput()
-        .contains("Container replication was unsuccessful."));
+        .contains("Container 1 replication was unsuccessful."));
   }
 
   private ReplicationSupervisor supervisorWithSuccessfulReplicator() {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -18,9 +18,12 @@
 
 package org.apache.hadoop.ozone.container.replication;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -33,12 +36,14 @@ import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import javax.annotation.Nonnull;
 
@@ -171,6 +176,36 @@ public class TestReplicationSupervisor {
     } finally {
       supervisor.stop();
     }
+  }
+
+  @Test
+  public void testDownloadAndImportReplicatorFailure() {
+    ReplicationSupervisor supervisor =
+        new ReplicationSupervisor(set, mutableReplicator,
+            newDirectExecutorService());
+
+    // Mock to fetch an exception in the importContainer method.
+    SimpleContainerDownloader moc =
+        Mockito.mock(SimpleContainerDownloader.class);
+    CompletableFuture<Path> res = new CompletableFuture<>();
+    res.complete(Paths.get("file:/tmp/file"));
+    Mockito.when(
+        moc.getContainerDataFromReplicas(Mockito.anyLong(), Mockito.anyList()))
+        .thenReturn(res);
+
+    ContainerReplicator replicatorFactory =
+        new DownloadAndImportReplicator(set, null, moc, null);
+
+    replicatorRef.set(replicatorFactory);
+
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(DownloadAndImportReplicator.LOG);
+
+    supervisor.addTask(new ReplicationTask(1L, emptyList()));
+    Assert.assertEquals(1, supervisor.getReplicationFailureCount());
+    Assert.assertEquals(0, supervisor.getReplicationSuccessCount());
+    Assert.assertTrue(logCapturer.getOutput()
+        .contains("Container replication was unsuccessful."));
   }
 
   private ReplicationSupervisor supervisorWithSuccessfulReplicator() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In case of a failure during the importContainer phase the replication task status should be failed rather than being success.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4413

## How was this patch tested?

Added a UT in TestReplicationSupervisor
