### PR TITLE
HDDS-4631. Fix client set quota with 0.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -201,8 +201,8 @@ public final class OzoneQuota {
           " value cannot be greater than Long.MAX_VALUE BYTES");
     }
 
-    if (nSize < 0) {
-      throw new IllegalArgumentException("Quota cannot be negative.");
+    if (nSize <= 0) {
+      throw new IllegalArgumentException("Invalid values for quota: " + nSize);
     }
 
     return new OzoneQuota(new RawQuotaInBytes(currUnit, nSize));
@@ -217,8 +217,12 @@ public final class OzoneQuota {
    * @return OzoneQuota object
    */
   public static OzoneQuota parseNameSpaceQuota(String quotaInNamespace) {
-    return new OzoneQuota(Long.parseLong(quotaInNamespace),
-        new RawQuotaInBytes(Units.BYTES, -1));
+    long nameSpaceQuota = Long.parseLong(quotaInNamespace);
+    if (nameSpaceQuota <= 0) {
+      throw new IllegalArgumentException(
+          "Invalid values for quota: " + nameSpaceQuota);
+    }
+    return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.BYTES, -1));
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,6 +173,11 @@ public final class OzoneQuota {
    */
   public static OzoneQuota parseSpaceQuota(String quotaInBytes) {
 
+    if (Strings.isNullOrEmpty(quotaInBytes)) {
+      throw new IllegalArgumentException(
+          "Quota string cannot be null or empty.");
+    }
+
     String uppercase = quotaInBytes.toUpperCase()
         .replaceAll("\\s+", "");
     String size = "";
@@ -217,6 +223,10 @@ public final class OzoneQuota {
    * @return OzoneQuota object
    */
   public static OzoneQuota parseNameSpaceQuota(String quotaInNamespace) {
+    if (Strings.isNullOrEmpty(quotaInNamespace)) {
+      throw new IllegalArgumentException(
+          "Quota string cannot be null or empty.");
+    }
     long nameSpaceQuota = Long.parseLong(quotaInNamespace);
     if (nameSpaceQuota <= 0) {
       throw new IllegalArgumentException(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -144,7 +144,7 @@ public final class OzoneQuota {
   /**
    * Constructor for Ozone Quota.
    *
-   * @param quotaInNamespace Volume quota in counts
+   * @param quotaInNamespace ozone quota in counts
    * @param rawQuotaInBytes RawQuotaInBytes value
    */
   private OzoneQuota(long quotaInNamespace, RawQuotaInBytes rawQuotaInBytes) {
@@ -167,7 +167,7 @@ public final class OzoneQuota {
    * Parses a user provided string space quota and returns the
    * Quota Object.
    *
-   * @param quotaInBytes Volume quota in bytes
+   * @param quotaInBytes ozone quota in bytes
    *
    * @return OzoneQuota object
    */
@@ -219,7 +219,7 @@ public final class OzoneQuota {
    * Parses a user provided string Namespace quota and returns the
    * Quota Object.
    *
-   * @param quotaInNamespace Volume quota in counts
+   * @param quotaInNamespace ozone quota in counts
    *
    * @return OzoneQuota object
    */
@@ -240,8 +240,8 @@ public final class OzoneQuota {
    * Parses a user provided string and returns the
    * Quota Object.
    *
-   * @param quotaInBytes Volume quota in bytes
-   * @param quotaInNamespace Volume quota in counts
+   * @param quotaInBytes ozone quota in bytes
+   * @param quotaInNamespace ozone quota in counts
    *
    * @return OzoneQuota object
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hdds.client;
 
-import com.google.common.base.Strings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -123,6 +122,25 @@ public final class OzoneQuota {
   }
 
   /**
+   * Constructor for Ozone Space Quota.
+   *
+   * @param rawQuotaInBytes RawQuotaInBytes value
+   */
+  private OzoneQuota(RawQuotaInBytes rawQuotaInBytes) {
+    this.rawQuotaInBytes = rawQuotaInBytes;
+    this.quotaInBytes = rawQuotaInBytes.sizeInBytes();
+  }
+
+  /**
+   * Constructor for Ozone NameSpace Quota.
+   *
+   * @param quotaInNamespace long value
+   */
+  private OzoneQuota(long quotaInNamespace) {
+    this.quotaInNamespace = quotaInNamespace;
+  }
+
+  /**
    * Constructor for Ozone Quota.
    *
    * @param quotaInNamespace Volume quota in counts
@@ -145,21 +163,14 @@ public final class OzoneQuota {
   }
 
   /**
-   * Parses a user provided string and returns the
+   * Parses a user provided string space quota and returns the
    * Quota Object.
    *
    * @param quotaInBytes Volume quota in bytes
-   * @param quotaInNamespace Volume quota in counts
    *
    * @return OzoneQuota object
    */
-  public static OzoneQuota parseQuota(String quotaInBytes,
-      long quotaInNamespace) {
-
-    if (Strings.isNullOrEmpty(quotaInBytes)) {
-      throw new IllegalArgumentException(
-          "Quota string cannot be null or empty.");
-    }
+  public static OzoneQuota parseSpaceQuota(String quotaInBytes) {
 
     String uppercase = quotaInBytes.toUpperCase()
         .replaceAll("\\s+", "");
@@ -194,10 +205,36 @@ public final class OzoneQuota {
       throw new IllegalArgumentException("Quota cannot be negative.");
     }
 
-    return new OzoneQuota(quotaInNamespace,
-        new RawQuotaInBytes(currUnit, nSize));
+    return new OzoneQuota(new RawQuotaInBytes(currUnit, nSize));
   }
 
+  /**
+   * Parses a user provided string Namespace quota and returns the
+   * Quota Object.
+   *
+   * @param quotaInNamespace Volume quota in counts
+   *
+   * @return OzoneQuota object
+   */
+  public static OzoneQuota parseNameSpaceQuota(String quotaInNamespace) {
+    return new OzoneQuota(Long.parseLong(quotaInNamespace),
+        new RawQuotaInBytes(Units.BYTES, -1));
+  }
+
+  /**
+   * Parses a user provided string and returns the
+   * Quota Object.
+   *
+   * @param quotaInBytes Volume quota in bytes
+   * @param quotaInNamespace Volume quota in counts
+   *
+   * @return OzoneQuota object
+   */
+  public static OzoneQuota parseQuota(String quotaInBytes,
+      String quotaInNamespace) {
+    return new OzoneQuota(parseNameSpaceQuota(quotaInNamespace)
+        .quotaInNamespace, parseSpaceQuota(quotaInBytes).rawQuotaInBytes);
+  }
 
   /**
    * Returns OzoneQuota corresponding to size in bytes.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/OzoneQuota.java
@@ -208,7 +208,8 @@ public final class OzoneQuota {
     }
 
     if (nSize <= 0) {
-      throw new IllegalArgumentException("Invalid values for quota: " + nSize);
+      throw new IllegalArgumentException("Invalid values for space quota: "
+          + nSize);
     }
 
     return new OzoneQuota(new RawQuotaInBytes(currUnit, nSize));
@@ -230,7 +231,7 @@ public final class OzoneQuota {
     long nameSpaceQuota = Long.parseLong(quotaInNamespace);
     if (nameSpaceQuota <= 0) {
       throw new IllegalArgumentException(
-          "Invalid values for quota: " + nameSpaceQuota);
+          "Invalid values for namespace quota: " + nameSpaceQuota);
     }
     return new OzoneQuota(nameSpaceQuota, new RawQuotaInBytes(Units.BYTES, -1));
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
@@ -32,13 +32,17 @@ public class TestJsonUtils {
 
   @Test
   public void printObjectAsJson() throws IOException {
-    OzoneQuota quota = OzoneQuota.parseQuota("123MB", 1000L);
+    OzoneQuota spaceQuota = OzoneQuota.parseSpaceQuota("123MB");
 
-    String result = JsonUtils.toJsonStringWithDefaultPrettyPrinter(quota);
+    String spaceStr =
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(spaceQuota);
+    assertContains(spaceStr, "\"rawSize\" : 123");
+    assertContains(spaceStr, "\"unit\" : \"MB\"");
 
-    assertContains(result, "\"rawSize\" : 123");
-    assertContains(result, "\"unit\" : \"MB\"");
-    assertContains(result, "\"quotaInNamespace\" : 1000");
+    OzoneQuota nameSpace = OzoneQuota.parseNameSpaceQuota("1000");
+    String nameSpaceStr =
+        JsonUtils.toJsonStringWithDefaultPrettyPrinter(nameSpace);
+    assertContains(nameSpaceStr, "\"quotaInNamespace\" : 1000");
   }
 
   private static void assertContains(String str, String part) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 import java.util.HashMap;
 import java.util.List;
@@ -178,6 +179,8 @@ public final class BucketArgs {
 
     public Builder() {
       metadata = new HashMap<>();
+      quotaInBytes = OzoneConsts.QUOTA_RESET;
+      quotaInNamespace = OzoneConsts.QUOTA_RESET;
     }
 
     public BucketArgs.Builder setVersioning(Boolean versionFlag) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/VolumeArgs.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -125,6 +126,13 @@ public final class VolumeArgs {
     private List<OzoneAcl> listOfAcls;
     private Map<String, String> metadata = new HashMap<>();
 
+    /**
+     * Constructs a builder.
+     */
+    public Builder() {
+      quotaInBytes = OzoneConsts.QUOTA_RESET;
+      quotaInNamespace = OzoneConsts.QUOTA_RESET;
+    }
 
     public VolumeArgs.Builder setAdmin(String admin) {
       this.adminName = admin;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -238,8 +238,8 @@ public class RpcClient implements ClientProtocol {
         ugi.getUserName() : volArgs.getAdmin();
     String owner = volArgs.getOwner() == null ?
         ugi.getUserName() : volArgs.getOwner();
-    long quotaInNamespace = getQuotaValue(volArgs.getQuotaInNamespace());
-    long quotaInBytes = getQuotaValue(volArgs.getQuotaInBytes());
+    long quotaInNamespace = volArgs.getQuotaInNamespace();
+    long quotaInBytes = volArgs.getQuotaInBytes();
     List<OzoneAcl> listOfAcls = new ArrayList<>();
     //User ACL
     listOfAcls.add(new OzoneAcl(ACLIdentityType.USER,
@@ -418,8 +418,8 @@ public class RpcClient implements ClientProtocol {
         .setStorageType(storageType)
         .setSourceVolume(bucketArgs.getSourceVolume())
         .setSourceBucket(bucketArgs.getSourceBucket())
-        .setQuotaInBytes(getQuotaValue(bucketArgs.getQuotaInBytes()))
-        .setQuotaInNamespace(getQuotaValue(bucketArgs.getQuotaInNamespace()))
+        .setQuotaInBytes(bucketArgs.getQuotaInBytes())
+        .setQuotaInNamespace(bucketArgs.getQuotaInNamespace())
         .setAcls(listOfAcls.stream().distinct().collect(Collectors.toList()));
 
     if (bek != null) {
@@ -451,24 +451,16 @@ public class RpcClient implements ClientProtocol {
   }
 
   private static void verifyCountsQuota(long quota) throws OMException {
-    if (quota < OzoneConsts.QUOTA_RESET) {
+    if (quota < OzoneConsts.QUOTA_RESET || quota == 0) {
       throw new IllegalArgumentException("Invalid values for quota : " +
           "counts quota is :" + quota + ".");
     }
   }
 
   private static void verifySpaceQuota(long quota) throws OMException {
-    if (quota < OzoneConsts.QUOTA_RESET) {
+    if (quota < OzoneConsts.QUOTA_RESET || quota == 0) {
       throw new IllegalArgumentException("Invalid values for quota : " +
           "space quota is :" + quota + ".");
-    }
-  }
-
-  private static long getQuotaValue(long quota) throws OMException {
-    if (quota == 0) {
-      return OzoneConsts.QUOTA_RESET;
-    } else {
-      return quota;
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmBucketArgs.java
@@ -156,6 +156,14 @@ public final class OmBucketArgs extends WithMetadata implements Auditable {
     private long quotaInBytes;
     private long quotaInNamespace;
 
+    /**
+     * Constructs a builder.
+     */
+    public Builder() {
+      quotaInBytes = OzoneConsts.QUOTA_RESET;
+      quotaInNamespace = OzoneConsts.QUOTA_RESET;
+    }
+
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
       return this;

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -82,16 +82,6 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
                     Should Be Equal     ${result}       -1
-                    Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 0TB --namespace-quota 0
-    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
-                    Should Be Equal     ${result}       0
-    ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInNamespace'
-                    Should Be Equal     ${result}       0
-                    Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 0TB --namespace-quota 0
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
-                    Should Be Equal     ${result}       0
-    ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
-                    Should Be Equal     ${result}       0
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
 

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -84,14 +84,14 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh volume setquota ${protocol}${server}/${volume} --space-quota 0TB --namespace-quota 0
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInBytes'
-                    Should Be Equal     ${result}       -1
+                    Should Be Equal     ${result}       0
     ${result} =     Execute             ozone sh volume info ${protocol}${server}/${volume} | jq -r '. | select(.name=="${volume}") | .quotaInNamespace'
-                    Should Be Equal     ${result}       -1
+                    Should Be Equal     ${result}       0
                     Execute             ozone sh bucket setquota ${protocol}${server}/${volume}/bb1 --space-quota 0TB --namespace-quota 0
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInBytes'
-                    Should Be Equal     ${result}       -1
+                    Should Be Equal     ${result}       0
     ${result} =     Execute             ozone sh bucket info ${protocol}${server}/${volume}/bb1 | jq -r '. | select(.name=="bb1") | .quotaInNamespace'
-                    Should Be Equal     ${result}       -1
+                    Should Be Equal     ${result}       0
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1005,8 +1005,13 @@ public abstract class TestOzoneRpcClientAbstract {
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     // Reset bucket quota, the original usedNamespace needs to remain the same
+<<<<<<< HEAD
     bucket.setQuota(OzoneQuota.parseQuota(
         Long.MAX_VALUE + " Bytes", "100"));
+=======
+    bucket.setQuota(
+        OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", "100"));
+>>>>>>> rabase master and add more comprehensive UT
     Assert.assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -397,6 +397,16 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testSetVolumeQuotaIllegal() throws Exception {
     String volumeName = UUID.randomUUID().toString();
+
+    VolumeArgs volumeArgs = VolumeArgs.newBuilder()
+        .addMetadata("key1", "val1")
+        .setQuotaInNamespace(0)
+        .setQuotaInBytes(0)
+        .build();
+    LambdaTestUtils.intercept(IllegalArgumentException.class,
+        "Invalid values for quota",
+        () -> store.createVolume(volumeName, volumeArgs));
+
     store.createVolume(volumeName);
 
     // test volume set quota 0
@@ -450,7 +460,8 @@ public abstract class TestOzoneRpcClientAbstract {
         .build();
     store.createVolume(volumeName, volumeArgs);
     OzoneVolume volume = store.getVolume(volumeName);
-
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
     Assert.assertEquals("val1", volume.getMetadata().get("key1"));
     Assert.assertEquals(volumeName, volume.getName());
   }
@@ -462,11 +473,15 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
     BucketArgs args = BucketArgs.newBuilder()
         .addMetadata("key1", "value1").build();
     volume.createBucket(bucketName, args);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
+    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
     Assert.assertNotNull(bucket.getMetadata());
     Assert.assertEquals("value1", bucket.getMetadata().get("key1"));
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -349,16 +349,16 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // test bucket set quota 0
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("0GB", "10")));
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for namespace quota",
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("10GB", "0")));
 
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for namespace quota",
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("1GB", "-100")));
 
@@ -373,7 +373,7 @@ public abstract class TestOzoneRpcClientAbstract {
             OzoneQuota.parseQuota("9223372036854775808 BYTES", "100")));
 
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> store.getVolume(volumeName).getBucket(bucketName).setQuota(
             OzoneQuota.parseQuota("-10GB", "100")));
 
@@ -411,11 +411,11 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // test volume set quota 0
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "0GB", "10")));
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for namespace quota",
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "10GB", "0")));
 
@@ -433,7 +433,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // The value cannot be negative.
     LambdaTestUtils.intercept(IllegalArgumentException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
             "-10GB", "1000")));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -289,13 +289,13 @@ public abstract class TestOzoneRpcClientAbstract {
     store.createVolume(volumeName);
 
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-        "0GB", 0L));
+        "0GB", "0"));
     volume = store.getVolume(volumeName);
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, volume.getQuotaInNamespace());
+    Assert.assertEquals(0, volume.getQuotaInBytes());
+    Assert.assertEquals(0, volume.getQuotaInNamespace());
 
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-        "10GB", 10000L));
+        "10GB", "10000"));
     store.getVolume(volumeName).createBucket(bucketName);
     volume = store.getVolume(volumeName);
     Assert.assertEquals(10 * GB, volume.getQuotaInBytes());
@@ -305,12 +305,13 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
 
     store.getVolume(volumeName).getBucket(bucketName).setQuota(
-        OzoneQuota.parseQuota("0GB", 0));
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInBytes());
-    Assert.assertEquals(OzoneConsts.QUOTA_RESET, bucket.getQuotaInNamespace());
+        OzoneQuota.parseQuota("0GB", "0"));
+    bucket = store.getVolume(volumeName).getBucket(bucketName);
+    Assert.assertEquals(0, bucket.getQuotaInBytes());
+    Assert.assertEquals(0, bucket.getQuotaInNamespace());
 
     store.getVolume(volumeName).getBucket(bucketName).setQuota(
-        OzoneQuota.parseQuota("1GB", 1000L));
+        OzoneQuota.parseQuota("1GB", "1000"));
     OzoneBucket ozoneBucket = store.getVolume(volumeName).getBucket(bucketName);
     Assert.assertEquals(1024 * 1024 * 1024,
         ozoneBucket.getQuotaInBytes());
