### PR TITLE
HDDS-4430. OM failover timeout is too short

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1620,18 +1620,27 @@
 
   <property>
     <name>ozone.om.ratis.minimum.timeout</name>
-    <value>1s</value>
+    <value>5s</value>
     <tag>OZONE, OM, RATIS, MANAGEMENT</tag>
     <description>The minimum timeout duration for OM's Ratis server rpc.
     </description>
   </property>
 
   <property>
+    <name>ozone.om.ratis.leader.step.down.wait.time</name>
+    <value>30s</value>
+    <tag>OZONE, OM, RATIS, MANAGEMENT, DEPRECATED</tag>
+    <description>The time OM Ratis Leader waits before stepping down on loosing
+      majority heartbeats from followers.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.om.leader.election.minimum.timeout.duration</name>
-    <value>1s</value>
-    <tag>OZONE, OM, RATIS, MANAGEMENT</tag>
-    <description>The minimum timeout duration for OM ratis leader election.
-      Default is 1s.
+    <value>5s</value>
+    <tag>OZONE, OM, RATIS, MANAGEMENT, DEPRECATED</tag>
+    <description>DEPRECATED. Leader election timeout uses ratis
+      rpc timeout which can be set via ozone.om.ratis.minimum.timeout.
     </description>
   </property>
 

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1627,15 +1627,6 @@
   </property>
 
   <property>
