### PR TITLE
HDDS-4731. Fix compatibility issue caused by new enum DatanodeDetails.Port.Name.REPLICATION

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -445,6 +445,7 @@ public class DatanodeDetails extends NodeImpl implements
         ipAddress +
         ", host: " +
         hostName +
+        ", ports: " + ports +
         ", networkLocation: " +
         getNetworkLocation() +
         ", certSerialId: " + certSerialId +
@@ -784,6 +785,11 @@ public class DatanodeDetails extends NodeImpl implements
         return name.equals(((Port) anObject).name);
       }
       return false;
+    }
+
+    @Override
+    public String toString() {
+      return name + "=" + value;
     }
 
     public HddsProtos.Port toProto() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -279,8 +279,12 @@ public class DatanodeDetails extends NodeImpl implements
       builder.setCertSerialId(datanodeDetailsProto.getCertSerialId());
     }
     for (HddsProtos.Port port : datanodeDetailsProto.getPortsList()) {
-      builder.addPort(newPort(
-          Port.Name.valueOf(port.getName().toUpperCase()), port.getValue()));
+      try {
+        Port.Name name = Port.Name.valueOf(port.getName().toUpperCase());
+        builder.addPort(newPort(name, port.getValue()));
+      } catch (IllegalArgumentException ignored) {
+        // ignore unknown port type
+      }
     }
     if (datanodeDetailsProto.hasNetworkName()) {
       builder.setNetworkName(datanodeDetailsProto.getNetworkName());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -255,12 +255,11 @@ public class DatanodeDetails extends NodeImpl implements
   }
 
   /**
-   * Returns a DatanodeDetails from the protocol buffers.
+   * Starts building a new DatanodeDetails from the protobuf input.
    *
-   * @param datanodeDetailsProto - protoBuf Message
-   * @return DatanodeDetails
+   * @param datanodeDetailsProto protobuf message
    */
