### PR TITLE
HDDS-4450. Cannot run ozone if HADOOP_HOME points to Hadoop install

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -18,7 +18,9 @@
 # The name of the script being executed.
 HADOOP_SHELL_EXECNAME="ozone"
 MYNAME="${BASH_SOURCE-$0}"
+bin=$(cd -P -- "$(dirname -- "${MYNAME}")" >/dev/null && pwd -P)
 JVM_PID="$$"
+
 ## @description  build up the hdfs command's usage text.
 ## @audience     public
 ## @stability    stable
@@ -233,7 +235,6 @@ function ozonecmd_case
 if [[ -n "${HADOOP_HOME}" ]]; then
   HADOOP_DEFAULT_LIBEXEC_DIR="${HADOOP_HOME}/libexec"
 else
-  bin=$(cd -P -- "$(dirname -- "${MYNAME}")" >/dev/null && pwd -P)
   HADOOP_DEFAULT_LIBEXEC_DIR="${bin}/../libexec"
 fi
 
@@ -242,6 +243,11 @@ HADOOP_LIBEXEC_DIR="${HADOOP_LIBEXEC_DIR:-$HADOOP_DEFAULT_LIBEXEC_DIR}"
 HADOOP_NEW_CONFIG=true
 if [[ -f "${HADOOP_LIBEXEC_DIR}/ozone-config.sh" ]]; then
   # shellcheck source=./hadoop-ozone/common/src/main/bin/ozone-config.sh
+  . "${HADOOP_LIBEXEC_DIR}/ozone-config.sh"
+elif [[ -f "${bin}/../libexec/ozone-config.sh" ]]; then
+  HADOOP_HOME="${bin}/../"
+  HADOOP_LIBEXEC_DIR="${HADOOP_HOME}/libexec"
+  HADOOP_DEFAULT_LIBEXEC_DIR="${HADOOP_HOME}/libexec"
   . "${HADOOP_LIBEXEC_DIR}/ozone-config.sh"
 else
   echo "ERROR: Cannot execute ${HADOOP_LIBEXEC_DIR}/ozone-config.sh." 2>&1

--- a/hadoop-ozone/dist/src/shell/ozone/stop-ozone.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/stop-ozone.sh
@@ -42,6 +42,11 @@ HADOOP_NEW_CONFIG=true
 if [[ -f "${HADOOP_LIBEXEC_DIR}/ozone-config.sh" ]]; then
   # shellcheck disable=SC1090
   . "${HADOOP_LIBEXEC_DIR}/ozone-config.sh"
+elif [[ -f "${bin}/../libexec/ozone-config.sh" ]]; then
+  HADOOP_HOME="${bin}/../"
+  HADOOP_LIBEXEC_DIR="${HADOOP_HOME}/libexec"
+  HADOOP_DEFAULT_LIBEXEC_DIR="${HADOOP_HOME}/libexec"
+  . "${HADOOP_LIBEXEC_DIR}/ozone-config.sh"
 else
   echo "ERROR: Cannot execute ${HADOOP_LIBEXEC_DIR}/ozone-config.sh." 2>&1
   exit 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `HADOOP_HOME` does not point to Ozone install, make an attempt to find it relative to the script being run.  This logic is copied from `start-ozone.sh`, where it was added for HDDS-1912 to fix similar problem.

https://issues.apache.org/jira/browse/HDDS-4450

## How was this patch tested?

Tested using `ozonescripts` compose environment after temporarily adding `HADOOP_HOME=/usr/local/hadoop` to `docker-config`.  Verified that all three scripts (`ozone` and `stop-ozone.sh`, changed here, and `start-ozone.sh`, changed previously) work fine.

```
cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/compose/ozonescripts
docker-compose up -d
# <wait a bit>
./start.sh
...
./ps.sh
# <output with Ozone processes>
docker-compose exec scm bash
bash-4.2$ ozone freon ockg -n1 -t1 -F ONE
...
Successful executions: 1
bash-4.2$ echo $HADOOP_HOME
/usr/local/hadoop
bash-4.2$ exit
./stop.sh
...
./ps.sh
# <no more Ozone process>
```