### PR TITLE
HDDS-4492. CLI flag --quota should default to 'spaceQuota' to preserve backward compatibility.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
@@ -24,9 +24,9 @@ import picocli.CommandLine;
  */
 public class SetSpaceQuotaOptions {
 
-  @CommandLine.Option(names = {"--space-quota"},
+  // Added --quota for backward compatibility.
+  @CommandLine.Option(names = {"--space-quota", "--quota"},
       description = "The maximum space quota can be used (eg. 1GB)")
-
   private String quotaInBytes;
 
   @CommandLine.Option(names = {"--count-quota"},
@@ -34,13 +34,8 @@ public class SetSpaceQuotaOptions {
           "buckets, and for buckets represents the number of keys (eg. 5)")
   private long quotaInCounts;
 
-  // Hidden option, added for backward compatibility.
-  @CommandLine.Option(names = {"--quota"}, hidden = true,
-      description = "Deprecated use --space-quota")
-  private String quotaInBytesDep;
-
   public String getQuotaInBytes() {
-    return quotaInBytes != null ? quotaInBytes : quotaInBytesDep;
+    return quotaInBytes;
   }
 
   public long getQuotaInCounts() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
@@ -26,6 +26,7 @@ public class SetSpaceQuotaOptions {
 
   @CommandLine.Option(names = {"--space-quota"},
       description = "The maximum space quota can be used (eg. 1GB)")
+
   private String quotaInBytes;
 
   @CommandLine.Option(names = {"--count-quota"},
@@ -33,8 +34,13 @@ public class SetSpaceQuotaOptions {
           "buckets, and for buckets represents the number of keys (eg. 5)")
   private long quotaInCounts;
 
+  // Hidden option, added for backward compatibility.
+  @CommandLine.Option(names = {"--quota"}, hidden = true,
+      description = "Deprecated use --space-quota")
+  private String quotaInBytesDep;
+
   public String getQuotaInBytes() {
-    return quotaInBytes;
+    return quotaInBytes != null ? quotaInBytes : quotaInBytesDep;
   }
 
   public long getQuotaInCounts() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added a hidden option --quota, to work same as --space-quota, if --space-quota isn't specified. Made hidden so as to prevent new users from using it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4492

## How was this patch tested?

Added UT and on docker cluster ::

```
Usage: ozone sh volume create [-hV] [--count-quota=<quotaInCounts>]
                              [--space-quota=<quotaInBytes>] [-u=<ownerName>]
                              <value>
Creates a volume for the specified user
      <value>              URI of the volume.
                           Ozone URI could start with o3:// or without prefix.
                             URI may contain the host/serviceId  and port of
                             the OM server. Both are optional. If they are not
                             specified it will be identified from the config
                             files.
      --count-quota=<quotaInCounts>
                           For volume this parameter represents the number of
                             buckets, and for buckets represents the number of
                             keys (eg. 5)
  -h, --help               Show this help message and exit.
      --space-quota=<quotaInBytes>
                           The maximum space quota can be used (eg. 1GB)
  -u, --user=<ownerName>   Owner of the volume
  -V, --version            Print version information and exit.
bash-4.2$ ozone sh volume create vol1 --quota 10BYTES
bash-4.2$ ozone sh volume info vol1
{
  "metadata" : { },
  "name" : "vol1",
  "admin" : "hadoop",
  "owner" : "hadoop",
  "quotaInBytes" : 10,
  "quotaInCounts" : -1,
  "creationTime" : "2020-11-22T17:42:57.206Z",
  "modificationTime" : "2020-11-22T17:43:32.772081Z",
  "acls" : [ {
    "type" : "USER",
    "name" : "hadoop",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  }, {
    "type" : "GROUP",
    "name" : "users",
    "aclScope" : "ACCESS",
    "aclList" : [ "ALL" ]
  } ],
  "usedBytes" : 0
}
bash-4.2$ 


Usage: ozone sh bucket create [-ghV] [--count-quota=<quotaInCounts>]
                              [-k=<bekName>] [--space-quota=<quotaInBytes>]
                              <value>
creates a bucket in a given volume
      <value>         URI of the volume/bucket.
                      Ozone URI could start with o3:// or without prefix. URI
                        may contain the host/serviceId  and port of the OM
                        server. Both are optional. If they are not specified it
                        will be identified from the config files.
      --count-quota=<quotaInCounts>
                      For volume this parameter represents the number of
                        buckets, and for buckets represents the number of keys
                        (eg. 5)
  -g, --enforcegdpr   if true, indicates GDPR enforced bucket,
                        false/unspecified indicates otherwise
  -h, --help          Show this help message and exit.
  -k, --bucketkey=<bekName>
                      bucket encryption key name
      --space-quota=<quotaInBytes>
                      The maximum space quota can be used (eg. 1GB)
  -V, --version       Print version information and exit.
bash-4.2$ ozone sh bucket create vol1/buck1 --quota 5BYTES
bash-4.2$ ozone sh bucket info vol1/buck1               
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "buck1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "creationTime" : "2020-11-22T17:45:14.969Z",
  "modificationTime" : "2020-11-22T17:45:14.969Z",
  "encryptionKeyName" : null,
  "sourceVolume" : null,
  "sourceBucket" : null,
  "quotaInBytes" : 5,
  "quotaInCounts" : -1
}
bash-4.2$
```