### PR TITLE
HDDS-4643. Ratis Snapshot should be loaded from the config

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -149,7 +149,8 @@ public final class RatisUtil {
   private static void setRaftSnapshotProperties(
       final RaftProperties properties, final SCMHAConfiguration conf) {
     Snapshot.setAutoTriggerEnabled(properties, true);
-    Snapshot.setAutoTriggerThreshold(properties, 400000);
+    Snapshot.setAutoTriggerThreshold(properties,
+        conf.getRatisSnapshotThreshold());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -120,7 +120,7 @@ public class SCMHAConfiguration {
       tags = {SCM, OZONE, HA, RATIS},
       description = "The threshold to trigger a Ratis taking snapshot " +
           "operation")
-  private long ratisSnapshotThreshold = 100000L;
+  private long ratisSnapshotThreshold = 1000L;
 
   @Config(key = "ratis.request.timeout",
       type = ConfigType.TIME,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -116,10 +116,10 @@ public class SCMHAConfiguration {
 
   @Config(key = "ratis.snapshot.threshold",
       type = ConfigType.LONG,
-      defaultValue = "100000L",
+      defaultValue = "1000L",
       tags = {SCM, OZONE, HA, RATIS},
       description = "The threshold to trigger a Ratis taking snapshot " +
-          "operation")
+          "operation for SCM")
   private long ratisSnapshotThreshold = 1000L;
 
   @Config(key = "ratis.request.timeout",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -114,6 +114,14 @@ public class SCMHAConfiguration {
   )
   private int raftLogPurgeGap = 1000000;
 
+  @Config(key = "ratis.snapshot.threshold",
+      type = ConfigType.LONG,
+      defaultValue = "100000L",
+      tags = {SCM, OZONE, HA, RATIS},
+      description = "The threshold to trigger a Ratis taking snapshot " +
+          "operation")
+  private long ratisSnapshotThreshold = 100000L;
+
   @Config(key = "ratis.request.timeout",
       type = ConfigType.TIME,
       defaultValue = "3000ms",
@@ -195,6 +203,14 @@ public class SCMHAConfiguration {
 
   public int getRaftLogPurgeGap() {
     return raftLogPurgeGap;
+  }
+
+  public long getRatisSnapshotThreshold() {
+    return ratisSnapshotThreshold;
+  }
+
+  public void setRatisSnapshotThreshold(long threshold) {
+    this.ratisSnapshotThreshold = threshold;
   }
 
   public long getRatisRetryCacheTimeout() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -116,7 +116,7 @@ public class SCMHAConfiguration {
 
   @Config(key = "ratis.snapshot.threshold",
       type = ConfigType.LONG,
-      defaultValue = "1000L",
+      defaultValue = "1000",
       tags = {SCM, OZONE, HA, RATIS},
       description = "The threshold to trigger a Ratis taking snapshot " +
           "operation for SCM")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -88,8 +88,7 @@ public class TestReplicationAnnotation {
 
     try {
       proxy.addContainer(HddsProtos.ContainerInfoProto.getDefaultInstance());
-      // Should have seen a IOException.
-      Assert.fail();
+      Assert.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException ignore) {
       // Expecting to hit here.
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now Ratis snapshot auto trigger threshold is a fixed number. We should load it from the HA configuration. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4643

## How was this patch tested?

N/A
