### PR TITLE
HDDS-4538: Workaround on HDDS-2823, hard code scmUuid and clusterID

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/StorageInfo.java
@@ -27,7 +27,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Properties;
-import java.util.UUID;
 
 /**
  * Common class for storage information. This class defines the common
@@ -198,7 +197,11 @@ public class StorageInfo {
    * @return new clusterID
    */
   public static String newClusterID() {
-    return "CID-" + UUID.randomUUID().toString();
+    // TODO:
+    //  Please check https://issues.apache.org/jira/browse/HDDS-4538
+    //  hard code clusterID and scmUuid on HDDS-2823,
+    //  so that multi SCMs won't cause chaos in Datanode side.
+    return "CID-1df51ed9-19f1-4283-8f61-5d90a84c196c";
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.common.Storage;
 import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
-import java.util.UUID;
 
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.STORAGE_DIR;
@@ -69,7 +68,11 @@ public class SCMStorageConfig extends Storage {
   protected Properties getNodeProperties() {
     String scmId = getScmId();
     if (scmId == null) {
-      scmId = UUID.randomUUID().toString();
+      // TODO:
+      //  Please check https://issues.apache.org/jira/browse/HDDS-4538
+      //  hard code clusterID and scmUuid on HDDS-2823,
+      //  so that multi SCMs won't cause chaos in Datanode side.
+      scmId = "3a11fedb-cce5-46ac-bb0d-cfdf17df9a19";
     }
     Properties scmProperties = new Properties();
     scmProperties.setProperty(SCM_ID, scmId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

A typical SCM group consists of 3 SCMs. If each of the them has its own scmUuid and clusterID, it will cause chaos in Datanode side.
For now, we just hard code the clusterID and scmUuid on HDDS-2823, so that we can setup a SCM raft group.
We need figure out a decent solution when merging back HDDS-2823 back to master. 

## What is the link to the Apache JIRA

HDDS-4538

## How was this patch tested?

CI