### PR TITLE
HDDS-4645. Starting OM with the --upgrade flag should delete the prepare marker file.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HDDS_VERSION=${hdds.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
+OZONE_DIR=/opt/hadoop
+OZONE_VOLUME=.

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
@@ -14,8 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HDDS_VERSION=${hdds.version}
-OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
-OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
+HDDS_VERSION=1.1.0-SNAPSHOT
+OZONE_RUNNER_VERSION=20200625-1
+OZONE_IMAGE=apache/ozone-runner:20200625-1
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=.
+OM_HA_ARGS=--

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
@@ -19,4 +19,7 @@ OZONE_RUNNER_VERSION=20200625-1
 OZONE_IMAGE=apache/ozone-runner:20200625-1
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=.
+# Inidcate no arguments to the OM.
+# This variable must be set to some non-empty value, or docker compose will
+# expand it to an empty string and pass that to the OM as an argument.
 OM_HA_ARGS=--

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
@@ -1,0 +1,108 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+# reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
+x-common-config:
+  &common-config
+  env_file:
+    - docker-config
+  image: ${OZONE_IMAGE}
+
+x-replication:
+  &replication
+  OZONE-SITE.XML_ozone.replication: ${OZONE_REPLICATION_FACTOR:-1}
+
+x-datanode:
+  &datanode
+  command: ["ozone","datanode"]
+  <<: *common-config
+  environment:
+    <<: *replication
+  ports:
+    - 9864
+    - 9882
+
+services:
+  dn1:
+    <<: *datanode
+    volumes:
+      - ${OZONE_VOLUME}/dn1:/data
+      - ../..:${OZONE_DIR}
+  dn2:
+    <<: *datanode
+    volumes:
+      - ${OZONE_VOLUME}/dn2:/data
+      - ../..:${OZONE_DIR}
+  dn3:
+    <<: *datanode
+    volumes:
+      - ${OZONE_VOLUME}/dn3:/data
+      - ../..:${OZONE_DIR}
+
+  om1:
+    command: ["ozone", "om"]
+    <<: *common-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      <<: *replication
+    ports:
+      - 9862
+      - 9872
+    volumes:
+      - ${OZONE_VOLUME}/om1:/data
+      - ../..:${OZONE_DIR}
+
+  om2:
+    command: ["ozone", "om"]
+    <<: *common-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      <<: *replication
+    ports:
+      - 9862
+      - 9872
+    volumes:
+      - ${OZONE_VOLUME}/om2:/data
+      - ../..:${OZONE_DIR}
+
+  om3:
+    command: ["ozone", "om"]
+    <<: *common-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      <<: *replication
+    ports:
+      - 9862
+      - 9872
+    volumes:
+      - ${OZONE_VOLUME}/om3:/data
+      - ../..:${OZONE_DIR}
+
+  scm:
+    command: ["ozone","scm"]
+    <<: *common-config
+    environment:
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+      OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
+      <<: *replication
+    ports:
+      - 9876:9876
+    volumes:
+      - ${OZONE_VOLUME}/scm:/data
+      - ../..:${OZONE_DIR}
+

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
@@ -37,58 +37,66 @@ x-datanode:
     - 9864
     - 9882
 
+x-om:
+  &om
+  command: ["ozone","om","${OM_HA_ARGS}"]
+  <<: *common-config
+  environment:
+    ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+    <<: *replication
+  ports:
+    - 9862
+    - 9872
+
 services:
   dn1:
     <<: *datanode
+    networks:
+     net:
+       ipv4_address: 10.9.0.11
     volumes:
       - ${OZONE_VOLUME}/dn1:/data
       - ../..:${OZONE_DIR}
   dn2:
     <<: *datanode
+    networks:
+     net:
+       ipv4_address: 10.9.0.12
     volumes:
       - ${OZONE_VOLUME}/dn2:/data
       - ../..:${OZONE_DIR}
   dn3:
     <<: *datanode
+    networks:
+     net:
+       ipv4_address: 10.9.0.13
     volumes:
       - ${OZONE_VOLUME}/dn3:/data
       - ../..:${OZONE_DIR}
 
   om1:
-    command: ["ozone", "om"]
-    <<: *common-config
-    environment:
-      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
-    ports:
-      - 9862
-      - 9872
+    <<: *om
+    networks:
+      net:
+        ipv4_address: 10.9.0.14
     volumes:
       - ${OZONE_VOLUME}/om1:/data
       - ../..:${OZONE_DIR}
 
   om2:
-    command: ["ozone", "om"]
-    <<: *common-config
-    environment:
-      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
-    ports:
-      - 9862
-      - 9872
+    <<: *om
+    networks:
+      net:
+        ipv4_address: 10.9.0.15
     volumes:
       - ${OZONE_VOLUME}/om2:/data
       - ../..:${OZONE_DIR}
 
   om3:
-    command: ["ozone", "om"]
-    <<: *common-config
-    environment:
-      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
-      <<: *replication
-    ports:
-      - 9862
-      - 9872
+    <<: *om
+    networks:
+      net:
+        ipv4_address: 10.9.0.16
     volumes:
       - ${OZONE_VOLUME}/om3:/data
       - ../..:${OZONE_DIR}
@@ -96,6 +104,9 @@ services:
   scm:
     command: ["ozone","scm"]
     <<: *common-config
+    networks:
+      net:
+        ipv4_address: 10.9.0.17
     environment:
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
@@ -106,3 +117,9 @@ services:
       - ${OZONE_VOLUME}/scm:/data
       - ../..:${OZONE_DIR}
 
+networks:
+  net:
+    driver: bridge
+    ipam:
+      config:
+      - subnet: 10.9.0.0/16

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-config
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CORE-SITE.XML_fs.defaultFS=ofs://omservice/
+
+OZONE-SITE.XML_ozone.om.service.ids=omservice
+OZONE-SITE.XML_ozone.om.nodes.omservice=om1,om2,om3
+OZONE-SITE.XML_ozone.om.address.omservice.om1=om1
+OZONE-SITE.XML_ozone.om.address.omservice.om2=om2
+OZONE-SITE.XML_ozone.om.address.omservice.om3=om3
+OZONE-SITE.XML_ozone.om.ratis.enable=true
+
+OZONE-SITE.XML_ozone.scm.names=scm
+OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
+OZONE-SITE.XML_ozone.scm.block.client.address=scm
+OZONE-SITE.XML_ozone.scm.container.size=1GB
+OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
+OZONE-SITE.XML_ozone.scm.client.address=scm
+OZONE-SITE.XML_ozone.client.failover.max.attempts=6
+OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+
+no_proxy=om1,om2,om3,scm,s3g,recon,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -39,22 +39,17 @@ export OZONE_DIR=/opt/hadoop
 # shellcheck source=/dev/null
 source "${COMPOSE_DIR}/../testlib.sh"
 
-# prepare pre-upgrade cluster
-#export OM_HA_ARGS='--upgrade'
+# Write data and prepare cluster.
 start_docker_env
-docker-compose ps
-echo "Before prepare test"
 execute_robot_test scm omha/om-prepare.robot
-echo "After prepare test"
-#KEEP_RUNNING=false stop_docker_env
-#stop_docker_env
+KEEP_RUNNING=false stop_docker_env
 
 # re-start cluster with --upgrade flag to take it out of prepare.
-#export OM_HA_ARGS='--upgrade'
-#export OZONE_KEEP_RESULTS=true
-#start_docker_env
+export OM_HA_ARGS='--upgrade'
+export OZONE_KEEP_RESULTS=true
+start_docker_env
 # Writes should now succeed.
-#execute_robot_test scm topology/loaddata.robot
+execute_robot_test scm topology/loaddata.robot
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -25,7 +25,7 @@ export OZONE_VOLUME
 
 # Clean up saved internal state from each container's volume for the next run.
 rm -rf "${OZONE_VOLUME}"
-mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om,recon,s3g,scm}
+mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om1,om2,om3,scm}
 
 if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
   current_user=$(whoami)

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+
+: "${OZONE_REPLICATION_FACTOR:=3}"
+: "${OZONE_VOLUME:="${COMPOSE_DIR}/data"}"
+
+export OZONE_VOLUME
+
+# Clean up saved internal state from each container's volume for the next run.
+rm -rf "${OZONE_VOLUME}"
+mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om,recon,s3g,scm}
+
+if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
+  current_user=$(whoami)
+  if [[ "${OZONE_VOLUME_OWNER}" != "${current_user}" ]]; then
+    chown -R "${OZONE_VOLUME_OWNER}" "${OZONE_VOLUME}" \
+      || sudo chown -R "${OZONE_VOLUME_OWNER}" "${OZONE_VOLUME}"
+  fi
+fi
+
+export OZONE_DIR=/opt/hadoop
+# shellcheck source=/dev/null
+source "${COMPOSE_DIR}/../testlib.sh"
+
+# prepare pre-upgrade cluster
+#export OM_HA_ARGS='--upgrade'
+start_docker_env
+docker-compose ps
+echo "Before prepare test"
+execute_robot_test scm omha/om-prepare.robot
+echo "After prepare test"
+#KEEP_RUNNING=false stop_docker_env
+#stop_docker_env
+
+# re-start cluster with --upgrade flag to take it out of prepare.
+#export OM_HA_ARGS='--upgrade'
+#export OZONE_KEEP_RESULTS=true
+#start_docker_env
+# Writes should now succeed.
+#execute_robot_test scm topology/loaddata.robot
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -25,6 +25,7 @@ export OZONE_VOLUME
 
 # Clean up saved internal state from each container's volume for the next run.
 rm -rf "${OZONE_VOLUME}"
