### PR TITLE
HDDS-4757. Unnecessary WARNING to set OZONE_CONF_DIR

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/cli/envvars.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/cli/envvars.robot
@@ -49,6 +49,7 @@ Find valid dirs
                         Should Contain   ${output}   OZONE_CONF_DIR='/opt/hadoop/etc/hadoop'
                         Should Contain   ${output}   OZONE_LIBEXEC_DIR='/opt/hadoop/libexec'
                         Should Contain   ${output}   WARNING: HADOOP_HOME
+                        Should Not Contain   ${output}   WARNING: OZONE_CONF_DIR
                         Should Not Contain   ${output}   WARNING: HADOOP_CONF_DIR
 
 Picks up deprecated vars if valid

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-config.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-config.sh
@@ -71,7 +71,6 @@ ozone_exec_userfuncs
 #
 
 ozone_exec_user_env
-ozone_verify_confdir
 
 ozone_deprecate_envvar HADOOP_SLAVES HADOOP_WORKERS
 ozone_deprecate_envvar HADOOP_SLAVE_NAMES HADOOP_WORKER_NAMES

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -653,7 +653,7 @@ function ozone_verify_confdir
 {
   # Check only log4j.properties by default.
   # --loglevel does not work without logger settings in log4j.properties.
-  [[ -f "${OZONE_CONF_DIR}/log4j.properties" ]]
+  [[ -f "${1:?ozone_verify_confir requires parameter}/log4j.properties" ]]
 }
 
 ## @description  Import the ozone-env.sh settings


### PR DESCRIPTION
## What changes were proposed in this pull request?

I executed a simple ozone command ("ozone admin pipeline list") on my latest deploy and got a warning:

```
ozone admin pipeline list
WARNING: OZONE_CONF_DIR not defined and cannot be found, setting in OZONE_HOME: /opt/ozone/etc/hadoop.
```

Same with bash debug log (set -x):

```
++ local conf_dir=etc/hadoop
++ [[ -n '' ]]
++ [[ -n /opt/ozone ]]
++ ozone_verify_confdir /opt/ozone/etc/hadoop
++ [[ -f /log4j.properties ]]
++ [[ -n /opt/ozone/libexec ]]
++ ozone_verify_confdir /opt/ozone/libexec/../etc/hadoop
++ [[ -f /log4j.properties ]]
++ OZONE_CONF_DIR=/opt/ozone/etc/hadoop
++ ozone_error 'WARNING: OZONE_CONF_DIR not defined and cannot be found, setting in OZONE_HOME: /opt/ozone/etc/hadoop.'
++ echo 'WARNING: OZONE_CONF_DIR not defined and cannot be found, setting in OZONE_HOME: /opt/ozone/etc/hadoop.'
WARNING: OZONE_CONF_DIR not defined and cannot be found, setting in OZONE_HOME: /opt/ozone/etc/hadoop.
```

This error supposed to be hidden as conf dir is under the default location (/opt/ozone/etc/hadoop).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4757

## How was this patch tested?

Executed "ozone version" with and without the patch in your host os (without docker) whete HADOOP/OZONE_CONF_DIR is not set.