### PR TITLE
HDDS-4535. Use fixed thread pool for closed container replication

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -25,11 +25,11 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +58,8 @@ public class ReplicationSupervisor {
   @VisibleForTesting
   ReplicationSupervisor(
       ContainerSet containerSet, ContainerReplicator replicator,
-      ExecutorService executor) {
+      ExecutorService executor
+  ) {
     this.containerSet = containerSet;
     this.replicator = replicator;
     this.containersInFlight = ConcurrentHashMap.newKeySet();
@@ -67,9 +68,10 @@ public class ReplicationSupervisor {
 
   public ReplicationSupervisor(
       ContainerSet containerSet,
-      ContainerReplicator replicator, int poolSize) {
+      ContainerReplicator replicator, int poolSize
+  ) {
     this(containerSet, replicator, new ThreadPoolExecutor(
-        0, poolSize, 60, TimeUnit.SECONDS,
+        poolSize, poolSize, 60, TimeUnit.SECONDS,
         new LinkedBlockingQueue<>(),
         new ThreadFactoryBuilder().setDaemon(true)
             .setNameFormat("ContainerReplicationThread-%d")
@@ -83,6 +85,12 @@ public class ReplicationSupervisor {
     if (containersInFlight.add(task.getContainerId())) {
       executor.execute(new TaskRunner(task));
     }
+  }
+
+  @VisibleForTesting
+  public void shutdownAfterFinish() throws InterruptedException {
+    executor.shutdown();
+    executor.awaitTermination(1L, TimeUnit.DAYS);
   }
 
   public void stop() {
@@ -100,6 +108,7 @@ public class ReplicationSupervisor {
   /**
    * Get the number of containers currently being downloaded
    * or scheduled for download.
+   *
    * @return Count of in-flight replications.
    */
   @VisibleForTesting

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorScheduling.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Helper to check scheduling efficiency.
+ * <p>
+ * This unit test is not enabled (doesn't start with Test) but can be used
+ * to validate changes manually.
+ */
+public class ReplicationSupervisorScheduling {
+
+  private final Random random = new Random();
+
+  @Test
+  public void test() throws InterruptedException {
+    List<DatanodeDetails> datanodes = new ArrayList<>();
+    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+
+    //locks representing the limited resource of remote and local disks
+
+    //datanode -> disk -> lock object (remote resources)
+    Map<UUID, Map<Integer, Object>> volumeLocks = new HashMap<>();
+
+    //disk -> lock (local resources)
+    Map<Integer, Object> destinationLocks = new HashMap<>();
+
+    //init the locks
+    for (DatanodeDetails datanode : datanodes) {
+      volumeLocks.put(datanode.getUuid(), new HashMap<>());
+      for (int i = 0; i < 10; i++) {
+        volumeLocks.get(datanode.getUuid()).put(i, new Object());
+      }
+    }
+
+    for (int i = 0; i < 10; i++) {
+      destinationLocks.put(i, new Object());
+    }
+
+    ContainerSet cs = new ContainerSet();
+
+    ReplicationSupervisor rs = new ReplicationSupervisor(cs,
+
+        //simplified executor emulating the current sequential download +
+        //import.
+        task -> {
+
+          //download, limited by the number of source datanodes
+          final DatanodeDetails sourceDatanode =
+              task.getSources().get(random.nextInt(task.getSources().size()));
+
+          final Map<Integer, Object> volumes =
+              volumeLocks.get(sourceDatanode.getUuid());
+          synchronized (volumes.get(random.nextInt(volumes.size()))) {
+            System.out.println("Downloading " + task.getContainerId() + " from "
+                + sourceDatanode.getUuid());
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+              ex.printStackTrace();
+            }
+          }
+
+          //import, limited by the destination datanode
+          final int volumeIndex = random.nextInt(destinationLocks.size());
+          synchronized (destinationLocks.get(volumeIndex)) {
+            System.out.println(
+                "Importing " + task.getContainerId() + " to disk "
+                    + volumeIndex);
+
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+              ex.printStackTrace();
+            }
+          }
+
+        }, 10);
+
+    final long start = System.currentTimeMillis();
+
+    //schedule 100 container replication
+    for (int i = 0; i < 100; i++) {
+      List<DatanodeDetails> sources = new ArrayList<>();
+      sources.add(datanodes.get(random.nextInt(datanodes.size())));
+      rs.addTask(new ReplicationTask(i, sources));
+    }
+    rs.shutdownAfterFinish();
+    final long executionTime = System.currentTimeMillis() - start;
+    System.out.println(executionTime);
+    Assert.assertTrue("Execution was too slow : " + executionTime + " ms",
+        executionTime < 100_000);
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Number of threads for closed container replications can be adjusted by the settings  `hdds.datanode.replication.streams.limit`. But this number is ignored today due to the misuse of `ThreadPoolExecutor`:

```java
new ThreadPoolExecutor(
        0, poolSize, 60, TimeUnit.SECONDS,
        new LinkedBlockingQueue<>(),
        new ThreadFactoryBuilder().setDaemon(true)
            .setNameFormat("ContainerReplicationThread-%d")
            .build())
```

Here the minimal number of threads is 0 and the maximum number of the threads is the configured value.  Threads in the thread pool supposed to be scaled up, but it doesn't.

[From the JDK docs](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html#ThreadPoolExecutor(int,%20int,%20long,%20java.util.concurrent.TimeUnit,%20java.util.concurrent.BlockingQueue)):

> A ThreadPoolExecutor will automatically adjust the pool size (see getPoolSize()) according to the bounds set by corePoolSize (see getCorePoolSize()) and maximumPoolSize (see getMaximumPoolSize()). When a new task is submitted in method execute(java.lang.Runnable), [...] [AND]  If there are more than corePoolSize but less than maximumPoolSize threads running, a new thread will be created only if the queue is full.

So if queue is not full (and `LinkedBlockgingQueue` is unbounded by default) the threads will never be created.

For a quick fix we can switch to use static thread pool instead of dynamic and always keep the required number of threads.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4535

## How was this patch tested?

A new utility is committed as a unit test (`ReplicationSupervisorScheduling`). It helps to test the scheduling (and thread numbers can be checked by jstack) but it's not executed as part of the unit test (because it's slow and un-predictable) as it doesn't start with `Test*`