### PR TITLE
HDDS-4369. Datanode should store the delete transaction as is in rocksDB

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -252,7 +252,8 @@ public final class OzoneConsts {
   // versions, requiring this property to be tracked on a per container basis.
   // V1: All data in default column family.
   public static final String SCHEMA_V1 = "1";
-  // V2: Metadata, block data, and deleted blocks in their own column families.
+  // V2: Metadata, block data, and transactions to be deleted in their own
+  // column families.
   public static final String SCHEMA_V2 = "2";
   // Most recent schema version that all new containers should be created with.
   public static final String SCHEMA_LATEST = SCHEMA_V2;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -252,7 +252,7 @@ public final class OzoneConsts {
   // versions, requiring this property to be tracked on a per container basis.
   // V1: All data in default column family.
   public static final String SCHEMA_V1 = "1";
-  // V2: Metadata, block data, and transactions to be deleted in their own
+  // V2: Metadata, block data, and delete transactions in their own
   // column families.
   public static final String SCHEMA_V2 = "2";
   // Most recent schema version that all new containers should be created with.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -257,6 +257,9 @@ public final class OzoneConsts {
   // Most recent schema version that all new containers should be created with.
   public static final String SCHEMA_LATEST = SCHEMA_V2;
 
+  public static final String[] SCHEMA_VERSIONS =
+      new String[] {SCHEMA_V1, SCHEMA_V2};
+
   // Supported store types.
   public static final String OZONE = "ozone";
   public static final String S3 = "s3";

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -135,10 +135,10 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
             cont.writeLock();
             try {
               if (containerData.getSchemaVersion().equals(SCHEMA_V1)) {
-                deleteKeyValueContainerBlocks(containerData, entry);
+                markBlocksForDeletionSchemaV1(containerData, entry);
               } else if (containerData.getSchemaVersion().equals(SCHEMA_V2)) {
-                putTxns(containerData, entry, newDeletionBlocks,
-                    entry.getTxID());
+                markBlocksForDeletionSchemaV2(containerData, entry,
+                    newDeletionBlocks, entry.getTxID());
               } else {
                 throw new UnsupportedOperationException(
                     "Only schema version 1 and schema version 2 are "
@@ -202,71 +202,62 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
    * @throws IOException if I/O error occurs.
    */
 
-  private void putTxns(KeyValueContainerData containerData,
-      DeletedBlocksTransaction delTX, int newDeletionBlocks, long txnID)
-      throws IOException {
-    try(ReferenceCountedDB containerDB =
-        BlockUtils.getDB(containerData, conf)){
+  private void markBlocksForDeletionSchemaV2(
+      KeyValueContainerData containerData, DeletedBlocksTransaction delTX,
+      int newDeletionBlocks, long txnID) throws IOException {
+    long containerId = delTX.getContainerID();
+    if (!isTxnIdValid(containerId, containerData, delTX)) {
+      return;
+    }
+    try (ReferenceCountedDB containerDB = BlockUtils
+        .getDB(containerData, conf)) {
       DatanodeStore ds = containerDB.getStore();
       DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
           (DatanodeStoreSchemaTwoImpl) ds;
       Table<Long, DeletedBlocksTransaction> delTxTable =
-          dnStoreTwoImpl.getTxnTable();
-      try(BatchOperation batch = containerDB.getStore()
-          .getBatchHandler().initBatchOperation()){
+          dnStoreTwoImpl.getDeleteTransactionTable();
+      try (BatchOperation batch = containerDB.getStore().getBatchHandler()
+          .initBatchOperation()) {
         delTxTable.putWithBatch(batch, txnID, delTX);
-        containerDB.getStore().getBatchHandler()
-            .commitBatchOperation(batch);
         newDeletionBlocks += delTX.getLocalIDList().size();
+        updateMetaData(containerData, delTX, newDeletionBlocks, containerDB,
+            batch);
+        containerDB.getStore().getBatchHandler().commitBatchOperation(batch);
       }
     }
-    updateMetaData(containerData, delTX, newDeletionBlocks);
   }
 
-  private void deleteKeyValueContainerBlocks(
+  private void markBlocksForDeletionSchemaV1(
       KeyValueContainerData containerData, DeletedBlocksTransaction delTX)
       throws IOException {
     long containerId = delTX.getContainerID();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Processing Container : {}, DB path : {}", containerId,
-          containerData.getMetadataPath());
-    }
-
-    if (delTX.getTxID() < containerData.getDeleteTransactionId()) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug(String.format("Ignoring delete blocks for containerId: %d."
-                + " Outdated delete transactionId %d < %d", containerId,
-            delTX.getTxID(), containerData.getDeleteTransactionId()));
-      }
+    if (!isTxnIdValid(containerId, containerData, delTX)) {
       return;
     }
-
     int newDeletionBlocks = 0;
-    try(ReferenceCountedDB containerDB =
-            BlockUtils.getDB(containerData, conf)) {
+    try (ReferenceCountedDB containerDB = BlockUtils
+        .getDB(containerData, conf)) {
       Table<String, BlockData> blockDataTable =
-              containerDB.getStore().getBlockDataTable();
+          containerDB.getStore().getBlockDataTable();
       Table<String, ChunkInfoList> deletedBlocksTable =
-              containerDB.getStore().getDeletedBlocksTable();
+          containerDB.getStore().getDeletedBlocksTable();
 
-      for (Long blkLong : delTX.getLocalIDList()) {
-        String blk = blkLong.toString();
-        BlockData blkInfo = blockDataTable.get(blk);
-        if (blkInfo != null) {
-          String deletingKey = OzoneConsts.DELETING_KEY_PREFIX + blk;
-
-          if (blockDataTable.get(deletingKey) != null
-              || deletedBlocksTable.get(blk) != null) {
-            if (LOG.isDebugEnabled()) {
-              LOG.debug(String.format(
-                  "Ignoring delete for block %s in container %d."
-                      + " Entry already added.", blk, containerId));
+      try (BatchOperation batch = containerDB.getStore().getBatchHandler()
+          .initBatchOperation()) {
+        for (Long blkLong : delTX.getLocalIDList()) {
+          String blk = blkLong.toString();
+          BlockData blkInfo = blockDataTable.get(blk);
+          if (blkInfo != null) {
+            String deletingKey = OzoneConsts.DELETING_KEY_PREFIX + blk;
+            if (blockDataTable.get(deletingKey) != null
+                || deletedBlocksTable.get(blk) != null) {
+              if (LOG.isDebugEnabled()) {
+                LOG.debug(String.format(
+                    "Ignoring delete for block %s in container %d."
+                        + " Entry already added.", blk, containerId));
+              }
+              continue;
             }
-            continue;
-          }
-
-          try(BatchOperation batch = containerDB.getStore()
-              .getBatchHandler().initBatchOperation()) {
             // Found the block in container db,
             // use an atomic update to change its state to deleting.
             blockDataTable.putWithBatch(batch, deletingKey, blkInfo);
@@ -278,57 +269,59 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
               LOG.debug("Transited Block {} to DELETING state in container {}",
                   blk, containerId);
             }
-          } catch (IOException e) {
-            // if some blocks failed to delete, we fail this TX,
-            // without sending this ACK to SCM, SCM will resend the TX
-            // with a certain number of retries.
-            throw new IOException(
-                "Failed to delete blocks for TXID = " + delTX.getTxID(), e);
-          }
-        } else {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Block {} not found or already under deletion in"
-                + " container {}, skip deleting it.", blk, containerId);
+          } else {
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Block {} not found or already under deletion in"
+                  + " container {}, skip deleting it.", blk, containerId);
+            }
           }
         }
-      }
-
-      if (newDeletionBlocks > 0) {
-        // Finally commit the DB counters.
-        try(BatchOperation batchOperation =
-                containerDB.getStore().getBatchHandler().initBatchOperation()) {
-          Table< String, Long > metadataTable = containerDB.getStore()
-              .getMetadataTable();
-
-          // In memory is updated only when existing delete transactionID is
-          // greater.
-          if (delTX.getTxID() > containerData.getDeleteTransactionId()) {
-            // Update in DB pending delete key count and delete transaction ID.
-            metadataTable.putWithBatch(batchOperation,
-                OzoneConsts.DELETE_TRANSACTION_KEY, delTX.getTxID());
-          }
-
-          long pendingDeleteBlocks =
-              containerData.getNumPendingDeletionBlocks() + newDeletionBlocks;
-          metadataTable.putWithBatch(batchOperation,
-              OzoneConsts.PENDING_DELETE_BLOCK_COUNT, pendingDeleteBlocks);
-
-          containerDB.getStore().getBatchHandler()
-              .commitBatchOperation(batchOperation);
-
-          // update pending deletion blocks count and delete transaction ID in
-          // in-memory container status
-          containerData.updateDeleteTransactionId(delTX.getTxID());
-          containerData.incrPendingDeletionBlocks(newDeletionBlocks);
-        }
+        updateMetaData(containerData, delTX, newDeletionBlocks, containerDB,
+            batch);
+      } catch (IOException e) {
+        // if some blocks failed to delete, we fail this TX,
+        // without sending this ACK to SCM, SCM will resend the TX
+        // with a certain number of retries.
+        throw new IOException(
+            "Failed to delete blocks for TXID = " + delTX.getTxID(), e);
       }
     }
   }
 
-  private void updateMetaData(
-      KeyValueContainerData containerData, DeletedBlocksTransaction delTX,
-      int newDeletionBlocks) throws IOException {
-    long containerId = delTX.getContainerID();
+  private void updateMetaData(KeyValueContainerData containerData,
+      DeletedBlocksTransaction delTX, int newDeletionBlocks,
+      ReferenceCountedDB containerDB, BatchOperation batchOperation)
+      throws IOException {
+    if (newDeletionBlocks > 0) {
+      // Finally commit the DB counters.
+      Table<String, Long> metadataTable =
+          containerDB.getStore().getMetadataTable();
+
+      // In memory is updated only when existing delete transactionID is
+      // greater.
+      if (delTX.getTxID() > containerData.getDeleteTransactionId()) {
+        // Update in DB pending delete key count and delete transaction ID.
+        metadataTable
+            .putWithBatch(batchOperation, OzoneConsts.DELETE_TRANSACTION_KEY,
+                delTX.getTxID());
+      }
+
+      long pendingDeleteBlocks =
+          containerData.getNumPendingDeletionBlocks() + newDeletionBlocks;
+      metadataTable
+          .putWithBatch(batchOperation, OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
+              pendingDeleteBlocks);
+
+      // update pending deletion blocks count and delete transaction ID in
+      // in-memory container status
+      containerData.updateDeleteTransactionId(delTX.getTxID());
+      containerData.incrPendingDeletionBlocks(newDeletionBlocks);
+    }
+  }
+
+  private boolean isTxnIdValid(long containerId,
+      KeyValueContainerData containerData, DeletedBlocksTransaction delTX) {
+    boolean b = true;
     if (LOG.isDebugEnabled()) {
       LOG.debug("Processing Container : {}, DB path : {}", containerId,
           containerData.getMetadataPath());
@@ -340,41 +333,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
                 + " Outdated delete transactionId %d < %d", containerId,
             delTX.getTxID(), containerData.getDeleteTransactionId()));
       }
-      return;
+      b = false;
     }
-
-    try(ReferenceCountedDB containerDB =
-        BlockUtils.getDB(containerData, conf)) {
-
-      if (newDeletionBlocks > 0) {
-        // Finally commit the DB counters.
-        try(BatchOperation batchOperation =
-            containerDB.getStore().getBatchHandler().initBatchOperation()) {
-          Table< String, Long > metadataTable = containerDB.getStore()
-              .getMetadataTable();
-
-          // In memory is updated only when existing delete transactionID is
-          // greater.
-          if (delTX.getTxID() > containerData.getDeleteTransactionId()) {
-            // Update in DB pending delete key count and delete transaction ID.
-            metadataTable.putWithBatch(batchOperation,
-                OzoneConsts.DELETE_TRANSACTION_KEY, delTX.getTxID());
-          }
-
-          long pendingDeleteBlocks =
-              containerData.getNumPendingDeletionBlocks() + newDeletionBlocks;
-          metadataTable.putWithBatch(batchOperation,
-              OzoneConsts.PENDING_DELETE_BLOCK_COUNT, pendingDeleteBlocks);
-          containerDB.getStore().getBatchHandler()
-              .commitBatchOperation(batchOperation);
-
-          // update pending deletion blocks count and delete transaction ID in
-          // in-memory container status
-          containerData.updateDeleteTransactionId(delTX.getTxID());
-          containerData.incrPendingDeletionBlocks(newDeletionBlocks);
-        }
-      }
-    }
+    return b;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -262,8 +262,6 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
             // use an atomic update to change its state to deleting.
             blockDataTable.putWithBatch(batch, deletingKey, blkInfo);
             blockDataTable.deleteWithBatch(batch, blk);
-            containerDB.getStore().getBatchHandler()
-                .commitBatchOperation(batch);
             newDeletionBlocks++;
             if (LOG.isDebugEnabled()) {
               LOG.debug("Transited Block {} to DELETING state in container {}",
@@ -278,6 +276,7 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
         }
         updateMetaData(containerData, delTX, newDeletionBlocks, containerDB,
             batch);
+        containerDB.getStore().getBatchHandler().commitBatchOperation(batch);
       } catch (IOException e) {
         // if some blocks failed to delete, we fail this TX,
         // without sending this ACK to SCM, SCM will resend the TX

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeDBDefinition.java
@@ -60,7 +60,7 @@ public abstract class AbstractDatanodeDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
-            getMetadataColumnFamily(), getDeletedBlocksColumnFamily()};
+        getMetadataColumnFamily(), getDeletedBlocksColumnFamily()};
   }
 
   public abstract DBColumnFamilyDefinition<String, BlockData>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -89,7 +89,6 @@ public class DatanodeSchemaOneDBDefinition
     return DELETED_BLOCKS;
   }
 
-  @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
         getMetadataColumnFamily(), getDeletedBlocksColumnFamily() };

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -88,4 +88,10 @@ public class DatanodeSchemaOneDBDefinition
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
   }
