### PR TITLE
HDDS-4751. TestOzoneFileSystem#testTrash failed when enabledFileSystemPaths and omRatisDisabled

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -107,6 +109,9 @@ public class TrashOzoneFileSystem extends FileSystem {
       throws Exception {
     ozoneManager.getMetrics().incNumTrashWriteRequests();
     if (ozoneManager.isRatisEnabled()) {
+      OMClientRequest omClientRequest =
+          OzoneManagerRatisUtils.createClientRequest(omRequest);
+      omRequest = omClientRequest.preExecute(ozoneManager);
       RaftClientRequest req = getRatisRequest(omRequest);
       ozoneManager.getOmRatisServer().submitRequest(omRequest, req);
     } else {
@@ -434,12 +439,14 @@ public class TrashOzoneFileSystem extends FileSystem {
 
   private class DeleteIterator extends OzoneListingIterator {
     final private boolean recursive;
+    private List<String> keysList;
 
 
     DeleteIterator(Path f, boolean recursive)
         throws IOException {
       super(f);
       this.recursive = recursive;
+      keysList = new ArrayList<>();
       if (getStatus().isDirectory()
           && !this.recursive
           && listStatus(f).length != 0) {
@@ -470,22 +477,23 @@ public class TrashOzoneFileSystem extends FileSystem {
       String volumeName = keyPath.getVolumeName();
       String bucketName = keyPath.getBucketName();
       String keyName = keyPath.getKeyName();
-
-      OzoneManagerProtocolProtos.KeyArgs keyArgs =
-          OzoneManagerProtocolProtos.KeyArgs.newBuilder()
-              .setKeyName(keyName)
-              .setVolumeName(volumeName)
+      keysList.clear();
+      // Keys List will have only 1 entry.
+      keysList.add(keyName);
+      OzoneManagerProtocolProtos.DeleteKeyArgs.Builder deleteKeyArgs =
+          OzoneManagerProtocolProtos.DeleteKeyArgs.newBuilder()
               .setBucketName(bucketName)
-              .build();
-      OzoneManagerProtocolProtos.DeleteKeyRequest deleteKeyRequest =
-          OzoneManagerProtocolProtos.DeleteKeyRequest.newBuilder()
-              .setKeyArgs(keyArgs)
+              .setVolumeName(volumeName);
+      deleteKeyArgs.addAllKeys(keysList);
+      OzoneManagerProtocolProtos.DeleteKeysRequest deleteKeysRequest =
+          OzoneManagerProtocolProtos.DeleteKeysRequest.newBuilder()
+              .setDeleteKeys(deleteKeyArgs)
               .build();
       OzoneManagerProtocolProtos.OMRequest omRequest =
           OzoneManagerProtocolProtos.OMRequest.newBuilder()
               .setClientId(CLIENT_ID.toString())
-              .setDeleteKeyRequest(deleteKeyRequest)
-              .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKey)
+              .setDeleteKeysRequest(deleteKeysRequest)
+              .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
               .build();
       return omRequest;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
TestOzoneFileSystem testTrash fails while setting `enableFsPaths` to true. This is because of using `DeleteKeyRequest `for delete. 
There are 2 operations that happen when a key is moved to Trash 1. rename 2 .delete .
 While Renaming a directory key,  the renamedKey is stored  in KeyTable with  "/"  (`RenameKeyRequest`)  irrespective of `enableFsPaths` value but while deleting a key via `DeleteKeyRequest` the "/" is removed and a lookup is done on KeyTable which results in KEY_NOT_FOUND.  Using `DeleteKeys` instead of `DeleteKey` will solve this issue as a lookup is not done on the normalised key.
[This PR](https://github.com/apache/ozone/pull/1256) explains why normalisation is not done while rename
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4751
## How was this patch tested?
Existing Test Trash unit test.
