### PR TITLE
HDDS-4507. Add SCM CA CLI to query certificate.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -17,7 +17,10 @@
 package org.apache.hadoop.hdds.protocol;
 
 import java.io.IOException;
+import java.util.List;
+
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -76,5 +79,17 @@ public interface SCMSecurityProtocol {
    * @return String         - pem encoded CA certificate.
    */
   String getCACertificate() throws IOException;
+
+  /**
+   * Get list of certificates meet the query criteria.
+   *
+   * @param type            - node type: OM/SCM/DN.
+   * @param startSerialId   - start certificate serial id.
+   * @param count           - max number of certificates returned in a batch.
+   * @param isRevoked       - whether list for revoked certs only.
+   * @return list of PEM encoded certificate strings.
+   */
+  List<String> listCertificate(HddsProtos.NodeType type, long startSerialId,
+      int count, boolean isRevoked) throws IOException;
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -18,9 +18,11 @@ package org.apache.hadoop.hdds.protocolPB;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import java.util.function.Consumer;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
@@ -28,6 +30,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCAC
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetDataNodeCertRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest.Builder;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityResponse;
@@ -199,6 +202,30 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
         builder -> builder.setGetCACertificateRequest(protoIns))
         .getGetCertResponseProto().getX509Certificate();
 
+  }
+
+  /**
+   *
+   * @param role            - node type: OM/SCM/DN.
+   * @param startSerialId   - start cert serial id.
+   * @param count           - max number of certificates returned in a batch.
+   * @param isRevoked       - whether return revoked cert only.
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public List<String> listCertificate(HddsProtos.NodeType role,
+      long startSerialId, int count, boolean isRevoked) throws IOException {
+    SCMListCertificateRequestProto protoIns = SCMListCertificateRequestProto
+        .newBuilder()
+        .setRole(role)
+        .setStartCertId(startSerialId)
+        .setCount(count)
+        .setIsRevoked(isRevoked)
+        .build();
+    return submitRequest(Type.ListCertificate,
+        builder -> builder.setListCertificateRequest(protoIns))
+        .getListCertificateResponseProto().getCertificatesList();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType;
@@ -28,6 +29,7 @@ import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import java.io.IOException;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.concurrent.Future;
 
 /**
@@ -112,6 +114,16 @@ public interface CertificateServer {
    * framework.
    */
 
+  /**
+   * List certificates.
+   * @param type            - node type: OM/SCM/DN
+   * @param startSerialId   - start certificate serial id
+   * @param count           - max number of certificates returned in a batch
+   * @return
+   * @throws IOException
+   */
+  List<X509Certificate> listCertificate(HddsProtos.NodeType type,
+      long startSerialId, int count, boolean isRevoked) throws IOException;
 
   /**
    * Make it explicit what type of CertificateServer we are creating here.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -19,9 +19,12 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  * This interface allows the DefaultCA to be portable and use different DB
@@ -67,6 +70,19 @@ public interface CertificateStore {
    * @throws IOException
    */
   X509Certificate getCertificateByID(BigInteger serialID, CertType certType)
+      throws IOException;
+
+  /**
+   *
+   * @param role - role of the certificate owner (OM/DN).
+   * @param startSerialID - start cert serial id.
+   * @param count - max number of certs returned.
+   * @param certType cert type (valid/revoked).
+   * @return list of X509 certificates.
+   * @throws IOException
+   */
+  List<X509Certificate> listCertificate(HddsProtos.NodeType role,
+      BigInteger startSerialID, int count, CertType certType)
       throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.validator.routines.DomainValidator;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.DefaultProfile;
@@ -51,6 +52,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
@@ -286,6 +288,23 @@ public class DefaultCAServer implements CertificateServer {
       throw new SCMSecurityException(ex);
     }
     return revoked;
