### PR TITLE
HDDS-4468. Fix Goofys listBucket large than 1000 objects will stuck forever

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -112,6 +112,9 @@ public class BucketEndpoint extends EndpointBase {
     ContinueToken decodedToken =
         ContinueToken.decodeFromString(continueToken);
 
+    if (startAfter == null) {
+      startAfter = marker;
+    }
     if (startAfter != null && continueToken != null) {
       // If continuation token and start after both are provided, then we
       // ignore start After
@@ -187,6 +190,7 @@ public class BucketEndpoint extends EndpointBase {
       response.setTruncated(true);
       ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
       response.setNextToken(nextToken.encodeToString());
+      response.setNextMarker(lastKey);
     } else {
       response.setTruncated(false);
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -133,7 +133,7 @@ public class BucketEndpoint extends EndpointBase {
     response.setDelimiter(delimiter);
     response.setName(bucketName);
     response.setPrefix(prefix);
-    response.setMarker("");
+    response.setMarker(marker == null ? "" : marker);
     response.setMaxKeys(maxKeys);
     response.setEncodingType(ENCODING_TYPE);
     response.setTruncated(false);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -112,6 +112,7 @@ public class BucketEndpoint extends EndpointBase {
     ContinueToken decodedToken =
         ContinueToken.decodeFromString(continueToken);
 
+    // stand for startAfter
     if (startAfter == null) {
       startAfter = marker;
     }
@@ -190,6 +191,7 @@ public class BucketEndpoint extends EndpointBase {
       response.setTruncated(true);
       ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
       response.setNextToken(nextToken.encodeToString());
+      // For aws api v1 compatibility purpose, set nextMarker with lastKey
       response.setNextMarker(lastKey);
     } else {
       response.setTruncated(false);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -191,7 +191,7 @@ public class BucketEndpoint extends EndpointBase {
       response.setTruncated(true);
       ContinueToken nextToken = new ContinueToken(lastKey, prevDir);
       response.setNextToken(nextToken.encodeToString());
-      // For aws api v1 compatibility purpose, set nextMarker with lastKey
+      // Set nextMarker to be lastKey. for the compatibility of aws api v1
       response.setNextMarker(lastKey);
     } else {
       response.setTruncated(false);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -112,8 +112,8 @@ public class BucketEndpoint extends EndpointBase {
     ContinueToken decodedToken =
         ContinueToken.decodeFromString(continueToken);
 
-    // stand for startAfter
-    if (startAfter == null) {
+    // Assign marker to startAfter. for the compatibility of aws api v1
+    if (startAfter == null && marker != null) {
       startAfter = marker;
     }
     if (startAfter != null && continueToken != null) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ListObjectResponse.java
@@ -63,6 +63,9 @@ public class ListObjectResponse {
   @XmlElement(name = "NextContinuationToken")
   private String nextToken;
 
+  @XmlElement(name = "NextMarker")
+  private String nextMarker;
+
   @XmlElement(name = "continueToken")
   private String continueToken;
 
@@ -176,5 +179,13 @@ public class ListObjectResponse {
 
   public void setKeyCount(int keyCount) {
     this.keyCount = keyCount;
+  }
+
+  public void setNextMarker(String nextMarker) {
+    this.nextMarker = nextMarker;
+  }
+
+  public String getNextMarker() {
+    return nextMarker;
   }
 }


### PR DESCRIPTION
## Description

The following is the `ListObjectsOutput`, `ListObjectsV2Output` and `ListObjectsInput`, `ListObjectsV2Input` from `github.com/aws/aws-sdk-go/service/s3/api.go`,   

For goofys talk to s3g, it use the `ListObjectsOutput` and `ListObjectsInput`, so I think s3g should return `NextMarker` in the `ListBucketResult` and use `mark` to list key from.

For this PR, I purpose to make `BucketEndpoint` of `s3g` can both serve to `V1` and `V2`

```go
type ListObjectsOutput struct {
	_ struct{} `type:"structure"`
	CommonPrefixes []*CommonPrefix `type:"list" flattened:"true"`
	Contents []*Object `type:"list" flattened:"true"`
	Delimiter *string `type:"string"`
	EncodingType *string `type:"string" enum:"EncodingType"`
	IsTruncated *bool `type:"boolean"`
	Marker *string `type:"string"`
	MaxKeys *int64 `type:"integer"`
	Name *string `type:"string"`
	NextMarker *string `type:"string"`
	Prefix *string `type:"string"`
}

type ListObjectsV2Output struct {
	_ struct{} `type:"structure"`
	CommonPrefixes []*CommonPrefix `type:"list" flattened:"true"`
	Contents []*Object `type:"list" flattened:"true"`
	ContinuationToken *string `type:"string"`
	Delimiter *string `type:"string"`
	EncodingType *string `type:"string" enum:"EncodingType"`
	IsTruncated *bool `type:"boolean"`
	KeyCount *int64 `type:"integer"`
	MaxKeys *int64 `type:"integer"`
	Name *string `type:"string"`
	NextContinuationToken *string `type:"string"`
	Prefix *string `type:"string"`
	StartAfter *string `type:"string"`
}

type ListObjectsInput struct {
	_ struct{} `type:"structure"`
	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
	Delimiter *string `location:"querystring" locationName:"delimiter" type:"string"`
	EncodingType *string `location:"querystring" locationName:"encoding-type" type:"string" enum:"EncodingType"`
	Marker *string `location:"querystring" locationName:"marker" type:"string"`
	MaxKeys *int64 `location:"querystring" locationName:"max-keys" type:"integer"`
	Prefix *string `location:"querystring" locationName:"prefix" type:"string"`
	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
}

type ListObjectsV2Input struct {
	_ struct{} `type:"structure"`

	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
	ContinuationToken *string `location:"querystring" locationName:"continuation-token" type:"string"`
	Delimiter *string `location:"querystring" locationName:"delimiter" type:"string"`
	EncodingType *string `location:"querystring" locationName:"encoding-type" type:"string" enum:"EncodingType"`
	FetchOwner *bool `location:"querystring" locationName:"fetch-owner" type:"boolean"`
	MaxKeys *int64 `location:"querystring" locationName:"max-keys" type:"integer"`
	Prefix *string `location:"querystring" locationName:"prefix" type:"string"`
	RequestPayer *string `location:"header" locationName:"x-amz-request-payer" type:"string" enum:"RequestPayer"`
	StartAfter *string `location:"querystring" locationName:"start-after" type:"string"`
}
```

## What changes were proposed in this pull request?

Fill `startAfter` with marker parameter when `startAfter` is `null`

Fill nextMark to the response, so that Goofys can use the nextMark to list follow-up objects.

## What is the link to the Apache JIRA

HDDS-4468

## How was this patch tested?

- Create an ozone cluster with s3g.
- Start a goofys with this s3g.
- Generate more than 1000 file in the test bucket
- list the goofys mounted path.

I've tested this PR on my local env.
