### PR TITLE
Hdds 4710

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -299,8 +299,8 @@ public class ContainerStateMachine extends BaseStateMachine {
             snapshotFile);
         throw ioe;
       }
-      LOG.info("{}: Finished taking a snapshot at:{} file:{} time:{}", gid, ti,
-          snapshotFile, (Time.monotonicNow() - startTime));
+      LOG.info("{}: Finished taking a snapshot at:{} file:{} took: {} ms",
+          gid, ti, snapshotFile, (Time.monotonicNow() - startTime));
       return ti.getIndex();
     }
     return -1;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -347,21 +347,18 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   }
 
   /**
-   * Find a node from the healthy list and return it after removing it from the
-   * list that we are operating on.
+   * Just chose a node randomly and remove it from the set of nodes we can
+   * chose from.
    *
-   * @param healthyNodes - Set of healthy nodes we can choose from.
-   * @return chosen datanodDetails
+   * @param healthyNodes - all healthy datanodes.
+   * @return one randomly chosen datanode that from two randomly chosen datanode
    */
   @Override
-  public DatanodeDetails chooseNode(
-      List<DatanodeDetails> healthyNodes) {
-    if (healthyNodes == null || healthyNodes.isEmpty()) {
-      return null;
-    }
-    DatanodeDetails datanodeDetails = healthyNodes.get(0);
-    healthyNodes.remove(datanodeDetails);
-    return datanodeDetails;
+  public DatanodeDetails chooseNode(final List<DatanodeDetails> healthyNodes) {
+    DatanodeDetails selectedNode =
+            healthyNodes.get(getRand().nextInt(healthyNodes.size()));
+    healthyNodes.remove(selectedNode);
+    return selectedNode;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix Randomly-pick policy in chooseDatanodes.
The  implementation of **chooseNode()** is replaced with a random policy as same as the one in class **SCMContainerPlacementRandom** . 
The other usages of **chooseNode**  in  class **PipelinePlacementPolicy** won't affect the topology & rack-awareness based node-choose policy
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4710

## How was this patch tested?
manually I tested the **chooseDatanodes()** method with a  test method similar to  **testChooseNodeWithSingleNodeRack()**  where i added serveal equal nodes. The pipeline members are randomly generated.
