### PR TITLE
HDDS-4728. Ozone debug chunkinfo is not working correctly.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -52,7 +52,6 @@ import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.keys.KeyHandler;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.Parameters;
 
 /**
  * Class that gives chunk location given a specific key.
@@ -63,9 +62,6 @@ import picocli.CommandLine.Parameters;
 @MetaInfServices(SubcommandWithParent.class)
 public class ChunkKeyHandler extends KeyHandler implements
     SubcommandWithParent {
-
-  @Parameters(arity = "1..1", description = "key to be located")
-    private String uri;
 
   private ContainerOperationClient containerOperationClient;
   private  XceiverClientManager xceiverClientManager;


### PR DESCRIPTION
## What changes were proposed in this pull request?
When chunkinfo command is run on a key , it asks for param "uri" twice.  Removed parameter since it is extending Keyhandler which requires uri .

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4728

## How was this patch tested?
Manually.
