### PR TITLE
HDDS-4562. Old bucket needs to be accessible after the cluster was upgraded to the Quota version.

### DIFF
--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -35,13 +35,15 @@ Administrators should be able to define how much storage space a Volume or Bucke
 
 a. By default, the quota for volume and bucket is not enabled.
 
-b. When volume quota is enabled, the total size of bucket quota cannot exceed volume.
+b. When volume quota is enabled, the total quota of the buckets, cannot exceed the volume quota.
 
 c. Bucket quota can be set separately without enabling Volume quota. The size of bucket quota is unrestricted at this point.
 
 d. Volume quota is not currently supported separately, and volume quota takes effect only if bucket quota is set. Because ozone only check the usedBytes of the bucket when we write the key.
 
-e. If the cluster is upgraded from old version less than 1.1.0, use of quota on older volumes and buckets is not recommended. Since the old key is not counted to the bucket's usedBytes, the quota setting is inaccurate at this point.
+e. If the cluster is upgraded from old version less than 1.1.0, use of quota on older volumes and buckets(We can confirm by looking at the info for the volume or bucket, and if the quota value is -2 the volume or bucket is old) is not recommended. Since the old key is not counted to the bucket's usedBytes, the quota setting is inaccurate at this point.
+
+f. If volume's quota is enabled then bucket's quota cannot be cleared. 
 
 ## Client usage
 ### Storage Space level quota
@@ -71,9 +73,10 @@ This behavior changes the quota for Bucket1 to 10GB
 
 Total bucket quota should not be greater than its Volume quota. If we have a 10MB Volume, The sum of the sizes of all buckets under this volume cannot exceed 10MB, otherwise the bucket set quota fails.
 
-#### Clear the quota for Volume1. The Bucket cleanup command is similar.
+#### Clear the quota for volume and bucket
 ```shell
 bin/ozone sh volume clrquota --space-quota /volume1
+bin/ozone sh bucket clrquota --space-quota /volume1/bucket1
 ```
 
 #### Check quota and usedBytes for volume and bucket

--- a/hadoop-hdds/docs/content/feature/Quota.md
+++ b/hadoop-hdds/docs/content/feature/Quota.md
@@ -32,11 +32,16 @@ So far, we know that Ozone allows users to create volumes, buckets, and keys. A 
 1. Storage Space level quota
 
 Administrators should be able to define how much storage space a Volume or Bucket can use. The following Settings for Storage space quota are currently supported：
+
 a. By default, the quota for volume and bucket is not enabled.
+
 b. When volume quota is enabled, the total size of bucket quota cannot exceed volume.
+
 c. Bucket quota can be set separately without enabling Volume quota. The size of bucket quota is unrestricted at this point.
+
 d. Volume quota is not currently supported separately, and volume quota takes effect only if bucket quota is set. Because ozone only check the usedBytes of the bucket when we write the key.
 
+e. If the cluster is upgraded from old version less than 1.1.0, use of quota on older volumes and buckets is not recommended. Since the old key is not counted to the bucket's usedBytes, the quota setting is inaccurate at this point.
 
 ## Client usage
 ### Storage Space level quota

--- a/hadoop-hdds/docs/content/feature/Quota.zh.md
+++ b/hadoop-hdds/docs/content/feature/Quota.zh.md
@@ -30,10 +30,16 @@ menu:
 1. Storage space级别配额
 
  管理员应该能够定义一个Volume或Bucket可以使用多少存储空间。目前支持以下storage space quota的设置:
+ 
  a. 默认情况下volume和bucket的quota不启用。
+ 
  b. 当volume quota启用时，bucket quota的总大小不能超过volume。
+ 
  c. 可以在不启用volume quota的情况下单独给bucket设置quota。此时bucket quota的大小是不受限制的。
+ 
  d. 目前不支持单独设置volume quota，只有在设置了bucket quota的情况下volume quota才会生效。因为ozone在写入key时只检查bucket的usedBytes。
+ 
+ e. 如果集群从小于1.1.0的旧版本升级而来，则不建议在旧volume和bucket上使用配额。由于旧的key没有计算到bucket的usedBytes中，所以此时配额设置是不准确的。
 
 ## 客户端用法
 ### Storage space级别配额

--- a/hadoop-hdds/docs/content/feature/Quota.zh.md
+++ b/hadoop-hdds/docs/content/feature/Quota.zh.md
@@ -39,7 +39,9 @@ menu:
  
  d. 目前不支持单独设置volume quota，只有在设置了bucket quota的情况下volume quota才会生效。因为ozone在写入key时只检查bucket的usedBytes。
  
- e. 如果集群从小于1.1.0的旧版本升级而来，则不建议在旧volume和bucket上使用配额。由于旧的key没有计算到bucket的usedBytes中，所以此时配额设置是不准确的。
+ e. 如果集群从小于1.1.0的旧版本升级而来，则不建议在旧volume和bucket(可以通过查看volume或者bucket的info确认，如果quota值是-2，那么这个volume或者bucket就是旧的)上使用配额。由于旧的key没有计算到bucket的usedBytes中，所以此时配额设置是不准确的。
+ 
+ f. 如果volume quota被启用，那么bucket quota将不能被清除。
 
 ## 客户端用法
 ### Storage space级别配额