+  }
+
+  /**
+   *
+   * @param role            - node type: OM/SCM/DN.
+   * @param startSerialId   - start cert serial id.
+   * @param count           - max number of certificates returned in a batch.
+   * @param isRevoked       - whether return revoked cert only.
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
+      long startSerialId, int count, boolean isRevoked) throws IOException {
+    return store.listCertificate(role, BigInteger.valueOf(startSerialId), count,
+        isRevoked? CertificateStore.CertType.REVOKED_CERTS :
+            CertificateStore.CertType.VALID_CERTS);
   }
 
   /**

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -59,6 +60,6 @@ public class MockCAStore implements CertificateStore {
   public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
       BigInteger startSerialID, int count, CertType certType)
       throws IOException {
-    return null;
+    return Collections.emptyList();
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -19,9 +19,12 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 /**
  *
@@ -48,6 +51,13 @@ public class MockCAStore implements CertificateStore {
   @Override
   public X509Certificate getCertificateByID(BigInteger serialID,
                                             CertType certType)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
+      BigInteger startSerialID, int count, CertType certType)
       throws IOException {
     return null;
   }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
@@ -48,6 +48,7 @@ message SCMSecurityRequest {
     optional SCMGetOMCertRequestProto getOMCertRequest = 4;
     optional SCMGetCertificateRequestProto getCertificateRequest = 5;
     optional SCMGetCACertificateRequestProto getCACertificateRequest = 6;
+    optional SCMListCertificateRequestProto listCertificateRequest = 7;
 
 }
 
@@ -66,6 +67,8 @@ message SCMSecurityResponse {
 
     optional SCMGetCertResponseProto getCertResponseProto = 6;
 
+    optional SCMListCertificateResponseProto listCertificateResponseProto = 7;
+
 }
 
 enum Type {
@@ -73,6 +76,7 @@ enum Type {
     GetOMCertificate = 2;
     GetCertificate = 3;
     GetCACertificate = 4;
+    ListCertificate = 5;
 }
 
 enum Status {
@@ -110,6 +114,16 @@ message SCMGetCACertificateRequestProto {
 }
 
 /**
+* Proto request to list certificates by node type or all.
+*/
+message SCMListCertificateRequestProto {
+    optional NodeType role = 1;
+    optional int64 startCertId = 2;
+    required uint32 count = 3; // Max
+    optional bool isRevoked = 4; // list revoked certs
+}
+
+/**
  * Returns a certificate signed by SCM.
  */
 message SCMGetCertResponseProto {
@@ -121,6 +135,18 @@ message SCMGetCertResponseProto {
     required ResponseCode responseCode = 1;
     required string x509Certificate = 2; // Base64 encoded X509 certificate.
     optional string x509CACertificate = 3; // Base64 encoded CA X509 certificate.
+}
+
+/**
+* Return a list of PEM encoded certificates.
+*/
+message SCMListCertificateResponseProto {
+    enum ResponseCode {
+        success = 1;
+        authenticationFailed = 2;
+    }
+    required ResponseCode responseCode = 1;
+    repeated string certificates = 2;
 }
 
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.scm.protocol;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
@@ -25,6 +26,8 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCer
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetDataNodeCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetOMCertRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityResponse;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.Status;
@@ -102,6 +105,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .setGetCertResponseProto(
                 getDataNodeCertificate(request.getGetDataNodeCertRequest()))
             .build();
+        case ListCertificate:
+          return SCMSecurityResponse.newBuilder()
+              .setCmdType(request.getCmdType())
+              .setStatus(Status.OK)
+              .setListCertificateResponseProto(
+                  listCertificate(request.getListCertificateRequest())
+              )
+              .build();
       default:
         throw new IllegalArgumentException(
             "Unknown request type: " + request.getCmdType());
@@ -184,4 +195,19 @@ public class SCMSecurityProtocolServerSideTranslatorPB
 
   }
 
