### PR TITLE
HDDS-4761. Implement increment count optimization in DeletedBlockLog V2

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
@@ -279,9 +279,10 @@ public class DeletedBlockLogImplV2
 
   /**
    * Called in SCMStateMachine#notifyLeaderChanged when current SCM becomes
-   *  leader.
+   * leader.
    */
-  public void clearTransactionToDNsCommitMap() {
+  public void clear() {
+    deletedBlockLogStateManager.clear();
     transactionToDNsCommitMap.clear();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManager.java
@@ -42,4 +42,6 @@ public interface DeletedBlockLogStateManager {
       KeyValue<Long, DeletedBlocksTransaction>> getReadOnlyIterator();
 
   void onFlush();
+
+  void clear();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -216,6 +216,9 @@ public class DeletedBlockLogStateManagerImpl
     }
   }
 
+  public void clear() {
+    transactionRetryCountMap.clear();
+  }
 
   public void onFlush() {
     deletingTxIDs.clear();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -165,7 +165,7 @@ public class SCMStateMachine extends BaseStateMachine {
     Preconditions.checkArgument(
         deletedBlockLog instanceof DeletedBlockLogImplV2);
     ((DeletedBlockLogImplV2) deletedBlockLog)
-          .clearTransactionToDNsCommitMap();
+          .clear();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -266,7 +266,12 @@ public class TestDeletedBlockLog {
     OzoneConfiguration testConf = OzoneConfiguration.of(conf);
     testConf.setInt(OZONE_SCM_BLOCK_DELETION_MAX_RETRY, 120);
 
-    deletedBlockLog.addTransactions(generateData(1));
+    deletedBlockLog = new DeletedBlockLogImplV2(testConf, containerManager,
+        MockSCMHAManager.getInstance(true).getRatisServer(),
+        scm.getScmMetadataStore().getDeletedBlocksTXTable(),
+        dbTransactionBuffer, SCMContext.emptyContext());
+
+    addTransactions(generateData(30));
 
     List<DeletedBlocksTransaction> blocks =
         getTransactions(40 * BLOCKS_PER_TXN);
@@ -274,7 +279,7 @@ public class TestDeletedBlockLog {
         .collect(Collectors.toList());
 
     for (int i = 0; i < 50; i++) {
-      deletedBlockLog.incrementCount(txIDs);
+      incrementCount(txIDs);
     }
     blocks = getTransactions(40 * BLOCKS_PER_TXN);
     for (DeletedBlocksTransaction block : blocks) {
@@ -283,7 +288,7 @@ public class TestDeletedBlockLog {
     }
 
     for (int i = 0; i < 60; i++) {
-      deletedBlockLog.incrementCount(txIDs);
+      incrementCount(txIDs);
     }
     blocks = getTransactions(40 * BLOCKS_PER_TXN);
     for (DeletedBlocksTransaction block : blocks) {
@@ -292,7 +297,7 @@ public class TestDeletedBlockLog {
     }
 
     for (int i = 0; i < 50; i++) {
-      deletedBlockLog.incrementCount(txIDs);
+      incrementCount(txIDs);
     }
     blocks = getTransactions(40 * BLOCKS_PER_TXN);
     for (DeletedBlocksTransaction block : blocks) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement increment count optimization in DeletedBlockLog V2. We only write retry count to DB in every 100 times.

This optimization is already in master branch: https://github.com/apache/ozone/commit/39027e4b33eaa2c233c10ced2863fed7d937e944

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4761

## How was this patch tested?

UT
