### PR TITLE
HDDS-4618. Prefix resource type access check not effect after set key prefix ACLs

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/acl/OzoneNativeAuthorizer.java
@@ -148,8 +148,8 @@ public class OzoneNativeAuthorizer implements IAccessAuthorizer {
       // key will not exist at the time of creation
       boolean keyAccess = isACLTypeCreate
           || keyManager.checkAccess(objInfo, context);
-      return (keyAccess
-          && prefixManager.checkAccess(objInfo, parentContext)
+      return ((keyAccess
+          || prefixManager.checkAccess(objInfo, parentContext))
           && bucketManager.checkAccess(objInfo, parentContext)
           && volumeManager.checkAccess(objInfo, parentContext));
     case PREFIX:


### PR DESCRIPTION
Prefix resource type access check not effect after set key prefix ACLs

## What changes were proposed in this pull request?

user/groups has access permission if key or prefix matched either

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4618

## How was this patch tested?

envs:
Spring Boot: 2.2.6.RELEASE
Apache Ozone: 1.1.0-SNAPSHOT(master)
Apache HDFS: 2.7.2

cases:
1. set PREFIX resource type ACLs for "dir" key with native java api, clear KEY resource type ACLs, checked PREFIX permission -- passed
2. set KEY resource type ACLs for "dir" key with native java api, clear PREFIX resource type ACLs, checked KEY permission -- passed
