### PR TITLE
HDDS-4540. Add a new OM admin operation to submit the OMPrepareRequest.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -587,4 +587,14 @@ public interface OzoneManagerProtocol
     return false;
   }
 
+  /**
+   *
+   * @param flushWaitTimeout
+   * @param flushCheckInterval
+   * @return
+   */
+  default long prepareOzoneManager(long flushWaitTimeout,
+                                   long flushCheckInterval) throws IOException {
+    return -1;
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -589,12 +589,17 @@ public interface OzoneManagerProtocol
 
   /**
    *
-   * @param flushWaitTimeout
-   * @param flushCheckInterval
+   * @param txnApplyWaitTimeoutSeconds Max time in SECONDS to wait for all
+   *                                   transactions before the prepare request
+   *                                   to be applied to the OM DB.
+   * @param txnApplyCheckIntervalSeconds Time in SECONDS to wait between
+   *                                     successive checks for all transactions
+   *                                     to be applied to the OM DB.
    * @return
    */
-  default long prepareOzoneManager(long flushWaitTimeout,
-                                   long flushCheckInterval) throws IOException {
+  default long prepareOzoneManager(
+      long txnApplyWaitTimeoutSeconds, long txnApplyCheckIntervalSeconds)
+      throws IOException {
     return -1;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1548,21 +1548,22 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public long prepareOzoneManager(long flushWaitTimeout,
-                                  long flushCheckInterval) throws IOException {
-    Preconditions.checkArgument(flushWaitTimeout > 0,
-        "flushWaitTimeout has to be > zero");
+  public long prepareOzoneManager(
+      long txnApplyWaitTimeoutSeconds, long txnApplyCheckIntervalSeconds)
+      throws IOException {
+    Preconditions.checkArgument(txnApplyWaitTimeoutSeconds > 0,
+        "txnApplyWaitTimeoutSeconds has to be > zero");
 
-    Preconditions.checkArgument(flushCheckInterval > 0 &&
-            flushCheckInterval < flushWaitTimeout / 2,
-        "flushCheckInterval has to be > zero and < half of " +
-            "flushWaitTimeout to make sense.");
+    Preconditions.checkArgument(txnApplyCheckIntervalSeconds > 0 &&
+            txnApplyCheckIntervalSeconds < txnApplyWaitTimeoutSeconds / 2,
+        "txnApplyCheckIntervalSeconds has to be > zero and < half "
+            + "of txnApplyWaitTimeoutSeconds to make sense.");
 
     PrepareRequest prepareRequest =
         PrepareRequest.newBuilder().setArgs(
             PrepareRequestArgs.newBuilder()
-                .setFlushWaitCheckInterval(flushCheckInterval)
-                .setFlushWaitTimeOut(flushWaitTimeout)
+                .setTxnApplyWaitTimeoutSeconds(txnApplyWaitTimeoutSeconds)
+                .setTxnApplyCheckIntervalSeconds(txnApplyCheckIntervalSeconds)
                 .build()).build();
 
     OMRequest omRequest = createOMRequest(Type.Prepare)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1547,6 +1547,32 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return recoverResponse.getResponse();
   }
 
+  @Override
+  public long prepareOzoneManager(long flushWaitTimeout,
+                                  long flushCheckInterval) throws IOException {
+    Preconditions.checkArgument(flushWaitTimeout > 0,
+        "flushWaitTimeout has to be > zero");
+
+    Preconditions.checkArgument(flushCheckInterval > 0 &&
+            flushCheckInterval < flushWaitTimeout / 2,
+        "flushCheckInterval has to be > zero and < half of " +
+            "flushWaitTimeout to make sense.");
+
+    PrepareRequest prepareRequest =
+        PrepareRequest.newBuilder().setArgs(
+            PrepareRequestArgs.newBuilder()
+                .setFlushWaitCheckInterval(flushCheckInterval)
+                .setFlushWaitTimeOut(flushWaitTimeout)
+                .build()).build();
+
+    OMRequest omRequest = createOMRequest(Type.Prepare)
+        .setPrepareRequest(prepareRequest).build();
+
+    PrepareResponse prepareResponse =
+        handleError(submitRequest(omRequest)).getPrepareResponse();
+    return prepareResponse.getTxnID();
+  }
+
   @VisibleForTesting
   public OmTransport getTransport() {
     return transport;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -102,8 +102,10 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
     // Make sure all OMs have logs from writing data, so we can check that
     // they are purged after prepare.
-    cluster.getOzoneManagersList().forEach(om ->
-        Assert.assertTrue(logFilesPresentInRatisPeer(om)));
+    for (OzoneManager om: cluster.getOzoneManagersList()) {
+      LambdaTestUtils.await(timeoutMillis, 1000,
+          () -> logFilesPresentInRatisPeer(om));
+    }
 
     OzoneManagerProtocol ozoneManagerClient =
         ozClient.getObjectStore().getClientProxy().getOzoneManagerClient();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 
@@ -35,20 +36,13 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
-import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
-import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareRequest;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.apache.ratis.protocol.ClientId;
-import org.apache.ratis.protocol.Message;
-import org.apache.ratis.protocol.RaftClientRequest;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,22 +61,16 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   @Test
   public void testPrepareWithoutTransactions() throws Exception {
     MiniOzoneHAClusterImpl cluster = getCluster();
-    OzoneManager leader = cluster.getOMLeader();
-    OMResponse omResponse = submitPrepareRequest(leader.getOmRatisServer());
-    // Get the log index of the prepare request.
+    ClientProtocol ozClient = OzoneClientFactory.getRpcClient(getConf())
+        .getObjectStore().getClientProxy();
     long prepareRequestLogIndex =
-        omResponse.getPrepareResponse().getTxnID();
+        ozClient.getOzoneManagerClient().prepareOzoneManager(300, 5);
 
     // Prepare response processing is included in the snapshot,
     // giving index of 1.
     Assert.assertEquals(1, prepareRequestLogIndex);
     for (OzoneManager om: cluster.getOzoneManagersList()) {
-      // Leader should be prepared as soon as it returns response.
-      if (om == leader) {
-        checkPrepared(om, prepareRequestLogIndex);
-      } else {
-        waitAndCheckPrepared(om, prepareRequestLogIndex);
-      }
+      waitAndCheckPrepared(om, prepareRequestLogIndex);
     }
   }
 
@@ -112,26 +100,17 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
     // Make sure all OMs have logs from writing data, so we can check that
     // they are purged after prepare.
-    for (OzoneManager om: cluster.getOzoneManagersList()) {
-      LambdaTestUtils.await(timeoutMillis, 1000,
-          () -> logFilesPresentInRatisPeer(om));
-    }
+    cluster.getOzoneManagersList().forEach(om ->
+        Assert.assertTrue(logFilesPresentInRatisPeer(om)));
 
-    OzoneManager leader = cluster.getOMLeader();
-    OMResponse omResponse = submitPrepareRequest(leader.getOmRatisServer());
-    // Get the log index of the prepare request.
+    OzoneManagerProtocol ozoneManagerClient =
+        ozClient.getObjectStore().getClientProxy().getOzoneManagerClient();
     long prepareRequestLogIndex =
-        omResponse.getPrepareResponse().getTxnID();
+        ozoneManagerClient.prepareOzoneManager(300, 5);
 
     // Make sure all OMs are prepared and all OMs still have their data.
     for (OzoneManager om: cluster.getOzoneManagersList()) {
-      // Leader should be prepared as soon as it returns response.
-      if (om == leader) {
-        checkPrepared(om, prepareRequestLogIndex);
-      } else {
-        waitAndCheckPrepared(om, prepareRequestLogIndex);
-      }
-
+      waitAndCheckPrepared(om, prepareRequestLogIndex);
       List<OmKeyInfo> keys = om.getMetadataManager().listKeys(volumeName,
           bucketName, null, keyPrefix, 100);
 
@@ -152,11 +131,10 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
    * Checks that third OM received all transactions and is prepared.
    * @throws Exception
    */
-  // TODO: Fix this test so it passes.
-  //   @Test
+//  @Test
   public void testPrepareDownedOM() throws Exception {
     // Index of the OM that will be shut down during this test.
-    final int shutdownOMIndex = 2;
+    final int shutdownOMIndex = new Random().nextInt(3);
 
     MiniOzoneHAClusterImpl cluster = getCluster();
     OzoneClient ozClient = OzoneClientFactory.getRpcClient(getConf());
@@ -179,10 +157,8 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
     // Make sure all OMs have logs from writing data, so we can check that
     // they are purged after prepare.
-    for (OzoneManager om: cluster.getOzoneManagersList()) {
-      LambdaTestUtils.await(timeoutMillis, 1000,
-          () -> logFilesPresentInRatisPeer(om));
-    }
+    cluster.getOzoneManagersList().forEach(om ->
+        Assert.assertTrue(logFilesPresentInRatisPeer(om)));
 
     // Shut down one OM.
     cluster.stopOzoneManager(shutdownOMIndex);
@@ -196,18 +172,13 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
       writtenKeys.add(keyName);
     }
 
-    // Submit prepare request via Ratis.
-    OzoneManager leaderOM = cluster.getOMLeader();
-    long prepareIndex = submitPrepareRequest(leaderOM.getOmRatisServer())
-            .getPrepareResponse()
-            .getTxnID();
+    OzoneManagerProtocol ozoneManagerClient =
+        ozClient.getObjectStore().getClientProxy().getOzoneManagerClient();
+    long prepareIndex = ozoneManagerClient.prepareOzoneManager(300, 5);
 
     // Check that the two live OMs are prepared.
     for (OzoneManager om: cluster.getOzoneManagersList()) {
-      if (om == leaderOM) {
-        // Leader should have been prepared after we got the response.
-        checkPrepared(om, prepareIndex);
-      } else if (om != downedOM) {
+      if (om != downedOM) {
         // Follower may still be applying transactions.
         waitAndCheckPrepared(om, prepareIndex);
       }
@@ -217,15 +188,11 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     // Since prepare was the last Ratis transaction, it should have all data
     // it missed once it receives the prepare transaction.
     cluster.restartOzoneManager(downedOM, true);
-    // Wait for other OMs to catch this one up on transactions.
-    LambdaTestUtils.await(timeoutMillis, 1000,
-        () -> downedOM.getRatisSnapshotIndex() == prepareIndex);
-    checkPrepared(downedOM, prepareIndex);
+    LambdaTestUtils.await(timeoutMillis, 2000,
+        () -> checkPrepared(downedOM, prepareIndex));
 
     // Make sure all OMs are prepared and still have data.
     for (OzoneManager om: cluster.getOzoneManagersList()) {
-      waitAndCheckPrepared(om, prepareIndex);
-
       List<OmKeyInfo> readKeys = om.getMetadataManager().listKeys(volumeName,
           bucketName, null, keyPrefix, 100);
 
@@ -266,61 +233,23 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     keyStream.close();
   }
 
-  private OMRequest buildPrepareRequest() {
-    PrepareRequest requestProto = PrepareRequest.newBuilder().build();
-
-    return OMRequest.newBuilder()
-        .setPrepareRequest(requestProto)
-        .setCmdType(Type.Prepare)
-        .setClientId(UUID.randomUUID().toString())
-        .build();
-  }
-
   private void waitAndCheckPrepared(OzoneManager om,
       long prepareRequestLogIndex) throws Exception {
     // Log files are deleted after the snapshot is taken,
     // So once log files have been deleted, OM should be prepared.
     LambdaTestUtils.await(timeoutMillis, 1000,
         () -> !logFilesPresentInRatisPeer(om));
-    checkPrepared(om, prepareRequestLogIndex);
+    Assert.assertTrue(checkPrepared(om, prepareRequestLogIndex));
   }
 
-  private void checkPrepared(OzoneManager om, long prepareRequestLogIndex)
+  private boolean checkPrepared(OzoneManager om, long prepareRequestLogIndex)
       throws Exception {
-    Assert.assertFalse(logFilesPresentInRatisPeer(om));
-
     // If no transactions have been persisted to the DB, transaction info
     // will be null, not zero.
     // This will cause a null pointer exception if we use
     // OzoneManager#getRatisSnapshotIndex to get the index from the DB.
     OMTransactionInfo txnInfo = om.getMetadataManager()
         .getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
-    if (prepareRequestLogIndex == 0) {
-      Assert.assertNull(txnInfo);
-    } else {
-      Assert.assertEquals(txnInfo.getTransactionIndex(),
-          prepareRequestLogIndex);
-    }
-  }
-
-  private OMResponse submitPrepareRequest(OzoneManagerRatisServer server)
-      throws Exception {
-    PrepareRequest requestProto = PrepareRequest.newBuilder().build();
-
-    OMRequest omRequest = OMRequest.newBuilder()
-        .setPrepareRequest(requestProto)
-        .setCmdType(Type.Prepare)
-        .setClientId(UUID.randomUUID().toString())
-        .build();
-
-    RaftClientRequest raftClientRequest = new RaftClientRequest(
-        ClientId.randomId(),
-        server.getRaftPeerId(),
-        server.getRaftGroupId(),
-        0,
-        Message.valueOf(OMRatisHelper.convertRequestToByteString(omRequest)),
-        RaftClientRequest.writeRequestType(), null);
-
-    return server.submitRequest(omRequest, raftClientRequest);
+    return (txnInfo.getTransactionIndex() == prepareRequestLogIndex);
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1083,8 +1083,8 @@ message PrepareRequest {
 }
 
 message PrepareRequestArgs {
-    optional uint64 flushWaitTimeOut = 1 [default = 300];
-    optional uint64 flushWaitCheckInterval = 2 [default = 5];
+    optional uint64 txnApplyWaitTimeoutSeconds = 1 [default = 300];
+    optional uint64 txnApplyCheckIntervalSeconds = 2 [default = 5];
 }
 
 message PrepareResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1079,7 +1079,12 @@ message FinalizeUpgradeProgressResponse {
 }
 
 message PrepareRequest {
+    required PrepareRequestArgs args = 1;
+}
 
+message PrepareRequestArgs {
+    optional uint64 flushWaitTimeOut = 1 [default = 300];
+    optional uint64 flushWaitCheckInterval = 2 [default = 5];
 }
 
 message PrepareResponse {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -80,10 +80,10 @@ public class OMPrepareRequest extends OMClientRequest {
     // Allow double buffer this many seconds to flush all transactions before
     // returning an error to the caller.
     Duration flushTimeout =
-        Duration.of(args.getFlushWaitTimeOut(), ChronoUnit.SECONDS);
+        Duration.of(args.getTxnApplyWaitTimeoutSeconds(), ChronoUnit.SECONDS);
     // Time between checks to see if double buffer finished flushing.
     Duration flushCheckInterval =
-        Duration.of(args.getFlushWaitCheckInterval(), ChronoUnit.SECONDS);
+        Duration.of(args.getTxnApplyCheckIntervalSeconds(), ChronoUnit.SECONDS);
 
     try {
       // Create response.
@@ -167,7 +167,9 @@ public class OMPrepareRequest extends OMClientRequest {
             && (ratisTxnIndex >= indexToWaitFor);
       }
 
-      Thread.sleep(flushCheckInterval.toMillis());
+      if (!success) {
+        Thread.sleep(flushCheckInterval.toMillis());
+      }
     }
 
     // If the timeout waiting for all transactions to reach the state machine

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.upgrade.OMPrepareResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -57,14 +58,6 @@ public class OMPrepareRequest extends OMClientRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMPrepareRequest.class);
 
-  // Allow double buffer this many seconds to flush all transactions before
-  // returning an error to the caller.
-  private static final Duration DOUBLE_BUFFER_FLUSH_TIMEOUT =
-      Duration.of(5, ChronoUnit.MINUTES);
-  // Time between checks to see if double buffer finished flushing.
-  private static final Duration DOUBLE_BUFFER_FLUSH_CHECK_INTERVAL =
-      Duration.of(1, ChronoUnit.SECONDS);
-
   public OMPrepareRequest(OMRequest omRequest) {
     super(omRequest);
   }
@@ -76,10 +69,21 @@ public class OMPrepareRequest extends OMClientRequest {
 
     LOG.info("Received prepare request with log index {}", transactionLogIndex);
 
+    OMRequest omRequest = getOmRequest();
+    OzoneManagerProtocolProtos.PrepareRequestArgs args =
+        omRequest.getPrepareRequest().getArgs();
     OMResponse.Builder responseBuilder =
-        OmResponseUtil.getOMResponseBuilder(getOmRequest());
+        OmResponseUtil.getOMResponseBuilder(omRequest);
     responseBuilder.setCmdType(Type.Prepare);
     OMClientResponse response = null;
+
+    // Allow double buffer this many seconds to flush all transactions before
+    // returning an error to the caller.
+    Duration flushTimeout =
+        Duration.of(args.getFlushWaitTimeOut(), ChronoUnit.SECONDS);
+    // Time between checks to see if double buffer finished flushing.
+    Duration flushCheckInterval =
+        Duration.of(args.getFlushWaitCheckInterval(), ChronoUnit.SECONDS);
 
     try {
       // Create response.
@@ -106,7 +110,8 @@ public class OMPrepareRequest extends OMClientRequest {
       // already, once this index reaches the state machine, we know all
       // transactions have been flushed.
       waitForLogIndex(transactionLogIndex,
-          ozoneManager.getMetadataManager(), serverImpl);
+          ozoneManager.getMetadataManager(), serverImpl,
+          flushTimeout, flushCheckInterval);
       takeSnapshotAndPurgeLogs(serverImpl);
 
       // TODO: Create marker file with txn index.
@@ -132,11 +137,11 @@ public class OMPrepareRequest extends OMClientRequest {
    * disk, and to be updated in memory in Ratis.
    */
   private static void waitForLogIndex(long indexToWaitFor,
-      OMMetadataManager metadataManager, RaftServerImpl server)
+      OMMetadataManager metadataManager, RaftServerImpl server,
+      Duration flushTimeout, Duration flushCheckInterval)
       throws InterruptedException, IOException {
 
-    long endTime = System.currentTimeMillis() +
-        DOUBLE_BUFFER_FLUSH_TIMEOUT.toMillis();
+    long endTime = System.currentTimeMillis() + flushTimeout.toMillis();
     boolean success = false;
 
     while (!success && System.currentTimeMillis() < endTime) {
@@ -162,9 +167,7 @@ public class OMPrepareRequest extends OMClientRequest {
             && (ratisTxnIndex >= indexToWaitFor);
       }
 
-      if (!success) {
-        Thread.sleep(DOUBLE_BUFFER_FLUSH_CHECK_INTERVAL.toMillis());
-      }
+      Thread.sleep(flushCheckInterval.toMillis());
     }
 
     // If the timeout waiting for all transactions to reach the state machine
@@ -173,7 +176,7 @@ public class OMPrepareRequest extends OMClientRequest {
     if (!success) {
       throw new IOException(String.format("After waiting for %d seconds, " +
               "State Machine has not applied  all the transactions.",
-          DOUBLE_BUFFER_FLUSH_TIMEOUT.toMillis() * 1000));
+          flushTimeout.getSeconds()));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -151,7 +151,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
   }
 
-  // Client --> Rpc Handler --> OMSST -> Ratis Leader
   /**
    * Create OMResponse from the specified OMRequest and exception.
    *

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -151,6 +151,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
   }
 
+  // Client --> Rpc Handler --> OMSST -> Ratis Leader
   /**
    * Create OMResponse from the specified OMRequest and exception.
    *

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -54,7 +54,8 @@ import java.util.Collection;
     versionProvider = HddsVersionProvider.class,
     subcommands = {
         FinalizeUpgradeSubCommand.class,
-        GetServiceRolesSubcommand.class
+        GetServiceRolesSubcommand.class,
+        PrepareSubCommand.class
     })
 @MetaInfServices(SubcommandWithParent.class)
 public class OMAdmin extends GenericCli implements SubcommandWithParent {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -29,7 +29,11 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
     name = "prepare",
-    description = "Prepares OM",
+    description = "Prepares Ozone Manager for upgrade/downgrade, by applying " +
+        "all pending transactions, taking a Ratis snapshot at the last txn " +
+        "and purging all logs on each OM instance. The returned txn id " +
+        "corresponds to the last txn in the quorum in which the snapshot is " +
+        "taken.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
@@ -40,7 +44,8 @@ public class PrepareSubCommand implements Callable<Void> {
 
   @CommandLine.Option(
       names = {"-id", "--service-id"},
-      description = "Ozone Manager Service ID"
+      description = "Ozone Manager Service ID",
+      required = true
   )
   private String omServiceId;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -30,10 +30,10 @@ import picocli.CommandLine;
 @CommandLine.Command(
     name = "prepare",
     description = "Prepares Ozone Manager for upgrade/downgrade, by applying " +
-        "all pending transactions, taking a Ratis snapshot at the last txn " +
-        "and purging all logs on each OM instance. The returned txn id " +
-        "corresponds to the last txn in the quorum in which the snapshot is " +
-        "taken.",
+        "all pending transactions, taking a Ratis snapshot at the last " +
+        "transaction and purging all logs on each OM instance. The returned " +
+        "transaction #ID corresponds to the last transaction in the quorum in" +
+        " which the snapshot is taken.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class
 )
@@ -50,16 +50,28 @@ public class PrepareSubCommand implements Callable<Void> {
   private String omServiceId;
 
   @CommandLine.Option(
-      names = {"-ft", "--flush-wait-timeout"},
-      description = "Max time to wait for OM Double Buffer flush in seconds.",
-      defaultValue = "300"
+      names = {"-tawt", "--transaction-apply-wait-timeout"},
+      description = "Max time in SECONDS to wait for all transactions before" +
+          "the prepare request to be applied to the OM DB.",
+      defaultValue = "300",
+      hidden = true
   )
-  private long flushWaitTime;
+  private long txnApplyWaitTimeSeconds;
+
+  @CommandLine.Option(
+      names = {"-tact", "--transaction-apply-check-interval"},
+      description = "Time in SECONDS to wait between successive checks for " +
+          "all transactions to be applied to the OM DB.",
+      defaultValue = "5",
+      hidden = true
+  )
+  private long txnApplyCheckIntervalSeconds;
 
   @Override
   public Void call() throws Exception {
     OzoneManagerProtocol client = parent.createOmClient(omServiceId);
-    long prepareTxnId = client.prepareOzoneManager(flushWaitTime, 5);
+    long prepareTxnId = client.prepareOzoneManager(txnApplyWaitTimeSeconds,
+        txnApplyCheckIntervalSeconds);
     System.out.println("Ozone Manager Prepare Request successfully returned " +
         "with Txn Id " + prepareTxnId);
     return null;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -17,21 +17,10 @@
 
 package org.apache.hadoop.ozone.admin.om;
 
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
-
-import java.io.IOException;
-import java.util.UUID;
 import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 
 import picocli.CommandLine;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
+
+import picocli.CommandLine;
+
+/**
+ * Handler of ozone admin om finalizeUpgrade command.
+ */
+@CommandLine.Command(
+    name = "prepare",
+    description = "Prepares OM",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+public class PrepareSubCommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(
+      names = {"-id", "--service-id"},
+      description = "Ozone Manager Service ID"
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+      names = {"-ft", "--flush-wait-timeout"},
+      description = "Max time to wait for OM Double Buffer flush in seconds.",
+      defaultValue = "300"
+  )
+  private long flushWaitTime;
+
+  @Override
+  public Void call() throws Exception {
+    OzoneManagerProtocol client = parent.createOmClient(omServiceId);
+    long prepareTxnId = client.prepareOzoneManager(flushWaitTime, 5);
+    System.out.println("Ozone Manager Prepare Request successfully returned " +
+        "with Txn Id " + prepareTxnId);
+    return null;
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Introduce a new OM client operation to "prepare" the OM quorum.
- As a first pass, the client will just submit the request (HDDS-4480) and print out the response (Txn ID)
- In a follow up JIRA, the subsequent steps to probe every individual OM for preparation completeness will be added.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4540

## How was this patch tested?
Manually tested.