### PR TITLE
HDDS-4488. Open RocksDB read only when loading containers at Datanode startup

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -157,7 +157,7 @@ public final class ContainerCache extends LRUMap {
       try {
         long start = Time.monotonicNow();
         DatanodeStore store = BlockUtils.getUncachedDatanodeStore(containerID,
-            containerDBPath, schemaVersion, conf);
+            containerDBPath, schemaVersion, conf, false);
         db = new ReferenceCountedDB(store, containerDBPath);
         metrics.incDbOpenLatency(Time.monotonicNow() - start);
       } catch (Exception e) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -61,15 +61,15 @@ public final class BlockUtils {
    */
   public static DatanodeStore getUncachedDatanodeStore(long containerID,
       String containerDBPath, String schemaVersion,
-      ConfigurationSource conf) throws IOException {
+      ConfigurationSource conf, boolean readOnly) throws IOException {
 
     DatanodeStore store;
     if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
       store = new DatanodeStoreSchemaOneImpl(conf,
-          containerID, containerDBPath);
+          containerID, containerDBPath, readOnly);
     } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V2)) {
       store = new DatanodeStoreSchemaTwoImpl(conf,
-          containerID, containerDBPath);
+          containerID, containerDBPath, readOnly);
     } else {
       throw new IllegalArgumentException(
           "Unrecognized database schema version: " + schemaVersion);
@@ -88,11 +88,11 @@ public final class BlockUtils {
    * @throws IOException
    */
   public static DatanodeStore getUncachedDatanodeStore(
-      KeyValueContainerData containerData, ConfigurationSource conf)
-      throws IOException {
+      KeyValueContainerData containerData, ConfigurationSource conf,
+      boolean readOnly) throws IOException {
     return getUncachedDatanodeStore(containerData.getContainerID(),
         containerData.getDbFile().getAbsolutePath(),
-        containerData.getSchemaVersion(), conf);
+        containerData.getSchemaVersion(), conf, readOnly);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -106,10 +106,10 @@ public final class KeyValueContainerUtil {
     DatanodeStore store;
     if (schemaVersion.equals(OzoneConsts.SCHEMA_V1)) {
       store = new DatanodeStoreSchemaOneImpl(conf,
-              containerID, dbFile.getAbsolutePath());
+              containerID, dbFile.getAbsolutePath(), false);
     } else if (schemaVersion.equals(OzoneConsts.SCHEMA_V2)) {
       store = new DatanodeStoreSchemaTwoImpl(conf,
-              containerID, dbFile.getAbsolutePath());
+              containerID, dbFile.getAbsolutePath(), false);
     } else {
       throw new IllegalArgumentException(
               "Unrecognized schema version for container: " + schemaVersion);
@@ -192,7 +192,8 @@ public final class KeyValueContainerUtil {
     DatanodeStore store = null;
     try {
       try {
-        store = BlockUtils.getUncachedDatanodeStore(kvContainerData, config);
+        store = BlockUtils.getUncachedDatanodeStore(
+            kvContainerData, config, true);
       } catch (IOException e) {
         // If an exception is thrown, then it may indicate the RocksDB is
         // already open in the container cache. As this code is only executed at

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -77,6 +77,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private static final DBProfile DEFAULT_PROFILE = DBProfile.DISK;
   private static final Map<ConfigurationSource, ColumnFamilyOptions>
       OPTIONS_CACHE = new ConcurrentHashMap<>();
+  private final boolean openReadOnly;
 
   /**
    * Constructs the metadata store and starts the DB services.
@@ -85,7 +86,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
    * @throws IOException - on Failure.
    */
   protected AbstractDatanodeStore(ConfigurationSource config, long containerID,
-      AbstractDatanodeDBDefinition dbDef) throws IOException {
+      AbstractDatanodeDBDefinition dbDef, boolean openReadOnly)
+      throws IOException {
 
     // The same config instance is used on each datanode, so we can share the
     // corresponding column family options, providing a single shared cache
@@ -97,6 +99,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
 
     this.dbDef = dbDef;
     this.containerID = containerID;
+    this.openReadOnly = openReadOnly;
     start(config);
   }
 
@@ -121,6 +124,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       this.store = DBStoreBuilder.newBuilder(config, dbDef)
               .setDBOptions(options)
               .setDefaultCFOptions(cfOptions)
+              .setOpenReadOnly(openReadOnly)
               .build();
 
       // Use the DatanodeTable wrapper to disable the table iterator on

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaOneImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaOneImpl.java
@@ -35,9 +35,10 @@ public class DatanodeStoreSchemaOneImpl extends AbstractDatanodeStore {
    * @throws IOException - on Failure.
    */
   public DatanodeStoreSchemaOneImpl(ConfigurationSource config,
-                                    long containerID, String dbPath)
-          throws IOException {
-    super(config, containerID, new DatanodeSchemaOneDBDefinition(dbPath));
+      long containerID, String dbPath, boolean openReadOnly)
+      throws IOException {
+    super(config, containerID, new DatanodeSchemaOneDBDefinition(dbPath),
+        openReadOnly);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
@@ -37,8 +37,9 @@ public class DatanodeStoreSchemaTwoImpl extends AbstractDatanodeStore {
    * @throws IOException - on Failure.
    */
   public DatanodeStoreSchemaTwoImpl(ConfigurationSource config,
-                                    long containerID, String dbPath)
-          throws IOException {
-    super(config, containerID, new DatanodeSchemaTwoDBDefinition(dbPath));
+      long containerID, String dbPath, boolean openReadOnly)
+      throws IOException {
+    super(config, containerID, new DatanodeSchemaTwoDBDefinition(dbPath),
+        openReadOnly);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -54,7 +54,7 @@ public class TestContainerCache {
   private void createContainerDB(OzoneConfiguration conf, File dbFile)
       throws Exception {
     DatanodeStore store = new DatanodeStoreSchemaTwoImpl(
-            conf, 1, dbFile.getAbsolutePath());
+            conf, 1, dbFile.getAbsolutePath(), false);
 
     // we close since the SCM pre-creates containers.
     // we will open and put Db handle into a cache when keys are being created

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -229,8 +229,8 @@ public final class DBStoreBuilder {
     return this;
   }
 
-  public DBStoreBuilder setOpenReadOnly(boolean openReadOnly) {
-    this.openReadOnly = openReadOnly;
+  public DBStoreBuilder setOpenReadOnly(boolean readOnly) {
+    this.openReadOnly = readOnly;
     return this;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -87,6 +87,8 @@ public final class DBStoreBuilder {
   private CodecRegistry registry;
   private String rocksDbStat;
   private RocksDBConfiguration rocksDBConfiguration;
+  // Flag to indicate if the RocksDB should be opened readonly.
+  private boolean openReadOnly = false;
 
   /**
    * Create DBStoreBuilder from a generic DBDefinition.
@@ -187,7 +189,7 @@ public final class DBStoreBuilder {
     }
 
     return new RDBStore(dbFile, rocksDBOption, writeOptions, tableConfigs,
-        registry);
+        registry, openReadOnly);
   }
 
   public DBStoreBuilder setName(String name) {
@@ -224,6 +226,11 @@ public final class DBStoreBuilder {
   public DBStoreBuilder setPath(Path path) {
     Preconditions.checkNotNull(path);
     dbPath = path;
+    return this;
+  }
+
+  public DBStoreBuilder setOpenReadOnly(boolean openReadOnly) {
+    this.openReadOnly = openReadOnly;
     return this;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a datanode is started, it must read some metadata from all the Containers. Part of that metadata is stored in RocksDB, so the startup process involves opening each rocksDB and closing it again.

Testing on a dense node, with 45 high performance spinning disks and 200K containers, I saw about 75ms on average to open each RockDB. Further testing demonstrated that if we open RockDB read only, the average open time is about 35ms.

At startup time, the DBs are only read, and never written, so opening read only is fine. HDDS-4427 already ensures these opened DBs are not cached.

This change adds an "openReadOnly" flag to RDBStore and the related classes to pass it down the stack, allowing the DB to be opened read only.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4488

## How was this patch tested?

Currently existing unit tests.
