### PR TITLE
HDDS-4467. Acceptance test fails due to new Hadoop 3 image

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-compose.yaml
@@ -33,6 +33,8 @@ services:
       - 9600:9600
     env_file:
       - ./docker-config
+    environment:
+      HADOOP_CONF_DIR: /opt/hadoop/etc/hadoop
     command: ["hadoop", "kms"]
     networks:
       ozone_net:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -30,6 +30,8 @@ services:
       - 9600:9600
       env_file:
       - ./docker-config
+      environment:
+        HADOOP_CONF_DIR: /opt/hadoop/etc/hadoop
       command: ["hadoop", "kms"]
 
   datanode:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance test is broken by new Hadoop 3 docker image (HADOOP-17320).  KMS container fails to start with:

```
2020-11-16 14:03:22,641 ERROR [main] conf.Configuration (Configuration.java:loadResource(3047)) - error parsing conf file:/etc/hadoop/core-site.xml
java.io.FileNotFoundException: /etc/hadoop/core-site.xml (No such file or directory)
```

The problem is that the new `hadoop:3` image is based on more recent `hadoop-runner`, which [sets `HADOOP_CONF_DIR`](https://github.com/apache/hadoop/blob/3f6d7a6ce2236292a2d044b5c3c80bdec28b2922/Dockerfile#L42), whereas previously it was unset.

https://issues.apache.org/jira/browse/HDDS-4467

## How was this patch tested?

[`ozonesecure-om-ha`](https://github.com/adoroszlai/hadoop-ozone/runs/1406793619#step:8:1673) test passed, `ozonesecure` had no problem with `kms` container.