### PR TITLE
HDDS-4659. No cleanup in TestOzoneFSWithObjectStoreCreate

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
@@ -36,6 +37,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -99,6 +101,13 @@ public class TestOzoneFSWithObjectStoreCreate {
     o3fs = (OzoneFileSystem) FileSystem.get(new URI(rootPath), conf);
   }
 
+  @After
+  public void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(o3fs);
+  }
 
   @Test
   public void test() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Mini cluster needs to be shutdown after each test.

https://issues.apache.org/jira/browse/HDDS-4659

## How was this patch tested?

Checked size of `hadoop-ozone/integration-test/target/test-dir` after running `TestOzoneFSWithObjectStoreCreate`.