### PR TITLE
HDDS-4570. Reduce memory footprint of OMUpdateEventBatch for Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -113,8 +113,14 @@ public class ContainerKeyMapperTask implements ReconOmTask {
   public Pair<String, Boolean> process(OMUpdateEventBatch events) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
     int eventCount = 0;
+    final Collection<String> taskTables = getTaskTables();
+
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent = eventIterator.next();
+      // Filter event inside process method to avoid duping
+      if (!taskTables.contains(omdbUpdateEvent.getTable())) {
+        continue;
+      }
       String updatedKey = omdbUpdateEvent.getKey();
       OmKeyInfo updatedKeyValue = omdbUpdateEvent.getValue();
       try {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -104,7 +104,6 @@ public class ContainerKeyMapperTask implements ReconOmTask {
     return "ContainerKeyMapperTask";
   }
 
-  @Override
   public Collection<String> getTaskTables() {
     return Collections.singletonList(KEY_TABLE);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -110,7 +110,6 @@ public class FileSizeCountTask implements ReconOmTask {
     return "FileSizeCountTask";
   }
 
-  @Override
   public Collection<String> getTaskTables() {
     return Collections.singletonList(KEY_TABLE);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -126,9 +126,14 @@ public class FileSizeCountTask implements ReconOmTask {
   public Pair<String, Boolean> process(OMUpdateEventBatch events) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
     Map<FileSizeCountKey, Long> fileSizeCountMap = new HashMap<>();
+    final Collection<String> taskTables = getTaskTables();
 
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent = eventIterator.next();
+      // Filter event inside process method to avoid duping
+      if (!taskTables.contains(omdbUpdateEvent.getTable())) {
+        continue;
+      }
       String updatedKey = omdbUpdateEvent.getKey();
       OmKeyInfo omKeyInfo = omdbUpdateEvent.getValue();
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
@@ -18,10 +18,8 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * Wrapper class to hold multiple OM DB update events.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -29,10 +28,10 @@ import java.util.stream.Collectors;
  */
 public class OMUpdateEventBatch {
 
-  private List<OMDBUpdateEvent> events;
+  private final List<OMDBUpdateEvent> events;
 
-  public OMUpdateEventBatch(Collection<OMDBUpdateEvent> e) {
-    events = new ArrayList<>(e);
+  public OMUpdateEventBatch(List<OMDBUpdateEvent> e) {
+    events = e;
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMUpdateEventBatch.java
@@ -55,18 +55,6 @@ public class OMUpdateEventBatch {
   }
 
   /**
-   * Filter events based on Tables.
-   * @param tables set of tables to filter on.
-   * @return trimmed event batch.
-   */
-  public OMUpdateEventBatch filter(Collection<String> tables) {
-    return new OMUpdateEventBatch(events
-        .stream()
-        .filter(e -> tables.contains(e.getTable()))
-        .collect(Collectors.toList()));
-  }
-
-  /**
    * Return if empty.
    * @return true if empty, else false.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconOmTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconOmTask.java
@@ -18,8 +18,6 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
-import java.util.Collection;
-
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 
@@ -33,13 +31,6 @@ public interface ReconOmTask {
    * @return task name
    */
   String getTaskName();
-
-  /**
-   * Return the list of tables that the task is listening on.
-   * Empty list means the task is NOT listening on any tables.
-   * @return Collection of Tables.
-   */
-  Collection<String> getTaskTables();
 
   /**
    * Process a set of OM events on tables that the task is listening on.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ReconTaskControllerImpl.java
@@ -109,8 +109,8 @@ public class ReconTaskControllerImpl implements ReconTaskController {
         for (Map.Entry<String, ReconOmTask> taskEntry :
             reconOmTasks.entrySet()) {
           ReconOmTask task = taskEntry.getValue();
-          Collection<String> tables = task.getTaskTables();
-          tasks.add(() -> task.process(events.filter(tables)));
+          // events passed to process method is no longer filtered
+          tasks.add(() -> task.process(events));
         }
 
         List<Future<Pair<String, Boolean>>> results =
@@ -123,8 +123,8 @@ public class ReconTaskControllerImpl implements ReconTaskController {
           tasks.clear();
           for (String taskName : failedTasks) {
             ReconOmTask task = reconOmTasks.get(taskName);
-            Collection<String> tables = task.getTaskTables();
-            tasks.add(() -> task.process(events.filter(tables)));
+            // events passed to process method is no longer filtered
+            tasks.add(() -> task.process(events));
           }
           results = executorService.invokeAll(tasks);
           retryFailedTasks = processTaskResults(results, events);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
@@ -99,7 +99,6 @@ public class TableCountTask implements ReconOmTask {
     return "TableCountTask";
   }
 
-  @Override
   public Collection<String> getTaskTables() {
     return new ArrayList<>(reconOMMetadataManager.listTableNames());
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
@@ -114,11 +114,15 @@ public class TableCountTask implements ReconOmTask {
   @Override
   public Pair<String, Boolean> process(OMUpdateEventBatch events) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
-
     HashMap<String, Long> objectCountMap = initializeCountMap();
+    final Collection<String> taskTables = getTaskTables();
 
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, Object> omdbUpdateEvent = eventIterator.next();
+      // Filter event inside process method to avoid duping
+      if (!taskTables.contains(omdbUpdateEvent.getTable())) {
+        continue;
+      }
       String rowKey = getRowKeyFromTable(omdbUpdateEvent.getTable());
       try{
         switch (omdbUpdateEvent.getAction()) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/DummyReconDBTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/DummyReconDBTask.java
@@ -49,7 +49,6 @@ public class DummyReconDBTask implements ReconOmTask {
     return taskName;
   }
 
-  @Override
   public Collection<String> getTaskTables() {
     return Collections.singletonList("volumeTable");
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -198,6 +198,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(PUT)
         .setKey("newKey")
         .setValue(newKey)
+        .setTable(OmMetadataManagerImpl.KEY_TABLE)
         .build();
 
     // Update existing key.
@@ -211,6 +212,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setKey("updatedKey")
         .setValue(updatedKey)
         .setOldValue(toBeUpdatedKey)
+        .setTable(OmMetadataManagerImpl.KEY_TABLE)
         .build();
 
     // Delete another existing key.
@@ -218,6 +220,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(DELETE)
         .setKey("deletedKey")
         .setValue(toBeDeletedKey)
+        .setTable(OmMetadataManagerImpl.KEY_TABLE)
         .build();
 
     omUpdateEventBatch = new OMUpdateEventBatch(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestFileSizeCountTask.java
@@ -153,6 +153,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(PUT)
         .setKey("deletedKey")
         .setValue(toBeDeletedKey)
+        .setTable(OmMetadataManagerImpl.KEY_TABLE)
         .build();
 
     OmKeyInfo toBeUpdatedKey = mock(OmKeyInfo.class);
@@ -164,6 +165,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
         .setAction(PUT)
         .setKey("updatedKey")
         .setValue(toBeUpdatedKey)
+        .setTable(OmMetadataManagerImpl.KEY_TABLE)
         .build();
 
     OMUpdateEventBatch omUpdateEventBatch =
@@ -322,6 +324,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
               .setAction(PUT)
               .setKey("key" + keyIndex)
               .setValue(omKeyInfo)
+              .setTable(OmMetadataManagerImpl.KEY_TABLE)
               .build());
         }
       }
@@ -365,6 +368,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
                 .setAction(DELETE)
                 .setKey("key" + keyIndex)
                 .setValue(omKeyInfo)
+                .setTable(OmMetadataManagerImpl.KEY_TABLE)
                 .build());
           } else {
             // update all the files with keyIndex > 5 to filesize 1023L
@@ -374,6 +378,7 @@ public class TestFileSizeCountTask extends AbstractReconSqlDBTest {
                 .setAction(UPDATE)
                 .setKey("key" + keyIndex)
                 .setValue(omKeyInfo)
+                .setTable(OmMetadataManagerImpl.KEY_TABLE)
                 .setOldValue(
                     omKeyInfoList.get((volIndex * bktIndex) + keyIndex))
                 .build());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -78,8 +78,6 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
     OMUpdateEventBatch omUpdateEventBatchMock = mock(OMUpdateEventBatch.class);
     when(omUpdateEventBatchMock.getLastSequenceNumber()).thenReturn(100L);
     when(omUpdateEventBatchMock.isEmpty()).thenReturn(false);
-    when(omUpdateEventBatchMock.filter(Collections.singleton("MockTable")))
-        .thenReturn(omUpdateEventBatchMock);
 
     long startTime = System.currentTimeMillis();
     reconTaskController.consumeOMEvents(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -203,11 +203,7 @@ public class TestReconTaskControllerImpl extends AbstractReconSqlDBTest {
    */
   private ReconOmTask getMockTask(String taskName) {
     ReconOmTask reconOmTaskMock = mock(ReconOmTask.class);
-    when(reconOmTaskMock.getTaskTables()).thenReturn(Collections
-        .EMPTY_LIST);
     when(reconOmTaskMock.getTaskName()).thenReturn(taskName);
-    when(reconOmTaskMock.getTaskTables())
-        .thenReturn(Collections.singleton("MockTable"));
     return reconOmTaskMock;
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestReconTaskControllerImpl.java
@@ -27,7 +27,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.HashSet;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Reduce new object creation when Recon is consuming batches OM events (`consumeOMEvents()`)
2. ~~Improve `OMUpdateEventBatch#filter` to reduce memory usage.~~ Ended up removing `OMUpdateEventBatch#filter`. Instead just "filters" the events by task table name in `ReconOmTask#process`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4570

## How was this patch tested?

All existing UTs shall pass.