### PR TITLE
HDDS-4418. TestContainerMetrics is flaky

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -17,27 +17,22 @@
 
 package org.apache.hadoop.ozone.container.metrics;
 
-import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
-import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
-import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
-import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
-import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-
-import com.google.common.collect.Maps;
+import java.io.File;
+import java.util.Map;
+import java.util.UUID;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.client.BlockID;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
-import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerCommandRequestProto;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
@@ -50,23 +45,23 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerGrpc;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.replication.GrpcReplicationService;
 import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
 import org.apache.hadoop.test.GenericTestUtils;
 
+import com.google.common.collect.Maps;
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
+import static org.apache.hadoop.test.MetricsAsserts.assertQuantileGauges;
+import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import org.junit.Assert;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import java.io.File;
-import java.util.Map;
-import java.util.UUID;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.Mockito;
 
 /**
  * Test for metrics published by storage containers.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/metrics/TestContainerMetrics.java
@@ -182,9 +182,7 @@ public class TestContainerMetrics {
       assertCounter("ReadOpCount", 1L, volumeIOMetrics);
       assertCounter("WriteBytes", 1024L, volumeIOMetrics);
       assertCounter("WriteOpCount", 1L, volumeIOMetrics);
-      // ReadTime and WriteTime vary from run to run, only checking non-zero
-      Assert.assertNotEquals(0L, getLongCounter("ReadTime", volumeIOMetrics));
-      Assert.assertNotEquals(0L, getLongCounter("WriteTime", volumeIOMetrics));
+
     } finally {
       if (client != null) {
         client.close();


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestContainerMetrics is flaky since HDDS-4359. Failed in following master builds:

```
2020/10/26/3569/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/27/3581/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/28/3591/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/29/3619/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/30/3628/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/30/3642/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/31/3650/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
2020/10/31/3654/it-ozone/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.container.metrics.TestContainerMetrics.xml
```

Some of the added assertions couldn't be guaranteed all the time:

```java
      // ReadTime and WriteTime vary from run to run, only checking non-zero
      Assert.assertNotEquals(0L, getLongCounter("ReadTime", volumeIOMetrics));
      Assert.assertNotEquals(0L, getLongCounter("WriteTime", volumeIOMetrics));
```

In lucky case the read/write time can be zero.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4418

## How was this patch tested?

Two assertions are removed. It's a safe modification.