### PR TITLE
HDDS-2212. Genconf tool should generate config files for secure clust…

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -330,6 +330,8 @@ public final class OzoneConfigKeys {
   public static final String OZONE_HTTP_SECURITY_ENABLED_KEY =
       "ozone.security.http.kerberos.enabled";
   public static final boolean OZONE_HTTP_SECURITY_ENABLED_DEFAULT = false;
+  public static final String OZONE_HTTP_FILTER_INITIALIZERS_KEY =
+      "ozone.http.filter.initializers";
 
   public static final String OZONE_CONTAINER_COPY_WORKDIR =
       "hdds.datanode.replication.work.dir";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -430,4 +430,12 @@ public final class OzoneConsts {
 
   public static final String SCM_SUB_CA_PREFIX = "scm-sub@";
   public static final String SCM_ROOT_CA_PREFIX = "scm@";
+
+  // Kerberos constants
+  public static final String KERBEROS_CONFIG_VALUE = "kerberos";
+  public static final String HTTP_AUTH_TYPE_SUFFIX = "http.auth.type";
+  public static final String OZONE_SECURITY_ENABLED_SECURE = "true";
+  public static final String OZONE_HTTP_SECURITY_ENABLED_SECURE = "true";
+  public static final String OZONE_HTTP_FILTER_INITIALIZERS_SECURE =
+      "org.apache.hadoop.security.AuthenticationFilterInitializer";
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -434,7 +434,7 @@
   </property>
   <property>
     <name>ozone.om.service.ids</name>
-    <value></value>
+    <value/>
     <tag>OM, HA</tag>
     <description>
       Comma-separated list of OM service Ids. This property allows the client
@@ -443,7 +443,7 @@
   </property>
   <property>
     <name>ozone.om.internal.service.id</name>
-    <value></value>
+    <value/>
     <tag>OM, HA</tag>
     <description>
       Service ID of the Ozone Manager. If this is not set fall back to
@@ -452,7 +452,7 @@
   </property>
   <property>
     <name>ozone.om.nodes.EXAMPLEOMSERVICEID</name>
-    <value></value>
+    <value/>
     <tag>OM, HA</tag>
     <description>
       Comma-separated list of OM node Ids for a given OM service ID (eg.
@@ -470,7 +470,7 @@
   </property>
   <property>
     <name>ozone.om.node.id</name>
-    <value></value>
+    <value/>
     <tag>OM, HA</tag>
     <description>
       The ID of this OM node. If the OM node ID is not configured it
@@ -1262,7 +1262,7 @@
 
   <property>
     <name>hdds.datanode.plugins</name>
-    <value></value>
+    <value/>
     <description>
       Comma-separated list of HDDS datanode plug-ins to be activated when
       HDDS service starts as part of datanode.
@@ -1455,6 +1455,37 @@
   </property>
 
   <property>
+    <name>hdds.scm.kerberos.keytab.file</name>
+    <value/>
+    <tag>SCM, SECURITY, KERBEROS</tag>
+    <description> The keytab file used by SCM daemon to login as its service principal.
+    </description>
+  </property>
+  <property>
+    <name>hdds.scm.kerberos.principal</name>
+    <value/>
+    <tag>SCM, SECURITY, KERBEROS</tag>
+    <description>The SCM service principal. e.g. scm/_HOST@REALM.COM</description>
+  </property>
+  <property>
+    <name>hdds.scm.http.auth.kerberos.principal</name>
+    <value>HTTP/_HOST@REALM</value>
+    <tag>SCM, SECURITY, KERBEROS</tag>
+    <description>
+      SCM http server service principal if SPNEGO is enabled for SCM http server.
+    </description>
+  </property>
+  <property>
+    <name>hdds.scm.http.auth.kerberos.keytab</name>
+    <value>/path/to/HTTP.keytab</value>
+    <tag>SCM, SECURITY, KERBEROS</tag>
+    <description>
+      The keytab file used by SCM http server to login as its service
+      principal if SPNEGO is enabled for SCM http server.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.s3g.volume.name</name>
     <value>s3v</value>
     <tag>OZONE, S3GATEWAY</tag>
@@ -1519,8 +1550,8 @@
 
   <property>
     <name>ozone.s3g.http.auth.kerberos.principal</name>
-    <value/>
-    <tag>OZONE, S3GATEWAY</tag>
+    <value>HTTP/_HOST@REALM</value>
+    <tag>OZONE, S3GATEWAY, KERBEROS</tag>
     <description>The server principal used by Ozone S3Gateway server. This is
       typically set to
       HTTP/_HOST@REALM.TLD The SPNEGO server principal begins with the prefix
@@ -1529,8 +1560,8 @@
 
   <property>
     <name>ozone.s3g.http.auth.kerberos.keytab</name>
-    <value/>
-    <tag>OZONE, S3GATEWAY</tag>
+    <value>/path/to/HTTP.keytab</value>
+    <tag>OZONE, S3GATEWAY, KERBEROS</tag>
     <description>The keytab file used by the S3Gateway server to login as its
       service principal. </description>
   </property>
@@ -1547,7 +1578,7 @@
   <property>
     <name>ozone.security.enabled</name>
     <value>false</value>
-    <tag>OZONE, SECURITY</tag>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>True if security is enabled for ozone. When this property is
      true, hadoop.security.authentication should be Kerberos.
     </description>
@@ -1555,11 +1586,21 @@
   <property>
     <name>ozone.security.http.kerberos.enabled</name>
     <value>false</value>
-    <tag>OZONE, SECURITY</tag>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>True if Kerberos authentication for Ozone HTTP web consoles
       is enabled using the SPNEGO protocol. When this property is
       true, hadoop.security.authentication should be Kerberos and
       ozone.security.enabled should be set to true.
+    </description>
+  </property>
+  <property>
+    <name>ozone.http.filter.initializers</name>
+    <value/>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
+    <description>Set to org.apache.hadoop.security.AuthenticationFilterInitializer
+      to enable Kerberos authentication for Ozone HTTP web consoles
+      is enabled using the SPNEGO protocol. When this property is
+      set, ozone.security.http.kerberos.enabled should be set to true.
     </description>
   </property>
 
@@ -1760,8 +1801,8 @@
   </property>
   <property>
     <name>ozone.om.kerberos.keytab.file</name>
-    <value></value>
-    <tag> OZONE, SECURITY</tag>
+    <value/>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description> The keytab file used by OzoneManager daemon to login as its
       service principal. The principal name is configured with
       ozone.om.kerberos.principal.
@@ -1769,22 +1810,25 @@
   </property>
   <property>
     <name>ozone.om.kerberos.principal</name>
-    <value></value>
-    <tag> OZONE, SECURITY</tag>
+    <value/>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>The OzoneManager service principal. Ex om/_HOST@REALM.COM</description>
   </property>
   <property>
     <name>ozone.om.http.auth.kerberos.principal</name>
-    <value>HTTP/_HOST@EXAMPLE.COM</value>
+    <value>HTTP/_HOST@REALM</value>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>
-      OzoneManager http server kerberos principal.
+      Ozone Manager http server service principal if SPNEGO is enabled for om http server.
     </description>
   </property>
   <property>
     <name>ozone.om.http.auth.kerberos.keytab</name>
-    <value>/etc/security/keytabs/HTTP.keytab</value>
+    <value>/path/to/HTTP.keytab</value>
+    <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>
-      OzoneManager http server kerberos keytab.
+      The keytab file used by OM http server to login as its service
+      principal if SPNEGO is enabled for om http server.
     </description>
   </property>
   <property>
@@ -2233,7 +2277,7 @@
   </property>
   <property>
     <name>ozone.freon.http.auth.kerberos.principal</name>
-    <value>HTTP/_HOST@EXAMPLE.COM</value>
+    <value>HTTP/_HOST@REALM</value>
     <tag>SECURITY</tag>
     <description>
      Security principal used by freon.
@@ -2241,7 +2285,7 @@
   </property>
   <property>
     <name>ozone.freon.http.auth.kerberos.keytab</name>
-    <value>/etc/security/keytabs/HTTP.keytab</value>
+    <value>/path/to/HTTP.keytab</value>
     <tag>SECURITY</tag>
     <description>
        Keytab used by Freon.
@@ -2295,16 +2339,16 @@
 
   <property>
     <name>hdds.datanode.http.auth.kerberos.principal</name>
-    <value>HTTP/_HOST@EXAMPLE.COM</value>
-    <tag>HDDS, SECURITY, MANAGEMENT</tag>
+    <value>HTTP/_HOST@REALM</value>
+    <tag>HDDS, SECURITY, MANAGEMENT, KERBEROS</tag>
     <description>
       The kerberos principal for the datanode http server.
     </description>
   </property>
   <property>
     <name>hdds.datanode.http.auth.kerberos.keytab</name>
-    <value>/etc/security/keytabs/HTTP.keytab</value>
-    <tag>HDDS, SECURITY, MANAGEMENT</tag>
+    <value>/path/to/HTTP.keytab</value>
+    <tag>HDDS, SECURITY, MANAGEMENT, KERBEROS</tag>
     <description>
       The kerberos keytab file for datanode http server
     </description>
@@ -2429,31 +2473,31 @@
   </property>
   <property>
     <name>ozone.recon.http.auth.kerberos.keytab</name>
-    <value/>
-    <tag>RECON, SECURITY</tag>
+    <value>/path/to/HTTP.keytab</value>
+    <tag>RECON, SECURITY, KERBEROS</tag>
     <description>
       The keytab file for HTTP Kerberos authentication in Recon.
     </description>
   </property>
   <property>
     <name>ozone.recon.http.auth.kerberos.principal</name>
-    <value/>
-    <tag>RECON</tag>
+    <value>HTTP/_HOST@REALM</value>
+    <tag>RECON, KERBEROS</tag>
     <description>The server principal used by Ozone Recon server. This is
       typically set to HTTP/_HOST@REALM.TLD The SPNEGO server principal
       begins with the prefix HTTP/ by convention.
     </description>
   </property>
   <property>
-    <name>hdds.datanode.http.auth.type </name>
+    <name>hdds.datanode.http.auth.type</name>
     <value>simple</value>
-    <tag>DATANODE, SECURITY</tag>
+    <tag>DATANODE, SECURITY, KERBEROS</tag>
     <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
   <property>
-    <name>ozone.freon.http.auth.type </name>
+    <name>ozone.freon.http.auth.type</name>
     <value>simple</value>
     <tag>FREON, SECURITY</tag>
     <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
@@ -2461,25 +2505,33 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.http.auth.type </name>
+    <name>ozone.om.http.auth.type</name>
     <value>simple</value>
-    <tag>OM, SECURITY</tag>
+    <tag>OM, SECURITY, KERBEROS</tag>
     <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
   <property>
-    <name>ozone.recon.http.auth.type </name>
+    <name>hdds.scm.http.auth.type</name>
     <value>simple</value>
-    <tag>RECON, SECURITY</tag>
+    <tag>OM, SECURITY, KERBEROS</tag>
     <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
   </property>
   <property>
-    <name>ozone.s3g.http.auth.type </name>
+    <name>ozone.recon.http.auth.type</name>
     <value>simple</value>
-    <tag>S3G, SECURITY</tag>
+    <tag>RECON, SECURITY, KERBEROS</tag>
+    <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
+      will be used for http authentication.
+    </description>
+  </property>
+  <property>
+    <name>ozone.s3g.http.auth.type</name>
+    <value>simple</value>
+    <tag>S3G, SECURITY, KERBEROS</tag>
     <description> simple or kerberos. If kerberos is set, Kerberos SPNEOGO
       will be used for http authentication.
     </description>
@@ -2633,7 +2685,7 @@
   </property>
   <property>
     <name>ozone.http.basedir</name>
-    <value></value>
+    <value/>
     <tag>OZONE, OM, SCM, MANAGEMENT</tag>
     <description>
       The base dir for HTTP Jetty server to extract contents. If this property
@@ -2694,14 +2746,14 @@
   <property>
     <name>ssl.server.keystore.keypassword</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
-    <value></value>
+    <value/>
     <description>Keystore key password for HTTPS SSL configuration
     </description>
   </property>
   <property>
     <name>ssl.server.keystore.location</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
-    <value></value>
+    <value/>
     <description>
       Keystore location for HTTPS SSL configuration
     </description>
@@ -2709,7 +2761,7 @@
   <property>
     <name>ssl.server.keystore.password</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
-    <value></value>
+    <value/>
     <description>
       Keystore password for HTTPS SSL configuration
     </description>
@@ -2717,7 +2769,7 @@
   <property>
     <name>ssl.server.truststore.location</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
-    <value></value>
+    <value/>
     <description>
       Truststore location for HTTPS SSL configuration
     </description>
@@ -2725,7 +2777,7 @@
   <property>
     <name>ssl.server.truststore.password</name>
     <tag>OZONE, SECURITY, MANAGEMENT</tag>
-    <value></value>
+    <value/>
     <description>
       Truststore password for HTTPS SSL configuration
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1456,7 +1456,7 @@
 
   <property>
     <name>hdds.scm.kerberos.keytab.file</name>
-    <value>/path/to/SCM.keytab</value>
+    <value>/etc/security/keytabs/SCM.keytab</value>
     <tag>SCM, SECURITY, KERBEROS</tag>
     <description> The keytab file used by SCM daemon to login as its service principal.
     </description>
@@ -1477,7 +1477,7 @@
   </property>
   <property>
     <name>hdds.scm.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>SCM, SECURITY, KERBEROS</tag>
     <description>
       The keytab file used by SCM http server to login as its service
@@ -1560,7 +1560,7 @@
 
   <property>
     <name>ozone.s3g.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>OZONE, S3GATEWAY, KERBEROS</tag>
     <description>The keytab file used by the S3Gateway server to login as its
       service principal. </description>
@@ -1801,7 +1801,7 @@
   </property>
   <property>
     <name>ozone.om.kerberos.keytab.file</name>
-    <value>/path/to/OM.keytab</value>
+    <value>/etc/security/keytabs/OM.keytab</value>
     <tag>OZONE, SECURITY, KERBEROS</tag>
     <description> The keytab file used by OzoneManager daemon to login as its
       service principal. The principal name is configured with
@@ -1824,7 +1824,7 @@
   </property>
   <property>
     <name>ozone.om.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>
       The keytab file used by OM http server to login as its service
@@ -2285,7 +2285,7 @@
   </property>
   <property>
     <name>ozone.freon.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>SECURITY</tag>
     <description>
        Keytab used by Freon.
@@ -2347,7 +2347,7 @@
   </property>
   <property>
     <name>hdds.datanode.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>HDDS, SECURITY, MANAGEMENT, KERBEROS</tag>
     <description>
       The kerberos keytab file for datanode http server
@@ -2473,7 +2473,7 @@
   </property>
   <property>
     <name>ozone.recon.http.auth.kerberos.keytab</name>
-    <value>/path/to/HTTP.keytab</value>
+    <value>/etc/security/keytabs/HTTP.keytab</value>
     <tag>RECON, SECURITY, KERBEROS</tag>
     <description>
       The keytab file for HTTP Kerberos authentication in Recon.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1551,7 +1551,7 @@
   <property>
     <name>ozone.s3g.http.auth.kerberos.principal</name>
     <value>HTTP/_HOST@REALM</value>
-    <tag>OZONE, S3GATEWAY, KERBEROS</tag>
+    <tag>OZONE, S3GATEWAY, SECURITY, KERBEROS</tag>
     <description>The server principal used by Ozone S3Gateway server. This is
       typically set to
       HTTP/_HOST@REALM.TLD The SPNEGO server principal begins with the prefix
@@ -1561,7 +1561,7 @@
   <property>
     <name>ozone.s3g.http.auth.kerberos.keytab</name>
     <value>/etc/security/keytabs/HTTP.keytab</value>
-    <tag>OZONE, S3GATEWAY, KERBEROS</tag>
+    <tag>OZONE, S3GATEWAY, SECURITY, KERBEROS</tag>
     <description>The keytab file used by the S3Gateway server to login as its
       service principal. </description>
   </property>
@@ -2482,7 +2482,7 @@
   <property>
     <name>ozone.recon.http.auth.kerberos.principal</name>
     <value>HTTP/_HOST@REALM</value>
-    <tag>RECON, KERBEROS</tag>
+    <tag>RECON, SECURITY, KERBEROS</tag>
     <description>The server principal used by Ozone Recon server. This is
       typically set to HTTP/_HOST@REALM.TLD The SPNEGO server principal
       begins with the prefix HTTP/ by convention.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1456,14 +1456,14 @@
 
   <property>
     <name>hdds.scm.kerberos.keytab.file</name>
-    <value/>
+    <value>/path/to/SCM.keytab</value>
     <tag>SCM, SECURITY, KERBEROS</tag>
     <description> The keytab file used by SCM daemon to login as its service principal.
     </description>
   </property>
   <property>
     <name>hdds.scm.kerberos.principal</name>
-    <value/>
+    <value>SCM/_HOST@REALM</value>
     <tag>SCM, SECURITY, KERBEROS</tag>
     <description>The SCM service principal. e.g. scm/_HOST@REALM.COM</description>
   </property>
@@ -1801,7 +1801,7 @@
   </property>
   <property>
     <name>ozone.om.kerberos.keytab.file</name>
-    <value/>
+    <value>/path/to/OM.keytab</value>
     <tag>OZONE, SECURITY, KERBEROS</tag>
     <description> The keytab file used by OzoneManager daemon to login as its
       service principal. The principal name is configured with
@@ -1810,7 +1810,7 @@
   </property>
   <property>
     <name>ozone.om.kerberos.principal</name>
-    <value/>
+    <value>OM/_HOST@REALM</value>
     <tag>OZONE, SECURITY, KERBEROS</tag>
     <description>The OzoneManager service principal. Ex om/_HOST@REALM.COM</description>
   </property>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.conf.TestConfigurationFieldsBase;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -48,7 +49,9 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
             OMConfigKeys.class, HddsConfigKeys.class,
             ReconServerConfigKeys.class,
             S3GatewayConfigKeys.class,
-            SCMHTTPServerConfig.class
+            SCMHTTPServerConfig.class,
+            SCMHTTPServerConfig.ConfigStrings.class,
+            ScmConfig.ConfigStrings.class
         };
     errorIfMissingConfigProps = true;
     errorIfMissingXmlProps = true;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genconf/GenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genconf/GenerateOzoneRequiredConfigurations.java
@@ -62,7 +62,8 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
       description = "Directory path where ozone-site file should be generated.")
   private String path;
 
-  @Option(names = "--security", description = "Generate security config.")
+  @Option(names = "--security", description = "Generates security config " +
+      "template, update Kerberos principal and keytab file before use.")
   private boolean genSecurityConf;
 
   /**
@@ -126,7 +127,8 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
 
     for (OzoneConfiguration.Property p : allProperties) {
       if (p.getTag() != null && (p.getTag().contains("REQUIRED") ||
-          (genSecurityConf && p.getTag().contains("SECURITY")))) {
+          (genSecurityConf && p.getTag().contains("KERBEROS")))) {
+        // Set default value for common required configs
         if (p.getName().equalsIgnoreCase(
             OzoneConfigKeys.OZONE_METADATA_DIRS)) {
           p.setValue(System.getProperty(OzoneConsts.JAVA_TMP_DIR));
@@ -136,6 +138,20 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
             || p.getName().equalsIgnoreCase(
               ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY)) {
           p.setValue(OzoneConsts.LOCALHOST);
+        }
+
+        // Set default value for KERBEROS configs
+        if (p.getName().equalsIgnoreCase(
+            OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY)) {
+          p.setValue(OzoneConsts.OZONE_SECURITY_ENABLED_SECURE);
+        } else if (p.getName().equalsIgnoreCase(
+            OzoneConfigKeys.OZONE_HTTP_SECURITY_ENABLED_KEY)) {
+          p.setValue(OzoneConsts.OZONE_HTTP_SECURITY_ENABLED_SECURE);
+        } else if (p.getName().equalsIgnoreCase(
+            OzoneConfigKeys.OZONE_HTTP_FILTER_INITIALIZERS_KEY)) {
+          p.setValue(OzoneConsts.OZONE_HTTP_FILTER_INITIALIZERS_SECURE);
+        } else if (p.getName().endsWith(OzoneConsts.HTTP_AUTH_TYPE_SUFFIX)) {
+          p.setValue(OzoneConsts.KERBEROS_CONFIG_VALUE);
         }
 
         requiredProperties.add(p);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
@@ -182,6 +182,56 @@ public class TestGenerateOzoneRequiredConfigurations {
   }
 
   /**
+   * Tests a valid path and generates secure ozone-site.xml by calling
+   * {@code GenerateOzoneRequiredConfigurations#generateConfigurations}.
+   * Further verifies that all properties have a default value.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testGenerateSecurityConfigurations() throws Exception {
+    int ozoneConfigurationCount, ozoneSecurityConfigurationCount;
+
+    // Generate default Ozone Configuration
+    File tempPath = getRandomTempDir();
+    String[] args = new String[]{tempPath.getAbsolutePath()};
+    execute(args, "ozone-site.xml has been generated at " +
+        tempPath.getAbsolutePath());
+
+    URL url = new File(tempPath.getAbsolutePath() + "/ozone-site.xml")
+        .toURI().toURL();
+    OzoneConfiguration oc = new OzoneConfiguration();
+    List<OzoneConfiguration.Property> allProperties =
+        oc.readPropertyFromXml(url);
+
+    for (OzoneConfiguration.Property p : allProperties) {
+      Assert.assertTrue(
+          p.getValue() != null && p.getValue().length() > 0);
+    }
+    ozoneConfigurationCount = allProperties.size();
+
+    // Generate secure Ozone Configuration
+    tempPath = getRandomTempDir();
+    args = new String[]{"--security", tempPath.getAbsolutePath()};
+    execute(args, "ozone-site.xml has been generated at " +
+        tempPath.getAbsolutePath());
+
+    url = new File(tempPath.getAbsolutePath() + "/ozone-site.xml")
+        .toURI().toURL();
+    oc = new OzoneConfiguration();
+    allProperties = oc.readPropertyFromXml(url);
+
+    for (OzoneConfiguration.Property p : allProperties) {
+      Assert.assertTrue(
+          p.getValue() != null && p.getValue().length() > 0);
+    }
+    ozoneSecurityConfigurationCount = allProperties.size();
+
+    Assert.assertNotEquals(ozoneConfigurationCount,
+        ozoneSecurityConfigurationCount);
+  }
+
+  /**
    * Generates ozone-site.xml at specified path.
    * Verify that it does not overwrite if file already exists in path.
    *

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
@@ -242,7 +242,7 @@ public class TestGenerateOzoneRequiredConfigurations {
   public void genconfHelp() throws Exception {
     File tempPath = getRandomTempDir();
     String[] args = new String[]{"--help"};
-    execute(args, "Usage: ozone genconf [-hV] [--verbose]");
+    execute(args, "Usage: ozone genconf [-hV] [--security] [--verbose]");
   }
 
   private File getRandomTempDir() throws IOException {


### PR DESCRIPTION
…er setup

## What changes were proposed in this pull request?

- Add the option of "--security" to the tool of "genconf".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2212

## How was this patch tested?

Manually tested. The usage of the tool is now as follows.
```
Usage: ozone genconf [-hV] [--security] [--verbose] [-conf=<configurationPath>]
                     [-D=<String=String>]... <path>
Tool to generate template ozone-site.xml
      <path>       Directory path where ozone-site file should be generated.
      --security   Generate security config.
      --verbose    More verbose output. Show the stack trace of the errors.
      -conf=<configurationPath>

  -D, --set=<String=String>

  -h, --help       Show this help message and exit.
  -V, --version    Print version information and exit.
```
