### PR TITLE
HDDS-2402. Adapt hadolint check to improved CI framework

### DIFF
--- a/hadoop-ozone/dev-support/checks/hadolint.sh
+++ b/hadoop-ozone/dev-support/checks/hadolint.sh
@@ -21,26 +21,20 @@ REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/hadolint"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-for Dockerfile in $(find "$REPO_DIR/hadoop-ozone" "$REPO_DIR/hadoop-hdds" -name Dockerfile | sort); do
-  echo "Checking $Dockerfile" | tee -a "$REPORT_FILE"
-
+for Dockerfile in $(find hadoop-ozone hadoop-hdds -name Dockerfile | sort); do
   result=$( hadolint $Dockerfile )
   if [ ! -z "$result" ]
   then
     echo "$result" | tee -a "$REPORT_FILE"
-    echo "" | tee -a "$REPORT_FILE"
   fi
 done
 
-cat "$REPORT_FILE" |  egrep -v '^$|^Checking' | wc -l | awk '{print $1}'> "$REPORT_DIR/failures"
+wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
 
 if [ -s "${REPORT_FILE}" ]
 then
   echo "" | tee -a "$REPORT_FILE"
   echo "" | tee -a "$REPORT_FILE"
   echo "Hadolint errors were found. Exit code: 1." | tee -a "$REPORT_FILE"
-fi
-
-if [[ -s "${REPORT_FILE}" ]]; then
-   exit 1
+  exit 1
 fi

--- a/hadoop-ozone/dev-support/checks/hadolint.sh
+++ b/hadoop-ozone/dev-support/checks/hadolint.sh
@@ -20,13 +20,10 @@ REPO_DIR="$DIR/../../.."
 REPORT_DIR=${OUTPUT_DIR:-"$DIR/../../../target/hadolint"}
 mkdir -p "$REPORT_DIR"
 REPORT_FILE="$REPORT_DIR/summary.txt"
+echo -n > "$REPORT_FILE"
 
 for Dockerfile in $(find hadoop-ozone hadoop-hdds -name Dockerfile | sort); do
-  result=$( hadolint $Dockerfile )
-  if [ ! -z "$result" ]
-  then
-    echo "$result" | tee -a "$REPORT_FILE"
-  fi
+  hadolint $Dockerfile | tee -a "$REPORT_FILE"
 done
 
 wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Save the list of failures to summary.txt (while also outputting everything to stdout)
- Save output number of failures to failures

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2402

## How was this patch tested?

manually tested. Failures and output numbers are written to summary.txt and failures correctly.
