### PR TITLE
HDDS-4688. Update Hadoop version to 3.2.2

### DIFF
--- a/hadoop-hdds/hadoop-dependency-client/README.md
+++ b/hadoop-hdds/hadoop-dependency-client/README.md
@@ -35,20 +35,20 @@ mvn dependency:tree
 [INFO]
 [INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-hdds-hadoop-dependency-client ---
 [INFO] org.apache.hadoop:hadoop-hdds-hadoop-dependency-client:jar:1.0.0
-[INFO] +- org.apache.hadoop:hadoop-annotations:jar:3.2.1:compile
+[INFO] +- org.apache.hadoop:hadoop-annotations:jar:3.2.2:compile
 [INFO] |  \- jdk.tools:jdk.tools:jar:1.8:system
-[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.1:compile
+[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.2:compile
 [INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
 [INFO] |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
 [INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
 [INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
 [INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
-[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.1:compile
+[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.2:compile
 [INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.0:compile
 [INFO] |  +- org.apache.htrace:htrace-core4:jar:4.1.0-incubating:compile
 [INFO] |  +- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
 [INFO] |  \- com.fasterxml.woodstox:woodstox-core:jar:5.0.3:compile
-[INFO] +- org.apache.hadoop:hadoop-hdfs:jar:3.2.1:compile
+[INFO] +- org.apache.hadoop:hadoop-hdfs:jar:3.2.2:compile
 [INFO] \- junit:junit:jar:4.11:test
 [INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
 [INFO] ------------------------------------------------------------------------

--- a/hadoop-hdds/hadoop-dependency-client/README.md
+++ b/hadoop-hdds/hadoop-dependency-client/README.md
@@ -35,20 +35,20 @@ mvn dependency:tree
 [INFO]
 [INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ hadoop-hdds-hadoop-dependency-client ---
 [INFO] org.apache.hadoop:hadoop-hdds-hadoop-dependency-client:jar:1.0.0
-[INFO] +- org.apache.hadoop:hadoop-annotations:jar:3.2.2:compile
+[INFO] +- org.apache.hadoop:hadoop-annotations:jar:3.2.1:compile
 [INFO] |  \- jdk.tools:jdk.tools:jar:1.8:system
-[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.2:compile
+[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.1:compile
 [INFO] |  +- org.apache.httpcomponents:httpclient:jar:4.5.2:compile
 [INFO] |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
 [INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
 [INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
 [INFO] |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
-[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.2:compile
+[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.1:compile
 [INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.0:compile
 [INFO] |  +- org.apache.htrace:htrace-core4:jar:4.1.0-incubating:compile
 [INFO] |  +- org.codehaus.woodstox:stax2-api:jar:3.1.4:compile
 [INFO] |  \- com.fasterxml.woodstox:woodstox-core:jar:5.0.3:compile
-[INFO] +- org.apache.hadoop:hadoop-hdfs:jar:3.2.2:compile
+[INFO] +- org.apache.hadoop:hadoop-hdfs:jar:3.2.1:compile
 [INFO] \- junit:junit:jar:4.11:test
 [INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test
 [INFO] ------------------------------------------------------------------------

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManagerHttpServer;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
@@ -102,6 +103,7 @@ public class TestStorageContainerManagerHttpServer {
 
     StorageContainerManagerHttpServer server = null;
     try {
+      DefaultMetricsSystem.initialize("TestStorageContainerManagerHttpServer");
       server = new StorageContainerManagerHttpServer(conf);
       server.start();
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
@@ -16,6 +16,6 @@
 
 HDDS_VERSION=@hdds.version@
 HADOOP_IMAGE=flokkr/hadoop
-HADOOP_VERSION=3.2.1
+HADOOP_VERSION=3.2.2
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
 HADOOP_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -16,6 +16,6 @@
 
 HDDS_VERSION=${hdds.version}
 HADOOP_IMAGE=flokkr/hadoop
-HADOOP_VERSION=3.2.1
+HADOOP_VERSION=3.2.2
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 HADOOP_OPTS=

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
 import org.apache.hadoop.http.HttpConfig;
 import org.apache.hadoop.http.HttpConfig.Policy;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
@@ -101,6 +102,7 @@ public class TestOzoneManagerHttpServer {
     OzoneManagerHttpServer server = null;
     try {
       server = new OzoneManagerHttpServer(conf, null);
+      DefaultMetricsSystem.initialize("TestOzoneManagerHttpServer");
       server.start();
 
       Assert.assertTrue(implies(policy.isHttpEnabled(),

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   </organization>
 
   <properties>
-    <hadoop.version>3.2.1</hadoop.version>
+    <hadoop.version>3.2.2</hadoop.version>
 
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Changed hadoop.version from 3.2.1 to 3.2.2 in pom.xml
- Changed hadoop.version from 3.2.1 to 3.2.2 in other related files.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4688

## How was this patch tested?

Manual test. Maven package passed.
