### PR TITLE
HDDS-4338. Fix the issue that SCM web UI banner shows "HDFS SCM".

### DIFF
--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/index.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/index.html
@@ -22,7 +22,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="HDFS Storage Container Manager">
+    <meta name="description" content="HDDS Storage Container Manager">
 
     <title>HDDS Datanode Service</title>
 

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/index.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/index.html
@@ -22,9 +22,9 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="HDFS Storage Container Manager">
+    <meta name="description" content="HDDS Storage Container Manager">
 
-    <title>HDFS Storage Container Manager</title>
+    <title>HDDS Storage Container Manager</title>
 
     <link href="static/bootstrap-3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="static/hadoop.css" rel="stylesheet">
@@ -46,7 +46,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="#">HDFS SCM</a>
+            <a class="navbar-brand" href="#">HDDS SCM</a>
         </div>
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the issue that the SCM web UI banner shows "HDFS SCM". Change the "HDFS SCM" to the "Ozone SCM".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4338

## How was this patch tested?

Passed all default unit tests and checked it after the actual startup.
