### PR TITLE
HDDS-3205. DeleteBlock via Ratis in SCM HA

### DIFF
--- a/hadoop-hdds/interface-server/src/main/proto/SCMRatisProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/SCMRatisProtocol.proto
@@ -23,6 +23,7 @@ option java_generate_equals_and_hash = true;
 enum RequestType {
     PIPELINE = 1;
     CONTAINER = 2;
+    BLOCK = 3;
 }
 
 message Method {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -101,8 +101,11 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
     mxBean = MBeans.register("BlockManager", "BlockManagerImpl", this);
 
     // SCM block deleting transaction log and deleting service.
-    deletedBlockLog = new DeletedBlockLogImpl(conf, scm.getContainerManager(),
-        scm.getScmMetadataStore());
+    deletedBlockLog = new DeletedBlockLogImplV2(conf, scm.getContainerManager(),
+        scm.getScmHAManager().getRatisServer(),
+        scm.getScmMetadataStore().getDeletedBlocksTXTable(),
+        scm.getScmHAManager().getDBTransactionBuffer(),
+        scm.getScmContext());
     Duration svcInterval = conf.getObject(
             ScmConfig.class).getBlockDeletionInterval();
     long serviceTimeout =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLog.java
@@ -81,17 +81,6 @@ public interface DeletedBlockLog extends Closeable {
       UUID dnID);
 
   /**
-   * Creates a block deletion transaction and adds that into the log.
-   *
-   * @param containerID - container ID.
-   * @param blocks - blocks that belong to the same container.
-   *
-   * @throws IOException
-   */
-  void addTransaction(long containerID, List<Long> blocks)
-      throws IOException;
-
-  /**
    * Creates block deletion transactions for a set of containers,
    * add into the log and persist them atomically. An object key
    * might be stored in multiple containers and multiple blocks,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.block;
+
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.metadata.Replicate;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+public interface DeletedBlockLogStateManager {
+  @Replicate
+  void addTransactionsToDB(ArrayList<DeletedBlocksTransaction> txs)
+      throws IOException;
+
+  @Replicate
+  void removeTransactionsFromDB(ArrayList<Long> txIDs)
+      throws IOException;
+
+  @Replicate
+  void increaseRetryCountOfTransactionInDB(ArrayList<Long> txIDs)
+      throws IOException;
+
+  TableIterator<Long,
+      KeyValue<Long, DeletedBlocksTransaction>> getReadOnlyIterator();
+
+  void onFlush();
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.block;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
+import org.apache.hadoop.hdds.scm.ha.DBTransactionBuffer;
+import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.TypedTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT;
+
+public class DeletedBlockLogStateManagerImpl
+    implements DeletedBlockLogStateManager {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(DeletedBlockLogStateManagerImpl.class);
+
+  private final Table<Long, DeletedBlocksTransaction> deletedTable;
+  private final DBTransactionBuffer transactionBuffer;
+  private final int maxRetry;
+  private Set<Long> deletingTxIDs;
+
+  public DeletedBlockLogStateManagerImpl(
+      ConfigurationSource conf,
+      Table<Long, DeletedBlocksTransaction> deletedTable,
+      DBTransactionBuffer txBuffer) {
+    this.maxRetry = conf.getInt(OZONE_SCM_BLOCK_DELETION_MAX_RETRY,
+        OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT);
+    this.deletedTable = deletedTable;
+    this.transactionBuffer = txBuffer;
+    this.deletingTxIDs = ConcurrentHashMap.newKeySet();
+  }
+
+  public TableIterator<Long, TypedTable.KeyValue<Long,
+      DeletedBlocksTransaction>> getReadOnlyIterator() {
+    return new TableIterator<Long, TypedTable.KeyValue<Long,
+        DeletedBlocksTransaction>>() {
+
+      private TableIterator<Long,
+          ? extends Table.KeyValue<Long, DeletedBlocksTransaction>> iter =
+          deletedTable.iterator();
+      private TypedTable.KeyValue<Long, DeletedBlocksTransaction> nextTx;
+
+      {
+        findNext();
+      }
+
+      private void findNext() {
+        while (iter.hasNext()) {
+          TypedTable.KeyValue<Long, DeletedBlocksTransaction> next = iter
+              .next();
+          long txID;
+          try {
+            txID = next.getKey();
+          } catch (IOException e) {
+            throw new IllegalStateException("");
+          }
+
+          if (!deletingTxIDs.contains(txID)) {
+            nextTx = next;
+            if (LOG.isTraceEnabled()) {
+              LOG.trace("DeletedBlocksTransaction matching txID:{}",
+                  txID);
+            }
+            return;
+          }
+        }
+        nextTx = null;
+      }
+
+      @Override
+      public boolean hasNext() {
+        return nextTx != null;
+      }
+
+      @Override
+      public TypedTable.KeyValue<Long, DeletedBlocksTransaction> next() {
+        if (nextTx == null) {
+          throw new NoSuchElementException("DeletedBlocksTransaction " +
+              "Iterator reached end");
+        }
+        TypedTable.KeyValue<Long, DeletedBlocksTransaction> returnTx = nextTx;
+        findNext();
+        return returnTx;
+      }
+
+      @Override
+      public void close() throws IOException {
+        iter.close();
+      }
+
+      @Override
+      public void seekToFirst() {
+        throw new UnsupportedOperationException("seekToFirst");
+      }
+
+      @Override
+      public void seekToLast() {
+        throw new UnsupportedOperationException("seekToLast");
+      }
+
+      @Override
+      public TypedTable.KeyValue<Long, DeletedBlocksTransaction> seek(
+          Long key) throws IOException {
+        throw new UnsupportedOperationException("seek");
+      }
+
+      @Override
+      public Long key() throws IOException {
+        throw new UnsupportedOperationException("key");
+      }
+
+      @Override
+      public TypedTable.KeyValue<Long, DeletedBlocksTransaction> value() {
+        throw new UnsupportedOperationException("value");
+      }
+
+      @Override
+      public void removeFromDB() throws IOException {
+        throw new UnsupportedOperationException("read-only");
+      }
+    };
+  }
+
+  @Override
+  public void addTransactionsToDB(ArrayList<DeletedBlocksTransaction> txs)
+      throws IOException {
+    for (DeletedBlocksTransaction tx : txs) {
+      deletedTable.putWithBatch(
+          transactionBuffer.getCurrentBatchOperation(), tx.getTxID(), tx);
+    }
+  }
+
+  @Override
+  public void removeTransactionsFromDB(ArrayList<Long> txIDs)
+      throws IOException {
+    for (Long txID : txIDs) {
+      deletedTable.deleteWithBatch(
+          transactionBuffer.getCurrentBatchOperation(), txID);
+    }
+  }
+
+  @Override
+  public void increaseRetryCountOfTransactionInDB(
+      ArrayList<Long> txIDs) throws IOException {
+    for (Long txID : txIDs) {
+      DeletedBlocksTransaction block =
+          deletedTable.get(txID);
+      if (block == null) {
+        if (LOG.isDebugEnabled()) {
+          // This can occur due to race condition between retry and old
+          // service task where old task removes the transaction and the new
+          // task is resending
+          LOG.debug("Deleted TXID {} not found.", txID);
+        }
+        continue;
+      }
+      DeletedBlocksTransaction.Builder builder = block.toBuilder();
+      int currentCount = block.getCount();
+      if (currentCount > -1) {
+        builder.setCount(++currentCount);
+      }
+      // if the retry time exceeds the maxRetry value
+      // then set the retry value to -1, stop retrying, admins can
+      // analyze those blocks and purge them manually by SCMCli.
+      if (currentCount > maxRetry) {
+        builder.setCount(-1);
+      }
+      deletedTable.putWithBatch(
+          transactionBuffer.getCurrentBatchOperation(), txID, builder.build());
+    }
+  }
+
+
+  public void onFlush() {
+    deletingTxIDs.clear();
+    LOG.info("Clear cached deletingTxIDs.");
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for ContainerStateManager.
+   */
+  public static class Builder {
+    private ConfigurationSource conf;
+    private SCMRatisServer scmRatisServer;
+    private Table<Long, DeletedBlocksTransaction> table;
+    private DBTransactionBuffer transactionBuffer;
+
+    public Builder setConfiguration(final ConfigurationSource config) {
+      conf = config;
+      return this;
+    }
+
+    public Builder setRatisServer(final SCMRatisServer ratisServer) {
+      scmRatisServer = ratisServer;
+      return this;
+    }
+
+    public Builder setDeletedBlocksTable(
+        final Table<Long, DeletedBlocksTransaction> deletedBlocksTable) {
+      table = deletedBlocksTable;
+      return this;
+    }
+
+    public Builder setSCMDBTransactionBuffer(DBTransactionBuffer buffer) {
+      this.transactionBuffer = buffer;
+      return this;
+    }
+
+    public DeletedBlockLogStateManager build() {
+      Preconditions.checkNotNull(conf);
+      Preconditions.checkNotNull(scmRatisServer);
+      Preconditions.checkNotNull(table);
+      Preconditions.checkNotNull(table);
+
+      final DeletedBlockLogStateManager impl =
+          new DeletedBlockLogStateManagerImpl(conf, table, transactionBuffer);
+
+      final SCMHAInvocationHandler invocationHandler =
+          new SCMHAInvocationHandler(SCMRatisProtocol.RequestType.BLOCK,
+              impl, scmRatisServer);
+
+      return (DeletedBlockLogStateManager) Proxy.newProxyInstance(
+          SCMHAInvocationHandler.class.getClassLoader(),
+          new Class<?>[]{DeletedBlockLogStateManager.class},
+          invocationHandler);
+    }
+
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -48,7 +48,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
       final StorageContainerManager scm) throws IOException {
     this.conf = conf;
     this.transactionBuffer =
-        new SCMDBTransactionBuffer(scm.getScmMetadataStore());
+        new SCMDBTransactionBuffer(scm);
     this.ratisServer = new SCMRatisServerImpl(
         conf.getObject(SCMHAConfiguration.class), conf, scm, transactionBuffer);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -26,7 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImplV2;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftGroupMemberId;
@@ -156,6 +159,13 @@ public class SCMStateMachine extends BaseStateMachine {
 
     scm.getScmContext().updateLeaderAndTerm(true, term);
     scm.getSCMServiceManager().notifyStatusChanged();
+
+    DeletedBlockLog deletedBlockLog = scm.getScmBlockManager()
+        .getDeletedBlockLog();
+    Preconditions.checkArgument(
+        deletedBlockLog instanceof DeletedBlockLogImplV2);
+    ((DeletedBlockLogImplV2) deletedBlockLog)
+          .clearTransactionToDNsCommitMap();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -61,7 +61,7 @@ import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
 import org.apache.hadoop.hdds.scm.block.BlockManagerImpl;
-import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
+import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImplV2;
 import org.apache.hadoop.hdds.scm.block.PendingDeleteHandler;
 import org.apache.hadoop.hdds.scm.command.CommandStatusReportHandler;
 import org.apache.hadoop.hdds.scm.container.CloseContainerEventHandler;
@@ -362,7 +362,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     eventQueue
         .addHandler(SCMEvents.PENDING_DELETE_STATUS, pendingDeleteHandler);
     eventQueue.addHandler(SCMEvents.DELETE_BLOCK_STATUS,
-        (DeletedBlockLogImpl) scmBlockManager.getDeletedBlockLog());
+        (DeletedBlockLogImplV2) scmBlockManager.getDeletedBlockLog());
     eventQueue.addHandler(SCMEvents.PIPELINE_ACTIONS, pipelineActionHandler);
     eventQueue.addHandler(SCMEvents.PIPELINE_REPORT, pipelineReportHandler);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -280,9 +280,15 @@ public class TestDeleteWithSlowFollower {
     client.getObjectStore().getVolume(volumeName).getBucket(bucketName).
             deleteKey("ratis");
     GenericTestUtils.waitFor(() -> {
-      return
-          dnStateMachine.getCommandDispatcher().getDeleteBlocksCommandHandler()
-              .getInvocationCount() >= 1;
+      try {
+        cluster.getStorageContainerManager().getScmHAManager()
+            .getDBTransactionBuffer().flush();
+        return
+            dnStateMachine.getCommandDispatcher()
+                .getDeleteBlocksCommandHandler().getInvocationCount() >= 1;
+      } catch (IOException e) {
+        return false;
+      }
     }, 500, 100000);
     Assert.assertTrue(containerData.getDeleteTransactionId() > delTrxId);
     Assert.assertTrue(


### PR DESCRIPTION
## What changes were proposed in this pull request?

DeleteBlock needs to add/update/delete DELETED_BLOCKS_TABLE in SCMMetadataDB. So SCM does these operations via ratis.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3205

## How was this patch tested?

Existed UT.
