### PR TITLE
HDDS-4537. Remove refreshPipeline in listKeys.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -923,7 +923,7 @@ public class KeyManagerImpl implements KeyManager {
 
     List<OmKeyInfo> keyList = metadataManager.listKeys(volumeName, bucketName,
         startKey, keyPrefix, maxKeys);
-    refreshPipeline(keyList);
+
     return keyList;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -397,7 +397,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         request.getPrefix(),
         request.getCount());
     for (OmKeyInfo key : keys) {
-      resp.addKeyInfo(key.getProtobuf());
+      resp.addKeyInfo(key.getProtobuf(true));
     }
 
     return resp.build();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove refreshPipeline in listKeys implementation.

For client for list Keys, it needs basic info KeyName, replication type factor, etc., For more refer OzoneKey class. 

As RpcClient is returning only info like KeyName, length, replication type, factor, modificationTime, creationTime. So we don't really need an extra param, as previously even though server sent pipelineInfo it is not used/returned to the client. So we don't need extra param, we can remove refresh pipeline in OM Server.


Note: Right now we are passing OMKeyInfo with block info, if we really want to send only required to the client( This way, we pass less info via wire), we can return only required information by introducing a new API, which will not break compatibility between old client and server. Not taking this approach in this PR, if needed I can open a new Jira for this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4537

## How was this patch tested?

Existing tests.
