### PR TITLE
HDDS-4477. Delete txnId in SCMMetadataStoreImpl may drop to 0 after SCM restart.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManagerImpl.java
@@ -90,7 +90,8 @@ public class BlockManagerImpl implements BlockManager, BlockmanagerMXBean {
    * @throws IOException
    */
   public BlockManagerImpl(final ConfigurationSource conf,
-                          final StorageContainerManager scm) {
+                          final StorageContainerManager scm)
+      throws IOException {
     Objects.requireNonNull(scm, "SCM cannot be null");
     this.pipelineManager = scm.getPipelineManager();
     this.containerManager = scm.getContainerManager();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -73,6 +73,8 @@ public class DeletedBlockLogImpl
 
   public static final Logger LOG =
       LoggerFactory.getLogger(DeletedBlockLogImpl.class);
+  private static final DeletedBlocksTransaction.Builder DUMMY_TXN_BUILDER =
+      DeletedBlocksTransaction.newBuilder().setContainerID(1).setCount(1);
 
   private final int maxRetry;
   private final ContainerManager containerManager;
@@ -82,7 +84,7 @@ public class DeletedBlockLogImpl
   private Map<Long, Set<UUID>> transactionToDNsCommitMap;
 
   private final AtomicLong txID;
-  // largest transactionId is stored by largestTxnIdHolderKey
+  // largest transactionId is stored at largestTxnIdHolderKey
   private final long largestTxnIdHolderKey = 0L;
 
 
@@ -343,10 +345,11 @@ public class DeletedBlockLogImpl
             constructNewTransaction(nextTXID, entry.getKey(),
                 entry.getValue()));
       }
+      // Add a dummy transaction to store the largestTransactionId at
+      // largestTxnIdHolderKey
       scmMetadataStore.getDeletedBlocksTXTable()
           .putWithBatch(batch, largestTxnIdHolderKey,
-              DeletedBlocksTransaction.newBuilder().setTxID(getCurrentTXID())
-                  .setContainerID(1).setCount(1).build());
+              DUMMY_TXN_BUILDER.setTxID(getCurrentTXID()).build());
       scmMetadataStore.getStore().commitBatchOperation(batch);
     } finally {
       lock.unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.metadata;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -68,20 +69,6 @@ public interface SCMMetadataStore {
    * @return Table
    */
   Table<Long, DeletedBlocksTransaction> getDeletedBlocksTXTable();
-
-  /**
-   * Returns the current TXID for the deleted blocks.
-   *
-   * @return Long
-   */
-  Long getCurrentTXID();
-
-  /**
-   * Returns the next TXID for the Deleted Blocks.
-   *
-   * @return Long.
-   */
-  Long getNextDeleteBlockTXID();
 
   /**
    * A table that maintains all the valid certificates issued by the SCM CA.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.metadata;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
-import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.metadata;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -30,10 +31,10 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
@@ -64,7 +65,6 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
       LoggerFactory.getLogger(SCMMetadataStoreImpl.class);
   private DBStore store;
   private final OzoneConfiguration configuration;
-  private final AtomicLong txID;
 
   /**
    * Constructs the metadata store and starts the DB Services.
@@ -76,7 +76,6 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
       throws IOException {
     this.configuration = config;
     start(this.configuration);
-    this.txID = new AtomicLong(this.getLargestRecordedTXID());
   }
 
   @Override
@@ -124,10 +123,6 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
     return deletedBlocksTable;
   }
 
-  @Override
-  public Long getNextDeleteBlockTXID() {
-    return this.txID.incrementAndGet();
-  }
 
   @Override
   public Table<BigInteger, X509Certificate> getValidCertsTable() {
@@ -167,28 +162,6 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
     return containerTable;
   }
 
-  @Override
-  public Long getCurrentTXID() {
-    return this.txID.get();
-  }
-
-  /**
-   * Returns the largest recorded TXID from the DB.
-   *
-   * @return Long
-   * @throws IOException
-   */
-  private Long getLargestRecordedTXID() throws IOException {
-    try (TableIterator<Long, ? extends KeyValue<Long, DeletedBlocksTransaction>>
-        txIter = deletedBlocksTable.iterator()) {
-      txIter.seekToLast();
-      Long txid = txIter.key();
-      if (txid != null) {
-        return txid;
-      }
-    }
-    return 0L;
-  }
 
 
   private void checkTableStatus(Table table, String name) throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hdds.scm.metadata;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
-import java.util.List;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -31,7 +29,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -300,7 +300,7 @@ public class TestDeletedBlockLog {
         // verify the number of added and committed.
         try (TableIterator<Long,
             ? extends Table.KeyValue<Long, DeletedBlocksTransaction>> iter =
-            scm.getScmMetadataStore().getDeletedBlocksTXTable().iterator()) {
+            deletedBlockLog.getIterator()) {
           AtomicInteger count = new AtomicInteger();
           iter.forEachRemaining((keyValue) -> count.incrementAndGet());
           Assert.assertEquals(added, count.get() + committed);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -328,6 +328,15 @@ public class TestDeletedBlockLog {
     blocks = getTransactions(BLOCKS_PER_TXN * 40);
     Assert.assertEquals(40, blocks.size());
     commitTransactions(blocks);
+
+    // close db and reopen it again to make sure
+    // currentTxnID = 50
+    deletedBlockLog.close();
+    deletedBlockLog = new DeletedBlockLogImpl(conf, containerManager,
+        scm.getScmMetadataStore());
+    blocks = getTransactions(BLOCKS_PER_TXN * 40);
+    Assert.assertEquals(0, blocks.size());
+    Assert.assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -88,21 +88,6 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
   }
 
   @Override
-  public void addDeleteTransactions(List<DeletedBlocksTransaction> txns) {
-    return;
-  }
-
-  @Override
-  public Long getCurrentTXID() {
-    return null;
-  }
-
-  @Override
-  public Long getNextDeleteBlockTXID() {
-    return null;
-  }
-
-  @Override
   public Table<BigInteger, X509Certificate> getValidCertsTable() {
     return null;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
@@ -84,6 +85,11 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
   @Override
   public Table<Long, DeletedBlocksTransaction> getDeletedBlocksTXTable() {
     return null;
+  }
+
+  @Override
+  public void addDeleteTransactions(List<DeletedBlocksTransaction> txns) {
+    return;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
-import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;


### PR DESCRIPTION
## What changes were proposed in this pull request?

If SCM cleans up all the DeletedBlocksTransaction in deletedBlocksTable, then restart, the txID in SCMMetadataStoreImpl will drop to 0.

in SCMMetadataStoreImpl.java
```
public SCMMetadataStoreImpl(OzoneConfiguration config)
    throws IOException {
  this.configuration = config;
  start(this.configuration);
  this.txID = new AtomicLong(this.getLargestRecordedTXID());
}

private Long getLargestRecordedTXID() throws IOException {
  try (TableIterator<Long, ? extends KeyValue<Long, DeletedBlocksTransaction>>
      txIter = deletedBlocksTable.iterator()) {
    txIter.seekToLast();
    Long txid = txIter.key();
    if (txid != null) {
      return txid;
    }
  }
  return 0L;
}
```

in DeletedBlockLogImpl.java
```
public void commitTransactions(
    List<DeleteBlockTransactionResult> transactionResults, UUID dnID) {
  ...
  scmMetadataStore.getDeletedBlocksTXTable().delete(txID);
  ...
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4477

## How was this patch tested?

Adds UT
