### PR TITLE
HDDS-4543. Failed to list keys when there are two bucket names with s…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -765,7 +765,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       skipStartKey = true;
     } else {
       // This allows us to seek directly to the first key with the right prefix.
-      seekKey = getOzoneKey(volumeName, bucketName, keyPrefix);
+      seekKey = getOzoneKey(volumeName, bucketName,
+          StringUtil.isNotBlank(keyPrefix) ? keyPrefix : OM_KEY_PREFIX);
     }
 
     String seekPrefix;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -324,19 +324,21 @@ public class TestOmMetadataManager {
     String volumeNameB = "volumeB";
     String ozoneBucket = "ozoneBucket";
     String hadoopBucket = "hadoopBucket";
-
+    String ozoneTestBucket = "ozoneBucket-Test";
 
     // Create volumes and buckets.
     TestOMRequestUtils.addVolumeToDB(volumeNameA, omMetadataManager);
     TestOMRequestUtils.addVolumeToDB(volumeNameB, omMetadataManager);
     addBucketsToCache(volumeNameA, ozoneBucket);
     addBucketsToCache(volumeNameB, hadoopBucket);
-
+    addBucketsToCache(volumeNameA, ozoneTestBucket);
 
     String prefixKeyA = "key-a";
     String prefixKeyB = "key-b";
+    String prefixKeyC = "key-c";
     TreeSet<String> keysASet = new TreeSet<>();
     TreeSet<String> keysBSet = new TreeSet<>();
+    TreeSet<String> keysCSet = new TreeSet<>();
     for (int i=1; i<= 100; i++) {
       if (i % 2 == 0) {
         keysASet.add(
@@ -348,7 +350,8 @@ public class TestOmMetadataManager {
         addKeysToOM(volumeNameA, hadoopBucket, prefixKeyB + i, i);
       }
     }
-
+    keysCSet.add(prefixKeyC + 1);
+    addKeysToOM(volumeNameA, ozoneTestBucket, prefixKeyC + 0, 0);
 
     TreeSet<String> keysAVolumeBSet = new TreeSet<>();
     TreeSet<String> keysBVolumeBSet = new TreeSet<>();
@@ -442,6 +445,14 @@ public class TestOmMetadataManager {
 
     Assert.assertEquals(omKeyInfoList.size(), 0);
 
+    // List all keys with empty prefix
+    omKeyInfoList = omMetadataManager.listKeys(volumeNameA, ozoneBucket,
+        null, null, 100);
+    Assert.assertEquals(50, omKeyInfoList.size());
+    for (OmKeyInfo omKeyInfo : omKeyInfoList) {
+      Assert.assertTrue(omKeyInfo.getKeyName().startsWith(
+          prefixKeyA));
+    }
   }
 
   @Test


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4543


This task fixes the bug that bucket listKeys operation returns empty list,  when there are two buckets with same prefix names, such as "hadoop" and "hadoop-ozone". 