### PR TITLE
HDDS-4673. NodeStateMap leaks internal representation of container sets

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/states/NodeStateMap.java
@@ -18,18 +18,23 @@
 
 package org.apache.hadoop.hdds.scm.node.states;
 
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
-import org.apache.hadoop.hdds.scm.node.NodeStatus;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 
 /**
  * Maintains the state of datanodes in SCM. This class should only be used by
@@ -334,7 +339,8 @@ public class NodeStateMap {
     lock.readLock().lock();
     try {
       checkIfNodeExist(uuid);
-      return Collections.unmodifiableSet(nodeToContainer.get(uuid));
+      return Collections
+          .unmodifiableSet(new HashSet<>(nodeToContainer.get(uuid)));
     } finally {
       lock.readLock().unlock();
     }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4673

## What changes were proposed in this pull request?

@jojochuang  [reported](https://issues.apache.org/jira/browse/HDDS-3918?focusedCommentId=17223103&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17223103) that some `ConcurrentModificationException` is visible even after #1174 (https://issues.apache.org/jira/browse/HDDS-3918) 

The root cause of this issue is a leak of internal representation of sets in `NodeStateMap`. 

`NodeStateMap`  returns an unmodifiable copy of containers for one specific node:

```
Collections.unmodifiableSet(nodeToContainer.get(uuid))
```

With this approach the users of the `nodeStateMap.getContainers` method couldn't modify the set anymore. But `nodeStateMap` can modify the original set which is referenced (instead of copy) by the `unmodifiableSet`. Even if it's unmodifiable it throws an exception during the iteration if the original set is modified in the background.

## How was this patch tested?

There is a new unit test method which reproduce the specific race condition with the help of `CountDownLatch`-es