### PR TITLE
HDDS-4564. Prepare client should check every OM individually for the prepared check based on Txn ID.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -31,10 +31,12 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.Path;
@@ -53,6 +55,8 @@ import org.apache.hadoop.security.token.SecretManager;
 
 import com.google.common.base.Joiner;
 import org.apache.commons.lang3.StringUtils;
+
+import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
@@ -699,5 +703,27 @@ public final class OmUtils {
     }
 
     return keyName;
+  }
+
+
+  /**
+   * For a given service ID, return th of configured OM hosts.
+   * @param conf configuration
+   * @param omServiceId service id
+   * @return Set of hosts.
+   */
+  public static Set<String> getOmHostsFromConfig(OzoneConfiguration conf,
+                                                 String omServiceId) {
+    Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf,
+        omServiceId);
+    Set<String> omHosts = new HashSet<>();
+    for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {
+      String rpcAddrKey = OmUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
+          omServiceId, nodeId);
+      String rpcAddrStr = OmUtils.getOmRpcAddress(conf, rpcAddrKey);
+      Optional<String> hostName = getHostName(rpcAddrStr);
+      hostName.ifPresent(omHosts::add);
+    }
+    return omHosts;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -260,6 +260,7 @@ public final class OmUtils {
     case DBUpdates:
     case ListMultipartUploads:
     case FinalizeUpgradeProgress:
+    case PrepareStatus:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -609,7 +609,7 @@ public interface OzoneManagerProtocol
       throws IOException {
     return PrepareStatusResponse.newBuilder()
         .setCurrentTxnIndex(-1)
-        .setStatus(PrepareStatus.NOT_IN_PREPARE_STATE)
+        .setStatus(PrepareStatus.PREPARE_NOT_STARTED)
         .build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -49,6 +49,8 @@ import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
@@ -601,5 +603,13 @@ public interface OzoneManagerProtocol
       long txnApplyWaitTimeoutSeconds, long txnApplyCheckIntervalSeconds)
       throws IOException {
     return -1;
+  }
+
+  default PrepareStatusResponse getOzoneManagerPrepareStatus(long txnId)
+      throws IOException {
+    return PrepareStatusResponse.newBuilder()
+        .setCurrentTxnIndex(-1)
+        .setStatus(PrepareStatus.NOT_IN_PREPARE_STATE)
+        .build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -605,6 +605,12 @@ public interface OzoneManagerProtocol
     return -1;
   }
 
+  /**
+   * Check if Ozone Manager is 'prepared' at a specific Txn Id.
+   * @param txnId passed in Txn Id
+   * @return PrepareStatus response
+   * @throws IOException on exception.
+   */
   default PrepareStatusResponse getOzoneManagerPrepareStatus(long txnId)
       throws IOException {
     return PrepareStatusResponse.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1574,6 +1574,17 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return prepareResponse.getTxnID();
   }
 
+  public PrepareStatusResponse getOzoneManagerPrepareStatus(long txnId)
+      throws IOException {
+    PrepareStatusRequest prepareStatusRequest =
+        PrepareStatusRequest.newBuilder().setTxnID(txnId).build();
+    OMRequest omRequest = createOMRequest(Type.PrepareStatus)
+        .setPrepareStatusRequest(prepareStatusRequest).build();
+    PrepareStatusResponse prepareStatusResponse =
+        handleError(submitRequest(omRequest)).getPrepareStatusResponse();
+    return prepareStatusResponse;
+  }
+
   @VisibleForTesting
   public OmTransport getTransport() {
     return transport;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1574,6 +1574,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return prepareResponse.getTxnID();
   }
 
+  @Override
   public PrepareStatusResponse getOzoneManagerPrepareStatus(long txnId)
       throws IOException {
     PrepareStatusRequest prepareStatusRequest =

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -28,6 +28,10 @@ start_docker_env
 
 execute_robot_test scm basic/ozone-shell-single.robot
 
+# prepare test should be the last test to run, until a cancel prepare test is
+# added. (TODO)
+execute_robot_test scm omha/om-prepare.robot
+
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-prepare.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-prepare.robot
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoke test to start cluster with docker-compose environments.
+Library             OperatingSystem
+Library             String
+Library             BuiltIn
+Resource            ../commonlib.robot
+Test Timeout        5 minutes
+Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+Suite Setup         Create Specific OM data for prepare
+
+*** Keywords ***
+Create Specific OM data for prepare
+    # Freon data to make sure there are a reasonable number of transactions in the system.
+    Execute             ozone freon rk --replication-type=RATIS --num-of-volumes 1 --num-of-buckets 1 --num-of-keys 100
+    ${random} =         Generate Random String  5  [NUMBERS]
+    Set Suite Variable  ${volume_name}  ${random}-volume-for-prepare
+    Set Suite Variable  ${bucket_name}  ${random}-bucket-for-prepare
+    Execute             ozone sh volume create /${volume_name}
+    Execute             ozone sh bucket create /${volume_name}/${bucket_name}
+    Execute             ozone sh key put /${volume_name}/${bucket_name}/prepare-key /opt/hadoop/NOTICE.txt
+
+** Test Cases ***
+Prepare Ozone Manager
+    ${result} =        Execute      ozone admin om prepare -id=omservice
+                       Wait Until Keyword Succeeds      3min       10sec     Should contain   ${result}   OM Preparation successful!
+
+Checks if the expected data is present in OM
+    ${result} =         Execute             ozone sh key info /${volume_name}/${bucket_name}/prepare-key
+                        Should contain      ${result}       \"name\" : \"prepare-key\"

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -52,7 +52,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
   private final String keyPrefix = "key";
   private final int timeoutMillis = 30000;
-  private final static Long PREPARE_FLUSH_WAIT_TIMEOUT_SECONDS = 300L;
+  private final static Long PREPARE_FLUSH_WAIT_TIMEOUT_SECONDS = 120L;
   private final static Long PREPARE_FLUSH_INTERVAL_SECONDS = 5L;
 
   /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -75,6 +75,7 @@ enum Type {
   FinalizeUpgrade = 54;
   FinalizeUpgradeProgress = 55;
   Prepare = 56;
+  PrepareStatus = 57;
 
   GetDelegationToken = 61;
   RenewDelegationToken = 62;
@@ -147,6 +148,7 @@ message OMRequest {
   optional FinalizeUpgradeRequest           finalizeUpgradeRequest         = 54;
   optional FinalizeUpgradeProgressRequest   finalizeUpgradeProgressRequest = 55;
   optional PrepareRequest                   prepareRequest                 = 56;
+  optional PrepareStatusRequest             prepareStatusRequest           = 57;
 
   optional hadoop.common.GetDelegationTokenRequestProto getDelegationTokenRequest = 61;
   optional hadoop.common.RenewDelegationTokenRequestProto renewDelegationTokenRequest= 62;
@@ -223,6 +225,7 @@ message OMResponse {
   optional FinalizeUpgradeResponse           finalizeUpgradeResponse       = 54;
   optional FinalizeUpgradeProgressResponse finalizeUpgradeProgressResponse = 55;
   optional PrepareResponse                 prepareResponse                 = 56;
+  optional PrepareStatusResponse           prepareStatusResponse           = 57;
 
   optional GetDelegationTokenResponseProto getDelegationTokenResponse = 61;
   optional RenewDelegationTokenResponseProto renewDelegationTokenResponse = 62;
@@ -1089,6 +1092,21 @@ message PrepareRequestArgs {
 
 message PrepareResponse {
     required uint64 txnID = 1;
+}
+
+message PrepareStatusRequest {
+    required uint64 txnID = 1;
+}
+
+message PrepareStatusResponse {
+    enum PrepareStatus {
+        NOT_IN_PREPARE_STATE = 1;
+        PREPARE_NOT_DONE = 2;
+        PREPARE_TXN_MISMATCH = 3;
+        PREPARE_DONE = 4;
+    }
+    required PrepareStatus status = 1;
+    optional uint64 currentTxnIndex = 2;
 }
 
 message ServicePort {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1100,10 +1100,12 @@ message PrepareStatusRequest {
 
 message PrepareStatusResponse {
     enum PrepareStatus {
-        NOT_IN_PREPARE_STATE = 1;
-        PREPARE_NOT_DONE = 2;
-        PREPARE_TXN_MISMATCH = 3;
-        PREPARE_DONE = 4;
+        // TODO
+        // HDDS-4569 may introduce new states here, like marker file found
+        // but with different txn id. We can add them as make sense.
+        PREPARE_NOT_STARTED = 1;
+        PREPARE_IN_PROGRESS = 2;
+        PREPARE_COMPLETED = 3;
     }
     required PrepareStatus status = 1;
     optional uint64 currentTxnIndex = 2;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -205,7 +205,7 @@ public class OMPrepareRequest extends OMClientRequest {
     // prepare request, this one will end up purging that request.
     // This means that an OM cannot support 2 prepare requests in the
     // transaction pipeline (un-applied) at the same time.
-    if (raftLogIndex > snapshotIndex ) {
+    if (raftLogIndex > snapshotIndex) {
       LOG.warn("Snapshot index {} does not " +
           "match last log index {}.", snapshotIndex, raftLogIndex);
       snapshotIndex = raftLogIndex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -116,14 +116,19 @@ public class OMPrepareRequest extends OMClientRequest {
 
       // TODO: Create marker file with txn index.
 
-      LOG.info("OM prepared at log index {}. Returning response {}",
+      LOG.info("OM {} prepared at log index {}. Returning response {}",
+          ozoneManager.getOMNodeId(),
           ozoneManager.getRatisSnapshotIndex(), omResponse);
     } catch (OMException e) {
+      LOG.error("Prepare Request Apply failed in {}. ",
+          ozoneManager.getOMNodeId(), e);
       response = new OMPrepareResponse(
           createErrorOMResponse(responseBuilder, e));
     } catch (InterruptedException | IOException e) {
       // Set error code so that prepare failure does not cause the OM to
       // terminate.
+      LOG.error("Prepare Request Apply failed in {}. ",
+          ozoneManager.getOMNodeId(), e);
       response = new OMPrepareResponse(
           createErrorOMResponse(responseBuilder, new OMException(e,
               OMException.ResultCodes.PREPARE_FAILED)));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone.protocolPB;
 
 import static org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils.getRequest;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.PrepareStatus;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -185,7 +186,8 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
   private OMResponse submitReadRequestToOM(OMRequest request)
       throws ServiceException {
     // Check if this OM is the leader.
-    if (omRatisServer.isLeader()) {
+    if (omRatisServer.isLeader() ||
+        request.getCmdType().equals(PrepareStatus)) {
       return handler.handleReadRequest(request);
     } else {
       throw createNotLeaderException();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -219,11 +219,11 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         responseBuilder
             .setFinalizeUpgradeProgressResponse(upgradeProgressResponse);
         break;
-        case PrepareStatus:
-          PrepareStatusResponse prepareStatusResponse =
-              getPrepareStatus(request.getPrepareStatusRequest());
-          responseBuilder.setPrepareStatusResponse(prepareStatusResponse);
-          break;
+      case PrepareStatus:
+        PrepareStatusResponse prepareStatusResponse =
+            getPrepareStatus(request.getPrepareStatusRequest());
+        responseBuilder.setPrepareStatusResponse(prepareStatusResponse);
+        break;
       default:
         responseBuilder.setSuccess(false);
         responseBuilder.setMessage("Unrecognized Command Type: " + cmdType);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -98,8 +98,8 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartUploadInfo;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PartInfo;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus.PREPARE_DONE;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus.PREPARE_NOT_DONE;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus.PREPARE_COMPLETED;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus.PREPARE_IN_PROGRESS;
 
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.slf4j.Logger;
@@ -635,14 +635,17 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
   private PrepareStatusResponse getPrepareStatus(PrepareStatusRequest request)
       throws IOException {
+    // TODO After HDDS-4569,
+    // When there is a global "prepared" state in OM, we can return
+    // PREPARE_NOT_STARTED instead of PREPARE_IN_PROGRESS appropriately.
     PrepareStatus prepareStatus = null;
     long txnID = request.getTxnID();
     long ratisSnapshotIndex = impl.getRatisSnapshotIndex();
     if (ratisSnapshotIndex != txnID) {
       LOG.info("Last Txn Index = {}", ratisSnapshotIndex);
-      prepareStatus =  PREPARE_NOT_DONE;
+      prepareStatus =  PREPARE_IN_PROGRESS;
     } else {
-      prepareStatus = PREPARE_DONE;
+      prepareStatus = PREPARE_COMPLETED;
     }
     return PrepareStatusResponse.newBuilder().setStatus(prepareStatus)
         .setCurrentTxnIndex(ratisSnapshotIndex).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -642,7 +642,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     long txnID = request.getTxnID();
     long ratisSnapshotIndex = impl.getRatisSnapshotIndex();
     if (ratisSnapshotIndex != txnID) {
-      LOG.info("Last Txn Index = {}", ratisSnapshotIndex);
+      LOG.info("Last Txn Id = {}, PrepareStatusRequest Txn Id = {}",
+          ratisSnapshotIndex, request.getTxnID());
       prepareStatus =  PREPARE_IN_PROGRESS;
     } else {
       prepareStatus = PREPARE_COMPLETED;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -17,10 +17,23 @@
 
 package org.apache.hadoop.ozone.admin.om;
 
+import static org.apache.hadoop.hdds.HddsUtils.getHostName;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 
 import picocli.CommandLine;
 
@@ -53,7 +66,7 @@ public class PrepareSubCommand implements Callable<Void> {
       names = {"-tawt", "--transaction-apply-wait-timeout"},
       description = "Max time in SECONDS to wait for all transactions before" +
           "the prepare request to be applied to the OM DB.",
-      defaultValue = "300",
+      defaultValue = "120",
       hidden = true
   )
   private long txnApplyWaitTimeSeconds;
@@ -67,13 +80,92 @@ public class PrepareSubCommand implements Callable<Void> {
   )
   private long txnApplyCheckIntervalSeconds;
 
+  @CommandLine.Option(
+      names = {"-pct", "--prepare-check-interval"},
+      description = "Time in SECONDS to wait between successive checks for OM" +
+          " preparation.",
+      defaultValue = "10",
+      hidden = true
+  )
+  private long prepareCheckInterval;
+
+  @CommandLine.Option(
+      names = {"-pt", "--prepare-timeout"},
+      description = "Max time in SECONDS to wait for all OMs to be prepared",
+      defaultValue = "300",
+      hidden = true
+  )
+  private long prepareTimeOut;
+
   @Override
   public Void call() throws Exception {
     OzoneManagerProtocol client = parent.createOmClient(omServiceId);
     long prepareTxnId = client.prepareOzoneManager(txnApplyWaitTimeSeconds,
         txnApplyCheckIntervalSeconds);
     System.out.println("Ozone Manager Prepare Request successfully returned " +
-        "with Txn Id " + prepareTxnId);
+        "with Txn Id : [" + prepareTxnId + "].");
+
+    Map<String, Boolean> omPreparedStatusMap = new HashMap<>();
+    Set<String> omHosts  = getOmHostsFromConfig();
+    omHosts.forEach(h -> omPreparedStatusMap.put(h, false));
+
+    System.out.println();
+    System.out.println("Checking individual OM instances for prepare request " +
+        "completion...");
+    long endTime = System.currentTimeMillis() + (prepareTimeOut * 1000);
+    int expectedNumPreparedOms = omPreparedStatusMap.size();
+    int currentNumPreparedOms = 0;
+    while (System.currentTimeMillis() < endTime &&
+        currentNumPreparedOms < expectedNumPreparedOms) {
+      for (Map.Entry<String, Boolean> e : omPreparedStatusMap.entrySet()) {
+        if (!e.getValue()) {
+          String omHost = e.getKey();
+          OzoneManagerProtocol singleOmClient =
+              parent.createOmClient(omServiceId, omHost, false);
+          PrepareStatusResponse response =
+              singleOmClient.getOzoneManagerPrepareStatus(prepareTxnId);
+          PrepareStatus status = response.getStatus();
+          System.out.println("OM : [" + omHost + "], Prepare " +
+              "Status : [" + status.name() + "], Current Txn Id : [" +
+              response.getCurrentTxnIndex() + "]");
+          if (status.equals(PrepareStatus.PREPARE_DONE)) {
+            e.setValue(true);
+            currentNumPreparedOms++;
+          }
+        }
+      }
+      if (currentNumPreparedOms < expectedNumPreparedOms) {
+        System.out.println("Waiting for " + prepareCheckInterval +
+            " seconds before retrying...");
+        Thread.sleep(prepareCheckInterval * 1000);
+      }
+    }
+    if (currentNumPreparedOms < expectedNumPreparedOms) {
+      throw new Exception("OM Preparation failed since all OMs are not " +
+          "prepared yet.");
+    } else {
+      System.out.println();
+      System.out.println("OM Preparation successful! ");
+      System.out.println("No new write requests will be " +
+      "allowed until preparation is cancelled or upgrade/downgrade is done.");
+    }
+
     return null;
   }
+
+  private Set<String> getOmHostsFromConfig() {
+    OzoneConfiguration configuration = parent.getParent().getOzoneConf();
+    Collection<String> omNodeIds = OmUtils.getOMNodeIds(configuration,
+        omServiceId);
+    Set<String> omHosts = new HashSet<>();
+    for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {
+      String rpcAddrKey = OmUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
+          omServiceId, nodeId);
+      String rpcAddrStr = OmUtils.getOmRpcAddress(configuration, rpcAddrKey);
+      Optional<String> hostName = getHostName(rpcAddrStr);
+      hostName.ifPresent(omHosts::add);
+    }
+    return omHosts;
+  }
+
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/PrepareSubCommand.java
@@ -103,7 +103,7 @@ public class PrepareSubCommand implements Callable<Void> {
     long prepareTxnId = client.prepareOzoneManager(txnApplyWaitTimeSeconds,
         txnApplyCheckIntervalSeconds);
     System.out.println("Ozone Manager Prepare Request successfully returned " +
-        "with Txn Id : [" + prepareTxnId + "].");
+        "with Transaction Id : [" + prepareTxnId + "].");
 
     Map<String, Boolean> omPreparedStatusMap = new HashMap<>();
     Set<String> omHosts  = getOmHostsFromConfig();
@@ -126,7 +126,7 @@ public class PrepareSubCommand implements Callable<Void> {
               singleOmClient.getOzoneManagerPrepareStatus(prepareTxnId);
           PrepareStatus status = response.getStatus();
           System.out.println("OM : [" + omHost + "], Prepare " +
-              "Status : [" + status.name() + "], Current Txn Id : [" +
+              "Status : [" + status.name() + "], Current Transaction Id : [" +
               response.getCurrentTxnIndex() + "]");
           if (status.equals(PrepareStatus.PREPARE_DONE)) {
             e.setValue(true);
@@ -146,8 +146,8 @@ public class PrepareSubCommand implements Callable<Void> {
     } else {
       System.out.println();
       System.out.println("OM Preparation successful! ");
-      System.out.println("No new write requests will be " +
-      "allowed until preparation is cancelled or upgrade/downgrade is done.");
+      System.out.println("No new write requests will be allowed until " +
+          "preparation is cancelled or upgrade/downgrade is done.");
     }
 
     return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

- After getting a successful response for the OMPrepareRequest, the prepare client should use the Txn ID from the response to check every OM's preparation completeness.
- This JIRA is partially dependent on HDDS-4569 which plans to introduce a marker file at the end of preparation. In a follow up JIRA, this will be refined to take up that logic, along with an integration test.
- A basic acceptance test for prepare has been added. 
- User facing message screenshot has been attached (om1, om2, om3 are actually hostnames in the screenshot).

<img width="712" alt="Screen Shot 2020-12-11 at 11 15 03 AM" src="https://user-images.githubusercontent.com/14299376/101944786-236cb680-3ba2-11eb-9262-1aee134202a7.png">

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4564

## How was this patch tested?
Manually tested. 
Added acceptance test.