### PR TITLE
HDDS-4443. Recon: Using Mysql database throws exception and fails startup

### DIFF
--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/ReconSqlDbConfig.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/codegen/ReconSqlDbConfig.java
@@ -97,7 +97,7 @@ public class ReconSqlDbConfig {
 
   @Config(key = "auto.commit",
       type = ConfigType.BOOLEAN,
-      defaultValue = "false",
+      defaultValue = "true",
       tags = {ConfigTag.STORAGE, ConfigTag.RECON, ConfigTag.OZONE},
       description = "Sets the Ozone Recon database connection property of " +
           "auto-commit to true/false."

--- a/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ReconTaskSchemaDefinition.java
+++ b/hadoop-ozone/recon-codegen/src/main/java/org/hadoop/ozone/recon/schema/ReconTaskSchemaDefinition.java
@@ -61,7 +61,7 @@ public class ReconTaskSchemaDefinition implements ReconSchemaDefinition {
    */
   private void createReconTaskStatusTable(Connection conn) {
     DSL.using(conn).createTableIfNotExists(RECON_TASK_STATUS_TABLE_NAME)
-        .column("task_name", SQLDataType.VARCHAR(768).nullable(false))
+        .column("task_name", SQLDataType.VARCHAR(766).nullable(false))
         .column("last_updated_timestamp", SQLDataType.BIGINT)
         .column("last_updated_seq_number", SQLDataType.BIGINT)
         .constraint(DSL.constraint("pk_task_name")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix length of the primary key in one of the SQL tables of Recon and set auto-commit flag to default to true.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4443

## How was this patch tested?

Tested the changes in a real cluster by replacing recon jar and using mariadb connector jar and jdbc URL configs for recon. 