### PR TITLE
HDDS-4595. RDBScanner should print table name if it is not present in the db definition.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -142,7 +142,9 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
     this.columnFamilyMap = new HashMap<>();
     DBColumnFamilyDefinition[] columnFamilyDefinitions = dbDefinition
             .getColumnFamilies();
-    for(DBColumnFamilyDefinition definition:columnFamilyDefinitions){
+    for (DBColumnFamilyDefinition definition:columnFamilyDefinitions) {
+      System.out.println("Added definition for table:" +
+          definition.getTableName());
       this.columnFamilyMap.put(definition.getTableName(), definition);
     }
   }
@@ -173,7 +175,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
             getDefinition(new File(dbPath).getName()));
     if (this.columnFamilyMap !=null) {
       if (!this.columnFamilyMap.containsKey(tableName)) {
-        System.out.print("Table with specified name does not exist");
+        System.out.print("Table with name:" + tableName + " does not exist");
       } else {
         DBColumnFamilyDefinition columnFamilyDefinition =
                 this.columnFamilyMap.get(tableName);


### PR DESCRIPTION
## What changes were proposed in this pull request?
Recently discovered that with branch HDDS-2939, the newly added directory table is missing from the DB definition array.
So the tool wasn't able to parse the table which really exists on the rocksdb.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4595

## How was this patch tested?
Manual testing
