### PR TITLE
HDDS-4447. SCMBlockDeletingService should handle ContainerNotFoundException

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -371,7 +371,8 @@ public class DeletedBlockLogImpl
                   .putIfAbsent(txn.getTxID(), new LinkedHashSet<>());
             }
           } catch (ContainerNotFoundException ex) {
-            LOG.warn("Container: "+id+" was not found for the transaction: "+txn);
+            LOG.warn("Container: " + id + " was not found for the transaction: "
+                + txn);
             txnsToBePurged.add(txn);
           }
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -386,13 +386,14 @@ public class DeletedBlockLogImpl
 
   public void purgeTransactions(List<DeletedBlocksTransaction> txnsToBePurged)
       throws IOException {
-    BatchOperation batch =
-        scmMetadataStore.getBatchHandler().initBatchOperation();
-    for (int i = 0; i < txnsToBePurged.size(); i++) {
-      scmMetadataStore.getDeletedBlocksTXTable()
-          .deleteWithBatch(batch, txnsToBePurged.get(i).getTxID());
+    try (BatchOperation batch = scmMetadataStore.getBatchHandler()
+        .initBatchOperation()) {
+      for (int i = 0; i < txnsToBePurged.size(); i++) {
+        scmMetadataStore.getDeletedBlocksTXTable()
+            .deleteWithBatch(batch, txnsToBePurged.get(i).getTxID());
+      }
+      scmMetadataStore.getBatchHandler().commitBatchOperation(batch);
     }
-    scmMetadataStore.getBatchHandler().commitBatchOperation(batch);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -407,18 +407,23 @@ public class SCMContainerManager implements ContainerManager {
         ContainerID containerIdObject = new ContainerID(containerID);
         ContainerInfo containerInfo =
             containerStore.get(containerIdObject);
-        ContainerInfo containerInfoInMem = containerStateManager
-            .getContainer(containerIdObject);
-        if (containerInfo == null || containerInfoInMem == null) {
-          throw new SCMException("Failed to increment number of deleted " +
-              "blocks for container " + containerID + ", reason : " +
-              "container doesn't exist.", FAILED_TO_FIND_CONTAINER);
+        try {
+          ContainerInfo containerInfoInMem = containerStateManager
+              .getContainer(containerIdObject);
+          if (containerInfo == null || containerInfoInMem == null) {
+            throw new SCMException("Failed to increment number of deleted " +
+                "blocks for container " + containerID + ", reason : " +
+                "container doesn't exist.", FAILED_TO_FIND_CONTAINER);
+          }
+          containerInfo.updateDeleteTransactionId(entry.getValue());
+          containerInfo.setNumberOfKeys(containerInfoInMem.getNumberOfKeys());
+          containerInfo.setUsedBytes(containerInfoInMem.getUsedBytes());
+          containerStore.putWithBatch(batchOperation, containerIdObject,
+              containerInfo);
+        } catch (ContainerNotFoundException ex) {
+          // Container is not present therefore we don't need to update
+          // transaction id for this container.
         }
-        containerInfo.updateDeleteTransactionId(entry.getValue());
-        containerInfo.setNumberOfKeys(containerInfoInMem.getNumberOfKeys());
-        containerInfo.setUsedBytes(containerInfoInMem.getUsedBytes());
-        containerStore.putWithBatch(batchOperation, containerIdObject,
-            containerInfo);
       }
       batchHandler.commitBatchOperation(batchOperation);
       containerStateManager.updateDeleteTransactionId(deleteTransactionMap);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/SCMContainerManager.java
@@ -423,6 +423,10 @@ public class SCMContainerManager implements ContainerManager {
         } catch (ContainerNotFoundException ex) {
           // Container is not present therefore we don't need to update
           // transaction id for this container.
+          LOG.warn(
+              "Failed to update the transaction Id as container: " + containerID
+                  + " for transaction: " + entry.getValue()
+                  + " does not exists");
         }
       }
       batchHandler.commitBatchOperation(batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCMBlockDeletingService terminates task on receiving ContainerNotFoundException. As a result, SCM stops deleting blocks.

> 2020-11-09 23:53:10,026 ERROR org.apache.hadoop.hdds.scm.block.SCMBlockDeletingService: Failed to get block deletion transactions from delTX log
org.apache.hadoop.hdds.scm.container.ContainerNotFoundException: Container with id #193 not found.
        at org.apache.hadoop.hdds.scm.container.states.ContainerStateMap.checkIfContainerExist(ContainerStateMap.java:542)
        at org.apache.hadoop.hdds.scm.container.states.ContainerStateMap.getContainerInfo(ContainerStateMap.java:188)
        at org.apache.hadoop.hdds.scm.container.ContainerStateManager.getContainer(ContainerStateManager.java:499)
        at org.apache.hadoop.hdds.scm.container.SCMContainerManager.getContainer(SCMContainerManager.java:212)
        at org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl.getTransactions(DeletedBlockLogImpl.java:364)
        at org.apache.hadoop.hdds.scm.block.SCMBlockDeletingService$DeletedBlockTransactionScanner.call(SCMBlockDeletingService.java:126)
        at org.apache.hadoop.hdds.scm.block.SCMBlockDeletingService$DeletedBlockTransactionScanner.call(SCMBlockDeletingService.java:106)
        at org.apache.hadoop.hdds.utils.BackgroundService$PeriodicalTask.lambda$run$0(BackgroundService.java:112)
        at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1640)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4447
## How was this patch tested?

Tested Manually 
