### PR TITLE
HDDS-4758. Adjust classpath of ozone version to include log4j

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -208,7 +208,7 @@ function ozonecmd_case
     ;;
     version)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.util.OzoneVersionInfo
-      OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-common"
+      OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     genconf)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.genconf.GenerateOzoneRequiredConfigurations


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4758

## What changes were proposed in this pull request?

`ozone version` command prints out an annoying warning about missing log4j (first 3 lines):

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
                  //////////////                 
               ////////////////////              
            ////////     ////////////////        
           //////      ////////////////          
          /////      ////////////////  /         
         /////            ////////   ///         
         ////           ////////    /////        
        /////         ////////////////           
        /////       ////////////////   //        
         ////     ///////////////   /////        
         /////  ///////////////     ////         
          /////       //////      /////          
           //////   //////       /////           
             ///////////     ////////            
               //////  ////////////              
               ///   //////////                  
              /    1.1.0-SNAPSHOT(Denali)

Source code repository git@github.com:apache/ozone.git -r aa2f05485fecbfbec01661e189f60dc590abfc4b
Compiled by elek on 2021-01-27T12:58Z
Compiled with protoc 2.5.0
From source with checksum c83ca7b0afebec969e72499bb78d45d
With Apache Ratis: 1.1.0-eb66796d-SNAPSHOT from de7172d9c1140dba2dbd4516b11f6a4f720d2f12

Using HDDS 1.1.0-SNAPSHOT
Source code repository git@github.com:apache/ozone.git -r aa2f05485fecbfbec01661e189f60dc590abfc4b
Compiled by elek on 2021-01-27T12:57Z
Compiled with protoc 2.5.0
```

We should use a classpath definition which includes `slf4j-log4j` binding

## How was this patch tested?

Executed `ozone version` with or without the patch.