### PR TITLE
HDDS-4533.Avoid rewriting pipeline information during PipelineStateManagerV2Impl initialization

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerV2Impl.java
@@ -78,7 +78,8 @@ public class PipelineStateManagerV2Impl implements StateManager {
         iterator = pipelineStore.iterator();
     while (iterator.hasNext()) {
       Pipeline pipeline = iterator.next().getValue();
-      addPipeline(pipeline.getProtobufMessage());
+      pipelineStateMap.addPipeline(pipeline);
+      nodeManager.addPipeline(pipeline);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

During initialization, PipelineStateManagerV2Impl will rewrites pipeline info into the store. We should avoid it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4533

## How was this patch tested?

UT