### PR TITLE
HDDS-4584. Coverage not updated since TLP

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -274,7 +274,7 @@ jobs:
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
       - name: Upload coverage to Sonar
         uses: ./.github/buildenv
-        if: github.repository == 'apache/hadoop-ozone' && github.event_name != 'pull_request'
+        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         with:
           args: ./hadoop-ozone/dev-support/checks/sonar.sh
         env:
@@ -282,7 +282,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
-        if: github.repository == 'apache/hadoop-ozone' && github.event_name != 'pull_request'
+        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         with:
           file: ./target/coverage/all.xml
           name: codecov-umbrella


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the name of the repository for which coverage data is to be uploaded in `post-commit` workflow.

https://issues.apache.org/jira/browse/HDDS-4584

## How was this patch tested?

Validated workflow file (for syntax errors) by running in own fork.  The fix itself is not verified, since it only applies to `apache/ozone` repo.