### PR TITLE
HDDS-4445. Owner info is not passed to authorizer for BUCKET/KEY crea…

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -46,7 +46,7 @@ Create volume with non-admin user
 Create bucket with non-admin owner(testuser2)
     Run Keyword   Kinit test user     testuser     testuser.keytab
     Execute       ozone sh volume create o3://om/${volume4} -u testuser2
-
+    Run Keyword         Setup volume names
     Run Keyword   Kinit test user     testuser2    testuser2.keytab
     ${result} =   Execute     ozone sh bucket create o3://om/${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -30,6 +30,7 @@ Setup volume names
     Set Suite Variable   ${volume1}            fstest${random}
     Set Suite Variable   ${volume2}            fstest2${random}
     Set Suite Variable   ${volume3}            fstest3${random}
+    Set Suite Variable   ${volume4}            fstest4${random}
 
 *** Test Cases ***
 Create volume bucket with wrong credentials
@@ -41,6 +42,22 @@ Create volume with non-admin user
     Run Keyword         Kinit test user     testuser2     testuser2.keytab
     ${rc}               ${output} =          Run And Return Rc And Output       ozone sh volume create o3://om/fstest
     Should contain      ${output}       doesn't have CREATE permission to access volume
+
+Create bucket with non-admin owner(testuser2)
+    Run Keyword   Kinit test user     testuser     testuser.keytab
+    Execute       ozone sh volume create o3://om/${volume4} -u testuser2
+
+    Run Keyword   Kinit test user     testuser2    testuser2.keytab
+    ${result} =   Execute     ozone sh bucket create o3://om/${volume4}/bucket1
+                  Should not contain  ${result}       PERMISSION_DENIED
+    ${result} =   Execute     ozone sh key put ${volume4}/bucket1/key1 /opt/hadoop/NOTICE.txt
+                  Should not contain  ${result}       PERMISSION_DENIED
+    ${result} =   Execute     ozone sh key list ${volume4}/bucket1
+                  Should not contain  ${result}       PERMISSION_DENIED
+    ${result} =   Execute     ozone sh key delete ${volume4}/bucket1/key1
+                  Should not contain  ${result}       PERMISSION_DENIED
+    ${result} =   Execute     ozone sh bucket delete ${volume4}/bucket1
+                  Should not contain  ${result}       PERMISSION_DENIED
 
 Create volume bucket with credentials
                         # Authenticate testuser

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -45,8 +45,8 @@ Create volume with non-admin user
 
 Create bucket with non-admin owner(testuser2)
     Run Keyword   Kinit test user     testuser     testuser.keytab
+    Run Keyword   Setup volume names
     Execute       ozone sh volume create o3://om/${volume4} -u testuser2
-    Run Keyword         Setup volume names
     Run Keyword   Kinit test user     testuser2    testuser2.keytab
     ${result} =   Execute     ozone sh bucket create o3://om/${volume4}/bucket1
                   Should not contain  ${result}       PERMISSION_DENIED

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1629,7 +1629,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         ProtobufRpcEngine.Server.getRemoteUser(),
         ProtobufRpcEngine.Server.getRemoteIp(),
         ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
-        true, getVolumeOwner(vol, acl));
+        true, getVolumeOwner(vol, acl, resType));
   }
 
   /**
@@ -1644,16 +1644,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           UserGroupInformation.createRemoteUser(userName),
           ProtobufRpcEngine.Server.getRemoteIp(),
           ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
-          false, getVolumeOwner(vol, acl));
+          false, getVolumeOwner(vol, acl, resType));
     } catch (OMException ex) {
       // Should not trigger exception here at all
       return false;
     }
   }
 
-  public String getVolumeOwner(String vol, ACLType type) throws OMException {
+  public String getVolumeOwner(String vol, ACLType type, ResourceType resType)
+      throws OMException {
     String volOwnerName = null;
-    if (!vol.equals(OzoneConsts.OZONE_ROOT) && (type != ACLType.CREATE)) {
+    if (!vol.equals(OzoneConsts.OZONE_ROOT) &&
+        !(type == ACLType.CREATE && resType == ResourceType.VOLUME)) {
       volOwnerName = getVolumeOwner(vol);
     }
     return volOwnerName;
@@ -3578,7 +3580,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       checkAcls(ResourceType.BUCKET, StoreType.OZONE, type,
           volumeName, bucketName, null, userGroupInformation,
           remoteAddress, hostName, true,
-          getVolumeOwner(volumeName, type));
+          getVolumeOwner(volumeName, type, ResourceType.BUCKET));
     }
 
     return resolveBucketLink(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -152,7 +152,7 @@ public abstract class OMClientRequest implements RequestAuditor {
       OzoneObj.StoreType storeType, IAccessAuthorizer.ACLType aclType,
       String vol, String bucket, String key) throws IOException {
     checkAcls(ozoneManager, resType, storeType, aclType, vol, bucket, key,
-        ozoneManager.getVolumeOwner(vol, aclType));
+        ozoneManager.getVolumeOwner(vol, aclType, resType));
   }
 
   /**


### PR DESCRIPTION

skip passing volume owner info only for volume creation(admin only) or root access. For bucket/key create, we should populate the volume owner to the authorizer. 


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4445

## How was this patch tested?
New acceptance test added for native authorizer. 
Tested with Ranger authorizer in real cluster. 
