### PR TITLE
HDDS-4428.  IT TestOzoneManagerHAMetadataOnly.testOMRetryCache is flaky

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -71,8 +71,10 @@ public class IncrementalContainerReportHandler extends
     for (ContainerReplicaProto replicaProto :
         report.getReport().getReportList()) {
       try {
+
         final ContainerID id = ContainerID.valueof(
             replicaProto.getContainerID());
+
         if (!replicaProto.getState().equals(
             ContainerReplicaProto.State.DELETED)) {
           nodeManager.addContainer(dd, id);
@@ -87,7 +89,7 @@ public class IncrementalContainerReportHandler extends
             report.getDatanodeDetails(), ex);
       } catch (IOException e) {
         success = false;
-        LOG.error("Exception while processing ICR for container {}",
+        LOG.warn("Exception while processing ICR for container {}",
             replicaProto.getContainerID(), e);
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -71,10 +71,8 @@ public class IncrementalContainerReportHandler extends
     for (ContainerReplicaProto replicaProto :
         report.getReport().getReportList()) {
       try {
-
         final ContainerID id = ContainerID.valueof(
             replicaProto.getContainerID());
-
         if (!replicaProto.getState().equals(
             ContainerReplicaProto.State.DELETED)) {
           nodeManager.addContainer(dd, id);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -88,7 +88,8 @@ public class IncrementalContainerReportHandler extends
             report.getDatanodeDetails(), ex);
       } catch (ContainerReplicaNotFoundException e){
         success = false;
-        LOG.warn("Container {} replica not found!", replicaProto.getContainerID());
+        LOG.warn("Container {} replica not found!",
+            replicaProto.getContainerID());
       } catch (IOException e) {
         success = false;
         LOG.error("Exception while processing ICR for container {}",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -80,8 +80,7 @@ public class IncrementalContainerReportHandler extends
         processContainerReplica(dd, replicaProto, publisher);
       } catch (ContainerNotFoundException e) {
         success = false;
-        LOG.warn("Container {} not found!",
-            replicaProto.getContainerID());
+        LOG.warn("Container {} not found!", replicaProto.getContainerID());
       } catch (NodeNotFoundException ex) {
         success = false;
         LOG.error("Received ICR from unknown datanode {}",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -85,9 +85,12 @@ public class IncrementalContainerReportHandler extends
         success = false;
         LOG.error("Received ICR from unknown datanode {}",
             report.getDatanodeDetails(), ex);
+      } catch (ContainerReplicaNotFoundException e){
+        success = false;
+        LOG.warn("Container {} replica not found!", replicaProto.getContainerID());
       } catch (IOException e) {
         success = false;
-        LOG.warn("Exception while processing ICR for container {}",
+        LOG.error("Exception while processing ICR for container {}",
             replicaProto.getContainerID(), e);
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -80,7 +80,8 @@ public class IncrementalContainerReportHandler extends
         processContainerReplica(dd, replicaProto, publisher);
       } catch (ContainerNotFoundException e) {
         success = false;
-        LOG.warn("Container {} not found!", replicaProto.getContainerID());
+        LOG.warn("Container {} not found!",
+            replicaProto.getContainerID());
       } catch (NodeNotFoundException ex) {
         success = false;
         LOG.error("Received ICR from unknown datanode {}",

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -406,6 +406,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
     Assert.assertTrue(logCapturer.getOutput().contains("created volume:"
         + volumeName));
 
+    Thread.sleep(100L);
     logCapturer.clearOutput();
 
     raftClientReply =


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the bug about `org.apache.hadoop.ozone.om.TestOzoneManagerHAMetadataOnly`


(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4428?jql=project%20%3D%20HDDS%20AND%20status%20%3D%20Open%20AND%20assignee%20in%20(currentUser())%20AND%20text%20~%20%22flaky%22

## How was this patch tested?

In my original test, an error occurred on average 30 times,but now there are no more errors in several tests.
![Screenshot from 2020-11-12 18-05-03](https://user-images.githubusercontent.com/43372856/98928040-3db86380-2514-11eb-94ca-b7d043f9ff8c.png)
