### PR TITLE
HDDS-4444. Remove KeyManagerImpl#refreshPipeline because it is the same as refresh().

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1181,7 +1181,7 @@ public class TestKeyManagerImpl {
       KeyManagerImpl keyManagerImpl =
           new KeyManagerImpl(ozoneManager, scmClientMock, conf, "om1");
 
-      keyManagerImpl.refreshPipeline(omKeyInfo);
+      keyManagerImpl.refresh(omKeyInfo);
 
       verify(sclProtocolMock, times(1))
           .getContainerWithPipelineBatch(containerIDs);
@@ -1226,7 +1226,7 @@ public class TestKeyManagerImpl {
           new KeyManagerImpl(ozoneManager, scmClientMock, conf, "om1");
 
       try {
-        keyManagerImpl.refreshPipeline(omKeyInfo);
+        keyManagerImpl.refresh(omKeyInfo);
         Assert.fail();
       } catch (OMException omEx) {
         Assert.assertEquals(SCM_GET_PIPELINE_EXCEPTION, omEx.getResult());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -696,22 +696,12 @@ public class KeyManagerImpl implements KeyManager {
     // Refresh container pipeline info from SCM
     // based on OmKeyArgs.refreshPipeline flag
     // value won't be null as the check is done inside try/catch block.
-    refreshPipeline(value);
+    refresh(value);
 
     if (args.getSortDatanodes()) {
       sortDatanodeInPipeline(value, clientAddress);
     }
     return value;
-  }
-
-  /**
-   * Refresh pipeline info in OM by asking SCM.
-   * @param value OmKeyInfo
-   */
-  @VisibleForTesting
-  protected void refreshPipeline(OmKeyInfo value) throws IOException {
-    Preconditions.checkNotNull(value, "OMKeyInfo cannot be null");
-    refreshPipeline(Arrays.asList(value));
   }
 
   /**
@@ -1825,7 +1815,7 @@ public class KeyManagerImpl implements KeyManager {
         // refreshPipeline flag check has been removed as part of
         // https://issues.apache.org/jira/browse/HDDS-3658.
         // Please refer this jira for more details.
-        refreshPipeline(fileKeyInfo);
+        refresh(fileKeyInfo);
         if (sortDatanodes) {
           sortDatanodeInPipeline(fileKeyInfo, clientAddress);
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove KeyManagerImpl#refreshPipeline() and replace with KeyManagerImpl#refresh().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4444

## How was this patch tested?

Unit test passed.
