### PR TITLE
HDDS-4347.Make Ozone specific Trash remover multi threaded

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/conf/OMClientConfig.java
@@ -36,6 +36,8 @@ import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 public class OMClientConfig {
 
   public static final String OM_CLIENT_RPC_TIME_OUT = "rpc.timeout";
+  public static final String OM_TRASH_EMPTIER_CORE_POOL_SIZE
+      = "trash.core.pool.size";
 
   @Config(key = OM_CLIENT_RPC_TIME_OUT,
       defaultValue = "15m",
@@ -51,6 +53,21 @@ public class OMClientConfig {
   )
   private long rpcTimeOut = 15 * 60 * 1000;
 
+  @Config(key = OM_TRASH_EMPTIER_CORE_POOL_SIZE,
+      defaultValue = "5",
+      type = ConfigType.INT,
+      tags = {OZONE, OM, CLIENT},
+      description = "Total number of threads in pool for the Trash Emptier")
+  private int trashEmptierPoolSize = 5;
+
+
+  public int getTrashEmptierPoolSize() {
+    return trashEmptierPoolSize;
+  }
+
+  public void setTrashEmptierPoolSize(int trashEmptierPoolSize) {
+    this.trashEmptierPoolSize = trashEmptierPoolSize;
+  }
 
   public long getRpcTimeOut() {
     return rpcTimeOut;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -28,7 +28,16 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.InvalidPathException;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.Trash;
+import org.apache.hadoop.fs.TrashPolicy;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -24,15 +24,20 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.TrashPolicyDefault;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.conf.OMClientConfig;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +59,8 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
 
   private static final Path CURRENT = new Path("Current");
 
+  private final static int TRASH_EMPTIER_CORE_POOL_SIZE = 5;
+
   private static final FsPermission PERMISSION =
       new FsPermission(FsAction.ALL, FsAction.NONE, FsAction.NONE);
 
@@ -71,6 +78,21 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
   private OzoneManager om;
 
   public TrashPolicyOzone(){
+  }
+
+  private TrashPolicyOzone(FileSystem fs, Configuration conf){
+    super.initialize(conf, fs);
+  }
+
+  @Override
+  public void initialize(Configuration conf, FileSystem fs, Path path) {
+    this.fs = fs;
+    this.deletionInterval = (long)(conf.getFloat(
+        FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT)
+        * MSECS_PER_MINUTE);
+    this.emptierInterval = (long)(conf.getFloat(
+        FS_TRASH_CHECKPOINT_INTERVAL_KEY, FS_TRASH_CHECKPOINT_INTERVAL_DEFAULT)
+        * MSECS_PER_MINUTE);
   }
 
   @Override
@@ -98,8 +120,10 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
 
   @Override
   public Runnable getEmptier() throws IOException {
-    return new TrashPolicyOzone.Emptier(configuration, emptierInterval);
+    return new TrashPolicyOzone.Emptier((OzoneConfiguration)configuration,
+        emptierInterval);
   }
+
 
   protected class Emptier implements Runnable {
 
@@ -107,7 +131,10 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
     // same as checkpoint interval
     private long emptierInterval;
 
-    Emptier(Configuration conf, long emptierInterval) throws IOException {
+
+    private ThreadPoolExecutor executor;
+
+    Emptier(OzoneConfiguration conf, long emptierInterval) throws IOException {
       this.conf = conf;
       this.emptierInterval = emptierInterval;
       if (emptierInterval > deletionInterval || emptierInterval <= 0) {
@@ -118,24 +145,31 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
             " minutes that is used for deletion instead");
         this.emptierInterval = deletionInterval;
       }
+      int trashEmptierCorePoolSize = conf.getObject(OMClientConfig.class)
+          .getTrashEmptierPoolSize();
       LOG.info("Ozone Manager trash configuration: Deletion interval = "
           + (deletionInterval / MSECS_PER_MINUTE)
           + " minutes, Emptier interval = "
           + (this.emptierInterval / MSECS_PER_MINUTE) + " minutes.");
+      executor = new ThreadPoolExecutor(TRASH_EMPTIER_CORE_POOL_SIZE,
+          TRASH_EMPTIER_CORE_POOL_SIZE, 1,
+          TimeUnit.SECONDS, new ArrayBlockingQueue<>(1024),
+          new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     @Override
     public void run() {
-      // if this is not the leader node,don't run the emptier
-      if (emptierInterval == 0 || !om.isLeaderReady()) {
+      if (emptierInterval == 0) {
         return;                                   // trash disabled
       }
       long now, end;
       while (true) {
         now = Time.now();
         end = ceiling(now, emptierInterval);
-        try {                                     // sleep for interval
+        try {
+          // sleep for interval
           Thread.sleep(end - now);
+          // if not leader, thread will always be sleeping
           if (!om.isLeaderReady()){
             continue;
           }
@@ -147,20 +181,24 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           now = Time.now();
           if (now >= end) {
             Collection<FileStatus> trashRoots;
-            trashRoots = fs.getTrashRoots(true);      // list all trash dirs
-
-            for (FileStatus trashRoot : trashRoots) {   // dump each trash
+            trashRoots = fs.getTrashRoots(true); // list all trash dirs
+            LOG.debug("Trash root Size: " + trashRoots.size());
+            for (FileStatus trashRoot : trashRoots) {  // dump each trash
+              LOG.info("Trashroot:" + trashRoot.getPath().toString());
               if (!trashRoot.isDirectory()) {
                 continue;
               }
-              try {
-                TrashPolicyOzone trash = new TrashPolicyOzone(fs, conf, om);
-                trash.deleteCheckpoint(trashRoot.getPath(), false);
-                trash.createCheckpoint(trashRoot.getPath(), new Date(now));
-              } catch (IOException e) {
-                LOG.warn("Trash caught: "+e+". Skipping " +
-                    trashRoot.getPath() + ".");
-              }
+              TrashPolicyOzone trash = new TrashPolicyOzone(fs, conf, om);
+              Runnable task = ()->{
+                try {
+                  trash.deleteCheckpoint(trashRoot.getPath(), false);
+                  trash.createCheckpoint(trashRoot.getPath(),
+                      new Date(Time.now()));
+                } catch (Exception e) {
+                  LOG.info("Unable to checkpoint");
+                }
+              };
+              executor.submit(task);
             }
           }
         } catch (Exception e) {
@@ -171,6 +209,13 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
         fs.close();
       } catch(IOException e) {
         LOG.warn("Trash cannot close FileSystem: ", e);
+      } finally {
+        executor.shutdown();
+        try {
+          executor.awaitTermination(60, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          LOG.error("Error attempting to shutdown");
+        }
       }
     }
 
@@ -265,3 +310,4 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
     return time;
   }
 }
+

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -59,8 +59,6 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
 
   private static final Path CURRENT = new Path("Current");
 
-  private final static int TRASH_EMPTIER_CORE_POOL_SIZE = 5;
-
   private static final FsPermission PERMISSION =
       new FsPermission(FsAction.ALL, FsAction.NONE, FsAction.NONE);
 
@@ -78,21 +76,6 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
   private OzoneManager om;
 
   public TrashPolicyOzone(){
-  }
-
-  private TrashPolicyOzone(FileSystem fs, Configuration conf){
-    super.initialize(conf, fs);
-  }
-
-  @Override
-  public void initialize(Configuration conf, FileSystem fs, Path path) {
-    this.fs = fs;
-    this.deletionInterval = (long)(conf.getFloat(
-        FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT)
-        * MSECS_PER_MINUTE);
-    this.emptierInterval = (long)(conf.getFloat(
-        FS_TRASH_CHECKPOINT_INTERVAL_KEY, FS_TRASH_CHECKPOINT_INTERVAL_DEFAULT)
-        * MSECS_PER_MINUTE);
   }
 
   @Override
@@ -151,8 +134,8 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           + (deletionInterval / MSECS_PER_MINUTE)
           + " minutes, Emptier interval = "
           + (this.emptierInterval / MSECS_PER_MINUTE) + " minutes.");
-      executor = new ThreadPoolExecutor(TRASH_EMPTIER_CORE_POOL_SIZE,
-          TRASH_EMPTIER_CORE_POOL_SIZE, 1,
+      executor = new ThreadPoolExecutor(trashEmptierCorePoolSize,
+          trashEmptierCorePoolSize, 1,
           TimeUnit.SECONDS, new ArrayBlockingQueue<>(1024),
           new ThreadPoolExecutor.CallerRunsPolicy());
     }
@@ -310,4 +293,3 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
     return time;
   }
 }
-


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change makes the Trash Emptier multithreaded. i.e the main emptier thread starts a thread pool executor and executes tasks (checkpointing and deletion) present in the task queue. the parallelism is obtained at the  bucket level as fs.trashRoots for a root OFS URI returns a list of bucket level trashroots. 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4347


## How was this patch tested?
Added unit tests and tested manually