### PR TITLE
HDDS-4707. Failed to generate reports using "mvn site"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <make-maven-plugin.version>1.0-beta-1</make-maven-plugin.version>
     <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <checkstyle.version>8.29</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
     <aws-java-sdk.version>1.11.901</aws-java-sdk.version>
@@ -1978,6 +1979,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <outputFile>${project.build.directory}/test/checkstyle-errors.xml</outputFile>
           </configuration>
         </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>${maven-site-plugin.version}</version>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the plugin of maven-site-plugin to support "mvn site".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4707

## How was this patch tested?

Manually test. "mvn site" works fine now.
