### PR TITLE
HDDS-4672. Add warning log when old volume and bucket set quota

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -196,6 +196,7 @@ public final class OzoneConsts {
    * Quota RESET default is -1, which means quota is not set.
    */
   public static final long QUOTA_RESET = -1;
+  public static final long OLD_QUOTA_DEFAULT = -2;
 
   /**
    * Quota Units.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -299,8 +299,9 @@ public class RpcClient implements ClientProtocol {
     // that it is not recommended to enable quota.
     OmVolumeArgs omVolumeArgs = ozoneManagerClient.getVolumeInfo(volumeName);
     if (omVolumeArgs.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
-      LOG.warn("Volume: {} is a old volume, usedNamespace may be " +
-          "inaccurate and it is not recommended to enable quota.", volumeName);
+      LOG.warn("Volume {} is created before version 1.1.0, usedNamespace " +
+          "may be inaccurate and it is not recommended to enable quota.",
+          volumeName);
     }
     ozoneManagerClient.setQuota(volumeName, quotaInNamespace, quotaInBytes);
   }
@@ -594,14 +595,17 @@ public class RpcClient implements ClientProtocol {
     OmBucketInfo omBucketInfo = ozoneManagerClient.getBucketInfo(
         volumeName, bucketName);
     if (omBucketInfo.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
-      LOG.warn("Bucket: {} is a old bucket, usedNamespace may be " +
-          "inaccurate and it is not recommended to enable quota.", bucketName);
+      LOG.warn("Bucket {} is created before version 1.1.0, usedNamespace " +
+          "may be inaccurate and it is not recommended to enable quota.",
+          bucketName);
     }
     if (omBucketInfo.getUsedBytes() == OLD_QUOTA_DEFAULT) {
-      LOG.warn("Bucket: {} is a old bucket, usedBytes may be " +
-          "inaccurate and it is not recommended to enable quota.", bucketName);
+      LOG.warn("Bucket {} is created before version 1.1.0, usedBytes " +
+          "may be inaccurate and it is not recommended to enable quota.",
+          bucketName);
     }
     ozoneManagerClient.setBucketProperty(builder.build());
+
   }
 
   @Override

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -594,15 +594,11 @@ public class RpcClient implements ClientProtocol {
     // that it is not recommended to enable quota.
     OmBucketInfo omBucketInfo = ozoneManagerClient.getBucketInfo(
         volumeName, bucketName);
-    if (omBucketInfo.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
-      LOG.warn("Bucket {} is created before version 1.1.0, usedNamespace " +
-          "may be inaccurate and it is not recommended to enable quota.",
-          bucketName);
-    }
-    if (omBucketInfo.getUsedBytes() == OLD_QUOTA_DEFAULT) {
-      LOG.warn("Bucket {} is created before version 1.1.0, usedBytes " +
-          "may be inaccurate and it is not recommended to enable quota.",
-          bucketName);
+    if (omBucketInfo.getQuotaInNamespace() == OLD_QUOTA_DEFAULT ||
+        omBucketInfo.getUsedBytes() == OLD_QUOTA_DEFAULT) {
+      LOG.warn("Bucket {} is created before version 1.1.0, usedBytes or " +
+          "usedNamespace may be inaccurate and it is not recommended to " +
+          "enable quota.", bucketName);
     }
     ozoneManagerClient.setBucketProperty(builder.build());
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -110,6 +110,8 @@ import org.apache.hadoop.security.token.Token;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
+
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
 import org.slf4j.Logger;
@@ -293,6 +295,13 @@ public class RpcClient implements ClientProtocol {
     HddsClientUtils.verifyResourceName(volumeName);
     verifyCountsQuota(quotaInNamespace);
     verifySpaceQuota(quotaInBytes);
+    // If the volume is old, we need to remind the user on the client side
+    // that it is not recommended to enable quota.
+    OmVolumeArgs omVolumeArgs = ozoneManagerClient.getVolumeInfo(volumeName);
+    if (omVolumeArgs.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
+      LOG.warn("Volume: {} is a old volume, usedNamespace may be " +
+          "inaccurate and it is not recommended to enable quota.", volumeName);
+    }
     ozoneManagerClient.setQuota(volumeName, quotaInNamespace, quotaInBytes);
   }
 
@@ -580,8 +589,19 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setQuotaInBytes(quotaInBytes)
         .setQuotaInNamespace(quotaInNamespace);
+    // If the bucket is old, we need to remind the user on the client side
+    // that it is not recommended to enable quota.
+    OmBucketInfo omBucketInfo = ozoneManagerClient.getBucketInfo(
+        volumeName, bucketName);
+    if (omBucketInfo.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
+      LOG.warn("Bucket: {} is a old bucket, usedNamespace may be " +
+          "inaccurate and it is not recommended to enable quota.", bucketName);
+    }
+    if (omBucketInfo.getUsedBytes() == OLD_QUOTA_DEFAULT) {
+      LOG.warn("Bucket: {} is a old bucket, usedBytes may be " +
+          "inaccurate and it is not recommended to enable quota.", bucketName);
+    }
     ozoneManagerClient.setBucketProperty(builder.build());
-
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -118,6 +118,10 @@ public abstract class Handler implements Callable<Void> {
     out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(o));
   }
 
+  protected void printMsg(String msg) {
+    out().println(msg);
+  }
+
   protected OzoneConfiguration getConf() {
     return conf;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetQuotaHandler.java
@@ -28,6 +28,8 @@ import picocli.CommandLine.Command;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
+
 /**
  * set quota of the bucket.
  */
@@ -57,6 +59,14 @@ public class SetQuotaHandler extends BucketHandler {
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
       namespaceQuota = OzoneQuota.parseNameSpaceQuota(
           quotaOptions.getQuotaInNamespace()).getQuotaInNamespace();
+    }
+
+    if (bucket.getQuotaInNamespace() == OLD_QUOTA_DEFAULT ||
+        bucket.getUsedBytes() == OLD_QUOTA_DEFAULT) {
+      String msg = "Bucket " + bucketName + " is created before version " +
+          "1.1.0, usedBytes or usedNamespace may be inaccurate and it is not" +
+          " recommended to enable quota.";
+      printMsg(msg);
     }
     bucket.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, namespaceQuota));
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/SetQuotaHandler.java
@@ -29,6 +29,8 @@ import picocli.CommandLine.Command;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
+
 /**
  * Executes set volume quota calls.
  */
