### PR TITLE
HDDS-4404. Datanode can go OOM when a Recon or SCM Server is very slow in processing reports

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -147,8 +147,12 @@ public class HeartbeatEndpointTask
       rpcEndpoint.setLastSuccessfulHeartbeat(ZonedDateTime.now());
       rpcEndpoint.zeroMissedCount();
     } catch (IOException ex) {
-      // put back the reports which failed to be sent
-      putBackReports(requestBuilder);
+      // don't resend reports to recon as it could be down for days
+      // DN is expected to work fine without recon and not go OOM
+      if (!rpcEndpoint.isPassive()) {
+        // put back the reports which failed to be sent
+        putBackReports(requestBuilder);
+      }
 
       rpcEndpoint.logIfNeeded(ex);
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`HeartbeatEndpointTask#call` should not resend reports to passive endpoints (Recon)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4404

## How was this patch tested?

No new test added. Existing ones should do.