### PR TITLE
HDDS-4592. False negative acceptance test in ozone-mr

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
@@ -35,3 +35,4 @@ for t in ${tests}; do
   copy_results "${d}" "${ALL_RESULT_DIR}"
 done
 
+exit ${RESULT}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone-mr/test.sh` needs to return its result to allow `test-all.sh` to catch failures.

https://issues.apache.org/jira/browse/HDDS-4592

## How was this patch tested?

Verified that _acceptance (misc)_ fails if `hadoop27` is failed:

https://github.com/adoroszlai/hadoop-ozone/runs/1558684166#step:7:247
https://github.com/adoroszlai/hadoop-ozone/runs/1558684166#step:7:1896

```
ERROR: Test execution of ./hadoop27 is FAILED!!!!
...
Error: Process completed with exit code 1.
```

and that it is successful with a fix for `hadoop27` test (HDDS-4591):

https://github.com/adoroszlai/hadoop-ozone/runs/1562851938#step:7:208
https://github.com/adoroszlai/hadoop-ozone/runs/1562851938