### PR TITLE
HDDS-4370. Datanode deletion service can avoid storing deleted blocks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-Apache Hadoop Ozone
+Apache Ozone
 ===
 
-Ozone is a scalable, redundant, and distributed object store for Hadoop. Apart from scaling to billions of objects of varying sizes, Ozone can function effectively in containerized environments such as Kubernetes and YARN.
+Ozone is a scalable, redundant, and distributed object store for Hadoop and Cloud-native environments. Apart from scaling to billions of objects of varying sizes, Ozone can function effectively in containerized environments such as Kubernetes and YARN.
 
 
  * MULTI-PROTOCOL SUPPORT: Ozone supports different protocols like S3 and Hadoop File System APIs.
@@ -15,24 +15,22 @@ Ozone is a scalable, redundant, and distributed object store for Hadoop. Apart f
 
 The latest documentation is generated together with the releases and hosted on the apache side.
 
-Please check [the documentation page](https://hadoop.apache.org/ozone/docs/) for more information.
+Please check [the documentation page](https://ozone.apache.org/docs/) for more information.
 
 ## Contact
 
-Ozone is part of the [Apache Hadoop](https://hadoop.apache.org) project.
+Ozone is a top level project under the [Apache Software Foundation](https://apache.org)
 
- * Ozone [web page](https://hadoop.apache.org/ozone/) is available from the Hadoop site
+ * Ozone [web page](https://ozone.apache.org)
  * Mailing lists
-     * For dev questions use: [ozone-dev@hadoop.apache.org](https://lists.apache.org/list.html?ozone-dev@hadoop.apache.org)
-     * For user questions use: [user@hadoop.apache.org](https://lists.apache.org/list.html?user@hadoop.apache.org)
+     * For any questions use: [dev@ozone.apache.org](https://lists.apache.org/list.html?dev@ozone.apache.org)
  * Chat: You can find the #ozone channel on the official ASF slack. Invite link is [here](http://s.apache.org/slack-invite).
  * There are Open [Weekly calls](https://cwiki.apache.org/confluence/display/HADOOP/Ozone+Community+Calls) where you can ask anything about Ozone.
      * Past meeting notes are also available from the wiki.
 
-
 ## Download
 
-Latest release artifacts (source release and binary packages) are [available](https://hadoop.apache.org/ozone/downloads/) from the Ozone web page.
+Latest release artifacts (source release and binary packages) are [available](https://ozone.apache.org/downloads/) from the Ozone web page.
 
 ## Quick start
 
@@ -53,7 +51,7 @@ aws s3 --endpoint http://localhost:9878 cp --storage-class REDUCED_REDUNDANCY  /
 
 ### Run Ozone from released artifact
 
-If you need a more realistic cluster, you can [download](https://hadoop.apache.org/ozone/downloads/) the last (binary) release package, and start a cluster with the help of docker-compose:
+If you need a more realistic cluster, you can [download](https://ozone.apache.org/downloads/) the latest (binary) release package, and start a cluster with the help of docker-compose:
 
 After you untar the binary:
 
@@ -95,4 +93,4 @@ For more information, you can check the [Contribution guideline](./CONTRIBUTING.
 
 ## License
 
-The Apache Hadoop Ozone  project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE.txt) file for details.
+The Apache Ozone project is licensed under the Apache 2.0 License. See the [LICENSE](./LICENSE.txt) file for details.

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -20,10 +20,8 @@ package org.apache.hadoop.ozone.container.common;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.nio.ByteBuffer;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -37,37 +35,40 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
+import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
+import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.impl.TopNOrderedContainerDeletionChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
-import org.apache.hadoop.ozone.container.common.interfaces.Handler;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
+import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerBlockStrategy;
+import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerChunkStrategy;
+import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.testutils.BlockDeletingServiceTestImpl;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -75,12 +76,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-
+import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
+import static org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Tests to test block deleting service.
@@ -91,9 +92,12 @@ public class TestBlockDeletingService {
   private static File testRoot;
   private static String scmId;
   private static String clusterID;
-  private Handler handler;
+  private static String datanodeUuid;
+  private static MutableConfigurationSource conf;
 
   private final ChunkLayOutVersion layout;
+  private int blockLimitPerTask;
+  private static VolumeSet volumeSet;
 
   public TestBlockDeletingService(ChunkLayOutVersion layout) {
     this.layout = layout;
@@ -113,6 +117,10 @@ public class TestBlockDeletingService {
     }
     scmId = UUID.randomUUID().toString();
     clusterID = UUID.randomUUID().toString();
+    conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
+    datanodeUuid = UUID.randomUUID().toString();
+    volumeSet = new MutableVolumeSet(datanodeUuid, conf);
   }
 
   @AfterClass
@@ -120,30 +128,44 @@ public class TestBlockDeletingService {
     FileUtils.deleteDirectory(testRoot);
   }
 
+  private static final DispatcherContext WRITE_STAGE =
+      new DispatcherContext.Builder()
+          .setStage(DispatcherContext.WriteChunkStage.WRITE_DATA).build();
+
+  private static final DispatcherContext COMMIT_STAGE =
+      new DispatcherContext.Builder()
+          .setStage(DispatcherContext.WriteChunkStage.COMMIT_DATA).build();
+
   /**
    * A helper method to create some blocks and put them under deletion
    * state for testing. This method directly updates container.db and
    * creates some fake chunk files for testing.
    */
   private void createToDeleteBlocks(ContainerSet containerSet,
-      MutableConfigurationSource conf, int numOfContainers,
+      int numOfContainers,
       int numOfBlocksPerContainer,
       int numOfChunksPerBlock) throws IOException {
+    ChunkManager chunkManager;
+    if (layout == FILE_PER_BLOCK) {
+      chunkManager = new FilePerBlockStrategy(true);
+    } else {
+      chunkManager = new FilePerChunkStrategy(true, null);
+    }
+    byte[] arr = randomAlphanumeric(1048576).getBytes(UTF_8);
+    ChunkBuffer buffer = ChunkBuffer.wrap(ByteBuffer.wrap(arr));
     for (int x = 0; x < numOfContainers; x++) {
-      conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
       long containerID = ContainerTestHelper.getTestContainerID();
-      KeyValueContainerData data = new KeyValueContainerData(containerID,
-          layout,
-          ContainerTestHelper.CONTAINER_MAX_SIZE, UUID.randomUUID().toString(),
-          UUID.randomUUID().toString());
+      KeyValueContainerData data =
+          new KeyValueContainerData(containerID, layout,
+              ContainerTestHelper.CONTAINER_MAX_SIZE,
+              UUID.randomUUID().toString(), datanodeUuid);
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
-      container.create(new MutableVolumeSet(scmId, clusterID, conf),
+      container.create(volumeSet,
           new RoundRobinVolumeChoosingPolicy(), scmId);
       containerSet.addContainer(container);
       data = (KeyValueContainerData) containerSet.getContainer(
           containerID).getContainerData();
-
       long blockLength = 100;
       try(ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
         for (int j = 0; j < numOfBlocksPerContainer; j++) {
@@ -154,24 +176,29 @@ public class TestBlockDeletingService {
           BlockData kd = new BlockData(blockID);
           List<ContainerProtos.ChunkInfo> chunks = Lists.newArrayList();
           for (int k = 0; k < numOfChunksPerBlock; k++) {
+            final String chunkName = String.format("block.%d.chunk.%d", j, k);
+            final long offset = k * blockLength;
             ContainerProtos.ChunkInfo info =
                 ContainerProtos.ChunkInfo.newBuilder()
-                    .setChunkName(blockID.getLocalID() + "_chunk_" + k)
+                    .setChunkName(chunkName)
                     .setLen(blockLength)
-                    .setOffset(0)
+                    .setOffset(offset)
                     .setChecksumData(Checksum.getNoChecksumDataProto())
                     .build();
             chunks.add(info);
+            ChunkInfo chunkInfo = new ChunkInfo(chunkName, offset, blockLength);
+            ChunkBuffer chunkData = buffer.duplicate(0, (int) blockLength);
+            chunkManager.writeChunk(container, blockID, chunkInfo, chunkData,
+                WRITE_STAGE);
+            chunkManager.writeChunk(container, blockID, chunkInfo, chunkData,
+                COMMIT_STAGE);
           }
           kd.setChunks(chunks);
           metadata.getStore().getBlockDataTable().put(
                   deleteStateName, kd);
           container.getContainerData().incrPendingDeletionBlocks(1);
         }
-
         container.getContainerData().setKeyCount(numOfBlocksPerContainer);
-        container.getContainerData().setBytesUsed(
-            blockLength * numOfBlocksPerContainer);
         // Set block count, bytes used and pending delete block count.
         metadata.getStore().getMetadataTable().put(
                 OzoneConsts.BLOCK_COUNT, (long)numOfBlocksPerContainer);
@@ -206,21 +233,23 @@ public class TestBlockDeletingService {
         MetadataKeyFilters.getDeletingKeyFilter()).size();
   }
 
-  private int getDeletedBlocksCount(ReferenceCountedDB db) throws IOException {
-    return db.getStore().getDeletedBlocksTable()
-          .getRangeKVs(null, 100).size();
-  }
 
   @Test
   public void testBlockDeletion() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
+    this.blockLimitPerTask =
+        conf.getInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER,
+            OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT);
     ContainerSet containerSet = new ContainerSet();
-    createToDeleteBlocks(containerSet, conf, 1, 3, 1);
-
+    createToDeleteBlocks(containerSet, 1, 3, 1);
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        });
     BlockDeletingServiceTestImpl svc =
-        getBlockDeletingService(containerSet, conf);
+        getBlockDeletingService(containerSet, conf, keyValueHandler);
     svc.start();
     GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
 
@@ -239,40 +268,37 @@ public class TestBlockDeletingService {
           .get(containerData.get(0).getContainerID()).getContainerData())
           .getDeleteTransactionId();
 
-
+      long containerSpace = containerData.get(0).getBytesUsed();
       // Number of deleted blocks in container should be equal to 0 before
       // block delete
+
       Assert.assertEquals(0, transactionId);
 
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
       Assert.assertEquals(3, getUnderDeletionBlocksCount(meta));
-      Assert.assertEquals(3,
-          meta.getStore().getMetadataTable()
-                  .get(OzoneConsts.PENDING_DELETE_BLOCK_COUNT).longValue());
-      Assert.assertEquals(0, getDeletedBlocksCount(meta));
+      Assert.assertEquals(3, meta.getStore().getMetadataTable()
+          .get(OzoneConsts.PENDING_DELETE_BLOCK_COUNT).longValue());
+
+      // Container contains 3 blocks. So, space used by the container
+      // should be greater than zero.
+      Assert.assertTrue(containerSpace > 0);
 
       // An interval will delete 1 * 2 blocks
       deleteAndWait(svc, 1);
-      Assert.assertEquals(1, getUnderDeletionBlocksCount(meta));
-      Assert.assertEquals(2, getDeletedBlocksCount(meta));
-
       deleteAndWait(svc, 2);
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(meta));
-      Assert.assertEquals(3, getDeletedBlocksCount(meta));
 
-      deleteAndWait(svc, 3);
-      Assert.assertEquals(0, getUnderDeletionBlocksCount(meta));
-      Assert.assertEquals(3, getDeletedBlocksCount(meta));
-
+      // After deletion of all 3 blocks, space used by the containers
+      // should be zero.
+      containerSpace = containerData.get(0).getBytesUsed();
+      Assert.assertTrue(containerSpace == 0);
 
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
+      Assert.assertEquals(0, meta.getStore().getMetadataTable()
+          .get(OzoneConsts.PENDING_DELETE_BLOCK_COUNT).longValue());
       Assert.assertEquals(0,
-              meta.getStore().getMetadataTable()
-                      .get(OzoneConsts.PENDING_DELETE_BLOCK_COUNT).longValue());
-      Assert.assertEquals(0,
-              meta.getStore().getMetadataTable()
-                      .get(OzoneConsts.BLOCK_COUNT).longValue());
+          meta.getStore().getMetadataTable().get(OzoneConsts.BLOCK_COUNT)
+              .longValue());
     }
 
     svc.shutdown();
@@ -281,17 +307,20 @@ public class TestBlockDeletingService {
   @Test
   @SuppressWarnings("java:S2699") // waitFor => assertion with timeout
   public void testShutdownService() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 500,
         TimeUnit.MILLISECONDS);
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 10);
     ContainerSet containerSet = new ContainerSet();
     // Create 1 container with 100 blocks
-    createToDeleteBlocks(containerSet, conf, 1, 100, 1);
-
+    createToDeleteBlocks(containerSet, 1, 100, 1);
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        });
     BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf);
+        getBlockDeletingService(containerSet, conf, keyValueHandler);
     service.start();
     GenericTestUtils.waitFor(service::isStarted, 100, 3000);
 
@@ -306,15 +335,19 @@ public class TestBlockDeletingService {
 
   @Test
   public void testBlockDeletionTimeout() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
     ContainerSet containerSet = new ContainerSet();
-    createToDeleteBlocks(containerSet, conf, 1, 3, 1);
-
+    createToDeleteBlocks(containerSet, 1, 3, 1);
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        });
     // set timeout value as 1ns to trigger timeout behavior
     long timeout  = 1;
-    OzoneContainer ozoneContainer = mockDependencies(containerSet);
+    OzoneContainer ozoneContainer =
+        mockDependencies(containerSet, keyValueHandler);
     BlockDeletingService svc = new BlockDeletingService(ozoneContainer,
         TimeUnit.MILLISECONDS.toNanos(1000), timeout, TimeUnit.NANOSECONDS,
         conf);
@@ -335,7 +368,7 @@ public class TestBlockDeletingService {
 
     // test for normal case that doesn't have timeout limitation
     timeout  = 0;
-    createToDeleteBlocks(containerSet, conf, 1, 3, 1);
+    createToDeleteBlocks(containerSet, 1, 3, 1);
     svc = new BlockDeletingService(ozoneContainer,
         TimeUnit.MILLISECONDS.toNanos(1000), timeout, TimeUnit.MILLISECONDS,
         conf);
@@ -366,19 +399,21 @@ public class TestBlockDeletingService {
   }
 
   private BlockDeletingServiceTestImpl getBlockDeletingService(
-      ContainerSet containerSet, ConfigurationSource conf) {
-    OzoneContainer ozoneContainer = mockDependencies(containerSet);
-    return new BlockDeletingServiceTestImpl(ozoneContainer, 1000, conf);
+      ContainerSet containerSet, ConfigurationSource config,
+      KeyValueHandler keyValueHandler) {
+    OzoneContainer ozoneContainer =
+        mockDependencies(containerSet, keyValueHandler);
+    return new BlockDeletingServiceTestImpl(ozoneContainer, 1000, config);
   }
 
-  private OzoneContainer mockDependencies(ContainerSet containerSet) {
+  private OzoneContainer mockDependencies(ContainerSet containerSet,
+      KeyValueHandler keyValueHandler) {
     OzoneContainer ozoneContainer = mock(OzoneContainer.class);
     when(ozoneContainer.getContainerSet()).thenReturn(containerSet);
     when(ozoneContainer.getWriteChannel()).thenReturn(null);
     ContainerDispatcher dispatcher = mock(ContainerDispatcher.class);
     when(ozoneContainer.getDispatcher()).thenReturn(dispatcher);
-    handler = mock(KeyValueHandler.class);
-    when(dispatcher.getHandler(any())).thenReturn(handler);
+    when(dispatcher.getHandler(any())).thenReturn(keyValueHandler);
     return ozoneContainer;
   }
 
@@ -393,7 +428,6 @@ public class TestBlockDeletingService {
     //
     // Each time only 1 container can be processed, so each time
     // 1 block from 1 container can be deleted.
-    OzoneConfiguration conf = new OzoneConfiguration();
     // Process 1 container per interval
     conf.set(
         ScmConfigKeys.OZONE_SCM_KEY_VALUE_CONTAINER_DELETION_CHOOSING_POLICY,
@@ -401,28 +435,54 @@ public class TestBlockDeletingService {
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 1);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 1);
     ContainerSet containerSet = new ContainerSet();
+
     int containerCount = 2;
     int chunksPerBlock = 10;
     int blocksPerContainer = 1;
-    createToDeleteBlocks(containerSet, conf, containerCount, blocksPerContainer,
+    createToDeleteBlocks(containerSet, containerCount, blocksPerContainer,
         chunksPerBlock);
-
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        });
     BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf);
+        getBlockDeletingService(containerSet, conf, keyValueHandler);
     service.start();
-
+    List<ContainerData> containerData = Lists.newArrayList();
+    containerSet.listContainer(0L, containerCount, containerData);
     try {
       GenericTestUtils.waitFor(service::isStarted, 100, 3000);
-      for (int i = 1; i <= containerCount; i++) {
-        deleteAndWait(service, i);
-        verify(handler, times(i * blocksPerContainer))
-            .deleteBlock(any(), any());
-      }
+
+      // Deleting one of the two containers and its single block.
+      // Hence, space used by the container of whose block has been
+      // deleted should be zero.
+      deleteAndWait(service, 1);
+      Assert.assertTrue((containerData.get(0).getBytesUsed() == 0)
+          || containerData.get(1).getBytesUsed() == 0);
+
+      Assert.assertFalse((containerData.get(0).getBytesUsed() == 0) && (
+          containerData.get(1).getBytesUsed() == 0));
+
+      // Deleting the second container. Hence, space used by both the
+      // containers should be zero.
+      deleteAndWait(service, 2);
+
+      Assert.assertTrue((containerData.get(1).getBytesUsed() == 0) && (
+          containerData.get(1).getBytesUsed() == 0));
     } finally {
       service.shutdown();
     }
   }
 
+  public long currentBlockSpace(List<ContainerData> containerData,
+      int totalContainers) {
+    long totalSpaceUsed = 0;
+    for (int i = 0; i < totalContainers; i++) {
+      totalSpaceUsed += containerData.get(i).getBytesUsed();
+    }
+    return totalSpaceUsed;
+  }
 
   @Test(timeout = 30000)
   public void testBlockThrottle() throws Exception {
@@ -436,92 +496,54 @@ public class TestBlockDeletingService {
     // Each time containers can be all scanned, but only 2 blocks
     // per container can be actually deleted. So it requires 2 waves
     // to cleanup all blocks.
-    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
-    int blockLimitPerTask = 2;
+    blockLimitPerTask = 2;
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, blockLimitPerTask);
     ContainerSet containerSet = new ContainerSet();
+    ContainerMetrics metrics = ContainerMetrics.create(conf);
+    KeyValueHandler keyValueHandler =
+        new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
+            metrics, c -> {
+        });
     int containerCount = 5;
     int blocksPerContainer = 3;
-    createToDeleteBlocks(containerSet, conf, containerCount,
+    createToDeleteBlocks(containerSet, containerCount,
         blocksPerContainer, 1);
 
     BlockDeletingServiceTestImpl service =
-        getBlockDeletingService(containerSet, conf);
+        getBlockDeletingService(containerSet, conf, keyValueHandler);
     service.start();
-
+    List<ContainerData> containerData = Lists.newArrayList();
+    containerSet.listContainer(0L, containerCount, containerData);
+    long blockSpace = containerData.get(0).getBytesUsed() / blocksPerContainer;
+    long totalContainerSpace =
+        containerCount * containerData.get(0).getBytesUsed();
     try {
       GenericTestUtils.waitFor(service::isStarted, 100, 3000);
       // Total blocks = 3 * 5 = 15
       // block per task = 2
       // number of containers = 5
       // each interval will at most runDeletingTasks 5 * 2 = 10 blocks
+
+      // Deleted space of 10 blocks should be equal to (initial total space
+      // of container - current total space of container).
       deleteAndWait(service, 1);
-      verify(handler, times(blockLimitPerTask * containerCount))
-          .deleteBlock(any(), any());
+      Assert.assertEquals(blockLimitPerTask * containerCount * blockSpace,
+          (totalContainerSpace - currentBlockSpace(containerData,
+              containerCount)));
 
       // There is only 5 blocks left to runDeletingTasks
+
+      // (Deleted space of previous 10 blocks + these left 5 blocks) should
+      // be equal to (initial total space of container
+      // - current total space of container(it will be zero as all blocks
+      // in all the containers are deleted)).
       deleteAndWait(service, 2);
-      verify(handler, times(
-          blocksPerContainer * containerCount))
-          .deleteBlock(any(), any());
+      Assert.assertEquals(blocksPerContainer * containerCount * blockSpace,
+          (totalContainerSpace - currentBlockSpace(containerData,
+              containerCount)));
     } finally {
       service.shutdown();
-    }
-  }
-
-  @Test
-  public void testDeletedChunkInfo() throws Exception {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
-    conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
-    ContainerSet containerSet = new ContainerSet();
-    createToDeleteBlocks(containerSet, conf, 1, 2, 3);
-
-    List<ContainerData> containerData = Lists.newArrayList();
-    containerSet.listContainer(0L, 1, containerData);
-
-    try(ReferenceCountedDB meta = BlockUtils.getDB(
-            (KeyValueContainerData) containerData.get(0), conf)) {
-
-      // Collect all ChunkInfo from blocks marked for deletion.
-      List<? extends Table.KeyValue<String, BlockData>> deletingBlocks =
-              meta.getStore().getBlockDataTable()
-              .getRangeKVs(null, 100,
-                      MetadataKeyFilters.getDeletingKeyFilter());
-
-      // Delete all blocks marked for deletion.
-      BlockDeletingServiceTestImpl svc =
-              getBlockDeletingService(containerSet, conf);
-      svc.start();
-      GenericTestUtils.waitFor(svc::isStarted, 100, 3000);
-      deleteAndWait(svc, 1);
-      svc.shutdown();
-
-      // Get deleted blocks from their table, and check their ChunkInfo lists
-      // against those we saved for them before deletion.
-      List<? extends Table.KeyValue<String, ChunkInfoList>> deletedBlocks =
-              meta.getStore().getDeletedBlocksTable()
-              .getRangeKVs(null, 100);
-
-      Assert.assertEquals(deletingBlocks.size(), deletedBlocks.size());
-
-      Iterator<? extends Table.KeyValue<String, BlockData>>
-              deletingBlocksIter = deletingBlocks.iterator();
-      Iterator<? extends Table.KeyValue<String, ChunkInfoList>>
-              deletedBlocksIter = deletedBlocks.iterator();
-
-      while(deletingBlocksIter.hasNext() && deletedBlocksIter.hasNext())  {
-        List<ContainerProtos.ChunkInfo> deletingChunks =
-                deletingBlocksIter.next().getValue().getChunks();
-        List<ContainerProtos.ChunkInfo> deletedChunks =
-                deletedBlocksIter.next().getValue().asList();
-
-        // On each element of each list, this call uses the equals method
-        // for ChunkInfos generated by protobuf.
-        // This checks their internal fields for equality.
-        Assert.assertEquals(deletingChunks, deletedChunks);
-      }
     }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.ozone.container.common;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently BlockDeletingService in datanode processes the blocks to be deleted and then stores them in a deleted blocks table. We can avoid storing deleted blocks in the container rocksDB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4370

## How was this patch tested?

Tested Manually