-    <name>ozone.om.ratis.leader.step.down.wait.time</name>
-    <value>30s</value>
-    <tag>OZONE, OM, RATIS, MANAGEMENT, DEPRECATED</tag>
-    <description>The time OM Ratis Leader waits before stepping down on loosing
-      majority heartbeats from followers.
-    </description>
-  </property>
-
-  <property>
     <name>ozone.om.leader.election.minimum.timeout.duration</name>
     <value>5s</value>
     <tag>OZONE, OM, RATIS, MANAGEMENT, DEPRECATED</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -155,12 +155,6 @@ public final class OMConfigKeys {
   public static final TimeDuration OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
       = TimeDuration.valueOf(5, TimeUnit.SECONDS);
 
-  public static final String OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_KEY
-      = "ozone.om.ratis.leader.step.down.wait.time";
-  public static final TimeDuration
-      OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
-      = TimeDuration.valueOf(30, TimeUnit.SECONDS);
-
   public static final String OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_KEY
       = "ozone.om.ratis.server.failure.timeout.duration";
   public static final TimeDuration

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -153,15 +153,14 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY
       = "ozone.om.ratis.minimum.timeout";
   public static final TimeDuration OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
-      = TimeDuration.valueOf(1, TimeUnit.SECONDS);
+      = TimeDuration.valueOf(5, TimeUnit.SECONDS);
 
-  // OM Ratis Leader Election configurations
-  public static final String
-      OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY =
-      "ozone.om.leader.election.minimum.timeout.duration";
+  public static final String OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_KEY
+      = "ozone.om.ratis.leader.step.down.wait.time";
   public static final TimeDuration
-      OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_DEFAULT =
-      TimeDuration.valueOf(1, TimeUnit.SECONDS);
+      OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
+      = TimeDuration.valueOf(30, TimeUnit.SECONDS);
+
   public static final String OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_KEY
       = "ozone.om.ratis.server.failure.timeout.duration";
   public static final TimeDuration

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -275,6 +275,7 @@ public interface MiniOzoneCluster {
     protected static final int DEFAULT_HB_PROCESSOR_INTERVAL_MS = 100;
     protected static final int ACTIVE_OMS_NOT_SET = -1;
     protected static final int DEFAULT_PIPELIME_LIMIT = 3;
+    protected static final int DEFAULT_RATIS_RPC_TIMEOUT_SEC = 1;
 
     protected final OzoneConfiguration conf;
     protected String path;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -618,6 +618,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.setInt(ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT,
           pipelineNumLimit >= DEFAULT_PIPELIME_LIMIT ?
               pipelineNumLimit : DEFAULT_PIPELIME_LIMIT);
+      conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+          DEFAULT_RATIS_RPC_TIMEOUT_SEC, TimeUnit.SECONDS);
       configureTrace();
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -69,7 +69,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
   private int waitForOMToBeReadyTimeout = 120000; // 2 min
 
   private static final Random RANDOM = new Random();
-  private static final int RATIS_LEADER_ELECTION_TIMEOUT = 1000; // 1 second
+  private static final int RATIS_RPC_TIMEOUT = 1000; // 1 second
   public static final int NODE_FAILURE_TIMEOUT = 2000; // 2 seconds
 
   /**
@@ -308,19 +308,18 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     protected void initOMRatisConf() {
       conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, true);
       conf.setInt(OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY, numOfOmHandlers);
+      
       // If test change the following config values we will respect,
       // otherwise we will set lower timeout values.
-      long defaultDuration =
-          OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_DEFAULT
+      long defaultDuration = OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_DEFAULT
               .getDuration();
-      long curLeaderElectionTimeout = conf.getTimeDuration(
-          OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
+      long curRatisRpcTimeout = conf.getTimeDuration(
+          OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
               defaultDuration, TimeUnit.MILLISECONDS);
-      conf.setTimeDuration(
-          OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
-          defaultDuration == curLeaderElectionTimeout ?
-              RATIS_LEADER_ELECTION_TIMEOUT : curLeaderElectionTimeout,
-          TimeUnit.MILLISECONDS);
+      conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+          defaultDuration == curRatisRpcTimeout ?
+              RATIS_RPC_TIMEOUT : curRatisRpcTimeout, TimeUnit.MILLISECONDS);
+
       long defaultNodeFailureTimeout =
           OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT.
               getDuration();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -54,6 +54,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
+    xmlPropsToSkipCompare.add("ozone.om.leader.election.minimum.timeout" +
+        ".duration"); // Deprecated config
     addPropertiesNotInXml();
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -66,7 +66,7 @@ public class TestOzoneManagerConfiguration {
   private OzoneManager om;
   private OzoneManagerRatisServer omRatisServer;
 
-  private static final long LEADER_ELECTION_TIMEOUT = 500L;
+  private static final long RATIS_RPC_TIMEOUT = 500L;
 
   @Before
   public void init() throws IOException {
@@ -79,9 +79,8 @@ public class TestOzoneManagerConfiguration {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDirPath.toString());
     conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY, "127.0.0.1:0");
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, true);
-    conf.setTimeDuration(
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
-        LEADER_ELECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
 
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -498,22 +498,18 @@ public final class OzoneManagerRatisServer {
 
     // TODO: set max write buffer size
 
-    // Set the ratis leader election timeout
-    TimeUnit leaderElectionMinTimeoutUnit =
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_DEFAULT
+    // Set the ratis leader step down time
+    TimeUnit leaderStepDownWaitTimeUnit =
+        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
             .getUnit();
-    long leaderElectionMinTimeoutduration = conf.getTimeDuration(
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_DEFAULT
-            .getDuration(), leaderElectionMinTimeoutUnit);
-    final TimeDuration leaderElectionMinTimeout = TimeDuration.valueOf(
-        leaderElectionMinTimeoutduration, leaderElectionMinTimeoutUnit);
-    RaftServerConfigKeys.Rpc.setTimeoutMin(properties,
-        leaderElectionMinTimeout);
-    long leaderElectionMaxTimeout = leaderElectionMinTimeout.toLong(
-        TimeUnit.MILLISECONDS) + 200;
-    RaftServerConfigKeys.Rpc.setTimeoutMax(properties,
-        TimeDuration.valueOf(leaderElectionMaxTimeout, TimeUnit.MILLISECONDS));
+    long leaderStepDownWaitTimeDuration = conf.getTimeDuration(
+        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_KEY,
+        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
+            .getDuration(), leaderStepDownWaitTimeUnit);
+    final TimeDuration leaderStepDownWaitTime = TimeDuration.valueOf(
+        leaderStepDownWaitTimeDuration, leaderStepDownWaitTimeUnit);
+    RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(
+        properties, leaderStepDownWaitTime);
 
     TimeUnit nodeFailureTimeoutUnit =
         OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -487,7 +487,7 @@ public final class OzoneManagerRatisServer {
     long serverMaxTimeoutDuration =
         serverMinTimeout.toLong(TimeUnit.MILLISECONDS) + 200;
     final TimeDuration serverMaxTimeout = TimeDuration.valueOf(
-        serverMaxTimeoutDuration, serverMinTimeoutUnit);
+        serverMaxTimeoutDuration, TimeUnit.MILLISECONDS);
     RaftServerConfigKeys.Rpc.setTimeoutMin(properties,
         serverMinTimeout);
     RaftServerConfigKeys.Rpc.setTimeoutMax(properties,
@@ -497,19 +497,6 @@ public final class OzoneManagerRatisServer {
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
 
     // TODO: set max write buffer size
-
-    // Set the ratis leader step down time
-    TimeUnit leaderStepDownWaitTimeUnit =
-        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
-            .getUnit();
-    long leaderStepDownWaitTimeDuration = conf.getTimeDuration(
-        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_KEY,
-        OMConfigKeys.OZONE_OM_RATIS_LEADER_STEP_DOWN_WAIT_TIME_DEFAULT
-            .getDuration(), leaderStepDownWaitTimeUnit);
-    final TimeDuration leaderStepDownWaitTime = TimeDuration.valueOf(
-        leaderStepDownWaitTimeDuration, leaderStepDownWaitTimeUnit);
-    RaftServerConfigKeys.LeaderElection.setLeaderStepDownWaitTime(
-        properties, leaderStepDownWaitTime);
 
     TimeUnit nodeFailureTimeoutUnit =
         OMConfigKeys.OZONE_OM_RATIS_SERVER_FAILURE_TIMEOUT_DURATION_DEFAULT

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -69,7 +69,7 @@ public class TestOzoneManagerRatisServer {
   private OzoneManagerRatisServer omRatisServer;
   private String omID;
   private String clientId = UUID.randomUUID().toString();
-  private static final long LEADER_ELECTION_TIMEOUT = 500L;
+  private static final long RATIS_RPC_TIMEOUT = 500L;
   private OMMetadataManager omMetadataManager;
   private OzoneManager ozoneManager;
   private OMNodeDetails omNodeDetails;
@@ -82,9 +82,8 @@ public class TestOzoneManagerRatisServer {
     final String path = GenericTestUtils.getTempPath(omID);
     Path metaDirPath = Paths.get(path, "om-meta");
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDirPath.toString());
-    conf.setTimeDuration(
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
-        LEADER_ELECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+    conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
     int ratisPort = conf.getInt(
         OMConfigKeys.OZONE_OM_RATIS_PORT_KEY,
         OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT);
@@ -202,9 +201,8 @@ public class TestOzoneManagerRatisServer {
     String path = GenericTestUtils.getTempPath(newOmId);
     Path metaDirPath = Paths.get(path, "om-meta");
     newConf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDirPath.toString());
-    newConf.setTimeDuration(
-        OMConfigKeys.OZONE_OM_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY,
-        LEADER_ELECTION_TIMEOUT, TimeUnit.MILLISECONDS);
+    newConf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
+        RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
     int ratisPort = 9873;
     InetSocketAddress rpcAddress = new InetSocketAddress(
         InetAddress.getLocalHost(), 0);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current OM has one second failover timeout. This is too short as any network hiccup, system I/O or JVM GC pause could easily trigger a failover. Increasing Ratis rpc timeout to 5 sec by default.
Also, Ratis does not have a leader election timeout. Hence, deprecating Ozone OM's leader election timeout.
Instead, setting the leader step down wait time to 30 sec.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4430

## How was this patch tested?

No new tests

