### PR TITLE
HDDS-4610. Fix issues in 'prepare' operation with one OM down.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -383,6 +383,8 @@ public final class OzoneConsts {
   public static final String TRANSACTION_INFO_KEY = "#TRANSACTIONINFO";
   public static final String TRANSACTION_INFO_SPLIT_KEY = "#";
 
+  public static final String PREPARE_MARKER_KEY = "#PREPAREDINFO";
+
   public static final String CONTAINER_DB_TYPE_ROCKSDB = "RocksDB";
   public static final String CONTAINER_DB_TYPE_LEVELDB = "LevelDB";
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/test.sh
@@ -36,6 +36,8 @@ if [[ -n "${OZONE_VOLUME_OWNER}" ]]; then
 fi
 
 export OZONE_DIR=/opt/hadoop
+export OM_SERVICE_ID=omservice
+
 # shellcheck source=/dev/null
 source "${COMPOSE_DIR}/../testlib.sh"
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -87,7 +87,7 @@ public class TestHDDSUpgrade {
   private ContainerManager scmContainerManager;
   private PipelineManager scmPipelineManager;
   private Pipeline ratisPipeline1;
-  private final int CONTAINERS_CREATED_FOR_TESTING = 1;
+  private final int numContainersCreated = 1;
   private HDDSLayoutVersionManager scmVersionManager;
 
   /**
@@ -145,7 +145,7 @@ public class TestHDDSUpgrade {
           (ciState == HddsProtos.LifeCycleState.QUASI_CLOSED));
       countContainers++;
     }
-    Assert.assertEquals(CONTAINERS_CREATED_FOR_TESTING, countContainers);
+    Assert.assertEquals(numContainersCreated, countContainers);
   }
 
   private void testPreUpgradeConditionsDataNodes() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -58,9 +58,9 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -81,22 +81,22 @@ public class TestHDDSUpgrade {
       LoggerFactory.getLogger(TestHDDSUpgrade.class);
   private static final int NUM_DATA_NODES = 3;
 
-  private static MiniOzoneCluster cluster;
-  private static OzoneConfiguration conf;
-  private static StorageContainerManager scm;
-  private static ContainerManager scmContainerManager;
-  private static PipelineManager scmPipelineManager;
-  private static Pipeline ratisPipeline1;
-  private static final int CONTAINERS_CREATED_FOR_TESTING = 1;
-  private static HDDSLayoutVersionManager scmVersionManager;
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration conf;
+  private StorageContainerManager scm;
+  private ContainerManager scmContainerManager;
+  private PipelineManager scmPipelineManager;
+  private Pipeline ratisPipeline1;
+  private final int CONTAINERS_CREATED_FOR_TESTING = 1;
+  private HDDSLayoutVersionManager scmVersionManager;
 
   /**
    * Create a MiniDFSCluster for testing.
    *
    * @throws IOException
    */
-  @BeforeClass
-  public static void init() throws Exception {
+  @Before
+  public void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1000,
             TimeUnit.MILLISECONDS);
@@ -119,8 +119,8 @@ public class TestHDDSUpgrade {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
-  public static void shutdown() {
+  @After
+  public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -48,7 +48,7 @@ public class OMCancelPrepareRequest extends OMClientRequest {
       OzoneManager ozoneManager, long transactionLogIndex,
       OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
 
-    LOG.info("OM {} Received cancel request with log index {}",
+    LOG.info("OM {} Received cancel prepare request with log index {}",
         ozoneManager.getOMNodeId(), transactionLogIndex);
 
     OMRequest omRequest = getOmRequest();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -177,10 +177,10 @@ public class OMPrepareRequest extends OMClientRequest {
         // If there are no transactions in the DB, we are prepared to log
         // index 0 only.
         success = (indexToWaitFor == 0)
-            && (ratisTxnIndex >= indexToWaitFor);
+            && (ratisTxnIndex == indexToWaitFor + 1);
       } else {
         success = (dbTxnInfo.getTransactionIndex() == indexToWaitFor)
-            && (ratisTxnIndex >= indexToWaitFor);
+            && (ratisTxnIndex >= indexToWaitFor + 1);
       }
 
       if (!success) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMPrepareRequest.java
@@ -94,7 +94,7 @@ public class OMPrepareRequest extends OMClientRequest {
               .setTxnID(prepareIndex)
               .build();
       responseBuilder.setPrepareResponse(omResponse);
-      response = new OMPrepareResponse(responseBuilder.build());
+      response = new OMPrepareResponse(responseBuilder.build(), prepareIndex);
 
       // Add response to double buffer before clearing logs.
       // This guarantees the log index of this request will be the same as

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/upgrade/OMCancelPrepareResponse.java
@@ -16,6 +16,8 @@
  */
 package org.apache.hadoop.ozone.om.response.upgrade;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TRANSACTION_INFO_TABLE;
+
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -27,7 +29,7 @@ import java.io.IOException;
 /**
  * Response for cancel prepare.
  */
-@CleanupTableInfo()
+@CleanupTableInfo(cleanupTables = {TRANSACTION_INFO_TABLE})
 public class OMCancelPrepareResponse extends OMClientResponse {
   public OMCancelPrepareResponse(
       OzoneManagerProtocolProtos.OMResponse omResponse) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -43,8 +43,6 @@ import org.apache.hadoop.ozone.om.request.file.OMFileCreateRequest;
 import org.apache.hadoop.ozone.om.request.key.OMKeyCreateRequest;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
-import org.apache.hadoop.ozone.om.response.upgrade.OMCancelPrepareResponse;
-import org.apache.hadoop.ozone.om.response.upgrade.OMPrepareResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
@@ -157,11 +155,6 @@ public class TestCleanupTableInfo {
         Assert.assertTrue(
             Arrays.stream(cleanupTables).allMatch(tables::contains)
         );
-      } else if (aClass != OMPrepareResponse.class &&
-          aClass != OMCancelPrepareResponse.class) {
-        // Prepare and cancel responses are allowed to have no cleanup tables,
-        // since they do not modify the DB.
-        Assert.assertTrue(cleanupAll);
       }
     });
   }

--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>1.1.0-0bdf24f-SNAPSHOT</ratis.version>
+    <ratis.version>1.1.0-371fbfe-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.6.0</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Add integration test for prepare request with one OM down
- Picks up changes from RATIS-1241.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4610

## How was this patch tested?
Integration test.