### PR TITLE
HDDS-4235. Ozone client FS path validation is not present in OFS.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1230,15 +1230,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   private void checkInvalidPath(Path path) throws Exception {
-    FSDataOutputStream outputStream = null;
-    try {
-      LambdaTestUtils.intercept(InvalidPathException.class, "Invalid path Name",
-          () -> fs.create(path, false));
-    } finally {
-      if (outputStream != null) {
-        outputStream.close();
-      }
-    }
+    LambdaTestUtils.intercept(InvalidPathException.class, "Invalid path Name",
+        () -> fs.create(path, false));
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.Trash;
@@ -47,6 +48,7 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.test.GenericTestUtils;
+import org.apache.hadoop.test.LambdaTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -1210,4 +1212,33 @@ public class TestRootedOzoneFileSystem {
     ofs.delete(trashRoot, true);
 
   }
+
+  @Test
+  public void testCreateWithInvalidPaths() throws Exception {
+    // Test for path with ..
+    Path parent = new Path("../../../../../d1/d2/");
+    Path file1 = new Path(parent, "key1");
+    checkInvalidPath(file1);
+
+    // Test for path with :
+    file1 = new Path("/:/:");
+    checkInvalidPath(file1);
+
+    // Test for path with scheme and authority.
+    file1 = new Path(fs.getUri() + "/:/:");
+    checkInvalidPath(file1);
+  }
+
+  private void checkInvalidPath(Path path) throws Exception {
+    FSDataOutputStream outputStream = null;
+    try {
+      LambdaTestUtils.intercept(InvalidPathException.class, "Invalid path Name",
+          () -> fs.create(path, false));
+    } finally {
+      if (outputStream != null) {
+        outputStream.close();
+      }
+    }
+  }
+
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -814,9 +814,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     // removing leading '/' char
     String key = path.toUri().getPath();
 
-    if (OzoneFSUtils.isValidName(key)) {
-      key = path.toUri().getPath();
-    } else {
+    if (!OzoneFSUtils.isValidName(key)) {
       throw new InvalidPathException("Invalid path Name " + key);
     }
     LOG.trace("path for key:{} is:{}", key, path);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -817,7 +817,7 @@ public class BasicOzoneFileSystem extends FileSystem {
     if (OzoneFSUtils.isValidName(key)) {
       key = path.toUri().getPath();
     } else {
-      throw new InvalidPathException("Invalid path Name" + key);
+      throw new InvalidPathException("Invalid path Name " + key);
     }
     LOG.trace("path for key:{} is:{}", key, path);
     return key.substring(1);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.Progressable;
@@ -840,8 +842,12 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     if (!path.isAbsolute()) {
       path = new Path(workingDir, path);
     }
+    String key = path.toUri().getPath();
+    if (!OzoneFSUtils.isValidName(path.toUri().getPath())) {
+      throw new InvalidPathException("Invalid path Name " + key);
+    }
     // removing leading '/' char
-    String key = path.toUri().getPath().substring(1);
+    key = key.substring(1);
     LOG.trace("path for key: {} is: {}", key, path);
     return key;
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -843,7 +843,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       path = new Path(workingDir, path);
     }
     String key = path.toUri().getPath();
-    if (!OzoneFSUtils.isValidName(path.toUri().getPath())) {
+    if (!OzoneFSUtils.isValidName(key)) {
       throw new InvalidPathException("Invalid path Name " + key);
     }
     // removing leading '/' char


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added path name validation in OFS

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4235

## How was this patch tested?

Added UT