### PR TITLE
HDDS-4464. Upgrade httpclient version due to CVE-2020-13956.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <hk2.version>2.5.0</hk2.version>
 
     <!-- httpcomponents versions -->
-    <httpclient.version>4.5.2</httpclient.version>
-    <httpcore.version>4.4.4</httpcore.version>
+    <httpclient.version>4.5.13</httpclient.version>
+    <httpcore.version>4.4.13</httpcore.version>
 
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HDDS-4464