### PR TITLE
HDDS-4722. Creating RDBStore fails due to RDBMetrics instance race

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBMetrics.java
@@ -101,7 +101,7 @@ public class RDBMetrics {
     return numDBKeyMayExistMisses.value();
   }
 
-  public static void unRegister() {
+  public static synchronized void unRegister() {
     instance = null;
     MetricsSystem ms = DefaultMetricsSystem.instance();
     ms.unregisterSource(SOURCE_NAME);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make RDBMetrics#unRegister() synchronized. Accessing the instance object inside RDMBetrics#create() is synchronized, and therefore RDBMetrics#unRegister() should be made synchronized to protect the instance object.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4722

## How was this patch tested?
Manually tested.