### PR TITLE
HDDS-4552. Read data from chunk into ByteBuffer[] instead of single ByteBuffer.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -109,13 +109,13 @@ public class OzoneClientConfig {
   private String checksumType = ChecksumType.CRC32.name();
 
   @Config(key = "bytes.per.checksum",
-      defaultValue = "1MB",
+      defaultValue = "256KB",
       type = ConfigType.SIZE,
       description = "Checksum will be computed for every bytes per checksum "
           + "number of bytes and stored sequentially. The minimum value for "
-          + "this config is 256KB.",
+          + "this config is 16KB.",
       tags = ConfigTag.CLIENT)
-  private int bytesPerChecksum = 1024 * 1024;
+  private int bytesPerChecksum = 256 * 1024;
 
   @Config(key = "verify.checksum",
       defaultValue = "true",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -109,13 +109,13 @@ public class OzoneClientConfig {
   private String checksumType = ChecksumType.CRC32.name();
 
   @Config(key = "bytes.per.checksum",
-      defaultValue = "256KB",
+      defaultValue = "1MB",
       type = ConfigType.SIZE,
       description = "Checksum will be computed for every bytes per checksum "
           + "number of bytes and stored sequentially. The minimum value for "
           + "this config is 16KB.",
       tags = ConfigTag.CLIENT)
-  private int bytesPerChecksum = 256 * 1024;
+  private int bytesPerChecksum = 1024 * 1024;
 
   @Config(key = "verify.checksum",
       defaultValue = "true",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -502,4 +502,9 @@ public class BlockInputStream extends InputStream
 
     refreshPipeline(cause);
   }
+
+  @VisibleForTesting
+  public synchronized List<ChunkInputStream> getChunkStreams() {
+    return chunkStreams;
+  }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -386,7 +386,8 @@ public class ChunkInputStream extends InputStream
    * Send RPC call to get the chunk from the container.
    */
   @VisibleForTesting
-  protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo) throws IOException {
+  protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo)
+      throws IOException {
     ReadChunkResponseProto readChunkResponse;
 
     try {
@@ -432,10 +433,10 @@ public class ChunkInputStream extends InputStream
               ByteString byteString = readChunkResponse.getData();
               if (byteString.size() != reqChunkInfo.getLen()) {
                 // Bytes read from chunk should be equal to chunk size.
-                throw new OzoneChecksumException(String
-                    .format("Inconsistent read for chunk=%s len=%d bytesRead=%d",
-                        reqChunkInfo.getChunkName(), reqChunkInfo.getLen(),
-                        byteString.size()));
+                throw new OzoneChecksumException(String.format(
+                    "Inconsistent read for chunk=%s len=%d bytesRead=%d",
+                    reqChunkInfo.getChunkName(), reqChunkInfo.getLen(),
+                    byteString.size()));
               }
               byteStrings = new ArrayList<>();
               byteStrings.add(byteString);
@@ -445,10 +446,10 @@ public class ChunkInputStream extends InputStream
               long buffersLen = BufferUtils.getBuffersLen(byteStrings);
               if (buffersLen != reqChunkInfo.getLen()) {
                 // Bytes read from chunk should be equal to chunk size.
-                throw new OzoneChecksumException(String
-                    .format("Inconsistent read for chunk=%s len=%d bytesRead=%d",
-                        reqChunkInfo.getChunkName(), reqChunkInfo.getLen(),
-                        buffersLen));
+                throw new OzoneChecksumException(String.format(
+                    "Inconsistent read for chunk=%s len=%d bytesRead=%d",
+                    reqChunkInfo.getChunkName(), reqChunkInfo.getLen(),
+                    buffersLen));
               }
             }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -78,7 +78,7 @@ public class ChunkInputStream extends InputStream
   private int bufferIndex;
   // bufferOffsets[i] stores the index of the first data byte in buffer i
   // (buffers.get(i)) w.r.t first byte in the buffers.
-  // Let's each buffer has a capacity of 40 bytes. The bufferOffset for
+  // Let's say each buffer has a capacity of 40 bytes. The bufferOffset for
   // the first buffer would always be 0 as this would be the first data byte
   // in buffers. BufferOffset for the 2nd buffer would be 40 as bytes 0-39
   // would be stored in buffer 0. Hence, bufferOffsets[0] = 0,
@@ -105,8 +105,7 @@ public class ChunkInputStream extends InputStream
   ChunkInputStream(ChunkInfo chunkInfo, BlockID blockId,
       XceiverClientFactory xceiverClientFactory,
       Supplier<Pipeline> pipelineSupplier,
-      boolean verifyChecksum,
-      Token<? extends TokenIdentifier> token) {
+      boolean verifyChecksum, Token<? extends TokenIdentifier> token) {
     this.chunkInfo = chunkInfo;
     this.length = chunkInfo.getLen();
     this.blockID = blockId;

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.storage;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -25,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 /**
@@ -48,12 +50,29 @@ public class DummyChunkInputStream extends ChunkInputStream {
   }
 
   @Override
-  protected ByteString readChunk(ChunkInfo readChunkInfo) {
-    ByteString byteString = ByteString.copyFrom(chunkData,
-        (int) readChunkInfo.getOffset(),
-        (int) readChunkInfo.getLen());
-    getReadByteBuffers().add(byteString);
-    return byteString;
+  protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo) {
+    int offset = (int) readChunkInfo.getOffset();
+    int remainingToRead = (int) readChunkInfo.getLen();
+
+    int bufferCapacity = readChunkInfo.getChecksumData().getBytesPerChecksum();
+    int bufferLen;
+    readByteBuffers.clear();
+    while (remainingToRead > 0) {
+      if (remainingToRead < bufferCapacity) {
+        bufferLen = remainingToRead;
+      } else {
+        bufferLen = bufferCapacity;
+      }
+      ByteString byteString = ByteString.copyFrom(chunkData,
+          offset, bufferLen);
+
+      readByteBuffers.add(byteString);
+
+      offset += bufferLen;
+      remainingToRead -= bufferLen;
+    }
+
+    return BufferUtils.getReadOnlyByteBuffers(readByteBuffers);
   }
 
   @Override

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.hdds.scm.storage;
 
 import java.io.EOFException;
+import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -216,8 +218,8 @@ public class TestChunkInputStream {
     ChunkInputStream subject = new ChunkInputStream(chunkInfo, null,
         clientFactory, pipelineRef::get, false, null) {
       @Override
-      protected ByteString readChunk(ChunkInfo readChunkInfo) {
-        return ByteString.copyFrom(chunkData);
+      protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo) {
+        return ByteString.copyFrom(chunkData).asReadOnlyByteBufferList();
       }
     };
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -96,6 +96,19 @@ public class TestChunkInputStream {
     }
   }
 
+  private void matchWithInputData(List<ByteString> byteStrings,
+      int inputDataStartIndex, int length) {
+    int offset = inputDataStartIndex;
+    int totalBufferLen = 0;
+    for (ByteString byteString : byteStrings) {
+      int bufferLen = byteString.size();
+      matchWithInputData(byteString.toByteArray(), offset, bufferLen);
+      offset += bufferLen;
+      totalBufferLen += bufferLen;
+    }
+    Assert.assertEquals(length, totalBufferLen);
+  }
+
   /**
    * Seek to a position and verify through getPos().
    */
@@ -125,10 +138,9 @@ public class TestChunkInputStream {
     // To read chunk data from index 0 to 49 (len = 50), we need to read
     // chunk from offset 0 to 60 as the checksum boundary is at every 20
     // bytes. Verify that 60 bytes of chunk data are read and stored in the
-    // buffers.
-    matchWithInputData(chunkStream.getReadByteBuffers().get(0).toByteArray(),
-        0, 60);
-
+    // buffers. Since checksum boundary is at every 20 bytes, there should be
+    // 60/20 number of buffers.
+    matchWithInputData(chunkStream.getReadByteBuffers(), 0, 60);
   }
 
   @Test
@@ -154,8 +166,7 @@ public class TestChunkInputStream {
     byte[] b = new byte[30];
     chunkStream.read(b, 0, 30);
     matchWithInputData(b, 25, 30);
-    matchWithInputData(chunkStream.getReadByteBuffers().get(0).toByteArray(),
-        20, 40);
+    matchWithInputData(chunkStream.getReadByteBuffers(), 20, 40);
 
     // After read, the position of the chunkStream is evaluated from the
     // buffers and the chunkPosition should be reset to -1.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -133,6 +133,11 @@ public final class ScmConfigKeys {
   // 4 MB by default
   public static final String OZONE_SCM_CHUNK_SIZE_DEFAULT = "4MB";
 
+  public static final String OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY =
+      "ozone.chunk.read.buffer.default.size";
+  public static final String OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_DEFAULT =
+      "64KB";
+
   public static final String OZONE_SCM_CHUNK_LAYOUT_KEY =
       "ozone.scm.chunk.layout";
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetSmallFi
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutBlockResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutSmallFileResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadChunkResponseProto;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadChunkVersion;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
@@ -295,7 +294,6 @@ public final class ContainerCommandResponseBuilders {
           .setBlockID(request.getReadChunk().getBlockID());
     } else {
       // V1 splits response data into a list of ByteBuffers
-      List<ByteBuffer> byteBuffers = data.asByteBufferList();
       response = ReadChunkResponseProto.newBuilder()
           .setChunkData(request.getReadChunk().getChunkData())
           .setDataBuffers(DataBuffers.newBuilder()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -226,7 +226,8 @@ public final class ContainerProtocolCalls  {
     ReadChunkRequestProto.Builder readChunkRequest =
         ReadChunkRequestProto.newBuilder()
             .setBlockID(blockID.getDatanodeBlockIDProtobuf())
-            .setChunkData(chunk);
+            .setChunkData(chunk)
+            .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
     String id = xceiverClient.getPipeline().getClosestNode().getUuidString();
     ContainerCommandRequestProto.Builder builder =
         ContainerCommandRequestProto.newBuilder().setCmdType(Type.ReadChunk)

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/storage/ContainerProtocolCalls.java
@@ -490,6 +490,7 @@ public final class ContainerProtocolCalls  {
     ContainerProtos.GetSmallFileRequestProto getSmallFileRequest =
         GetSmallFileRequestProto
             .newBuilder().setBlock(getBlock)
+            .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1)
             .build();
     String id = client.getPipeline().getClosestNode().getUuidString();
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/ClientCommandsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/ClientCommandsUtils.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.utils;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+
+public final class ClientCommandsUtils {
+
+  public static ContainerProtos.ReadChunkVersion getReadChunkVersion(
+      ContainerProtos.ReadChunkRequestProto readChunkRequest) {
+    if (readChunkRequest.hasReadChunkVersion()) {
+      return readChunkRequest.getReadChunkVersion();
+    } else {
+      return ContainerProtos.ReadChunkVersion.V0;
+    }
+  }
+
+  public static ContainerProtos.ReadChunkVersion getReadChunkVersion(
+      ContainerProtos.GetSmallFileRequestProto getSmallFileRequest) {
+    if (getSmallFileRequest.hasReadChunkVersion()) {
+      return getSmallFileRequest.getReadChunkVersion();
+    } else {
+      return ContainerProtos.ReadChunkVersion.V0;
+    }
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/ClientCommandsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/ClientCommandsUtils.java
@@ -22,6 +22,11 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
 public final class ClientCommandsUtils {
 
+  /** Utility classes should not be constructed. **/
+  private ClientCommandsUtils() {
+
+  }
+
   public static ContainerProtos.ReadChunkVersion getReadChunkVersion(
       ContainerProtos.ReadChunkRequestProto readChunkRequest) {
     if (readChunkRequest.hasReadChunkVersion()) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/package-info.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/utils/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.utils;
+
+/**
+ * This package contains utils classes for the SCM and client protocols.
+ */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -333,7 +333,7 @@ public final class OzoneConfigKeys {
       "hdds.datanode.replication.work.dir";
 
 
-  public static final int OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE = 256 * 1024;
+  public static final int OZONE_CLIENT_BYTES_PER_CHECKSUM_MIN_SIZE = 16 * 1024;
 
   public static final String OZONE_CLIENT_READ_TIMEOUT
           = "ozone.client.read.timeout";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -145,6 +145,13 @@ public class Checksum {
     return computeChecksum(ChunkBuffer.wrap(data));
   }
 
+  public ChecksumData computeChecksum(List<ByteString> byteStrings)
+      throws OzoneChecksumException {
+    final List<ByteBuffer> buffers =
+        BufferUtils.getReadOnlyByteBuffers(byteStrings);
+    return computeChecksum(ChunkBuffer.wrap(buffers));
+  }
+
   public ChecksumData computeChecksum(ChunkBuffer data)
       throws OzoneChecksumException {
     if (checksumType == ChecksumType.NONE) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -144,12 +144,26 @@ public interface ChunkBuffer {
     return toByteStringImpl(b -> applyAndAssertFunction(b, function, this));
   }
 
+  /**
+   * Convert this buffer(s) to a list of {@link ByteString}.
+   * The position and limit of this {@link ChunkBuffer} remains unchanged.
+   * The given function must preserve the position and limit
+   * of the input {@link ByteBuffer}.
+   */
+  default List<ByteString> toByteStringList(
+      Function<ByteBuffer, ByteString> function) {
+    return toByteStringListImpl(b -> applyAndAssertFunction(b, function, this));
+  }
+
   // for testing
   default ByteString toByteString() {
     return toByteString(ByteStringConversion::safeWrap);
   }
 
   ByteString toByteStringImpl(Function<ByteBuffer, ByteString> function);
+
+  List<ByteString> toByteStringListImpl(
+      Function<ByteBuffer, ByteString> function);
 
   static void assertInt(int expected, int computed, Supplier<String> prefix) {
     if (expected != computed) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBuffer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.common;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -119,6 +120,12 @@ final class ChunkBufferImplWithByteBuffer implements ChunkBuffer {
   @Override
   public ByteString toByteStringImpl(Function<ByteBuffer, ByteString> f) {
     return f.apply(buffer);
+  }
+
+  @Override
+  public List<ByteString> toByteStringListImpl(
+      Function<ByteBuffer, ByteString> f) {
+    return Arrays.asList(f.apply(buffer));
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.common;
 
 import com.google.common.base.Preconditions;
+import java.util.stream.Collectors;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.io.IOException;
@@ -271,6 +272,12 @@ final class IncrementalChunkBuffer implements ChunkBuffer {
   @Override
   public ByteString toByteStringImpl(Function<ByteBuffer, ByteString> f) {
     return buffers.stream().map(f).reduce(ByteString.EMPTY, ByteString::concat);
+  }
+
+  @Override
+  public List<ByteString> toByteStringListImpl(
+      Function<ByteBuffer, ByteString> f) {
+    return buffers.stream().map(f).collect(Collectors.toList());
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -43,8 +43,7 @@ public final class BufferUtils {
     Preconditions.checkArgument(bufferCapacity > 0, "Buffer Capacity should " +
         "be a positive integer.");
 
-    int numBuffers =
-        (int) Math.ceil((double) totalLen / (double) bufferCapacity);
+    int numBuffers = getNumberOfBins(totalLen, bufferCapacity);
 
     ByteBuffer[] dataBuffers = new ByteBuffer[numBuffers];
     int buffersAllocated = 0;
@@ -81,5 +80,16 @@ public final class BufferUtils {
       length += buffer.size();
     }
     return length;
+  }
+
+  /**
+   * Return the number of bins required to hold all the elements given a max
+   * capacity for each bin.
+   * @param numElements total number of elements to put in bin
+   * @param maxElementsPerBin max number of elements per bin
+   * @return number of bins
+   */
+  public static int getNumberOfBins(long numElements, long maxElementsPerBin) {
+    return (int) Math.ceil((double) numElements / (double) maxElementsPerBin);
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.common.utils;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+
+public final class BufferUtils {
+
+  /**
+   * Assign an array of ByteBuffers.
+   * @param totalLen total length of all ByteBuffers
+   * @param bufferCapacity max capacity of each ByteBuffer
+   */
+  public static ByteBuffer[] assignByteBuffers(long totalLen,
+      long bufferCapacity) {
+    int numBuffers = (int) Math.ceil(totalLen / bufferCapacity);
+
+    ByteBuffer[] dataBuffers = new ByteBuffer[numBuffers];
+    int buffersAllocated = 0;
+    // For each ByteBuffer (except the last) allocate bufferLen of capacity
+    for (int i = 0; i < numBuffers - 1; i++) {
+      dataBuffers[i] = ByteBuffer.allocate((int) bufferCapacity);
+      buffersAllocated += bufferCapacity;
+    }
+    // For the last ByteBuffer, allocate as much space as is needed to fit
+    // remaining bytes
+    dataBuffers[numBuffers - 1] = ByteBuffer.allocate(
+        (int) (totalLen - buffersAllocated));
+    return dataBuffers;
+  }
+
+  /**
+   * Return a read only ByteBuffer list for the input ByteStrings list.
+   */
+  public static List<ByteBuffer> getReadOnlyByteBuffers(
+      List<ByteString> byteStrings) {
+    List<ByteBuffer> buffers = new ArrayList<>();
+    for (ByteString byteString : byteStrings) {
+      buffers.add(byteString.asReadOnlyByteBuffer());
+    }
+    return buffers;
+  }
+
+  /**
+   * Return the summation of the length of all ByteStrings.
+   */
+  public static long getBuffersLen(List<ByteString> buffers) {
+    long length = 0;
+    for (ByteString buffer : buffers) {
+      length += buffer.size();
+    }
+    return length;
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -18,12 +18,18 @@
 
 package org.apache.hadoop.ozone.common.utils;
 
+import com.google.common.base.Preconditions;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 public final class BufferUtils {
+
+  /** Utility classes should not be constructed. **/
+  private BufferUtils() {
+
+  }
 
   /**
    * Assign an array of ByteBuffers.
@@ -32,7 +38,13 @@ public final class BufferUtils {
    */
   public static ByteBuffer[] assignByteBuffers(long totalLen,
       long bufferCapacity) {
-    int numBuffers = (int) Math.ceil(totalLen / bufferCapacity);
+    Preconditions.checkArgument(totalLen > 0, "Buffer Length should be a " +
+        "positive integer.");
+    Preconditions.checkArgument(bufferCapacity > 0, "Buffer Capacity should " +
+        "be a positive integer.");
+
+    int numBuffers =
+        (int) Math.ceil((double) totalLen / (double) bufferCapacity);
 
     ByteBuffer[] dataBuffers = new ByteBuffer[numBuffers];
     int buffersAllocated = 0;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -71,6 +71,10 @@ public final class BufferUtils {
     return buffers;
   }
 
+  public static ByteString concatByteStrings(List<ByteString> byteStrings) {
+    return byteStrings.stream().reduce(ByteString::concat).orElse(null);
+  }
+
   /**
    * Return the summation of the length of all ByteStrings.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/package-info.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/package-info.java
@@ -16,8 +16,8 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hdds.scm.utils;
+package org.apache.hadoop.ozone.common.utils;
 
 /**
- * This package contains utility classes for the SCM and client protocols.
+ * This package contains common utility classes for HDDS.
  */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ChunkInfo.java
@@ -38,6 +38,10 @@ public class ChunkInfo {
   private ChecksumData checksumData;
   private final Map<String, String> metadata;
 
+  // For older clients reading chunks in V0 version (all read data should
+  // reside in one buffer). This variable should be set to true for older
+  // clients to maintain backward wire compatibility.
+  private boolean readDataIntoSingleBuffer = false;
 
   /**
    * Constructs a ChunkInfo.
@@ -181,5 +185,13 @@ public class ChunkInfo {
         ", offset=" + offset +
         ", len=" + len +
         '}';
+  }
+
+  public void setReadDataIntoSingleBuffer(boolean readDataIntoSingleBuffer) {
+    this.readDataIntoSingleBuffer = readDataIntoSingleBuffer;
+  }
+
+  public boolean isReadDataIntoSingleBuffer() {
+    return readDataIntoSingleBuffer;
   }
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -701,6 +701,19 @@
     </description>
   </property>
   <property>
+    <name>ozone.chunk.read.buffer.default.size</name>
+    <value>64KB</value>
+    <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>
+    <description>
+      The default read buffer size during read chunk operations when checksum
+      is disabled. Chunk data will be cached in buffers of this capacity.
+
+      For chunk data with checksum, the read buffer size will be the
+      same as the number of bytes per checksum
+      (ozone.client.bytes.per.checksum) corresponding to the chunk.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.chunk.layout</name>
     <value>FILE_PER_BLOCK</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -281,10 +281,22 @@ public final class ContainerUtils {
     if (msg.hasReadChunk() || msg.hasGetSmallFile()) {
       ContainerCommandResponseProto.Builder builder = msg.toBuilder();
       if (msg.hasReadChunk()) {
-        builder.getReadChunkBuilder().setData(REDACTED);
+        if (msg.getReadChunk().hasData()) {
+          builder.getReadChunkBuilder().setData(REDACTED);
+        }
+        if (msg.getReadChunk().hasDataBuffers()) {
+          builder.getReadChunkBuilder().getDataBuffersBuilder()
+              .addBuffers(REDACTED);
+        }
       }
       if (msg.hasGetSmallFile()) {
-        builder.getGetSmallFileBuilder().getDataBuilder().setData(REDACTED);
+        if (msg.getGetSmallFile().getData().hasData()) {
+          builder.getGetSmallFileBuilder().getDataBuilder().setData(REDACTED);
+        }
+        if (msg.getGetSmallFile().getData().hasDataBuffers()) {
+          builder.getGetSmallFileBuilder().getDataBuilder()
+              .getDataBuffersBuilder().addBuffers(REDACTED);
+        }
       }
       return builder.build();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -572,7 +572,8 @@ public class ContainerStateMachine extends BaseStateMachine {
     ReadChunkRequestProto.Builder readChunkRequestProto =
         ReadChunkRequestProto.newBuilder()
             .setBlockID(writeChunkRequestProto.getBlockID())
-            .setChunkData(chunkInfo);
+            .setChunkData(chunkInfo)
+            .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
     ContainerCommandRequestProto dataContainerCommandProto =
         ContainerCommandRequestProto.newBuilder(requestProto)
             .setCmdType(Type.ReadChunk).setReadChunk(readChunkRequestProto)

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.hdds.utils.Cache;
 import org.apache.hadoop.hdds.utils.ResourceLimitCache;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.util.Time;
@@ -596,14 +597,22 @@ public class ContainerStateMachine extends BaseStateMachine {
     }
 
     ReadChunkResponseProto responseProto = response.getReadChunk();
+    ByteString data;
+    if (responseProto.hasData()) {
+      data = responseProto.getData();
+    } else {
+      data = BufferUtils.concatByteStrings(
+          responseProto.getDataBuffers().getBuffersList());
+    }
 
-    ByteString data = responseProto.getData();
     // assert that the response has data in it.
     Preconditions
-        .checkNotNull(data, "read chunk data is null for chunk: %s", chunkInfo);
+        .checkNotNull(data, "read chunk data is null for chunk: %s",
+            chunkInfo);
     Preconditions.checkState(data.size() == chunkInfo.getLen(),
         "read chunk len=%s does not match chunk expected len=%s for chunk:%s",
         data.size(), chunkInfo.getLen(), chunkInfo);
+
     return data;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -861,7 +861,7 @@ public class KeyValueHandler extends Handler {
           // all the data read from chunk file is returned as a single
           // ByteString. Older clients cannot process data returned as a list
           // of ByteStrings.
-           chunkInfo.setReadDataIntoSingleBuffer(true);
+          chunkInfo.setReadDataIntoSingleBuffer(true);
         }
         ChunkBuffer data = chunkManager.readChunk(kvContainer, blockID,
             chunkInfo, dispatcherContext);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -167,11 +167,11 @@ public final class ChunkUtils {
   }
 
   /**
-   * Reads data from an existing chunk file.
+   * Reads data from an existing chunk file into a list of ByteBuffers.
    *
    * @param file file where data lives
    */
-  public static void readData(File file, ByteBuffer buf,
+  public static void readData(File file, ByteBuffer[] buffers,
       long offset, long len, VolumeIOStats volumeIOStats)
       throws StorageContainerException {
 
@@ -184,7 +184,7 @@ public final class ChunkUtils {
         try (FileChannel channel = open(path, READ_OPTIONS, NO_ATTRIBUTES);
              FileLock ignored = channel.lock(offset, len, true)) {
 
-          return channel.read(buf, offset);
+          return channel.position(offset).read(buffers);
         } catch (IOException e) {
           throw new UncheckedIOException(e);
         }
@@ -204,7 +204,9 @@ public final class ChunkUtils {
 
     validateReadSize(len, bytesRead);
 
-    buf.flip();
+    for (ByteBuffer buf : buffers) {
+      buf.flip();
+    }
   }
 
   /**
@@ -347,5 +349,4 @@ public final class ChunkUtils {
 
     return CONTAINER_INTERNAL_ERROR;
   }
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
@@ -59,6 +61,9 @@ public class BlockManagerImpl implements BlockManager {
   private static final String NO_SUCH_BLOCK_ERR_MSG =
       "Unable to find the block.";
 
+  // Default Read Buffer capacity when Checksum is not present
+  private final long defaultReadBufferCapacity;
+
   /**
    * Constructs a Block Manager.
    *
@@ -67,6 +72,10 @@ public class BlockManagerImpl implements BlockManager {
   public BlockManagerImpl(ConfigurationSource conf) {
     Preconditions.checkNotNull(conf, "Config cannot be null");
     this.config = conf;
+    this.defaultReadBufferCapacity = (long) config.getStorageSize(
+        ScmConfigKeys.OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY,
+        ScmConfigKeys.OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_DEFAULT,
+        StorageUnit.BYTES);
   }
 
   /**
@@ -242,6 +251,11 @@ public class BlockManagerImpl implements BlockManager {
       BlockData blockData = getBlockByID(db, blockID);
       return blockData.getSize();
     }
+  }
+
+  @Override
+  public long getDefaultReadBufferCapacity() {
+    return defaultReadBufferCapacity;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -58,7 +58,7 @@ public class ChunkManagerDispatcher implements ChunkManager {
 
   ChunkManagerDispatcher(boolean sync, BlockManager manager) {
     handlers.put(FILE_PER_CHUNK, new FilePerChunkStrategy(sync, manager));
-    handlers.put(FILE_PER_BLOCK, new FilePerBlockStrategy(sync));
+    handlers.put(FILE_PER_BLOCK, new FilePerBlockStrategy(sync, manager));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -154,7 +154,7 @@ public class FilePerBlockStrategy implements ChunkManager {
     long len = info.getLen();
     long offset = info.getOffset();
 
-    long bufferCapacity;
+    long bufferCapacity = 0;
     if (info.isReadDataIntoSingleBuffer()) {
       // Older client - read all chunk data into one single buffer.
       bufferCapacity = len;
@@ -164,10 +164,13 @@ public class FilePerBlockStrategy implements ChunkManager {
       // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
       ChecksumData checksumData = info.getChecksumData();
 
-      if (checksumData.getChecksumType() == ContainerProtos.ChecksumType.NONE) {
-        bufferCapacity = defaultReadBufferCapacity;
-      } else {
-        bufferCapacity = checksumData.getBytesPerChecksum();
+      if (checksumData != null) {
+        if (checksumData.getChecksumType() ==
+            ContainerProtos.ChecksumType.NONE) {
+          bufferCapacity = defaultReadBufferCapacity;
+        } else {
+          bufferCapacity = checksumData.getBytesPerChecksum();
+        }
       }
     }
     // If the buffer capacity is 0, set all the data into one ByteBuffer

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -22,11 +22,15 @@ import com.google.common.base.Preconditions;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
+import com.google.common.collect.Lists;
+
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -35,6 +39,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
+import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 
@@ -67,9 +72,12 @@ public class FilePerBlockStrategy implements ChunkManager {
 
   private final boolean doSyncWrite;
   private final OpenFiles files = new OpenFiles();
+  private final long defaultReadBufferCapacity;
 
-  public FilePerBlockStrategy(boolean sync) {
+  public FilePerBlockStrategy(boolean sync, BlockManager manager) {
     doSyncWrite = sync;
+    this.defaultReadBufferCapacity = manager == null ? 0 :
+        manager.getDefaultReadBufferCapacity();
   }
 
   private static void checkLayoutVersion(Container container) {
@@ -145,10 +153,34 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     long len = info.getLen();
     long offset = info.getOffset();
-    ByteBuffer data = ByteBuffer.allocate((int) len);
-    ChunkUtils.readData(chunkFile, data, offset, len, volumeIOStats);
 
-    return ChunkBuffer.wrap(data);
+    long bufferCapacity;
+    if (info.isReadDataIntoSingleBuffer()) {
+      // Older client - read all chunk data into one single buffer.
+      bufferCapacity = len;
+    } else {
+      // Set buffer capacity to checksum boundary size so that each buffer
+      // corresponds to one checksum. If checksum is NONE, then set buffer
+      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
+      ChecksumData checksumData = info.getChecksumData();
+
+      if (checksumData.getChecksumType() == ContainerProtos.ChecksumType.NONE) {
+        bufferCapacity = defaultReadBufferCapacity;
+      } else {
+        bufferCapacity = checksumData.getBytesPerChecksum();
+      }
+    }
+    // If the buffer capacity is 0, set all the data into one ByteBuffer
+    if (bufferCapacity == 0) {
+      bufferCapacity = len;
+    }
+
+    ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
+        bufferCapacity);
+
+    ChunkUtils.readData(chunkFile, dataBuffers, offset, len, volumeIOStats);
+
+    return ChunkBuffer.wrap(Lists.newArrayList(dataBuffers));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -229,7 +229,7 @@ public class FilePerChunkStrategy implements ChunkManager {
 
     long len = info.getLen();
 
-    long bufferCapacity;
+    long bufferCapacity = 0;
     if (info.isReadDataIntoSingleBuffer()) {
       // Older client - read all chunk data into one single buffer.
       bufferCapacity = len;
@@ -239,10 +239,13 @@ public class FilePerChunkStrategy implements ChunkManager {
       // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
       ChecksumData checksumData = info.getChecksumData();
 
-      if (checksumData.getChecksumType() == ContainerProtos.ChecksumType.NONE) {
-        bufferCapacity = defaultReadBufferCapacity;
-      } else {
-        bufferCapacity = checksumData.getBytesPerChecksum();
+      if (checksumData != null) {
+        if (checksumData.getChecksumType() ==
+            ContainerProtos.ChecksumType.NONE) {
+          bufferCapacity = defaultReadBufferCapacity;
+        } else {
+          bufferCapacity = checksumData.getBytesPerChecksum();
+        }
       }
     }
     // If the buffer capacity is 0, set all the data into one ByteBuffer

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -20,12 +20,15 @@ package org.apache.hadoop.ozone.container.keyvalue.impl;
 
 import com.google.common.base.Preconditions;
 
+import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -65,10 +68,13 @@ public class FilePerChunkStrategy implements ChunkManager {
 
   private final boolean doSyncWrite;
   private final BlockManager blockManager;
+  private final long defaultReadBufferCapacity;
 
   public FilePerChunkStrategy(boolean sync, BlockManager manager) {
     doSyncWrite = sync;
     blockManager = manager;
+    this.defaultReadBufferCapacity = manager == null ? 0 :
+        manager.getDefaultReadBufferCapacity();
   }
 
   private static void checkLayoutVersion(Container container) {
@@ -222,7 +228,30 @@ public class FilePerChunkStrategy implements ChunkManager {
     }
 
     long len = info.getLen();
-    ByteBuffer data = ByteBuffer.allocate((int) len);
+
+    long bufferCapacity;
+    if (info.isReadDataIntoSingleBuffer()) {
+      // Older client - read all chunk data into one single buffer.
+      bufferCapacity = len;
+    } else {
+      // Set buffer capacity to checksum boundary size so that each buffer
+      // corresponds to one checksum. If checksum is NONE, then set buffer
+      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
+      ChecksumData checksumData = info.getChecksumData();
+
+      if (checksumData.getChecksumType() == ContainerProtos.ChecksumType.NONE) {
+        bufferCapacity = defaultReadBufferCapacity;
+      } else {
+        bufferCapacity = checksumData.getBytesPerChecksum();
+      }
+    }
+    // If the buffer capacity is 0, set all the data into one ByteBuffer
+    if (bufferCapacity == 0) {
+      bufferCapacity = len;
+    }
+
+    ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
+        bufferCapacity);
 
     long chunkFileOffset = 0;
     if (info.getOffset() != 0) {
@@ -255,8 +284,8 @@ public class FilePerChunkStrategy implements ChunkManager {
         if (file.exists()) {
           long offset = info.getOffset() - chunkFileOffset;
           Preconditions.checkState(offset >= 0);
-          ChunkUtils.readData(file, data, offset, len, volumeIOStats);
-          return ChunkBuffer.wrap(data);
+          ChunkUtils.readData(file, dataBuffers, offset, len, volumeIOStats);
+          return ChunkBuffer.wrap(Lists.newArrayList(dataBuffers));
         }
       } catch (StorageContainerException ex) {
         //UNABLE TO FIND chunk is not a problem as we will try with the
@@ -264,7 +293,7 @@ public class FilePerChunkStrategy implements ChunkManager {
         if (ex.getResult() != UNABLE_TO_FIND_CHUNK) {
           throw ex;
         }
-        data.clear();
+        dataBuffers = null;
       }
     }
     throw new StorageContainerException(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -90,6 +90,8 @@ public interface BlockManager {
   long getCommittedBlockLength(Container container, BlockID blockID)
       throws IOException;
 
+  long getDefaultReadBufferCapacity();
+
   /**
    * Shutdown ContainerManager.
    */

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ContainerTestHelper.java
@@ -245,6 +245,7 @@ public final class ContainerTestHelper {
         ContainerProtos.ReadChunkRequestProto.newBuilder();
     readRequest.setBlockID(request.getBlockID());
     readRequest.setChunkData(request.getChunkData());
+    readRequest.setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
 
     Builder newRequest =
         ContainerCommandRequestProto.newBuilder();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -185,7 +185,7 @@ public class TestBlockDeletingService {
       int numOfChunksPerBlock) throws IOException {
     ChunkManager chunkManager;
     if (layout == FILE_PER_BLOCK) {
-      chunkManager = new FilePerBlockStrategy(true);
+      chunkManager = new FilePerBlockStrategy(true, null);
     } else {
       chunkManager = new FilePerChunkStrategy(true, null);
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerAction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.ozone.common.Checksum;
+import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
@@ -178,8 +179,10 @@ public class TestHddsDispatcher {
       response =
           hddsDispatcher.dispatch(getReadChunkRequest(writeChunkRequest), null);
       Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-      Assert.assertEquals(response.getReadChunk().getData(),
-          writeChunkRequest.getWriteChunk().getData());
+      ByteString responseData = BufferUtils.concatByteStrings(
+          response.getReadChunk().getDataBuffers().getBuffersList());
+      Assert.assertEquals(writeChunkRequest.getWriteChunk().getData(),
+          responseData);
     } finally {
       ContainerMetrics.remove();
       FileUtils.deleteDirectory(new File(testDir));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -358,7 +358,8 @@ public class TestHddsDispatcher {
     ContainerProtos.ReadChunkRequestProto.Builder readChunkRequest =
         ContainerProtos.ReadChunkRequestProto.newBuilder()
             .setBlockID(writeChunk.getBlockID())
-            .setChunkData(writeChunk.getChunkData());
+            .setChunkData(writeChunk.getChunkData())
+            .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
     return ContainerCommandRequestProto.newBuilder()
         .setCmdType(ContainerProtos.Type.ReadChunk)
         .setContainerID(writeChunk.getBlockID().getContainerID())

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ChunkLayoutTestInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ChunkLayoutTestInfo.java
@@ -81,7 +81,7 @@ public enum ChunkLayoutTestInfo {
   FILE_PER_BLOCK {
     @Override
     public ChunkManager createChunkManager(boolean sync, BlockManager manager) {
-      return new FilePerBlockStrategy(sync);
+      return new FilePerBlockStrategy(sync, null);
     }
 
     @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandlerWithUnhealthyContainer.java
@@ -202,7 +202,8 @@ public class TestKeyValueHandlerWithUnhealthyContainer {
       break;
     case ReadChunk:
       builder.setReadChunk(ContainerProtos.ReadChunkRequestProto.newBuilder()
-          .setBlockID(fakeBlockId).setChunkData(fakeChunkInfo).build());
+          .setBlockID(fakeBlockId).setChunkData(fakeChunkInfo)
+          .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1).build());
       break;
     case DeleteChunk:
       builder

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerBlockStrategy.java
@@ -125,12 +125,17 @@ public class TestFilePerBlockStrategy extends CommonChunkManagerTestCases {
     subject.writeChunk(container, blockID, info, data, ctx);
 
     ChunkBuffer readData = subject.readChunk(container, blockID, info, ctx);
-    assertEquals(data.rewind(), readData.rewind());
+    // data will be ChunkBufferImplWithByteBuffer and readData will return
+    // ChunkBufferImplWithByteBufferList. Hence, convert both ByteStrings
+    // before comparing.
+    assertEquals(data.rewind().toByteString(),
+        readData.rewind().toByteString());
 
     ChunkInfo info2 = getChunk(blockID.getLocalID(), 0, start, length);
     ChunkBuffer readData2 = subject.readChunk(container, blockID, info2, ctx);
     assertEquals(length, info2.getLen());
-    assertEquals(data.duplicate(start, start + length), readData2.rewind());
+    assertEquals(data.rewind().toByteString().substring(start, start + length),
+        readData2.rewind().toByteString());
   }
 
   @Override

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -398,15 +398,29 @@ message  WriteChunkRequestProto  {
 message  WriteChunkResponseProto {
 }
 
+enum ReadChunkVersion {
+  V0 = 0; // Response data is sent in a single ByteBuffer
+  V1 = 1; // Response data is split into multiple buffers
+}
+
 message  ReadChunkRequestProto  {
   required DatanodeBlockID blockID = 1;
   required ChunkInfo chunkData = 2;
+  optional ReadChunkVersion readChunkVersion = 3 [default = V0];
 }
 
 message  ReadChunkResponseProto {
   required DatanodeBlockID blockID = 1;
   required ChunkInfo chunkData = 2;
-  required bytes data = 3;
+  // Chunk data should be returned in one of the two for
+  oneof responseData {
+    bytes data = 3; // Chunk data is returned as single buffer for V0
+    DataBuffers dataBuffers = 4; // Chunk data is returned as a list of buffers
+  }
+}
+
+message DataBuffers {
+  repeated bytes buffers = 1;
 }
 
 message  DeleteChunkRequestProto {
@@ -443,6 +457,7 @@ message PutSmallFileResponseProto {
 
 message GetSmallFileRequestProto {
   required GetBlockRequestProto block = 1;
+  optional ReadChunkVersion readChunkVersion = 3 [default = V0];
 }
 
 message GetSmallFileResponseProto {

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -406,7 +406,7 @@ enum ReadChunkVersion {
 message  ReadChunkRequestProto  {
   required DatanodeBlockID blockID = 1;
   required ChunkInfo chunkData = 2;
-  optional ReadChunkVersion readChunkVersion = 3 [default = V0];
+  optional ReadChunkVersion readChunkVersion = 3;
 }
 
 message  ReadChunkResponseProto {
@@ -457,7 +457,7 @@ message PutSmallFileResponseProto {
 
 message GetSmallFileRequestProto {
   required GetBlockRequestProto block = 1;
-  optional ReadChunkVersion readChunkVersion = 3 [default = V0];
+  optional ReadChunkVersion readChunkVersion = 2;
 }
 
 message GetSmallFileResponseProto {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -385,4 +385,9 @@ public class KeyInputStream extends InputStream
       is.unbuffer();
     }
   }
+
+  @VisibleForTesting
+  public List<BlockInputStream> getBlockStreams() {
+    return blockStreams;
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -28,7 +28,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests {@link ChunkInputStream}
+ * Tests {@link ChunkInputStream}.
  */
 public class TestChunkInputStream extends TestInputStreamBase {
 
@@ -52,7 +52,6 @@ public class TestChunkInputStream extends TestInputStreamBase {
     block0Stream.initialize();
 
     ChunkInputStream chunk0Stream = block0Stream.getChunkStreams().get(0);
-    ChunkInputStream chunk1Stream = block0Stream.getChunkStreams().get(1);
 
     // To read 1 byte of chunk data, ChunkInputStream should get one full
     // checksum boundary worth of data from Container and store it in buffers.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.client.rpc.read;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
+import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
+import org.apache.hadoop.ozone.client.io.KeyInputStream;
+import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests {@link ChunkInputStream}
+ */
+public class TestChunkInputStream extends TestInputStreamBase {
+
+  public TestChunkInputStream(ChunkLayOutVersion layout) {
+    super(layout);
+  }
+
+  /**
+   * Test to verify that data read from chunks is stored in a list of buffers
+   * with max capacity equal to the bytes per checksum.
+   */
+  @Test
+  public void testChunkReadBuffers() throws Exception {
+    String keyName = getNewKeyName();
+    int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE);
+    byte[] inputData = writeRandomBytes(keyName, dataLength);
+
+    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+
+    BlockInputStream block0Stream = keyInputStream.getBlockStreams().get(0);
+    block0Stream.initialize();
+
+    ChunkInputStream chunk0Stream = block0Stream.getChunkStreams().get(0);
+    ChunkInputStream chunk1Stream = block0Stream.getChunkStreams().get(1);
+
+    // To read 1 byte of chunk data, ChunkInputStream should get one full
+    // checksum boundary worth of data from Container and store it in buffers.
+    chunk0Stream.read(new byte[1]);
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1,
+        BYTES_PER_CHECKSUM);
+
+    // Read > checksum boundary of data from chunk0
+    int readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
+    byte[] readData = readDataFromChunk(chunk0Stream, readDataLen, 0);
+    validateData(inputData, 0, readData);
+
+    // The first checksum boundary size of data was already existing in the
+    // ChunkStream buffers. Once that data is read, the next checksum
+    // boundary size of data will be fetched again to read the remaining data.
+    // Hence there should be 1 checksum boundary size of data stored in the
+    // ChunkStreams buffers at the end of the read.
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1,
+        BYTES_PER_CHECKSUM);
+
+    // Seek to a position in the third checksum boundary (so that current
+    // buffers do not have the seeked position) and read > BYTES_PER_CHECKSUM
+    // bytes of data. This should result in 2 * BYTES_PER_CHECKSUM amount of
+    // data being read into the buffers. There should be 2 buffers each with
+    // BYTES_PER_CHECKSUM capacity.
+    readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
+    int offset = 2 * BYTES_PER_CHECKSUM + 1;
+    readData = readDataFromChunk(chunk0Stream, readDataLen, offset);
+    validateData(inputData, offset, readData);
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 2,
+        BYTES_PER_CHECKSUM);
+
+
+    // Read the full chunk data -1 and verify that all chunk data is read into
+    // buffers. We read CHUNK_SIZE - 1 as otherwise the buffers will be
+    // released once all chunk data is read.
+    readData = readDataFromChunk(chunk0Stream, CHUNK_SIZE - 1, 0);
+    validateData(inputData, 0, readData);
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(),
+        CHUNK_SIZE / BYTES_PER_CHECKSUM, BYTES_PER_CHECKSUM);
+
+    // Read the last byte of chunk and verify that the buffers are released.
+    chunk0Stream.read(new byte[1]);
+    Assert.assertNull("ChunkInputStream did not release buffers after " +
+        "reaching EOF.", chunk0Stream.getCachedBuffers());
+
+  }
+
+  private byte[] readDataFromChunk(ChunkInputStream chunkInputStream,
+      int readDataLength, int offset) throws IOException {
+    byte[] readData = new byte[readDataLength];
+    chunkInputStream.seek(offset);
+    chunkInputStream.read(readData, 0, readDataLength);
+    return readData;
+  }
+
+  private void checkBufferSizeAndCapacity(List<ByteBuffer> buffers,
+      int expectedNumBuffers, long expectedBufferCapacity) {
+    Assert.assertEquals("ChunkInputStream does not have expected number of " +
+        "ByteBuffers", expectedNumBuffers, buffers.size());
+    for (ByteBuffer buffer : buffers) {
+      Assert.assertEquals("ChunkInputStream ByteBuffer capacity is wrong",
+          expectedBufferCapacity, buffer.capacity());
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -209,7 +209,7 @@ public class TestInputStreamBase {
   public void testInputStreams() throws Exception {
     String keyName = getNewKeyName();
     int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE) + 1;
-    byte[] inputData = writeRandomBytes(keyName, dataLength);
+    writeRandomBytes(keyName, dataLength);
 
     KeyInputStream keyInputStream = getKeyInputStream(keyName);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.client.rpc.read;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.io.KeyInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.container.ContainerTestHelper;
+import org.apache.hadoop.ozone.container.TestHelper;
+import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
+import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+
+@RunWith(Parameterized.class)
+public class TestInputStreamBase {
+
+  MiniOzoneCluster cluster;
+  OzoneConfiguration conf = new OzoneConfiguration();
+  OzoneClient client;
+  ObjectStore objectStore;
+
+  String volumeName;
+  String bucketName;
+  String keyString;
+
+  private ChunkLayOutVersion chunkLayout;
+  private static final Random RAND = new Random();
+
+  static final int CHUNK_SIZE = 1024 * 1024;          // 1MB
+  static final int FLUSH_SIZE = 2 * CHUNK_SIZE;       // 2MB
+  static final int MAX_FLUSH_SIZE = 2 * FLUSH_SIZE;   // 4MB
+  static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;   // 8MB
+  static final int BYTES_PER_CHECKSUM = 256 * 1024;   // 256KB
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  @Parameterized.Parameters
+  public static Iterable<Object[]> parameters() {
+    return ChunkLayoutTestInfo.chunkLayoutParameters();
+  }
+
+  public TestInputStreamBase(ChunkLayOutVersion layout) {
+    this.chunkLayout = layout;
+  }
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * @throws IOException
+   */
+  @Before
+  public void init() throws Exception {
+    OzoneClientConfig config = new OzoneClientConfig();
+    config.setBytesPerChecksum(BYTES_PER_CHECKSUM);
+    conf.setFromObject(config);
+
+    conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
+    conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+    conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
+    conf.setQuietMode(false);
+    conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 64,
+        StorageUnit.MB);
+    conf.set(ScmConfigKeys.OZONE_SCM_CHUNK_LAYOUT_KEY, chunkLayout.toString());
+
+    ReplicationManagerConfiguration repConf =
+        conf.getObject(ReplicationManagerConfiguration.class);
+    repConf.setInterval(Duration.ofSeconds(1));
+    conf.setFromObject(repConf);
+
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(4)
+        .setTotalPipelineNumLimit(5)
+        .setBlockSize(BLOCK_SIZE)
+        .setChunkSize(CHUNK_SIZE)
+        .setStreamBufferFlushSize(FLUSH_SIZE)
+        .setStreamBufferMaxSize(MAX_FLUSH_SIZE)
+        .setStreamBufferSizeUnit(StorageUnit.BYTES)
+        .build();
+    cluster.waitForClusterToBeReady();
+    //the easiest way to create an open container is creating a key
+    client = OzoneClientFactory.getRpcClient(conf);
+    objectStore = client.getObjectStore();
+
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+    keyString = UUID.randomUUID().toString();
+
+    objectStore.createVolume(volumeName);
+    objectStore.getVolume(volumeName).createBucket(bucketName);
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @After
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  KeyInputStream getKeyInputStream(String keyName) throws IOException {
+    return (KeyInputStream) objectStore
+        .getVolume(volumeName)
+        .getBucket(bucketName)
+        .readKey(keyName).getInputStream();
+  }
+
+  String getNewKeyName() {
+    return UUID.randomUUID().toString();
+  }
+
+  byte[] writeKey(String keyName, int dataLength) throws Exception {
+    OzoneOutputStream key = TestHelper.createKey(keyName,
+        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
+
+    byte[] inputData = ContainerTestHelper.getFixedLengthString(
+        keyString, dataLength).getBytes(UTF_8);
+    key.write(inputData);
+    key.close();
+
+    return inputData;
+  }
+
+  byte[] writeRandomBytes(String keyName, int dataLength)
+      throws Exception {
+    OzoneOutputStream key = TestHelper.createKey(keyName,
+        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
+
+    byte[] inputData = new byte[dataLength];
+    RAND.nextBytes(inputData);
+    key.write(inputData);
+    key.close();
+
+    return inputData;
+  }
+
+  void validateData(byte[] inputData, int offset, byte[] readData) {
+    int readDataLen = readData.length;
+    byte[] expectedData = new byte[readDataLen];
+    System.arraycopy(inputData, (int) offset, expectedData, 0, readDataLen);
+
+    for (int i=0; i < readDataLen; i++) {
+      Assert.assertEquals("Read data at does not match the input data at " +
+              "position " + (offset + i), expectedData[i], readData[i]);
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -55,23 +55,23 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 @RunWith(Parameterized.class)
 public class TestInputStreamBase {
 
-  MiniOzoneCluster cluster;
-  OzoneConfiguration conf = new OzoneConfiguration();
-  OzoneClient client;
-  ObjectStore objectStore;
+  protected MiniOzoneCluster cluster;
+  protected OzoneConfiguration conf = new OzoneConfiguration();
+  protected OzoneClient client;
+  protected ObjectStore objectStore;
 
-  String volumeName;
-  String bucketName;
-  String keyString;
+  protected String volumeName;
+  protected String bucketName;
+  private String keyString;
 
   private ChunkLayOutVersion chunkLayout;
   private static final Random RAND = new Random();
 
-  static final int CHUNK_SIZE = 1024 * 1024;          // 1MB
-  static final int FLUSH_SIZE = 2 * CHUNK_SIZE;       // 2MB
-  static final int MAX_FLUSH_SIZE = 2 * FLUSH_SIZE;   // 4MB
-  static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;   // 8MB
-  static final int BYTES_PER_CHECKSUM = 256 * 1024;   // 256KB
+  protected static final int CHUNK_SIZE = 1024 * 1024;          // 1MB
+  protected static final int FLUSH_SIZE = 2 * CHUNK_SIZE;       // 2MB
+  protected static final int MAX_FLUSH_SIZE = 2 * FLUSH_SIZE;   // 4MB
+  protected static final int BLOCK_SIZE = 2 * MAX_FLUSH_SIZE;   // 8MB
+  protected static final int BYTES_PER_CHECKSUM = 256 * 1024;   // 256KB
 
   @Rule
   public Timeout timeout = Timeout.seconds(300);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -56,11 +56,8 @@ public class TestKeyInputStream extends TestInputStreamBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyInputStream.class);
 
-  private MiniOzoneCluster cluster;
-
   public TestKeyInputStream(ChunkLayOutVersion layout) {
     super(layout);
-    this.cluster = getCluster();
   }
 
   /**
@@ -273,7 +270,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
   }
 
   private void testReadAfterReplication(boolean doUnbuffer) throws Exception {
-    Assume.assumeTrue(cluster.getHddsDatanodes().size() > 3);
+    Assume.assumeTrue(getCluster().getHddsDatanodes().size() > 3);
 
     int dataLength = 2 * CHUNK_SIZE;
     String keyName = getNewKeyName();
@@ -285,7 +282,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
         .setType(HddsProtos.ReplicationType.RATIS)
         .setFactor(HddsProtos.ReplicationFactor.THREE)
         .build();
-    OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
+    OmKeyInfo keyInfo = getCluster().getOzoneManager().lookupKey(keyArgs);
 
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
     Assert.assertNotNull(locations);
@@ -293,9 +290,9 @@ public class TestKeyInputStream extends TestInputStreamBase {
     Assert.assertEquals(1, locationInfoList.size());
     OmKeyLocationInfo loc = locationInfoList.get(0);
     long containerID = loc.getContainerID();
-    Assert.assertEquals(3, countReplicas(containerID, cluster));
+    Assert.assertEquals(3, countReplicas(containerID, getCluster()));
 
-    TestHelper.waitForContainerClose(cluster, containerID);
+    TestHelper.waitForContainerClose(getCluster(), containerID);
 
     List<DatanodeDetails> pipelineNodes = loc.getPipeline().getNodes();
 
@@ -309,7 +306,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
         keyInputStream.unbuffer();
       }
 
-      cluster.shutdownHddsDatanode(pipelineNodes.get(0));
+      getCluster().shutdownHddsDatanode(pipelineNodes.get(0));
 
       // check that we can still read it
       assertReadFully(data, keyInputStream, dataLength - 1, 1);
@@ -329,7 +326,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
     HddsProtos.NodeState health = null;
     try {
       NodeManager nodeManager =
-          cluster.getStorageContainerManager().getScmNodeManager();
+          getCluster().getStorageContainerManager().getScmNodeManager();
       health = nodeManager.getNodeStatus(dn).getHealth();
     } catch (NodeNotFoundException e) {
       fail("Unexpected NodeNotFound exception");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
@@ -55,8 +56,11 @@ public class TestKeyInputStream extends TestInputStreamBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyInputStream.class);
 
+  private MiniOzoneCluster cluster;
+
   public TestKeyInputStream(ChunkLayOutVersion layout) {
     super(layout);
+    this.cluster = getCluster();
   }
 
   /**
@@ -275,8 +279,8 @@ public class TestKeyInputStream extends TestInputStreamBase {
     String keyName = getNewKeyName();
     byte[] data = writeRandomBytes(keyName, dataLength);
 
-    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
-        .setBucketName(bucketName)
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(getVolumeName())
+        .setBucketName(getBucketName())
         .setKeyName(keyName)
         .setType(HddsProtos.ReplicationType.RATIS)
         .setFactor(HddsProtos.ReplicationFactor.THREE)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -225,12 +225,16 @@ public class TestKeyInputStream extends TestInputStreamBase {
     KeyInputStream keyInputStream = getKeyInputStream(keyName);
 
     // skip 150
-    keyInputStream.skip(70);
+    long skipped = keyInputStream.skip(70);
+    Assert.assertEquals(70, skipped);
     Assert.assertEquals(70, keyInputStream.getPos());
-    keyInputStream.skip(0);
-    Assert.assertEquals(70, keyInputStream.getPos());
-    keyInputStream.skip(80);
 
+    skipped = keyInputStream.skip(0);
+    Assert.assertEquals(0, skipped);
+    Assert.assertEquals(70, keyInputStream.getPos());
+
+    skipped = keyInputStream.skip(80);
+    Assert.assertEquals(80, skipped);
     Assert.assertEquals(150, keyInputStream.getPos());
 
     // Skip operation should not result in any readChunk operation.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -15,208 +15,48 @@
  * the License.
  */
 
-package org.apache.hadoop.ozone.client.rpc;
+package org.apache.hadoop.ozone.client.rpc.read;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
-import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Random;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.conf.StorageUnit;
-import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.scm.OzoneClientConfig;
-import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientMetrics;
-import org.apache.hadoop.hdds.scm.container.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.client.ObjectStore;
-import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
-import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.apache.hadoop.ozone.container.TestHelper.countReplicas;
-import static org.junit.Assert.fail;
-
+import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.test.GenericTestUtils;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.Timeout;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.container.TestHelper.countReplicas;
+import static org.junit.Assert.fail;
 
 /**
  * Tests {@link KeyInputStream}.
  */
-@RunWith(Parameterized.class)
-public class TestKeyInputStream {
+public class TestKeyInputStream extends TestInputStreamBase {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(TestKeyInputStream.class);
 
-  private MiniOzoneCluster cluster;
-  private OzoneConfiguration conf = new OzoneConfiguration();
-  private OzoneClient client;
-  private ObjectStore objectStore;
-  private int chunkSize;
-  private int flushSize;
-  private int maxFlushSize;
-  private int blockSize;
-  private String volumeName;
-  private String bucketName;
-  private String keyString;
-  private ChunkLayoutTestInfo chunkLayout;
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> layouts() {
-    return Arrays.asList(new Object[][] {
-        {ChunkLayoutTestInfo.FILE_PER_CHUNK},
-        {ChunkLayoutTestInfo.FILE_PER_BLOCK}
-    });
-  }
-
-  public TestKeyInputStream(ChunkLayoutTestInfo layout) {
-    this.chunkLayout = layout;
-  }
-  /**
-   * Create a MiniDFSCluster for testing.
-   * <p>
-   * Ozone is made active by setting OZONE_ENABLED = true
-   *
-   * @throws IOException
-   */
-  @Before
-  public void init() throws Exception {
-    chunkSize = 256 * 1024 * 2;
-    flushSize = 2 * chunkSize;
-    maxFlushSize = 2 * flushSize;
-    blockSize = 2 * maxFlushSize;
-
-    OzoneClientConfig config = new OzoneClientConfig();
-    config.setBytesPerChecksum(256 * 1024 * 1024);
-    conf.setFromObject(config);
-
-
-    conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);
-    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
-    conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
-    conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 1);
-    conf.setQuietMode(false);
-    conf.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 64,
-        StorageUnit.MB);
-    conf.set(ScmConfigKeys.OZONE_SCM_CHUNK_LAYOUT_KEY, chunkLayout.name());
-
-    ReplicationManagerConfiguration repConf =
-        conf.getObject(ReplicationManagerConfiguration.class);
-    repConf.setInterval(Duration.ofSeconds(1));
-    conf.setFromObject(repConf);
-
-    cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(4)
-        .setTotalPipelineNumLimit(5)
-        .setBlockSize(blockSize)
-        .setChunkSize(chunkSize)
-        .setStreamBufferFlushSize(flushSize)
-        .setStreamBufferMaxSize(maxFlushSize)
-        .setStreamBufferSizeUnit(StorageUnit.BYTES)
-        .build();
-    cluster.waitForClusterToBeReady();
-    //the easiest way to create an open container is creating a key
-    client = OzoneClientFactory.getRpcClient(conf);
-    objectStore = client.getObjectStore();
-    keyString = UUID.randomUUID().toString();
-    volumeName = "test-key-input-stream-volume";
-    bucketName = "test-key-input-stream-bucket";
-    objectStore.createVolume(volumeName);
-    objectStore.getVolume(volumeName).createBucket(bucketName);
-  }
-
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
-
-  /**
-   * Shutdown MiniDFSCluster.
-   */
-  @After
-  public void shutdown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
-  }
-
-  private String getKeyName() {
-    return UUID.randomUUID().toString();
-  }
-
-
-  @Test
-  public void testSeekRandomly() throws Exception {
-    String keyName = getKeyName();
-    OzoneOutputStream key = TestHelper.createKey(keyName,
-        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
-
-    // write data of more than 2 blocks.
-    int dataLength = (2 * blockSize) + (chunkSize);
-
-    byte[] inputData = writeRandomBytes(key, dataLength);
-
-    KeyInputStream keyInputStream = (KeyInputStream) objectStore
-        .getVolume(volumeName).getBucket(bucketName).readKey(keyName)
-        .getInputStream();
-
-    // Seek to some where end.
-    validate(keyInputStream, inputData, dataLength-200, 100);
-
-    // Now seek to start.
-    validate(keyInputStream, inputData, 0, 140);
-
-    validate(keyInputStream, inputData, 200, 300);
-
-    validate(keyInputStream, inputData, 30, 500);
-
-    randomSeek(dataLength, keyInputStream, inputData);
-
-    // Read entire key.
-    validate(keyInputStream, inputData, 0, dataLength);
-
-    // Repeat again and check.
-    randomSeek(dataLength, keyInputStream, inputData);
-
-    validate(keyInputStream, inputData, 0, dataLength);
-
-    keyInputStream.close();
+  public TestKeyInputStream(ChunkLayOutVersion layout) {
+    super(layout);
   }
 
   /**
@@ -260,18 +100,42 @@ public class TestKeyInputStream {
       long seek, int readLength) throws Exception {
     keyInputStream.seek(seek);
 
-    byte[] expectedData = new byte[readLength];
-    keyInputStream.read(expectedData, 0, readLength);
+    byte[] readData = new byte[readLength];
+    keyInputStream.read(readData, 0, readLength);
 
-    byte[] dest = new byte[readLength];
-
-    System.arraycopy(inputData, (int)seek, dest, 0, readLength);
-
-    for (int i=0; i < readLength; i++) {
-      Assert.assertEquals(expectedData[i], dest[i]);
-    }
+    validateData(inputData, (int) seek, readData);
   }
 
+  @Test
+  public void testSeekRandomly() throws Exception {
+    String keyName = getNewKeyName();
+    int dataLength = (2 * BLOCK_SIZE) + (CHUNK_SIZE);
+    byte[] inputData = writeRandomBytes(keyName, dataLength);
+
+    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+
+    // Seek to some where end.
+    validate(keyInputStream, inputData, dataLength-200, 100);
+
+    // Now seek to start.
+    validate(keyInputStream, inputData, 0, 140);
+
+    validate(keyInputStream, inputData, 200, 300);
+
+    validate(keyInputStream, inputData, 30, 500);
+
+    randomSeek(dataLength, keyInputStream, inputData);
+
+    // Read entire key.
+    validate(keyInputStream, inputData, 0, dataLength);
+
+    // Repeat again and check.
+    randomSeek(dataLength, keyInputStream, inputData);
+
+    validate(keyInputStream, inputData, 0, dataLength);
+
+    keyInputStream.close();
+  }
 
   @Test
   public void testSeek() throws Exception {
@@ -283,23 +147,15 @@ public class TestKeyInputStream {
     long readChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.ReadChunk);
 
-    String keyName = getKeyName();
-    OzoneOutputStream key = TestHelper.createKey(keyName,
-        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
-
+    String keyName = getNewKeyName();
     // write data spanning 3 chunks
-    int dataLength = (2 * chunkSize) + (chunkSize / 2);
-    byte[] inputData = ContainerTestHelper.getFixedLengthString(
-        keyString, dataLength).getBytes(UTF_8);
-    key.write(inputData);
-    key.close();
+    int dataLength = (2 * CHUNK_SIZE) + (CHUNK_SIZE / 2);
+    byte[] inputData = writeKey(keyName, dataLength);
 
     Assert.assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
 
-    KeyInputStream keyInputStream = (KeyInputStream) objectStore
-        .getVolume(volumeName).getBucket(bucketName).readKey(keyName)
-        .getInputStream();
+    KeyInputStream keyInputStream = getKeyInputStream(keyName);
 
     // Seek to position 150
     keyInputStream.seek(150);
@@ -310,8 +166,8 @@ public class TestKeyInputStream {
     Assert.assertEquals(readChunkCount, metrics
         .getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
-    byte[] readData = new byte[chunkSize];
-    keyInputStream.read(readData, 0, chunkSize);
+    byte[] readData = new byte[CHUNK_SIZE];
+    keyInputStream.read(readData, 0, CHUNK_SIZE);
 
     // Since we reading data from index 150 to 250 and the chunk boundary is
     // 100 bytes, we need to read 2 chunks.
@@ -322,29 +178,25 @@ public class TestKeyInputStream {
 
     // Verify that the data read matches with the input data at corresponding
     // indices.
-    for (int i = 0; i < chunkSize; i++) {
-      Assert.assertEquals(inputData[chunkSize + 50 + i], readData[i]);
+    for (int i = 0; i < CHUNK_SIZE; i++) {
+      Assert.assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
     }
   }
 
   @Test
   public void testReadChunk() throws Exception {
-    String keyName = getKeyName();
-    OzoneOutputStream key = TestHelper.createKey(keyName,
-        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
+    String keyName = getNewKeyName();
 
     // write data spanning multiple blocks/chunks
-    int dataLength = 2 * blockSize + (blockSize / 2);
-    byte[] data = writeRandomBytes(key, dataLength);
+    int dataLength = 2 * BLOCK_SIZE + (BLOCK_SIZE / 2);
+    byte[] data = writeRandomBytes(keyName, dataLength);
 
     // read chunk data
-    try (KeyInputStream keyInputStream = (KeyInputStream) objectStore
-        .getVolume(volumeName).getBucket(bucketName).readKey(keyName)
-        .getInputStream()) {
+    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
 
-      int[] bufferSizeList = {chunkSize / 4, chunkSize / 2, chunkSize - 1,
-          chunkSize, chunkSize + 1, blockSize - 1, blockSize, blockSize + 1,
-          blockSize * 2};
+      int[] bufferSizeList = {BYTES_PER_CHECKSUM + 1, CHUNK_SIZE / 4,
+          CHUNK_SIZE / 2, CHUNK_SIZE - 1, CHUNK_SIZE, CHUNK_SIZE + 1,
+          BLOCK_SIZE - 1, BLOCK_SIZE, BLOCK_SIZE + 1, BLOCK_SIZE * 2};
       for (int bufferSize : bufferSizeList) {
         assertReadFully(data, keyInputStream, bufferSize, 0);
         keyInputStream.seek(0);
@@ -362,23 +214,15 @@ public class TestKeyInputStream {
     long readChunkCount = metrics.getContainerOpCountMetrics(
         ContainerProtos.Type.ReadChunk);
 
-    String keyName = getKeyName();
-    OzoneOutputStream key = TestHelper.createKey(keyName,
-        ReplicationType.RATIS, 0, objectStore, volumeName, bucketName);
-
+    String keyName = getNewKeyName();
     // write data spanning 3 chunks
-    int dataLength = (2 * chunkSize) + (chunkSize / 2);
-    byte[] inputData = ContainerTestHelper.getFixedLengthString(
-        keyString, dataLength).getBytes(UTF_8);
-    key.write(inputData);
-    key.close();
+    int dataLength = (2 * CHUNK_SIZE) + (CHUNK_SIZE / 2);
+    byte[] inputData = writeKey(keyName, dataLength);
 
     Assert.assertEquals(writeChunkCount + 3,
         metrics.getContainerOpCountMetrics(ContainerProtos.Type.WriteChunk));
 
-    KeyInputStream keyInputStream = (KeyInputStream) objectStore
-        .getVolume(volumeName).getBucket(bucketName).readKey(keyName)
-        .getInputStream();
+    KeyInputStream keyInputStream = getKeyInputStream(keyName);
 
     // skip 150
     keyInputStream.skip(70);
@@ -393,8 +237,8 @@ public class TestKeyInputStream {
     Assert.assertEquals(readChunkCount, metrics
         .getContainerOpCountMetrics(ContainerProtos.Type.ReadChunk));
 
-    byte[] readData = new byte[chunkSize];
-    keyInputStream.read(readData, 0, chunkSize);
+    byte[] readData = new byte[CHUNK_SIZE];
+    keyInputStream.read(readData, 0, CHUNK_SIZE);
 
     // Since we reading data from index 150 to 250 and the chunk boundary is
     // 100 bytes, we need to read 2 chunks.
@@ -405,8 +249,8 @@ public class TestKeyInputStream {
 
     // Verify that the data read matches with the input data at corresponding
     // indices.
-    for (int i = 0; i < chunkSize; i++) {
-      Assert.assertEquals(inputData[chunkSize + 50 + i], readData[i]);
+    for (int i = 0; i < CHUNK_SIZE; i++) {
+      Assert.assertEquals(inputData[CHUNK_SIZE + 50 + i], readData[i]);
     }
   }
 
@@ -423,12 +267,9 @@ public class TestKeyInputStream {
   private void testReadAfterReplication(boolean doUnbuffer) throws Exception {
     Assume.assumeTrue(cluster.getHddsDatanodes().size() > 3);
 
-    int dataLength = 2 * chunkSize;
-    String keyName = getKeyName();
-    OzoneOutputStream key = TestHelper.createKey(keyName,
-        ReplicationType.RATIS, dataLength, objectStore, volumeName, bucketName);
-
-    byte[] data = writeRandomBytes(key, dataLength);
+    int dataLength = 2 * CHUNK_SIZE;
+    String keyName = getNewKeyName();
+    byte[] data = writeRandomBytes(keyName, dataLength);
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
@@ -451,9 +292,7 @@ public class TestKeyInputStream {
     List<DatanodeDetails> pipelineNodes = loc.getPipeline().getNodes();
 
     // read chunk data
-    try (KeyInputStream keyInputStream = (KeyInputStream) objectStore
-        .getVolume(volumeName).getBucket(bucketName)
-        .readKey(keyName).getInputStream()) {
+    try (KeyInputStream keyInputStream = getKeyInputStream(keyName)) {
 
       int b = keyInputStream.read();
       Assert.assertNotEquals(-1, b);
@@ -490,17 +329,7 @@ public class TestKeyInputStream {
     return health;
   }
 
-  private byte[] writeRandomBytes(OutputStream key, int size)
-      throws IOException {
-    byte[] data = new byte[size];
-    Random r = new Random();
-    r.nextBytes(data);
-    key.write(data);
-    key.close();
-    return data;
-  }
-
-  private static void assertReadFully(byte[] data, InputStream in,
+  private void assertReadFully(byte[] data, InputStream in,
       int bufferSize, int totalRead) throws IOException {
 
     byte[] buffer = new byte[bufferSize];
@@ -518,5 +347,4 @@ public class TestKeyInputStream {
     }
     Assert.assertEquals(data.length, totalRead);
   }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestContainerSmallFile.java
@@ -103,7 +103,8 @@ public class TestContainerSmallFile {
         "data123".getBytes(UTF_8), null);
     ContainerProtos.GetSmallFileResponseProto response =
         ContainerProtocolCalls.readSmallFile(client, blockID, null);
-    String readData = response.getData().getData().toStringUtf8();
+    String readData = response.getData().getDataBuffers().getBuffersList()
+        .get(0).toStringUtf8();
     Assert.assertEquals("data123", readData);
     xceiverClientManager.releaseClient(client, false);
   }
@@ -204,7 +205,8 @@ public class TestContainerSmallFile {
     blockID1.setBlockCommitSequenceId(bcsId);
     ContainerProtos.GetSmallFileResponseProto response =
         ContainerProtocolCalls.readSmallFile(client, blockID1, null);
-    String readData = response.getData().getData().toStringUtf8();
+    String readData = response.getData().getDataBuffers().getBuffersList()
+        .get(0).toStringUtf8();
     Assert.assertEquals("data123", readData);
     xceiverClientManager.releaseClient(client, false);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -172,9 +172,13 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
         xceiverClientSpi.sendCommand(request);
 
     checksum = new Checksum(ContainerProtos.ChecksumType.CRC32, chunkSize);
-    checksumReference = checksum.computeChecksum(
-        response.getReadChunk().getData().toByteArray()
-    );
+    if (response.getReadChunk().hasData()) {
+      checksumReference = checksum.computeChecksum(
+          response.getReadChunk().getData().toByteArray());
+    } else {
+      checksumReference = checksum.computeChecksum(
+          response.getReadChunk().getDataBuffers().getBuffersList());
+    }
 
   }
 
@@ -221,10 +225,14 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
         ContainerProtos.ContainerCommandResponseProto response =
             xceiverClientSpi.sendCommand(request);
 
-        ChecksumData checksumOfChunk =
-            checksum.computeChecksum(
-                response.getReadChunk().getData().toByteArray()
-            );
+        ChecksumData checksumOfChunk;
+        if (response.getReadChunk().hasData()) {
+          checksumOfChunk = checksum.computeChecksum(
+              response.getReadChunk().getData().toByteArray());
+        } else {
+          checksumOfChunk = checksum.computeChecksum(
+              response.getReadChunk().getDataBuffers().getBuffersList());
+        }
 
         if (!checksumReference.equals(checksumOfChunk)) {
           throw new IllegalStateException(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
@@ -203,7 +203,8 @@ public class BenchMarkDatanodeDispatcher {
     ReadChunkRequestProto.Builder readChunkRequest = ReadChunkRequestProto
         .newBuilder()
         .setBlockID(blockID.getDatanodeBlockIDProtobuf())
-        .setChunkData(getChunkInfo(blockID, chunkName));
+        .setChunkData(getChunkInfo(blockID, chunkName))
+        .setReadChunkVersion(ContainerProtos.ReadChunkVersion.V1);
 
     ContainerCommandRequestProto.Builder request = ContainerCommandRequestProto
         .newBuilder();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
@@ -139,7 +139,7 @@ public class BenchmarkChunkManager {
   public void writeSingleFile(BenchmarkState state, Blackhole sink)
       throws StorageContainerException {
 
-    ChunkManager chunkManager = new FilePerBlockStrategy(true);
+    ChunkManager chunkManager = new FilePerBlockStrategy(true, null);
     benchmark(chunkManager, FILE_PER_BLOCK, state, sink);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a ReadChunk operation is performed, all the data to be read from one chunk is read into a single ByteBuffer. 

```
#ChunkUtils#readData()
public static void readData(File file, ByteBuffer buf,
    long offset, long len, VolumeIOStats volumeIOStats)
    throws StorageContainerException {
  .....
  try {
    bytesRead = processFileExclusively(path, () -> {
      try (FileChannel channel = open(path, READ_OPTIONS, NO_ATTRIBUTES);
           FileLock ignored = channel.lock(offset, len, true)) {
        return channel.read(buf, offset);
      } catch (IOException e) {
        throw new UncheckedIOException(e);
      }
    });
  } catch (UncheckedIOException e) {
    throw wrapInStorageContainerException(e.getCause());
  }
  .....
  .....
```
This Jira proposes to read the data from the channel and put it into an array of ByteBuffers for optimizing reads. For example, currently we hold onto the buffer until the chunkInputStream is closed or the last chunk byte is read (which can lead upto 4MB of data being cached in memory per ChunkInputStream). If we have smaller buffers, they can be released sooner, thus helping to optimize memory utilization (HDDS-4553). This Jira is a pre-requisite for optimizing client memory utilization.

We propose to add ReadChunk version to the ReadChunkRequestProto to determine if the response should have all the chunk data as a single ByteString (V0) or as a list of ByteStrings (V1). Default version will be V0. Older clients will get data back as a single ByteString to maintain wire compatibility. 

For new clients, data will be returned as a list of ByteStrings with each ByteString having the capacity equal to its number of bytes per checksum. This is done so that checksum verification is uncomplicated and doesn't require extra buffer copying. For chunks with no checksum, the buffer capacity will be set to a configurable default.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4552

## How was this patch tested?

Added unit tests. Working on adding more unit tests.
