### PR TITLE
HDDS-4588. If volume's quota is enabled then bucket's quota cannot be cleared

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -231,7 +231,9 @@ public class OMException extends IOException {
 
     PARTIAL_RENAME,
 
-    QUOTA_EXCEEDED
+    QUOTA_EXCEEDED,
+
+    QUOTA_ERROR
 
   }
 }

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -58,17 +58,17 @@ Test ozone shell
     ${result} =     Execute             ozone sh bucket list ${protocol}${server}/${volume}/ | jq -r '. | select(.name=="bb1") | .volumeName'
                     Should Be Equal     ${result}       ${volume}
                     Run Keyword         Test key handling       ${protocol}       ${server}       ${volume}
-                    Execute             ozone sh bucket clrquota --space-quota ${protocol}${server}/${volume}/bb1
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
-                    Should Be Equal     ${result}       -1
-                    Execute             ozone sh bucket clrquota --namespace-quota ${protocol}${server}/${volume}/bb1
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
-                    Should Be Equal     ${result}       -1
                     Execute             ozone sh volume clrquota --space-quota ${protocol}${server}/${volume}
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh volume clrquota --namespace-quota ${protocol}${server}/${volume}
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInNamespace'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket clrquota --space-quota ${protocol}${server}/${volume}/bb1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
+                    Should Be Equal     ${result}       -1
+                    Execute             ozone sh bucket clrquota --namespace-quota ${protocol}${server}/${volume}/bb1
+    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -318,10 +318,6 @@ public abstract class TestOzoneRpcClientAbstract {
         " spaceQuota because volume spaceQuota is not cleared.",
         () -> ozoneBucket.clearSpaceQuota());
 
