### PR TITLE
HDDS-4428. IT TestOzoneManagerHAMetadataOnly.testOMRetryCache is flaky

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -406,6 +406,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
     Assert.assertTrue(logCapturer.getOutput().contains("created volume:"
         + volumeName));
 
+    Thread.sleep(100L);
     logCapturer.clearOutput();
 
     raftClientReply =


### PR DESCRIPTION
## What changes were proposed in this pull request? 

Fix the bug about `org.apache.hadoop.ozone.om.TestOzoneManagerHAMetadataOnly.`

## What is the link to the Apache JIRA 

https://issues.apache.org/jira/browse/HDDS-4428

## How was this patch tested? 

In my original test, an error occurred on average 30 times,but now there are no more errors in several tests. 
![Screenshot from 2020-11-12 18-05-03](https://user-images.githubusercontent.com/43372856/98939655-b6bfb700-2524-11eb-99d0-9b18cf9837de.png)
``