### PR TITLE
HDDS-4760. Intermittent failure in ozone-ha acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -29,7 +29,6 @@ OZONE-SITE.XML_ozone.scm.block.client.address=scm
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.scm.client.address=scm
-OZONE-SITE.XML_ozone.client.failover.max.attempts=6
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Restore default failover attempt count (15) for `ozone-ha`.  The custom value (6) was inherited from `ozone-om-ha`, which exercises failovers.

The error happened if OM leader election took too long:

```
2021/01/28/5550/acceptance-misc:om2_1 leader elected after 6899ms
2021/01/27/5516/acceptance-misc:om2_1 leader elected after 7346ms
2021/01/27/5510/acceptance-misc:om3_1 leader elected after 7254ms
2021/01/28/5536/acceptance-misc:om2_1 leader elected after 7149ms
2021/01/26/5496/acceptance-misc:om2_1 leader elected after 6740ms
```

https://issues.apache.org/jira/browse/HDDS-4760

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/520001429

```
om1_1 leader elected after 6877ms
```