### PR TITLE
HDDS-4622. Use single ratis server in MiniOzoneCluster tests for SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -77,6 +77,10 @@ public final class RatisUtil {
     String storageDir = haConf.getRatisStorageDir();
     if (Strings.isNullOrEmpty(storageDir)) {
       storageDir = ServerUtils.getDefaultRatisDirectory(conf);
+    } else {
+      storageDir =
+          (new File(ServerUtils.getOzoneMetaDirPath(conf), storageDir))
+              .getPath();
     }
     RaftServerConfigKeys.setStorageDir(properties,
         Collections.singletonList(new File(storageDir)));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -38,7 +38,7 @@ public class SCMHAConfiguration {
 
   @Config(key = "ratis.storage.dir",
       type = ConfigType.STRING,
-      defaultValue = "",
+      defaultValue = "scm-ratis",
       tags = {OZONE, SCM, HA, RATIS},
       description = "Storage directory used by SCM to write Ratis logs."
   )
@@ -163,6 +163,10 @@ public class SCMHAConfiguration {
 
   public String getRatisStorageDir() {
     return ratisStorageDir;
+  }
+
+  public void setRatisStorageDir(String dir) {
+    this.ratisStorageDir = dir;
   }
 
   public InetSocketAddress getRatisBindAddress() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -200,12 +200,6 @@ public class SCMRatisServerImpl implements SCMRatisServer {
           Arrays.stream(conf.getTrimmedStrings(ScmConfigKeys.OZONE_SCM_NAMES))
               .map(scmName -> HddsUtils.getHostName(scmName).get())
               .collect(Collectors.toList());
-
-      List<OptionalInt> ports =
-          Arrays.stream(conf.getTrimmedStrings(ScmConfigKeys.OZONE_SCM_NAMES))
-              .map(scmName -> HddsUtils.getHostPort(scmName))
-              .collect(Collectors.toList());
-
       final List<RaftPeer> raftPeers = new ArrayList<>();
       for (int i = 0; i < hosts.size(); ++i) {
         String nodeId = "scm" + i;
@@ -217,11 +211,9 @@ public class SCMRatisServerImpl implements SCMRatisServer {
           selfPeerId = peerId;
         }
 
-        int p = ports.get(i).isPresent() ? ports.get(i).getAsInt() : port;
-
         raftPeers.add(RaftPeer.newBuilder()
             .setId(peerId)
-            .setAddress(host + ":" + p)
+            .setAddress(host + ":" + port)
             .build());
       }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
@@ -200,6 +201,11 @@ public class SCMRatisServerImpl implements SCMRatisServer {
               .map(scmName -> HddsUtils.getHostName(scmName).get())
               .collect(Collectors.toList());
 
+      List<OptionalInt> ports =
+          Arrays.stream(conf.getTrimmedStrings(ScmConfigKeys.OZONE_SCM_NAMES))
+              .map(scmName -> HddsUtils.getHostPort(scmName))
+              .collect(Collectors.toList());
+
       final List<RaftPeer> raftPeers = new ArrayList<>();
       for (int i = 0; i < hosts.size(); ++i) {
         String nodeId = "scm" + i;
@@ -211,9 +217,11 @@ public class SCMRatisServerImpl implements SCMRatisServer {
           selfPeerId = peerId;
         }
 
+        int p = ports.get(i).isPresent() ? ports.get(i).getAsInt() : port;
+
         raftPeers.add(RaftPeer.newBuilder()
             .setId(peerId)
-            .setAddress(host + ":" + port)
+            .setAddress(host + ":" + p)
             .build());
       }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -206,7 +206,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
         RaftPeerId peerId = RaftPeerId.getRaftPeerId(nodeId);
 
         String host = hosts.get(i);
-        if (InetAddress.getByName(host).equals(localHost)) {
+        if (InetAddress.getByName(host).equals(localHost)
+            || host.toLowerCase().equals("localhost")) {
           selfPeerId = peerId;
         }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -24,7 +24,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.OptionalInt;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -476,7 +476,7 @@ public final class TestUtils {
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
     conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost:0");
-//    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     return StorageContainerManager.createSCM(conf, configurator);
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -475,7 +475,7 @@ public final class TestUtils {
   public static StorageContainerManager getScmSimple(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost");
+    conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost:0");
 //    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     return StorageContainerManager.createSCM(conf, configurator);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -475,7 +475,7 @@ public final class TestUtils {
   public static StorageContainerManager getScmSimple(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost:0");
+    conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost");
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     return StorageContainerManager.createSCM(conf, configurator);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -475,7 +475,8 @@ public final class TestUtils {
   public static StorageContainerManager getScmSimple(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
+    conf.set(ScmConfigKeys.OZONE_SCM_NAMES, "localhost");
+//    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
     return StorageContainerManager.createSCM(conf, configurator);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,6 +100,12 @@ public class TestOzoneFSWithObjectStoreCreate {
     o3fs = (OzoneFileSystem) FileSystem.get(new URI(rootPath), conf);
   }
 
+  @After
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
 
   @Test
   public void test() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -307,10 +307,16 @@ public interface MiniOzoneCluster {
     protected boolean  startDataNodes = true;
     protected CertificateClient certClient;
     protected int pipelineNumLimit = DEFAULT_PIPELIME_LIMIT;
+    protected boolean useMockSCMHAManager = false;
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
       setClusterId(UUID.randomUUID().toString());
+    }
+
+    public Builder setUseMockSCMHAManager(boolean use) {
+      this.useMockSCMHAManager = use;
+      return this;
     }
 
     /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -635,7 +635,12 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       configureSCM();
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
       initializeScmStorage(scmStore);
-      StorageContainerManager scm = TestUtils.getScmSimple(conf);
+      StorageContainerManager scm;
+      if (useMockSCMHAManager) {
+        scm = TestUtils.getScm(conf);
+      } else {
+        scm = TestUtils.getScmSimple(conf);
+      }
       HealthyPipelineSafeModeRule rule =
           scm.getScmSafeModeManager().getHealthyPipelineSafeModeRule();
       if (rule != null) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -169,17 +169,21 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> {
       final int healthy = scm.getNodeCount(HEALTHY);
+      // When SCM HA is not enabled, scm is always leader.
+      final boolean checkScmLeader = scm.checkLeader();
       final boolean isNodeReady = healthy == hddsDatanodes.size();
       final boolean exitSafeMode = !scm.isInSafeMode();
 
       LOG.info("{}. Got {} of {} DN Heartbeats.",
           isNodeReady ? "Nodes are ready" : "Waiting for nodes to be ready",
           healthy, hddsDatanodes.size());
+      LOG.info(checkScmLeader ? "SCM became leader" :
+          "SCM has not become leader");
       LOG.info(exitSafeMode ? "Cluster exits safe mode" :
               "Waiting for cluster to exit safe mode",
           healthy, hddsDatanodes.size());
 
-      return isNodeReady && exitSafeMode;
+      return isNodeReady && exitSafeMode && checkScmLeader;
     }, 1000, waitForClusterToBeReadyTimeout);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -140,7 +140,7 @@ public class TestContainerStateMachineFailures {
     conf.setQuietMode(false);
     cluster =
         MiniOzoneCluster.newBuilder(conf).setNumDatanodes(10).setHbInterval(200)
-            .build();
+            .setUseMockSCMHAManager(true).build();
     cluster.waitForClusterToBeReady();
     cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.ONE, 60000);
     //the easiest way to create an open container is creating a key

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestKeyInputStream.java
@@ -153,6 +153,7 @@ public class TestKeyInputStream {
         .setStreamBufferFlushSize(flushSize)
         .setStreamBufferMaxSize(maxFlushSize)
         .setStreamBufferSizeUnit(StorageUnit.BYTES)
+        .setUseMockSCMHAManager(true)
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientRetriesOnExceptionFlushDelay.java
@@ -110,6 +110,7 @@ public class TestOzoneClientRetriesOnExceptionFlushDelay {
         .setStreamBufferFlushSize(flushSize)
         .setStreamBufferMaxSize(maxFlushSize)
         .setStreamBufferSizeUnit(StorageUnit.BYTES)
+        .setUseMockSCMHAManager(true)
         .build();
     cluster.waitForClusterToBeReady();
     //the easiest way to create an open container is creating a key

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -121,6 +121,7 @@ public class TestDecommissionAndMaintenance {
 
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(numOfDatanodes)
+        .setUseMockSCMHAManager(true)
         .build();
     cluster.waitForClusterToBeReady();
     setManagers();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The intention is to replace MockRatisServer by production Ratis server in integration tests (tests that use  `MiniOzoneCluster`s)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4622

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
