### PR TITLE
HDDS-4632: Add term into SetNodeOperationalStateCommand

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -352,6 +352,10 @@ public class HeartbeatEndpointTask
         SetNodeOperationalStateCommand setNodeOperationalStateCommand =
             SetNodeOperationalStateCommand.getFromProtobuf(
                 commandResponseProto.getSetNodeOperationalStateCommandProto());
+        if (commandResponseProto.hasTerm()) {
+          setNodeOperationalStateCommand.setTerm(
+              commandResponseProto.getTerm());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM set operational state command. State: {} " +
               "Expiry: {}", setNodeOperationalStateCommand.getOpState(),

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -304,13 +304,13 @@ message SCMCommandProto {
   optional ReplicateContainerCommandProto replicateContainerCommandProto = 6;
   optional CreatePipelineCommandProto createPipelineCommandProto = 7;
   optional ClosePipelineCommandProto closePipelineCommandProto = 8;
+  optional SetNodeOperationalStateCommandProto setNodeOperationalStateCommandProto = 9;
 
   // Under HA mode, holds term of underlying RaftServer iff current
   // SCM is a leader, otherwise, holds term 0.
   // Notes that, the first elected leader is from term 1, term 0,
   // as the initial value of currentTerm, is never used under HA mode.
   optional uint64 term = 15;
-  optional SetNodeOperationalStateCommandProto setNodeOperationalStateCommandProto = 9;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -436,7 +436,7 @@ public class SCMNodeManager implements NodeManager {
           reportedDn.getPersistedOpStateExpiryEpochSec(),
           scmStatus.getOperationalState(),
           scmStatus.getOpStateExpiryEpochSeconds());
-      commandQueue.addCommand(reportedDn.getUuid(),
+      addDatanodeCommand(reportedDn.getUuid(),
           new SetNodeOperationalStateCommand(
               Time.monotonicNow(), scmStatus.getOperationalState(),
               scmStatus.getOpStateExpiryEpochSeconds()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need add term into SCMCommand to help DN distinguish SCMCommand from stale leader.
SetNodeOperationalStateCommand is a new added SCMCommand by Decommission, which misses the adding of the term.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4632

## How was this patch tested?

CI
