### PR TITLE
HDDS-4622: Use singe server raft cluster in MiniOzoneCluster.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -76,7 +76,8 @@ public final class RatisUtil {
                                        final ConfigurationSource conf) {
     String storageDir = haConf.getRatisStorageDir();
     if (Strings.isNullOrEmpty(storageDir)) {
-      storageDir = ServerUtils.getDefaultRatisDirectory(conf);
+      File metaDirPath = ServerUtils.getOzoneMetaDirPath(conf);
+      storageDir = (new File(metaDirPath, "scm-ha")).getPath();
     }
     RaftServerConfigKeys.setStorageDir(properties,
         Collections.singletonList(new File(storageDir)));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
@@ -82,9 +82,11 @@ public class SCMHAInvocationHandler implements InvocationHandler {
    */
   private Object invokeRatis(Method method, Object[] args)
       throws Exception {
-    LOG.trace("Invoking method {} on target {}", method, ratisHandler);
+    long startTime = Time.monotonicNowNanos();
     final SCMRatisResponse response =  ratisHandler.submitRequest(
         SCMRatisRequest.of(requestType, method.getName(), args));
+    LOG.info("Invoking method {} on target {}, cost {}us",
+        method, ratisHandler, (Time.monotonicNowNanos() - startTime) / 1000.0);
     if (response.isSuccess()) {
       return response.getResult();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -475,7 +475,7 @@ public final class TestUtils {
   public static StorageContainerManager getScmSimple(OzoneConfiguration conf)
       throws IOException, AuthenticationException {
     SCMConfigurator configurator = new SCMConfigurator();
-    configurator.setSCMHAManager(MockSCMHAManager.getInstance(true));
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     return StorageContainerManager.createSCM(conf, configurator);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.junit.Assert;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -99,6 +100,12 @@ public class TestOzoneFSWithObjectStoreCreate {
     o3fs = (OzoneFileSystem) FileSystem.get(new URI(rootPath), conf);
   }
 
+  @After
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
 
   @Test
   public void test() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -171,6 +171,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       final int healthy = scm.getNodeCount(HEALTHY);
       final boolean isNodeReady = healthy == hddsDatanodes.size();
       final boolean exitSafeMode = !scm.isInSafeMode();
+      final boolean checkScmLeader = scm.checkLeader();
 
       LOG.info("{}. Got {} of {} DN Heartbeats.",
           isNodeReady ? "Nodes are ready" : "Waiting for nodes to be ready",
@@ -178,8 +179,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       LOG.info(exitSafeMode ? "Cluster exits safe mode" :
               "Waiting for cluster to exit safe mode",
           healthy, hddsDatanodes.size());
+      LOG.info(checkScmLeader ? "SCM became leader" :
+          "SCM has not become leader");
 
-      return isNodeReady && exitSafeMode;
+      return isNodeReady && exitSafeMode && checkScmLeader;
     }, 1000, waitForClusterToBeReadyTimeout);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use SCMHAManagerImpl and SCMRatisServerImpl instead of MockSCMHAManager and MockRatisServer in MiniOzoneCluster.
The MockRatisServer and MockSCMHAManager can not fully test the HA code.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4622

## How was this patch tested?

CI
