### PR TITLE
HDDS-4501. Reload OM State fail should terminate OM for any exceptions.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3324,8 +3324,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       omRatisServer.getOmStateMachine().unpause(lastAppliedIndex, term);
       LOG.info("Reloaded OM state with Term: {} and Index: {}", term,
           lastAppliedIndex);
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       String errorMsg = "Failed to reload OM state and instantiate services.";
+      // Delete the backup DB if exists and then terminate OM.
+      try {
+        if (dbBackup != null) {
+          FileUtils.deleteFully(dbBackup);
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to delete the backup of the original DB {}", dbBackup);
+      }
       exitManager.exitSystem(1, errorMsg, ex, LOG);
     }
 
@@ -3334,7 +3342,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (dbBackup != null) {
         FileUtils.deleteFully(dbBackup);
       }
-    } catch (IOException e) {
+    } catch (Exception e) {
       LOG.error("Failed to delete the backup of the original DB {}", dbBackup);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3332,7 +3332,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           FileUtils.deleteFully(dbBackup);
         }
       } catch (Exception e) {
-        LOG.error("Failed to delete the backup of the original DB {}", dbBackup);
+        LOG.error("Failed to delete the backup of the original DB {}",
+            dbBackup);
       }
       exitManager.exitSystem(1, errorMsg, ex, LOG);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3326,15 +3326,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           lastAppliedIndex);
     } catch (Exception ex) {
       String errorMsg = "Failed to reload OM state and instantiate services.";
-      // Delete the backup DB if exists and then terminate OM.
-      try {
-        if (dbBackup != null) {
-          FileUtils.deleteFully(dbBackup);
-        }
-      } catch (Exception e) {
-        LOG.error("Failed to delete the backup of the original DB {}",
-            dbBackup);
-      }
       exitManager.exitSystem(1, errorMsg, ex, LOG);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During reload state for any exception terminate OM, and also cleanup DB backup folder.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4501

## How was this patch tested?

Existing tests, this issue is idenitified from one of our customer issues, due to this follower OM went into bad state.