+  public SCMListCertificateResponseProto listCertificate(
+      SCMListCertificateRequestProto request) throws IOException {
+    List<String> certs = impl.listCertificate(request.getRole(),
+        request.getStartCertId(), request.getCount(), request.getIsRevoked());
+
+    SCMListCertificateResponseProto.Builder builder =
+        SCMListCertificateResponseProto
+            .newBuilder()
+            .setResponseCode(SCMListCertificateResponseProto
+                .ResponseCode.success)
+            .addAllCertificates(certs);
+    return builder.build();
+
+
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -105,8 +105,8 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .setGetCertResponseProto(
                 getDataNodeCertificate(request.getGetDataNodeCertRequest()))
             .build();
-        case ListCertificate:
-          return SCMSecurityResponse.newBuilder()
+      case ListCertificate:
+        return SCMSecurityResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setListCertificateResponseProto(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -107,12 +107,11 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .build();
         case ListCertificate:
           return SCMSecurityResponse.newBuilder()
-              .setCmdType(request.getCmdType())
-              .setStatus(Status.OK)
-              .setListCertificateResponseProto(
-                  listCertificate(request.getListCertificateRequest())
-              )
-              .build();
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setListCertificateResponseProto(
+                listCertificate(request.getListCertificateRequest()))
+            .build();
       default:
         throw new IllegalArgumentException(
             "Unknown request type: " + request.getCmdType());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -147,7 +147,9 @@ public class SCMCertStore implements CertificateStore {
         // CN=FQDN/user=root/role=datanode/...
         results.add(cert);
       } catch (IOException e) {
-        LOG.error("Fail to get certificate from SCM metadata store", e);
+        LOG.error("Fail to list certificate from SCM metadata store", e);
+        throw new SCMSecurityException(
+            "Fail to list certificate from SCM metadata store.");
       }
     }
     return results;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -22,12 +22,17 @@ package org.apache.hadoop.hdds.scm.server;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -111,5 +116,40 @@ public class SCMCertStore implements CertificateStore {
     } else {
       return scmMetadataStore.getRevokedCertsTable().get(serialID);
     }
+  }
+
+  @Override
+  public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
+      BigInteger startSerialID, int count, CertType certType)
+      throws IOException {
+    // TODO: Filter by role
+    List<? extends Table.KeyValue<BigInteger, X509Certificate>> certs;
+    if (startSerialID.longValue() == 0) {
+      startSerialID = null;
+    }
+    if (certType == CertType.VALID_CERTS) {
+      certs = scmMetadataStore.getValidCertsTable().getRangeKVs(
+          startSerialID, count);
+    } else {
+      certs = scmMetadataStore.getRevokedCertsTable().getRangeKVs(
+          startSerialID, count);
+    }
+    List<X509Certificate> results = new ArrayList<>(certs.size());
+    for (Table.KeyValue<BigInteger, X509Certificate> kv : certs) {
+      try {
+        X509Certificate cert = kv.getValue();
+        // TODO: filter certificate based on CN and specified role.
+        // This requires change of the approved subject CN format:
+        // Subject: O=CID-e66d4728-32bb-4282-9770-351a7e913f07,
+        // OU=9a7c4f86-c862-4067-b12c-e7bca51d3dfe, CN=root@98dba189d5f0
+
+        // The new format will look like below that are easier to filter.
+        // CN=FQDN/user=root/role=datanode/...
+        results.add(cert);
+      } catch (IOException e) {
+        LOG.error("Fail to get certificate from SCM metadata store", e);
+      }
+    }
+    return results;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -29,11 +31,13 @@ import java.util.concurrent.Future;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -69,7 +73,6 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
   SCMSecurityProtocolServer(OzoneConfiguration conf,
       CertificateServer certificateServer) throws IOException {
     this.certificateServer = certificateServer;
-
     final int handlerCount =
         conf.getInt(ScmConfigKeys.OZONE_SCM_SECURITY_HANDLER_COUNT_KEY,
             ScmConfigKeys.OZONE_SCM_SECURITY_HANDLER_COUNT_DEFAULT);
@@ -190,6 +193,33 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
     } catch (CertificateException e) {
       throw new IOException("getRootCertificate operation failed. ", e);
     }
+  }
+
+  /**
+   *
+   * @param role            - node role: OM/SCM/DN.
+   * @param startSerialId   - start certificate serial id.
+   * @param count           - max number of certificates returned in a batch.
+   * @param isRevoked       - whether list for revoked certs only.
+   * @return
+   * @throws IOException
+   */
+  @Override
+  public List<String> listCertificate(HddsProtos.NodeType role,
+      long startSerialId, int count, boolean isRevoked) throws IOException {
+    List<X509Certificate> certificates =
+        certificateServer.listCertificate(role, startSerialId, count,
+            isRevoked);
+    List<String> results = new ArrayList<>(certificates.size());
+    for (X509Certificate cert : certificates) {
+      try {
+        String certStr = CertificateCodec.getPEMEncodedString(cert);
+        results.add(certStr);
+      } catch (SCMSecurityException e) {
+        LOGGER.error("listCertificate fail to encode certificate.", e);
+      }
+    }
+    return results;
   }
 
   public RPC.Server getRpcServer() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -216,7 +216,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
         String certStr = CertificateCodec.getPEMEncodedString(cert);
         results.add(certStr);
       } catch (SCMSecurityException e) {
-        LOGGER.error("listCertificate fail to encode certificate.", e);
+        throw new IOException("listCertificate operation failed. ", e);
       }
     }
     return results;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
