### PR TITLE
HDDS-4725. Change metrics unit from nanosecond to millisecond

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -468,7 +468,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     final CompletableFuture<ContainerCommandResponseProto> replyFuture =
         new CompletableFuture<>();
     semaphore.acquire();
-    long requestTime = System.nanoTime();
+    long requestTime = System.currentTimeMillis();
     metrics.incrPendingContainerOpsMetrics(request.getCmdType());
     // create a new grpc stream for each non-async call.
 
@@ -482,7 +482,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
               public void onNext(ContainerCommandResponseProto value) {
                 replyFuture.complete(value);
                 metrics.decrPendingContainerOpsMetrics(request.getCmdType());
-                long cost = System.nanoTime() - requestTime;
+                long cost = System.currentTimeMillis() - requestTime;
                 metrics.addContainerOpsLatency(request.getCmdType(),
                     cost);
                 if (LOG.isDebugEnabled()) {
@@ -497,9 +497,9 @@ public class XceiverClientGrpc extends XceiverClientSpi {
               public void onError(Throwable t) {
                 replyFuture.completeExceptionally(t);
                 metrics.decrPendingContainerOpsMetrics(request.getCmdType());
-                long cost = System.nanoTime() - requestTime;
+                long cost = System.currentTimeMillis() - requestTime;
                 metrics.addContainerOpsLatency(request.getCmdType(),
-                    System.nanoTime() - requestTime);
+                    System.currentTimeMillis() - requestTime);
                 if (LOG.isDebugEnabled()) {
                   LOG.debug("Executed command {} on datanode {}, cost = {}, "
                           + "cmdType = {}", request, dn,

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientMetrics.java
@@ -92,8 +92,8 @@ public class XceiverClientMetrics {
   }
 
   public void addContainerOpsLatency(ContainerProtos.Type type,
-      long latencyNanos) {
-    containerOpsLatency[type.ordinal()].add(latencyNanos);
+      long latencyMillis) {
+    containerOpsLatency[type.ordinal()].add(latencyMillis);
   }
 
   public long getPendingContainerOpCountMetrics(ContainerProtos.Type type) {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientRatis.java
@@ -301,7 +301,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
   public XceiverClientReply sendCommandAsync(
       ContainerCommandRequestProto request) {
     XceiverClientReply asyncReply = new XceiverClientReply(null);
-    long requestTime = System.nanoTime();
+    long requestTime = System.currentTimeMillis();
     CompletableFuture<RaftClientReply> raftClientReply =
         sendRequestAsync(request);
     metrics.incrPendingContainerOpsMetrics(request.getCmdType());
@@ -315,7 +315,7 @@ public final class XceiverClientRatis extends XceiverClientSpi {
           }
           metrics.decrPendingContainerOpsMetrics(request.getCmdType());
           metrics.addContainerOpsLatency(request.getCmdType(),
-              System.nanoTime() - requestTime);
+              System.currentTimeMillis() - requestTime);
         }).thenApply(reply -> {
           try {
             if (!reply.isSuccess()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerMetrics.java
@@ -111,10 +111,10 @@ public class ContainerMetrics {
   }
 
   public void incContainerOpsLatencies(ContainerProtos.Type type,
-                                       long latencyNanos) {
-    opsLatency[type.ordinal()].add(latencyNanos);
+                                       long latencyMillis) {
+    opsLatency[type.ordinal()].add(latencyMillis);
     for (MutableQuantiles q: opsLatQuantiles[type.ordinal()]) {
-      q.add(latencyNanos);
+      q.add(latencyMillis);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -193,7 +193,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
 
     ContainerType containerType;
     ContainerCommandResponseProto responseProto = null;
-    long startTime = System.nanoTime();
+    long startTime = System.currentTimeMillis();
     Type cmdType = msg.getCmdType();
     long containerID = msg.getContainerID();
     metrics.incContainerOpsMetrics(cmdType);
@@ -308,7 +308,8 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
     }
     responseProto = handler.handle(msg, container, dispatcherContext);
     if (responseProto != null) {
-      metrics.incContainerOpsLatencies(cmdType, System.nanoTime() - startTime);
+      metrics.incContainerOpsLatencies(cmdType,
+          System.currentTimeMillis() - startTime);
 
       // If the request is of Write Type and the container operation
       // is unsuccessful, it implies the applyTransaction on the container

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -193,9 +193,9 @@ public class CSMMetrics {
     return applyTransaction;
   }
 
-  public void incPipelineLatency(ContainerProtos.Type type, long latencyNanos) {
-    opsLatency[type.ordinal()].add(latencyNanos);
-    transactionLatency.add(latencyNanos);
+  public void incPipelineLatency(ContainerProtos.Type type, long latencyMillis) {
+    opsLatency[type.ordinal()].add(latencyMillis);
+    transactionLatency.add(latencyMillis);
   }
 
   public void incNumStartTransactionVerifyFailures() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/CSMMetrics.java
@@ -193,7 +193,8 @@ public class CSMMetrics {
     return applyTransaction;
   }
 
-  public void incPipelineLatency(ContainerProtos.Type type, long latencyMillis) {
+  public void incPipelineLatency(ContainerProtos.Type type,
+      long latencyMillis) {
     opsLatency[type.ordinal()].add(latencyMillis);
     transactionLatency.add(latencyMillis);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -764,7 +764,7 @@ public class ContainerStateMachine extends BaseStateMachine {
             && trx.getStateMachineContext() != null) {
           long startTime = (long) trx.getStateMachineContext();
           metrics.incPipelineLatency(cmdType,
-              Time.monotonicNowNanos() - startTime);
+              (Time.monotonicNowNanos() - startTime) / 1000000L);
         }
         // ignore close container exception while marking the stateMachine
         // unhealthy

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -82,11 +82,11 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
             serviceName, type);
       }
 
-      long startTime = System.nanoTime();
+      long startTime = System.currentTimeMillis();
 
       RESPONSE response = methodCall.apply(request);
 
-      protocolMessageMetrics.increment(type, System.nanoTime() - startTime);
+      protocolMessageMetrics.increment(type, System.currentTimeMillis() - startTime);
 
       if (logger.isTraceEnabled()) {
         logger.trace(

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneProtocolMessageDispatcher.java
@@ -86,7 +86,8 @@ public class OzoneProtocolMessageDispatcher<REQUEST, RESPONSE, TYPE> {
 
       RESPONSE response = methodCall.apply(request);
 
-      protocolMessageMetrics.increment(type, System.currentTimeMillis() - startTime);
+      protocolMessageMetrics.increment(type,
+          System.currentTimeMillis() - startTime);
 
       if (logger.isTraceEnabled()) {
         logger.trace(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -283,7 +283,7 @@ public final class OzoneManagerDoubleBuffer {
                   return null;
                 });
 
-            long startTime = Time.monotonicNowNanos();
+            long startTime = Time.monotonicNow();
             flushBatchWithTrace(lastTraceId.get(), readyBuffer.size(),
                 (SupplierWithIOException<Void>) () -> {
                   omMetadataManager.getStore().commitBatchOperation(
@@ -291,7 +291,7 @@ public final class OzoneManagerDoubleBuffer {
                   return null;
                 });
             ozoneManagerDoubleBufferMetrics.updateFlushTime(
-                Time.monotonicNowNanos() - startTime);
+                Time.monotonicNow() - startTime);
           }
 
           // Complete futures first and then do other things. So, that

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -325,9 +325,9 @@ public class OzoneManagerServiceProviderImpl
   boolean updateReconOmDBWithNewSnapshot() throws IOException {
     // Obtain the current DB snapshot from OM and
     // update the in house OM metadata managed DB instance.
-    long startTime = Time.monotonicNowNanos();
+    long startTime = Time.monotonicNow();
     DBCheckpoint dbSnapshot = getOzoneManagerDBSnapshot();
-    metrics.updateSnapshotRequestLatency(Time.monotonicNowNanos() - startTime);
+    metrics.updateSnapshotRequestLatency(Time.monotonicNow() - startTime);
     if (dbSnapshot != null && dbSnapshot.getCheckpointLocation() != null) {
       LOG.info("Got new checkpoint from OM : " +
           dbSnapshot.getCheckpointLocation());


### PR DESCRIPTION
## What changes were proposed in this pull request?

 Change metrics unit from nanosecond to millisecond uniformly 

Some metrics unit is nanosecond, and some is millisecond. The metrics are following

```
EventWatcherMetrics   ms

ProtocolMessageMetrics ns

CSMMetrics ns

ContainerMetrics ns

XceiverClientMetrics ns

OzoneManagerDoubleBufferMetrics ns

OzoneManagerSyncMetrics ns

ContainerCacheMetrics ms
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4725

## How was this patch tested?

manual tests

