### PR TITLE
HDDS-3363. Intermittent failure in testContainerImportExport

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -528,6 +528,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
               + getContainerData().getContainerID() + " is in state " + state);
     }
     compactDB();
+    // Close DB (and remove from cache) to avoid concurrent modification while
+    // packing it.
+    BlockUtils.removeDB(containerData, config);
     packer.pack(this, destination);
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -199,7 +199,6 @@ public class TestKeyValueContainer {
       metadataStore.getStore().getMetadataTable()
               .put(OzoneConsts.BLOCK_COUNT, numberOfKeysToWrite);
     }
-    BlockUtils.removeDB(keyValueContainerData, CONF);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("key1", "value1");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Container DBs are compacted during export for replication.  This opens the DB, but does not close it, only decrements the reference count.  So RocksDB keeps running and may modify files while they are being archived.

This change makes sure the DB is closed after compaction to avoid concurrent writes.

https://issues.apache.org/jira/browse/HDDS-3363

## How was this patch tested?

Ran unit test 100x: [failed 6% without the fix](https://github.com/adoroszlai/hadoop-ozone/runs/1447259621), but [0% with it](https://github.com/adoroszlai/hadoop-ozone/runs/1447198023).

Regular CI: https://github.com/adoroszlai/hadoop-ozone/actions/runs/380843788