### PR TITLE
HDDS-4512. Remove unused netty3 transitive dependency

### DIFF
--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -52,11 +52,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
 
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -102,6 +102,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -46,6 +46,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-common</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -54,6 +55,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
@@ -96,12 +101,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <scope>test</scope>
-      <type>test-jar</type>
     </dependency>
   </dependencies>
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -27,6 +27,8 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
@@ -40,8 +42,6 @@ import org.apache.hadoop.util.DiskChecker;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.base.Preconditions;
-import org.apache.yetus.audience.InterfaceAudience;
-import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -52,6 +52,22 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdds-hadoop-dependency-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-servlet</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-webapp</artifactId>
+    </dependency>
+    <dependency>
       <artifactId>ratis-server</artifactId>
       <groupId>org.apache.ratis</groupId>
       <exclusions>
@@ -68,10 +84,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <artifactId>bcprov-jdk15on</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-util</artifactId>
     </dependency>
     <dependency>
       <groupId>org.rocksdb</groupId>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -83,6 +83,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdfs</artifactId>
       <version>${hadoop.version}</version>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -35,12 +35,24 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-common</artifactId>
       <version>${hadoop.version}</version>
       <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs</artifactId>
       <version>${hadoop.version}</version>
       <type>test-jar</type>
+      <exclusions>
+        <exclusion>
+          <groupId>*</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -372,7 +372,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                   <prefix>$HDDS_LIB_JARS_DIR</prefix>
                   <outputFilterFile>true</outputFilterFile>
                   <includeScope>runtime</includeScope>
-<!--                  <excludeScope>test,provided</excludeScope>-->
                 </configuration>
               </execution>
             </executions>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -160,6 +160,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>hadoop-hdds-common</artifactId>
         <version>${hdds.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -167,6 +168,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>hadoop-hdds-container-service</artifactId>
         <version>${hdds.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -174,6 +176,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>hadoop-hdds-server-scm</artifactId>
         <type>test-jar</type>
         <version>${hdds.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -369,6 +372,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                   <prefix>$HDDS_LIB_JARS_DIR</prefix>
                   <outputFilterFile>true</outputFilterFile>
                   <includeScope>runtime</includeScope>
+<!--                  <excludeScope>test,provided</excludeScope>-->
                 </configuration>
               </execution>
             </executions>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -90,6 +90,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -40,7 +40,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
+      <artifactId>hadoop-hdds-hadoop-dependency-server</artifactId>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -93,6 +93,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -13,8 +13,8 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
     https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
@@ -51,14 +51,20 @@
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
+      <artifactId>hadoop-hdds-common</artifactId>
+      <type>test-jar</type>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-server-scm</artifactId>
-      <scope>test</scope>
       <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-test-utils</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -88,6 +88,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -161,6 +161,13 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-hdds-common</artifactId>
+        <version>${hdds.version}</version>
+        <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-ozone-integration-test</artifactId>
         <version>${ozone.version}</version>
         <type>test-jar</type>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -263,6 +263,12 @@
       <artifactId>jersey-hk2</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-common</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -75,7 +75,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
+      <artifactId>hadoop-hdds-hadoop-dependency-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.ratis</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1021,12 +1021,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
       <dependency>
         <groupId>io.netty</groupId>
-        <artifactId>netty</artifactId>
-        <version>3.10.5.Final</version>
-      </dependency>
-
-      <dependency>
-        <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <version>${netty.version}</version>
       </dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?



Ozone uses Netty either as direct dependency (ozone-csi) or from the ratis shaded dependency (for ratis gprc server). Both use Netty 4.x.

But netty 3 is also included in share/lib/ozone which is not required. The declared netty 3 version has security issues, we need to remove it to make it clear it's not used. (And make classpath safer)

It turned out that netty (and other dependencies) came with the test-jar dependencies used from Hadoop.

Based on the reference of Maven, compile time dependencies of a test dependency should be used as test dependency (https://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html) but in this case it doesn't work:

```
cd hadoop-hdds/container-service
mvn dependency:tree

...
[INFO] +- org.apache.hadoop:hadoop-hdfs:test-jar:tests:3.2.1:test
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.34.v20201102:test
[INFO] |  |  +- org.eclipse.jetty:jetty-http:jar:9.4.34.v20201102:test
[INFO] |  |  \- org.eclipse.jetty:jetty-io:jar:9.4.34.v20201102:test
[INFO] |  +- org.eclipse.jetty:jetty-util-ajax:jar:9.4.34.v20201102:test
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19:test
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:test
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19:test
[INFO] |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  +- commons-codec:commons-codec:jar:1.11:compile
[INFO] |  +- commons-daemon:commons-daemon:jar:1.0.13:test
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:test
[INFO] |  +- io.netty:netty:jar:3.10.5.Final:compile
[INFO] |  +- org.apache.htrace:htrace-core4:jar:4.1.0-incubating:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-databind:jar:2.10.3:compile
[INFO] \- junit:junit:jar:4.11:test
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
...
```

Here all the dependencies of the hadop-hdfs:test-jar suppposed to have test scope.

I didn't find the exact MVN issue, but found that there are multiple open issues related to transitive dependency resolution (can be the https://issues.apache.org/jira/browse/MNG-1378, but there are other open issues, too).

As a result, we should remain on the same side. I ssugest:

 1. Exclude ALL the TRANSITIVE test dependencies for hadoop test-jars. Hadoop test-jars can still be used, but if we need any other class, they should be requested with an explicit dependency

 2. hadoop-ozone-dependency-test should be used everywhere instead of using hadoop-hdfs or hadoop-common test jars (because it includes all the required excludes )

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4512

## How was this patch tested?

With full CI on the fork. If all the components are started and testable, it supposed to be OK (and it was green)

Also tested with checking the existence of netty3 jar in share/lib/ozone.