### PR TITLE
HDDS-4502. [OFS] Listing volumes under root should return all volumes whenever possible

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -638,8 +638,8 @@ public class BasicRootedOzoneClientAdapterImpl
 
     OFSPath ofsStartPath = new OFSPath(startPath);
     // list volumes
-    Iterator<? extends OzoneVolume> iter = objectStore.listVolumesByUser(
-        username, null, ofsStartPath.getVolumeName());
+    Iterator<? extends OzoneVolume> iter =
+        objectStore.listVolumes(null, ofsStartPath.getVolumeName());
     List<FileStatusAdapter> res = new ArrayList<>();
     while (iter.hasNext() && res.size() < numEntries) {
       OzoneVolume volume = iter.next();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4502

Currently `listStatusRoot()` only lists volumes owned(ACL disabled) or accessible(ACL enabled) by current user.

**This prevents HttpFS from listing all volumes under OFS root.**

Since we probably can't provide an argument to allow passing in parameter `--all` due to conforming to HCFS, we should default to list ALL volumes whenever this is possible.

Note: `ozone.om.volume.listall.allowed` is an OM side argument that controls whether any user can list all volumes on an Ozone cluster, it defaults to `true`.

## TBD

- [ ] Check how OFS list root would behave when OM has `ozone.om.volume.listall.allowed` = `false` when ACL is enabled.

## Testing

Pending CI. May need to add new UT to check whether the change breaks any existing UTs.