### PR TITLE
HDDS-4628: min/max election timeout of SCMRatisServer is not set properly.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -100,9 +100,9 @@ public final class RatisUtil {
     Rpc.setRequestTimeout(properties, TimeDuration.valueOf(
         conf.getRatisRequestTimeout(), TimeUnit.MILLISECONDS));
     Rpc.setTimeoutMin(properties, TimeDuration.valueOf(
-        conf.getRatisRequestMinTimeout(), TimeUnit.MILLISECONDS));
+        conf.getLeaderElectionMinTimeout(), TimeUnit.MILLISECONDS));
     Rpc.setTimeoutMax(properties, TimeDuration.valueOf(
-        conf.getRatisRequestMaxTimeout(), TimeUnit.MILLISECONDS));
+        conf.getLeaderElectionMaxTimeout(), TimeUnit.MILLISECONDS));
     Rpc.setSlownessTimeout(properties, TimeDuration.valueOf(
         conf.getRatisNodeFailureTimeout(), TimeUnit.MILLISECONDS));
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -203,16 +203,12 @@ public class SCMHAConfiguration {
     return ratisRequestTimeout;
   }
 
-  public long getRatisRequestMinTimeout() {
-    return ratisRequestTimeout - 1000L;
-  }
-
-  public long getRatisRequestMaxTimeout() {
-    return ratisRequestTimeout + 1000L;
-  }
-
-  public long getRatisLeaderElectionTimeout() {
+  public long getLeaderElectionMinTimeout() {
     return ratisLeaderElectionTimeout;
+  }
+
+  public long getLeaderElectionMaxTimeout() {
+    return ratisLeaderElectionTimeout + 200L;
   }
 
   public long getRatisNodeFailureTimeout() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

min/max election timeout of SCMRatisServer is not properly set.
Previously, it is `[ratisRequestTimeout - 1s, ratisRequestTimeout + 1s]`
It should be  `[ratisLeaderElectionTimeout, ratisLeaderElectionTimeout + 0.2s]`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4628

## How was this patch tested?

CI
