### PR TITLE
HDDS-4601. envtoconf broken for .conf and few other formats

### DIFF
--- a/hadoop-ozone/dist/src/main/dockerlibexec/transformation.py
+++ b/hadoop-ozone/dist/src/main/dockerlibexec/transformation.py
@@ -91,7 +91,7 @@ def to_env(content):
   """transform to environment variables"""
   result = ""
   props = process_properties(content)
-  for key, val in props:
+  for key, val in props.items():
     result += "{}={}\n".format(key, val)
   return result
 
@@ -100,7 +100,7 @@ def to_sh(content):
   """transform to shell"""
   result = ""
   props = process_properties(content)
-  for key, val in props:
+  for key, val in props.items():
     result += "export {}=\"{}\"\n".format(key, val)
   return result
 
@@ -109,7 +109,7 @@ def to_cfg(content):
   """transform to config"""
   result = ""
   props = process_properties(content)
-  for key, val in props:
+  for key, val in props.items():
     result += "{}={}\n".format(key, val)
   return result
 
@@ -118,7 +118,7 @@ def to_conf(content):
   """transform to configuration"""
   result = ""
   props = process_properties(content)
-  for key, val in props:
+  for key, val in props.items():
     result += "export {}={}\n".format(key, val)
   return result
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `envtoconf` for some output formats that are currently broken.  These are not used in Ozone, nor covered by tests.  The problem may be accidentally triggered by specific environment variable names, eg. `HBASE_CONF_DIR` or similar.

https://issues.apache.org/jira/browse/HDDS-4601

## How was this patch tested?

Test:

```
cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT
OZONE_RUNNER_VERSION=20200625-1
docker run -it --rm -e DUMMY.CONF_key=value -v $(pwd)/libexec:/opt/hadoop/libexec apache/ozone:0.5.0 bash -c 'ls ${HADOOP_CONF_DIR}/dummy.conf'
docker run -it --rm -e DUMMY.SH_key=value -v $(pwd)/libexec:/opt/hadoop/libexec apache/ozone:1.0.0 bash -c 'ls ${HADOOP_CONF_DIR}/dummy.sh'
docker run -it --rm -e DUMMY.ENV_key=value -v $(pwd)/libexec/transformation.py:/opt/transformation.py apache/hadoop:3 bash -c 'ls ${HADOOP_CONF_DIR}/dummy.env'
docker run -it --rm -e DUMMY.CFG_key=value -v $(pwd):/opt/hadoop apache/ozone-runner:${OZONE_RUNNER_VERSION} bash -c 'ls ${HADOOP_CONF_DIR}/dummy.cfg'
```

Output:

```
/etc/hadoop/dummy.conf
/etc/hadoop/dummy.sh
/etc/hadoop/dummy.env
/etc/hadoop/dummy.cfg
```