### PR TITLE
HDDS-4644. Block token verification failed: no READ permission for WriteChunk

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -114,6 +114,8 @@ import org.apache.commons.lang3.StringUtils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.HADOOP_SECURITY_KEY_PROVIDER_PATH;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.READ;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.WRITE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_CONTAINER_RATIS_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
@@ -377,8 +379,7 @@ public class KeyManagerImpl implements KeyManager {
       if (grpcBlockTokenEnabled) {
         builder.setToken(secretManager
             .generateToken(remoteUser, allocatedBlock.getBlockID().toString(),
-                EnumSet.of(HddsProtos.BlockTokenSecretProto.
-                    AccessModeProto.WRITE), scmBlockSize));
+                EnumSet.of(READ, WRITE), scmBlockSize));
       }
       locationInfos.add(builder.build());
     }
@@ -698,8 +699,7 @@ public class KeyManagerImpl implements KeyManager {
         key.getLocationList().forEach(k -> {
           k.setToken(secretManager.generateToken(remoteUser,
               k.getBlockID().getContainerBlockID().toString(),
-              EnumSet.of(HddsProtos.BlockTokenSecretProto.
-                  AccessModeProto.READ), k.getLength()));
+              EnumSet.of(READ), k.getLength()));
         });
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -73,6 +73,8 @@ import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.READ;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockTokenSecretProto.AccessModeProto.WRITE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .BUCKET_NOT_FOUND;
@@ -142,8 +144,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       if (grpcBlockTokenEnabled) {
         builder.setToken(secretManager
             .generateToken(remoteUser, allocatedBlock.getBlockID().toString(),
-                EnumSet.of(HddsProtos.BlockTokenSecretProto.
-                    AccessModeProto.WRITE),
+                EnumSet.of(READ, WRITE),
                 scmBlockSize));
       }
       locationInfos.add(builder.build());


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-4558 secure acceptance test logs increased considerably (over 1GB).

https://github.com/apache/ozone/actions/runs/462095579

I think the root cause is that `WriteChunk` request may trigger `ReadChunk`, which now fails because it only has write access:

```
datanode_3  | 2021-01-05 10:41:23,067 [ChunkWriter-1-0] INFO impl.HddsDispatcher: Operation: ReadChunk , Trace ID:  , Message: Block token verification failed. Block token with conID: 1 locID: 105502689303461889 doesn't have READ permission , Result: BLOCK_TOKEN_VERIFICATION_FAILED , StorageContainerException Occurred.
datanode_3  | org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException: Block token verification failed. Block token with conID: 1 locID: 105502689303461889 doesn't have READ permission
datanode_3  | 	at org.apache.hadoop.ozone.container.common.impl.HddsDispatcher.dispatchRequest(HddsDispatcher.java:214)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.impl.HddsDispatcher.lambda$dispatch$0(HddsDispatcher.java:171)
datanode_3  | 	at org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher.processRequest(OzoneProtocolMessageDispatcher.java:87)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.impl.HddsDispatcher.dispatch(HddsDispatcher.java:170)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine.dispatchCommand(ContainerStateMachine.java:398)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine.readStateMachineData(ContainerStateMachine.java:585)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine.lambda$read$5(ContainerStateMachine.java:656)
datanode_3  | 	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
datanode_3  | 	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
datanode_3  | 	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
datanode_3  | 	at java.base/java.lang.Thread.run(Thread.java:834)
datanode_3  | Caused by: org.apache.hadoop.hdds.security.token.BlockTokenException: Block token with conID: 1 locID: 105502689303461889 doesn't have READ permission
datanode_3  | 	at org.apache.hadoop.hdds.security.token.BlockTokenVerifier.verify(BlockTokenVerifier.java:131)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.impl.HddsDispatcher.validateBlockToken(HddsDispatcher.java:431)
datanode_3  | 	at org.apache.hadoop.ozone.container.common.impl.HddsDispatcher.dispatchRequest(HddsDispatcher.java:211)
datanode_3  | 	... 10 more
datanode_3  | 2021-01-05 10:41:23,083 [ChunkWriter-1-0] ERROR ratis.ContainerStateMachine: gid group-5BCDF056E270 : ReadStateMachine failed. cmd ReadChunk logIndex 4 msg : Block token verification failed. Block token with conID: 1 locID: 105502689303461889 doesn't have READ permission Container Result: BLOCK_TOKEN_VERIFICATION_FAILED
```

https://issues.apache.org/jira/browse/HDDS-4644

## How was this patch tested?

Artifact is back to 35MB:
https://github.com/adoroszlai/hadoop-ozone/runs/1650453722