### PR TITLE
HDDS-4724. Revert column family names of Datanode db to avoid compatibility issue.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaTwoDBDefinition.java
@@ -37,7 +37,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<String, BlockData>
           BLOCK_DATA =
           new DBColumnFamilyDefinition<>(
-                  "blockData",
+                  "block_data",
                   String.class,
                   new StringCodec(),
                   BlockData.class,
@@ -55,7 +55,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<String, ChunkInfoList>
           DELETED_BLOCKS =
           new DBColumnFamilyDefinition<>(
-                  "deletedBlocks",
+                  "deleted_blocks",
                   String.class,
                   new StringCodec(),
                   ChunkInfoList.class,
@@ -64,7 +64,7 @@ public class DatanodeSchemaTwoDBDefinition extends
   public static final DBColumnFamilyDefinition<Long, DeletedBlocksTransaction>
       DELETE_TRANSACTION =
       new DBColumnFamilyDefinition<>(
-          "deleteTxns",
+          "delete_txns",
           Long.class,
           new LongCodec(),
           StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction.class,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tencent monthly deploy the latest master to our production environment.

During latest upgrade test, we found that new Ozone(version at Jan 14 2021) can not read the data written by old Ozone(version at Dec 14 2020). We found following traces:

```
2021-01-20 16:36:39,575 INFO org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet: Added Volume : /data4/hdds/hdds to VolumeSet
2021-01-20 16:36:39,582 INFO org.apache.hadoop.ozone.container.common.volume.ThrottledAsyncChecker: Scheduling a check for /data4/hdds/hdds
2021-01-20 16:36:39,594 INFO org.apache.hadoop.ozone.container.common.volume.HddsVolumeChecker: Scheduled health check for volume /data4/hdds/hdds
2021-01-20 16:36:39,595 INFO org.apache.hadoop.ozone.container.common.volume.ThrottledAsyncChecker: Scheduling a check for /data1/hdds/hdds
2021-01-20 16:36:39,595 INFO org.apache.hadoop.ozone.container.common.volume.HddsVolumeChecker: Scheduled health check for volume /data1/hdds/hdds
2021-01-20 16:36:39,595 INFO org.apache.hadoop.ozone.container.common.volume.ThrottledAsyncChecker: Scheduling a check for /data2/hdds/hdds
2021-01-20 16:36:39,596 INFO org.apache.hadoop.ozone.container.common.volume.HddsVolumeChecker: Scheduled health check for volume /data2/hdds/hdds
2021-01-20 16:36:39,596 INFO org.apache.hadoop.ozone.container.common.volume.ThrottledAsyncChecker: Scheduling a check for /data3/hdds/hdds
2021-01-20 16:36:39,596 INFO org.apache.hadoop.ozone.container.common.volume.HddsVolumeChecker: Scheduled health check for volume /data3/hdds/hdds
2021-01-20 16:36:39,793 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,794 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,794 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,797 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,916 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,916 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,916 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:39,927 INFO org.apache.hadoop.hdds.utils.db.RDBStore: Found the following extra column families in existing DB : [block_data, deleted_blocks]
2021-01-20 16:36:40,001 WARN org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil: Attempt to get an uncached RocksDB handle failed and an instance was retrieved from the cache. This should only happen in tests
2021-01-20 16:36:40,006 WARN org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil: Attempt to get an uncached RocksDB handle failed and an instance was retrieved from the cache. This should only happen in tests
2021-01-20 16:36:40,013 WARN org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil: Attempt to get an uncached RocksDB handle failed and an instance was retrieved from the cache. This should only happen in tests
2021-01-20 16:36:40,018 WARN org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil: Attempt to get an uncached RocksDB handle failed and an instance was retrieved from the cache. This should only happen in tests
```

The name changing of the datanode column families done in HDDS-4369 is actually not backward compatible.

This PR aims to revert the name from deletedBlocks, deleteTxns, blockData to block_data, deleted_blocks, delete_txns.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4724

## How was this patch tested?

CI
