### PR TITLE
HDDS-4554. numKey metrics goes negative after intermediate directory deletion.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -30,7 +30,10 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.junit.*;
+import org.junit.Rule;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -34,6 +34,7 @@ import org.junit.Rule;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.junit.Test;
+import org.junit.Assert;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -110,17 +110,20 @@ public class TestOzoneFileSystemMetrics {
   }
 
   private void testOzoneFileCommit(TestOps op) throws Exception {
-    long numKeysBeforeCreate = cluster.getOzoneManager().getMetrics().getNumKeys();
+    long numKeysBeforeCreate = cluster
+        .getOzoneManager().getMetrics().getNumKeys();
 
     int fileLen = 30 * 1024 * 1024;
     byte[] data = string2Bytes(RandomStringUtils.randomAlphanumeric(fileLen));
 
     Path parentDir = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
-    Path filePath = new Path(parentDir, RandomStringUtils.randomAlphanumeric(5));
+    Path filePath = new Path(parentDir,
+        RandomStringUtils.randomAlphanumeric(5));
 
     switch (op) {
     case Key:
-      try (OzoneOutputStream stream = bucket.createKey(filePath.toString(), fileLen)) {
+      try (OzoneOutputStream stream =
+               bucket.createKey(filePath.toString(), fileLen)) {
         stream.write(data);
       }
       break;
@@ -132,14 +135,18 @@ public class TestOzoneFileSystemMetrics {
     case Directory:
       fs.mkdirs(filePath);
       break;
+    default:
+      throw new IOException("Execution should never reach here." + op);
     }
 
-    long numKeysAfterCommit = cluster.getOzoneManager().getMetrics().getNumKeys();
+    long numKeysAfterCommit = cluster
+        .getOzoneManager().getMetrics().getNumKeys();
     Assert.assertTrue(numKeysAfterCommit > 0);
     Assert.assertEquals(numKeysBeforeCreate + 2, numKeysAfterCommit);
     fs.delete(parentDir, true);
 
-    long numKeysAfterDelete = cluster.getOzoneManager().getMetrics().getNumKeys();
+    long numKeysAfterDelete = cluster
+        .getOzoneManager().getMetrics().getNumKeys();
     Assert.assertTrue(numKeysAfterDelete >= 0);
     Assert.assertEquals(numKeysBeforeCreate, numKeysAfterDelete);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.junit.*;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdds.StringUtils.string2Bytes;
+
+/**
+ * Test OM Metrics for OzoneFileSystem operations.
+ */
+public class TestOzoneFileSystemMetrics {
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = new Timeout(300000);
+  private static MiniOzoneCluster cluster = null;
+  private static FileSystem fs;
+  private static OzoneBucket bucket;
+
+  enum TestOps {
+    File,
+    Directory,
+    Key
+  }
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   * Ozone is made active by setting OZONE_ENABLED = true
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .setChunkSize(2) // MB
+        .setBlockSize(8) // MB
+        .setStreamBufferFlushSize(2) // MB
+        .setStreamBufferMaxSize(4) // MB
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a bucket to be used by OzoneFileSystem
+    bucket = TestDataUtil.createVolumeAndBucket(cluster);
+
+    // Set the fs.defaultFS and start the filesystem
+    String uri = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, bucket.getName(), bucket.getVolumeName());
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, uri);
+    fs =  FileSystem.get(conf);
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterClass
+  public static void shutdown() throws IOException {
+    fs.close();
+    cluster.shutdown();
+  }
+
+  @Test
+  public void testKeyOps() throws Exception {
+    testOzoneFileCommit(TestOps.Key);
+  }
+
+  @Test
+  public void testFileOps() throws Exception {
+    testOzoneFileCommit(TestOps.File);
+  }
+
+  @Test
+  public void testDirOps() throws Exception {
+    testOzoneFileCommit(TestOps.Directory);
+  }
+
+  private void testOzoneFileCommit(TestOps op) throws Exception {
+    long numKeysBeforeCreate = cluster.getOzoneManager().getMetrics().getNumKeys();
+
+    int fileLen = 30 * 1024 * 1024;
+    byte[] data = string2Bytes(RandomStringUtils.randomAlphanumeric(fileLen));
+
+    Path parentDir = new Path("/" + RandomStringUtils.randomAlphanumeric(5));
+    Path filePath = new Path(parentDir, RandomStringUtils.randomAlphanumeric(5));
+
+    switch (op) {
+    case Key:
+      try (OzoneOutputStream stream = bucket.createKey(filePath.toString(), fileLen)) {
+        stream.write(data);
+      }
+      break;
+    case File:
+      try (FSDataOutputStream stream = fs.create(filePath)) {
+        stream.write(data);
+      }
+      break;
+    case Directory:
+      fs.mkdirs(filePath);
+      break;
+    }
+
+    long numKeysAfterCommit = cluster.getOzoneManager().getMetrics().getNumKeys();
+    Assert.assertTrue(numKeysAfterCommit > 0);
+    Assert.assertEquals(numKeysBeforeCreate + 2, numKeysAfterCommit);
+    fs.delete(parentDir, true);
+
+    long numKeysAfterDelete = cluster.getOzoneManager().getMetrics().getNumKeys();
+    Assert.assertTrue(numKeysAfterDelete >= 0);
+    Assert.assertEquals(numKeysBeforeCreate, numKeysAfterDelete);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -200,6 +200,10 @@ public class OMMetrics {
     numKeys.incr();
   }
 
+  public void incNumKeys(int count) {
+    numKeys.incr(count);
+  }
+
   public void decNumKeys() {
     numKeys.incr(-1);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -144,6 +144,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     OMClientResponse omClientResponse = null;
     Result result = Result.FAILURE;
     List<OmKeyInfo> missingParentInfos;
+    int numMissingParents = 0;
 
     try {
       keyArgs = resolveBucketLink(ozoneManager, keyArgs, auditMap);
@@ -195,6 +196,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
         missingParentInfos = getAllParentInfo(ozoneManager, keyArgs,
             missingParents, inheritAcls, trxnLogIndex);
 
+        numMissingParents = missingParentInfos.size();
         OMFileRequest.addKeyTableCacheEntries(omMetadataManager, volumeName,
             bucketName, Optional.of(dirKeyInfo),
             Optional.of(missingParentInfos), trxnLogIndex);
@@ -224,8 +226,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     auditLog(auditLogger, buildAuditMessage(OMAction.CREATE_DIRECTORY,
         auditMap, exception, userInfo));
 
-    logResult(createDirectoryRequest, keyArgs, omMetrics, result, trxnLogIndex,
-        exception);
+    logResult(createDirectoryRequest, keyArgs, omMetrics, result,
+        exception, numMissingParents);
 
     return omClientResponse;
   }
@@ -284,8 +286,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
   }
 
   private void logResult(CreateDirectoryRequest createDirectoryRequest,
-      KeyArgs keyArgs, OMMetrics omMetrics, Result result, long trxnLogIndex,
-      IOException exception) {
+      KeyArgs keyArgs, OMMetrics omMetrics, Result result,
+      IOException exception, int numMissingParents) {
 
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();
@@ -293,7 +295,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
-      omMetrics.incNumKeys();
+      omMetrics.incNumKeys(numMissingParents + 1);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Directory created. Volume:{}, Bucket:{}, Key:{}",
             volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -295,6 +295,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
+      // Count for the missing parents plus the directory being created.
       omMetrics.incNumKeys(numMissingParents + 1);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Directory created. Volume:{}, Bucket:{}, Key:{}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -166,6 +166,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
     String volumeName = keyArgs.getVolumeName();
     String bucketName = keyArgs.getBucketName();
     String keyName = keyArgs.getKeyName();
+    int numMissingParents = 0;
 
     // if isRecursive is true, file would be created even if parent
     // directories does not exist.
@@ -303,6 +304,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       omVolumeArgs.getUsedBytes().add(preAllocatedSpace);
       omBucketInfo.getUsedBytes().add(preAllocatedSpace);
 
+      numMissingParents = missingParentInfos.size();
       // Prepare response
       omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()
           .setKeyInfo(omKeyInfo.getProtobuf())
@@ -336,6 +338,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
+      omMetrics.incNumKeys(numMissingParents);
       LOG.debug("File created. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);
       break;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -338,6 +338,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
+      // Missing directories are created immediately, counting that here.
+      // The metric for the file is incremented as part of the file commit.
       omMetrics.incNumKeys(numMissingParents);
       LOG.debug("File created. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -208,6 +208,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
     IOException exception = null;
     Result result = null;
     List<OmKeyInfo> missingParentInfos = null;
+    int numMissingParents = 0;
     try {
       keyArgs = resolveBucketLink(ozoneManager, keyArgs, auditMap);
       volumeName = keyArgs.getVolumeName();
@@ -267,7 +268,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
         OMFileRequest.addKeyTableCacheEntries(omMetadataManager, volumeName,
             bucketName, Optional.absent(), Optional.of(missingParentInfos),
             trxnLogIndex);
-
+        numMissingParents = missingParentInfos.size();
       }
 
       omKeyInfo = prepareKeyInfo(omMetadataManager, keyArgs, dbKeyInfo,
@@ -345,6 +346,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
+      omMetrics.incNumKeys(numMissingParents);
       LOG.debug("Key created. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);
       break;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -346,6 +346,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
     switch (result) {
     case SUCCESS:
+      // Missing directories are created immediately, counting that here.
+      // The metric for the key is incremented as part of the key commit.
       omMetrics.incNumKeys(numMissingParents);
       LOG.debug("Key created. Volume:{}, Bucket:{}, Key:{}", volumeName,
           bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -390,7 +390,7 @@ public class TestOMDirectoryCreateRequest {
     Assert.assertNotNull(omMetadataManager.getKeyTable().get(
         omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
 
-    Assert.assertEquals(1L, omMetrics.getNumKeys());
+    Assert.assertEquals(4L, omMetrics.getNumKeys());
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
During Ozone Key, File, and Directory creations, intermediate directories are not counted towards the number of keys in the system. When a directory is deleted, however, we traverse each of the keys and delete it, this results in underflow of the numKey metric.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4554

(Please explain how this patch was tested. Ex: unit tests, manual tests)
Added a new unit test.