### PR TITLE
HDDS-4710. PipelinePlacementPolicy altered to randomly pick

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -354,17 +354,17 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
    * list that we are operating on.
    *
    * @param healthyNodes - Set of healthy nodes we can choose from.
-   * @return chosen datanodDetails
+   * @return chosen datanodeDetails
    */
   @Override
-  public DatanodeDetails chooseNode(
-      List<DatanodeDetails> healthyNodes) {
+  public DatanodeDetails chooseNode(final List<DatanodeDetails> healthyNodes) {
     if (healthyNodes == null || healthyNodes.isEmpty()) {
       return null;
     }
-    DatanodeDetails datanodeDetails = healthyNodes.get(0);
-    healthyNodes.remove(datanodeDetails);
-    return datanodeDetails;
+    DatanodeDetails selectedNode =
+            healthyNodes.get(getRand().nextInt(healthyNodes.size()));
+    healthyNodes.remove(selectedNode);
+    return selectedNode;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix Randomly-pick policy in chooseDatanodes.
Problem:
I was trying to configure a four-node cluster to test SCM HA, after configuring the ozone.datanode.pipeline.limit to 3 and 5 separately, the pipeline existed only chose the first three data nodes, the fourth node was never chosen.(They are equal nodes)

Solution:
The implementation of chooseNode() is replaced with a random policy as the same as the one in class SCMContainerPlacementRandom.
The other usages of chooseNode in class PipelinePlacementPolicy won't affect the topology & rack-awareness based node-choose policy

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4710

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

manually I tested the chooseDatanodes() method with a test method similar to testChooseNodeWithSingleNodeRack() where i added several equal nodes. The pipeline members are randomly generated.
