### PR TITLE
HDDS-4505. Increase default value for SCM heartbeat timeout to 5s.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -239,7 +239,7 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_HEARTBEAT_RPC_TIMEOUT =
       "ozone.scm.heartbeat.rpc-timeout";
   public static final String OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT =
-      "1s";
+      "5s";
 
   public static final String OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT =
       "ozone.scm.heartbeat.rpc-retry-count";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -943,7 +943,7 @@
   </property>
   <property>
     <name>ozone.scm.heartbeat.rpc-timeout</name>
-    <value>1s</value>
+    <value>5s</value>
     <tag>OZONE, MANAGEMENT</tag>
     <description>
       Timeout value for the RPC from Datanode to SCM.


### PR DESCRIPTION
## What changes were proposed in this pull request?

On increasing the block deletion limit for SCM from 10000 blocks per interval to 100000 blocks, the heartbeats were timing out in the datanodes. Current rpc timeout configured for SCM heartbeat is 1 second. The jira proposes to increase the rpc timeout to 5 seconds.
With 5 second configuration timeouts were not seen by the datanodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4505

## How was this patch tested?

Existing UT. 