@@ -55,6 +57,13 @@ public class SetQuotaHandler extends VolumeHandler {
     if (!Strings.isNullOrEmpty(quotaOptions.getQuotaInNamespace())) {
       namespaceQuota = OzoneQuota.parseNameSpaceQuota(
           quotaOptions.getQuotaInNamespace()).getQuotaInNamespace();
+    }
+
+    if (volume.getQuotaInNamespace() == OLD_QUOTA_DEFAULT) {
+      String msg = "Volume " + volumeName + " is created before version " +
+          "1.1.0, usedNamespace may be inaccurate and it is not recommended" +
+          " to enable quota.";
+      printMsg(msg);
     }
 
     volume.setQuota(OzoneQuota.getOzoneQuota(spaceQuota, namespaceQuota));


### PR DESCRIPTION
## What changes were proposed in this pull request?
https://github.com/apache/ozone/blob/master/hadoop-hdds/docs/content/feature/Quota.md
![image](https://user-images.githubusercontent.com/13825159/104286107-90e86b80-54ef-11eb-977f-f3a1c87a74af.png)


Currently we only advise users in the doc document not to enable quota for old volumes and buckets. Sometimes the user might not notice. So we added a warning on the client side, when user set quota on old volume and bucket.
![image](https://user-images.githubusercontent.com/13825159/104286353-e886d700-54ef-11eb-8660-8546b48a44fa.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4672

## How was this patch tested?

Add log no need UT
