### PR TITLE
HDDS-4627. Disable coverage upload to codecov

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -280,13 +280,6 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
-        with:
-          file: ./target/coverage/all.xml
-          name: codecov-umbrella
-          fail_ci_if_error: false
       - name: Archive build results
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4627

## What changes were proposed in this pull request?

Today CI scripts upload the code coverage data to two places: Sonar and codecov.io. The second one uses a custom codecov github actions (`codecov/codecov-action@v1`) the only foreign actions in our scripts.

After Apache INFRA [switched to a more strict](https://lists.apache.org/thread.html/r900f8f9a874006ed8121bdc901a0d1acccbb340882c1f94dad61a5e9%40%3Cusers.infra.apache.org%3E) configuration, foreign github actions are not allowed anymore which breaks all of our builds. 

I suggest disabling the coverage upload to codedcov.io (we have the data in sonar anyway) for quick fix (long-term we can do the upload with a CLI application).
 
## How was this patch tested?

CI