### PR TITLE
HDDS-4337. Implement RocksDB options cache for new datanode DB utilities.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -343,10 +343,10 @@ public final class OzoneConfigKeys {
   public static final double
       HDDS_DATANODE_STORAGE_UTILIZATION_CRITICAL_THRESHOLD_DEFAULT = 0.95;
 
+  public static final String HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE =
+      "hdds.datanode.metadata.rocksdb.cache.size";
   public static final String
-      HDDS_DATANODE_METADATA_CACHE_SIZE = "hdds.datanode.metadata.cache.size";
-  public static final String
-      HDDS_DATANODE_CACHE_SIZE_DEFAULT = "64MB";
+      HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT = "64MB";
 
   public static final String OZONE_SECURITY_ENABLED_KEY =
       "ozone.security.enabled";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -343,6 +343,11 @@ public final class OzoneConfigKeys {
   public static final double
       HDDS_DATANODE_STORAGE_UTILIZATION_CRITICAL_THRESHOLD_DEFAULT = 0.95;
 
+  public static final String
+      HDDS_DATANODE_METADATA_CACHE_SIZE = "hdds.datanode.metadata.cache.size";
+  public static final String
+      HDDS_DATANODE_CACHE_SIZE_DEFAULT = "64MB";
+
   public static final String OZONE_SECURITY_ENABLED_KEY =
       "ozone.security.enabled";
   public static final boolean OZONE_SECURITY_ENABLED_DEFAULT = false;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1279,6 +1279,16 @@
   </property>
 
   <property>
+    <name>hdds.datanode.metadata.cache.size</name>
+    <value>64MB</value>
+    <tag>OZONE, DATANODE, MANAGEMENT</tag>
+    <description>
+        Size of the shared block metadata cache on each datanode. All
+        containers on a datanode will share this cache.
+    </description>
+  </property>
+
+  <property>
     <name>hdds.command.status.report.interval</name>
     <value>30s</value>
     <tag>OZONE, DATANODE, MANAGEMENT</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1279,12 +1279,12 @@
   </property>
 
   <property>
-    <name>hdds.datanode.metadata.cache.size</name>
+    <name>hdds.datanode.metadata.rocksdb.cache.size</name>
     <value>64MB</value>
     <tag>OZONE, DATANODE, MANAGEMENT</tag>
     <description>
-        Size of the shared block metadata cache on each datanode. All
-        containers on a datanode will share this cache.
+        Size of the block metadata cache shared among RocksDB instances on each
+        datanode. All containers on a datanode will share this cache.
     </description>
   </property>
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -107,7 +107,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       }
 
       this.store = DBStoreBuilder.newBuilder(config, dbDef)
-              .setDBOption(options)
+              .setDBOptions(options)
               .build();
 
       // Use the DatanodeTable wrapper to disable the table iterator on

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -26,9 +26,14 @@ import org.apache.hadoop.hdds.utils.db.*;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
+import org.rocksdb.LRUCache;
+import org.rocksdb.Options;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
+import org.rocksdb.util.SizeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +64,15 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private DBStore store;
   private final AbstractDatanodeDBDefinition dbDef;
   private final long containerID;
+  private static final ColumnFamilyOptions cfOptions;
+
+  static {
+    BlockBasedTableConfig table_config = new BlockBasedTableConfig();
+    table_config.setBlockCache(new LRUCache(8 * SizeUnit.MB));
+    Options options = new Options();
+    options.setTableFormatConfig(table_config);
+    cfOptions = new ColumnFamilyOptions(options);
+  }
 
   /**
    * Constructs the metadata store and starts the DB services.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -65,8 +65,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private DBStore store;
   private final AbstractDatanodeDBDefinition dbDef;
   private final long containerID;
-  private static final ColumnFamilyOptions cfOptions;
 
+  private static final ColumnFamilyOptions COLUMN_FAMILY_OPTIONS;
   private static final DBProfile DEFAULT_PROFILE = DBProfile.DISK;
   private static final long CACHE_SIZE = 8 * SizeUnit.MB;
 
@@ -79,8 +79,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
         .setPinL0FilterAndIndexBlocksInCache(true)
         .setFilterPolicy(new BloomFilter());
 
-    cfOptions = DEFAULT_PROFILE.getColumnFamilyOptions();
-    cfOptions.setTableFormatConfig(tableConfig);
+    COLUMN_FAMILY_OPTIONS = DEFAULT_PROFILE.getColumnFamilyOptions();
+    COLUMN_FAMILY_OPTIONS.setTableFormatConfig(tableConfig);
   }
 
   /**
@@ -116,7 +116,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
       this.store = DBStoreBuilder.newBuilder(config, dbDef)
               .setDBOptions(options)
-              .setDefaultCFOptions(cfOptions)
+              .setDefaultCFOptions(COLUMN_FAMILY_OPTIONS)
               .build();
 
       // Use the DatanodeTable wrapper to disable the table iterator on

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.*;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
@@ -51,6 +50,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT;
 
 /**
  * Implementation of the {@link DatanodeStore} interface that contains
@@ -226,8 +227,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private static ColumnFamilyOptions buildColumnFamilyOptions(
       ConfigurationSource config) {
     long cacheSize = (long) config.getStorageSize(
-        OzoneConfigKeys.HDDS_DATANODE_METADATA_CACHE_SIZE,
-        OzoneConfigKeys.HDDS_DATANODE_CACHE_SIZE_DEFAULT,
+        HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE,
+        HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT,
         StorageUnit.BYTES);
 
     // Enables static creation of RocksDB objects.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -94,7 +94,7 @@ public class TestKeyValueContainer {
   // Use one configuration object across parameterized runs of tests.
   // This preserves the column family options in the container options
   // cache for testContainersShareColumnFamilyOptions.
-  private static final OzoneConfiguration conf = new OzoneConfiguration();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
 
   public TestKeyValueContainer(ChunkLayOutVersion layout) {
     this.layout = layout;
@@ -109,7 +109,7 @@ public class TestKeyValueContainer {
   public void setUp() throws Exception {
     datanodeId = UUID.randomUUID();
     HddsVolume hddsVolume = new HddsVolume.Builder(folder.getRoot()
-        .getAbsolutePath()).conf(conf).datanodeUuid(datanodeId
+        .getAbsolutePath()).conf(CONF).datanodeUuid(datanodeId
         .toString()).build();
 
     volumeSet = mock(MutableVolumeSet.class);
@@ -122,14 +122,14 @@ public class TestKeyValueContainer {
         (long) StorageUnit.GB.toBytes(5), UUID.randomUUID().toString(),
         datanodeId.toString());
 
-    keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
+    keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
   }
 
   private void addBlocks(int count) throws Exception {
     long containerId = keyValueContainerData.getContainerID();
 
     try(ReferenceCountedDB metadataStore = BlockUtils.getDB(keyValueContainer
-        .getContainerData(), conf)) {
+        .getContainerData(), CONF)) {
       for (int i = 0; i < count; i++) {
         // Creating BlockData
         BlockID blockID = new BlockID(containerId, i);
@@ -186,7 +186,7 @@ public class TestKeyValueContainer {
     long numberOfKeysToWrite = 12;
     //write one few keys to check the key count after import
     try(ReferenceCountedDB metadataStore =
-        BlockUtils.getDB(keyValueContainerData, conf)) {
+        BlockUtils.getDB(keyValueContainerData, CONF)) {
       Table<String, BlockData> blockDataTable =
               metadataStore.getStore().getBlockDataTable();
 
@@ -199,7 +199,7 @@ public class TestKeyValueContainer {
       metadataStore.getStore().getMetadataTable()
               .put(OzoneConsts.BLOCK_COUNT, numberOfKeysToWrite);
     }
-    BlockUtils.removeDB(keyValueContainerData, conf);
+    BlockUtils.removeDB(keyValueContainerData, CONF);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("key1", "value1");
@@ -225,7 +225,7 @@ public class TestKeyValueContainer {
             keyValueContainerData.getLayOutVersion(),
             keyValueContainerData.getMaxSize(), UUID.randomUUID().toString(),
             datanodeId.toString());
-    KeyValueContainer container = new KeyValueContainer(containerData, conf);
+    KeyValueContainer container = new KeyValueContainer(containerData, CONF);
 
     HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
         .getVolumesList(), 1);
@@ -297,7 +297,7 @@ public class TestKeyValueContainer {
     keyValueContainerData.setState(ContainerProtos.ContainerDataProto.State
         .CLOSED);
     keyValueContainer = new KeyValueContainer(
-        keyValueContainerData, conf);
+        keyValueContainerData, CONF);
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
     keyValueContainer.delete();
 
@@ -376,7 +376,7 @@ public class TestKeyValueContainer {
     try {
       keyValueContainerData.setState(
           ContainerProtos.ContainerDataProto.State.CLOSED);
-      keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
+      keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
       keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
       Map<String, String> metadata = new HashMap<>();
       metadata.put(OzoneConsts.VOLUME, OzoneConsts.OZONE);
@@ -399,7 +399,7 @@ public class TestKeyValueContainer {
     // Create Container 1
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
     Assert.assertEquals(1, cachedOptions.size());
-    ColumnFamilyOptions options1 = cachedOptions.get(conf);
+    ColumnFamilyOptions options1 = cachedOptions.get(CONF);
     Assert.assertNotNull(options1);
 
     // Create Container 2
@@ -407,11 +407,11 @@ public class TestKeyValueContainer {
         layout,
         (long) StorageUnit.GB.toBytes(5), UUID.randomUUID().toString(),
         datanodeId.toString());
-    keyValueContainer = new KeyValueContainer(keyValueContainerData, conf);
+    keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
 
     Assert.assertEquals(1, cachedOptions.size());
-    ColumnFamilyOptions options2 = cachedOptions.get(conf);
+    ColumnFamilyOptions options2 = cachedOptions.get(CONF);
     Assert.assertNotNull(options2);
 
     // Column family options object should be reused.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -82,7 +82,6 @@ public class TestKeyValueContainer {
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
-  private OzoneConfiguration conf;
   private String scmId = UUID.randomUUID().toString();
   private VolumeSet volumeSet;
   private RoundRobinVolumeChoosingPolicy volumeChoosingPolicy;
@@ -91,6 +90,11 @@ public class TestKeyValueContainer {
   private UUID datanodeId;
 
   private final ChunkLayOutVersion layout;
+
+  // Use one configuration object across parameterized runs of tests.
+  // This preserves the column family options in the container options
+  // cache for testContainersShareColumnFamilyOptions.
+  private static final OzoneConfiguration conf = new OzoneConfiguration();
 
   public TestKeyValueContainer(ChunkLayOutVersion layout) {
     this.layout = layout;
@@ -103,7 +107,6 @@ public class TestKeyValueContainer {
 
   @Before
   public void setUp() throws Exception {
-    conf = new OzoneConfiguration();
     datanodeId = UUID.randomUUID();
     HddsVolume hddsVolume = new HddsVolume.Builder(folder.getRoot()
         .getAbsolutePath()).conf(conf).datanodeUuid(datanodeId
@@ -392,7 +395,6 @@ public class TestKeyValueContainer {
     // Get a read only view (not a copy) of the options cache.
     Map<ConfigurationSource, ColumnFamilyOptions> cachedOptions =
         AbstractDatanodeStore.getColumnFamilyOptionsCache();
-    Assert.assertTrue(cachedOptions.isEmpty());
 
     // Create Container 1
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
@@ -410,6 +412,7 @@ public class TestKeyValueContainer {
 
     Assert.assertEquals(1, cachedOptions.size());
     ColumnFamilyOptions options2 = cachedOptions.get(conf);
+    Assert.assertNotNull(options2);
 
     // Column family options object should be reused.
     Assert.assertSame(options1, options2);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -132,7 +132,7 @@ public final class DBStoreBuilder {
     LOG.debug("Default DB profile:{}", dbProfile);
 
     defaultDBOptions = dbProfile.getDBOptions();
-    setDefaultCfOptions(dbProfile.getColumnFamilyOptions());
+    setDefaultCFOptions(dbProfile.getColumnFamilyOptions());
   }
 
   private void applyDBDefinition(DBDefinition definition) {
@@ -215,7 +215,7 @@ public final class DBStoreBuilder {
     return this;
   }
 
-  public DBStoreBuilder setDefaultCfOptions(
+  public DBStoreBuilder setDefaultCFOptions(
       ColumnFamilyOptions cfOptions) {
     defaultCfOptions = cfOptions;
     return this;
@@ -233,7 +233,7 @@ public final class DBStoreBuilder {
    */
   public DBStoreBuilder setProfile(DBProfile prof) {
     setDBOptions(prof.getDBOptions());
-    setDefaultCfOptions(prof.getColumnFamilyOptions());
+    setDefaultCFOptions(prof.getColumnFamilyOptions());
     return this;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -227,6 +227,10 @@ public final class DBStoreBuilder {
     return this;
   }
 
+  /**
+   * Set the {@link DBOptions} and default {@link ColumnFamilyOptions} based
+   * on {@code prof}.
+   */
   public DBStoreBuilder setProfile(DBProfile prof) {
     setDBOptions(prof.getDBOptions());
     setDefaultCfOptions(prof.getColumnFamilyOptions());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -216,8 +216,8 @@ public final class DBStoreBuilder {
   }
 
   public DBStoreBuilder setDefaultCFOptions(
-      ColumnFamilyOptions cfOptions) {
-    defaultCfOptions = cfOptions;
+      ColumnFamilyOptions options) {
+    defaultCfOptions = options;
     return this;
   }
 
@@ -258,8 +258,7 @@ public final class DBStoreBuilder {
       if (options == null) {
         LOG.debug("using default column family options for table: {}", name);
         tableConfigs.add(new TableConfig(name, defaultCfOptions));
-      }
-      else {
+      } else {
         tableConfigs.add(new TableConfig(name, options));
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request

Add a cache of `ColumnFamilyOptions` objects to `AbstractDatanodeStore`, so that each `ConfigurationSource` object used to construct a container will result in the same RocksDB `ColumnFamilyOptions` object being used. Since the same configuration instance is used for all containers on a datanode, this results in all containers on a datanode using the same  `ColumnFamilyOptions`, and by extension the same RocksDB metadata cache. A configuration parameter is added for adjusting the size of this cache. Each RocksDB instance will have its own `DBOptions`, since this requires the use of RocksDB `Statistics` objects which are not thread safe and cannot be shared.

The `DBStoreBuilder` class was refactored to make configuration easier. It is now possible to use the same configurable column family options for all column families, and it is easier to reason about which configurations will be applied. It is no longer an error to register a table twice with the builder, the second call will simply override the first, which is usually the expected behavior in setters for builders. There should be no other functionality changes to this class.

## What is the link to the Apache JIRA

HDDS-4337

## How was this patch tested?

### Automated Testing

- `DBStoreBuilder` unit tests were updated.
- A unit test was added to `TestKeyValueContainer` to test that `ColumnFamilyOptions` objects are shared between containers with the same configuration.

### Manual Testing

Manual testing was also done with a docker cluster to verify that the same cache is used for all containers on a datanode. Steps:

1. Start an ozone docker cluster and enter a datanode.
2. Write 100 keys: `ozone freon ockg -n 100`
3. Close the pipeline those keys were written to.
    - `ozone admin pipeline list` to get the pipeline IDs.
    - `ozone admin pipeline close <id>` to close the pipeline.
4. Write 100 more keys.
5. Get the address of the cache object from the RocksDB log for each of the two containers:
`grep -A5 "block_cache:" /data/hdds/hdds/*/current/containerDir0/1/metadata/1-dn-container.db/LOG`
and
`grep -A5 "block_cache:" /data/hdds/hdds/*/current/containerDir0/2/metadata/2-dn-container.db/LOG`

- Make sure that the address listed after `block_cache:` is the same for both containers.