+mkdir -p "${OZONE_VOLUME}"/{dn1,dn2,dn3,om1,om2,om3,scm}
 
 if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
   current_user=$(whoami)
@@ -59,6 +60,7 @@ start_docker_env
 
 # Writes should now succeed.
 execute_robot_test scm topology/loaddata.robot
+execute_robot_test scm topology/readdata.robot
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-prepare.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-prepare.robot
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Smoke test to start cluster with docker-compose environments.
+Documentation       Smoke test to test preparing OMs in an OM HA cluster.
 Library             OperatingSystem
 Library             String
 Library             BuiltIn
@@ -42,3 +42,8 @@ Prepare Ozone Manager
 Checks if the expected data is present in OM
     ${result} =         Execute             ozone sh key info /${volume_name}/${bucket_name}/prepare-key
                         Should contain      ${result}       \"name\" : \"prepare-key\"
+
+Test write operation fails
+    ${result} =        Execute and checkrc    ozone sh key put /${volume_name}/${bucket_name}/prepare-key2 /opt/hadoop/NOTICE.txt    255
+                       Should contain         ${result}       OM is in prepare mode
+                       Execute and checkrc    ozone sh key info /${volume_name}/${bucket_name}/prepare-key2    255

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-prepared.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-prepared.robot
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoke test to test that OMs are prepared in an OM HA cluster.
+Library             OperatingSystem
+Library             String
+Library             BuiltIn
+Resource            ../commonlib.robot
+Test Timeout        5 minutes
+Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+
+** Test Cases ***
+Test create volume fails
+    ${random} =         Generate Random String    5    [NUMBERS]
+                        Set Suite Variable    ${volume_name}    ${random}-volume-for-prepare
+    ${result} =         Execute and checkrc    ozone sh volume create /${volume_name}    255
+                        Should contain         ${result}       OM is in prepare mode
+    ${result} =         Execute and checkrc    ozone sh volume info /${volume_name}    255
+                        Should contain         ${result}       VOLUME_NOT_FOUND
+
+Test list volumes succeeds
+    ${result} =    Execute    ozone sh volume list
+

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -150,10 +150,8 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     assertKeysWritten(writtenKeys, runningOms);
   }
 
