### PR TITLE
HDDS-4542. Need throw exception to trigger FailoverProxyProvider of SCM client to work

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -107,13 +107,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   public SCMBlockLocationResponse send(RpcController controller,
       SCMBlockLocationRequest request) throws ServiceException {
     if (!isLeader()) {
-      SCMBlockLocationResponse.Builder response = createSCMBlockResponse(
-          request.getCmdType(),
-          request.getTraceID());
-      response.setSuccess(false);
-      response.setStatus(Status.SCM_NOT_LEADER);
-      response.setLeaderSCMNodeId(null);
-      return response.build();
+      throw new ServiceException(new IOException("SCM IS NOT LEADER"));
     }
     return dispatcher.processRequest(
         request,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -133,9 +133,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public ScmContainerLocationResponse submitRequest(RpcController controller,
       ScmContainerLocationRequest request) throws ServiceException {
     if (!isLeader()) {
-      return ScmContainerLocationResponse.newBuilder()
-              .setCmdType(request.getCmdType()).setTraceID(request.getTraceID())
-              .setSuccess(false).setStatus(Status.SCM_NOT_LEADER).build();
+      throw new ServiceException(new IOException("SCM IS NOT LEADER"));
     }
     return dispatcher
         .processRequest(request, this::processRequest, request.getCmdType(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

ScmBlockLocationProtocolServerSideTranslatorPB and StorageContainerLocationProtocolServerSideTranslatorPB need throw exception to trigger FailoverProxyProvider of SCM client to work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4542

## How was this patch tested?

CI