### PR TITLE
HDDS-4640. Intermittent failure in MapReduce test due to existing output file

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
@@ -41,7 +41,7 @@ Execute PI calculation
 
 Execute WordCount
                     ${exampleJar}    Find example jar
-                    ${random}        Generate Random String  2   [NUMBERS]
+    ${random} =     Generate Random String
     ${root} =       Format FS URL    ${SCHEME}    ${volume}    ${bucket}
     ${dir} =        Format FS URL    ${SCHEME}    ${volume}    ${bucket}   input/
     ${result} =     Format FS URL    ${SCHEME}    ${volume}    ${bucket}   wordcount-${random}.txt


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase length of random part of output file name for wordcount MR test to avoid getting the same filename for both O3FS and OFS.

https://issues.apache.org/jira/browse/HDDS-4640

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/461028151