-  public static DatanodeDetails getFromProtoBuf(
+  public static DatanodeDetails.Builder newBuilder(
       HddsProtos.DatanodeDetailsProto datanodeDetailsProto) {
     DatanodeDetails.Builder builder = newBuilder();
     if (datanodeDetailsProto.hasUuid128()) {
@@ -296,7 +295,18 @@ public class DatanodeDetails extends NodeImpl implements
       builder.setPersistedOpStateExpiry(
           datanodeDetailsProto.getPersistedOpStateExpiry());
     }
-    return builder.build();
+    return builder;
+  }
+
+  /**
+   * Returns a DatanodeDetails from the protocol buffers.
+   *
+   * @param datanodeDetailsProto - protoBuf Message
+   * @return DatanodeDetails
+   */
+  public static DatanodeDetails getFromProtoBuf(
+      HddsProtos.DatanodeDetailsProto datanodeDetailsProto) {
+    return newBuilder(datanodeDetailsProto).build();
   }
 
   /**
@@ -307,11 +317,11 @@ public class DatanodeDetails extends NodeImpl implements
    */
   public static DatanodeDetails getFromProtoBuf(
       HddsProtos.ExtendedDatanodeDetailsProto extendedDetailsProto) {
-    DatanodeDetails.Builder builder = newBuilder();
+    DatanodeDetails.Builder builder;
     if (extendedDetailsProto.hasDatanodeDetails()) {
-      DatanodeDetails datanodeDetails = getFromProtoBuf(
-          extendedDetailsProto.getDatanodeDetails());
-      builder.setDatanodeDetails(datanodeDetails);
+      builder = newBuilder(extendedDetailsProto.getDatanodeDetails());
+    } else {
+      builder = newBuilder();
     }
     if (extendedDetailsProto.hasVersion()) {
       builder.setVersion(extendedDetailsProto.getVersion());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -355,7 +355,7 @@ public class DatanodeDetails extends NodeImpl implements
    * @return HddsProtos.DatanodeDetailsProto
    */
   public HddsProtos.DatanodeDetailsProto getProtoBufMessage() {
-    return toProto(Name.PUBLIC_PORTS);
+    return toProto(Name.ALL_PORTS);
   }
 
   public HddsProtos.DatanodeDetailsProto toProto(Set<Name> exposedPorts) {
@@ -415,12 +415,9 @@ public class DatanodeDetails extends NodeImpl implements
    * @return HddsProtos.ExtendedDatanodeDetailsProto
    */
   public HddsProtos.ExtendedDatanodeDetailsProto getExtendedProtoBufMessage() {
-    HddsProtos.DatanodeDetailsProto datanodeDetailsProto =
-        toProto(Name.ALL_PORTS);
-
     HddsProtos.ExtendedDatanodeDetailsProto.Builder extendedBuilder =
         HddsProtos.ExtendedDatanodeDetailsProto.newBuilder()
-            .setDatanodeDetails(datanodeDetailsProto);
+            .setDatanodeDetails(toProto(Port.Name.ALL_PORTS));
 
     if (!Strings.isNullOrEmpty(getVersion())) {
       extendedBuilder.setVersion(getVersion());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ContainerWithPipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/common/helpers/ContainerWithPipeline.java
@@ -56,12 +56,12 @@ public class ContainerWithPipeline implements Comparator<ContainerWithPipeline>,
         Pipeline.getFromProtobuf(allocatedContainer.getPipeline()));
   }
 
-  public HddsProtos.ContainerWithPipeline getProtobuf()
+  public HddsProtos.ContainerWithPipeline getProtobuf(int clientVersion)
       throws UnknownPipelineStateException {
     HddsProtos.ContainerWithPipeline.Builder builder =
         HddsProtos.ContainerWithPipeline.newBuilder();
     builder.setContainerInfo(getContainerInfo().getProtobuf())
-        .setPipeline(getPipeline().getProtobufMessage());
+        .setPipeline(getPipeline().getProtobufMessage(clientVersion));
 
     return builder.build();
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -43,6 +43,8 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.PUBLIC_PORTS;
+
 /**
  * Represents a group of datanodes which store a container.
  */
@@ -271,7 +273,7 @@ public final class Pipeline {
       throws UnknownPipelineStateException {
     List<HddsProtos.DatanodeDetailsProto> members = new ArrayList<>();
     for (DatanodeDetails dn : nodeStatus.keySet()) {
-      members.add(dn.getProtoBufMessage());
+      members.add(dn.toProto(PUBLIC_PORTS));
     }
 
     HddsProtos.Pipeline.Builder builder = HddsProtos.Pipeline.newBuilder()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -43,8 +43,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Preconditions;
 
-import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.PUBLIC_PORTS;
-
 /**
  * Represents a group of datanodes which store a container.
  */
@@ -140,8 +138,6 @@ public final class Pipeline {
 
   /**
    * Set the creation timestamp. Only for protobuf now.
-   *
-   * @param creationTimestamp
    */
   public void setCreationTimestamp(Instant creationTimestamp) {
     this.creationTimestamp = creationTimestamp;
@@ -174,6 +170,7 @@ public final class Pipeline {
 
   /**
    * Return an immutable set of nodes which form this pipeline.
+   *
    * @return Set of DatanodeDetails
    */
   public Set<DatanodeDetails> getNodeSet() {
@@ -182,7 +179,7 @@ public final class Pipeline {
 
   /**
    * Check if the input pipeline share the same set of datanodes.
-   * @param pipeline
+   *
    * @return true if the input pipeline shares the same set of datanodes.
    */
   public boolean sameDatanodes(Pipeline pipeline) {
@@ -269,11 +266,11 @@ public final class Pipeline {
     return nodeStatus.isEmpty();
   }
 
-  public HddsProtos.Pipeline getProtobufMessage()
+  public HddsProtos.Pipeline getProtobufMessage(int clientVersion)
       throws UnknownPipelineStateException {
     List<HddsProtos.DatanodeDetailsProto> members = new ArrayList<>();
     for (DatanodeDetails dn : nodeStatus.keySet()) {
-      members.add(dn.toProto(PUBLIC_PORTS));
+      members.add(dn.toProto(clientVersion));
     }
 
     HddsProtos.Pipeline.Builder builder = HddsProtos.Pipeline.newBuilder()

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -123,11 +123,12 @@ public interface StorageContainerLocationProtocol extends Closeable {
    *  state acts like a wildcard returning all nodes in that state.
    * @param opState The node operational state
    * @param state The node health
+   * @param clientVersion
    * @return List of Datanodes.
    */
   List<HddsProtos.Node> queryNode(HddsProtos.NodeOperationalState opState,
       HddsProtos.NodeState state, HddsProtos.QueryScope queryScope,
-      String poolName) throws IOException;
+      String poolName, int clientVersion) throws IOException;
 
   void decommissionNodes(List<String> nodes) throws IOException;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersions.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersions.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone;
+
+/**
+ * Versioning for protocol clients.
+ */
+public final class ClientVersions {
+
+  // old client, doesn't even send version number in requests
+  public static final int DEFAULT_VERSION = 0;
+
+  // DatanodeDetails#getFromProtobuf handles unknown types of ports
+  public static final int VERSION_HANDLES_UNKNOWN_DN_PORTS = 1;
+
+  // this should always point to the latest version
+  public static final int CURRENT_VERSION = VERSION_HANDLES_UNKNOWN_DN_PORTS;
+
+  private ClientVersions() {
+    // no instances
+  }
+
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/MockDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/MockDatanodeDetails.java
@@ -25,6 +25,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
+
 /**
  * Provides {@link DatanodeDetails} factory methods for testing.
  */
@@ -89,23 +91,20 @@ public final class MockDatanodeDetails {
 
   public static DatanodeDetails createDatanodeDetails(String uuid,
       String hostname, String ipAddress, String networkLocation, int port) {
-    DatanodeDetails.Port containerPort = DatanodeDetails.newPort(
-        DatanodeDetails.Port.Name.STANDALONE, port);
-    DatanodeDetails.Port ratisPort = DatanodeDetails.newPort(
-        DatanodeDetails.Port.Name.RATIS, port);
-    DatanodeDetails.Port restPort = DatanodeDetails.newPort(
-        DatanodeDetails.Port.Name.REST, port);
-    return DatanodeDetails.newBuilder()
+
+    DatanodeDetails.Builder dn = DatanodeDetails.newBuilder()
         .setUuid(UUID.fromString(uuid))
         .setHostName(hostname)
         .setIpAddress(ipAddress)
-        .addPort(containerPort)
-        .addPort(ratisPort)
-        .addPort(restPort)
         .setNetworkLocation(networkLocation)
         .setPersistedOpState(HddsProtos.NodeOperationalState.IN_SERVICE)
-        .setPersistedOpStateExpiry(0)
-        .build();
+        .setPersistedOpStateExpiry(0);
+
+    for (DatanodeDetails.Port.Name name : ALL_PORTS) {
+      dn.addPort(DatanodeDetails.newPort(name, port));
+    }
+
+    return dn.build();
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.protocol;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test for {@link DatanodeDetails}.
+ */
+public class TestDatanodeDetails {
+
+  @Test
+  public void protoIncludesAllPorts() {
+    DatanodeDetails subject = MockDatanodeDetails.randomDatanodeDetails();
+
+    HddsProtos.DatanodeDetailsProto proto = subject.getProtoBufMessage();
+
+    assertPorts(proto, ALL_PORTS);
+  }
+
+  public static void assertPorts(HddsProtos.DatanodeDetailsProto dn,
+      Set<Port.Name> expectedPorts) {
+    assertEquals(expectedPorts.size(), dn.getPortsCount());
+    for (HddsProtos.Port port : dn.getPortsList()) {
+      try {
+        assertTrue(expectedPorts.contains(Port.Name.valueOf(port.getName())));
+      } catch (IllegalArgumentException e) {
+        fail("Unknown port: " + port.getName());
+      }
+    }
+  }
+
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -24,6 +24,9 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS;
+import static org.apache.hadoop.ozone.ClientVersions.DEFAULT_VERSION;
+import static org.apache.hadoop.ozone.ClientVersions.VERSION_HANDLES_UNKNOWN_DN_PORTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -34,12 +37,15 @@ import static org.junit.Assert.fail;
 public class TestDatanodeDetails {
 
   @Test
-  public void protoIncludesAllPorts() {
+  public void protoIncludesNewPortsOnlyForV1() {
     DatanodeDetails subject = MockDatanodeDetails.randomDatanodeDetails();
 
-    HddsProtos.DatanodeDetailsProto proto = subject.getProtoBufMessage();
+    HddsProtos.DatanodeDetailsProto proto = subject.toProto(DEFAULT_VERSION);
+    assertPorts(proto, V0_PORTS);
 
-    assertPorts(proto, ALL_PORTS);
+    HddsProtos.DatanodeDetailsProto protoV1 = subject.toProto(
+        VERSION_HANDLES_UNKNOWN_DN_PORTS);
+    assertPorts(protoV1, ALL_PORTS);
   }
 
   public static void assertPorts(HddsProtos.DatanodeDetailsProto dn,

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -22,8 +22,11 @@ import org.junit.Test;
 
 import java.io.IOException;
 
-import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.PUBLIC_PORTS;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS;
 import static org.apache.hadoop.hdds.protocol.TestDatanodeDetails.assertPorts;
+import static org.apache.hadoop.ozone.ClientVersions.DEFAULT_VERSION;
+import static org.apache.hadoop.ozone.ClientVersions.VERSION_HANDLES_UNKNOWN_DN_PORTS;
 
 /**
  * Test for {@link Pipeline}.
@@ -31,13 +34,18 @@ import static org.apache.hadoop.hdds.protocol.TestDatanodeDetails.assertPorts;
 public class TestPipeline {
 
   @Test
-  public void protoOnlyIncludesPublicPorts() throws IOException {
+  public void protoIncludesNewPortsOnlyForV1() throws IOException {
     Pipeline subject = MockPipeline.createPipeline(3);
 
-    HddsProtos.Pipeline proto = subject.getProtobufMessage();
-
+    HddsProtos.Pipeline proto = subject.getProtobufMessage(DEFAULT_VERSION);
     for (HddsProtos.DatanodeDetailsProto dn : proto.getMembersList()) {
-      assertPorts(dn, PUBLIC_PORTS);
+      assertPorts(dn, V0_PORTS);
+    }
+
+    HddsProtos.Pipeline protoV1 = subject.getProtobufMessage(
+        VERSION_HANDLES_UNKNOWN_DN_PORTS);
+    for (HddsProtos.DatanodeDetailsProto dn : protoV1.getMembersList()) {
+      assertPorts(dn, ALL_PORTS);
     }
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.PUBLIC_PORTS;
+import static org.apache.hadoop.hdds.protocol.TestDatanodeDetails.assertPorts;
+
+/**
+ * Test for {@link Pipeline}.
+ */
+public class TestPipeline {
+
+  @Test
+  public void protoOnlyIncludesPublicPorts() throws IOException {
+    Pipeline subject = MockPipeline.createPipeline(3);
+
+    HddsProtos.Pipeline proto = subject.getProtobufMessage();
+
+    for (HddsProtos.DatanodeDetailsProto dn : proto.getMembersList()) {
+      assertPorts(dn, PUBLIC_PORTS);
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -342,7 +343,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       SCMSecurityProtocolClientSideTranslatorPB secureScmClient =
           HddsServerUtil.getScmSecurityClient(config);
       SCMGetCertResponseProto response = secureScmClient.
-          getDataNodeCertificateChain(datanodeDetails.getProtoBufMessage(),
+          getDataNodeCertificateChain(
+              datanodeDetails.toProto(Port.Name.ALL_PORTS),
               getEncodedString(csr));
       // Persist certificates.
       if(response.hasX509CACertificate()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -344,7 +343,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
           HddsServerUtil.getScmSecurityClient(config);
       SCMGetCertResponseProto response = secureScmClient.
           getDataNodeCertificateChain(
-              datanodeDetails.toProto(Port.Name.ALL_PORTS),
+              datanodeDetails.getProtoBufMessage(),
               getEncodedString(csr));
       // Persist certificates.
       if(response.hasX509CACertificate()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -17,10 +17,14 @@
  */
 package org.apache.hadoop.ozone.protocol.commands;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -41,6 +45,8 @@ public class ReplicateContainerCommand
 
   private final long containerID;
   private final List<DatanodeDetails> sourceDatanodes;
+  private static final Set<Port.Name> REPLICATION_PORT =
+      ImmutableSet.copyOf(EnumSet.of(Port.Name.REPLICATION));
 
   public ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
@@ -68,7 +74,7 @@ public class ReplicateContainerCommand
         .setCmdId(getId())
         .setContainerID(containerID);
     for (DatanodeDetails dd : sourceDatanodes) {
-      builder.addSources(dd.getProtoBufMessage());
+      builder.addSources(dd.toProtoBuilder(REPLICATION_PORT));
     }
     return builder.build();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -17,14 +17,10 @@
  */
 package org.apache.hadoop.ozone.protocol.commands;
 
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ReplicateContainerCommandProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -45,8 +41,6 @@ public class ReplicateContainerCommand
 
   private final long containerID;
   private final List<DatanodeDetails> sourceDatanodes;
-  private static final Set<Port.Name> REPLICATION_PORT =
-      ImmutableSet.copyOf(EnumSet.of(Port.Name.REPLICATION));
 
   public ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
@@ -74,7 +68,7 @@ public class ReplicateContainerCommand
         .setCmdId(getId())
         .setContainerID(containerID);
     for (DatanodeDetails dd : sourceDatanodes) {
-      builder.addSources(dd.toProtoBuilder(REPLICATION_PORT));
+      builder.addSources(dd.getProtoBufMessage());
     }
     return builder.build();
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -57,6 +57,7 @@ import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
 import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.Status.OK;
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * This class is the client-side translator to translate the requests made on
@@ -91,6 +92,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
   private SCMBlockLocationRequest.Builder createSCMBlockRequest(Type cmdType) {
     return SCMBlockLocationRequest.newBuilder()
         .setCmdType(cmdType)
+        .setVersion(CURRENT_VERSION)
         .setTraceID(TracingUtil.exportCurrentSpan());
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -80,6 +80,8 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 /**
  * This class is the client-side translator to translate the requests made on
  * the {@link StorageContainerLocationProtocol} interface to the RPC server
@@ -117,6 +119,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
 
       Builder builder = ScmContainerLocationRequest.newBuilder()
           .setCmdType(type)
+          .setVersion(CURRENT_VERSION)
           .setTraceID(TracingUtil.exportCurrentSpan());
       builderConsumer.accept(builder);
       ScmContainerLocationRequest wrapper = builder.build();
@@ -293,13 +296,14 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    *
    * @param opState The operation state of the node
    * @param nodeState The health of the node
+   * @param clientVersion
    * @return List of Datanodes.
    */
   @Override
   public List<HddsProtos.Node> queryNode(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState
-      nodeState, HddsProtos.QueryScope queryScope, String poolName)
-      throws IOException {
+      nodeState, HddsProtos.QueryScope queryScope, String poolName,
+      int clientVersion) throws IOException {
     // TODO : We support only cluster wide query right now. So ignoring checking
     // queryScope and poolName
     NodeQueryRequestProto.Builder builder = NodeQueryRequestProto.newBuilder()

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -40,6 +40,7 @@ message ScmContainerLocationRequest {
   // A string that identifies this command, we generate  Trace ID in Ozone
   // frontend and this allows us to trace that command all over ozone.
   optional string traceID = 2;
+  optional uint32 version = 3;
 
   optional ContainerRequestProto containerRequest = 6;
   optional GetContainerRequestProto getContainerRequest = 7;

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -198,7 +198,7 @@ message ContainerCommandRequestProto {
   optional   GetCommittedBlockLengthRequestProto getCommittedBlockLength = 22;
 
   optional   string encodedToken = 23;
-  optional uint32 version = 24;
+  optional   uint32 version = 24;
 }
 
 message ContainerCommandResponseProto {

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -196,7 +196,9 @@ message ContainerCommandRequestProto {
   optional   PutSmallFileRequestProto putSmallFile = 20;
   optional   GetSmallFileRequestProto getSmallFile = 21;
   optional   GetCommittedBlockLengthRequestProto getCommittedBlockLength = 22;
+
   optional   string encodedToken = 23;
+  optional uint32 version = 24;
 }
 
 message ContainerCommandResponseProto {
@@ -451,6 +453,7 @@ message CopyContainerRequestProto {
   required int64 containerID = 1;
   required uint64 readOffset = 2;
   optional uint64 len = 3;
+  optional uint32 version = 4;
 }
 
 message CopyContainerResponseProto {

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -48,6 +48,7 @@ message SCMBlockLocationRequest {
   optional string traceID = 2;
 
   optional UserInfo userInfo = 3;
+  optional uint32 version = 4;
 
   optional AllocateScmBlockRequestProto       allocateScmBlockRequest   = 11;
   optional DeleteScmKeyBlocksRequestProto     deleteScmKeyBlocksRequest = 12;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -968,7 +968,8 @@ public class ReplicationManager
                                     final List<DatanodeDetails> sources) {
 
     LOG.info("Sending replicate container command for container {}" +
-            " to datanode {}", container.containerID(), datanode);
+            " to datanode {} from datanodes {}",
+        container.containerID(), datanode, sources);
 
     final ContainerID id = container.containerID();
     final ReplicateContainerCommand replicateCommand =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.hdds.utils.db.Codec;
 
 import com.google.common.base.Preconditions;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 /**
  * Codec to serialize / deserialize Pipeline.
  */
@@ -34,7 +36,7 @@ public class PipelineCodec implements Codec<Pipeline> {
 
   @Override
   public byte[] toPersistedFormat(Pipeline object) throws IOException {
-    return object.getProtobufMessage().toByteArray();
+    return object.getProtobufMessage(CURRENT_VERSION).toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -53,6 +53,8 @@ import com.google.protobuf.ServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.PUBLIC_PORTS;
+
 /**
  * This class is the server-side translator that forwards requests received on
  * {@link StorageContainerLocationProtocolPB} to the
@@ -220,7 +222,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
       final List<DatanodeDetails> results =
           impl.sortDatanodes(nodeList, request.getClient());
       if (results != null && results.size() > 0) {
-        results.stream().forEach(dn -> resp.addNode(dn.getProtoBufMessage()));
+        results.stream().forEach(dn -> resp.addNode(dn.toProto(PUBLIC_PORTS)));
       }
       return resp.build();
     } catch (IOException ex) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -143,8 +143,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
-            .setContainerResponse(
-                allocateContainer(request.getContainerRequest()))
+            .setContainerResponse(allocateContainer(
+                request.getContainerRequest(), request.getVersion()))
             .build();
       case GetContainer:
         return ScmContainerLocationResponse.newBuilder()
@@ -158,7 +158,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setGetContainerWithPipelineResponse(getContainerWithPipeline(
-                request.getGetContainerWithPipelineRequest()))
+                request.getGetContainerWithPipelineRequest(),
+                request.getVersion()))
             .build();
       case GetContainerWithPipelineBatch:
         return ScmContainerLocationResponse.newBuilder()
@@ -166,7 +167,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStatus(Status.OK)
             .setGetContainerWithPipelineBatchResponse(
                 getContainerWithPipelineBatch(
-                    request.getGetContainerWithPipelineBatchRequest()))
+                    request.getGetContainerWithPipelineBatchRequest(),
+                    request.getVersion()))
             .build();
       case ListContainer:
         return ScmContainerLocationResponse.newBuilder()
@@ -179,7 +181,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
-            .setNodeQueryResponse(queryNode(request.getNodeQueryRequest()))
+            .setNodeQueryResponse(queryNode(request.getNodeQueryRequest(),
+                request.getVersion()))
             .build();
       case CloseContainer:
         return ScmContainerLocationResponse.newBuilder()
@@ -192,14 +195,15 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
-            .setPipelineResponse(allocatePipeline(request.getPipelineRequest()))
+            .setPipelineResponse(allocatePipeline(
+                request.getPipelineRequest(), request.getVersion()))
             .build();
       case ListPipelines:
         return ScmContainerLocationResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setListPipelineResponse(listPipelines(
-                request.getListPipelineRequest()))
+                request.getListPipelineRequest(), request.getVersion()))
             .build();
       case ActivatePipeline:
         return ScmContainerLocationResponse.newBuilder()
@@ -269,7 +273,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
             .setGetPipelineResponse(getPipeline(
-                request.getGetPipelineRequest()))
+                request.getGetPipelineRequest(), request.getVersion()))
             .build();
       case GetSafeModeRuleStatuses:
         return ScmContainerLocationResponse.newBuilder()
@@ -307,13 +311,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
     }
   }
 
-  public ContainerResponseProto allocateContainer(ContainerRequestProto request)
-      throws IOException {
-    ContainerWithPipeline containerWithPipeline = impl
+  public ContainerResponseProto allocateContainer(ContainerRequestProto request,
+      int clientVersion) throws IOException {
+    ContainerWithPipeline cp = impl
         .allocateContainer(request.getReplicationType(),
             request.getReplicationFactor(), request.getOwner());
     return ContainerResponseProto.newBuilder()
-        .setContainerWithPipeline(containerWithPipeline.getProtobuf())
+        .setContainerWithPipeline(cp.getProtobuf(clientVersion))
         .setErrorCode(ContainerResponseProto.Error.success)
         .build();
 
@@ -328,24 +332,25 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public GetContainerWithPipelineResponseProto getContainerWithPipeline(
-      GetContainerWithPipelineRequestProto request)
-      throws IOException {
+      GetContainerWithPipelineRequestProto request,
+      int clientVersion) throws IOException {
     ContainerWithPipeline container = impl
         .getContainerWithPipeline(request.getContainerID());
     return GetContainerWithPipelineResponseProto.newBuilder()
-        .setContainerWithPipeline(container.getProtobuf())
+        .setContainerWithPipeline(container.getProtobuf(clientVersion))
         .build();
   }
 
   public GetContainerWithPipelineBatchResponseProto
       getContainerWithPipelineBatch(
-      GetContainerWithPipelineBatchRequestProto request) throws IOException {
+      GetContainerWithPipelineBatchRequestProto request,
+      int clientVersion) throws IOException {
     List<ContainerWithPipeline> containers = impl
         .getContainerWithPipelineBatch(request.getContainerIDsList());
     GetContainerWithPipelineBatchResponseProto.Builder builder =
         GetContainerWithPipelineBatchResponseProto.newBuilder();
     for (ContainerWithPipeline container : containers) {
-      builder.addContainerWithPipelines(container.getProtobuf());
+      builder.addContainerWithPipelines(container.getProtobuf(clientVersion));
     }
     return builder.build();
   }
@@ -381,8 +386,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public NodeQueryResponseProto queryNode(
-      StorageContainerLocationProtocolProtos.NodeQueryRequestProto request)
-      throws IOException {
+      StorageContainerLocationProtocolProtos.NodeQueryRequestProto request,
+      int clientVersion) throws IOException {
 
     HddsProtos.NodeOperationalState opState = null;
     HddsProtos.NodeState nodeState = null;
@@ -393,7 +398,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       opState = request.getOpState();
     }
     List<HddsProtos.Node> datanodes = impl.queryNode(opState, nodeState,
-        request.getScope(), request.getPoolName());
+        request.getScope(), request.getPoolName(), clientVersion);
     return NodeQueryResponseProto.newBuilder()
         .addAllDatanodes(datanodes)
         .build();
@@ -407,8 +412,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public PipelineResponseProto allocatePipeline(
-      StorageContainerLocationProtocolProtos.PipelineRequestProto request)
-      throws IOException {
+      StorageContainerLocationProtocolProtos.PipelineRequestProto request,
+      int clientVersion) throws IOException {
     Pipeline pipeline = impl.createReplicationPipeline(
         request.getReplicationType(), request.getReplicationFactor(),
         HddsProtos.NodePool.getDefaultInstance());
@@ -416,31 +421,30 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
       return PipelineResponseProto.newBuilder()
           .setErrorCode(errorPipelineAlreadyExists).build();
     }
-    PipelineResponseProto response = PipelineResponseProto.newBuilder()
+    return PipelineResponseProto.newBuilder()
         .setErrorCode(success)
-        .setPipeline(pipeline.getProtobufMessage()).build();
-    return response;
+        .setPipeline(pipeline.getProtobufMessage(clientVersion)).build();
   }
 
   public ListPipelineResponseProto listPipelines(
-      ListPipelineRequestProto request)
+      ListPipelineRequestProto request, int clientVersion)
       throws IOException {
     ListPipelineResponseProto.Builder builder = ListPipelineResponseProto
         .newBuilder();
     List<Pipeline> pipelines = impl.listPipelines();
     for (Pipeline pipeline : pipelines) {
-      HddsProtos.Pipeline protobufMessage = pipeline.getProtobufMessage();
-      builder.addPipelines(protobufMessage);
+      builder.addPipelines(pipeline.getProtobufMessage(clientVersion));
     }
     return builder.build();
   }
 
   public GetPipelineResponseProto getPipeline(
-      GetPipelineRequestProto request) throws IOException {
+      GetPipelineRequestProto request,
+      int clientVersion) throws IOException {
     GetPipelineResponseProto.Builder builder = GetPipelineResponseProto
         .newBuilder();
     Pipeline pipeline = impl.getPipeline(request.getPipelineID());
-    builder.setPipeline(pipeline.getProtobufMessage());
+    builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
     return builder.build();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -386,8 +386,8 @@ public class SCMClientProtocolServer implements
   @Override
   public List<HddsProtos.Node> queryNode(
       HddsProtos.NodeOperationalState opState, HddsProtos.NodeState state,
-      HddsProtos.QueryScope queryScope, String poolName) throws
-      IOException {
+      HddsProtos.QueryScope queryScope, String poolName, int clientVersion)
+      throws IOException {
 
     if (queryScope == HddsProtos.QueryScope.POOL) {
       throw new IllegalArgumentException("Not Supported yet");
@@ -398,7 +398,7 @@ public class SCMClientProtocolServer implements
       try {
         NodeStatus ns = scm.getScmNodeManager().getNodeStatus(node);
         result.add(HddsProtos.Node.newBuilder()
-            .setNodeID(node.getProtoBufMessage())
+            .setNodeID(node.toProto(clientVersion))
             .addNodeStates(ns.getHealth())
             .addNodeOperationalStates(ns.getOperationalState())
             .build());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -40,6 +40,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * Test class for @{@link SCMBlockProtocolServer}.
@@ -120,7 +121,7 @@ public class TestSCMBlockProtocolServer {
             .setClient(client)
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
-        service.sortDatanodes(request);
+        service.sortDatanodes(request, CURRENT_VERSION);
     Assert.assertTrue(resp.getNodeList().size() == nodeCount);
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
@@ -136,7 +137,7 @@ public class TestSCMBlockProtocolServer {
         .addAllNodeNetworkName(nodes)
         .setClient(client)
         .build();
-    resp = service.sortDatanodes(request);
+    resp = service.sortDatanodes(request, CURRENT_VERSION);
     System.out.println("client = " + client);
     Assert.assertTrue(resp.getNodeList().size() == 0);
     resp.getNodeList().stream().forEach(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -58,6 +58,8 @@ import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClient;
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -275,7 +277,7 @@ public class ContainerOperationClient implements ScmClient {
       HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
     return storageContainerLocationClient.queryNode(opState, nodeState,
-        queryScope, poolName);
+        queryScope, poolName, CURRENT_VERSION);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -381,8 +381,8 @@ public final class OmKeyInfo extends WithObjectID {
    * For network transmit.
    * @return
    */
-  public KeyInfo getProtobuf() {
-    return getProtobuf(false);
+  public KeyInfo getProtobuf(int clientVersion) {
+    return getProtobuf(false, clientVersion);
   }
 
   /**
@@ -390,13 +390,14 @@ public final class OmKeyInfo extends WithObjectID {
    * @param ignorePipeline true for persist to DB, false for network transmit.
    * @return
    */
-  public KeyInfo getProtobuf(boolean ignorePipeline) {
+  public KeyInfo getProtobuf(boolean ignorePipeline, int clientVersion) {
     long latestVersion = keyLocationVersions.size() == 0 ? -1 :
         keyLocationVersions.get(keyLocationVersions.size() - 1).getVersion();
 
     List<KeyLocationList> keyLocations = new ArrayList<>();
     for (OmKeyLocationInfoGroup locationInfoGroup : keyLocationVersions) {
-      keyLocations.add(locationInfoGroup.getProtobuf(ignorePipeline));
+      keyLocations.add(locationInfoGroup.getProtobuf(
+          ignorePipeline, clientVersion));
     }
 
     KeyInfo.Builder kb = KeyInfo.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -152,15 +152,11 @@ public final class OmKeyLocationInfo {
     }
   }
 
-  public KeyLocation getCompactProtobuf() {
-    return getProtobuf(true);
+  public KeyLocation getProtobuf(int clientVersion) {
+    return getProtobuf(false, clientVersion);
   }
 
-  public KeyLocation getProtobuf() {
-    return getProtobuf(false);
-  }
-
-  private KeyLocation getProtobuf(boolean ignorePipeline) {
+  public KeyLocation getProtobuf(boolean ignorePipeline, int clientVersion) {
     KeyLocation.Builder builder = KeyLocation.newBuilder()
         .setBlockID(blockID.getProtobuf())
         .setLength(length)
@@ -171,7 +167,7 @@ public final class OmKeyLocationInfo {
     }
     if (!ignorePipeline) {
       try {
-        builder.setPipeline(pipeline.getProtobufMessage());
+        builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
       } catch (UnknownPipelineStateException e) {
         //TODO: fix me: we should not return KeyLocation without pipeline.
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -80,15 +80,15 @@ public class OmKeyLocationInfoGroup {
     return new ArrayList<>(locationVersionMap.get(versionToFetch));
   }
 
-  public KeyLocationList getProtobuf(boolean ignorePipeline) {
+  public KeyLocationList getProtobuf(boolean ignorePipeline,
+      int clientVersion) {
     KeyLocationList.Builder builder = KeyLocationList.newBuilder()
         .setVersion(version);
     List<OzoneManagerProtocolProtos.KeyLocation> keyLocationList =
         new ArrayList<>();
     for (List<OmKeyLocationInfo> locationList : locationVersionMap.values()) {
       for (OmKeyLocationInfo keyInfo : locationList) {
-        keyLocationList.add(ignorePipeline ?
-            keyInfo.getCompactProtobuf() : keyInfo.getProtobuf());
+        keyLocationList.add(keyInfo.getProtobuf(ignorePipeline, clientVersion));
       }
     }
     return  builder.addAllKeyLocations(keyLocationList).build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto.Builder;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
 /**
@@ -100,7 +101,7 @@ public class OzoneFileStatus {
         .setIsDirectory(isDirectory);
     //key info can be null for the fake root entry.
     if (keyInfo != null) {
-      builder.setKeyInfo(keyInfo.getProtobuf());
+      builder.setKeyInfo(keyInfo.getProtobuf(CURRENT_VERSION));
     }
     return builder.build();
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -65,10 +65,10 @@ public class RepeatedOmKeyInfo {
    * @param compact, true for persistence, false for network transmit
    * @return
    */
-  public RepeatedKeyInfo getProto(boolean compact) {
+  public RepeatedKeyInfo getProto(boolean compact, int clientVersion) {
     List<KeyInfo> list = new ArrayList<>();
     for(OmKeyInfo k : omKeyInfoList) {
-      list.add(k.getProtobuf(compact));
+      list.add(k.getProtobuf(compact, clientVersion));
     }
 
     RepeatedKeyInfo.Builder builder = RepeatedKeyInfo.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -149,6 +149,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.ACCESS_DENIED;
@@ -200,6 +201,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
+        .setVersion(CURRENT_VERSION)
         .setClientId(clientID);
   }
 
@@ -646,9 +648,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
-        .addAllKeyLocations(
-            locationInfoList.stream().map(OmKeyLocationInfo::getProtobuf)
-                .collect(Collectors.toList())).build();
+        .addAllKeyLocations(locationInfoList.stream()
+            // TODO use OM version?
+            .map(info -> info.getProtobuf(CURRENT_VERSION))
+            .collect(Collectors.toList())).build();
     req.setKeyArgs(keyArgs);
     req.setClientID(clientId);
 
@@ -898,9 +901,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setIsMultipartKey(omKeyArgs.getIsMultipartKey())
         .setMultipartNumber(omKeyArgs.getMultipartUploadPartNumber())
         .setDataSize(omKeyArgs.getDataSize())
-        .addAllKeyLocations(
-            locationInfoList.stream().map(OmKeyLocationInfo::getProtobuf)
-                .collect(Collectors.toList()));
+        .addAllKeyLocations(locationInfoList.stream()
+            // TODO use OM version?
+            .map(info -> info.getProtobuf(CURRENT_VERSION))
+            .collect(Collectors.toList()));
     multipartCommitUploadPartRequest.setClientID(clientId);
     multipartCommitUploadPartRequest.setKeyArgs(keyArgs.build());
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
 /**
@@ -59,7 +60,7 @@ public class TestOmKeyInfo {
         .build();
 
     OmKeyInfo keyAfterSerialization =
-        OmKeyInfo.getFromProtobuf(key.getProtobuf());
+        OmKeyInfo.getFromProtobuf(key.getProtobuf(CURRENT_VERSION));
 
     Assert.assertEquals(key, keyAfterSerialization);
   }

--- a/hadoop-ozone/dist/src/main/compose/xcompat/.env
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/.env
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HDDS_VERSION=${hdds.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+services:
+  old_client_0_5_0:
+    image: apache/ozone:0.5.0
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/ozone
+    environment:
+      HADOOP_OPTS:
+    command: ["sleep","1000000"]
+  old_client_1_0_0:
+    image: apache/ozone:1.0.0
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/ozone
+    environment:
+      HADOOP_OPTS:
+    command: ["sleep","1000000"]
+  new_client:
+    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/hadoop
+    environment:
+      OZONE_OPTS:
+    command: ["sleep","1000000"]

--- a/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+OZONE-SITE.XML_hdds.scm.safemode.min.datanode=3
+OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
+OZONE-SITE.XML_ozone.om.address=om
+OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.recon.address=recon:9891
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_ozone.replication=3
+OZONE-SITE.XML_ozone.scm.block.client.address=scm
+OZONE-SITE.XML_ozone.scm.client.address=scm
+OZONE-SITE.XML_ozone.scm.container.size=1GB
+OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
+OZONE-SITE.XML_ozone.scm.names=scm
+OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1
+OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+
+no_proxy=om,recon,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+# reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
+x-new-config:
+  &new-config
+  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  env_file:
+    - docker-config
+  volumes:
+    - ../..:/opt/hadoop
+
+services:
+  datanode:
+    <<: *new-config
+    ports:
+      - 9864
+      - 9882
+    environment:
+      OZONE_OPTS:
+    command: ["ozone","datanode"]
+  om:
+    <<: *new-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      OZONE_OPTS:
+    ports:
+      - 9874:9874
+      - 9862:9862
+    command: ["ozone","om"]
+  recon:
+    <<: *new-config
+    ports:
+      - 9888:9888
+    environment:
+      OZONE_OPTS:
+    command: ["ozone","recon"]
+  s3g:
+    <<: *new-config
+    environment:
+      OZONE_OPTS:
+    ports:
+      - 9878:9878
+    command: ["ozone","s3g"]
+  scm:
+    <<: *new-config
+    ports:
+      - 9876:9876
+    environment:
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+      OZONE_OPTS:
+    command: ["ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/old-cluster.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+# reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
+x-old-config:
+  &old-config
+  image: apache/ozone:${OZONE_VERSION}
+  env_file:
+    - docker-config
+  volumes:
+    - ../..:/opt/ozone
+
+services:
+  datanode:
+    <<: *old-config
+    ports:
+      - 9864
+      - 9882
+    environment:
+      HADOOP_OPTS:
+    command: ["ozone","datanode"]
+  om:
+    <<: *old-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      HADOOP_OPTS:
+    ports:
+      - 9874:9874
+      - 9862:9862
+    command: ["ozone","om"]
+  recon:
+    <<: *old-config
+    ports:
+      - 9888:9888
+    environment:
+      HADOOP_OPTS:
+    command: ["ozone","recon"]
+  s3g:
+    <<: *old-config
+    environment:
+      HADOOP_OPTS:
+    ports:
+      - 9878:9878
+    command: ["ozone","s3g"]
+  scm:
+    <<: *old-config
+    ports:
+      - 9876:9876
+    environment:
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+      HADOOP_OPTS:
+    command: ["ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -33,6 +33,7 @@ old_client() {
 new_client() {
   OZONE_DIR=/opt/hadoop
   container=new_client
+  client_version=${current_version}
   "$@"
 }
 
@@ -67,8 +68,8 @@ test_cross_compatibility() {
     old_client _write
     old_client _read ${client_version}
 
-    new_client _read ${client_version}
     old_client _read ${current_version}
+    new_client _read ${client_version}
   done
 
   KEEP_RUNNING=false stop_docker_env
@@ -77,7 +78,7 @@ test_cross_compatibility() {
 create_results_dir
 
 # current cluster with various clients
-COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} client_version=${current_version} test_cross_compatibility
+COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} test_cross_compatibility
 
 for cluster_version in 1.0.0 0.5.0; do
   # shellcheck source=/dev/null

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+basename=$(basename ${COMPOSE_DIR})
+
+current_version=1.1.0
+
+# shellcheck source=/dev/null
+source "${COMPOSE_DIR}/../testlib.sh"
+
+old_client() {
+  OZONE_DIR=/opt/ozone
+  container=${client}
+  "$@"
+}
+
+new_client() {
+  OZONE_DIR=/opt/hadoop
+  container=new_client
+  "$@"
+}
+
+_init() {
+  execute_command_in_container ${container} ozone freon ockg -n1 -t1 -p warmup
+}
+
+_write() {
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-write" -v SUFFIX:${client_version} compatibility/write.robot
+}
+
+_read() {
+  local data_version="$1"
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-read-${data_version}" -v SUFFIX:${data_version} compatibility/read.robot
+}
+
+test_cross_compatibility() {
+  echo "Starting cluster with COMPOSE_FILE=${COMPOSE_FILE}"
+
+  OZONE_KEEP_RESULTS=true start_docker_env
+
+  execute_command_in_container scm ozone freon ockg -n1 -t1 -p warmup
+  new_client _write
+  new_client _read ${current_version}
+
+  for client in $(docker ps | grep _old_client_ | awk '{ print $NF }'); do
+    client=${client#${basename}_}
+    client=${client%_1}
+    client_version=${client#old_client_}
+    client_version=${client_version//_/.}
+
+    old_client _write
+    old_client _read ${client_version}
+
+    new_client _read ${client_version}
+    old_client _read ${current_version}
+  done
+
+  KEEP_RUNNING=false stop_docker_env
+}
+
+create_results_dir
+
+# current cluster with various clients
+COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} client_version=${current_version} test_cross_compatibility
+
+for cluster_version in 1.0.0 0.5.0; do
+  # shellcheck source=/dev/null
+  source "${COMPOSE_DIR}/../upgrade/versions/ozone-${cluster_version}.sh"
+  # shellcheck source=/dev/null
+  source "${COMPOSE_DIR}/../testlib.sh"
+
+  export OZONE_VERSION=${cluster_version}
+  COMPOSE_FILE=old-cluster.yaml:clients.yaml test_cross_compatibility
+done
+
+generate_report

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Read Compatibility
+Resource            ../ozone-lib/shell.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${KEY_NAME_SUFFIX}    ${EMPTY}
+
+*** Test Cases ***
+Key Can Be Read
+    Key Should Match Local File    /vol1/bucket1/key-${KEY_NAME_SUFFIX}    /etc/passwd

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Write Compatibility
+Resource            ../ozone-lib/shell.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${KEY_NAME_SUFFIX}    ${EMPTY}
+
+*** Test Cases ***
+Key Can Be Written
+    Create Key    /vol1/bucket1/key-${KEY_NAME_SUFFIX}    /etc/passwd

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
@@ -31,7 +31,7 @@ Compare Key With Local File
     [arguments]    ${key}    ${file}
     ${postfix} =   Generate Random String  5  [NUMBERS]
     ${tmpfile} =   Set Variable    /tmp/tempkey-${postfix}
-    Execute        ozone sh key get -f ${key} ${tmpfile}
+    Execute        ozone sh key get ${key} ${tmpfile}
     ${rc} =        Run And Return Rc    diff -q ${file} ${tmpfile}
     Execute        rm -f ${tmpfile}
     ${result} =    Set Variable If    ${rc} == 0    ${TRUE}   ${FALSE}
@@ -55,3 +55,9 @@ Create Random Volume
 Find Jars Dir
     ${dir} =    Execute    ozone envvars | grep 'HDDS_LIB_JARS_DIR' | cut -f2 -d= | sed -e "s/'//g" -e 's/"//g'
     Set Environment Variable    HDDS_LIB_JARS_DIR    ${dir}
+
+Create Key
+    [arguments]    ${key}    ${file}
+    ${output} =    Execute          ozone sh key put ${key} ${file}
+                   Should not contain  ${output}       Failed
+    Log            Uploaded ${file} to ${key}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -18,43 +18,36 @@
 
 package org.apache.hadoop.ozone.container;
 
-import java.util.ArrayList;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+import static org.apache.hadoop.ozone.container.TestHelper.waitForContainerClose;
+import static org.apache.hadoop.ozone.container.TestHelper.waitForReplicaCount;
+import static org.junit.Assert.assertFalse;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerCommandRequestProto;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerCommandResponseProto;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .ContainerType;
-import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
-    .DatanodeBlockID;
-import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
-import org.apache.hadoop.hdds.scm.XceiverClientSpi;
-import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.container.common.helpers.BlockData;
-import org.apache.hadoop.ozone.container.common.interfaces.Container;
-import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
-import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
-import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
-import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
-import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
-import org.apache.hadoop.test.GenericTestUtils;
-
-import static org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer
-    .writeChunkForContainer;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -62,7 +55,6 @@ import org.junit.rules.Timeout;
 /**
  * Tests ozone containers replication.
  */
-@Ignore
 public class TestContainerReplication {
   /**
    * Set the timeout for every test.
@@ -70,18 +62,26 @@ public class TestContainerReplication {
   @Rule
   public Timeout testTimeout = new Timeout(300000);
 
-  private OzoneConfiguration conf;
+  private static final String VOLUME = "vol1";
+  private static final String BUCKET = "bucket1";
+  private static final String KEY = "key1";
+
   private MiniOzoneCluster cluster;
+  private OzoneClient client;
 
   @Before
-  public void setup() throws Exception {
-    conf = newOzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3)
-        .setRandomContainerPort(true).build();
+  public void setUp() throws Exception {
+    OzoneConfiguration conf = createConfiguration();
+
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(4).build();
+    cluster.waitForClusterToBeReady();
+
+    client = OzoneClientFactory.getRpcClient(conf);
+    createTestData();
   }
 
   @After
-  public void teardown() {
+  public void tearDown() {
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -89,107 +89,56 @@ public class TestContainerReplication {
 
   @Test
   public void testContainerReplication() throws Exception {
-    //GIVEN
-    long containerId = 1L;
+    List<OmKeyLocationInfo> keyLocations = lookupKey(cluster);
+    assertFalse(keyLocations.isEmpty());
 
-    cluster.waitForClusterToBeReady();
+    OmKeyLocationInfo keyLocation = keyLocations.get(0);
+    long containerID = keyLocation.getContainerID();
+    waitForContainerClose(cluster, containerID);
 
-    HddsDatanodeService firstDatanode = cluster.getHddsDatanodes().get(0);
+    cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
 
-    //copy from the first datanode
-    List<DatanodeDetails> sourceDatanodes = new ArrayList<>();
-    sourceDatanodes.add(firstDatanode.getDatanodeDetails());
-
-    Pipeline sourcePipelines =
-        MockPipeline.createPipeline(sourceDatanodes);
-
-    //create a new client
-    XceiverClientSpi client = new XceiverClientGrpc(sourcePipelines, conf);
-    client.connect();
-
-    //New container for testing
-    TestOzoneContainer.createContainerForTesting(client, containerId);
-
-    ContainerCommandRequestProto requestProto =
-        writeChunkForContainer(client, containerId, 1024);
-
-    DatanodeBlockID blockID = requestProto.getWriteChunk().getBlockID();
-
-    // Put Block to the test container
-    ContainerCommandRequestProto putBlockRequest = ContainerTestHelper
-        .getPutBlockRequest(sourcePipelines, requestProto.getWriteChunk());
-
-    ContainerCommandResponseProto response =
-        client.sendCommand(putBlockRequest);
-
-    Assert.assertNotNull(response);
-    Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-
-    HddsDatanodeService destinationDatanode =
-        chooseDatanodeWithoutContainer(sourcePipelines,
-            cluster.getHddsDatanodes());
-
-    // Close the container
-    ContainerCommandRequestProto closeContainerRequest = ContainerTestHelper
-        .getCloseContainer(sourcePipelines, containerId);
-    response = client.sendCommand(closeContainerRequest);
-    Assert.assertNotNull(response);
-    Assert.assertEquals(ContainerProtos.Result.SUCCESS, response.getResult());
-
-    //WHEN: send the order to replicate the container
-    cluster.getStorageContainerManager().getScmNodeManager()
-        .addDatanodeCommand(destinationDatanode.getDatanodeDetails().getUuid(),
-            new ReplicateContainerCommand(containerId,
-                sourcePipelines.getNodes()));
-
-    DatanodeStateMachine destinationDatanodeDatanodeStateMachine =
-        destinationDatanode.getDatanodeStateMachine();
-
-    //wait for the replication
-    GenericTestUtils.waitFor(()
-        -> destinationDatanodeDatanodeStateMachine.getSupervisor()
-        .getReplicationRequestCount() > 0, 1000, 20_000);
-
-    OzoneContainer ozoneContainer =
-        destinationDatanodeDatanodeStateMachine.getContainer();
-
-    Container container =
-        ozoneContainer
-            .getContainerSet().getContainer(containerId);
-
-    Assert.assertNotNull(
-        "Container is not replicated to the destination datanode",
-        container);
-
-    Assert.assertNotNull(
-        "ContainerData of the replicated container is null",
-        container.getContainerData());
-
-    KeyValueHandler handler = (KeyValueHandler) ozoneContainer.getDispatcher()
-        .getHandler(ContainerType.KeyValueContainer);
-
-    BlockData key = handler.getBlockManager()
-        .getBlock(container, BlockID.getFromProtobuf(blockID));
-
-    Assert.assertNotNull(key);
-    Assert.assertEquals(1, key.getChunks().size());
-    Assert.assertEquals(requestProto.getWriteChunk().getChunkData(),
-        key.getChunks().get(0));
+    waitForReplicaCount(containerID, 2, cluster);
+    waitForReplicaCount(containerID, 3, cluster);
   }
 
-  private HddsDatanodeService chooseDatanodeWithoutContainer(Pipeline pipeline,
-      List<HddsDatanodeService> dataNodes) {
-    for (HddsDatanodeService datanode : dataNodes) {
-      if (!pipeline.getNodes().contains(datanode.getDatanodeDetails())) {
-        return datanode;
-      }
+  private static OzoneConfiguration createConfiguration() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, TimeUnit.SECONDS);
+    conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, TimeUnit.SECONDS);
+
+    ReplicationManagerConfiguration repConf =
+        conf.getObject(ReplicationManagerConfiguration.class);
+    repConf.setInterval(Duration.ofSeconds(1));
+    conf.setFromObject(repConf);
+    return conf;
+  }
+
+  private void createTestData() throws IOException {
+    ObjectStore objectStore = client.getObjectStore();
+    objectStore.createVolume(VOLUME);
+    OzoneVolume volume = objectStore.getVolume(VOLUME);
+    volume.createBucket(BUCKET);
+
+    OzoneBucket bucket = volume.getBucket(BUCKET);
+    try (OutputStream out = bucket.createKey(KEY, 0)) {
+      out.write("Hello".getBytes(UTF_8));
     }
-    throw new AssertionError(
-        "No datanode outside of the pipeline");
   }
 
-  private static OzoneConfiguration newOzoneConfiguration() {
-    return new OzoneConfiguration();
+  private static List<OmKeyLocationInfo> lookupKey(MiniOzoneCluster cluster)
+      throws IOException {
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(VOLUME)
+        .setBucketName(BUCKET)
+        .setKeyName(KEY)
+        .setType(HddsProtos.ReplicationType.RATIS)
+        .setFactor(HddsProtos.ReplicationFactor.THREE)
+        .build();
+    OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
+    OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();
+    Assert.assertNotNull(locations);
+    return locations.getLocationList();
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
@@ -37,6 +37,8 @@ import java.io.File;
 import java.util.List;
 import java.util.ArrayList;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 
 /**
  * This class tests the Debug LDB CLI that reads from an om.db file.
@@ -86,7 +88,8 @@ public class TestOmLDBCli {
           HddsProtos.ReplicationFactor.ONE);
       String key = "key"+ (i);
       Table<byte[], byte[]> keyTable = dbStore.getTable("keyTable");
-      keyTable.put(key.getBytes(), value.getProtobuf().toByteArray());
+      byte[] arr = value.getProtobuf(CURRENT_VERSION).toByteArray();
+      keyTable.put(key.getBytes(), arr);
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());
     dbScanner.setParent(rdbParser);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -105,6 +105,7 @@ message OMRequest {
   required string clientId = 3;
 
   optional UserInfo userInfo = 4;
+  optional uint32 version = 5;
 
 
   optional CreateVolumeRequest              createVolumeRequest            = 11;

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
@@ -28,6 +28,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 /**
  * Codec to encode OmKeyInfo as byte array.
  */
@@ -38,14 +40,14 @@ public class OmKeyInfoCodec implements Codec<OmKeyInfo> {
   private final boolean ignorePipeline;
   public OmKeyInfoCodec(boolean ignorePipeline) {
     this.ignorePipeline = ignorePipeline;
-    LOG.info("OmKeyInfoCodec ignorePipeline = " + ignorePipeline);
+    LOG.info("OmKeyInfoCodec ignorePipeline = {}", ignorePipeline);
   }
 
   @Override
   public byte[] toPersistedFormat(OmKeyInfo object) throws IOException {
     Preconditions
         .checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.getProtobuf(ignorePipeline).toByteArray();
+    return object.getProtobuf(ignorePipeline, CURRENT_VERSION).toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
@@ -27,6 +27,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+
 /**
  * Codec to encode RepeatedOmKeyInfo as byte array.
  */
@@ -37,7 +39,7 @@ public class RepeatedOmKeyInfoCodec implements Codec<RepeatedOmKeyInfo> {
   private final boolean ignorePipeline;
   public RepeatedOmKeyInfoCodec(boolean ignorePipeline) {
     this.ignorePipeline = ignorePipeline;
-    LOG.info("RepeatedOmKeyInfoCodec ignorePipeline = " + ignorePipeline);
+    LOG.info("RepeatedOmKeyInfoCodec ignorePipeline = {}", ignorePipeline);
   }
 
   @Override
@@ -45,7 +47,7 @@ public class RepeatedOmKeyInfoCodec implements Codec<RepeatedOmKeyInfo> {
       throws IOException {
     Preconditions.checkNotNull(object,
         "Null object can't be converted to byte array.");
-    return object.getProto(ignorePipeline).toByteArray();
+    return object.getProto(ignorePipeline, CURRENT_VERSION).toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -128,6 +128,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BL
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_FOUND;
@@ -1139,7 +1140,8 @@ public class KeyManagerImpl implements KeyManager {
         PartKeyInfo.Builder partKeyInfo = PartKeyInfo.newBuilder();
         partKeyInfo.setPartName(partName);
         partKeyInfo.setPartNumber(partNumber);
-        partKeyInfo.setPartKeyInfo(keyInfo.getProtobuf());
+        // TODO remove unused write code path
+        partKeyInfo.setPartKeyInfo(keyInfo.getProtobuf(CURRENT_VERSION));
         multipartKeyInfo.addPartKeyInfo(partNumber, partKeyInfo.build());
         if (oldPartKeyInfo == null) {
           // This is the first time part is being added.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -141,7 +141,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
         .setDataSize(requestedSize);
 
     newKeyArgs.addAllKeyLocations(omKeyLocationInfoList.stream()
-        .map(OmKeyLocationInfo::getProtobuf).collect(Collectors.toList()));
+        .map(info -> info.getProtobuf(getOmRequest().getVersion()))
+        .collect(Collectors.toList()));
 
     generateRequiredEncryptionInfo(keyArgs, newKeyArgs, ozoneManager);
     CreateFileRequest.Builder newCreateFileRequest =
@@ -305,7 +306,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       numMissingParents = missingParentInfos.size();
       // Prepare response
       omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()
-          .setKeyInfo(omKeyInfo.getProtobuf())
+          .setKeyInfo(omKeyInfo.getProtobuf(getOmRequest().getVersion()))
           .setID(clientID)
           .setOpenVersion(openVersion).build())
           .setCmdType(Type.CreateFile);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -123,7 +123,7 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
     // Add allocated block info.
     newAllocatedBlockRequest.setKeyLocation(
-        omKeyLocationInfoList.get(0).getProtobuf());
+        omKeyLocationInfoList.get(0).getProtobuf(getOmRequest().getVersion()));
 
     return getOmRequest().toBuilder().setUserInfo(getUserInfo())
         .setAllocateBlockRequest(newAllocatedBlockRequest).build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -160,7 +160,9 @@ public class OMKeyCreateRequest extends OMKeyRequest {
               .setDataSize(requestedSize);
 
       newKeyArgs.addAllKeyLocations(omKeyLocationInfoList.stream()
-          .map(OmKeyLocationInfo::getProtobuf).collect(Collectors.toList()));
+          .map(info -> info.getProtobuf(false,
+              getOmRequest().getVersion()))
+          .collect(Collectors.toList()));
     } else {
       newKeyArgs = keyArgs.toBuilder().setModificationTime(Time.now());
     }
@@ -314,7 +316,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
       // Prepare response
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
-          .setKeyInfo(omKeyInfo.getProtobuf())
+          .setKeyInfo(omKeyInfo.getProtobuf(getOmRequest().getVersion()))
           .setID(clientID)
           .setOpenVersion(openVersion).build())
           .setCmdType(Type.CreateKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -183,7 +183,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           OzoneManagerProtocolProtos.PartKeyInfo.newBuilder();
       partKeyInfo.setPartName(partName);
       partKeyInfo.setPartNumber(partNumber);
-      partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf());
+      partKeyInfo.setPartKeyInfo(omKeyInfo.getProtobuf(
+          getOmRequest().getVersion()));
 
       // Add this part information in to multipartKeyInfo.
       multipartKeyInfo.addPartKeyInfo(partNumber, partKeyInfo.build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -149,17 +149,17 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case LookupKey:
         LookupKeyResponse lookupKeyResponse = lookupKey(
-            request.getLookupKeyRequest());
+            request.getLookupKeyRequest(), request.getVersion());
         responseBuilder.setLookupKeyResponse(lookupKeyResponse);
         break;
       case ListKeys:
         ListKeysResponse listKeysResponse = listKeys(
-            request.getListKeysRequest());
+            request.getListKeysRequest(), request.getVersion());
         responseBuilder.setListKeysResponse(listKeysResponse);
         break;
       case ListTrash:
         ListTrashResponse listTrashResponse = listTrash(
-            request.getListTrashRequest());
+            request.getListTrashRequest(), request.getVersion());
         responseBuilder.setListTrashResponse(listTrashResponse);
         break;
       case ListMultiPartUploadParts:
@@ -189,7 +189,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case LookupFile:
         LookupFileResponse lookupFileResponse =
-            lookupFile(request.getLookupFileRequest());
+            lookupFile(request.getLookupFileRequest(), request.getVersion());
         responseBuilder.setLookupFileResponse(lookupFileResponse);
         break;
       case ListStatus:
@@ -350,8 +350,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return resp.build();
   }
 
-  private LookupKeyResponse lookupKey(LookupKeyRequest request)
-      throws IOException {
+  private LookupKeyResponse lookupKey(LookupKeyRequest request,
+      int clientVersion) throws IOException {
     LookupKeyResponse.Builder resp =
         LookupKeyResponse.newBuilder();
     KeyArgs keyArgs = request.getKeyArgs();
@@ -363,7 +363,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
-    resp.setKeyInfo(keyInfo.getProtobuf());
+    resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
 
     return resp.build();
   }
@@ -385,7 +385,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return resp.build();
   }
 
-  private ListKeysResponse listKeys(ListKeysRequest request)
+  private ListKeysResponse listKeys(ListKeysRequest request, int clientVersion)
       throws IOException {
     ListKeysResponse.Builder resp =
         ListKeysResponse.newBuilder();
@@ -397,14 +397,14 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         request.getPrefix(),
         request.getCount());
     for (OmKeyInfo key : keys) {
-      resp.addKeyInfo(key.getProtobuf(true));
+      resp.addKeyInfo(key.getProtobuf(true, clientVersion));
     }
 
     return resp.build();
   }
 
-  private ListTrashResponse listTrash(ListTrashRequest request)
-      throws IOException {
+  private ListTrashResponse listTrash(ListTrashRequest request,
+      int clientVersion) throws IOException {
 
     ListTrashResponse.Builder resp =
         ListTrashResponse.newBuilder();
@@ -417,14 +417,14 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         request.getMaxKeys());
 
     for (RepeatedOmKeyInfo key: deletedKeys) {
-      resp.addDeletedKeys(key.getProto(false));
+      resp.addDeletedKeys(key.getProto(false, clientVersion));
     }
 
     return resp.build();
   }
 
-  private AllocateBlockResponse allocateBlock(AllocateBlockRequest request)
-      throws IOException {
+  private AllocateBlockResponse allocateBlock(AllocateBlockRequest request,
+      int clientVersion) throws IOException {
     AllocateBlockResponse.Builder resp =
         AllocateBlockResponse.newBuilder();
 
@@ -439,7 +439,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         request.getClientID(), ExcludeList.getFromProtoBuf(
             request.getExcludeList()));
 
-    resp.setKeyLocation(newLocation.getProtobuf());
+    resp.setKeyLocation(newLocation.getProtobuf(clientVersion));
 
     return resp.build();
   }
@@ -544,9 +544,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     return rb.build();
   }
 
-  private LookupFileResponse lookupFile(
-      LookupFileRequest request)
-      throws IOException {
+  private LookupFileResponse lookupFile(LookupFileRequest request,
+      int clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -556,7 +555,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .build();
     return LookupFileResponse.newBuilder()
-        .setKeyInfo(impl.lookupFile(omKeyArgs).getProtobuf())
+        .setKeyInfo(impl.lookupFile(omKeyArgs).getProtobuf(clientVersion))
         .build();
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 
 
@@ -93,7 +94,8 @@ public class ContainerMapper {
             Table.KeyValue<String, OmKeyInfo> keyValue =
                 keyValueTableIterator.next();
             OmKeyInfo omKeyInfo = keyValue.getValue();
-            byte[] value = omKeyInfo.getProtobuf(true).toByteArray();
+            byte[] value = omKeyInfo.getProtobuf(true, CURRENT_VERSION)
+                .toByteArray();
             OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));
             for (OmKeyLocationInfoGroup keyLocationInfoGroup : keyInfo


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Introduce `version` number to client messages.  Old client does not send version number, in this case it defaults to 0 at the other side.  Client with this change sends `version = 1`.
2. Only include pre-existing ports of datanode (ie. `STANDALONE`, `RATIS`, `REST`) in `DatanodeDetails` protobuf message sent to v0 client, which cannot handle new enum constants.
3. Make client more future-proof by ignoring unknown `Port.Name` values.  This in itself is not enough as a fix, since old client does not have this logic.  But this allows the server to send any new port from now on to `v >= 1` clients.

https://issues.apache.org/jira/browse/HDDS-4731

## How was this patch tested?

Added acceptance test which verifies cross-compatibility of key write/read among 0.5.0, 1.0.0, 1.1.0 versions.

Tested closed container replication using `ozone-topology` compose environment to check for regression.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/510263073