### PR TITLE
HDDS-4458. Fix Max Transaction ID value in OM.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -89,7 +89,7 @@ public final class OmUtils {
   // OzoneManager#addS3GVolumeToDB()}.
   public static final long EPOCH_ID_SHIFT = 62; // 64 - 2
   public static final long REVERSE_EPOCH_ID_SHIFT = 2; // 64 - EPOCH_ID_SHIFT
-  public static final long MAX_TRXN_ID = (long) ((1 << 54) - 2);
+  public static final long MAX_TRXN_ID = (1L << 54) - 2;
   public static final int EPOCH_WHEN_RATIS_NOT_ENABLED = 1;
   public static final int EPOCH_WHEN_RATIS_ENABLED = 2;
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -151,7 +151,7 @@ public class TestOmUtils {
 
   @Test
   public void checkMaxTransactionID() {
-    Assert.assertEquals((long) (Math.pow(2, 54) - 2 ), OmUtils.MAX_TRXN_ID);
+    Assert.assertEquals((long) (Math.pow(2, 54) - 2), OmUtils.MAX_TRXN_ID);
   }
 }
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -148,5 +148,10 @@ public class TestOmUtils {
               ".ids) configured"));
     }
   }
+
+  @Test
+  public void checkMaxTransactionID() {
+    Assert.assertEquals((long) (Math.pow(2, 54) - 2 ), OmUtils.MAX_TRXN_ID);
+  }
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now Max Transaction ID value is coming as 4194302, whereas it should be 18014398509481982.

Due to this after 4194302, all transactions in OM will fail.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4458

## How was this patch tested?

Added a test.
