### PR TITLE
HDDS-4422. Fix TestMiniOzoneHACluster.testGetOMLeader()

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineFactory.java
@@ -46,7 +46,7 @@ public class PipelineFactory {
         new SimplePipelineProvider(nodeManager, stateManager));
     providers.put(ReplicationType.RATIS,
         new RatisPipelineProvider(nodeManager,
-            (PipelineStateManager) stateManager, conf,
+            stateManager, conf,
             eventPublisher));
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -59,7 +59,7 @@ public class RatisPipelineProvider extends PipelineProvider {
 
   @VisibleForTesting
   public RatisPipelineProvider(NodeManager nodeManager,
-      PipelineStateManager stateManager, ConfigurationSource conf,
+      StateManager stateManager, ConfigurationSource conf,
       EventPublisher eventPublisher) {
     super(nodeManager, stateManager);
     this.conf = conf;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/DefaultLeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/DefaultLeaderChoosePolicy.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
 
 import java.util.List;
+import org.apache.hadoop.hdds.scm.pipeline.StateManager;
 
 /**
  * The default leader choose policy.
@@ -31,7 +31,7 @@ import java.util.List;
 public class DefaultLeaderChoosePolicy extends LeaderChoosePolicy {
 
   public DefaultLeaderChoosePolicy(
-      NodeManager nodeManager, PipelineStateManager pipelineStateManager) {
+      NodeManager nodeManager, StateManager pipelineStateManager) {
     super(nodeManager, pipelineStateManager);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/LeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/LeaderChoosePolicy.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
 
 import java.util.List;
+import org.apache.hadoop.hdds.scm.pipeline.StateManager;
 
 /**
  * A {@link LeaderChoosePolicy} support choosing leader from datanode list.
@@ -29,10 +29,10 @@ import java.util.List;
 public abstract class LeaderChoosePolicy {
 
   private final NodeManager nodeManager;
-  private final PipelineStateManager pipelineStateManager;
+  private final StateManager pipelineStateManager;
 
   public LeaderChoosePolicy(
-      NodeManager nodeManager, PipelineStateManager pipelineStateManager) {
+      NodeManager nodeManager, StateManager pipelineStateManager) {
     this.nodeManager = nodeManager;
     this.pipelineStateManager = pipelineStateManager;
   }
@@ -49,7 +49,7 @@ public abstract class LeaderChoosePolicy {
     return nodeManager;
   }
 
-  protected PipelineStateManager getPipelineStateManager() {
+  protected StateManager getPipelineStateManager() {
     return pipelineStateManager;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/LeaderChoosePolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/LeaderChoosePolicyFactory.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
+import org.apache.hadoop.hdds.scm.pipeline.StateManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +45,7 @@ public final class LeaderChoosePolicyFactory {
 
   public static LeaderChoosePolicy getPolicy(
       ConfigurationSource conf, final NodeManager nodeManager,
-      final PipelineStateManager pipelineStateManager) throws SCMException {
+      final StateManager pipelineStateManager) throws SCMException {
     final Class<? extends LeaderChoosePolicy> policyClass = conf
         .getClass(ScmConfigKeys.OZONE_SCM_PIPELINE_LEADER_CHOOSING_POLICY,
             OZONE_SCM_PIPELINE_LEADER_CHOOSING_POLICY_DEFAULT,
@@ -53,7 +53,7 @@ public final class LeaderChoosePolicyFactory {
     Constructor<? extends LeaderChoosePolicy> constructor;
     try {
       constructor = policyClass.getDeclaredConstructor(NodeManager.class,
-          PipelineStateManager.class);
+          StateManager.class);
       LOG.info("Create leader choose policy of type {}",
           policyClass.getCanonicalName());
     } catch (NoSuchMethodException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/MinLeaderCountChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/MinLeaderCountChoosePolicy.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
+import org.apache.hadoop.hdds.scm.pipeline.StateManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +67,7 @@ public class MinLeaderCountChoosePolicy extends LeaderChoosePolicy {
 
   private Map<DatanodeDetails, Integer> getSuggestedLeaderCount(
       List<DatanodeDetails> dns, NodeManager nodeManager,
-      PipelineStateManager pipelineStateManager) {
+      StateManager pipelineStateManager) {
     Map<DatanodeDetails, Integer> suggestedLeaderCount = new HashMap<>();
     for (DatanodeDetails dn : dns) {
       suggestedLeaderCount.put(dn, 0);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockRatisPipelineProvider.java
@@ -39,7 +39,7 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
       NodeManager nodeManager, StateManager stateManager,
       ConfigurationSource conf, EventPublisher eventPublisher,
       boolean autoOpen) {
-    super(nodeManager, (PipelineStateManager) stateManager,
+    super(nodeManager, stateManager,
         conf, eventPublisher);
     autoOpenPipeline = autoOpen;
   }
@@ -47,14 +47,14 @@ public class MockRatisPipelineProvider extends RatisPipelineProvider {
   public MockRatisPipelineProvider(NodeManager nodeManager,
       StateManager stateManager,
       ConfigurationSource conf) {
-    super(nodeManager, (PipelineStateManager) stateManager,
+    super(nodeManager, stateManager,
         conf, new EventQueue());
   }
 
   public MockRatisPipelineProvider(
       NodeManager nodeManager, StateManager stateManager,
       ConfigurationSource conf, EventPublisher eventPublisher) {
-    super(nodeManager, (PipelineStateManager) stateManager,
+    super(nodeManager, stateManager,
         conf, eventPublisher);
     autoOpenPipeline = true;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManagerV2Impl;
 import org.apache.hadoop.hdds.scm.pipeline.RatisPipelineProvider;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.junit.Assert;
@@ -49,7 +49,7 @@ public class TestLeaderChoosePolicy {
   public void testDefaultPolicy() {
     RatisPipelineProvider ratisPipelineProvider = new RatisPipelineProvider(
         mock(NodeManager.class),
-        mock(PipelineStateManager.class),
+        mock(PipelineStateManagerV2Impl.class),
         conf,
         mock(EventPublisher.class));
     Assert.assertSame(
@@ -65,7 +65,7 @@ public class TestLeaderChoosePolicy {
             ".HelloWorld");
     new RatisPipelineProvider(
         mock(NodeManager.class),
-        mock(PipelineStateManager.class),
+        mock(PipelineStateManagerV2Impl.class),
         conf,
         mock(EventPublisher.class));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix TestMiniOzoneHACluster.testGetOMLeader(). 

```
    providers.put(ReplicationType.RATIS,
        new RatisPipelineProvider(nodeManager,
            (PipelineStateManager) stateManager, conf,
            stateManager, conf,
            eventPublisher));
```
Because PipelineStateManager has been changed to PipelineStateManagerV2Impl, so `(PipelineStateManager) stateManager` will fail due to `cannot cast to PipelineStateManager`.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4422

## How was this patch tested?

UT