### PR TITLE
HDDS-4431. Improve output message for key/bucket list command.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -118,7 +118,7 @@ Test native authorizer
     Execute         kdestroy
     Run Keyword     Kinit test user     testuser2    testuser2.keytab
     ${result} =     Execute And Ignore Error         ozone sh bucket list /${volume3}/
-                    Should contain      ${result}    PERMISSION_DENIED org.apache.hadoop.ozone.om.exceptions.OMException: User testuser2/scm@EXAMPLE.COM doesn't have LIST permission to access volume
+                    Should contain      ${result}    PERMISSION_DENIED User testuser2/scm@EXAMPLE.COM doesn't have LIST permission to access volume
     Execute         ozone sh volume addacl ${volume3} -a user:testuser2/scm@EXAMPLE.COM:l
     Execute         ozone sh bucket list /${volume3}/
     Execute         ozone sh volume getacl /${volume3}/

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Shell.java
@@ -44,16 +44,24 @@ public abstract class Shell extends GenericCli {
 
   @Override
   protected void printError(Throwable errorArg) {
+    OMException omException = null;
+
     if (errorArg instanceof OMException) {
-      if (isVerbose()) {
-        errorArg.printStackTrace(System.err);
-      } else {
-        OMException omException = (OMException) errorArg;
-        System.err.println(String
-            .format("%s %s", omException.getResult().name(),
-                omException.getMessage()));
-      }
+      omException = (OMException) errorArg;
+    } else if (errorArg.getCause() instanceof OMException) {
+      // If the OMException occurred in a method that could not throw a
+      // checked exception (like an Iterator implementation), it will be
+      // chained to an unchecked exception and thrown.
+      omException = (OMException) errorArg.getCause();
+    }
+
+    if (omException != null && !isVerbose()) {
+      // In non-verbose mode, reformat OMExceptions as error messages to the
+      // user.
+      System.err.println(String.format("%s %s", omException.getResult().name(),
+              omException.getMessage()));
     } else {
+      // Prints the stack trace when in verbose mode.
       super.printError(errorArg);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently when a user which doesn't have permission to list on a bucket, they get the following message to stderr:

```
$ ozone sh key list o3://ozone1/volume1/bucket1
PERMISSION_DENIED org.apache.hadoop.ozone.om.exceptions.OMException: User  <user> doesn't have LIST permission to access bucket
```

The `org.apache.hadoop.ozone.om.exceptions.OMException:` should not be displayed in the error message to make it consistent with other PERMISSION_DENIED messages we get with other commands where we don't have this Exception class shown.
 
### Cause

The `Shell#printError` applies special formatting to `OMException` instances in order to render them as error messages to the user. The `OMException`s generated by ACL failure in list commands, however, are thrown from an `Iterator` interface implementation. This requires the exceptions to be unchecked to not break the interface spec, so methods like `ObjectStore#getNextListOfVolumes` chain any `IOExceptions` (including `OMException`) to a `RuntimeException` before throwing. When `Shell#printError` received this, it determined the exception was not an instance of `OMException`, and used the printing format for all other exception types, which displays the exception name with the message. `Shell#printError` has been updated to check both the derived class and cause of the `Throwable` it receives to determine whether it should convert it to the user error message format or not. 

## What is the link to the Apache JIRA

HDDS-4431

## How was this patch tested?

Robot acceptance test updated with the expected output for list command on ACL failure.
