### PR TITLE
HDDS-4583. TableCache Refactor to fix issues in cleanup never policy.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 
 /**
  * The DBStore interface provides the ability to create Tables, which store
@@ -49,8 +49,7 @@ public interface DBStore extends AutoCloseable, BatchOperationHandler {
 
   /**
    * Gets an existing TableStore with implicit key/value conversion and
-   * with default cleanup policy for cache. Default cache clean up policy is
-   * manual.
+   * with default cache type for cache. Default cache type is partial cache.
    *
    * @param name - Name of the TableStore to get
    * @param keyType
@@ -61,14 +60,9 @@ public interface DBStore extends AutoCloseable, BatchOperationHandler {
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType) throws IOException;
 
-  /**
-   * Gets an existing TableStore with implicit key/value conversion and
-   * with specified cleanup policy for cache.
-   * @throws IOException
-   */
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType,
-      TableCacheImpl.CacheCleanupPolicy cleanupPolicy) throws IOException;
+      TableCache.CacheType cacheType) throws IOException;
 
   /**
    * Lists the Known list of Tables in a DB.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -60,6 +60,16 @@ public interface DBStore extends AutoCloseable, BatchOperationHandler {
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType) throws IOException;
 
+  /**
+   * Gets an existing TableStore with implicit key/value conversion and
+   * with specified cache type.
+   * @param name - Name of the TableStore to get
+   * @param keyType
+   * @param valueType
+   * @param cacheType
+   * @return - TableStore.
+   * @throws IOException
+   */
   <KEY, VALUE> Table<KEY, VALUE> getTable(String name,
       Class<KEY> keyType, Class<VALUE> valueType,
       TableCache.CacheType cacheType) throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -307,6 +307,7 @@ public class RDBStore implements DBStore {
         valueType);
   }
 
+  @Override
   public <K, V> Table<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType,
       TableCache.CacheType cacheType) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -33,10 +33,10 @@ import java.util.stream.Collectors;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.utils.RocksDBStoreMBean;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.metrics2.util.MBeans;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.ColumnFamilyHandle;
@@ -307,12 +307,11 @@ public class RDBStore implements DBStore {
         valueType);
   }
 