-  // TODO: After HDDS-4610 and RATIS-1241, the NullPointerException when an
-  //  OM receives a snapshot should be fixed and this test should
-  //  consistently pass.
-//   @Test
+  // TODO: This test should be passing after HDDS-4610 and RATIS-1241
+  // @Test
   public void testPrepareWithRestart() throws Exception {
     setup();
     writeKeysAndWaitForLogs(10);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.apache.derby.impl.sql.GenericStorablePreparedStatement;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
@@ -46,11 +45,8 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.jooq.False;
 import org.junit.Assert;
 import org.junit.Test;
-import sun.reflect.generics.reflectiveObjects.LazyReflectiveObjectGenerator;
-import sun.util.locale.provider.LocaleServiceProviderPool;
 
 /**
  * Test OM prepare against actual mini cluster.
@@ -372,9 +368,9 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
               } else {
                 // State will not change if we are prepared at the wrong index.
                 // Break out of wait.
-                throw new Exception("OM " + om.getOMNodeId() + " prepared but " +
-                    "prepare index " + state.getIndex() + " does not match " +
-                    "expected prepare index " + preparedIndex);
+                throw new Exception("OM " + om.getOMNodeId() + " prepared " +
+                    "but prepare index " + state.getIndex() + " does not " +
+                    "match expected prepare index " + preparedIndex);
               }
             }
             return preparedAtIndex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMStarterInterface.java
@@ -30,4 +30,6 @@ public interface OMStarterInterface {
       AuthenticationException;
   boolean init(OzoneConfiguration conf) throws IOException,
       AuthenticationException;
+  void startAndCancelPrepare(OzoneConfiguration conf) throws IOException,
+      AuthenticationException;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerPrepareState.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerPrepareState.java
@@ -108,7 +108,7 @@ public final class OzoneManagerPrepareState {
 
   private void finishPrepare(long index, boolean writeFile) throws IOException {
     // Enabling the prepare gate is idempotent, and may have already been
-    // performed if we are the leader.If we are a follower, we must ensure this
+    // performed if we are the leader. If we are a follower, we must ensure this
     // is run now case we become the leader.
     enablePrepareGate();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -101,27 +101,20 @@ public class OzoneManagerStarter extends GenericCli {
 
   // TODO: Convert this flag to bring the OM out of prepare mode with the new
   //  bits when prepare marker files have been implemented.
-//  /**
-//   * This function implements a sub-command to allow the OM to be
-//   * "prepared for upgrade".
-//   */
-//  @CommandLine.Command(name = "--prepareForUpgrade",
-//      aliases = {"--prepareForDowngrade", "--flushTransactions"},
-//      customSynopsis = "ozone om [global options] --prepareForUpgrade",
-//      hidden = false,
-//      description = "Prepare the OM for upgrade/downgrade. (Flush Raft log " +
-//          "transactions.)",
-//      mixinStandardHelpOptions = true,
-//      versionProvider = HddsVersionProvider.class)
-//  @SuppressFBWarnings("DM_EXIT")
-//  public void prepareOmForUpgrade() throws Exception {
-//    commonInit();
-//    boolean result = receiver.prepareForUpgrade(conf);
-//    if (!result) {
-//      throw new Exception("Prepare OM For Upgrade failed.");
-//    }
-//    System.exit(0);
-//  }
+  /**
+   * This function implements a sub-command to allow the OM to be
+   * "prepared for upgrade".
+   */
+  @CommandLine.Command(name = "--upgrade",
+      customSynopsis = "ozone om [global options] --upgrade",
+      description = "Cancels prepare state in this OM on startup",
+      mixinStandardHelpOptions = true,
+      versionProvider = HddsVersionProvider.class)
+  public void startOmUpgrade() throws Exception {
+    commonInit();
+    receiver.startAndCancelPrepare(conf);
+    System.exit(0);
+  }
 
   /**
    * This function should be called by each command to ensure the configuration
@@ -156,6 +149,13 @@ public class OzoneManagerStarter extends GenericCli {
         AuthenticationException {
       return OzoneManager.omInit(conf);
     }
-  }
 
+    @Override
+    public void startAndCancelPrepare(OzoneConfiguration conf)
+        throws IOException, AuthenticationException {
+      OzoneManager om = OzoneManager.createOm(conf);
+      om.getPrepareState().cancelPrepare();
+      om.start();
+    }
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -99,8 +99,6 @@ public class OzoneManagerStarter extends GenericCli {
     }
   }
 
-  // TODO: Convert this flag to bring the OM out of prepare mode with the new
-  //  bits when prepare marker files have been implemented.
   /**
    * This function implements a sub-command to allow the OM to be
    * "prepared for upgrade".
@@ -115,7 +113,8 @@ public class OzoneManagerStarter extends GenericCli {
       commonInit();
       receiver.startAndCancelPrepare(conf);
     } catch (Exception ex) {
-      LOG.error("Starting OM in upgrade mode failed with exception", ex);
+      LOG.error("Cancelling prepare to start OM in upgrade mode failed " +
+          "with exception", ex);
       throw ex;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -111,9 +111,13 @@ public class OzoneManagerStarter extends GenericCli {
       mixinStandardHelpOptions = true,
       versionProvider = HddsVersionProvider.class)
   public void startOmUpgrade() throws Exception {
-    commonInit();
-    receiver.startAndCancelPrepare(conf);
-    System.exit(0);
+    try {
+      commonInit();
+      receiver.startAndCancelPrepare(conf);
+    } catch (Exception ex) {
+      LOG.error("Starting OM in upgrade mode failed with exception", ex);
+      throw ex;
+    }
   }
 
   /**
@@ -156,6 +160,7 @@ public class OzoneManagerStarter extends GenericCli {
       OzoneManager om = OzoneManager.createOm(conf);
       om.getPrepareState().cancelPrepare();
       om.start();
+      om.join();
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -101,9 +101,10 @@ public class OzoneManagerStarter extends GenericCli {
 
   /**
    * This function implements a sub-command to allow the OM to be
-   * "prepared for upgrade".
+   * Removed from prepare mode after an upgrade or downgrade.
    */
   @CommandLine.Command(name = "--upgrade",
+      aliases = "--downgrade",
       customSynopsis = "ozone om [global options] --upgrade",
       description = "Cancels prepare state in this OM on startup",
       mixinStandardHelpOptions = true,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -347,7 +347,6 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
    */
   public void unpause(long newLastAppliedSnaphsotIndex,
       long newLastAppliedSnapShotTermIndex) {
-    LOG.info("Unpausing State machine at {}", this.ozoneManager.getOMNodeId());
     getLifeCycle().startAndTransition(() -> {
       this.ozoneManagerDoubleBuffer = buildDoubleBufferForRatis();
       handler.updateDoubleBuffer(ozoneManagerDoubleBuffer);
@@ -388,8 +387,6 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
         ozoneManager.getMetadataManager().getTransactionInfoTable();
     txnInfoTable.put(TRANSACTION_INFO_KEY, build);
     ozoneManager.getMetadataManager().getStore().flushDB();
-    LOG.info("OM TransactionInfo Table : {}",
-        txnInfoTable.get(TRANSACTION_INFO_KEY).getTermIndex());
     return lastAppliedIndex;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -383,10 +384,12 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     OMTransactionInfo build = new OMTransactionInfo.Builder()
         .setTransactionIndex(lastAppliedIndex)
         .setCurrentTerm(lastTermIndex.getTerm()).build();
-    ozoneManager.getMetadataManager().getTransactionInfoTable().put(TRANSACTION_INFO_KEY, build);
+    Table<String, OMTransactionInfo> txnInfoTable =
+        ozoneManager.getMetadataManager().getTransactionInfoTable();
+    txnInfoTable.put(TRANSACTION_INFO_KEY, build);
     ozoneManager.getMetadataManager().getStore().flushDB();
     LOG.info("OM TransactionInfo Table : {}",
-        ozoneManager.getMetadataManager().getTransactionInfoTable().get(TRANSACTION_INFO_KEY).getTermIndex());
+        txnInfoTable.get(TRANSACTION_INFO_KEY).getTermIndex());
     return lastAppliedIndex;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -87,8 +87,11 @@ public class OMPrepareRequest extends OMClientRequest {
 
     try {
       // Create response.
+      // DB snapshot for prepare will include the transaction to commit it,
+      // making the prepare index one more than this txn's log index.
+      long prepareIndex = transactionLogIndex + 1;
       PrepareResponse omResponse = PrepareResponse.newBuilder()
-              .setTxnID(transactionLogIndex)
+              .setTxnID(prepareIndex)
               .build();
       responseBuilder.setPrepareResponse(omResponse);
       response = new OMPrepareResponse(responseBuilder.build());
@@ -113,19 +116,21 @@ public class OMPrepareRequest extends OMClientRequest {
           ozoneManager.getMetadataManager(), division,
           flushTimeout, flushCheckInterval);
 
-      // TODO: After the snapshot index update fix, the prepare index will
-      //  always be 1 more than the prepare txn index, because the Ratis
-      //  entry to commit the prepare request will be included in the snapshot.
-      long prepareIndex = takeSnapshotAndPurgeLogs(division);
+      long snapshotIndex = takeSnapshotAndPurgeLogs(division);
+      if (snapshotIndex != prepareIndex) {
+        LOG.warn("Snapshot index {} does not " +
+            "match expected prepare index {}.", snapshotIndex, prepareIndex);
+      }
 
       // Save transaction log index to a marker file, so if the OM restarts,
       // it will remain in prepare mode on that index as long as the file
       // exists.
       ozoneManager.getPrepareState().finishPrepare(prepareIndex);
 
-      LOG.info("OM {} prepared at log index {}. Returning response {}",
-          ozoneManager.getOMNodeId(),
-          ozoneManager.getRatisSnapshotIndex(), omResponse);
+      LOG.info("OM {} prepared at log index {}. Returning response {} with " +
+              "log index {}",
+          ozoneManager.getOMNodeId(), prepareIndex, omResponse,
+          omResponse.getTxnID());
     } catch (OMException e) {
       LOG.error("Prepare Request Apply failed in {}. ",
           ozoneManager.getOMNodeId(), e);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -128,8 +128,7 @@ public class OMPrepareRequest extends OMClientRequest {
       ozoneManager.getPrepareState().finishPrepare(prepareIndex);
 
       LOG.info("OM {} prepared at log index {}. Returning response {} with " +
-              "log index {}",
-          ozoneManager.getOMNodeId(), prepareIndex, omResponse,
+          "log index {}", ozoneManager.getOMNodeId(), prepareIndex, omResponse,
           omResponse.getTxnID());
     } catch (OMException e) {
       LOG.error("Prepare Request Apply failed in {}. ",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -115,6 +115,23 @@ public class TestOzoneManagerStarter {
   }
 
   @Test
+  public void testCallsStartAndCancelPrepareWithUpgradeFlag() {
+    executeCommand("--upgrade");
+    assertTrue(mock.startAndCancelPrepareCalled);
+  }
+
+  @Test
+  public void testUnsuccessfulUpgradeThrowsException() {
+    mock.throwOnStartAndCancelPrepare = true;
+    try {
+      executeCommand("--upgrade");
+      fail("Exception show have been thrown");
+    } catch (Exception e) {
+      assertTrue(true);
+    }
+  }
+
+  @Test
   public void testUsagePrintedOnInvalidInput() {
     executeCommand("--invalid");
     Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
@@ -133,9 +150,10 @@ public class TestOzoneManagerStarter {
     private boolean initStatus = true;
     private boolean throwOnStart = false;
     private boolean throwOnInit = false;
-    private boolean prepareUpgradeCalled = false;
-    private boolean throwOnPrepareUpgrade = false;
+    private boolean startAndCancelPrepareCalled = false;
+    private boolean throwOnStartAndCancelPrepare = false;
 
+    @Override
     public void start(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
       startCalled = true;
@@ -144,6 +162,7 @@ public class TestOzoneManagerStarter {
       }
     }
 
+    @Override
     public boolean init(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
       initCalled = true;
@@ -153,13 +172,13 @@ public class TestOzoneManagerStarter {
       return initStatus;
     }
 
-    public boolean prepareForUpgrade(OzoneConfiguration conf)
+    @Override
+    public void startAndCancelPrepare(OzoneConfiguration conf)
         throws IOException, AuthenticationException {
-      prepareUpgradeCalled = true;
-      if (throwOnPrepareUpgrade) {
+      startAndCancelPrepareCalled = true;
+      if (throwOnStartAndCancelPrepare) {
         throw new IOException("Simulated Exception");
       }
-      return true;
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When an OM is put in prepare mode, a marker file is written to disk so that it remains in prepare mode upon restart. After an OM has been upgraded, it can be restarted with a --upgrade flag to automatically delete the marker file and take the OM out of prepare mode.

This patch incorporates work in progress changes from HDDS-4610 to make sure that the commit transaction after prepare updates the transaction index in the OM DB, so it matches the index of the prepare marker file when the OM comes back up.

## What is the link to the Apache JIRA

HDDS-4645

## Testing

Acceptance test added.

The added test uses a similar approach to the existing *upgrade* acceptance test to restart the OMs. All containers in the cluster write their state to mounted volumes, and nodes are restarted by restarting their containers. These restarted containers have the previous on disk state still persistent in the volume when it is mounted on restart.
