### PR TITLE
HDDS-4494. Provide Guice module to inject configuration to annotated fields

### DIFF
--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -38,11 +38,16 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.inject</groupId>
+      <artifactId>guice</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-test-utils</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -117,6 +117,23 @@ public interface ConfigurationSource {
     return configMap;
   }
 
+  default <T> void inject(T configObject) {
+    Class<T> configurationClass = (Class<T>) configObject.getClass();
+
+    ConfigGroup configGroup =
+        configurationClass.getAnnotation(ConfigGroup.class);
+
+    String prefix = configGroup.prefix();
+
+    ConfigurationReflectionUtil
+        .injectConfiguration(this, configurationClass, configObject,
+            prefix);
+
+    ConfigurationReflectionUtil
+        .callPostConstruct(configurationClass, configObject);
+
+  }
+
   /**
    * Create a Configuration object and inject the required configuration values.
    *

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/ConfigInjector.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/ConfigInjector.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf.guice;
+
+import java.lang.reflect.Field;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigurationReflectionUtil;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+
+import com.google.inject.MembersInjector;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+
+/**
+ * COnfiguration injection listener for Guice modiles.
+ */
+public class ConfigInjector implements TypeListener {
+
+  private ConfigurationSource configurationSource;
+
+  public ConfigInjector(ConfigurationSource configurationSource) {
+    this.configurationSource = configurationSource;
+  }
+
+  @Override
+  public <I> void hear(
+      TypeLiteral<I> type, TypeEncounter<I> encounter
+  ) {
+    Class<?> clazz = type.getRawType();
+    final ConfigGroup configGroup = clazz.getAnnotation(ConfigGroup.class);
+    if (configGroup == null) {
+      return;
+    }
+
+    while (clazz != null) {
+      for (Field field : clazz.getDeclaredFields()) {
+
+        if (field.isAnnotationPresent(Config.class)) {
+
+          Class<?> finalClazz = clazz;
+
+          encounter.register((MembersInjector<I>) instance -> {
+
+            ConfigurationReflectionUtil.injectField(
+                configurationSource,
+                (Class<I>) finalClazz.getClass(),
+                instance,
+                configGroup.prefix(),
+                field);
+          });
+        }
+      }
+      clazz = clazz.getSuperclass();
+    }
+  }
+}

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/ConfigurationModule.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/ConfigurationModule.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf.guice;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.matcher.Matchers;
+
+/**
+ * Guice module to inject configuration variables based on annotations.
+ */
+public class ConfigurationModule extends AbstractModule {
+
+  private ConfigurationSource configuration;
+
+  public ConfigurationModule(ConfigurationSource configuration) {
+    this.configuration = configuration;
+  }
+
+  @Override
+  protected void configure() {
+    bindListener(Matchers.any(), new ConfigInjector(configuration));
+  }
+}

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/package-info.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/guice/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Guice injection helper for configuration annotations.
+ */
+package org.apache.hadoop.hdds.conf.guice;

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/guice/TestConfigInjector.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/guice/TestConfigInjector.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.conf.guice;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.hdds.conf.ConfigurationExample;
+import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test configuration injection.
+ */
+public class TestConfigInjector {
+
+  @Test
+  public void injectConfig() {
+
+    //GIVEN
+    InMemoryConfiguration config = new InMemoryConfiguration();
+    config.set("ozone.scm.client.address", "asd");
+
+    final Injector injector = Guice.createInjector(
+        new ConfigurationModule(config),
+        new AbstractModule() {
+          @Override
+          protected void configure() {
+            bind(TestService.class);
+          }
+        });
+
+    //WHEN
+    final ConfigurationExample instance =
+        injector.getInstance(ConfigurationExample.class);
+
+    //THEN
+    Assert.assertEquals("asd", instance.getClientAddress());
+
+  }
+
+
+  /**
+   * Example service.
+   */
+  @ConfigGroup(prefix = "ozone.scm.client")
+  public static class TestService {
+    @Config(key = "address", defaultValue = "localhost", description = "Client "
+        + "addres (To test string injection).", tags = ConfigTag.MANAGEMENT)
+    private String clientAddress;
+
+    public String getClientAddress() {
+      return clientAddress;
+    }
+
+    public void setClientAddress(String clientAddress) {
+      this.clientAddress = clientAddress;
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

hadoop-hdds/config project provides a light-weight annotation based configuration interface. It supports to create an object with injection:

```
ReplicationConfig replicationConfig := ozoneConfig.getObject(replicationConfig); 
```

However, it seems to be hard to inject configuration to the service itself as usually we inject a lot of other dependencies to the constructor, not just the configuration.

One possible solution is using a Guice module. Guice is already used by recon, and this patch adds some optional modules to inject configuration variables to any service / instance if required.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4494

## How was this patch tested?

New utility is not yet used by production code, but covered with a new unit test.