### PR TITLE
HDDS-4746. Fix delete container occurs unknown command type.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -298,6 +298,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setStartMaintenanceNodesResponse(startMaintenanceNodes(
                 request.getStartMaintenanceNodesRequest()))
           .build();
+      case DeleteContainer:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setScmDeleteContainerResponse(
+                deleteContainer(request.getScmDeleteContainerRequest()))
+            .build();
       default:
         throw new IllegalArgumentException(
             "Unknown command type: " + request.getCmdType());


### PR DESCRIPTION
## What changes were proposed in this pull request?

An exception "Unknown command type: DeleteContainer" occurs when we delete a container. This is a bug that needs to be fixed.
In fact, this part of the interface backend is already implemented, just not called.
![image](https://user-images.githubusercontent.com/13825159/105845603-01c27400-6016-11eb-9d5b-745c5d494fe8.png)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4746

## How was this patch tested?

UT added