@@ -29,6 +30,7 @@ import picocli.CommandLine;
 import java.io.IOException;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClient;
 import static picocli.CommandLine.Spec.Target.MIXEE;
 
 /**
@@ -66,6 +68,17 @@ public class ScmOption {
       throw new IllegalArgumentException(
           ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY
               + " should be set in ozone-site.xml or with the --scm option");
+    }
+  }
+
+  public SCMSecurityProtocol createScmSecurityClient() {
+    try {
+      GenericParentCommand parent = (GenericParentCommand)
+          spec.root().userObject();
+      return getScmSecurityClient(parent.createOzoneConfiguration());
+    } catch (IOException ex) {
+      throw new IllegalArgumentException(
+          "Can't create SCM Security client", ex);
     }
   }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/CertCommands.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.cert;
+
+import java.util.concurrent.Callable;
+
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/**
+ * Sub command for certificate related operations.
+ */
+@Command(
+    name = "cert",
+    description = "Certificate related operations",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class,
+    subcommands = {
+      InfoSubcommand.class,
+      ListSubcommand.class,
+    })
+
+@MetaInfServices(SubcommandWithParent.class)
+public class CertCommands implements Callable<Void>, SubcommandWithParent {
+
+  @Spec
+  private CommandSpec spec;
+
+  @Override
+  public Void call() throws Exception {
+    GenericCli.missingSubcommand(spec);
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneAdmin.class;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -63,8 +63,6 @@ class InfoSubcommand extends ScmCertSubcommand {
 
     // Print container report info.
     LOG.info("Certificate id: {}", serialId);
-    boolean verbose = spec.root().userObject() instanceof GenericParentCommand
-        && ((GenericParentCommand) spec.root().userObject()).isVerbose();
     try {
       X509Certificate cert = CertificateCodec.getX509Cert(certPemStr);
       LOG.info(cert.toString());

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.cert;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.cli.GenericParentCommand;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.Spec;
+
+/**
+ * This is the handler that process certificate info command.
+ */
+@Command(
+    name = "info",
+    description = "Show detail information of a specific certificate",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+
+class InfoSubcommand extends ScmCertSubcommand {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(InfoSubcommand.class);
+
+  @Spec
+  private CommandSpec spec;
+
+  @Parameters(description = "Serial id of the certificate in decimal.")
+  private String serialId;
+
+  @Override
+  public void execute(SCMSecurityProtocol client) throws IOException {
+    final String certPemStr =
+        client.getCertificate(serialId);
+    Preconditions.checkNotNull(certPemStr,
+        "Certificate can't be found");
+
+    // Print container report info.
+    LOG.info("Certificate id: {}", serialId);
+    boolean verbose = spec.root().userObject() instanceof GenericParentCommand
+        && ((GenericParentCommand) spec.root().userObject()).isVerbose();
+    try {
+      X509Certificate cert = CertificateCodec.getX509Cert(certPemStr);
+      LOG.info(cert.toString());
+    } catch (CertificateException ex) {
+      LOG.error("Fail to get certificate id " + serialId);
+      throw new IOException("Fail to get certificate id " + serialId, ex);
+    }
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -22,7 +22,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.cli.GenericParentCommand;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/InfoSubcommand.java
@@ -39,7 +39,7 @@ import picocli.CommandLine.Spec;
  */
 @Command(
     name = "info",
-    description = "Show detail information of a specific certificate",
+    description = "Show detailed information for a specific certificate",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 
@@ -69,7 +69,7 @@ class InfoSubcommand extends ScmCertSubcommand {
       X509Certificate cert = CertificateCodec.getX509Cert(certPemStr);
       LOG.info(cert.toString());
     } catch (CertificateException ex) {
-      LOG.error("Fail to get certificate id " + serialId);
+      LOG.error("Failed to get certificate id " + serialId);
       throw new IOException("Fail to get certificate id " + serialId, ex);
     }
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -66,10 +66,10 @@ public class ListSubcommand extends ScmCertSubcommand {
       defaultValue = "valid", showDefaultValue = Visibility.ALWAYS)
   private String type;
 
-  private HddsProtos.NodeType parseCertRole(String role) {
-    if (role.equalsIgnoreCase("om")) {
+  private HddsProtos.NodeType parseCertRole(String r) {
+    if (r.equalsIgnoreCase("om")) {
       return HddsProtos.NodeType.OM;
-    } else if (role.equalsIgnoreCase("scm")) {
+    } else if (r.equalsIgnoreCase("scm")) {
       return HddsProtos.NodeType.SCM;
     } else {
       return HddsProtos.NodeType.DATANODE;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -87,13 +87,13 @@ public class ListSubcommand extends ScmCertSubcommand {
     List<String> certPemList = client.listCertificate(
         parseCertRole(role), startSerialId, count, isRevoked);
     LOG.info("Total {} {} certificates: ", certPemList.size(), type);
-    LOG.info("SerialNumber\t\tValid From\t\tValid To\t\tSubjectDN");
+    LOG.info("SerialNumber\t\tValid From\t\tExpiry\t\tSubject");
     for (String certPemStr : certPemList) {
       try {
         X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);
         printCert(cert);
       } catch (CertificateException ex) {
-        LOG.error("Fail to parse certificate.");
+        LOG.error("Failed to parse certificate.");
       }
     }
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.cert;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Help.Visibility;
+import picocli.CommandLine.Option;
+
+/**
+ * This is the handler that process certificate list command.
+ */
+@Command(
+    name = "list",
+    description = "List certificates",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class ListSubcommand extends ScmCertSubcommand {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ListSubcommand.class);
+
+  @Option(names = {"-s", "--start"},
+      description = "Certificate serial id to start the iteration",
+      defaultValue = "0", showDefaultValue = Visibility.ALWAYS)
+  private long startSerialId;
+
+  @Option(names = {"-c", "--count"},
+      description = "Maximum number of certificates to list",
+      defaultValue = "20", showDefaultValue = Visibility.ALWAYS)
+  private int count;
+
+  @Option(names = {"-r", "--role"},
+      description = "Filter certificate by the role: om/datanode",
+      defaultValue = "datanode", showDefaultValue = Visibility.ALWAYS)
+  private String role;
+
+  @Option(names = {"-t", "--type"},
+      description = "Filter certificate by the type: valid or revoked",
+      defaultValue = "valid", showDefaultValue = Visibility.ALWAYS)
+  private String type;
+
+  private HddsProtos.NodeType parseCertRole(String role) {
+    if (role.equalsIgnoreCase("om")) {
+      return HddsProtos.NodeType.OM;
+    } else if (role.equalsIgnoreCase("scm")) {
+      return HddsProtos.NodeType.SCM;
+    } else {
+      return HddsProtos.NodeType.DATANODE;
+    }
+  }
+
+  private void printCert(X509Certificate cert) {
+    LOG.info("{}\t{}\t{}\t{}", cert.getSerialNumber(), cert.getNotBefore(),
+        cert.getNotAfter(), cert.getSubjectDN());
+  }
+
+  @Override
+  protected void execute(SCMSecurityProtocol client) throws IOException {
+    boolean isRevoked = type.equalsIgnoreCase("revoked");
+    List<String> certPemList = client.listCertificate(
+        parseCertRole(role), startSerialId, count, isRevoked);
+    LOG.info("Total {} {} certificates: ", certPemList.size(), type);
+    LOG.info("SerialNumber\t\tValid From\t\tValid To\t\tSubjectDN");
+    for (String certPemStr : certPemList) {
+      try {
+        X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);
+        printCert(cert);
+      } catch (CertificateException ex) {
+        LOG.error("Fail to parse certificate.");
+      }
+    }
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ListSubcommand.java
@@ -65,6 +65,7 @@ public class ListSubcommand extends ScmCertSubcommand {
       description = "Filter certificate by the type: valid or revoked",
       defaultValue = "valid", showDefaultValue = Visibility.ALWAYS)
   private String type;
+  private static final String OUTPUT_FORMAT = "%-17s %-30s %-30s %-110s";
 
   private HddsProtos.NodeType parseCertRole(String r) {
     if (r.equalsIgnoreCase("om")) {
@@ -77,8 +78,8 @@ public class ListSubcommand extends ScmCertSubcommand {
   }
 
   private void printCert(X509Certificate cert) {
-    LOG.info("{}\t{}\t{}\t{}", cert.getSerialNumber(), cert.getNotBefore(),
-        cert.getNotAfter(), cert.getSubjectDN());
+    LOG.info(String.format(OUTPUT_FORMAT, cert.getSerialNumber(),
+        cert.getNotBefore(), cert.getNotAfter(), cert.getSubjectDN()));
   }
 
   @Override
@@ -87,7 +88,8 @@ public class ListSubcommand extends ScmCertSubcommand {
     List<String> certPemList = client.listCertificate(
         parseCertRole(role), startSerialId, count, isRevoked);
     LOG.info("Total {} {} certificates: ", certPemList.size(), type);
-    LOG.info("SerialNumber\t\tValid From\t\tExpiry\t\tSubject");
+    LOG.info(String.format(OUTPUT_FORMAT, "SerialNumber", "Valid From",
+        "Expiry", "Subject"));
     for (String certPemStr : certPemList) {
       try {
         X509Certificate cert = CertificateCodec.getX509Certificate(certPemStr);

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ScmCertSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/ScmCertSubcommand.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.cert;
+
+import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
+import org.apache.hadoop.hdds.scm.cli.ScmOption;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+/**
+ * Base class for admin commands that connect via SCM security client.
+ */
+public abstract class ScmCertSubcommand implements Callable<Void> {
+
+  @CommandLine.Mixin
+  private ScmOption scmOption;
+
+  protected abstract void execute(SCMSecurityProtocol client)
+      throws IOException;
+
+  @Override
+  public final Void call() throws Exception {
+    SCMSecurityProtocol client = scmOption.createScmSecurityClient();
+    execute(client);
+    return null;
+  }
+}

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/package-info.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/cert/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all of the SCM CA certificate related commands.
+ */
+package org.apache.hadoop.hdds.scm.cli.cert;

--- a/hadoop-ozone/dist/src/main/smoketest/security/admin-cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/admin-cert.robot
@@ -39,6 +39,6 @@ List revoked certificates
                      Should Contain    ${output}    Total 0 revoked certificates
 
 Info of the cert
-    ${output} =      Execute   for id in $(ozone admin cert list |grep UTC|awk '{print $1}'); do ozone admin cert info $id; done
+    ${output} =      Execute   for id in $(ozone admin cert list -c 1|grep UTC|awk '{print $1}'); do ozone admin cert info $id; done
                      Should not Contain    ${output}    Certificate not found
 

--- a/hadoop-ozone/dist/src/main/smoketest/security/admin-cert.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/admin-cert.robot
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test for ozone admin cert command
+Library             BuiltIn
+Library             String
+Resource            ../commonlib.robot
+Resource            ../lib/os.robot
+Resource            ../ozone-lib/shell.robot
+Suite Setup         Setup Test
+Test Timeout        5 minutes
+
+*** Variables ***
+
+*** Keywords ***
+Setup Test
+    Run Keyword     Kinit test user     testuser     testuser.keytab
+
+*** Test Cases ***
+List valid certificates
+    ${output} =      Execute    ozone admin cert list
+                     Should Contain    ${output}    valid certificates
+
+List revoked certificates
+    ${output} =      Execute    ozone admin cert list -t revoked
+                     Should Contain    ${output}    Total 0 revoked certificates
+
+Info of the cert
+    ${output} =      Execute   for id in $(ozone admin cert list |grep UTC|awk '{print $1}'); do ozone admin cert info $id; done
+                     Should not Contain    ${output}    Certificate not found
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding scm admin CLI that allows list/info of certificates issued by SCM. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4507

## How was this patch tested?

Manual testing and added acceptance tests.

Some sample output from the secure docker-compose tests:
```
bash-4.2$ ozone admin cert list
   Total 2 certificates: 
   SerialNumber    Valid From      Valid To        SubjectDN
   162534446438373 Fri Dec 04 00:00:00 UTC 2020    Sat Dec 04 00:00:00 UTC 2021    O=CID-e66d4728-32bb-4282-9770-351a7e913f07, OU=9a7c4f86-c862-4067-b12c-e7bca51d3dfe, CN=root@98dba189d5f0
   162539371895176 Fri Dec 04 00:00:00 UTC 2020    Sat Dec 04 00:00:00 UTC 2021    O=CID-e66d4728-32bb-4282-9770-351a7e913f07, OU=9a7c4f86-c862-4067-b12c-e7bca51d3dfe, CN=root@om

bash-4.2$ ozone admin cert info 162534446438373
   Certificate id: 162534446438373
   [
   [
     Version: V3
     Subject: O=CID-e66d4728-32bb-4282-9770-351a7e913f07, OU=9a7c4f86-c862-4067-b12c-e7bca51d3dfe, CN=root@98dba189d5f0
     Signature Algorithm: SHA256withRSA, OID = 1.2.840.113549.1.1.11

     Key:  Sun RSA public key, 2048 bits
     params: null
     modulus: 24806810118367241194658833827043803266877657186456658855596213136768102796770845408683173562136109706337504703762278823248064939126605922536706398494552519304046563760721405567561225347040817363478681331703066244115852219139469122223241709063757595312816247866140634820764064474476952921773834501990682283839739318837357655559721194886161431153233435981439604681713663793973302213334133049194782787272432327228295568609757685618877407821955619561565819371349614206516475628783276797817072763118799254983084703106079148861996087128871753598723315633255615570964183253537675150414328735894758347846430289465070670386317
     public exponent: 65537
     Validity: [From: Fri Dec 04 00:00:00 UTC 2020,
                  To: Sat Dec 04 00:00:00 UTC 2021]
     Issuer: O=CID-e66d4728-32bb-4282-9770-351a7e913f07, OU=9a7c4f86-c862-4067-b12c-e7bca51d3dfe, CN=scm@scm
     SerialNumber: [    93d2fff1 97e5]

   Certificate Extensions: 2
   [1]: ObjectId: 2.5.29.15 Criticality=true
   KeyUsage [
     DigitalSignature
     Key_Encipherment
     Data_Encipherment
     Key_Agreement
   ]

   [2]: ObjectId: 2.5.29.17 Criticality=false
   SubjectAlternativeName [
     IPAddress: 172.27.0.2
   ]

   ]
     Algorithm: [SHA256withRSA]
     Signature:
   0000: 3D 29 84 1D 8D BA 53 F6   00 B7 21 85 E1 3F 0C C5  =)....S...!..?..
   0010: B3 AA 27 DA 5D E9 C7 9E   46 01 71 10 E4 2D D1 25  ..'.]...F.q..-.%
   0020: FC 93 49 0F 4F 97 37 18   E9 32 3E 2D 31 8F 59 17  ..I.O.7..2>-1.Y.
   0030: 89 6D A3 2D FD 7E BC FD   C5 38 57 92 C1 ED 99 C6  .m.-.....8W.....
   0040: 14 3B 9E CD 8E 90 26 3F   E7 D0 9B 33 E4 0A 37 03  .;....&?...3..7.
   0050: DF 33 08 75 FC F1 F3 44   E6 85 CF DD 37 2A 47 47  .3.u...D....7*GG
   0060: 28 CF E3 A2 19 92 2A C0   1A 93 2B B5 0D D1 7C 7F  (.....*...+.....
   0070: 32 5D 02 61 0B A1 DF 2E   71 07 98 22 91 93 5D A5  2].a....q.."..].
   0080: BD 77 28 8A E8 45 90 9A   AE 9D 45 F0 BB 33 7A 32  .w(..E....E..3z2
   0090: 6D 71 47 EB 0B 32 EA 76   8C 1D 92 AE 02 02 FB 73  mqG..2.v.......s
   00A0: CB AE 86 B6 00 51 58 96   F3 2E 7A 85 CB 4B 19 FF  .....QX...z..K..
   00B0: 49 AA ED F0 47 AA E8 1E   AD 80 92 BF 99 D4 C6 46  I...G..........F
   00C0: 9F B9 9E CF 8D 45 40 D2   A0 2A 02 98 DC 41 11 D5  .....E@..*...A..
   00D0: 90 CD 7E BC DE 95 AE 06   13 6C F4 C9 57 DA B2 80  .........l..W...
   00E0: 63 69 55 6C 25 9F 0A BE   EE 46 EF 9F 19 EE 1A 7A  ciUl%....F.....z
   00F0: 96 88 DD 48 5E CE E2 AE   D1 C6 5C C2 83 23 71 A9  ...H^.....\..#q.

   ]
```
  
