### PR TITLE
HDDS-4426. SCM should create transactions using all blocks received from OM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
@@ -21,12 +21,12 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.ozone.common.BlockGroup;
 
 /**
  *
@@ -59,7 +59,7 @@ public interface BlockManager extends Closeable,
    *                 a particular object key.
    * @throws IOException if exception happens, non of the blocks is deleted.
    */
-  void deleteBlocks(List<BlockID> blockIDs) throws IOException;
+  void deleteBlocks(List<BlockGroup> blockIDs) throws IOException;
 
   /**
    * @return the block deletion transaction log maintained by SCM.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -292,16 +292,16 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
    */
   @Override
   public void deleteBlocks(List<BlockGroup> keyBlocksInfoList)
-          throws IOException {
+      throws IOException {
     ScmUtils.preCheck(ScmOps.deleteBlock, safeModePrecheck);
 
     Map<Long, List<Long>> containerBlocks = new HashMap<>();
     // TODO: track the block size info so that we can reclaim the container
     // TODO: used space when the block is deleted.
-    for(BlockGroup bg : keyBlocksInfoList){
-      LOG.info("Deleting blocks {}", StringUtils.join(
-              ",", bg.getBlockIDList()));
-      for(BlockID block : bg.getBlockIDList()){
+    for (BlockGroup bg : keyBlocksInfoList) {
+      LOG.info("Deleting blocks {}",
+          StringUtils.join(",", bg.getBlockIDList()));
+      for (BlockID block : bg.getBlockIDList()) {
         long containerID = block.getContainerID();
         if (containerBlocks.containsKey(containerID)) {
           containerBlocks.get(containerID).add(block.getLocalID());
@@ -316,10 +316,9 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     try {
       deletedBlockLog.addTransactions(containerBlocks);
     } catch (IOException e) {
-      throw new IOException(
-          "Skip writing the deleted blocks info to"
-              + " the delLog because addTransaction fails. "
-              + keyBlocksInfoList.size() + "Keys skipped", e);
+      throw new IOException("Skip writing the deleted blocks info to"
+          + " the delLog because addTransaction fails. " + keyBlocksInfoList
+          .size() + "Keys skipped", e);
     }
     // TODO: Container report handling of the deleted blocks:
     // Remove tombstone and update open container usage.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -318,8 +318,8 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     } catch (IOException e) {
       throw new IOException(
           "Skip writing the deleted blocks info to"
-              + " the delLog because addTransaction fails. Keys skipped: "
-              + keyBlocksInfoList.size(), e);
+              + " the delLog because addTransaction fails. "
+              + keyBlocksInfoList.size() + "Keys skipped", e);
     }
     // TODO: Container report handling of the deleted blocks:
     // Remove tombstone and update open container usage.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.UniqueId;
 import org.apache.hadoop.metrics2.util.MBeans;
+import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.util.StringUtils;
 
 import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.INVALID_BLOCK_SIZE;
@@ -285,28 +286,30 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
    * successful, given blocks are
    * entering pending deletion state and becomes invisible from SCM namespace.
    *
-   * @param blockIDs block IDs. This is often the list of blocks of a
-   * particular object key.
+   * @param keyBlocksInfoList . This is the list of BlockGroup which contains
+   * groupID of keys and list of BlockIDs associated with them.
    * @throws IOException if exception happens, non of the blocks is deleted.
    */
   @Override
-  public void deleteBlocks(List<BlockID> blockIDs) throws IOException {
+  public void deleteBlocks(List<BlockGroup> keyBlocksInfoList)
+          throws IOException {
     ScmUtils.preCheck(ScmOps.deleteBlock, safeModePrecheck);
 
-    LOG.info("Deleting blocks {}", StringUtils.join(",", blockIDs));
     Map<Long, List<Long>> containerBlocks = new HashMap<>();
     // TODO: track the block size info so that we can reclaim the container
     // TODO: used space when the block is deleted.
-    for (BlockID block : blockIDs) {
-      // Merge blocks to a container to blocks mapping,
-      // prepare to persist this info to the deletedBlocksLog.
-      long containerID = block.getContainerID();
-      if (containerBlocks.containsKey(containerID)) {
-        containerBlocks.get(containerID).add(block.getLocalID());
-      } else {
-        List<Long> item = new ArrayList<>();
-        item.add(block.getLocalID());
-        containerBlocks.put(containerID, item);
+    for(BlockGroup bg : keyBlocksInfoList){
+      LOG.info("Deleting blocks {}", StringUtils.join(
+              ",", bg.getBlockIDList()));
+      for(BlockID block : bg.getBlockIDList()){
+        long containerID = block.getContainerID();
+        if (containerBlocks.containsKey(containerID)) {
+          containerBlocks.get(containerID).add(block.getLocalID());
+        } else {
+          List<Long> item = new ArrayList<>();
+          item.add(block.getLocalID());
+          containerBlocks.put(containerID, item);
+        }
       }
     }
 
@@ -315,8 +318,8 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     } catch (IOException e) {
       throw new IOException(
           "Skip writing the deleted blocks info to"
-              + " the delLog because addTransaction fails. Batch skipped: "
-              + StringUtils.join(",", blockIDs), e);
+              + " the delLog because addTransaction fails. Keys skipped: "
+              + keyBlocksInfoList.size(), e);
     }
     // TODO: Container report handling of the deleted blocks:
     // Remove tombstone and update open container usage.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -224,12 +224,12 @@ public class SCMBlockProtocolServer implements
     }
     List<DeleteBlockGroupResult> results = new ArrayList<>();
     Map<String, String> auditMap = Maps.newHashMap();
-    ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result codeResult;
+    ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result resultCode;
     try{
       scm.getScmBlockManager().deleteBlocks(keyBlocksInfoList);
-      codeResult = ScmBlockLocationProtocolProtos.
+      resultCode = ScmBlockLocationProtocolProtos.
               DeleteScmBlockResult.Result.success;
-      AUDIT.logReadSuccess(buildAuditMessageForSuccess(
+      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
               SCMAction.DELETE_KEY_BLOCK, auditMap));
     } catch (SCMException scmEx){
       LOG.warn("Fail to delete {} keys", keyBlocksInfoList.size(), scmEx);
@@ -239,15 +239,15 @@ public class SCMBlockProtocolServer implements
       );
       switch (scmEx.getResult()) {
       case SAFE_MODE_EXCEPTION:
-        codeResult = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
+        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
                 .Result.safeMode;
         break;
       case FAILED_TO_FIND_BLOCK:
-        codeResult = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
+        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
                 .Result.errorNotFound;
         break;
       default:
-        codeResult = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
+        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
                 .Result.unknownFailure;
       }
     } catch (IOException ex){
@@ -256,14 +256,14 @@ public class SCMBlockProtocolServer implements
               buildAuditMessageForFailure(SCMAction.DELETE_KEY_BLOCK, auditMap,
                       ex)
       );
-      codeResult = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
+      resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
               .Result.unknownFailure;
     }
     for(BlockGroup bg : keyBlocksInfoList){
       auditMap.put("KeyBlockToDelete", bg.toString());
       List<DeleteBlockResult> blockResult = new ArrayList<>();
       for(BlockID b : bg.getBlockIDList()){
-        blockResult.add(new DeleteBlockResult(b, codeResult));
+        blockResult.add(new DeleteBlockResult(b, resultCode));
       }
       results.add(new DeleteBlockGroupResult(bg.getGroupID(),
               blockResult));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -227,45 +227,44 @@ public class SCMBlockProtocolServer implements
     Map<String, String> auditMap = Maps.newHashMap();
     ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result resultCode;
     Exception e = null;
-    try{
+    try {
       scm.getScmBlockManager().deleteBlocks(keyBlocksInfoList);
       resultCode = ScmBlockLocationProtocolProtos.
-              DeleteScmBlockResult.Result.success;
-    } catch (IOException ioe){
+          DeleteScmBlockResult.Result.success;
+    } catch (IOException ioe) {
       e = ioe;
       LOG.warn("Fail to delete {} keys", keyBlocksInfoList.size(), ioe);
       switch (ioe instanceof SCMException ? ((SCMException) ioe).getResult() :
-              IO_EXCEPTION) {
+          IO_EXCEPTION) {
       case SAFE_MODE_EXCEPTION:
-        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
-                .Result.safeMode;
+        resultCode =
+            ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.safeMode;
         break;
       case FAILED_TO_FIND_BLOCK:
-        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
-                .Result.errorNotFound;
+        resultCode =
+            ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.
+                errorNotFound;
         break;
       default:
-        resultCode = ScmBlockLocationProtocolProtos.DeleteScmBlockResult
-                .Result.unknownFailure;
+        resultCode =
+            ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.
+                unknownFailure;
       }
     }
-    for(BlockGroup bg : keyBlocksInfoList){
+    for (BlockGroup bg : keyBlocksInfoList) {
       auditMap.put("KeyBlockToDelete", bg.toString());
       List<DeleteBlockResult> blockResult = new ArrayList<>();
-      for(BlockID b : bg.getBlockIDList()){
+      for (BlockID b : bg.getBlockIDList()) {
         blockResult.add(new DeleteBlockResult(b, resultCode));
       }
-      results.add(new DeleteBlockGroupResult(bg.getGroupID(),
-              blockResult));
+      results.add(new DeleteBlockGroupResult(bg.getGroupID(), blockResult));
     }
-    if(e == null){
-      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(
-              SCMAction.DELETE_KEY_BLOCK, auditMap));
-    } else{
+    if (e == null) {
+      AUDIT.logWriteSuccess(
+          buildAuditMessageForSuccess(SCMAction.DELETE_KEY_BLOCK, auditMap));
+    } else {
       AUDIT.logWriteFailure(
-              buildAuditMessageForFailure(SCMAction.DELETE_KEY_BLOCK, auditMap,
-                      e)
-      );
+          buildAuditMessageForFailure(SCMAction.DELETE_KEY_BLOCK, auditMap, e));
     }
     return results;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, SCM creates a transaction per key deleted by OM. If OM is deleting 1000 keys then SCM should create transaction using all these keys i.e. segregate the blocks by containerID and then create transactions per containerID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4426

## How was this patch tested?

Tested Manually 