### PR TITLE
HDDS-4681. SCM webui display wrong Node counts.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -31,10 +31,18 @@
 <h2>Node counts</h2>
 
 <table class="table table-bordered table-striped" class="col-md-6">
+    <thead>
+    <tr>
+        <th class="col-md-3"></th>
+        <th>HEALTHY</th>
+        <th>STALE</th>
+        <th>DEAD</th>
+    </tr>
+    </thead>
     <tbody>
-    <tr ng-repeat="typestat in $ctrl.nodemanagermetrics.NodeCount | orderBy:'key':false:$ctrl.nodeOrder">
-        <td>{{typestat.key}}</td>
-        <td>{{typestat.value}}</td>
+    <tr ng-repeat="nodeOpState in $ctrl.nodemanagermetrics.NodeCount | orderBy:'key':false:$ctrl.nodeOpStateOrder">
+        <td>{{nodeOpState.key}}</td>
+        <td ng-repeat="nodeState in nodeOpState.value | orderBy:'key':false:$ctrl.nodeStateOrder">{{nodeState.value}}</td>
     </tr>
     </tbody>
 </table>

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm.js
@@ -31,17 +31,28 @@
                     ctrl.nodemanagermetrics = result.data.beans[0];
                 });
 
-            var statusSortOrder = {
+            const nodeOpStateSortOrder = {
+                "IN_SERVICE": "a",
+                "DECOMMISSIONING": "b",
+                "DECOMMISSIONED": "c",
+                "ENTERING_MAINTENANCE": "d",
+                "IN_MAINTENANCE": "e"
+            };
+            ctrl.nodeOpStateOrder = function (v1, v2) {
+                //status with non defined sort order will be "undefined"
+                return ("" + nodeOpStateSortOrder[v1.value])
+                    .localeCompare("" + nodeOpStateSortOrder[v2.value])
+            }
+
+            const nodeStateSortOrder = {
                 "HEALTHY": "a",
                 "STALE": "b",
-                "DEAD": "c",
-                "UNKNOWN": "z",
-                "DECOMMISSIONING": "x",
-                "DECOMMISSIONED": "y"
+                "DEAD": "c"
             };
-            ctrl.nodeOrder = function (v1, v2) {
+            ctrl.nodeStateOrder = function (v1, v2) {
                 //status with non defined sort order will be "undefined"
-                return ("" + statusSortOrder[v1.value]).localeCompare("" + statusSortOrder[v2.value])
+                return ("" + nodeStateSortOrder[v1.value])
+                    .localeCompare("" + nodeStateSortOrder[v2.value])
             }
 
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix SCM webui Node Counts display.
The order is follow [hdds.proto#NodeState](https://github.com/apache/ozone/blob/984cf668a6f3e89dfbba659414de5749390723a6/hadoop-hdds/interface-client/src/main/proto/hdds.proto#L130) and [hdds.proto#NodeOperationalState](https://github.com/apache/ozone/blob/984cf668a6f3e89dfbba659414de5749390723a6/hadoop-hdds/interface-client/src/main/proto/hdds.proto#L136).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4681

Please replace this section with the link to the Apache JIRA)

Test on docker-compose.
![Screenshot from 2021-01-13 15-28-30](https://user-images.githubusercontent.com/2565172/104420590-0e29e400-55b5-11eb-9243-f4630838781b.png)