+
+  @Override
+  public DBColumnFamilyDefinition[] getColumnFamilies() {
+    return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
+        getMetadataColumnFamily(), getDeletedBlocksColumnFamily() };
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -17,11 +17,14 @@
  */
 package org.apache.hadoop.ozone.container.metadata;
 
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 
 /**
  * This class defines the RocksDB structure for datanodes following schema
@@ -58,8 +61,24 @@ public class DatanodeSchemaTwoDBDefinition extends
                   ChunkInfoList.class,
                   new ChunkInfoListCodec());
 
+  public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
+      TXN =
+      new DBColumnFamilyDefinition<>(
+          "txnTable",
+          Long.class,
+          new LongCodec(),
+          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.class,
+          new DeletedBlocksTransactionCodec());
+
   protected DatanodeSchemaTwoDBDefinition(String dbPath) {
     super(dbPath);
+  }
+
+  @Override
+  public DBColumnFamilyDefinition[] getColumnFamilies() {
+    return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
+        getMetadataColumnFamily(), getDeletedBlocksColumnFamily(),
+        getTxnBlocksColumnFamily()};
   }
 
   @Override
@@ -77,5 +96,10 @@ public class DatanodeSchemaTwoDBDefinition extends
   public DBColumnFamilyDefinition<String, ChunkInfoList>
       getDeletedBlocksColumnFamily() {
     return DELETED_BLOCKS;
+  }
+
+  public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
+      getTxnBlocksColumnFamily() {
+    return TXN;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -28,8 +28,8 @@ import org.apache.hadoop.hdds.protocol.proto
 
 /**
  * This class defines the RocksDB structure for datanodes following schema
- * version 2, where the block data, metadata, and deleted block ids are put in
- * their own separate column families.
+ * version 2, where the block data, metadata, and transactions which are to be
+ * deleted are put in their own separate column families.
  */
 public class DatanodeSchemaTwoDBDefinition extends
         AbstractDatanodeDBDefinition {
@@ -62,7 +62,7 @@ public class DatanodeSchemaTwoDBDefinition extends
                   new ChunkInfoListCodec());
 
   public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
