### PR TITLE
HDDS-4511: Avoiding StaleNodeHandler to take effect in TestDeleteWithSlowFollower.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -441,8 +441,8 @@ public class ReplicationManager
    */
   private boolean isContainerUnderReplicated(final ContainerInfo container,
       final Set<ContainerReplica> replicas) {
-    if (container.getState() != LifeCycleState.CLOSED &&
-        container.getState() != LifeCycleState.QUASI_CLOSED) {
+    if (container.getState() == LifeCycleState.DELETING ||
+        container.getState() == LifeCycleState.DELETED) {
       return false;
     }
     boolean misReplicated = !getPlacementStatus(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -130,9 +131,15 @@ public class TestDeleteWithSlowFollower {
 
     conf.setTimeDuration(OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL,
             1, TimeUnit.SECONDS);
+
     ScmConfig scmConfig = conf.getObject(ScmConfig.class);
     scmConfig.setBlockDeletionInterval(Duration.ofSeconds(1));
     conf.setFromObject(scmConfig);
+
+    DatanodeConfiguration datanodeConfiguration = conf.getObject(
+        DatanodeConfiguration.class);
+    datanodeConfiguration.setBlockDeletionInterval(Duration.ofMillis(100));
+    conf.setFromObject(datanodeConfiguration);
 
     RatisClientConfig ratisClientConfig =
         conf.getObject(RatisClientConfig.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change is inspired by avoiding StaleNodeHandler to take effect in TestDeleteWithSlowFollower.

Consider the follow logic in RM, 
```
      /*
       * We don't take any action if the container is in OPEN state and
       * the container is healthy. If the container is not healthy, i.e.
       * the replicas are not in OPEN state, send CLOSE_CONTAINER command.
       */
      if (state == LifeCycleState.OPEN) {
        if (!isContainerHealthy(container, replicas)) {
          eventPublisher.fireEvent(SCMEvents.CLOSE_CONTAINER, id);
        }
        return;
      }

  private boolean isContainerHealthy(final ContainerInfo container,
                                     final Set<ContainerReplica> replicas) {
    return !isContainerUnderReplicated(container, replicas) &&
        !isContainerOverReplicated(container, replicas) &&
        replicas.stream().allMatch(
            r -> compareState(container.getState(), r.getState()));
  }

  private boolean isContainerUnderReplicated(final ContainerInfo container,
      final Set<ContainerReplica> replicas) {
    if (container.getState() != LifeCycleState.CLOSED &&
        container.getState() != LifeCycleState.QUASI_CLOSED) {
      return false;
    }
    boolean misReplicated = !getPlacementStatus(
        replicas, container.getReplicationFactor().getNumber())
        .isPolicySatisfied();
    return container.getReplicationFactor().getNumber() >
        getReplicaCount(container.containerID(), replicas) || misReplicated;
  }
```

Consider this scenario: client triggers SCM to allocate one container by allocating blocks, then it crashes, never writes chunks to DN to trigger the creation of the container, thus no replica report for this container.

Previously, ReplicationManager will close such containers, since it is under replicated. This is a reasonable and legacy handling which is used to prevents StaleNodeHandler to take effect in TestDeleteWithSlowFollower.

This following logic is added by Sammi in her PR `HDDS-4023. Delete closed container after all blocks have been deleted`

```
    if (container.getState() != LifeCycleState.CLOSED &&
        container.getState() != LifeCycleState.QUASI_CLOSED) {
      return false;
    }
```

After talked with @ChenSammi , by design, it just needs to explicitly avoid replicating container in DELETING or DELETED state. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4511

## How was this patch tested?

CI
