### PR TITLE
HDDS-4739. Upgrade Ratis to 1.1.0-eb66796d-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>1.1.0-35f17fa-SNAPSHOT</ratis.version>
+    <ratis.version>1.1.0-eb66796d-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.6.0-SNAPSHOT</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Ratis snapshot to `1.1.0-eb66796d-SNAPSHOT` as we need RATIS-1290 for HDDS-4730.

https://issues.apache.org/jira/browse/HDDS-4739

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/509110072