### PR TITLE
HDDS-4660. Update OMTransactionInfo to TransactionInfo with functions added

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.util.ExitManager;
@@ -152,11 +152,11 @@ public class TestOMRatisSnapshots {
     List<String> keys = writeKeysToIncreaseLogIndex(leaderRatisServer, 200);
 
     // Get the latest db checkpoint from the leader OM.
-    OMTransactionInfo omTransactionInfo =
-        OMTransactionInfo.readTransactionInfo(leaderOM.getMetadataManager());
+    TransactionInfo transactionInfo =
+        TransactionInfo.readTransactionInfo(leaderOM.getMetadataManager());
     TermIndex leaderOMTermIndex =
-        TermIndex.valueOf(omTransactionInfo.getTerm(),
-            omTransactionInfo.getTransactionIndex());
+        TermIndex.valueOf(transactionInfo.getTerm(),
+            transactionInfo.getTransactionIndex());
     long leaderOMSnaphsotIndex = leaderOMTermIndex.getIndex();
     long leaderOMSnapshotTermIndex = leaderOMTermIndex.getTerm();
 
@@ -275,7 +275,7 @@ public class TestOMRatisSnapshots {
     DBCheckpoint leaderDbCheckpoint = leaderOM.getMetadataManager().getStore()
         .getCheckpoint(false);
     Path leaderCheckpointLocation = leaderDbCheckpoint.getCheckpointLocation();
-    OMTransactionInfo leaderCheckpointTrxnInfo = OzoneManagerRatisUtils
+    TransactionInfo leaderCheckpointTrxnInfo = OzoneManagerRatisUtils
         .getTrxnInfoFromCheckpoint(conf, leaderCheckpointLocation);
 
     // Corrupt the leader checkpoint and install that on the OM. The

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/snapshot/TestOzoneManagerSnapshotProvider.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.client.VolumeArgs;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmFailoverProxyUtil;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 
 import org.junit.After;
@@ -136,7 +136,7 @@ public class TestOzoneManagerSnapshotProvider {
   private long getDownloadedSnapshotIndex(DBCheckpoint dbCheckpoint)
       throws Exception {
 
-    OMTransactionInfo trxnInfoFromCheckpoint =
+    TransactionInfo trxnInfoFromCheckpoint =
         OzoneManagerRatisUtils.getTrxnInfoFromCheckpoint(conf,
             dbCheckpoint.getCheckpointLocation());
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.storage.proto.
     OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
@@ -343,7 +343,7 @@ public interface OMMetadataManager {
    */
   Table<String, S3SecretValue> getS3SecretTable();
 
-  Table<String, OMTransactionInfo> getTransactionInfoTable();
+  Table<String, TransactionInfo> getTransactionInfoTable();
 
   /**
    * Returns number of rows in a table.  This should not be used for very

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TransactionInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/TransactionInfoCodec.java
@@ -18,33 +18,33 @@
 package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 
 import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Codec to convert {@link OMTransactionInfo} to byte array and from byte array
- * to {@link OMTransactionInfo}.
+ * Codec to convert {@link TransactionInfo} to byte array and from byte array
+ * to {@link TransactionInfo}.
  */
-public class OMTransactionInfoCodec implements Codec<OMTransactionInfo> {
+public class TransactionInfoCodec implements Codec<TransactionInfo> {
   @Override
-  public byte[] toPersistedFormat(OMTransactionInfo object) throws IOException {
+  public byte[] toPersistedFormat(TransactionInfo object) throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
     return object.convertToByteArray();
   }
 
   @Override
-  public OMTransactionInfo fromPersistedFormat(byte[] rawData)
+  public TransactionInfo fromPersistedFormat(byte[] rawData)
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OMTransactionInfo.getFromByteArray(rawData);
+    return TransactionInfo.getFromByteArray(rawData);
   }
 
   @Override
-  public OMTransactionInfo copyObject(OMTransactionInfo object) {
+  public TransactionInfo copyObject(TransactionInfo object) {
     return object;
   }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/ratis/TransactionInfo.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/ratis/TransactionInfo.java
@@ -32,7 +32,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_SPLIT_KEY;
 /**
  * TransactionInfo which is persisted to OM DB.
  */
-public final class OMTransactionInfo {
+public final class TransactionInfo {
 
   // Term associated with Ratis Log index in Ratis enabled cluster. In
   // non-Ratis cluster, term is set to -1.
@@ -42,7 +42,7 @@ public final class OMTransactionInfo {
   // non-Ratis cluster
   private long transactionIndex;
 
-  private OMTransactionInfo(String transactionInfo) {
+  private TransactionInfo(String transactionInfo) {
     String[] tInfo =
         transactionInfo.split(TRANSACTION_INFO_SPLIT_KEY);
     Preconditions.checkState(tInfo.length==2,
@@ -52,9 +52,21 @@ public final class OMTransactionInfo {
     transactionIndex = Long.parseLong(tInfo[1]);
   }
 
-  private OMTransactionInfo(long currentTerm, long transactionIndex) {
+  private TransactionInfo(long currentTerm, long transactionIndex) {
     this.term = currentTerm;
     this.transactionIndex = transactionIndex;
+  }
+
+  public boolean isInitialized() {
+    return transactionIndex == -1 && term == 0;
+  }
+
+  public int compareTo(TransactionInfo info) {
+    if (info.getTerm() == this.getTerm()) {
+      return this.getTransactionIndex() <= info.getTransactionIndex() ? -1 : 1;
+    } else {
+      return this.getTerm() < info.getTerm() ? -1 : 1;
+    }
   }
 
   /**
@@ -104,9 +116,9 @@ public final class OMTransactionInfo {
    * @param bytes
    * @return OMTransactionInfo
    */
-  public static OMTransactionInfo getFromByteArray(byte[] bytes) {
+  public static TransactionInfo getFromByteArray(byte[] bytes) {
     String tInfo = StringUtils.bytes2String(bytes);
-    return new OMTransactionInfo(tInfo);
+    return new TransactionInfo(tInfo);
   }
 
   @Override
@@ -117,9 +129,14 @@ public final class OMTransactionInfo {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    OMTransactionInfo that = (OMTransactionInfo) o;
+    TransactionInfo that = (TransactionInfo) o;
     return term == that.term &&
         transactionIndex == that.transactionIndex;
+  }
+
+  public static TransactionInfo fromTermIndex(TermIndex termIndex) {
+    return new Builder().setCurrentTerm(termIndex.getTerm())
+        .setTransactionIndex(termIndex.getIndex()).build();
   }
 
   @Override
@@ -138,12 +155,12 @@ public final class OMTransactionInfo {
    * @return
    * @throws IOException
    */
-  public static OMTransactionInfo readTransactionInfo(
+  public static TransactionInfo readTransactionInfo(
       OMMetadataManager metadataManager) throws IOException {
     return metadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
   }
   /**
-   * Builder to build {@link OMTransactionInfo}.
+   * Builder to build {@link TransactionInfo}.
    */
   public static class Builder {
     private long currentTerm = 0;
@@ -159,8 +176,8 @@ public final class OMTransactionInfo {
       return this;
     }
 
-    public OMTransactionInfo build() {
-      return new OMTransactionInfo(currentTerm, transactionIndex);
+    public TransactionInfo build() {
+      return new TransactionInfo(currentTerm, transactionIndex);
     }
 
   }

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestTransactionInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestTransactionInfoCodec.java
@@ -17,7 +17,7 @@
 
 package org.apache.hadoop.ozone.om.codec;
 
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -30,29 +30,29 @@ import java.nio.charset.StandardCharsets;
 import static org.junit.Assert.fail;
 
 /**
- * Class to test {@link OMTransactionInfoCodec}.
+ * Class to test {@link TransactionInfoCodec}.
  */
-public class TestOMTransactionInfoCodec {
+public class TestTransactionInfoCodec {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
 
-  private OMTransactionInfoCodec codec;
+  private TransactionInfoCodec codec;
 
   @Before
   public void setUp() {
-    codec = new OMTransactionInfoCodec();
+    codec = new TransactionInfoCodec();
   }
   @Test
   public void toAndFromPersistedFormat() throws Exception {
-    OMTransactionInfo omTransactionInfo =
-        new OMTransactionInfo.Builder().setTransactionIndex(100)
+    TransactionInfo transactionInfo =
+        new TransactionInfo.Builder().setTransactionIndex(100)
             .setCurrentTerm(11).build();
 
-    OMTransactionInfo convertedTransactionInfo =
-        codec.fromPersistedFormat(codec.toPersistedFormat(omTransactionInfo));
+    TransactionInfo convertedTransactionInfo =
+        codec.fromPersistedFormat(codec.toPersistedFormat(transactionInfo));
 
-    Assert.assertEquals(omTransactionInfo, convertedTransactionInfo);
+    Assert.assertEquals(transactionInfo, convertedTransactionInfo);
 
   }
   @Test

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -47,7 +47,7 @@ import org.apache.hadoop.hdds.utils.db.cache.TableCache.CacheType;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.BlockGroup;
-import org.apache.hadoop.ozone.om.codec.OMTransactionInfoCodec;
+import org.apache.hadoop.ozone.om.codec.TransactionInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmBucketInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmMultipartKeyInfoCodec;
@@ -70,7 +70,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.lock.OzoneManagerLock;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.storage.proto
     .OzoneManagerStorageProtos.PersistedUserVolumeInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
@@ -345,7 +345,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addCodec(OmMultipartKeyInfo.class, new OmMultipartKeyInfoCodec())
         .addCodec(S3SecretValue.class, new S3SecretValueCodec())
         .addCodec(OmPrefixInfo.class, new OmPrefixInfoCodec())
-        .addCodec(OMTransactionInfo.class, new OMTransactionInfoCodec());
+        .addCodec(TransactionInfo.class, new TransactionInfoCodec());
   }
 
   /**
@@ -400,7 +400,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     checkTableStatus(prefixTable, PREFIX_TABLE);
 
     transactionInfoTable = this.store.getTable(TRANSACTION_INFO_TABLE,
-        String.class, OMTransactionInfo.class);
+        String.class, TransactionInfo.class);
     checkTableStatus(transactionInfoTable, TRANSACTION_INFO_TABLE);
   }
 
@@ -1130,7 +1130,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   @Override
-  public Table<String, OMTransactionInfo> getTransactionInfoTable() {
+  public Table<String, TransactionInfo> getTransactionInfoTable() {
     return transactionInfoTable;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -138,7 +138,7 @@ import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
 import org.apache.hadoop.ozone.om.ratis.OMRatisSnapshotInfo;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
@@ -1334,18 +1334,18 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @VisibleForTesting
   long getLastTrxnIndexForNonRatis() throws IOException {
-    OMTransactionInfo omTransactionInfo =
-        OMTransactionInfo.readTransactionInfo(metadataManager);
+    TransactionInfo transactionInfo =
+        TransactionInfo.readTransactionInfo(metadataManager);
     // If the OMTransactionInfo does not exist in DB or if the term is not -1
     // (corresponding to non-Ratis cluster), return 0 so that new incoming
     // requests can have transaction index starting from 1.
-    if (omTransactionInfo == null || omTransactionInfo.getTerm() != -1) {
+    if (transactionInfo == null || transactionInfo.getTerm() != -1) {
       return 0;
     }
     // If there exists a last transaction index in DB, the new incoming
     // requests in non-Ratis cluster must have transaction index
     // incrementally increasing from the stored transaction index onwards.
-    return omTransactionInfo.getTransactionIndex();
+    return transactionInfo.getTransactionIndex();
   }
 
   public OMRatisSnapshotInfo getSnapshotInfo() {
@@ -1354,7 +1354,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   @VisibleForTesting
   public long getRatisSnapshotIndex() throws IOException {
-    return OMTransactionInfo.readTransactionInfo(metadataManager)
+    return TransactionInfo.readTransactionInfo(metadataManager)
         .getTransactionIndex();
   }
 
@@ -3240,7 +3240,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws Exception {
 
     Path checkpointLocation = omDBCheckpoint.getCheckpointLocation();
-    OMTransactionInfo checkpointTrxnInfo = OzoneManagerRatisUtils
+    TransactionInfo checkpointTrxnInfo = OzoneManagerRatisUtils
         .getTrxnInfoFromCheckpoint(configuration, checkpointLocation);
 
     LOG.info("Installing checkpoint with OMTransactionInfo {}",
@@ -3250,7 +3250,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   TermIndex installCheckpoint(String leaderId, Path checkpointLocation,
-      OMTransactionInfo checkpointTrxnInfo) throws Exception {
+      TransactionInfo checkpointTrxnInfo) throws Exception {
 
     File oldDBLocation = metadataManager.getStore().getDbLocation();
     try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 
@@ -133,14 +133,14 @@ public class OMDBDefinition implements DBDefinition {
                     S3SecretValue.class,
                     new S3SecretValueCodec());
 
-  public static final DBColumnFamilyDefinition<String, OMTransactionInfo>
+  public static final DBColumnFamilyDefinition<String, TransactionInfo>
             TRANSACTION_INFO_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TRANSACTION_INFO_TABLE,
                     String.class,
                     new StringCodec(),
-                    OMTransactionInfo.class,
-                    new OMTransactionInfoCodec());
+                    TransactionInfo.class,
+                    new TransactionInfoCodec());
 
   @Override
   public String getName() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -215,7 +215,7 @@ public final class OzoneManagerDoubleBuffer {
   }
 
   /**
-   * Add to writeBatch {@link OMTransactionInfo}.
+   * Add to writeBatch {@link TransactionInfo}.
    */
   private Void addToBatchTransactionInfoWithTrace(String parentName,
       long transactionIndex, SupplierWithIOException<Void> supplier)
@@ -277,7 +277,7 @@ public final class OzoneManagerDoubleBuffer {
                 (SupplierWithIOException<Void>) () -> {
                   omMetadataManager.getTransactionInfoTable().putWithBatch(
                       batchOperation, TRANSACTION_INFO_KEY,
-                      new OMTransactionInfo.Builder()
+                      new TransactionInfo.Builder()
                           .setTransactionIndex(lastRatisTransactionIndex)
                           .setCurrentTerm(term).build());
                   return null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -505,15 +505,15 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     // This is done, as we have a check in Ratis for not throwing
     // LeaderNotReadyException, it checks stateMachineIndex >= raftLog
     // nextIndex (placeHolderIndex).
-    OMTransactionInfo omTransactionInfo =
-        OMTransactionInfo.readTransactionInfo(
+    TransactionInfo transactionInfo =
+        TransactionInfo.readTransactionInfo(
             ozoneManager.getMetadataManager());
-    if (omTransactionInfo != null) {
+    if (transactionInfo != null) {
       setLastAppliedTermIndex(TermIndex.valueOf(
-          omTransactionInfo.getTerm(),
-          omTransactionInfo.getTransactionIndex()));
-      snapshotInfo.updateTermIndex(omTransactionInfo.getTerm(),
-          omTransactionInfo.getTransactionIndex());
+          transactionInfo.getTerm(),
+          transactionInfo.getTransactionIndex()));
+      snapshotInfo.updateTermIndex(transactionInfo.getTerm(),
+          transactionInfo.getTransactionIndex());
     }
     LOG.info("LastAppliedIndex is set from TransactionInfo from OM DB as {}",
         getLastAppliedTermIndex());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketDeleteRequest;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketSetPropertyRequest;
@@ -233,7 +233,7 @@ public final class OzoneManagerRatisUtils {
   /**
    * Obtain OMTransactionInfo from Checkpoint.
    */
-  public static OMTransactionInfo getTrxnInfoFromCheckpoint(
+  public static TransactionInfo getTrxnInfoFromCheckpoint(
       OzoneConfiguration conf, Path dbPath) throws Exception {
 
     if (dbPath != null) {
@@ -255,25 +255,25 @@ public final class OzoneManagerRatisUtils {
    * @return OMTransactionInfo
    * @throws Exception
    */
-  private static OMTransactionInfo getTransactionInfoFromDB(
+  private static TransactionInfo getTransactionInfoFromDB(
       OzoneConfiguration tempConfig, Path dbDir, String dbName)
       throws Exception {
     DBStore dbStore = OmMetadataManagerImpl.loadDB(tempConfig, dbDir.toFile(),
         dbName);
 
-    Table<String, OMTransactionInfo> transactionInfoTable =
+    Table<String, TransactionInfo> transactionInfoTable =
         dbStore.getTable(TRANSACTION_INFO_TABLE,
-            String.class, OMTransactionInfo.class);
+            String.class, TransactionInfo.class);
 
-    OMTransactionInfo omTransactionInfo =
+    TransactionInfo transactionInfo =
         transactionInfoTable.get(TRANSACTION_INFO_KEY);
     dbStore.close();
 
-    if (omTransactionInfo == null) {
+    if (transactionInfo == null) {
       throw new IOException("Failed to read OMTransactionInfo from DB " +
           dbName + " at " + dbDir);
     }
-    return omTransactionInfo;
+    return transactionInfo;
   }
 
   /**
@@ -281,22 +281,22 @@ public final class OzoneManagerRatisUtils {
    *
    * If transaction info transaction Index is less than or equal to
    * lastAppliedIndex, return false, else return true.
-   * @param omTransactionInfo
+   * @param transactionInfo
    * @param lastAppliedIndex
    * @param leaderId
    * @param newDBlocation
    * @return boolean
    */
   public static boolean verifyTransactionInfo(
-      OMTransactionInfo omTransactionInfo,
+      TransactionInfo transactionInfo,
       long lastAppliedIndex,
       String leaderId, Path newDBlocation) {
-    if (omTransactionInfo.getTransactionIndex() <= lastAppliedIndex) {
+    if (transactionInfo.getTransactionIndex() <= lastAppliedIndex) {
       OzoneManager.LOG.error("Failed to install checkpoint from OM leader: {}" +
               ". The last applied index: {} is greater than or equal to the " +
               "checkpoint's applied index: {}. Deleting the downloaded " +
               "checkpoint {}", leaderId, lastAppliedIndex,
-          omTransactionInfo.getTransactionIndex(), newDBlocation);
+          transactionInfo.getTransactionIndex(), newDBlocation);
       try {
         FileUtils.deleteFully(newDBlocation);
       } catch (IOException e) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -25,7 +25,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
-import org.apache.hadoop.ozone.om.ratis.OMTransactionInfo;
+import org.apache.hadoop.ozone.om.ratis.TransactionInfo;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,22 +68,22 @@ public class TestOmMetadataManager {
   @Test
   public void testTransactionTable() throws Exception {
     omMetadataManager.getTransactionInfoTable().put(TRANSACTION_INFO_KEY,
-        new OMTransactionInfo.Builder().setCurrentTerm(1)
+        new TransactionInfo.Builder().setCurrentTerm(1)
             .setTransactionIndex(100).build());
 
     omMetadataManager.getTransactionInfoTable().put(TRANSACTION_INFO_KEY,
-        new OMTransactionInfo.Builder().setCurrentTerm(2)
+        new TransactionInfo.Builder().setCurrentTerm(2)
             .setTransactionIndex(200).build());
 
     omMetadataManager.getTransactionInfoTable().put(TRANSACTION_INFO_KEY,
-        new OMTransactionInfo.Builder().setCurrentTerm(3)
+        new TransactionInfo.Builder().setCurrentTerm(3)
             .setTransactionIndex(250).build());
 
-    OMTransactionInfo omTransactionInfo =
+    TransactionInfo transactionInfo =
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
 
-    Assert.assertEquals(3, omTransactionInfo.getTerm());
-    Assert.assertEquals(250, omTransactionInfo.getTransactionIndex());
+    Assert.assertEquals(3, transactionInfo.getTerm());
+    Assert.assertEquals(250, transactionInfo.getTransactionIndex());
 
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -133,13 +133,13 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
     assertEquals(bucketCount, lastAppliedIndex);
 
 
-    OMTransactionInfo omTransactionInfo =
+    TransactionInfo transactionInfo =
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
-    assertNotNull(omTransactionInfo);
+    assertNotNull(transactionInfo);
 
     Assert.assertEquals(lastAppliedIndex,
-        omTransactionInfo.getTransactionIndex());
-    Assert.assertEquals(term, omTransactionInfo.getTerm());
+        transactionInfo.getTransactionIndex());
+    Assert.assertEquals(term, transactionInfo.getTerm());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -196,13 +196,13 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
     Assert.assertEquals(bucketCount + deleteCount + 1, lastAppliedIndex);
 
 
-    OMTransactionInfo omTransactionInfo =
+    TransactionInfo transactionInfo =
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);
-    assertNotNull(omTransactionInfo);
+    assertNotNull(transactionInfo);
 
     Assert.assertEquals(lastAppliedIndex,
-        omTransactionInfo.getTransactionIndex());
-    Assert.assertEquals(term, omTransactionInfo.getTerm());
+        transactionInfo.getTransactionIndex());
+    Assert.assertEquals(term, transactionInfo.getTerm());
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -140,7 +140,7 @@ public class TestOzoneManagerRatisServer {
         snapshotInfo.getTerm(), snapshotInfo.getIndex() + 100);
 
     omMetadataManager.getTransactionInfoTable().put(TRANSACTION_INFO_KEY,
-        new OMTransactionInfo.Builder()
+        new TransactionInfo.Builder()
             .setCurrentTerm(snapshotInfo.getTerm())
             .setTransactionIndex(snapshotInfo.getIndex() + 100)
             .build());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Requirements:
1. Rename OMTransactionInfo to TransactionInfo (to be used by both OM and SCM), same for the codec.
2. Add extra functions in https://github.com/apache/ozone/blob/HDDS-2823/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMTransactionInfo.java to OMTransactionInfo.

By doing so, we can use the TransactionInfo in HDDS-2823 and remove duplicate code

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4660

## How was this patch tested?

UT
