### PR TITLE
HDDS-4680. Change default OM Node ID from UUID to a constant

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -343,6 +343,7 @@ public final class OzoneConsts {
 
   // Default OMServiceID for OM Ratis servers to use as RaftGroupId
   public static final String OM_SERVICE_ID_DEFAULT = "omServiceIdDefault";
+  public static final String OM_DEFAULT_NODE_ID = "om1";
 
   // Dummy OMNodeID for OM Clients to use for a non-HA OM setup
   public static final String OM_NODE_ID_DUMMY = "omNodeIdDummy";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -345,9 +345,6 @@ public final class OzoneConsts {
   public static final String OM_SERVICE_ID_DEFAULT = "omServiceIdDefault";
   public static final String OM_DEFAULT_NODE_ID = "om1";
 
-  // Dummy OMNodeID for OM Clients to use for a non-HA OM setup
-  public static final String OM_NODE_ID_DUMMY = "omNodeIdDummy";
-
   public static final String JAVA_TMP_DIR = "java.io.tmpdir";
   public static final String LOCALHOST = "localhost";
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -449,7 +449,7 @@
       with the configured address.
 
       If node ID is not deterministic from the configuration, then it is set
-      to the OmId from the OM version file.
+      to default node id - om1.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -143,9 +143,9 @@ public class OMFailoverProxyProvider implements
 
 
           // For a non-HA OM setup, nodeId might be null. If so, we assign it
-          // a dummy value
+          // the default value
           if (nodeId == null) {
-            nodeId = OzoneConsts.OM_NODE_ID_DUMMY;
+            nodeId = OzoneConsts.OM_DEFAULT_NODE_ID;
           }
           // ProxyInfo will be set during first time call to server.
           omProxies.put(nodeId, null);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
@@ -175,9 +176,10 @@ public class TestOzoneManagerConfiguration {
     Collection<RaftPeer> peers = omRatisServer.getRaftGroup().getPeers();
     Assert.assertEquals(1, peers.size());
 
-    // The RaftPeer id should match the configured omId
+    // The RaftPeer id should match OM_DEFAULT_NODE_ID
     RaftPeer raftPeer = peers.toArray(new RaftPeer[1])[0];
-    Assert.assertEquals(omId, raftPeer.getId().toString());
+    Assert.assertEquals(OzoneConsts.OM_DEFAULT_NODE_ID,
+        raftPeer.getId().toString());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -361,15 +361,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     omStorage = new OMStorage(conf);
     omId = omStorage.getOmId();
 
-    // In case of single OM Node Service there will be no OM Node ID
-    // specified, set it to value from om storage
-    if (this.omNodeDetails.getOMNodeId() == null) {
-      this.omNodeDetails = OMHANodeDetails.getOMNodeDetails(conf,
-          omNodeDetails.getOMServiceId(),
-          omStorage.getOmId(), omNodeDetails.getRpcAddress(),
-          omNodeDetails.getRatisPort());
-    }
-
     loginOMUserIfSecurityEnabled(conf);
 
     this.allowListAllVolumes = conf.getBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -207,8 +207,8 @@ public class OMHANodeDetails {
       int ratisPort = conf.getInt(OZONE_OM_RATIS_PORT_KEY,
           OZONE_OM_RATIS_PORT_DEFAULT);
 
-      LOG.info("Configuration either no {} set. Falling back to the default " +
-          "OM address {}", OZONE_OM_ADDRESS_KEY, omAddress);
+      LOG.info("Configuration does not have {} set. Falling back to the " +
+          "default OM address {}", OZONE_OM_ADDRESS_KEY, omAddress);
 
       return new OMHANodeDetails(getOMNodeDetails(conf, null,
           null, omAddress, ratisPort), new ArrayList<>());
@@ -237,6 +237,13 @@ public class OMHANodeDetails {
       serviceId = OzoneConsts.OM_SERVICE_ID_DEFAULT;
       LOG.info("OM Service ID is not set. Setting it to the default ID: {}",
           serviceId);
+    }
+
+    if (nodeId == null) {
+      // If no nodeId is provided, set the default nodeID - om1
+      nodeId = OzoneConsts.OM_DEFAULT_NODE_ID;
+      LOG.info("OM Node ID is not set. Setting it to the default ID: {}",
+          nodeId);
     }
 
     // We need to pass null for serviceID and nodeID as this is set for


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a nodeID is not set explicitly (for a single node OM cluster), then it defaults to the OM storage ID which is an UUID string. Proposing to change this default to a constant (such as "om1") instead. 
This would help when a cluster is upgraded to HA for example. It is not straightforward to change the nodeID after Ratis server has been instantiated (as the nodeID is used to generate the RaftPeerID). Hence, it would be good to have a more readable nodeID by default. 

Note that existing single node Ratis enabled OM clusters will have to set the nodeId explicitly if upgraded.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4680

## How was this patch tested?

Manually tested.
