### PR TITLE
HDDS-3212. Allow enabling purge SCM Ratis log

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -125,6 +125,7 @@ public final class RatisUtil {
     Log.setPreallocatedSize(properties,
         SizeInBytes.valueOf(conf.getRaftSegmentPreAllocatedSize()));
     Log.Appender.setInstallSnapshotEnabled(properties, false);
+    Log.setPurgeUptoSnapshotIndex(properties, conf.getRaftLogPurgeEnabled());
     Log.setPurgeGap(properties, conf.getRaftLogPurgeGap());
     Log.setSegmentCacheNumMax(properties, 2);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -105,6 +105,14 @@ public class SCMHAConfiguration {
   )
   private int raftLogAppenderQueueByteLimit = 32 * 1024 * 1024;
 
+  @Config(key = "ratis.log.purge.enabled",
+      type = ConfigType.BOOLEAN,
+      defaultValue = "false",
+      tags = {SCM, OZONE, HA, RATIS},
+      description = "whether enable raft log purge."
+  )
+  private boolean raftLogPurgeEnabled = false;
+
   @Config(key = "ratis.log.purge.gap",
       type = ConfigType.INT,
       defaultValue = "1000000",
@@ -199,6 +207,14 @@ public class SCMHAConfiguration {
 
   public int getRaftLogAppenderQueueByteLimit() {
     return raftLogAppenderQueueByteLimit;
+  }
+
+  public boolean getRaftLogPurgeEnabled() {
+    return raftLogPurgeEnabled;
+  }
+
+  public void setRaftLogPurgeEnabled(boolean enabled) {
+    this.raftLogPurgeEnabled = enabled;
   }
 
   public int getRaftLogPurgeGap() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -41,4 +41,16 @@ public class TestSCMHAConfiguration {
         SCMHAConfiguration.class);
     Assert.assertEquals("scm-ratis", scmhaConfiguration.getRatisStorageDir());
   }
+
+  @Test
+  public void testRaftLogPurgeEnabled() {
+    SCMHAConfiguration scmhaConfiguration = conf.getObject(
+        SCMHAConfiguration.class);
+    scmhaConfiguration.setRaftLogPurgeEnabled(true);
+    conf.setFromObject(scmhaConfiguration);
+
+    scmhaConfiguration = conf.getObject(
+        SCMHAConfiguration.class);
+    Assert.assertEquals(true, scmhaConfiguration.getRaftLogPurgeEnabled());
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Right now the `SCMHAConfiguration` does not have the way to enable log purge.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3212

## How was this patch tested?

UT
