### PR TITLE
HDDS-4475.Extend DatanodeChunkGenerator to write all on all pipelines…

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
@@ -85,7 +85,9 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
   private String pipelineIds;
 
   @Option(names = {"-d", "--datanodes"},
-      description = "Datanodes to use. ",
+      description = "Datanodes to use." +
+          " Test will write to all the existing pipelines " +
+          "which this datanode is member of.",
       defaultValue = "")
   private String datanodes;
 
@@ -133,8 +135,6 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
             .acquireClient(firstPipeline);
         xceiverClients = new ArrayList<>();
         xceiverClients.add(xceiverClientSpi);
-        LOG.info("Using pipeline {}", firstPipeline.getId());
-        runTest();
       } else {
         xceiverClients = new ArrayList<>();
         pipelines = new HashSet<>();
@@ -152,11 +152,10 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
         }
         if (pipelines.isEmpty()){
           throw new IllegalArgumentException(
-              "Coudln't find the any/the selected pipeline");
-        } else {
-          runTest();
+              "Couldn't find the any/the selected pipeline");
         }
       }
+      runTest();
     } finally {
       for (XceiverClientSpi xceiverClientSpi : xceiverClients) {
         if (xceiverClientSpi != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, DatanodeChunkGenerator takes a single pipeline as a parameter. This will allow passing a list of pipelines as comma-separated by their pipeline ids and the load will be generated on the dns of the provided pipelines.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4475

## How was this patch tested?
Tested on docker.
