### PR TITLE
HDDS-4421. Fix throwing INTERNAL_ERROR out of LOG.isDebugEnabled() check in OzoneClientProducer.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -132,8 +132,8 @@ public class OzoneClientProducer {
       // error.
       if (LOG.isDebugEnabled()) {
         LOG.debug("Error during Client Creation: ", t);
-        throw INTERNAL_ERROR;
       }
+      throw INTERNAL_ERROR;
     }
     return ozoneClient;
   }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Internal_Error need to be thrown outside of LOG.isDebugEnabled()  check.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4421

## How was this patch tested?

Existing tests.