@@ -355,13 +356,13 @@ public abstract class TestOzoneRpcClientAbstract {
     String bucketName = UUID.randomUUID().toString();
     store.createVolume(volumeName);
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-        "10GB", 1000L));
+        "10GB", "1000"));
     store.getVolume(volumeName).createBucket(bucketName);
 
     int countException = 0;
     try {
       store.getVolume(volumeName).getBucket(bucketName).setQuota(
-          OzoneQuota.parseQuota("1GB", -100L));
+          OzoneQuota.parseQuota("1GB", "-100"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -370,7 +371,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The unit should be legal.
     try {
       store.getVolume(volumeName).getBucket(bucketName).setQuota(
-          OzoneQuota.parseQuota("1TEST", 100L));
+          OzoneQuota.parseQuota("1TEST", "100"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -380,7 +381,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
     try {
       store.getVolume(volumeName).getBucket(bucketName).setQuota(
-          OzoneQuota.parseQuota("9223372036854775808 BYTES", 100L));
+          OzoneQuota.parseQuota("9223372036854775808 BYTES", "100"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -390,7 +391,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The value cannot be negative.
     try {
       store.getVolume(volumeName).getBucket(bucketName).setQuota(
-          OzoneQuota.parseQuota("-10GB", 100L));
+          OzoneQuota.parseQuota("-10GB", "100"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -408,7 +409,7 @@ public abstract class TestOzoneRpcClientAbstract {
         store.getVolume(volumeName).getQuotaInBytes());
     Assert.assertEquals(OzoneConsts.QUOTA_RESET,
         store.getVolume(volumeName).getQuotaInNamespace());
-    store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota("1GB", 1000L));
+    store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota("1GB", "1000"));
     OzoneVolume volume = store.getVolume(volumeName);
     Assert.assertEquals(1024 * 1024 * 1024,
         volume.getQuotaInBytes());
@@ -424,7 +425,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The unit should be legal.
     try {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-          "1TEST", 1000L));
+          "1TEST", "1000"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -434,7 +435,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The setting value cannot be greater than LONG.MAX_VALUE BYTES.
     try {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-          "9223372036854775808 BYTES", 1000L));
+          "9223372036854775808 BYTES", "1000"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -444,7 +445,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // The value cannot be negative.
     try {
       store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-          "-10GB", 1000L));
+          "-10GB", "1000"));
     } catch (IllegalArgumentException ex) {
       countException++;
       GenericTestUtils.assertExceptionContains(
@@ -858,11 +859,11 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // Test bucket quota.
     store.getVolume(volumeName).setQuota(
-        OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", 100));
+        OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", "100"));
     bucketName = UUID.randomUUID().toString();
     volume.createBucket(bucketName);
     bucket = volume.getBucket(bucketName);
-    bucket.setQuota(OzoneQuota.parseQuota("1 Bytes", 100));
+    bucket.setQuota(OzoneQuota.parseQuota("1 Bytes", "100"));
 
     // Test bucket quota: write key.
     // The remaining quota does not satisfy a block size, so the write fails.
@@ -891,7 +892,7 @@ public abstract class TestOzoneRpcClientAbstract {
     // Test bucket quota: write large key(with five blocks), the first four
     // blocks will succeed，while the later block will fail.
     bucket.setQuota(OzoneQuota.parseQuota(
-        4 * blockSize + " Bytes", 100));
+        4 * blockSize + " Bytes", "100"));
 
     try {
       OzoneOutputStream out = bucket.createKey(UUID.randomUUID().toString(),
@@ -910,7 +911,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // Reset bucket quota, the original usedBytes needs to remain the same
     bucket.setQuota(OzoneQuota.parseQuota(
-        100 + " GB", 100));
+        100 + " GB", "100"));
     Assert.assertEquals(4 * blockSize,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
 
@@ -918,7 +919,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // key with 0 bytes, usedBytes should not increase.
     bucket.setQuota(OzoneQuota.parseQuota(
-        5 * blockSize + " Bytes", 100));
+        5 * blockSize + " Bytes", "100"));
     OzoneOutputStream out = bucket.createKey(UUID.randomUUID().toString(),
         valueLength, STAND_ALONE, ONE, new HashMap<>());
     out.close();
@@ -967,7 +968,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
     // Reset volume quota, the original usedNamespace needs to remain the same
     store.getVolume(volumeName).setQuota(OzoneQuota.parseQuota(
-        100 + " GB", 100));
+        100 + " GB", "100"));
     Assert.assertEquals(1L,
         store.getVolume(volumeName).getUsedNamespace());
 
