### PR TITLE
HDDS-4329. Expose Ratis retry config cache in OM.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -239,4 +239,6 @@ public final class OMConfigKeys {
       "ozone.om.enable.filesystem.paths";
   public static final boolean OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT =
       false;
+
+  public static final String OZONE_OM_HA_PREFIX = "ozone.om.ha";
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -77,7 +77,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INITIAL_DELAY,
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
-        OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY
+        OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
+        OMConfigKeys.OZONE_OM_HA_PREFIX
         // TODO HDDS-2856
     ));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -79,7 +79,7 @@ public abstract class TestOzoneManagerHA {
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
   private static final long SNAPSHOT_THRESHOLD = 50;
-  private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(60);
+  private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -117,6 +117,10 @@ public abstract class TestOzoneManagerHA {
 
   public static int getOzoneClientFailoverMaxAttempts() {
     return OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS;
+  }
+
+  public static Duration getRetryCacheDuration() {
+    return RETRY_CACHE_DURATION;
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -79,7 +79,7 @@ public abstract class TestOzoneManagerHA {
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
   private static final long SNAPSHOT_THRESHOLD = 50;
-  private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
+  private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(60);
 
   @Rule
   public ExpectedException exception = ExpectedException.none();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Before;
 import org.junit.After;
@@ -46,6 +47,7 @@ import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.HashMap;
 
@@ -77,6 +79,7 @@ public abstract class TestOzoneManagerHA {
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
   private static final long SNAPSHOT_THRESHOLD = 50;
+  private static final Duration retryCacheDuration = Duration.ofSeconds(30);
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -143,6 +146,13 @@ public abstract class TestOzoneManagerHA {
     conf.setLong(
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
         SNAPSHOT_THRESHOLD);
+
+    OzoneManagerRatisServerConfig omHAConfig =
+        conf.getObject(OzoneManagerRatisServerConfig.class);
+
+    omHAConfig.setRetryCacheTimeout(retryCacheDuration);
+
+    conf.setFromObject(omHAConfig);
 
     /**
      * config for key deleting service.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -79,7 +79,7 @@ public abstract class TestOzoneManagerHA {
   private static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS = 5;
   private static final int IPC_CLIENT_CONNECT_MAX_RETRIES = 4;
   private static final long SNAPSHOT_THRESHOLD = 50;
-  private static final Duration retryCacheDuration = Duration.ofSeconds(30);
+  private static final Duration RETRY_CACHE_DURATION = Duration.ofSeconds(30);
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
@@ -150,7 +150,7 @@ public abstract class TestOzoneManagerHA {
     OzoneManagerRatisServerConfig omHAConfig =
         conf.getObject(OzoneManagerRatisServerConfig.class);
 
-    omHAConfig.setRetryCacheTimeout(retryCacheDuration);
+    omHAConfig.setRetryCacheTimeout(RETRY_CACHE_DURATION);
 
     conf.setFromObject(omHAConfig);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -422,6 +422,24 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
     Assert.assertFalse(logCapturer.getOutput().contains("created volume:"
         + volumeName));
 
+    //Sleep for little above seconds to get cache clear.
+    Thread.sleep(35000);
+
+    raftClientReply =
+        raftServer.submitClientRequest(new RaftClientRequest(clientId,
+            raftServer.getId(), ozoneManagerRatisServer.getRaftGroup()
+            .getGroupId(), callId, Message.valueOf(
+            OMRatisHelper.convertRequestToByteString(omRequest)),
+            RaftClientRequest.writeRequestType(), null));
+
+    Assert.assertTrue(raftClientReply.isSuccess());
+
+    // As second time with same client id and call id, this request should
+    // be executed ratis server as we are sending this request after cache
+    // expiry duration.
+    Assert.assertTrue(logCapturer.getOutput().contains(
+        "Volume creation failed"));
+
   }
 
   private void validateVolumesList(String userName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -419,11 +419,13 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
     // As second time with same client id and call id, this request should
     // not be executed ratis server should return from cache.
-    Assert.assertFalse(logCapturer.getOutput().contains("created volume:"
-        + volumeName));
+    // If 2nd time executed, it will fail with Volume creation failed. check
+    // for that.
+    Assert.assertFalse(logCapturer.getOutput().contains(
+        "Volume creation failed"));
 
-    //Sleep for little above seconds to get cache clear.
-    Thread.sleep(65000);
+    //Sleep for little above retry cache duration to get cache clear.
+    Thread.sleep(getRetryCacheDuration().toMillis() + 5000);
 
     raftClientReply =
         raftServer.submitClientRequest(new RaftClientRequest(clientId,
@@ -435,7 +437,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
     Assert.assertTrue(raftClientReply.isSuccess());
 
     // As second time with same client id and call id, this request should
-    // be executed ratis server as we are sending this request after cache
+    // be executed by ratis server as we are sending this request after cache
     // expiry duration.
     Assert.assertTrue(logCapturer.getOutput().contains(
         "Volume creation failed"));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -423,7 +423,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
         + volumeName));
 
     //Sleep for little above seconds to get cache clear.
-    Thread.sleep(35000);
+    Thread.sleep(65000);
 
     raftClientReply =
         raftServer.submitClientRequest(new RaftClientRequest(clientId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -26,6 +26,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -81,6 +82,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ipc.RpcConstants.DUMMY_CLIENT_ID;
 import static org.apache.hadoop.ipc.RpcConstants.INVALID_CALL_ID;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HA_PREFIX;
 
 /**
  * Creates a Ratis server endpoint for OM.
@@ -538,7 +540,23 @@ public final class OzoneManagerRatisServer {
 
     RaftServerConfigKeys.Snapshot.setAutoTriggerThreshold(properties,
         snapshotAutoTriggerThreshold);
+
+    createRaftServerProperties(conf, properties);
     return properties;
+  }
+
+  private void createRaftServerProperties(ConfigurationSource ozoneConf,
+      RaftProperties raftProperties) {
+    Map<String, String> ratisServerConf =
+        getOMHAConfigs(ozoneConf);
+    ratisServerConf.forEach((key, val) -> {
+        raftProperties.set(key, val);
+    });
+  }
+
+  private static Map<String, String> getOMHAConfigs(
+      ConfigurationSource configuration) {
+    return configuration.getPropsWithPrefix(OZONE_OM_HA_PREFIX + ".");
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -550,7 +550,7 @@ public final class OzoneManagerRatisServer {
     Map<String, String> ratisServerConf =
         getOMHAConfigs(ozoneConf);
     ratisServerConf.forEach((key, val) -> {
-        raftProperties.set(key, val);
+      raftProperties.set(key, val);
     });
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServerConfig.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigType;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.ratis.server.RaftServerConfigKeys;
+
+import java.time.Duration;
+
+import static org.apache.hadoop.hdds.conf.ConfigTag.OM;
+import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
+import static org.apache.hadoop.hdds.conf.ConfigTag.RATIS;
+
+/**
+ * Class which defines OzoneManager Ratis Server config.
+ */
+@ConfigGroup(prefix = OMConfigKeys.OZONE_OM_HA_PREFIX + "."
+    + RaftServerConfigKeys.PREFIX)
+public class OzoneManagerRatisServerConfig {
+
+  @Config(key = "retrycache.expirytime",
+      defaultValue = "300s",
+      type = ConfigType.TIME,
+      tags = {OZONE, OM, RATIS},
+      description = "The timeout duration of the retry cache."
+  )
+  private long retryCacheTimeout = Duration.ofSeconds(300).toMillis();
+
+  public long getRetryCacheTimeout() {
+    return retryCacheTimeout;
+  }
+
+  public void setRetryCacheTimeout(Duration duration) {
+    this.retryCacheTimeout = duration.toMillis();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Expose Ratis retry cache. Followed new config approach and also used same config name as RatisServer config.
And also with this Jira if any config is prefixed with "ozone.om.ha" and after that users try to use same the RatisServer config it will be used by OM RaftServer. (This allows if any configs need to be tuned and in OM we don't have a config, this capability can help in such scenarios)


Used 5 minutes as default value. As with default leader election time out and with retry 15 count, this value should be more than enough to catch retry requests and return from the cache.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4329

## How was this patch tested?

Added a test
