### PR TITLE
HDDS-4471. GrpcOutputStream length can overflow

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcOutputStream.java
@@ -44,7 +44,7 @@ class GrpcOutputStream extends OutputStream {
 
   private final int bufferSize;
 
-  private int writtenBytes;
+  private long writtenBytes;
 
   GrpcOutputStream(
       StreamObserver<CopyContainerResponseProto> responseObserver,


### PR DESCRIPTION
## What changes were proposed in this pull request?
Modified the type to prevent overflow.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4471

## How was this patch tested?
Not tested.

