### PR TITLE
HDDS-4624. Fix set configs from SCMHAConfiguration Object

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -78,7 +78,7 @@ public class SCMHAConfiguration {
       description = "The size of the raft segment used by Apache Ratis on" +
           " SCM. (16 KB by default)"
   )
-  private double raftSegmentSize = 16L * 1024L;
+  private long raftSegmentSize = 16L * 1024L;
 
   @Config(key = "ratis.segment.preallocated.size",
       type = ConfigType.SIZE,
@@ -87,7 +87,7 @@ public class SCMHAConfiguration {
       description = "The size of the buffer which is preallocated for" +
           " raft segment used by Apache Ratis on SCM.(16 KB by default)"
   )
-  private double raftSegmentPreAllocatedSize = 16 * 1024;
+  private long raftSegmentPreAllocatedSize = 16L * 1024L;
 
   @Config(key = "ratis.log.appender.queue.num-elements",
       type = ConfigType.INT,
@@ -103,7 +103,7 @@ public class SCMHAConfiguration {
       tags = {SCM, OZONE, HA, RATIS},
       description = "Byte limit for Raft's Log Worker queue."
   )
-  private double raftLogAppenderQueueByteLimit = 32 * 1024 * 1024;
+  private int raftLogAppenderQueueByteLimit = 32 * 1024 * 1024;
 
   @Config(key = "ratis.log.purge.gap",
       type = ConfigType.INT,
@@ -165,6 +165,10 @@ public class SCMHAConfiguration {
     return ratisStorageDir;
   }
 
+  public void setRatisStorageDir(String dir) {
+    this.ratisStorageDir = dir;
+  }
+
   public InetSocketAddress getRatisBindAddress() {
     return NetUtils.createSocketAddr(ratisBindHost, ratisBindPort);
   }
@@ -174,11 +178,11 @@ public class SCMHAConfiguration {
   }
 
   public long getRaftSegmentSize() {
-    return (long)raftSegmentSize;
+    return raftSegmentSize;
   }
 
   public long getRaftSegmentPreAllocatedSize() {
-    return (long)raftSegmentPreAllocatedSize;
+    return raftSegmentPreAllocatedSize;
   }
 
   public int getRaftLogAppenderQueueNum() {
@@ -186,7 +190,7 @@ public class SCMHAConfiguration {
   }
 
   public int getRaftLogAppenderQueueByteLimit() {
-    return (int)raftLogAppenderQueueByteLimit;
+    return raftLogAppenderQueueByteLimit;
   }
 
   public int getRaftLogPurgeGap() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.ha;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestSCMHAConfiguration {
+  private OzoneConfiguration conf;
+
+  @Before
+  public void setup() {
+    conf = new OzoneConfiguration();
+  }
+
+  @Test
+  public void testSetStorageDir() {
+    SCMHAConfiguration scmhaConfiguration = conf.getObject(
+        SCMHAConfiguration.class);
+    scmhaConfiguration.setRatisStorageDir("scm-ratis");
+    conf.setFromObject(scmhaConfiguration);
+
+    scmhaConfiguration = conf.getObject(
+        SCMHAConfiguration.class);
+    Assert.assertEquals("scm-ratis", scmhaConfiguration.getRatisStorageDir());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When setting SCMHAConfigration object to OzoneConfiguration `conf.setFromObject(scmhaConfiguration);`:  

```
java.lang.IllegalArgumentException: Attempt to get double field "org.apache.hadoop.hdds.scm.ha.SCMHAConfiguration.raftSegmentSize" with illegal data type conversion to long
```

In reflection, seems that a Double Field cannot be cast to Long at https://github.com/apache/ozone/blob/master/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationReflectionUtil.java#L247 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4624

## How was this patch tested?

UT