-  @Override
   public <K, V> Table<K, V> getTable(String name,
       Class<K> keyType, Class<V> valueType,
-      TableCacheImpl.CacheCleanupPolicy cleanupPolicy) throws IOException {
+      TableCache.CacheType cacheType) throws IOException {
     return new TypedTable<>(getTable(name), codecRegistry, keyType,
-        valueType, cleanupPolicy);
+        valueType, cacheType);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -62,7 +62,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   /**
    * Create an TypedTable from the raw table.
-   * Default cache type for the table is {@link CacheType#FullCache}.
+   * Default cache type for the table is {@link CacheType#PartialCache}.
    * @param rawTable
    * @param codecRegistry
    * @param keyType

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -62,7 +62,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   /**
    * Create an TypedTable from the raw table.
-   * Default cache type for the table is {@link CacheType#PartialCache}.
+   * Default cache type for the table is {@link CacheType#PARTIAL_CACHE}.
    * @param rawTable
    * @param codecRegistry
    * @param keyType
@@ -73,7 +73,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       CodecRegistry codecRegistry, Class<KEY> keyType,
       Class<VALUE> valueType) throws IOException {
     this(rawTable, codecRegistry, keyType, valueType,
-        CacheType.PartialCache);
+        CacheType.PARTIAL_CACHE);
   }
 
   /**
@@ -95,7 +95,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     this.keyType = keyType;
     this.valueType = valueType;
 
-    if (cacheType == CacheType.FullCache) {
+    if (cacheType == CacheType.FULL_CACHE) {
       cache = new FullTableCache<>();
       //fill cache
       try(TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> tableIterator =

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -76,6 +76,15 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
         CacheType.PartialCache);
   }
 
+  /**
+   * Create an TypedTable from the raw table with specified cache type.
+   * @param rawTable
+   * @param codecRegistry
+   * @param keyType
+   * @param valueType
+   * @param cacheType
+   * @throws IOException
+   */
   public TypedTable(
       Table<byte[], byte[]> rawTable,
       CodecRegistry codecRegistry, Class<KEY> keyType,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheResult;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
+import org.apache.hadoop.hdds.utils.db.cache.FullTableCache;
+import org.apache.hadoop.hdds.utils.db.cache.PartialTableCache;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
-import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl.CacheCleanupPolicy;
 
 import static org.apache.hadoop.hdds.utils.db.cache.CacheResult.CacheStatus.EXISTS;
 import static org.apache.hadoop.hdds.utils.db.cache.CacheResult.CacheStatus.NOT_EXIST;
@@ -61,8 +62,7 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   /**
    * Create an TypedTable from the raw table.
-   * Default cleanup policy used for the table is
-   * {@link CacheCleanupPolicy#MANUAL}.
+   * Default cache type for the table is {@link CacheType#FullCache}.
    * @param rawTable
    * @param codecRegistry
    * @param keyType
@@ -73,30 +73,21 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
       CodecRegistry codecRegistry, Class<KEY> keyType,
       Class<VALUE> valueType) throws IOException {
     this(rawTable, codecRegistry, keyType, valueType,
-        CacheCleanupPolicy.MANUAL);
+        CacheType.PartialCache);
   }
 
-  /**
-   * Create an TypedTable from the raw table with specified cleanup policy
-   * for table cache.
-   * @param rawTable
-   * @param codecRegistry
-   * @param keyType
-   * @param valueType
-   * @param cleanupPolicy
-   */
   public TypedTable(
       Table<byte[], byte[]> rawTable,
       CodecRegistry codecRegistry, Class<KEY> keyType,
       Class<VALUE> valueType,
-      TableCacheImpl.CacheCleanupPolicy cleanupPolicy) throws IOException {
+      CacheType cacheType) throws IOException {
     this.rawTable = rawTable;
     this.codecRegistry = codecRegistry;
     this.keyType = keyType;
     this.valueType = valueType;
-    cache = new TableCacheImpl<>(cleanupPolicy);
 
-    if (cleanupPolicy == CacheCleanupPolicy.NEVER) {
+    if (cacheType == CacheType.FullCache) {
+      cache = new FullTableCache<>();
       //fill cache
       try(TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> tableIterator =
               iterator()) {
@@ -111,6 +102,8 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
               new CacheValue<>(Optional.of(kv.getValue()), EPOCH_DEFAULT));
         }
       }
+    } else {
+      cache = new PartialTableCache<>();
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/FullTableCache.java
@@ -19,13 +19,11 @@
 
 package org.apache.hadoop.hdds.utils.db.cache;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -128,15 +128,15 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
       // condition between cache cleanup and requests updating same cache entry.
 
       cache.computeIfPresent(cachekey, ((k, v) -> {
-          if (v.getEpoch() == currentEpoch && epochs.contains(v.getEpoch())) {
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("CacheKey {} with epoch {} is removed from cache",
-                  k.getCacheKey(), currentEpoch);
-            }
-            iterator.remove();
-            removed.set(true);
-            return null;
+        if (v.getEpoch() == currentEpoch && epochs.contains(v.getEpoch())) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("CacheKey {} with epoch {} is removed from cache",
+                k.getCacheKey(), currentEpoch);
           }
+          iterator.remove();
+          removed.set(true);
+          return null;
+        }
         return v;
       }));
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -148,8 +148,8 @@ public class PartialTableCache<CACHEKEY extends CacheKey,
       // cache. Clean that epoch entry.
       if (!removed.get()) {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("CacheKey {} with epoch {} is removed from epochEntry for " +
-                  "a key not existing in cache", cachekey.getCacheKey(),
+          LOG.debug("CacheKey {} with epoch {} is removed from epochEntry " +
+                  "for a key not existing in cache", cachekey.getCacheKey(),
               currentEpoch);
         }
         iterator.remove();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.utils.db.cache;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
+import org.apache.hadoop.hdds.annotation.InterfaceStability.Evolving;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Cache implementation for the table. Partial Table cache, where the DB state
+ * and cache state will not be same. Partial table cache holds entries until
+ * flush to DB happens.
+ */
+@Private
+@Evolving
+public class PartialTableCache<CACHEKEY extends CacheKey,
+    CACHEVALUE extends CacheValue> implements TableCache<CACHEKEY, CACHEVALUE> {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(PartialTableCache.class);
+
+  private final Map<CACHEKEY, CACHEVALUE> cache;
+  private final NavigableSet<EpochEntry<CACHEKEY>> epochEntries;
+  private ExecutorService executorService;
+
+
+  public PartialTableCache() {
+    // We use concurrent Hash map for O(1) lookup for get API.
+    // During list operation for partial cache we anyway merge between DB and
+    // cache state. So entries in cache does not need to be in sorted order.
+
+    // And as concurrentHashMap computeIfPresent which is used by cleanup is
+    // atomic operation, and ozone level locks like bucket/volume locks
+    // protect updating same key, here it is not required to hold cache
+    // level locks during update/cleanup operation.
+
+    // 1. During update, it is caller responsibility to hold volume/bucket
+    // locks.
+    // 2. During cleanup which removes entry, while request is updating cache
+    // that should be guarded by concurrentHashMap guaranty.
+    cache = new ConcurrentHashMap<>();
+
+    epochEntries = new ConcurrentSkipListSet<>();
+    // Created a singleThreadExecutor, so one cleanup will be running at a
+    // time.
+    ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
+        .setNameFormat("PartialTableCache Cleanup Thread - %d").build();
+    executorService = Executors.newSingleThreadExecutor(build);
+  }
+
+  @Override
+  public CACHEVALUE get(CACHEKEY cachekey) {
+    return cache.get(cachekey);
+  }
+
+  @Override
+  public void loadInitial(CACHEKEY cacheKey, CACHEVALUE cacheValue) {
+    // Do nothing for full table cache.
+  }
+
+  @Override
+  public void put(CACHEKEY cacheKey, CACHEVALUE value) {
+    cache.put(cacheKey, value);
+    epochEntries.add(new EpochEntry<>(value.getEpoch(), cacheKey));
+  }
+
+  public void cleanup(List<Long> epochs) {
+    executorService.execute(() -> evictCache(epochs));
+  }
+
+  @Override
+  public int size() {
+    return cache.size();
+  }
+
+  @Override
+  public Iterator<Map.Entry<CACHEKEY, CACHEVALUE>> iterator() {
+    return cache.entrySet().iterator();
+  }
+
+  @VisibleForTesting
+  public void evictCache(List<Long> epochs) {
+    EpochEntry<CACHEKEY> currentEntry;
+    final AtomicBoolean removed = new AtomicBoolean();
+    CACHEKEY cachekey;
+    long lastEpoch = epochs.get(epochs.size() - 1);
+    for (Iterator<EpochEntry<CACHEKEY>> iterator = epochEntries.iterator();
+         iterator.hasNext();) {
+      currentEntry = iterator.next();
+      cachekey = currentEntry.getCachekey();
+      long currentEpoch = currentEntry.getEpoch();
+
+      // As ConcurrentHashMap computeIfPresent is atomic, there is no race
+      // condition between cache cleanup and requests updating same cache entry.
+
+      cache.computeIfPresent(cachekey, ((k, v) -> {
+          if (v.getEpoch() == currentEpoch && epochs.contains(v.getEpoch())) {
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("CacheKey {} with epoch {} is removed from cache",
+                  k.getCacheKey(), currentEpoch);
+            }
+            iterator.remove();
+            removed.set(true);
+            return null;
+          }
+        return v;
+      }));
+
+      // If currentEntry epoch is greater than last epoch provided, we have
+      // deleted all entries less than specified epoch. So, we can break.
+      if (currentEpoch > lastEpoch) {
+        break;
+      }
+
+      // When epoch entry is not removed, this might be a override entry in
+      // cache. Clean that epoch entry.
+      if (!removed.get()) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("CacheKey {} with epoch {} is removed from epochEntry for " +
+                  "a key not existing in cache", cachekey.getCacheKey(),
+              currentEpoch);
+        }
+        iterator.remove();
+      }
+
+      removed.set(false);
+    }
+  }
+
+  public CacheResult<CACHEVALUE> lookup(CACHEKEY cachekey) {
+
+    CACHEVALUE cachevalue = cache.get(cachekey);
+    if (cachevalue == null) {
+      return new CacheResult<>(CacheResult.CacheStatus.MAY_EXIST,
+            null);
+    } else {
+      if (cachevalue.getCacheValue() != null) {
+        return new CacheResult<>(CacheResult.CacheStatus.EXISTS, cachevalue);
+      } else {
+        // When entity is marked for delete, cacheValue will be set to null.
+        return new CacheResult<>(CacheResult.CacheStatus.NOT_EXIST, null);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  public Set<EpochEntry<CACHEKEY>> getEpochEntrySet() {
+    return epochEntries;
+  }
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/PartialTableCache.java
@@ -19,14 +19,12 @@
 
 package org.apache.hadoop.hdds.utils.db.cache;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -48,7 +48,7 @@ public interface TableCache<CACHEKEY extends CacheKey,
 
   /**
    * This method should be called for tables with cache type full cache.
-   * {@link TableCache.CacheType#FullCache} after system
+   * {@link TableCache.CacheType#FULL_CACHE} after system
    * restart to fill up the cache.
    * @param cacheKey
    * @param cacheValue
@@ -96,11 +96,11 @@ public interface TableCache<CACHEKEY extends CacheKey,
    *
    * If it does not exist:
    *  If cache type is
-   *  {@link TableCache.CacheType#FullCache}. It return's {@link CacheResult}
+   *  {@link TableCache.CacheType#FULL_CACHE}. It return's {@link CacheResult}
    *  with null and status as {@link CacheResult.CacheStatus#NOT_EXIST}.
    *
    *  If cache type is
-   *  {@link TableCache.CacheType#PartialCache}.
+   *  {@link TableCache.CacheType#PARTIAL_CACHE}.
    *  It return's {@link CacheResult} with null and status as MAY_EXIST.
    *
    * @param cachekey
@@ -112,9 +112,9 @@ public interface TableCache<CACHEKEY extends CacheKey,
   Set<EpochEntry<CACHEKEY>> getEpochEntrySet();
 
   enum CacheType {
-    FullCache, //  This mean's the table maintains full cache. Cache and DB
+    FULL_CACHE, //  This mean's the table maintains full cache. Cache and DB
     // state are same.
-    PartialCache // This is partial table cache, cache state is partial state
+    PARTIAL_CACHE // This is partial table cache, cache state is partial state
     // compared to DB state.
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -22,7 +22,6 @@ package org.apache.hadoop.hdds.utils.db.cache;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
 import org.apache.hadoop.hdds.annotation.InterfaceStability.Evolving;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import java.util.Iterator;
 import java.util.List;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.hdds.utils.db.cache;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience.Private;
 import org.apache.hadoop.hdds.annotation.InterfaceStability.Evolving;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import java.util.Iterator;
 import java.util.List;
@@ -47,9 +48,9 @@ public interface TableCache<CACHEKEY extends CacheKey,
   CACHEVALUE get(CACHEKEY cacheKey);
 
   /**
-   * This method should be called for tables with cache cleanup policy
-   * {@link TableCacheImpl.CacheCleanupPolicy#NEVER} after system restart to
-   * fill up the cache.
+   * This method should be called for tables with cache type full cache.
+   * {@link TableCache.CacheType#FullCache} after system
+   * restart to fill up the cache.
    * @param cacheKey
    * @param cacheValue
    */
@@ -73,6 +74,9 @@ public interface TableCache<CACHEKEY extends CacheKey,
    */
   void cleanup(List<Long> epochs);
 
+  @VisibleForTesting
+  void evictCache(List<Long> epochs);
+
   /**
    * Return the size of the cache.
    * @return size
@@ -92,15 +96,13 @@ public interface TableCache<CACHEKEY extends CacheKey,
    * {@link CacheResult.CacheStatus#EXISTS}
    *
    * If it does not exist:
-   *  If cache clean up policy is
-   *  {@link TableCacheImpl.CacheCleanupPolicy#NEVER} it means table cache is
-   *  full cache. It return's {@link CacheResult} with null
-   *  and status as {@link CacheResult.CacheStatus#NOT_EXIST}.
+   *  If cache type is
+   *  {@link TableCache.CacheType#FullCache}. It return's {@link CacheResult}
+   *  with null and status as {@link CacheResult.CacheStatus#NOT_EXIST}.
    *
-   *  If cache clean up policy is
-   *  {@link TableCacheImpl.CacheCleanupPolicy#MANUAL} it means
-   *  table cache is partial cache. It return's {@link CacheResult} with
-   *  null and status as MAY_EXIST.
+   *  If cache type is
+   *  {@link TableCache.CacheType#PartialCache}.
+   *  It return's {@link CacheResult} with null and status as MAY_EXIST.
    *
    * @param cachekey
    */
@@ -109,4 +111,11 @@ public interface TableCache<CACHEKEY extends CacheKey,
 
   @VisibleForTesting
   Set<EpochEntry<CACHEKEY>> getEpochEntrySet();
+
+  public enum CacheType {
+    FullCache, //  This mean's the table maintains full cache. Cache and DB
+    // state are same.
+    PartialCache // This is partial table cache, cache state is partial state
+    // compared to DB state.
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/cache/TableCache.java
@@ -111,7 +111,7 @@ public interface TableCache<CACHEKEY extends CacheKey,
   @VisibleForTesting
   Set<EpochEntry<CACHEKEY>> getEpochEntrySet();
 
-  public enum CacheType {
+  enum CacheType {
     FullCache, //  This mean's the table maintains full cache. Cache and DB
     // state are same.
     PartialCache // This is partial table cache, cache state is partial state

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -26,11 +26,13 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.slf4j.event.Level;
 
 import static org.junit.Assert.fail;
 
@@ -38,31 +40,35 @@ import static org.junit.Assert.fail;
  * Class tests partial table cache.
  */
 @RunWith(value = Parameterized.class)
-public class TestTableCacheImpl {
-  private TableCacheImpl<CacheKey<String>, CacheValue<String>> tableCache;
+public class TestTableCache {
+  private TableCache<CacheKey<String>, CacheValue<String>> tableCache;
 
-  private final TableCacheImpl.CacheCleanupPolicy cacheCleanupPolicy;
+  private final TableCache.CacheType cacheType;
 
 
   @Parameterized.Parameters
   public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] {
-        {TableCacheImpl.CacheCleanupPolicy.NEVER},
-        {TableCacheImpl.CacheCleanupPolicy.MANUAL}
+        {TableCache.CacheType.FullCache},
+        {TableCache.CacheType.PartialCache}
     };
     return Arrays.asList(params);
   }
 
-  public TestTableCacheImpl(
-      TableCacheImpl.CacheCleanupPolicy cacheCleanupPolicy) {
-    this.cacheCleanupPolicy = cacheCleanupPolicy;
+  public TestTableCache(
+      TableCache.CacheType cacheType) {
+    GenericTestUtils.setLogLevel(FullTableCache.LOG, Level.DEBUG);
+    this.cacheType = cacheType;
   }
 
 
   @Before
   public void create() {
-    tableCache =
-        new TableCacheImpl<>(cacheCleanupPolicy);
+    if (cacheType == TableCache.CacheType.FullCache) {
+      tableCache = new FullTableCache<>();
+    } else {
+      tableCache = new PartialTableCache<>();
+    }
   }
   @Test
   public void testPartialTableCache() {
@@ -119,7 +125,7 @@ public class TestTableCacheImpl {
     final int count = totalCount;
 
     // If cleanup policy is manual entries should have been removed.
-    if (cacheCleanupPolicy == TableCacheImpl.CacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
       Assert.assertEquals(count - epochs.size(), tableCache.size());
 
       // Check remaining entries exist or not and deleted entries does not
@@ -178,14 +184,13 @@ public class TestTableCacheImpl {
     epochs.add(3L);
     epochs.add(4L);
 
-    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
 
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
 
-      // Epoch entries which are overrided still exist.
-      Assert.assertEquals(2, tableCache.getEpochEntrySet().size());
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
     }
 
     // Add a new entry.
@@ -194,7 +199,7 @@ public class TestTableCacheImpl {
 
     epochs = new ArrayList<>();
     epochs.add(5L);
-    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
@@ -252,21 +257,19 @@ public class TestTableCacheImpl {
     epochs.add(6L);
 
 
-    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
 
-      // Epoch entries which are overrided still exist.
-      Assert.assertEquals(4, tableCache.getEpochEntrySet().size());
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
     } else {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(1, tableCache.size());
 
-      // Epoch entries which are overrided still exist and one not deleted As
-      // this cache clean up policy is NEVER.
-      Assert.assertEquals(5, tableCache.getEpochEntrySet().size());
+      // Epoch entries which are overrided also will be cleaned up.
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
     }
 
     // Add a new entry, now old override entries will be cleaned up.
@@ -276,7 +279,7 @@ public class TestTableCacheImpl {
     epochs = new ArrayList<>();
     epochs.add(7L);
 
-    if (cacheCleanupPolicy == cacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
@@ -289,9 +292,9 @@ public class TestTableCacheImpl {
       // 2 entries will be in cache, as 2 are not deleted.
       Assert.assertEquals(2, tableCache.size());
 
-      // Epoch entries which are not marked for delete will exist override
-      // entries will be cleaned up.
-      Assert.assertEquals(2, tableCache.getEpochEntrySet().size());
+      // Epoch entries which are not marked for delete will also be cleaned up.
+      // As they are override entries in full cache.
+      Assert.assertEquals(0, tableCache.getEpochEntrySet().size());
     }
 
 
@@ -337,7 +340,7 @@ public class TestTableCacheImpl {
 
     totalCount += value;
 
-    if (cacheCleanupPolicy == TableCacheImpl.CacheCleanupPolicy.MANUAL) {
+    if (cacheType == TableCache.CacheType.PartialCache) {
       int deleted = 5;
 
       // cleanup first 5 entires
@@ -378,6 +381,33 @@ public class TestTableCacheImpl {
     }
 
 
+  }
+
+  @Test
+  public void testTableCache() {
+
+    // In non-HA epoch entries might be out of order.
+    // Scenario is like create vol, set vol, set vol, delete vol
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(0)), 0));
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(1)), 1));
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.of(Long.toString(2)), 3));
+
+    tableCache.put(new CacheKey<>(Long.toString(0)),
+        new CacheValue<>(Optional.absent(), 2));
+
+    List<Long> epochs = new ArrayList<>();
+    epochs.add(0L);
+    epochs.add(1L);
+    epochs.add(2L);
+    epochs.add(3L);
+
+    tableCache.evictCache(epochs);
+
+    Assert.assertTrue(tableCache.size() == 0);
+    Assert.assertTrue(tableCache.getEpochEntrySet().size() == 0);
   }
 
   private int writeToCache(int count, int startVal, long sleep)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -49,8 +49,8 @@ public class TestTableCache {
   @Parameterized.Parameters
   public static Collection<Object[]> policy() {
     Object[][] params = new Object[][] {
-        {TableCache.CacheType.FullCache},
-        {TableCache.CacheType.PartialCache}
+        {TableCache.CacheType.FULL_CACHE},
+        {TableCache.CacheType.PARTIAL_CACHE}
     };
     return Arrays.asList(params);
   }
@@ -64,7 +64,7 @@ public class TestTableCache {
 
   @Before
   public void create() {
-    if (cacheType == TableCache.CacheType.FullCache) {
+    if (cacheType == TableCache.CacheType.FULL_CACHE) {
       tableCache = new FullTableCache<>();
     } else {
       tableCache = new PartialTableCache<>();
@@ -125,7 +125,7 @@ public class TestTableCache {
     final int count = totalCount;
 
     // If cleanup policy is manual entries should have been removed.
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       Assert.assertEquals(count - epochs.size(), tableCache.size());
 
       // Check remaining entries exist or not and deleted entries does not
@@ -184,7 +184,7 @@ public class TestTableCache {
     epochs.add(3L);
     epochs.add(4L);
 
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
 
       tableCache.evictCache(epochs);
 
@@ -199,7 +199,7 @@ public class TestTableCache {
 
     epochs = new ArrayList<>();
     epochs.add(5L);
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
@@ -257,7 +257,7 @@ public class TestTableCache {
     epochs.add(6L);
 
 
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
@@ -279,7 +279,7 @@ public class TestTableCache {
     epochs = new ArrayList<>();
     epochs.add(7L);
 
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       tableCache.evictCache(epochs);
 
       Assert.assertEquals(0, tableCache.size());
@@ -340,7 +340,7 @@ public class TestTableCache {
 
     totalCount += value;
 
-    if (cacheType == TableCache.CacheType.PartialCache) {
+    if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       int deleted = 5;
 
       // cleanup first 5 entires
@@ -453,7 +453,7 @@ public class TestTableCache {
 
     tableCache.evictCache(epochs);
 
-    if(cacheType == TableCache.CacheType.PartialCache) {
+    if(cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       Assert.assertTrue(tableCache.size() == 0);
       Assert.assertTrue(tableCache.getEpochEntrySet().size() == 0);
     } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.hdds.utils.db.cache.TableCacheImpl;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
@@ -359,17 +359,16 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
             PersistedUserVolumeInfo.class);
     checkTableStatus(userTable, USER_TABLE);
 
-    TableCacheImpl.CacheCleanupPolicy cleanupPolicy =
-        TableCacheImpl.CacheCleanupPolicy.NEVER;
+    TableCache.CacheType cacheType = TableCache.CacheType.FullCache;
 
     volumeTable =
         this.store.getTable(VOLUME_TABLE, String.class, OmVolumeArgs.class,
-            cleanupPolicy);
+            cacheType);
     checkTableStatus(volumeTable, VOLUME_TABLE);
 
     bucketTable =
         this.store.getTable(BUCKET_TABLE, String.class, OmBucketInfo.class,
-            cleanupPolicy);
+            cacheType);
 
     checkTableStatus(bucketTable, BUCKET_TABLE);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
+import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
@@ -359,7 +360,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
             PersistedUserVolumeInfo.class);
     checkTableStatus(userTable, USER_TABLE);
 
-    TableCache.CacheType cacheType = TableCache.CacheType.FullCache;
+    CacheType cacheType = CacheType.FULL_CACHE;
 
     volumeTable =
         this.store.getTable(VOLUME_TABLE, String.class, OmVolumeArgs.class,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
-import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -52,10 +52,6 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.ratis.util.ExitUtils;
 
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
-import static org.apache.hadoop.ozone.OzoneConsts.BUCKET;
-import static org.apache.hadoop.ozone.OzoneConsts.VOLUME;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteBucket;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteVolume;
 
 /**
  * This class implements DoubleBuffer implementation of OMClientResponse's. In

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -258,7 +258,7 @@ public final class OzoneManagerDoubleBuffer {
                       return null;
                     });
 
-                setCleanupEpoch(entry, cleanupEpochs);
+                addCleanupEntry(entry, cleanupEpochs);
 
               } catch (IOException ex) {
                 // During Adding to RocksDB batch entry got an exception.
@@ -364,34 +364,6 @@ public final class OzoneManagerDoubleBuffer {
             Thread.currentThread().getName() + "encountered Throwable error";
         ExitUtils.terminate(2, s, t, LOG);
       }
-    }
-  }
-
-  /**
-   * Set cleanup epoch for the DoubleBufferEntry.
-   * @param entry
-   * @param cleanupEpochs
-   */
-  private void setCleanupEpoch(DoubleBufferEntry entry, Map<String,
-      List<Long>> cleanupEpochs) {
-    // Add epochs depending on operated tables. In this way
-    // cleanup will be called only when required.
-
-    // As bucket and volume table is full cache add cleanup
-    // epochs only when request is delete to cleanup deleted
-    // entries.
-
-    String opName =
-        entry.getResponse().getOMResponse().getCmdType().name();
-
-    if (opName.toLowerCase().contains(VOLUME) ||
-        opName.toLowerCase().contains(BUCKET)) {
-      if (DeleteBucket.name().equals(opName)
-          || DeleteVolume.name().equals(opName)) {
-        addCleanupEntry(entry, cleanupEpochs);
-      }
-    } else {
-      addCleanupEntry(entry, cleanupEpochs);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Implement TableCache based on cache type FullTableCache and PartialTable Cache.
2. Fix cleanup eviction logic, where epoch entires are not getting removed.
3. Fix issue of race condition between request processing and cleanup thread in FullTableCache. This is solved using cache locks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4583

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Existing TestTableCache tests and added a test.
