### PR TITLE
HDDS-4647. Avoid hadoop-ozone-filesystem-shaded as transitive dependency

### DIFF
--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-filesystem-shaded</artifactId>
+      <optional>true</optional>
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -32,6 +32,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-ozone-filesystem-shaded</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

If `hadoop-ozone-filesystem-hadoop2` or `hadoop-ozone-filesystem-hadoop3` is added as dependency in some project, `hadoop-ozone-filesystem-shaded` is included as a transitive dependency.  But it should not be required for such downstream projects, as both Hadoop version-specific modules already repackage most of it.  This change marks the dependency as optional ([doc](http://maven.apache.org/pom.html#Dependencies)) so that such projects do not need to add `exclusion` for this module.

https://issues.apache.org/jira/browse/HDDS-4647

## How was this patch tested?

Checked dependency tree of downstream project no longer includes `hadoop-ozone-filesystem-shaded`:

```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ tez ---
[INFO] ...
[INFO] +- jdk.tools:jdk.tools:jar:1.8:system
[INFO] \- org.apache.hadoop:hadoop-ozone-filesystem-hadoop3:jar:1.1.0-SNAPSHOT:runtime
[INFO] ------------------------------------------------------------------------
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/465890389