-      TXN =
+      DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
           "txnTable",
           Long.class,
@@ -78,7 +78,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
         getMetadataColumnFamily(), getDeletedBlocksColumnFamily(),
-        getTxnBlocksColumnFamily()};
+        getDeleteTransactionsColumnFamily()};
   }
 
   @Override
@@ -99,7 +99,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   }
 
   public DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
-      getTxnBlocksColumnFamily() {
-    return TXN;
+      getDeleteTransactionsColumnFamily() {
+    return DELETE_TRANSACTION;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -37,7 +37,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<String, BlockData>
           BLOCK_DATA =
           new DBColumnFamilyDefinition<>(
-                  "block_data",
+                  "blockData",
                   String.class,
                   new StringCodec(),
                   BlockData.class,
@@ -55,7 +55,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<String, ChunkInfoList>
           DELETED_BLOCKS =
           new DBColumnFamilyDefinition<>(
-                  "deleted_blocks",
+                  "deletedBlocks",
                   String.class,
                   new StringCodec(),
                   ChunkInfoList.class,
@@ -64,7 +64,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
-          "txnTable",
+          "deleteTxns",
           Long.class,
           new LongCodec(),
           StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.class,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.proto.
+    StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.utils.db.TypedTable;
 
 import java.io.IOException;
 
@@ -30,6 +33,8 @@ import java.io.IOException;
  */
 public class DatanodeStoreSchemaTwoImpl extends AbstractDatanodeStore {
 
+  private TypedTable<Long, DeletedBlocksTransaction> txnTable;
+
   /**
    * Constructs the datanode store and starts the DB Services.
    *
@@ -41,5 +46,13 @@ public class DatanodeStoreSchemaTwoImpl extends AbstractDatanodeStore {
       throws IOException {
     super(config, containerID, new DatanodeSchemaTwoDBDefinition(dbPath),
         openReadOnly);
+    this.txnTable =
+        (TypedTable<Long, DeletedBlocksTransaction>) new
+            DatanodeSchemaTwoDBDefinition(
+            dbPath).getTxnBlocksColumnFamily().getTable(getStore());
+  }
+
+  public TypedTable<Long, DeletedBlocksTransaction> getTxnTable(){
+    return txnTable;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeStoreSchemaTwoImpl.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.container.metadata;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.
     StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
-import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.apache.hadoop.hdds.utils.db.Table;
 
 import java.io.IOException;
 
@@ -29,11 +29,12 @@ import java.io.IOException;
  * three column families/tables:
  * 1. A block data table.
  * 2. A metadata table.
- * 3. A deleted blocks table.
+ * 3. A Delete Transaction Table.
  */
 public class DatanodeStoreSchemaTwoImpl extends AbstractDatanodeStore {
 
-  private TypedTable<Long, DeletedBlocksTransaction> txnTable;
+  private final Table<Long, DeletedBlocksTransaction>
+      deleteTransactionTable;
 
   /**
    * Constructs the datanode store and starts the DB Services.
@@ -46,13 +47,11 @@ public class DatanodeStoreSchemaTwoImpl extends AbstractDatanodeStore {
       throws IOException {
     super(config, containerID, new DatanodeSchemaTwoDBDefinition(dbPath),
         openReadOnly);
-    this.txnTable =
-        (TypedTable<Long, DeletedBlocksTransaction>) new
-            DatanodeSchemaTwoDBDefinition(
-            dbPath).getTxnBlocksColumnFamily().getTable(getStore());
+    this.deleteTransactionTable = new DatanodeSchemaTwoDBDefinition(dbPath)
+        .getDeleteTransactionsColumnFamily().getTable(getStore());
   }
 
-  public TypedTable<Long, DeletedBlocksTransaction> getTxnTable(){
-    return txnTable;
+  public Table<Long, DeletedBlocksTransaction> getDeleteTransactionTable() {
+    return deleteTransactionTable;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DeletedBlocksTransactionCodec.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DeletedBlocksTransactionCodec.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.metadata;
+
+import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+
+import java.io.IOException;
+
+/**
+ * Supports encoding and decoding {@link DeletedBlocksTransaction} objects.
+ */
+public class DeletedBlocksTransactionCodec
+    implements Codec<DeletedBlocksTransaction> {
+
+  @Override public byte[] toPersistedFormat(
+      DeletedBlocksTransaction deletedBlocksTransaction) {
+    return deletedBlocksTransaction.toByteArray();
+  }
+
+  @Override public DeletedBlocksTransaction fromPersistedFormat(byte[] rawData)
+      throws IOException {
+    return DeletedBlocksTransaction.parseFrom(rawData);
+  }
+
+  @Override public DeletedBlocksTransaction copyObject(
+      DeletedBlocksTransaction deletedBlocksTransaction) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -89,7 +89,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTA
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
-import static org.apache.hadoop.ozone.OzoneConsts.*;
+import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_VERSIONS;
+import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V1;
+import static org.apache.hadoop.ozone.OzoneConsts.SCHEMA_V2;
 import static org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion.FILE_PER_BLOCK;
 import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
 import static org.mockito.ArgumentMatchers.any;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -21,9 +21,11 @@ package org.apache.hadoop.ozone.container.common;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.UUID;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -34,9 +36,13 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
@@ -55,7 +61,6 @@ import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
-import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
@@ -64,11 +69,14 @@ import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerBlockStrategy;
 import org.apache.hadoop.ozone.container.keyvalue.impl.FilePerChunkStrategy;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.container.testutils.BlockDeletingServiceTestImpl;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.GenericTestUtils.LogCapturer;
 
+import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
 
 import org.junit.AfterClass;
@@ -82,7 +90,9 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_CONTA
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
+import static org.apache.hadoop.ozone.OzoneConsts.*;
 import static org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion.FILE_PER_BLOCK;
+import static org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask.LOG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -101,16 +111,38 @@ public class TestBlockDeletingService {
   private static MutableConfigurationSource conf;
 
   private final ChunkLayOutVersion layout;
+  private final String schemaVersion;
   private int blockLimitPerTask;
   private static VolumeSet volumeSet;
 
-  public TestBlockDeletingService(ChunkLayOutVersion layout) {
-    this.layout = layout;
+  public TestBlockDeletingService(LayoutInfo layoutInfo) {
+    this.layout = layoutInfo.layout;
+    this.schemaVersion = layoutInfo.schemaVersion;
   }
 
   @Parameterized.Parameters
   public static Iterable<Object[]> parameters() {
-    return ChunkLayoutTestInfo.chunkLayoutParameters();
+    return LayoutInfo.layoutList.stream().map(each -> new Object[] {each})
+        .collect(toList());
+  }
+
+  public static class LayoutInfo {
+    private final String schemaVersion;
+    private final ChunkLayOutVersion layout;
+
+    public LayoutInfo(String schemaVersion, ChunkLayOutVersion layout) {
+      this.schemaVersion = schemaVersion;
+      this.layout = layout;
+    }
+
+    private static List<LayoutInfo> layoutList = new ArrayList<>();
+    static {
+      for (ChunkLayOutVersion ch : ChunkLayOutVersion.getAllVersions()) {
+        for (String sch : SCHEMA_VERSIONS) {
+          layoutList.add(new LayoutInfo(sch, ch));
+        }
+      }
+    }
   }
 
   @BeforeClass
@@ -158,6 +190,7 @@ public class TestBlockDeletingService {
     }
     byte[] arr = randomAlphanumeric(1048576).getBytes(UTF_8);
     ChunkBuffer buffer = ChunkBuffer.wrap(ByteBuffer.wrap(arr));
+    int txnID = 0;
     for (int x = 0; x < numOfContainers; x++) {
       long containerID = ContainerTestHelper.getTestContainerID();
       KeyValueContainerData data =
@@ -165,55 +198,156 @@ public class TestBlockDeletingService {
               ContainerTestHelper.CONTAINER_MAX_SIZE,
               UUID.randomUUID().toString(), datanodeUuid);
       data.closeContainer();
+      data.setSchemaVersion(schemaVersion);
       KeyValueContainer container = new KeyValueContainer(data, conf);
       container.create(volumeSet,
           new RoundRobinVolumeChoosingPolicy(), scmId);
       containerSet.addContainer(container);
       data = (KeyValueContainerData) containerSet.getContainer(
           containerID).getContainerData();
-      long chunkLength = 100;
-      try(ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
-        for (int j = 0; j < numOfBlocksPerContainer; j++) {
+      if (data.getSchemaVersion().equals(SCHEMA_V1)) {
+        try(ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
+          for (int j = 0; j < numOfBlocksPerContainer; j++) {
+            BlockID blockID =
+                ContainerTestHelper.getTestBlockID(containerID);
+            String deleteStateName = OzoneConsts.DELETING_KEY_PREFIX +
+                blockID.getLocalID();
+            BlockData kd = new BlockData(blockID);
+            List<ContainerProtos.ChunkInfo> chunks = Lists.newArrayList();
+            putChunksInBlock(numOfChunksPerBlock, j, chunks, buffer,
+                chunkManager, container, blockID);
+            kd.setChunks(chunks);
+            metadata.getStore().getBlockDataTable().put(
+                deleteStateName, kd);
+            container.getContainerData().incrPendingDeletionBlocks(1);
+          }
+          updateMetaData(data, container, numOfBlocksPerContainer,
+              numOfChunksPerBlock);
+        }
+      } else if (data.getSchemaVersion().equals(SCHEMA_V2)) {
+        Map<Long, List<Long>> containerBlocks = new HashMap<>();
+        int blockCount = 0;
+        for (int i = 0; i < numOfBlocksPerContainer; i++) {
+          txnID = txnID + 1;
           BlockID blockID =
               ContainerTestHelper.getTestBlockID(containerID);
-          String deleteStateName = OzoneConsts.DELETING_KEY_PREFIX +
-              blockID.getLocalID();
           BlockData kd = new BlockData(blockID);
           List<ContainerProtos.ChunkInfo> chunks = Lists.newArrayList();
-          for (int k = 0; k < numOfChunksPerBlock; k++) {
-            final String chunkName = String.format("block.%d.chunk.%d", j, k);
-            final long offset = k * chunkLength;
-            ContainerProtos.ChunkInfo info =
-                ContainerProtos.ChunkInfo.newBuilder()
-                    .setChunkName(chunkName)
-                    .setLen(chunkLength)
-                    .setOffset(offset)
-                    .setChecksumData(Checksum.getNoChecksumDataProto())
-                    .build();
-            chunks.add(info);
-            ChunkInfo chunkInfo = new ChunkInfo(chunkName, offset, chunkLength);
-            ChunkBuffer chunkData = buffer.duplicate(0, (int) chunkLength);
-            chunkManager.writeChunk(container, blockID, chunkInfo, chunkData,
-                WRITE_STAGE);
-            chunkManager.writeChunk(container, blockID, chunkInfo, chunkData,
-                COMMIT_STAGE);
-          }
+          putChunksInBlock(numOfChunksPerBlock, i, chunks, buffer, chunkManager,
+              container, blockID);
           kd.setChunks(chunks);
-          metadata.getStore().getBlockDataTable().put(
-                  deleteStateName, kd);
+          try(ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
+            String bID = blockID.getLocalID()+"";
+            metadata.getStore().getBlockDataTable().put(bID, kd);
+          }
           container.getContainerData().incrPendingDeletionBlocks(1);
+
+          // In below if statements we are checking if a single container
+          // consists of more blocks than 'blockLimitPerTask' then we create
+          // (totalBlocksInContainer / blockLimitPerTask) transactions which
+          // consists of blocks equal to blockLimitPerTask and last transaction
+          // consists of blocks equal to
+          // (totalBlocksInContainer % blockLimitPerTask).
+          if (blockCount < blockLimitPerTask) {
+            if (containerBlocks.containsKey(containerID)) {
+              containerBlocks.get(containerID).add(blockID.getLocalID());
+            } else {
+              List<Long> item = new ArrayList<>();
+              item.add(blockID.getLocalID());
+              containerBlocks.put(containerID, item);
+            }
+            blockCount++;
+          }
+          boolean flag = false;
+          if (blockCount == blockLimitPerTask) {
+            createTxn(data, containerBlocks, txnID);
+            containerBlocks.clear();
+            blockCount = 0;
+            flag = true;
+          }
+          if (i == (numOfBlocksPerContainer - 1) && !flag) {
+            createTxn(data, containerBlocks, txnID);
+          }
         }
-        container.getContainerData().setKeyCount(numOfBlocksPerContainer);
-        // Set block count, bytes used and pending delete block count.
-        metadata.getStore().getMetadataTable().put(
-                OzoneConsts.BLOCK_COUNT, (long)numOfBlocksPerContainer);
-        metadata.getStore().getMetadataTable().put(
-                OzoneConsts.CONTAINER_BYTES_USED,
-            chunkLength * numOfChunksPerBlock * numOfBlocksPerContainer);
-        metadata.getStore().getMetadataTable().put(
-                OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
-                (long)numOfBlocksPerContainer);
+        updateMetaData(data, container, numOfBlocksPerContainer,
+            numOfChunksPerBlock);
+      } else {
+        throw new UnsupportedOperationException(
+            "Only schema version 1 and schema version 2 are "
+                + "supported.");
       }
+    }
+  }
+
+  private void createTxn(KeyValueContainerData data,
+      Map<Long, List<Long>> containerBlocks, int txnID) {
+    try(ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
+      for (Map.Entry<Long, List<Long>> entry : containerBlocks.entrySet()) {
+        StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction
+            dtx =
+            StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction
+                .newBuilder().setTxID(txnID)
+                .setContainerID(entry.getKey())
+                .addAllLocalID(entry.getValue()).setCount(0).build();
+        try (BatchOperation batch = metadata.getStore().getBatchHandler()
+            .initBatchOperation()) {
+          DatanodeStore ds = metadata.getStore();
+          DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
+              (DatanodeStoreSchemaTwoImpl) ds;
+          dnStoreTwoImpl.getTxnTable()
+              .putWithBatch(batch, (long) txnID, dtx);
+          metadata.getStore().getBatchHandler().commitBatchOperation(batch);
+        }
+      }
+    } catch (IOException exception) {
+      LOG.warn("Transaction creation was not successful for txnID: " + txnID
+          + " consisting of " + containerBlocks.size() + " blocks.");
+    }
+  }
+
+  private void putChunksInBlock(int numOfChunksPerBlock, int i,
+      List<ContainerProtos.ChunkInfo> chunks, ChunkBuffer buffer,
+      ChunkManager chunkManager, KeyValueContainer container, BlockID blockID) {
+    long chunkLength = 100;
+    try {
+      for (int k = 0; k < numOfChunksPerBlock; k++) {
+        final String chunkName = String.format("block.%d.chunk.%d", i, k);
+        final long offset = k * chunkLength;
+        ContainerProtos.ChunkInfo info =
+            ContainerProtos.ChunkInfo.newBuilder().setChunkName(chunkName)
+                .setLen(chunkLength).setOffset(offset)
+                .setChecksumData(Checksum.getNoChecksumDataProto()).build();
+        chunks.add(info);
+        ChunkInfo chunkInfo = new ChunkInfo(chunkName, offset, chunkLength);
+        ChunkBuffer chunkData = buffer.duplicate(0, (int) chunkLength);
+        chunkManager
+            .writeChunk(container, blockID, chunkInfo, chunkData, WRITE_STAGE);
+        chunkManager
+            .writeChunk(container, blockID, chunkInfo, chunkData, COMMIT_STAGE);
+      }
+    } catch (IOException ex) {
+      LOG.warn("Putting chunks in blocks was not successful for BlockID: "
+          + blockID);
+    }
+  }
+
+  private void updateMetaData(KeyValueContainerData data,
+      KeyValueContainer container, int numOfBlocksPerContainer,
+      int numOfChunksPerBlock) {
+    long chunkLength = 100;
+    try (ReferenceCountedDB metadata = BlockUtils.getDB(data, conf)) {
+      container.getContainerData().setKeyCount(numOfBlocksPerContainer);
+      // Set block count, bytes used and pending delete block count.
+      metadata.getStore().getMetadataTable()
+          .put(OzoneConsts.BLOCK_COUNT, (long) numOfBlocksPerContainer);
+      metadata.getStore().getMetadataTable()
+          .put(OzoneConsts.CONTAINER_BYTES_USED,
+              chunkLength * numOfChunksPerBlock * numOfBlocksPerContainer);
+      metadata.getStore().getMetadataTable()
+          .put(OzoneConsts.PENDING_DELETE_BLOCK_COUNT,
+              (long) numOfBlocksPerContainer);
+    } catch (IOException exception) {
+      LOG.warn("Meta Data update was not successful for container: "+container);
     }
   }
 
@@ -231,11 +365,32 @@ public class TestBlockDeletingService {
    * Get under deletion blocks count from DB,
    * note this info is parsed from container.db.
    */
-  private int getUnderDeletionBlocksCount(ReferenceCountedDB meta)
-      throws IOException {
-    return meta.getStore().getBlockDataTable()
-        .getRangeKVs(null, 100,
-        MetadataKeyFilters.getDeletingKeyFilter()).size();
+  private int getUnderDeletionBlocksCount(ReferenceCountedDB meta,
+      KeyValueContainerData data) throws IOException {
+    if (data.getSchemaVersion().equals(SCHEMA_V1)) {
+      return meta.getStore().getBlockDataTable()
+          .getRangeKVs(null, 100, MetadataKeyFilters.getDeletingKeyFilter())
+          .size();
+    } else if (data.getSchemaVersion().equals(SCHEMA_V2)) {
+      int pendingBlocks = 0;
+      DatanodeStore ds = meta.getStore();
+      DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
+          (DatanodeStoreSchemaTwoImpl) ds;
+      try (
+          TableIterator<Long, ? extends Table.KeyValue<Long, 
+              StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction>> 
+              iter = dnStoreTwoImpl.getTxnTable().iterator()) {
+        while (iter.hasNext()) {
+          StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction
+              delTx = iter.next().getValue();
+          pendingBlocks += delTx.getLocalIDList().size();
+        }
+      }
+      return pendingBlocks;
+    } else {
+      throw new UnsupportedOperationException(
+          "Only schema version 1 and schema version 2 are supported.");
+    }
   }
 
 
@@ -261,6 +416,7 @@ public class TestBlockDeletingService {
     // Ensure 1 container was created
     List<ContainerData> containerData = Lists.newArrayList();
     containerSet.listContainer(0L, 1, containerData);
+    KeyValueContainerData data = (KeyValueContainerData) containerData.get(0);
     Assert.assertEquals(1, containerData.size());
 
     try(ReferenceCountedDB meta = BlockUtils.getDB(
@@ -280,7 +436,7 @@ public class TestBlockDeletingService {
       Assert.assertEquals(0, transactionId);
 
       // Ensure there are 3 blocks under deletion and 0 deleted blocks
-      Assert.assertEquals(3, getUnderDeletionBlocksCount(meta));
+      Assert.assertEquals(3, getUnderDeletionBlocksCount(meta, data));
       Assert.assertEquals(3, meta.getStore().getMetadataTable()
           .get(OzoneConsts.PENDING_DELETE_BLOCK_COUNT).longValue());
 
@@ -348,6 +504,9 @@ public class TestBlockDeletingService {
   public void testBlockDeletionTimeout() throws Exception {
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
+    this.blockLimitPerTask =
+        conf.getInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER,
+            OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT);
     ContainerSet containerSet = new ContainerSet();
     createToDeleteBlocks(containerSet, 1, 3, 1);
     ContainerMetrics metrics = ContainerMetrics.create(conf);
@@ -394,7 +553,7 @@ public class TestBlockDeletingService {
       LogCapturer newLog = LogCapturer.captureLogs(BackgroundService.LOG);
       GenericTestUtils.waitFor(() -> {
         try {
-          return getUnderDeletionBlocksCount(meta) == 0;
+          return getUnderDeletionBlocksCount(meta, data) == 0;
         } catch (IOException ignored) {
         }
         return false;
@@ -445,6 +604,9 @@ public class TestBlockDeletingService {
         TopNOrderedContainerDeletionChoosingPolicy.class.getName());
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 1);
     conf.setInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 1);
+    this.blockLimitPerTask =
+        conf.getInt(OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER,
+            OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER_DEFAULT);
     ContainerSet containerSet = new ContainerSet();
 
     int containerCount = 2;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -92,11 +92,15 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.NET_TOPOLOGY_NODE_SWITCH_MAPPING_IMPL_KEY;
-import static org.apache.hadoop.hdds.HddsConfigKeys.*;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Test class that exercises the StorageContainerManager.
@@ -272,8 +276,6 @@ public class TestStorageContainerManager {
 
       Map<Long, List<Long>> containerBlocks = createDeleteTXLog(delLog,
           keyLocations, helper);
-      Set<Long> containerIDs = containerBlocks.keySet();
-
       // Verify a few TX gets created in the TX log.
       Assert.assertTrue(delLog.getNumOfValidTransactions() > 0);
 
@@ -289,8 +291,7 @@ public class TestStorageContainerManager {
           return false;
         }
       }, 1000, 10000);
-      Assert.assertTrue(helper.getAllBlocks(containerIDs).isEmpty());
-
+      Assert.assertTrue(helper.verifyBlocksWithTxnTable(containerBlocks));
       // Continue the work, add some TXs that with known container names,
       // but unknown block IDs.
       for (Long containerID : containerBlocks.keySet()) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -151,12 +151,13 @@ public class TestStorageContainerManagerHelper {
       DatanodeStore ds = meta.getStore();
       DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
           (DatanodeStoreSchemaTwoImpl) ds;
-      List<? extends Table.KeyValue<Long, DeletedBlocksTransaction>> kvs =
-          dnStoreTwoImpl.getTxnTable()
-              .getRangeKVs(null, Integer.MAX_VALUE, null);
+      List<? extends Table.KeyValue<Long, DeletedBlocksTransaction>>
+          txnsInTxnTable = dnStoreTwoImpl.getDeleteTransactionTable()
+          .getRangeKVs(null, Integer.MAX_VALUE, null);
       List<Long> conID = new ArrayList<>();
-      for (Table.KeyValue<Long, DeletedBlocksTransaction> kv : kvs) {
-        conID.addAll(kv.getValue().getLocalIDList());
+      for (Table.KeyValue<Long, DeletedBlocksTransaction> txn :
+          txnsInTxnTable) {
+        conID.addAll(txn.getValue().getLocalIDList());
       }
       if (!conID.equals(containerBlocks.get(entry))) {
         return false;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,9 +33,14 @@ import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -135,6 +141,29 @@ public class TestStorageContainerManagerHelper {
     }
     meta.close();
     return allBlocks;
+  }
+
+  public boolean verifyBlocksWithTxnTable(Map<Long, List<Long>> containerBlocks)
+      throws IOException {
+    Set<Long> containerIDs = containerBlocks.keySet();
+    for (Long entry : containerIDs) {
+      ReferenceCountedDB meta = getContainerMetadata(entry);
+      DatanodeStore ds = meta.getStore();
+      DatanodeStoreSchemaTwoImpl dnStoreTwoImpl =
+          (DatanodeStoreSchemaTwoImpl) ds;
+      List<? extends Table.KeyValue<Long, DeletedBlocksTransaction>> kvs =
+          dnStoreTwoImpl.getTxnTable()
+              .getRangeKVs(null, Integer.MAX_VALUE, null);
+      List<Long> conID = new ArrayList<>();
+      for (Table.KeyValue<Long, DeletedBlocksTransaction> kv : kvs) {
+        conID.addAll(kv.getValue().getLocalIDList());
+      }
+      if (!conID.equals(containerBlocks.get(entry))) {
+        return false;
+      }
+      meta.close();
+    }
+    return true;
   }
 
   private ReferenceCountedDB getContainerMetadata(Long containerID)


### PR DESCRIPTION

## What changes were proposed in this pull request?

Currently datanode breaks down the transaction into individual blocks and then stores every block as separate entry in rocksDB. Since transaction can contain multiple blocks it is better to store the entire transaction in rocksDB.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4369

## How was this patch tested?

Tested Manually.