### PR TITLE
HDDS-4442. Make all Log4J2 loggers asynchronous

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -50,6 +50,8 @@ public class TestOzoneAuditLogger {
 
   static {
     System.setProperty("log4j.configurationFile", "auditlog.properties");
+    System.setProperty("log4j2.contextSelector",
+        "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
   }
 
   private static final AuditLogger AUDIT =
@@ -115,7 +117,7 @@ public class TestOzoneAuditLogger {
   public void verifyDefaultLogLevelForSuccess() throws IOException {
     AUDIT.logWriteSuccess(WRITE_SUCCESS_MSG);
     String expected =
-        "INFO  | OMAudit | " + WRITE_SUCCESS_MSG.getFormattedMessage();
+        "INFO  | OMAudit | ? | " + WRITE_SUCCESS_MSG.getFormattedMessage();
     verifyLog(expected);
   }
 
@@ -126,7 +128,7 @@ public class TestOzoneAuditLogger {
   public void verifyDefaultLogLevelForFailure() throws IOException {
     AUDIT.logWriteFailure(WRITE_FAIL_MSG);
     String expected =
-        "ERROR | OMAudit | " + WRITE_FAIL_MSG.getFormattedMessage();
+        "ERROR | OMAudit | ? | " + WRITE_FAIL_MSG.getFormattedMessage();
     verifyLog(expected);
   }
 
@@ -168,7 +170,7 @@ public class TestOzoneAuditLogger {
             .withException(testException).build();
     AUDIT.logWriteFailure(exceptionAuditMessage);
     verifyLog(
-        "ERROR | OMAudit | user=john | "
+        "ERROR | OMAudit | ? | user=john | "
             + "ip=192.168.0.1 | op=CREATE_VOLUME "
             + "{key1=value1, key2=value2} | ret=FAILURE",
         "org.apache.hadoop.ozone.audit."

--- a/hadoop-hdds/common/src/test/resources/auditlog.properties
+++ b/hadoop-hdds/common/src/test/resources/auditlog.properties
@@ -62,7 +62,7 @@ appender.audit.type = File
 appender.audit.name = AUDITLOG
 appender.audit.fileName=audit.log
 appender.audit.layout.type=PatternLayout
-appender.audit.layout.pattern= %-5level | %c{1} | %msg%n
+appender.audit.layout.pattern= %-5level | %c{1} | %C | %msg%n
 
 loggers=audit
 logger.audit.type=AsyncLogger

--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -107,6 +107,7 @@ function ozonecmd_case
       # exception as mentioned in HDDS-3812
       hadoop_deprecate_envvar HDDS_DN_OPTS OZONE_DATANODE_OPTS
       OZONE_DATANODE_OPTS="-Dorg.apache.ratis.thirdparty.io.netty.allocator.useCacheForAllThreads=false -Dorg.apache.ratis.thirdparty.io.netty.leakDetection.level=disabled -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/dn-audit-log4j2.properties ${OZONE_DATANODE_OPTS}"
+      OZONE_DATANODE_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_DATANODE_OPTS}"
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.HddsDatanodeService
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-datanode"
     ;;
@@ -156,6 +157,7 @@ function ozonecmd_case
       HADOOP_CLASSNAME=org.apache.hadoop.ozone.om.OzoneManagerStarter
       hadoop_deprecate_envvar HDFS_OM_OPTS OZONE_OM_OPTS
       OZONE_OM_OPTS="${OZONE_OM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/om-audit-log4j2.properties"
+      OZONE_OM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_OM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-ozone-manager"
     ;;
     sh | shell)
@@ -174,6 +176,7 @@ function ozonecmd_case
       HADOOP_CLASSNAME='org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter'
       hadoop_deprecate_envvar HDFS_STORAGECONTAINERMANAGER_OPTS OZONE_SCM_OPTS
       OZONE_SCM_OPTS="${OZONE_SCM_OPTS} -Dlog4j.configurationFile=${HADOOP_CONF_DIR}/scm-audit-log4j2.properties"
+      OZONE_SCM_OPTS="-Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector ${OZONE_SCM_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-hdds-server-scm"
     ;;
     s3g)


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Make all Log4J2 loggers asynchronous](http://logging.apache.org/log4j/2.0/manual/async.html#Making_All_Loggers_Asynchronous) (only used for audit logging in Ozone) via the system property `log4j2.contextSelector`.  This prevents lookup of location information by default, and "will give the best performance" by avoiding some intermediate threads.

https://issues.apache.org/jira/browse/HDDS-4442

## How was this patch tested?

Updated `TestOzoneAuditLogger` unit test:
 * include class name in the log message
 * verify that only `?` is logged, due to lack of location information

Temporarily made the same change in OM audit log pattern:

```diff
diff --git hadoop-ozone/dist/src/shell/conf/om-audit-log4j2.properties hadoop-ozone/dist/src/shell/conf/om-audit-log4j2.properties
index 57577e162..170d6840e 100644
--- hadoop-ozone/dist/src/shell/conf/om-audit-log4j2.properties
+++ hadoop-ozone/dist/src/shell/conf/om-audit-log4j2.properties
@@ -71,7 +71,7 @@ appender.rolling.name=RollingFile
 appender.rolling.fileName =${sys:hadoop.log.dir}/om-audit-${hostName}.log
 appender.rolling.filePattern=${sys:hadoop.log.dir}/om-audit-${hostName}-%d{yyyy-MM-dd-HH-mm-ss}-%i.log.gz
 appender.rolling.layout.type=PatternLayout
-appender.rolling.layout.pattern=%d{DEFAULT} | %-5level | %c{1} | %msg | %throwable{3} %n
+appender.rolling.layout.pattern=%d{DEFAULT} | %-5level | %c{1} | %C | %msg | %throwable{3} %n
 appender.rolling.policies.type=Policies
 appender.rolling.policies.time.type=TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval=86400
```

and checked OM audit log:

```
$ docker-compose exec om bash -c 'cat /var/log/hadoop/*audit*log'
2020-11-10 13:49:53,322 | INFO  | OMAudit | ? | user=hadoop | ip=192.168.96.6 | op=CREATE_VOLUME {admin=hadoop, owner=hadoop, volume=vol1, creationTime=1605016193288, modificationTime=1605016193288, quotaInBytes=-1, quotaInCounts=-1, objectID=256, updateID=1, usedBytes=0} | ret=SUCCESS |
2020-11-10 13:49:53,390 | INFO  | OMAudit | ? | user=hadoop | ip=192.168.96.6 | op=CREATE_BUCKET {volume=vol1, bucket=bucket1, gdprEnabled=null, acls=[user:hadoop:a[ACCESS], group:users:a[ACCESS]], isVersionEnabled=false, storageType=DISK, creationTime=1605016193368, bucketEncryptionKey=null, modificationTime=1605016193368, usedBytes=0} | ret=SUCCESS |
2020-11-10 13:49:53,587 | INFO  | OMAudit | ? | user=hadoop | ip=192.168.96.6 | op=ALLOCATE_KEY {volume=vol1, bucket=bucket1, key=vm7ozunjvq/0, dataSize=10240, replicationType=RATIS, replicationFactor=THREE} | ret=SUCCESS |
2020-11-10 13:49:57,490 | INFO  | OMAudit | ? | user=hadoop | ip=192.168.96.6 | op=COMMIT_KEY {volume=vol1, bucket=bucket1, key=vm7ozunjvq/0, dataSize=10240, replicationType=RATIS, replicationFactor=ONE} | ret=SUCCESS |
```