@@ -993,7 +994,7 @@ public abstract class TestOzoneRpcClientAbstract {
     volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
     bucket = volume.getBucket(bucketName);
-    bucket.setQuota(OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", 2));
+    bucket.setQuota(OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", "2"));
 
     writeKey(bucket, key1, ONE, value, value.length());
     Assert.assertEquals(1L,
@@ -1015,7 +1016,8 @@ public abstract class TestOzoneRpcClientAbstract {
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     // Reset bucket quota, the original usedNamespace needs to remain the same
-    bucket.setQuota(OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", 100));
+    bucket.setQuota(OzoneQuota.parseQuota(
+        Long.MAX_VALUE + " Bytes", "100"));
     Assert.assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1005,13 +1005,8 @@ public abstract class TestOzoneRpcClientAbstract {
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 
     // Reset bucket quota, the original usedNamespace needs to remain the same
-<<<<<<< HEAD
-    bucket.setQuota(OzoneQuota.parseQuota(
-        Long.MAX_VALUE + " Bytes", "100"));
-=======
     bucket.setQuota(
         OzoneQuota.parseQuota(Long.MAX_VALUE + " Bytes", "100"));
->>>>>>> rabase master and add more comprehensive UT
     Assert.assertEquals(2L,
         store.getVolume(volumeName).getBucket(bucketName).getUsedNamespace());
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -615,7 +615,7 @@ public class TestOzoneShellHA {
     out.reset();
 
     args = new String[]{"bucket", "clrquota", "vol4/buck4",
-        "--space-quota", "--namespace-quota",};
+        "--space-quota", "--namespace-quota"};
     execute(ozoneShell, args);
     assertEquals(-1,
         objectStore.getVolume("vol4").getBucket("buck4").getQuotaInBytes());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.shell;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -642,14 +642,14 @@ public class TestOzoneShellHA {
     String[] volumeArgs1 = new String[]{"volume", "setquota", "vol4",
         "--space-quota", "0GB"};
     LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> execute(ozoneShell, volumeArgs1));
     out.reset();
 
     String[] volumeArgs2 = new String[]{"volume", "setquota", "vol4",
         "--namespace-quota", "0"};
     LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for quota",
+        "Invalid values for namespace quota",
         () -> execute(ozoneShell, volumeArgs2));
     out.reset();
 
@@ -674,14 +674,14 @@ public class TestOzoneShellHA {
     String[] bucketArgs1 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--space-quota", "0GB"};
     LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for quota",
+        "Invalid values for space quota",
         () -> execute(ozoneShell, bucketArgs1));
     out.reset();
 
     String[] bucketArgs2 = new String[]{"bucket", "setquota", "vol4/buck4",
         "--namespace-quota", "0"};
     LambdaTestUtils.intercept(ExecutionException.class,
-        "Invalid values for quota",
+        "Invalid values for namespace quota",
         () -> execute(ozoneShell, bucketArgs2));
     out.reset();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -530,39 +530,106 @@ public class TestOzoneShellHA {
   @Test
   public void testShQuota() throws IOException {
     ObjectStore objectStore = cluster.getClient().getObjectStore();
-    try {
-      // Test --quota option.
+    // Test --quota option.
 
-      String[] args =
-          new String[] {"volume", "create", "vol1", "--quota", "100BYTES"};
-      execute(ozoneShell, args);
-      assertEquals(100, objectStore.getVolume("vol1").getQuotaInBytes());
-      out.reset();
+    String[] args =
+        new String[]{"volume", "create", "vol1", "--quota", "100BYTES"};
+    execute(ozoneShell, args);
+    assertEquals(100, objectStore.getVolume("vol1").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol1").getQuotaInNamespace());
+    out.reset();
 
-      args =
-          new String[] {"bucket", "create", "vol1/buck1", "--quota", "10BYTES"};
-      execute(ozoneShell, args);
-      assertEquals(10,
-          objectStore.getVolume("vol1").getBucket("buck1").getQuotaInBytes());
 
-      // Test --space-quota option.
+    args =
+        new String[]{"bucket", "create", "vol1/buck1", "--quota", "10BYTES"};
+    execute(ozoneShell, args);
+    assertEquals(10,
+        objectStore.getVolume("vol1").getBucket("buck1").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol1").getBucket("buck1")
+            .getQuotaInNamespace());
 
-      args = new String[] {"volume", "create", "vol2", "--space-quota",
-          "100BYTES"};
-      execute(ozoneShell, args);
-      assertEquals(100, objectStore.getVolume("vol2").getQuotaInBytes());
-      out.reset();
+    // Test --space-quota option.
 
-      args = new String[] {"bucket", "create", "vol2/buck2", "--space-quota",
-          "10BYTES"};
-      execute(ozoneShell, args);
-      assertEquals(10,
-          objectStore.getVolume("vol2").getBucket("buck2").getQuotaInBytes());
-    } finally {
-      objectStore.getVolume("vol1").deleteBucket("buck1");
-      objectStore.deleteVolume("vol1");
-      objectStore.getVolume("vol2").deleteBucket("buck2");
-      objectStore.deleteVolume("vol2");
-    }
+    args = new String[]{"volume", "create", "vol2", "--space-quota",
+        "100BYTES"};
+    execute(ozoneShell, args);
+    assertEquals(100, objectStore.getVolume("vol2").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol2").getQuotaInNamespace());
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol2/buck2", "--space-quota",
+        "10BYTES"};
+    execute(ozoneShell, args);
+    assertEquals(10,
+        objectStore.getVolume("vol2").getBucket("buck2").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol2").getBucket("buck2")
+            .getQuotaInNamespace());
+
+    // Test --namespace-quota option.
+    args =
+        new String[]{"volume", "create", "vol3", "--namespace-quota", "100"};
+    execute(ozoneShell, args);
+    assertEquals(-1, objectStore.getVolume("vol3").getQuotaInBytes());
+    assertEquals(100,
+        objectStore.getVolume("vol3").getQuotaInNamespace());
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol3/buck3",
+        "--namespace-quota", "10"};
+    execute(ozoneShell, args);
+    assertEquals(-1,
+        objectStore.getVolume("vol3").getBucket("buck3").getQuotaInBytes());
+    assertEquals(10,
+        objectStore.getVolume("vol3").getBucket("buck3")
+            .getQuotaInNamespace());
+
+    // Test both --space-quota and --namespace-quota option.
+    args = new String[]{"volume", "create", "vol4", "--space-quota",
+        "100BYTES", "--namespace-quota", "100"};
+    execute(ozoneShell, args);
+    assertEquals(100, objectStore.getVolume("vol4").getQuotaInBytes());
+    assertEquals(100,
+        objectStore.getVolume("vol4").getQuotaInNamespace());
+    out.reset();
+
+    args = new String[]{"bucket", "create", "vol4/buck4",
+        "--space-quota", "10BYTES", "--namespace-quota", "10"};
+    execute(ozoneShell, args);
+    assertEquals(10,
+        objectStore.getVolume("vol4").getBucket("buck4").getQuotaInBytes());
+    assertEquals(10,
+        objectStore.getVolume("vol4").getBucket("buck4")
+            .getQuotaInNamespace());
+
+    // Test clrquota option.
+    args = new String[]{"volume", "clrquota", "vol4", "--space-quota",
+        "--namespace-quota"};
+    execute(ozoneShell, args);
+    assertEquals(-1, objectStore.getVolume("vol4").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol4").getQuotaInNamespace());
+    out.reset();
+
+    args = new String[]{"bucket", "clrquota", "vol4/buck4",
+        "--space-quota", "--namespace-quota",};
+    execute(ozoneShell, args);
+    assertEquals(-1,
+        objectStore.getVolume("vol4").getBucket("buck4").getQuotaInBytes());
+    assertEquals(-1,
+        objectStore.getVolume("vol4").getBucket("buck4")
+            .getQuotaInNamespace());
+
+    objectStore.getVolume("vol1").deleteBucket("buck1");
+    objectStore.deleteVolume("vol1");
+    objectStore.getVolume("vol2").deleteBucket("buck2");
+    objectStore.deleteVolume("vol2");
+    objectStore.getVolume("vol3").deleteBucket("buck3");
+    objectStore.deleteVolume("vol3");
+    objectStore.getVolume("vol4").deleteBucket("buck4");
+    objectStore.deleteVolume("vol4");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -239,7 +239,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           OMException.ResultCodes.QUOTA_ERROR);
     }
 
-    if (quotaInBytes < OzoneConsts.QUOTA_RESET) {
+    if (quotaInBytes < OzoneConsts.QUOTA_RESET || quotaInBytes == 0) {
       return false;
     }
 
@@ -273,7 +273,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       OmBucketArgs omBucketArgs) {
     long quotaInNamespace = omBucketArgs.getQuotaInNamespace();
 
-    if (quotaInNamespace < OzoneConsts.QUOTA_RESET) {
+    if (quotaInNamespace < OzoneConsts.QUOTA_RESET || quotaInNamespace == 0) {
       return false;
     }
     return true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -239,7 +239,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           OMException.ResultCodes.QUOTA_ERROR);
     }
 
-    if (quotaInBytes == 0) {
+    if (quotaInBytes < OzoneConsts.QUOTA_RESET) {
       return false;
     }
 
@@ -273,8 +273,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       OmBucketArgs omBucketArgs) {
     long quotaInNamespace = omBucketArgs.getQuotaInNamespace();
 
-    if ((quotaInNamespace <= 0
-         && quotaInNamespace != OzoneConsts.QUOTA_RESET)) {
+    if (quotaInNamespace < OzoneConsts.QUOTA_RESET) {
       return false;
     }
     return true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -189,7 +189,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       long volumeQuotaInBytes, String volumeName) throws IOException {
     long totalBucketQuota = 0;
 
-    if (volumeQuotaInBytes == 0) {
+    if (volumeQuotaInBytes < OzoneConsts.QUOTA_RESET) {
       return false;
     }
 
@@ -213,8 +213,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
 
   public boolean checkQuotaNamespaceValid(long quotaInNamespace) {
 
-    if ((quotaInNamespace <= 0
-         && quotaInNamespace != OzoneConsts.QUOTA_RESET)) {
+    if (quotaInNamespace < OzoneConsts.QUOTA_RESET) {
       return false;
     }
     return true;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/volume/OMVolumeSetQuotaRequest.java
@@ -189,7 +189,8 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
       long volumeQuotaInBytes, String volumeName) throws IOException {
     long totalBucketQuota = 0;
 
-    if (volumeQuotaInBytes < OzoneConsts.QUOTA_RESET) {
+    if (volumeQuotaInBytes < OzoneConsts.QUOTA_RESET
+        || volumeQuotaInBytes == 0) {
       return false;
     }
 
@@ -213,7 +214,7 @@ public class OMVolumeSetQuotaRequest extends OMVolumeRequest {
 
   public boolean checkQuotaNamespaceValid(long quotaInNamespace) {
 
-    if (quotaInNamespace < OzoneConsts.QUOTA_RESET) {
+    if (quotaInNamespace < OzoneConsts.QUOTA_RESET || quotaInNamespace == 0) {
       return false;
     }
     return true;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetSpaceQuotaOptions.java
@@ -32,13 +32,13 @@ public class SetSpaceQuotaOptions {
   @CommandLine.Option(names = {"--namespace-quota"},
       description = "For volume this parameter represents the number of " +
           "buckets, and for buckets represents the number of keys (eg. 5)")
-  private long quotaInNamespace;
+  private String quotaInNamespace;
 
   public String getQuotaInBytes() {
     return quotaInBytes;
   }
 
-  public long getQuotaInNamespace() {
+  public String getQuotaInNamespace() {
     return quotaInNamespace;
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.shell.bucket;
 
+import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -80,12 +81,19 @@ public class CreateBucketHandler extends BucketHandler {
       }
     }
 
-    if (quotaOptions.getQuotaInBytes() != null) {
-      bb.setQuotaInBytes(OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaOptions.getQuotaInNamespace()).getQuotaInBytes());
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
+      bb.setQuotaInBytes(OzoneQuota.parseSpaceQuota(
+          quotaOptions.getQuotaInBytes()).getQuotaInBytes());
+    } else {
+      bb.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
     }
 
-    bb.setQuotaInNamespace(quotaOptions.getQuotaInNamespace());
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
+      bb.setQuotaInNamespace(OzoneQuota.parseNameSpaceQuota(
+          quotaOptions.getQuotaInNamespace()).getQuotaInNamespace());
+    } else {
+      bb.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
+    }
 
     String volumeName = address.getVolumeName();
     String bucketName = address.getBucketName();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -84,17 +84,12 @@ public class CreateBucketHandler extends BucketHandler {
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
       bb.setQuotaInBytes(OzoneQuota.parseSpaceQuota(
           quotaOptions.getQuotaInBytes()).getQuotaInBytes());
-    } else {
-      bb.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
     }
 
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
       bb.setQuotaInNamespace(OzoneQuota.parseNameSpaceQuota(
           quotaOptions.getQuotaInNamespace()).getQuotaInNamespace());
-    } else {
-      bb.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
     }
-
     String volumeName = address.getVolumeName();
     String bucketName = address.getBucketName();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.shell.bucket;
 
+import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -48,15 +49,15 @@ public class SetQuotaHandler extends BucketHandler {
     long spaceQuota = bucket.getQuotaInBytes();
     long namespaceQuota = bucket.getQuotaInNamespace();
 
-    if (quotaOptions.getQuotaInBytes() != null
-        && !quotaOptions.getQuotaInBytes().isEmpty()) {
-      spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaOptions.getQuotaInNamespace()).getQuotaInBytes();
-    }
-    if (quotaOptions.getQuotaInNamespace() >= 0) {
-      namespaceQuota = quotaOptions.getQuotaInNamespace();
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
+      spaceQuota = OzoneQuota.parseSpaceQuota(
+          quotaOptions.getQuotaInBytes()).getQuotaInBytes();
     }
 
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
+      namespaceQuota = OzoneQuota.parseNameSpaceQuota(
+          quotaOptions.getQuotaInNamespace()).getQuotaInNamespace();
+    }
     bucket.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, namespaceQuota));
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.shell.volume;
 
 import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.client.OzoneQuota;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -64,15 +63,11 @@ public class CreateVolumeHandler extends VolumeHandler {
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
       volumeArgsBuilder.setQuotaInBytes(OzoneQuota.parseSpaceQuota(
           quotaOptions.getQuotaInBytes()).getQuotaInBytes());
-    } else {
-      volumeArgsBuilder.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
     }
 
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
       volumeArgsBuilder.setQuotaInNamespace(OzoneQuota.parseNameSpaceQuota(
           quotaOptions.getQuotaInNamespace()).getQuotaInNamespace());
-    } else {
-      volumeArgsBuilder.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
     }
 
     client.getObjectStore().createVolume(volumeName,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/CreateVolumeHandler.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
+import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.client.OzoneQuota;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
@@ -59,13 +61,19 @@ public class CreateVolumeHandler extends VolumeHandler {
     VolumeArgs.Builder volumeArgsBuilder = VolumeArgs.newBuilder()
         .setAdmin(adminName)
         .setOwner(ownerName);
-    if (quotaOptions.getQuotaInBytes() != null) {
-      volumeArgsBuilder.setQuotaInBytes(OzoneQuota.parseQuota(
-          quotaOptions.getQuotaInBytes(),
-          quotaOptions.getQuotaInNamespace()).getQuotaInBytes());
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
+      volumeArgsBuilder.setQuotaInBytes(OzoneQuota.parseSpaceQuota(
+          quotaOptions.getQuotaInBytes()).getQuotaInBytes());
+    } else {
+      volumeArgsBuilder.setQuotaInBytes(OzoneConsts.QUOTA_RESET);
     }
 
-    volumeArgsBuilder.setQuotaInNamespace(quotaOptions.getQuotaInNamespace());
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
+      volumeArgsBuilder.setQuotaInNamespace(OzoneQuota.parseNameSpaceQuota(
+          quotaOptions.getQuotaInNamespace()).getQuotaInNamespace());
+    } else {
+      volumeArgsBuilder.setQuotaInNamespace(OzoneConsts.QUOTA_RESET);
+    }
 
     client.getObjectStore().createVolume(volumeName,
         volumeArgsBuilder.build());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
@@ -54,7 +54,7 @@ public class SetQuotaHandler extends VolumeHandler {
 
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
       namespaceQuota = OzoneQuota.parseNameSpaceQuota(
-          quotaOptions.getQuotaInNamespace()).getQuotaInBytes();
+          quotaOptions.getQuotaInNamespace()).getQuotaInNamespace();
     }
 
     volume.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, namespaceQuota));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.shell.volume;
 
+import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.client.OzoneQuota;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -46,14 +47,14 @@ public class SetQuotaHandler extends VolumeHandler {
 
     long spaceQuota = volume.getQuotaInBytes();
     long namespaceQuota = volume.getQuotaInNamespace();
-
-    if (quotaOptions.getQuotaInBytes() != null
-        && !quotaOptions.getQuotaInBytes().isEmpty()) {
-      spaceQuota = OzoneQuota.parseQuota(quotaOptions.getQuotaInBytes(),
-          quotaOptions.getQuotaInNamespace()).getQuotaInBytes();
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInBytes())) {
+      spaceQuota = OzoneQuota.parseSpaceQuota(
+          quotaOptions.getQuotaInBytes()).getQuotaInBytes();
     }
-    if (quotaOptions.getQuotaInNamespace() >= 0) {
-      namespaceQuota = quotaOptions.getQuotaInNamespace();
+
+    if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
+      namespaceQuota = OzoneQuota.parseNameSpaceQuota(
+          quotaOptions.getQuotaInNamespace()).getQuotaInBytes();
     }
 
     volume.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, namespaceQuota));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently setting Quota is invalid if set to 0. It's actually going to be set to -1.

`store.getVolume(volumeName).getBucket(bucketName).setQuota(`
`       OzoneQuota.parseQuota("0GB", 0));`
`  Assert.assertEquals(-1, bucket.getQuotaInBytes());`
`  Assert.assertEquals(-1, bucket.getQuotaInNamespace());`
This behavior is actually incorrect, and In general setting quota to 0 isn't a valid entry even in HDFS.  we can be consistent with HDFS on this part.

`java.lang.IllegalArgumentException: Invalid values for quota : 0 `

Because the original client quota type is long. If the user does not specify quota, the default value for this field is 0.
We cannot verify that the user did not specify quota or set quoat to 0, since both actions are passed to the backend to be 0.
So it would be more appropriate to change the long to a string. If the user does not specify quota, it is null. It's easier to judge.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4631

## How was this patch tested?

ut added
