### PR TITLE
HDDS-4590. Duplicate dependency hadoop-hdds-hadoop-dependency-server in datanode

### DIFF
--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -40,11 +40,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdds-hadoop-dependency-server</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdds-container-service</artifactId>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove duplicate `dependency` on `hadoop-hdds-hadoop-dependency-server` from `hadoop-ozone/datanode`.

https://issues.apache.org/jira/browse/HDDS-4590

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/422492007

No warning here:
https://github.com/adoroszlai/hadoop-ozone/runs/1555113377#step:6:13