### PR TITLE
HDDS-4608. Add a unit test to identify missing/extra tables in OMDBDefinition.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -69,15 +69,6 @@ public class OMDBDefinition implements DBDefinition {
                     OmVolumeArgs.class,
                     new OmVolumeArgsCodec());
 
-  public static final DBColumnFamilyDefinition<String, String>
-            S3_TABLE=
-            new DBColumnFamilyDefinition<>(
-                    "s3Table",
-                    String.class,
-                    new StringCodec(),
-                    String.class,
-                    new StringCodec());
-
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             OPEN_KEY_TABLE =
             new DBColumnFamilyDefinition<>(
@@ -164,7 +155,7 @@ public class OMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_TABLE, USER_TABLE,
-        VOLUME_TABLE, S3_TABLE, OPEN_KEY_TABLE, KEY_TABLE,
+        VOLUME_TABLE, OPEN_KEY_TABLE, KEY_TABLE,
         BUCKET_TABLE, MULTIPART_INFO_TABLE, PREFIX_TABLE, DTOKEN_TABLE,
         S3_SECRET_TABLE, TRANSACTION_INFO_TABLE};
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
 import org.apache.hadoop.hdds.utils.db.StringCodec;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -44,7 +45,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, RepeatedOmKeyInfo>
             DELETED_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "deletedTable",
+                    OmMetadataManagerImpl.DELETED_TABLE,
                     String.class,
                     new StringCodec(),
                     RepeatedOmKeyInfo.class,
@@ -54,7 +55,7 @@ public class OMDBDefinition implements DBDefinition {
             OzoneManagerStorageProtos.PersistedUserVolumeInfo>
             USER_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "userTable",
+                    OmMetadataManagerImpl.USER_TABLE,
                     String.class,
                     new StringCodec(),
                     OzoneManagerStorageProtos.PersistedUserVolumeInfo.class,
@@ -63,7 +64,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmVolumeArgs>
             VOLUME_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "volumeTable",
+                    OmMetadataManagerImpl.VOLUME_TABLE,
                     String.class,
                     new StringCodec(),
                     OmVolumeArgs.class,
@@ -72,7 +73,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             OPEN_KEY_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "openKeyTable",
+                    OmMetadataManagerImpl.OPEN_KEY_TABLE,
                     String.class,
                     new StringCodec(),
                     OmKeyInfo.class,
@@ -81,7 +82,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmKeyInfo>
             KEY_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "keyTable",
+                    OmMetadataManagerImpl.KEY_TABLE,
                     String.class,
                     new StringCodec(),
                     OmKeyInfo.class,
@@ -90,7 +91,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmBucketInfo>
             BUCKET_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "bucketTable",
+                    OmMetadataManagerImpl.BUCKET_TABLE,
                     String.class,
                     new StringCodec(),
                     OmBucketInfo.class,
@@ -99,7 +100,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmMultipartKeyInfo>
             MULTIPART_INFO_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "multipartInfoTable",
+                    OmMetadataManagerImpl.MULTIPARTINFO_TABLE,
                     String.class,
                     new StringCodec(),
                     OmMultipartKeyInfo.class,
@@ -108,7 +109,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, OmPrefixInfo>
             PREFIX_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "prefixTable",
+                    OmMetadataManagerImpl.PREFIX_TABLE,
                     String.class,
                     new StringCodec(),
                     OmPrefixInfo.class,
@@ -117,7 +118,7 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<OzoneTokenIdentifier, Long>
             DTOKEN_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "dTokenTable",
+                    OmMetadataManagerImpl.DELEGATION_TOKEN_TABLE,
                     OzoneTokenIdentifier.class,
                     new TokenIdentifierCodec(),
                     Long.class,
@@ -126,25 +127,24 @@ public class OMDBDefinition implements DBDefinition {
   public static final DBColumnFamilyDefinition<String, S3SecretValue>
             S3_SECRET_TABLE =
             new DBColumnFamilyDefinition<>(
-                    "s3SecretTable",
+                    OmMetadataManagerImpl.S3_SECRET_TABLE,
                     String.class,
                     new StringCodec(),
                     S3SecretValue.class,
                     new S3SecretValueCodec());
 
   public static final DBColumnFamilyDefinition<String, OMTransactionInfo>
-      TRANSACTION_INFO_TABLE =
-      new DBColumnFamilyDefinition<>(
-          OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
-          String.class,
-          new StringCodec(),
-          OMTransactionInfo.class,
-          new OMTransactionInfoCodec());
-
+            TRANSACTION_INFO_TABLE =
+            new DBColumnFamilyDefinition<>(
+                    OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
+                    String.class,
+                    new StringCodec(),
+                    OMTransactionInfo.class,
+                    new OMTransactionInfoCodec());
 
   @Override
   public String getName() {
-    return "om.db";
+    return OzoneConsts.OM_DB_NAME;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
+import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * Test that all the tables are covered both by OMDBDefinition
+ * as well as OmMetadataManagerImpl.
+ */
+public class TestOMDBDefinition {
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Test
+  public void testDBDefinition() throws Exception {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    File metaDir = folder.getRoot();
+    DBStore store = OmMetadataManagerImpl.loadDB(configuration, metaDir);
+    OMDBDefinition dbDef = new OMDBDefinition();
+
+    // Get list of tables from DB Definitions
+    DBColumnFamilyDefinition[] columnFamilyDefinitions =
+        dbDef.getColumnFamilies();
+    ArrayList<String> missingDBDefTables = new ArrayList<>();
+
+    // Get list of tables from the RocksDB Store
+    Collection<String> missingOmDBTables =
+        store.getTableNames().values();
+    missingOmDBTables.remove("default");
+
+    // Remove the file if it is found in both the datastructures
+    for(DBColumnFamilyDefinition definition : columnFamilyDefinitions) {
+      if (!missingOmDBTables.remove(definition.getName())) {
+        missingDBDefTables.add(definition.getName());
+      }
+    }
+
+    Assert.assertEquals(missingDBDefTables.size(), 0);
+    Assert.assertEquals(missingOmDBTables.size(), 0);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMDBDefinition.java
@@ -50,13 +50,14 @@ public class TestOMDBDefinition {
     // Get list of tables from DB Definitions
     DBColumnFamilyDefinition[] columnFamilyDefinitions =
         dbDef.getColumnFamilies();
+    int countOmDefTables = columnFamilyDefinitions.length;
     ArrayList<String> missingDBDefTables = new ArrayList<>();
 
     // Get list of tables from the RocksDB Store
     Collection<String> missingOmDBTables =
         store.getTableNames().values();
     missingOmDBTables.remove("default");
-
+    int countOmDBTables = missingOmDBTables.size();
     // Remove the file if it is found in both the datastructures
     for(DBColumnFamilyDefinition definition : columnFamilyDefinitions) {
       if (!missingOmDBTables.remove(definition.getName())) {
@@ -64,7 +65,10 @@ public class TestOMDBDefinition {
       }
     }
 
-    Assert.assertEquals(missingDBDefTables.size(), 0);
-    Assert.assertEquals(missingOmDBTables.size(), 0);
+    Assert.assertEquals("Tables in OmMetadataManagerImpl are:"
+            + missingDBDefTables, 0, missingDBDefTables.size());
+    Assert.assertEquals("Tables missing in OMDBDefinition are:"
+        + missingOmDBTables, 0, missingOmDBTables.size());
+    Assert.assertEquals(countOmDBTables, countOmDefTables);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a unit test to identify missing/extra tables in OMDBDefinition

One example of such a case is the s3Table

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4608

## How was this patch tested?
Added a new unit test
