### PR TITLE
HDDS-4713. Add build-helper-maven-plugin to interface-client module

### DIFF
--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -65,6 +65,26 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           </execution>
         </executions>
       </plugin>
+
+      <!-- Adding protobuf generated classes to build classpath. -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-sources/protobuf/java</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ozone/interface-client module, sources files are generated by protobuf  plugin. But when other modules depend on this module, idea always prompts "Cannot resolve symbol" message.

![image](https://user-images.githubusercontent.com/20113411/104839410-e95aa700-58fb-11eb-997c-74e97f81c9f5.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4713

## How was this patch tested?

Intellig IDEA.
