### PR TITLE
HDDS-4487. SCM can avoid using RETRIABLE_DATANODE_COMMAND for datanode deletion commands.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -141,7 +141,7 @@ public class SCMBlockDeletingService extends BackgroundService {
               // We should stop caching new commands if num of un-processed
               // command is bigger than a limit, e.g 50. In case datanode goes
               // offline for sometime, the cached commands be flooded.
-              eventPublisher.fireEvent(SCMEvents.RETRIABLE_DATANODE_COMMAND,
+              eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
                   new CommandForDatanode<>(dnId,
                       new DeleteBlocksCommand(dnTXs)));
               if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

RETRIABLE_DATANODE_COMMAND are used to retry deletion commands to datanode in case of timeout. SCM can avoid using RETRIABLE_DATANODE_COMMAND for deletion commands because the service would be sending any pending transactions in the next iteration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4487

## How was this patch tested?

Tested Manually 