### PR TITLE
HDDS-4698. Upgrade Java for Sonar check

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -272,11 +272,14 @@ jobs:
           path: target/artifacts
       - name: Calculate combined coverage
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
-      - name: Upload coverage to Sonar
-        uses: ./.github/buildenv
+      - name: Setup java 11
+        uses: actions/setup-java@v1
         if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         with:
-          args: ./hadoop-ozone/dev-support/checks/sonar.sh
+          java-version: 11
+      - name: Upload coverage to Sonar
+        run: ./hadoop-ozone/dev-support/checks/sonar.sh
+        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install and use Java 11 for running `sonar.sh` in CI, because:

> The version of Java installed in the scanner environment must be upgraded to at least Java 11 before 1 February 2021.  Pre-11 versions of Java are already deprecated and scanners using them will stop functioning on that date.

https://issues.apache.org/jira/browse/HDDS-4698

## How was this patch tested?

https://github.com/apache/ozone/runs/1702656137