### PR TITLE
HDDS-4563. Increase default value for key and block deletion limit.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -79,7 +79,7 @@ public class ScmConfig {
 
   @Config(key = "block.deletion.per-interval.max",
       type = ConfigType.INT,
-      defaultValue = "10000",
+      defaultValue = "20000",
       tags = { ConfigTag.SCM, ConfigTag.DELETION},
       description =
           "Maximum number of blocks which SCM processes during an interval. "

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -394,7 +394,7 @@
   </property>
   <property>
     <name>ozone.key.deleting.limit.per.task</name>
-    <value>1000</value>
+    <value>20000</value>
     <tag>OM, PERFORMANCE</tag>
     <description>
       A maximum number of keys to be scanned by key deleting service

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -85,7 +85,7 @@ public final class OMConfigKeys {
 
   public static final String OZONE_KEY_DELETING_LIMIT_PER_TASK =
       "ozone.key.deleting.limit.per.task";
-  public static final int OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT = 1000;
+  public static final int OZONE_KEY_DELETING_LIMIT_PER_TASK_DEFAULT = 20000;
 
   public static final String OZONE_OM_METRICS_SAVE_INTERVAL =
       "ozone.om.save.metrics.interval";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently ozone.key.deleting.limit.per.task defaults to 1000 and hdds.scm.block.deletion.per-interval.max defaults to 10000. These config values can be increased to 20000 based on the latest block deletion results.

Please refer these links for performance numbers.
https://issues.apache.org/jira/browse/HDDS-4344?focusedCommentId=17237974&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17237974 
https://issues.apache.org/jira/browse/HDDS-4344?focusedCommentId=17242233&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17242233

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4563

## How was this patch tested?

Existing UT