### PR TITLE
HDDS-4612. Create OMCancelPrepareRequest and Response to cancel the prepared state of an OM.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -296,6 +296,7 @@ public final class OmUtils {
     case RecoverTrash:
     case FinalizeUpgrade:
     case Prepare:
+    case CancelPrepare:
     case DeleteOpenKeys:
       return false;
     default:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelPrepareResponse;
 import org.apache.hadoop.ozone.security.OzoneDelegationTokenSelector;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
@@ -617,5 +618,14 @@ public interface OzoneManagerProtocol
         .setCurrentTxnIndex(-1)
         .setStatus(PrepareStatus.PREPARE_NOT_STARTED)
         .build();
+  }
+
+  /**
+   * Cancel the prepare state of the Ozone Manager. If ozone manager is not
+   * prepared, has no effect.
+   * @throws IOException on exception.
+   */
+  default CancelPrepareResponse cancelOzoneManagerPrepare() throws IOException {
+    return CancelPrepareResponse.newBuilder().build();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1587,6 +1587,18 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     return prepareStatusResponse;
   }
 
+  @Override
+  public CancelPrepareResponse cancelOzoneManagerPrepare() throws IOException {
+    CancelPrepareRequest cancelPrepareRequest =
+        CancelPrepareRequest.newBuilder().build();
+
+    OMRequest omRequest = createOMRequest(Type.CancelPrepare)
+        .setCancelPrepareRequest(cancelPrepareRequest).build();
+
+    // Cancel prepare response has no information for the caller.
+    return handleError(submitRequest(omRequest)).getCancelPrepareResponse();
+  }
+
   @VisibleForTesting
   public OmTransport getTransport() {
     return transport;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1595,7 +1595,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     OMRequest omRequest = createOMRequest(Type.CancelPrepare)
         .setCancelPrepareRequest(cancelPrepareRequest).build();
 
-    // Cancel prepare response has no information for the caller.
     return handleError(submitRequest(omRequest)).getCancelPrepareResponse();
   }
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -76,6 +76,7 @@ enum Type {
   FinalizeUpgradeProgress = 55;
   Prepare = 56;
   PrepareStatus = 57;
+  CancelPrepare = 58;
 
   GetDelegationToken = 61;
   RenewDelegationToken = 62;
@@ -149,6 +150,7 @@ message OMRequest {
   optional FinalizeUpgradeProgressRequest   finalizeUpgradeProgressRequest = 55;
   optional PrepareRequest                   prepareRequest                 = 56;
   optional PrepareStatusRequest             prepareStatusRequest           = 57;
+  optional CancelPrepareRequest             cancelPrepareRequest           = 58;
 
   optional hadoop.common.GetDelegationTokenRequestProto getDelegationTokenRequest = 61;
   optional hadoop.common.RenewDelegationTokenRequestProto renewDelegationTokenRequest= 62;
@@ -226,6 +228,7 @@ message OMResponse {
   optional FinalizeUpgradeProgressResponse finalizeUpgradeProgressResponse = 55;
   optional PrepareResponse                 prepareResponse                 = 56;
   optional PrepareStatusResponse           prepareStatusResponse           = 57;
+  optional CancelPrepareResponse           cancelPrepareResponse           = 58;
 
   optional GetDelegationTokenResponseProto getDelegationTokenResponse = 61;
   optional RenewDelegationTokenResponseProto renewDelegationTokenResponse = 62;
@@ -1088,15 +1091,20 @@ message PrepareStatusRequest {
 
 message PrepareStatusResponse {
     enum PrepareStatus {
-        // TODO
-        // HDDS-4569 may introduce new states here, like marker file found
-        // but with different txn id. We can add them as make sense.
         PREPARE_NOT_STARTED = 1;
         PREPARE_IN_PROGRESS = 2;
         PREPARE_COMPLETED = 3;
     }
     required PrepareStatus status = 1;
     optional uint64 currentTxnIndex = 2;
+}
+
+message CancelPrepareRequest {
+
+}
+
+message CancelPrepareResponse {
+
 }
 
 message ServicePort {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerPrepareState.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerPrepareState.java
@@ -199,8 +199,8 @@ public final class OzoneManagerPrepareState {
     boolean requestAllowed = true;
 
     if (prepareGateEnabled) {
-      // TODO: Also return true for cancel prepare when it is implemented.
-      requestAllowed = (requestType == Type.Prepare);
+      requestAllowed =
+          (requestType == Type.Prepare) || (requestType == Type.CancelPrepare);
     }
 
     return requestAllowed;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.upgrade;
+
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.upgrade.OMCancelPrepareResponse;
+import org.apache.hadoop.ozone.om.response.upgrade.OMPrepareResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelPrepareResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class OMCancelPrepareRequest extends OMClientRequest {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMCancelPrepareRequest.class);
+
+  public OMCancelPrepareRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(
+      OzoneManager ozoneManager, long transactionLogIndex,
+      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+
+    LOG.info("OM {} Received cancel request with log index {}",
+        ozoneManager.getOMNodeId(), transactionLogIndex);
+
+    OMRequest omRequest = getOmRequest();
+    OMResponse.Builder responseBuilder =
+        OmResponseUtil.getOMResponseBuilder(omRequest);
+    responseBuilder.setCmdType(Type.CancelPrepare);
+    OMClientResponse response = null;
+
+    try {
+      // Create response.
+      CancelPrepareResponse omResponse = CancelPrepareResponse.newBuilder()
+          .build();
+      responseBuilder.setCancelPrepareResponse(omResponse);
+      response = new OMCancelPrepareResponse(responseBuilder.build());
+
+      ozoneManagerDoubleBufferHelper.add(response, transactionLogIndex);
+
+      ozoneManager.getPrepareState().cancelPrepare();
+
+      LOG.info("OM {} prepare state cancelled at log index {}. Returning " +
+              "response {}",
+          ozoneManager.getOMNodeId(), transactionLogIndex, omResponse);
+    } catch (IOException e) {
+      LOG.error("Cancel Prepare Request apply failed in {}. ",
+          ozoneManager.getOMNodeId(), e);
+      response = new OMPrepareResponse(
+          createErrorOMResponse(responseBuilder, e));
+    }
+
+    return response;
+  }
+
+  public static String getRequestType() {
+    return Type.CancelPrepare.name();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -64,9 +64,10 @@ public class OMCancelPrepareRequest extends OMClientRequest {
       responseBuilder.setCancelPrepareResponse(omResponse);
       response = new OMCancelPrepareResponse(responseBuilder.build());
 
-      ozoneManagerDoubleBufferHelper.add(response, transactionLogIndex);
-
+      // Deletes on disk marker file, does not update DB and therefore does
+      // not update cache.
       ozoneManager.getPrepareState().cancelPrepare();
+      ozoneManagerDoubleBufferHelper.add(response, transactionLogIndex);
 
       LOG.info("OM {} prepare state cancelled at log index {}. Returning " +
               "response {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 /**
  * Response for cancel prepare.
  */
-@CleanupTableInfo
+@CleanupTableInfo()
 public class OMCancelPrepareResponse extends OMClientResponse {
   public OMCancelPrepareResponse(
       OzoneManagerProtocolProtos.OMResponse omResponse) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
@@ -36,7 +36,7 @@ public class OMCancelPrepareResponse extends OMClientResponse {
 
   @Override
   protected void addToDBBatch(OMMetadataManager omMetadataManager,
-    BatchOperation batchOperation) throws IOException {
+      BatchOperation batchOperation) throws IOException {
     // The cancel prepare request will delete the prepare marker file and
     // update in memory state, so this response does not need to perform  DB
     // update.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.response.upgrade;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.io.IOException;
+
+/**
+ * Response for cancel prepare.
+ */
+@CleanupTableInfo
+public class OMCancelPrepareResponse extends OMClientResponse {
+  public OMCancelPrepareResponse(
+      OzoneManagerProtocolProtos.OMResponse omResponse) {
+    super(omResponse);
+  }
+
+  @Override
+  protected void addToDBBatch(OMMetadataManager omMetadataManager,
+    BatchOperation batchOperation) throws IOException {
+    // The cancel prepare request will delete the prepare marker file and
+    // update in memory state, so this response does not need to perform  DB
+    // update.
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.KeyManagerImpl;
@@ -75,6 +77,7 @@ public class TestOMKeyRequest {
   protected OMMetrics omMetrics;
   protected OMMetadataManager omMetadataManager;
   protected AuditLogger auditLogger;
+  protected OzoneManagerPrepareState prepareState;
 
   protected ScmClient scmClient;
   protected OzoneBlockTokenSecretManager ozoneBlockTokenSecretManager;
@@ -106,6 +109,8 @@ public class TestOMKeyRequest {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
         folder.newFolder().getAbsolutePath());
+    ozoneConfiguration.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
+        folder.newFolder().getAbsolutePath());
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);
@@ -133,6 +138,9 @@ public class TestOMKeyRequest {
     when(ozoneManager.getOMNodeId()).thenReturn(UUID.randomUUID().toString());
     when(scmClient.getBlockClient()).thenReturn(scmBlockLocationProtocol);
     when(ozoneManager.getKeyManager()).thenReturn(keyManager);
+
+    prepareState = new OzoneManagerPrepareState(ozoneConfiguration);
+    when(ozoneManager.getPrepareState()).thenReturn(prepareState);
 
     Pipeline pipeline = Pipeline.newBuilder()
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om.request.upgrade;
+
+import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
+import org.apache.hadoop.ozone.om.request.key.TestOMKeyRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.key.OMOpenKeysDeleteRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
+  private static final long LOG_INDEX = 1;
+
+  @Test
+  public void testCancelPrepareWhenUnprepared() throws Exception {
+    assertUnprepared();
+    ozoneManager.getPrepareState().finishPrepare(LOG_INDEX);
+    assertPrepared(LOG_INDEX);
+    submitCancelPrepareRequest();
+    assertUnprepared();
+  }
+
+  @Test
+  public void testCancelPrepareWhenPrepared() throws Exception {
+    assertUnprepared();
+    submitCancelPrepareRequest();
+    assertUnprepared();
+  }
+
+  private void assertPrepared(long logIndex) {
+    OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
+    OzoneManagerPrepareState.State state = prepareState.getState();
+
+    Assert.assertEquals(state.getStatus(), PrepareStatus.PREPARE_COMPLETED);
+    Assert.assertEquals(state.getIndex(), logIndex);
+    Assert.assertTrue(prepareState.getPrepareMarkerFile().exists());
+    Assert.assertFalse(prepareState.requestAllowed(Type.CreateVolume));
+  }
+
+  private void assertUnprepared() {
+    OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
+    OzoneManagerPrepareState.State state = prepareState.getState();
+
+    Assert.assertEquals(state.getStatus(), PrepareStatus.PREPARE_NOT_STARTED);
+    Assert.assertEquals(state.getIndex(),
+        OzoneManagerPrepareState.NO_PREPARE_INDEX);
+    Assert.assertFalse(prepareState.getPrepareMarkerFile().exists());
+    Assert.assertTrue(prepareState.requestAllowed(Type.CreateVolume));
+  }
+
+  private void submitCancelPrepareRequest() throws Exception {
+    OMRequest omRequest =
+        doPreExecute(createCancelPrepareRequest());
+
+    OMCancelPrepareRequest cancelPrepareRequest =
+        new OMCancelPrepareRequest(omRequest);
+
+    OMClientResponse omClientResponse =
+        cancelPrepareRequest.validateAndUpdateCache(ozoneManager,
+            LOG_INDEX, ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
+    OMOpenKeysDeleteRequest omOpenKeysDeleteRequest =
+        new OMOpenKeysDeleteRequest(originalOmRequest);
+
+    OMRequest modifiedOmRequest =
+        omOpenKeysDeleteRequest.preExecute(ozoneManager);
+
+    // Will not be equal, as UserInfo will be set.
+    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+
+    return modifiedOmRequest;
+  }
+
+  private OMRequest createCancelPrepareRequest() {
+    OzoneManagerProtocolProtos.CancelPrepareRequest cancelPrepareRequest =
+        OzoneManagerProtocolProtos.CancelPrepareRequest.newBuilder().build();
+
+    return OMRequest.newBuilder()
+        .setCancelPrepareRequest(cancelPrepareRequest)
+        .setCmdType(OzoneManagerProtocolProtos.Type.CancelPrepare)
+        .setClientId(UUID.randomUUID().toString()).build();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
@@ -29,23 +29,24 @@ import org.junit.Test;
 
 import java.util.UUID;
 
+/**
+ * Unit testing of cancel prepare request. Cancel prepare response does not
+ * perform an action, so it has no unit testing.
+ */
 public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
   private static final long LOG_INDEX = 1;
 
   @Test
-  public void testCancelPrepareWhenUnprepared() throws Exception {
-    assertUnprepared();
+  public void testCancelPrepare() throws Exception {
+    assertNotPrepared();
     ozoneManager.getPrepareState().finishPrepare(LOG_INDEX);
     assertPrepared(LOG_INDEX);
     submitCancelPrepareRequest();
-    assertUnprepared();
-  }
+    assertNotPrepared();
 
-  @Test
-  public void testCancelPrepareWhenPrepared() throws Exception {
-    assertUnprepared();
+    // Another cancel prepare should be able to be submitted without error.
     submitCancelPrepareRequest();
-    assertUnprepared();
+    assertNotPrepared();
   }
 
   private void assertPrepared(long logIndex) {
@@ -58,7 +59,7 @@ public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
     Assert.assertFalse(prepareState.requestAllowed(Type.CreateVolume));
   }
 
-  private void assertUnprepared() {
+  private void assertNotPrepared() {
     OzoneManagerPrepareState prepareState = ozoneManager.getPrepareState();
     OzoneManagerPrepareState.State state = prepareState.getState();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.om.request.file.OMFileCreateRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCreateRequest;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
+import org.apache.hadoop.ozone.om.response.upgrade.OMCancelPrepareResponse;
 import org.apache.hadoop.ozone.om.response.upgrade.OMPrepareResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
@@ -156,9 +157,10 @@ public class TestCleanupTableInfo {
         Assert.assertTrue(
             Arrays.stream(cleanupTables).allMatch(tables::contains)
         );
-      } else if (aClass != OMPrepareResponse.class) {
-        // Prepare response is allowed to have no cleanup tables, since it
-        // does not modify the DB.
+      } else if (aClass != OMPrepareResponse.class &&
+          aClass != OMCancelPrepareResponse.class) {
+        // Prepare and cancel responses are allowed to have no cleanup tables,
+        // since they do not modify the DB.
         Assert.assertTrue(cleanupAll);
       }
     });

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOzoneManagerPrepareState.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/upgrade/TestOzoneManagerPrepareState.java
@@ -252,8 +252,7 @@ public class TestOzoneManagerPrepareState {
     // Once preparation has begun, only prepare and cancel prepare should be
     // allowed.
     for (Type cmdType: Type.values()) {
-      if (cmdType == Type.Prepare) {
-        // TODO: Add cancelPrepare to allowed request types when it is added.
+      if (cmdType == Type.Prepare || cmdType == Type.CancelPrepare) {
         Assert.assertTrue(prepareState.requestAllowed(cmdType));
       } else {
         Assert.assertFalse(prepareState.requestAllowed(cmdType));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement an OM request and response to cancel the prepared state of an ozone manager. Client protocol is added to allow integration testing. This will be connected to a client CLI command and acceptance tested in HDDS-4611.

## What is the link to the Apache JIRA

HDDS-4612

## How was this patch tested?

Unit and integration tests added.

