### PR TITLE
HDDS-4425. NM container does not wait for RM due to typo

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/common/docker-image/docker-krb5/Dockerfile-krb5
+++ b/hadoop-ozone/dist/src/main/compose/common/docker-image/docker-krb5/Dockerfile-krb5
@@ -20,7 +20,7 @@ FROM openjdk:8u191-jdk-alpine3.9
 RUN apk add --no-cache bash ca-certificates openssl krb5-server krb5 wget && update-ca-certificates
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0/dumb-init_1.2.0_amd64
 RUN chmod +x /usr/local/bin/dumb-init
-RUN wget -O /root/issuer https://github.com/ajayydv/docker/raw/kdc/issuer
+RUN wget -c https://github.com/flokkr/issuer/releases/download/1.0.3/issuer_1.0.3_linux_amd64.tar.gz  -O - |  tar -xz -C /root
 RUN chmod +x /root/issuer
 WORKDIR /opt
 COPY krb5.conf /etc/

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
@@ -90,7 +90,7 @@ services:
       - ../common-config
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop2-@project.version@.jar
-      WAIT_FOR: rm:8088
+      WAITFOR: rm:8088
     command: ["yarn","nodemanager"]
 # Optional section: comment out this part to get DNS resolution for all the containers.
 #  dns:

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
@@ -96,5 +96,5 @@ services:
       - ../common-config
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
-      WAIT_FOR: rm:8088
+      WAITFOR: rm:8088
     command: ["yarn","nodemanager"]

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
       - ../common-config
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
-      WAIT_FOR: rm:8088
+      WAITFOR: rm:8088
     command: ["yarn","nodemanager"]
 # Optional section: comment out this part to get DNS resolution for all the containers.
 #    Add 127.0.0.1 (or the ip of your docker machine) to the resolv.conf to get local DNS resolution

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -125,7 +125,7 @@ services:
       - ./docker-config
     environment:
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
-      WAIT_FOR: rm:8088
+      WAITFOR: rm:8088
       KERBEROS_KEYTABS: nm HTTP
     command: ["yarn","nodemanager"]
   jhs:
@@ -143,7 +143,7 @@ services:
     environment:
       KERBEROS_KEYTABS: jhs HTTP
       HADOOP_CLASSPATH: /opt/ozone/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-@project.version@.jar
-      WAIT_FOR: rm:8088
+      WAITFOR: rm:8088
     command: ["yarn","timelineserver"]
 networks:
   ozone:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo which caused `nm` not to wait for `rm` container before startup.

https://issues.apache.org/jira/browse/HDDS-4425

## How was this patch tested?

Checked logs of CI run:

```
$ grep 'Waiting' docker-*
docker-hadoop27-hadoop27-mapreduce-rm.log:nm_1        | Waiting for rm:8088
docker-hadoop27-hadoop27-mapreduce-rm.log:om_1        | Waiting for the service scm:9876
docker-hadoop31-hadoop31-mapreduce-rm.log:nm_1        | Waiting for rm:8088
docker-hadoop31-hadoop31-mapreduce-rm.log:om_1        | Waiting for the service scm:9876
docker-hadoop32-hadoop32-mapreduce-rm.log:om_1        | Waiting for the service scm:9876
docker-hadoop32-hadoop32-mapreduce-rm.log:nm_1        | Waiting for rm:8088
docker-ozonesecure-mr-ozonesecure-mr-mapreduce-rm.log:jhs         | Waiting for rm:8088
docker-ozonesecure-mr-ozonesecure-mr-mapreduce-rm.log:nm_1        | Waiting for rm:8088
```

https://github.com/adoroszlai/hadoop-ozone/runs/1347111124