### PR TITLE
HDDS-4521. Add the necessary dependencies to hadoop-ozone-filesystem-…

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -75,6 +75,11 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
…hadoop2 module.

## What changes were proposed in this pull request?

To resolve compilation errors, add the necessary com.google.protobuf dependencies to the hadoop-ozone-filesystem-hadoop2 module.

## What is the link to the Apache JIRA

[HDDS-4521](https://issues.apache.org/jira/browse/HDDS-4521). Module [hadoop-ozone-filesystem-hadoop2] compilation failure, missing dependencies

## How was this patch tested?

Can be compiled via maven.