### PR TITLE
HDDS-4485. [DOC] add the authentication rules of the Ozone Ranger.

### DIFF
--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -27,8 +27,9 @@ icon: user
 
 
 Apache Ranger™ is a framework to enable, monitor and manage comprehensive data
-security across the Hadoop platform. Any version of Apache Ranger which is greater
-than 1.20 is aware of Ozone, and can manage an Ozone cluster.
+security across the Hadoop platform. Apache Ranger has supported Ozone authentication 
+since version 2.0. However, due to some bugs in 2.0, we prefer to use Apache Ranger 
+2.1 and later version.
 
 
 To use Apache Ranger, you must have Apache Ranger installed in your Hadoop
@@ -44,3 +45,19 @@ Property|Value
 --------|------------------------------------------------------------
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
+
+The ranger permissions corresponding to Ozone operation are as follows:
+
+   | Volume  permission | Bucket permission | Key permission
+---- | -------------------| ------------------| --------------
+Create  volume | CREATE | | 
+List volume | LIST | | 
+Get volume Info | READ | | 
+Delete volume | DELETE | | 
+Create  bucket | READ | CREATE | 
+List bucket | LIST, READ | | 
+Get bucket info | READ | READ | 
+Delete bucket | READ | DELETE | 
+List key | READ | LIST, READ | 
+Write key | READ | READ | CREATE, WRITE
+Read key | READ | READ | READ

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -46,7 +46,7 @@ Property|Value
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
 
-The ranger permissions corresponding to the Ozone operations are as follows:
+The Ranger permissions corresponding to the Ozone operations are as follows:
 
 | operation&permission | Volume  permission | Bucket permission | Key permission |
 | :--- | :--- | :--- | :--- |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -46,7 +46,7 @@ Property|Value
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
 
-The ranger permissions corresponding to Ozone operation are as follows:
+The ranger permissions corresponding to the Ozone operations are as follows:
 
 | operation&permission | Volume  permission | Bucket permission | Key permission |
 | :--- | :--- | :--- | :--- |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -48,16 +48,16 @@ ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.Ran
 
 The ranger permissions corresponding to Ozone operation are as follows:
 
-   | Volume  permission | Bucket permission | Key permission
----- | -------------------| ------------------| --------------
-Create  volume | CREATE | | 
-List volume | LIST | | 
-Get volume Info | READ | | 
-Delete volume | DELETE | | 
-Create  bucket | READ | CREATE | 
-List bucket | LIST, READ | | 
-Get bucket info | READ | READ | 
-Delete bucket | READ | DELETE | 
-List key | READ | LIST, READ | 
-Write key | READ | READ | CREATE, WRITE
-Read key | READ | READ | READ
+| operation&permission | Volume  permission | Bucket permission | Key permission |
+| :--- | :--- | :--- | :--- |
+| Create  volume | CREATE | | |
+| List volume | LIST | | |
+| Get volume Info | READ | | |
+| Delete volume | DELETE | | |
+| Create  bucket | READ | CREATE | |
+| List bucket | LIST, READ | | |
+| Get bucket info | READ | READ | |
+| Delete bucket | READ | DELETE | |
+| List key | READ | LIST, READ | |
+| Write key | READ | READ | CREATE, WRITE |
+| Read key | READ | READ | READ |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -28,8 +28,8 @@ icon: user
 
 Apache Ranger™ is a framework to enable, monitor and manage comprehensive data
 security across the Hadoop platform. Apache Ranger has supported Ozone authentication 
-since version 2.0. However, due to some bugs in 2.0, we prefer to use Apache Ranger 
-2.1 and later version.
+since version 2.0. However, due to some bugs in 2.0, Apache Ranger 
+2.1 and later versions are recommended.
 
 
 To use Apache Ranger, you must have Apache Ranger installed in your Hadoop

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -26,7 +26,7 @@ icon: user
 -->
 
 
-Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限的框架。Apache Ranger 从2.0版本开始支持ozone鉴权。但由于在2.0中存在一些bug，因此我们更推荐使用Apache Ranger 2.1及以后版本。
+Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限的框架。Apache Ranger 从2.0版本开始支持Ozone鉴权。但由于在2.0中存在一些bug，因此我们更推荐使用Apache Ranger 2.1及以后版本。
 
 你需要先在你的 Hadoop 集群上安装 Apache Ranger，安装指南可以参考 [Apache Ranger 官网](https://ranger.apache.org/index.html).
 
@@ -37,11 +37,11 @@ Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限�
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
 
-Ozone各类操作对应ranger权限如下：
+Ozone各类操作对应Ranger权限如下：
 
 | operation&permission | Volume  permission | Bucket permission | Key permission |
 | :--- | :--- | :--- | :--- |
-| Create  volume | CREATE | | |
+| Create volume | CREATE | | |
 | List volume | LIST | | |
 | Get volume Info | READ | | |
 | Delete volume | DELETE | | |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -39,16 +39,16 @@ ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.Ran
 
 Ozone各类操作对应ranger权限如下：
 
-   | Volume  permission | Bucket permission | Key permission
----- | -------------------| ------------------| --------------
-Create  volume | CREATE | | 
-List volume | LIST | | 
-Get volume Info | READ | | 
-Delete volume | DELETE | | 
-Create  bucket | READ | CREATE | 
-List bucket | LIST, READ | | 
-Get bucket info | READ | READ | 
-Delete bucket | READ | DELETE | 
-List key | READ | LIST, READ | 
-Write key | READ | READ | CREATE, WRITE
-Read key | READ | READ | READ
+| operation&permission | Volume  permission | Bucket permission | Key permission |
+| :--- | :--- | :--- | :--- |
+| Create  volume | CREATE | | |
+| List volume | LIST | | |
+| Get volume Info | READ | | |
+| Delete volume | DELETE | | |
+| Create  bucket | READ | CREATE | |
+| List bucket | LIST, READ | | |
+| Get bucket info | READ | READ | |
+| Delete bucket | READ | DELETE | |
+| List key | READ | LIST, READ | |
+| Write key | READ | READ | CREATE, WRITE |
+| Read key | READ | READ | READ |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -26,7 +26,7 @@ icon: user
 -->
 
 
-Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限的框架。版本大于 1.20 的 Apache Ranger 都可以用于管理 Ozone 集群。
+Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限的框架。Apache Ranger 从2.0版本开始支持ozone鉴权。但由于在2.0中存在一些bug，因此我们更推荐使用Apache Ranger 2.1及以后版本。
 
 你需要先在你的 Hadoop 集群上安装 Apache Ranger，安装指南可以参考 [Apache Ranger 官网](https://ranger.apache.org/index.html).
 
@@ -36,3 +36,19 @@ Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限�
 --------|------------------------------------------------------------
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
+
+Ozone各类操作对应ranger权限如下：
+
+   | Volume  permission | Bucket permission | Key permission
+---- | -------------------| ------------------| --------------
+Create  volume | CREATE | | 
+List volume | LIST | | 
+Get volume Info | READ | | 
+Delete volume | DELETE | | 
+Create  bucket | READ | CREATE | 
+List bucket | LIST, READ | | 
+Get bucket info | READ | READ | 
+Delete bucket | READ | DELETE | 
+List key | READ | LIST, READ | 
+Write key | READ | READ | CREATE, WRITE
+Read key | READ | READ | READ


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/HDDS-4485

## What is the link to the Apache JIRA

There are few descriptions of Ranger in Ozone documents. I tried to install Ranger locally and verified the authentication strategy of Ozone. The authentication rules need to be added to the existing documentation. 
The effects of the changes can be viewed here:
https://github.com/captainzmc/hadoop-ozone/blob/add-ranger-doc/hadoop-hdds/docs/content/security/SecurityWithRanger.md

## How was this patch tested?

add doc no need tests
