### PR TITLE
HDDS-4603. Use Java built-in Supplier instead of Guava one

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -33,6 +33,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.HddsUtils;
@@ -51,7 +52,6 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Supplier;
 import org.apache.ratis.client.RaftClient;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.proto.RaftProtos;


### PR DESCRIPTION
HDDS-4603. Writing file to a new key failed when integrating Ozone and HBase in my custom project

## What changes were proposed in this pull request?

changed import com.google.common.base.Supplier to java.util.function.Supplier in org.apache.hadoop.hdds.scm.XceiverClientRatis

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4603

## How was this patch tested?
envs: 
Spring Boot: 2.2.6.RELEASE
Apache Ozone: 1.1.0-SNAPSHOT(master)
Apache HBase: 1.2.1
Apache HDFS: 2.7.2

cases:
1. upload a new file with ofs api -- passed
2. upload a new file with native java api -- passed
3. copy a exists file to new dir with ofs api -- passed
4. copy a exists file to new dir with native java api -- passed
 
