### PR TITLE
HDDS-4435. Fix can not insert the second entry when hive on ozone

### DIFF
--- a/hadoop-ozone/integration-test/src/test/resources/contract/ozone.xml
+++ b/hadoop-ozone/integration-test/src/test/resources/contract/ozone.xml
@@ -52,6 +52,11 @@
     </property>
 
     <property>
+        <name>fs.contract.rename-returns-false-if-dest-exists</name>
+        <value>true</value>
+    </property>
+
+    <property>
         <name>fs.contract.rename-remove-dest-if-empty-dir</name>
         <value>false</value>
     </property>

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -381,14 +380,14 @@ public class BasicOzoneFileSystem extends FileSystem {
 
         if (statuses != null && statuses.length > 0) {
           // If dst exists and not a directory not empty
-          throw new FileAlreadyExistsException(String.format(
-              "Failed to rename %s to %s, file already exists or not empty!",
-              src, dst));
+          LOG.warn("Failed to rename {} to {}, file already exists" +
+              " or not empty!", src, dst);
+          return false;
         }
       } else {
         // If dst is not a directory
-        throw new FileAlreadyExistsException(String.format(
-            "Failed to rename %s to %s, file already exists!", src, dst));
+        LOG.warn("Failed to rename {} to {}, file already exists!", src, dst);
+        return false;
       }
     }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.CreateFlag;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -360,14 +359,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
         if (statuses != null && statuses.length > 0) {
           // If dst exists and not a directory not empty
-          throw new FileAlreadyExistsException(String.format(
-              "Failed to rename %s to %s, file already exists or not empty!",
-              src, dst));
+          LOG.warn("Failed to rename {} to {}, file already exists" +
+              " or not empty!", src, dst);
+          return false;
         }
       } else {
         // If dst is not a directory
-        throw new FileAlreadyExistsException(String.format(
-            "Failed to rename %s to %s, file already exists!", src, dst));
+        LOG.warn("Failed to rename {} to {}, file already exists!", src, dst);
+        return false;
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
**What's the problem ?**
When use hive-2.3.7 on ozone, I can not insert the second entry to table, and exception thrown from ozone.
![image](https://user-images.githubusercontent.com/51938049/98432719-11f44280-20fc-11eb-9bf9-7c946afaa1c2.png)

**What's the reason ?**
The following [hive code](https://github.com/apache/hive/blob/rel/release-2.3.7/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java#L3046) will call ozone's `rename(src, dst)` method, but if the last file of src and dst is same, ozone will throw exception.
![image](https://user-images.githubusercontent.com/51938049/98432727-22a4b880-20fc-11eb-9c61-a2e2461983d1.png)

**How to fix ?**
Then I tried hive on hdfs, I find hdfs's rename in this case will not throw exception, it just [return false](https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/namenode/FSDirRenameOp.java#L186), then hive will change the dst path at `destFilePath =  new Path(destDirPath, name + ("_copy_" + counter) + (!type.isEmpty() ? "." + type : ""));`. So we should keep ozone and hdfs's behavior the same, so that hive can run on ozone.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4435

## How was this patch tested?

Use hive-2.3.7 on ozone,  insert the second entry to table successfully.


![image](https://user-images.githubusercontent.com/51938049/98795247-f6af6d00-2444-11eb-9b17-7e2d7d158931.png)



