### PR TITLE
HDDS-4741. Only test upgrade from 1.0.0

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -19,8 +19,8 @@ COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 
 : "${OZONE_REPLICATION_FACTOR:=3}"
-: "${OZONE_UPGRADE_FROM:="0.5.0"}"
-: "${OZONE_UPGRADE_TO:="1.0.0"}"
+: "${OZONE_UPGRADE_FROM:="1.0.0"}"
+: "${OZONE_UPGRADE_TO:="1.1.0"}"
 : "${OZONE_VOLUME:="${COMPOSE_DIR}/data"}"
 
 export OZONE_VOLUME

--- a/hadoop-ozone/dist/src/main/compose/upgrade/versions/ozone-1.1.0.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/versions/ozone-1.1.0.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export OZONE_ADMIN_COMMAND=admin
+export OZONE_SAFEMODE_STATUS_COMMAND='ozone admin safemode status --verbose'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make `upgrade` acceptance test verify upgrade from Ozone 1.0.0 instead of 0.5.0.  Upgrade from 0.5.0 to 1.0.0 is already verified by previous runs of the test.

https://issues.apache.org/jira/browse/HDDS-4741

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/1762340366