### PR TITLE
HDDS-4551: Remove checkLeader in PipelineManager.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -48,7 +48,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMHAManagerImpl.class);
 
-  private final SCMRatisServerImpl ratisServer;
+  private final SCMRatisServer ratisServer;
   private final ConfigurationSource conf;
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -475,7 +475,7 @@ public final class TestUtils {
   public static StorageContainerManager getScmSimple(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance());
+    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     return StorageContainerManager.createSCM(conf, configurator);
   }
 
@@ -492,7 +492,7 @@ public final class TestUtils {
   public static StorageContainerManager getScm(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance());
+    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     return getScm(conf, configurator);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -112,7 +112,7 @@ public class TestBlockManager {
     // Override the default Node Manager and SCMHAManager
     // in SCM with the Mock one.
     nodeManager = new MockNodeManager(true, 10);
-    scmHAManager = MockSCMHAManager.getInstance();
+    scmHAManager = MockSCMHAManager.getInstance(true);
 
     eventQueue = new EventQueue();
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -80,7 +80,7 @@ public class TestCloseContainerEventHandler {
     pipelineManager =
         PipelineManagerV2Impl.newPipelineManager(
             configuration,
-            MockSCMHAManager.getInstance(),
+            MockSCMHAManager.getInstance(true),
             nodeManager,
             scmMetadataStore.getPipelineTable(),
             eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -60,7 +60,7 @@ public class TestContainerManagerImpl {
     pipelineManager.createPipeline(HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.THREE);
     containerManager = new ContainerManagerImpl(conf,
-        MockSCMHAManager.getInstance(), pipelineManager,
+        MockSCMHAManager.getInstance(true), pipelineManager,
         SCMDBDefinition.CONTAINERS.getTable(dbStore));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestSCMContainerManager.java
@@ -95,7 +95,7 @@ public class TestSCMContainerManager {
     SCMMetadataStore scmMetadataStore = new SCMMetadataStoreImpl(conf);
     pipelineManager = PipelineManagerV2Impl.newPipelineManager(
         conf,
-        MockSCMHAManager.getInstance(),
+        MockSCMHAManager.getInstance(true),
         nodeManager,
         scmMetadataStore.getPipelineTable(),
         new EventQueue());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -118,7 +118,7 @@ public class TestContainerPlacement {
     PipelineManager pipelineManager =
         PipelineManagerV2Impl.newPipelineManager(
             config,
-            MockSCMHAManager.getInstance(),
+            MockSCMHAManager.getInstance(true),
             scmNodeManager,
             scmMetadataStore.getPipelineTable(),
             eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.MockSCMHAManager;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
@@ -91,15 +90,10 @@ public class TestPipelineManagerImpl {
     FileUtil.fullyDelete(testDir);
   }
 
-  private PipelineManagerV2Impl createPipelineManager(boolean leader)
+  private PipelineManagerV2Impl createPipelineManager(boolean isLeader)
       throws IOException {
-    SCMHAManager scmhaManager;
-    if (leader) {
-      scmhaManager = MockSCMHAManager.getLeaderInstance();
-    } else {
-      scmhaManager = MockSCMHAManager.getFollowerInstance();
-    }
-    return PipelineManagerV2Impl.newPipelineManager(conf, scmhaManager,
+    return PipelineManagerV2Impl.newPipelineManager(conf,
+        MockSCMHAManager.getInstance(isLeader),
         new MockNodeManager(true, 20),
         SCMDBDefinition.PIPELINES.getTable(dbStore),
         new EventQueue());
@@ -195,7 +189,8 @@ public class TestPipelineManagerImpl {
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
-    pipelineManager.setScmhaManager(MockSCMHAManager.getFollowerInstance());
+    assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
+    ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
     try {
       pipelineManager.openPipeline(pipeline.getId());
     } catch (NotLeaderException ex) {
@@ -216,7 +211,8 @@ public class TestPipelineManagerImpl {
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
-    pipelineManager.setScmhaManager(MockSCMHAManager.getFollowerInstance());
+    assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
+    ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
     try {
       pipelineManager.activatePipeline(pipeline.getId());
     } catch (NotLeaderException ex) {
@@ -237,7 +233,8 @@ public class TestPipelineManagerImpl {
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
-    pipelineManager.setScmhaManager(MockSCMHAManager.getFollowerInstance());
+    assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
+    ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
     try {
       pipelineManager.deactivatePipeline(pipeline.getId());
     } catch (NotLeaderException ex) {
@@ -301,7 +298,8 @@ public class TestPipelineManagerImpl {
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
-    pipelineManager.setScmhaManager(MockSCMHAManager.getFollowerInstance());
+    assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
+    ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
     try {
       pipelineManager.closePipeline(pipeline, false);
     } catch (NotLeaderException ex) {
@@ -496,8 +494,30 @@ public class TestPipelineManagerImpl {
 
   @Test (expected = NotLeaderException.class)
   public void testScrubPipelineShouldFailOnFollower() throws Exception {
-    PipelineManagerV2Impl pipelineManager = createPipelineManager(false);
+    // No timeout for pipeline scrubber.
+    conf.setTimeDuration(
+        OZONE_SCM_PIPELINE_ALLOCATED_TIMEOUT, -1,
+        TimeUnit.MILLISECONDS);
+
+    PipelineManagerV2Impl pipelineManager = createPipelineManager(true);
     pipelineManager.allowPipelineCreation();
+    Pipeline pipeline = pipelineManager
+        .createPipeline(HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.THREE);
+    // At this point, pipeline is not at OPEN stage.
+    Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
+        pipeline.getPipelineState());
+
+    // pipeline should be seen in pipelineManager as ALLOCATED.
+    Assert.assertTrue(pipelineManager
+        .getPipelines(HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.THREE,
+            Pipeline.PipelineState.ALLOCATED).contains(pipeline));
+
+    // Change to follower
+    assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
+    ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
+
     pipelineManager.scrubPipeline(HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.THREE);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -492,7 +492,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.close();
   }
 
-  @Test (expected = NotLeaderException.class)
+  @Test
   public void testScrubPipelineShouldFailOnFollower() throws Exception {
     // No timeout for pipeline scrubber.
     conf.setTimeDuration(
@@ -518,8 +518,15 @@ public class TestPipelineManagerImpl {
     assert pipelineManager.getScmhaManager() instanceof MockSCMHAManager;
     ((MockSCMHAManager) pipelineManager.getScmhaManager()).setIsLeader(false);
 
-    pipelineManager.scrubPipeline(HddsProtos.ReplicationType.RATIS,
-        HddsProtos.ReplicationFactor.THREE);
+    try {
+      pipelineManager.scrubPipeline(HddsProtos.ReplicationType.RATIS,
+          HddsProtos.ReplicationFactor.THREE);
+    } catch (NotLeaderException ex) {
+      pipelineManager.close();
+      return;
+    }
+    // Should not reach here.
+    Assert.fail();
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -74,7 +74,7 @@ public class TestHealthyPipelineSafeModeRule {
       PipelineManagerV2Impl pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               config,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               nodeManager,
               scmMetadataStore.getPipelineTable(),
               eventQueue);
@@ -123,7 +123,7 @@ public class TestHealthyPipelineSafeModeRule {
       PipelineManagerV2Impl pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               config,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               nodeManager,
               scmMetadataStore.getPipelineTable(),
               eventQueue);
@@ -217,7 +217,7 @@ public class TestHealthyPipelineSafeModeRule {
       PipelineManagerV2Impl pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               config,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               nodeManager,
               scmMetadataStore.getPipelineTable(),
               eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -84,7 +84,7 @@ public class TestOneReplicaPipelineSafeModeRule {
 
     pipelineManager = PipelineManagerV2Impl.newPipelineManager(
         ozoneConfiguration,
-        MockSCMHAManager.getInstance(),
+        MockSCMHAManager.getInstance(true),
         mockNodeManager,
         scmMetadataStore.getPipelineTable(),
         eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -303,7 +303,7 @@ public class TestSCMSafeModeManager {
       PipelineManager pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               conf,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               mockNodeManager,
               scmMetadataStore.getPipelineTable(),
               queue);
@@ -326,7 +326,7 @@ public class TestSCMSafeModeManager {
       PipelineManager pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               conf,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               mockNodeManager,
               scmMetadataStore.getPipelineTable(),
               queue);
@@ -348,7 +348,7 @@ public class TestSCMSafeModeManager {
       PipelineManager pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               conf,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               mockNodeManager,
               scmMetadataStore.getPipelineTable(),
               queue);
@@ -377,7 +377,7 @@ public class TestSCMSafeModeManager {
     PipelineManagerV2Impl pipelineManager =
         PipelineManagerV2Impl.newPipelineManager(
             conf,
-            MockSCMHAManager.getInstance(),
+            MockSCMHAManager.getInstance(true),
             mockNodeManager,
             scmMetadataStore.getPipelineTable(),
             queue);
@@ -627,7 +627,7 @@ public class TestSCMSafeModeManager {
       PipelineManagerV2Impl pipelineManager =
           PipelineManagerV2Impl.newPipelineManager(
               config,
-              MockSCMHAManager.getInstance(),
+              MockSCMHAManager.getInstance(true),
               nodeManager,
               scmMetadataStore.getPipelineTable(),
               queue);
@@ -690,7 +690,7 @@ public class TestSCMSafeModeManager {
     PipelineManagerV2Impl pipelineManager =
         PipelineManagerV2Impl.newPipelineManager(
             config,
-            MockSCMHAManager.getInstance(),
+            MockSCMHAManager.getInstance(true),
             nodeManager,
             scmMetadataStore.getPipelineTable(),
             queue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -59,7 +59,7 @@ public class TestSCMBlockProtocolServer {
     File dir = GenericTestUtils.getRandomizedTestDir();
     config.set(HddsConfigKeys.OZONE_METADATA_DIRS, dir.toString());
     SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance());
+    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     scm = TestUtils.getScm(config, configurator);
     scm.start();
     scm.exitSafeMode();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -171,7 +171,7 @@ public class TestKeyManagerImpl {
     SCMConfigurator configurator = new SCMConfigurator();
     configurator.setScmNodeManager(nodeManager);
     configurator.setNetworkTopology(clusterMap);
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance());
+    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     scm = TestUtils.getScm(conf, configurator);
     scm.start();
     scm.exitSafeMode();


### PR DESCRIPTION
## What changes were proposed in this pull request?

We do not need isLeader check in PipelineManager, just remove them.
By design, we just need do isLeader check when receiving rpc requests and firing datanode command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4551

## How was this patch tested?

CI