### PR TITLE
HDDS-4356. SCM is flooded with useless "Deleting blocks" messages.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -297,8 +297,10 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     // TODO: track the block size info so that we can reclaim the container
     // TODO: used space when the block is deleted.
     for (BlockGroup bg : keyBlocksInfoList) {
-      LOG.info("Deleting blocks {}",
-          StringUtils.join(",", bg.getBlockIDList()));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Deleting blocks {}",
+            StringUtils.join(",", bg.getBlockIDList()));
+      }
       for (BlockID block : bg.getBlockIDList()) {
         long containerID = block.getContainerID();
         if (containerBlocks.containsKey(containerID)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM deletes 1000 blocks max at a time, and the "Deleting blocks" message repeats for 1000 times. The PR changes the log level to DEBUG.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4356

## How was this patch tested?

Existing UT