@@ -68,9 +70,10 @@ bin/ozone sh bucket setquota  --space-quota 10GB /volume1/bucket1
 
 bucket的总配额 不应大于其Volume的配额。让我们看一个例子，如果我们有一个10MB的Volume，该volume下所有bucket的大小之和不能超过10MB，否则设置bucket quota将失败。
 
-#### 清除Volume1的配额, Bucket清除命令与此类似
+#### 清除volume和bucket的配额
 ```shell
 bin/ozone sh volume clrquota --space-quota /volume1
+bin/ozone sh bucket clrquota --space-quota /volume1/bucket1
 ```
 #### 查看volume和bucket的quota值以及usedBytes
 ```shell

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -65,9 +65,9 @@ source "${COMPOSE_DIR}/../testlib.sh"
 export OZONE_KEEP_RESULTS=true
 start_docker_env
 execute_robot_test scm -v PREFIX:pre freon/validate.robot
-# TODO can be enabled with HDDS-4562:
-# execute_robot_test scm -v PREFIX:post freon/generate.robot
-# execute_robot_test scm -v PREFIX:post freon/validate.robot
+# test write key to old bucket after upgrade
+execute_robot_test scm -v PREFIX:post freon/generate.robot
+execute_robot_test scm -v PREFIX:post freon/validate.robot
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -363,7 +363,7 @@ message VolumeInfo {
     optional uint64 objectID = 8;
     optional uint64 updateID = 9;
     optional uint64 modificationTime = 10;
-    optional sint64 quotaInNamespace = 11 [default = -1];
+    optional int64 quotaInNamespace = 11 [default = -2];
     optional uint64 usedNamespace = 12;
 }
 
@@ -503,8 +503,8 @@ message BucketInfo {
     optional string sourceVolume = 12;
     optional string sourceBucket = 13;
     optional uint64 usedBytes = 14;
-    optional sint64 quotaInBytes = 15 [default = -1];
-    optional sint64 quotaInNamespace = 16 [default = -1];
+    optional int64 quotaInBytes = 15 [default = -2];
+    optional int64 quotaInNamespace = 16 [default = -2];
 }
 
 enum StorageTypeProto {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -363,7 +363,7 @@ message VolumeInfo {
     optional uint64 objectID = 8;
     optional uint64 updateID = 9;
     optional uint64 modificationTime = 10;
-    optional uint64 quotaInNamespace = 11;
+    optional sint64 quotaInNamespace = 11 [default = -1];
     optional uint64 usedNamespace = 12;
 }
 
@@ -503,8 +503,8 @@ message BucketInfo {
     optional string sourceVolume = 12;
     optional string sourceBucket = 13;
     optional uint64 usedBytes = 14;
-    optional uint64 quotaInBytes = 15;
-    optional uint64 quotaInNamespace = 16;
+    optional sint64 quotaInBytes = 15 [default = -1];
+    optional sint64 quotaInNamespace = 16 [default = -1];
 }
 
 enum StorageTypeProto {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -314,7 +314,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
    */
   private void checkQuotaInNamespace(OmVolumeArgs omVolumeArgs,
       long allocatedNamespace) throws IOException {
-    if (omVolumeArgs.getQuotaInNamespace() != OzoneConsts.QUOTA_RESET) {
+    if (omVolumeArgs.getQuotaInNamespace() > 0) {
       long usedNamespace = omVolumeArgs.getUsedNamespace();
       long quotaInNamespace = omVolumeArgs.getQuotaInNamespace();
       long toUseNamespaceInTotal = usedNamespace + allocatedNamespace;
@@ -335,10 +335,10 @@ public class OMBucketCreateRequest extends OMClientRequest {
     long volumeQuotaInBytes = omVolumeArgs.getQuotaInBytes();
 
     long totalBucketQuota = 0;
-    if (quotaInBytes == OzoneConsts.QUOTA_RESET || quotaInBytes == 0) {
-      return false;
-    } else if (quotaInBytes > OzoneConsts.QUOTA_RESET) {
+    if (quotaInBytes > 0) {
       totalBucketQuota = quotaInBytes;
+    } else {
+      return false;
     }
 
     List<OmBucketInfo>  bucketList = metadataManager.listBuckets(


### PR DESCRIPTION
## What changes were proposed in this pull request?

long quotaInBytes are new fields in the bucketArgs, this field will go to 0 by default in the old bucket when the old cluster is upgraded. At this point, the data writes are rejected.

This is similar to creating a bucket without specifying quotaInBytes, where quotaInBytes is set to -1 by default via getQuotaValue. We can use 0 as a special term.

![image](https://user-images.githubusercontent.com/13825159/101566773-875c7700-3a0a-11eb-847e-f40d20a49cc4.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4562

## How was this patch tested?

ut added