-    LambdaTestUtils.intercept(IOException.class, "Can not clear bucket" +
-        " namespaceQuota because volume namespaceQuota is not cleared.",
-        () -> ozoneBucket.clearCountQuota());
-
     store.getVolume(volumeName).clearSpaceQuota();
     store.getVolume(volumeName).clearNamespaceQuota();
     OzoneVolume clrVolume = store.getVolume(volumeName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -327,7 +327,7 @@ public abstract class TestOzoneRpcClientAbstract {
       Assert.fail("clear quota should be failed");
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("Before clear bucket " +
-          "quotaInNameSpace, volume quotaInNameSpace need to be clear first.",
+          "quotaInNamespace, volume quotaInNamespace need to be clear first.",
           ex);
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -280,7 +280,7 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
-  public void testSetAndClrQuota() throws IOException {
+  public void testSetAndClrQuota() throws Exception {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     OzoneVolume volume = null;
@@ -314,22 +314,13 @@ public abstract class TestOzoneRpcClientAbstract {
         ozoneBucket.getQuotaInBytes());
     Assert.assertEquals(1000L, ozoneBucket.getQuotaInNamespace());
 
-    try {
-      ozoneBucket.clearSpaceQuota();
-      Assert.fail("clear quota should be failed");
-    } catch (IOException ex) {
-      GenericTestUtils.assertExceptionContains("Before clear bucket " +
-          "quotaInBytes, volume quotaInBytes need to be clear first.", ex);
-    }
+    LambdaTestUtils.intercept(IOException.class, "Can not clear bucket" +
+        " spaceQuota because volume spaceQuota is not cleared.",
+        () -> ozoneBucket.clearSpaceQuota());
 
-    try {
-      ozoneBucket.clearCountQuota();
-      Assert.fail("clear quota should be failed");
-    } catch (IOException ex) {
-      GenericTestUtils.assertExceptionContains("Before clear bucket " +
-          "quotaInNamespace, volume quotaInNamespace need to be clear first.",
-          ex);
-    }
+    LambdaTestUtils.intercept(IOException.class, "Can not clear bucket" +
+        " namespaceQuota because volume namespaceQuota is not cleared.",
+        () -> ozoneBucket.clearCountQuota());
 
     store.getVolume(volumeName).clearSpaceQuota();
     store.getVolume(volumeName).clearNamespaceQuota();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -314,6 +314,23 @@ public abstract class TestOzoneRpcClientAbstract {
         ozoneBucket.getQuotaInBytes());
     Assert.assertEquals(1000L, ozoneBucket.getQuotaInNamespace());
 
+    try {
+      ozoneBucket.clearSpaceQuota();
+      Assert.fail("clear quota should be failed");
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("Before clear bucket " +
+          "quotaInBytes, volume quotaInBytes need to be clear first.", ex);
+    }
+
+    try {
+      ozoneBucket.clearCountQuota();
+      Assert.fail("clear quota should be failed");
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("Before clear bucket " +
+          "quotaInNameSpace, volume quotaInNameSpace need to be clear first.",
+          ex);
+    }
+
     store.getVolume(volumeName).clearSpaceQuota();
     store.getVolume(volumeName).clearNamespaceQuota();
     OzoneVolume clrVolume = store.getVolume(volumeName);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -318,6 +318,8 @@ enum Status {
 
     QUOTA_EXCEEDED = 66;
 
+    QUOTA_ERROR = 67;
+
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -231,7 +231,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     if (quotaInBytes == OzoneConsts.QUOTA_RESET &&
         omVolumeArgs.getQuotaInBytes() != OzoneConsts.QUOTA_RESET) {
       throw new OMException("Before clear bucket quotaInBytes," +
-          " volume quotaInBytes need to be clear first.", OMException.ResultCodes.QUOTA_ERROR);
+          " volume quotaInBytes need to be clear first.",
+          OMException.ResultCodes.QUOTA_ERROR);
     }
 
     if (quotaInBytes == 0) {
@@ -271,7 +272,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
     if (quotaInNamespace == OzoneConsts.QUOTA_RESET &&
         omVolumeArgs.getQuotaInNamespace() != OzoneConsts.QUOTA_RESET) {
       throw new OMException("Before clear bucket " +
-          "quotaInNamespace, volume quotaInNamespace need to be clear first.", OMException.ResultCodes.QUOTA_ERROR);
+          "quotaInNamespace, volume quotaInNamespace need to be clear first.",
+          OMException.ResultCodes.QUOTA_ERROR);
     }
 
     if ((quotaInNamespace <= 0

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -230,8 +230,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
     if (quotaInBytes == OzoneConsts.QUOTA_RESET &&
         omVolumeArgs.getQuotaInBytes() != OzoneConsts.QUOTA_RESET) {
-      throw new OMException("Before clear bucket quotaInBytes," +
-          " volume quotaInBytes need to be clear first.",
+      throw new OMException("Can not clear bucket spaceQuota because" +
+          " volume spaceQuota is not cleared.",
           OMException.ResultCodes.QUOTA_ERROR);
     }
 
@@ -271,8 +271,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
     if (quotaInNamespace == OzoneConsts.QUOTA_RESET &&
         omVolumeArgs.getQuotaInNamespace() != OzoneConsts.QUOTA_RESET) {
-      throw new OMException("Before clear bucket " +
-          "quotaInNamespace, volume quotaInNamespace need to be clear first.",
+      throw new OMException("Can not clear bucket namespaceQuota because" +
+          " volume namespaceQuota is not cleared.",
           OMException.ResultCodes.QUOTA_ERROR);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -266,15 +266,8 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
   }
 
   public boolean checkQuotaNamespaceValid(OmVolumeArgs omVolumeArgs,
-      OmBucketArgs omBucketArgs) throws IOException{
+      OmBucketArgs omBucketArgs) {
     long quotaInNamespace = omBucketArgs.getQuotaInNamespace();
-
-    if (quotaInNamespace == OzoneConsts.QUOTA_RESET &&
-        omVolumeArgs.getQuotaInNamespace() != OzoneConsts.QUOTA_RESET) {
-      throw new OMException("Can not clear bucket namespaceQuota because" +
-          " volume namespaceQuota is not cleared.",
-          OMException.ResultCodes.QUOTA_ERROR);
-    }
 
     if ((quotaInNamespace <= 0
          && quotaInNamespace != OzoneConsts.QUOTA_RESET)) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -228,6 +228,12 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       throws IOException {
     long quotaInBytes = omBucketArgs.getQuotaInBytes();
 
+    if (quotaInBytes == OzoneConsts.QUOTA_RESET &&
+        omVolumeArgs.getQuotaInBytes() != OzoneConsts.QUOTA_RESET) {
+      throw new OMException("Before clear bucket quotaInBytes," +
+          " volume quotaInBytes need to be clear first.", OMException.ResultCodes.QUOTA_ERROR);
+    }
+
     if (quotaInBytes == 0) {
       return false;
     }
@@ -259,8 +265,14 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
   }
 
   public boolean checkQuotaNamespaceValid(OmVolumeArgs omVolumeArgs,
-      OmBucketArgs omBucketArgs) {
+      OmBucketArgs omBucketArgs) throws IOException{
     long quotaInNamespace = omBucketArgs.getQuotaInNamespace();
+
+    if (quotaInNamespace == OzoneConsts.QUOTA_RESET &&
+        omVolumeArgs.getQuotaInNamespace() != OzoneConsts.QUOTA_RESET) {
+      throw new OMException("Before clear bucket " +
+          "quotaInNamespace, volume quotaInNamespace need to be clear first.", OMException.ResultCodes.QUOTA_ERROR);
+    }
 
     if ((quotaInNamespace <= 0
          && quotaInNamespace != OzoneConsts.QUOTA_RESET)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If volume's quota is enabled then bucket's quota cannot be cleared. We need to prompt the user to clear volume quota first.
[For more details.](https://github.com/apache/ozone/pull/1677#issuecomment-745026394)

To prevent conflicts, I have updated the usage and behavior of clear space quota in #1677.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4588

## How was this patch tested?

ut added
