### PR TITLE
HDDS-4765. Update close-pending workflow for new repo

### DIFF
--- a/.github/close-pending.sh
+++ b/.github/close-pending.sh
@@ -27,15 +27,15 @@ while IFS= read -r number &&
         --data "$(jq --arg body "$MESSAGE" -n '{body: $body}')" \
         --header "authorization: Bearer $GITHUB_TOKEN" \
         --header 'content-type: application/json' \
-        "https://api.github.com/repos/apache/hadoop-ozone/issues/$number/comments"
+        "https://api.github.com/repos/apache/ozone/issues/$number/comments"
 
       curl -s -o /dev/null \
         -X PATCH \
         --data '{"state": "close"}' \
         --header "authorization: Bearer $GITHUB_TOKEN" \
         --header 'content-type: application/json' \
-        "https://api.github.com/repos/apache/hadoop-ozone/pulls/$number"
+        "https://api.github.com/repos/apache/ozone/pulls/$number"
 done < <(curl -H "Content-Type: application/json" \
      --header "authorization: Bearer $GITHUB_TOKEN" \
-     "https://api.github.com/search/issues?q=repo:apache/hadoop-ozone+type:pr+updated:<$(date -d "-21 days" +%Y-%m-%d)+label:pending+is:open" \
+     "https://api.github.com/search/issues?q=repo:apache/ozone+type:pr+updated:<$(date -d "-21 days" +%Y-%m-%d)+label:pending+is:open" \
      | jq -r '.items[] | (.number,.title)')

--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@master
       - name: Execute close-pending script
-        if: github.repository == 'apache/hadoop-ozone'
+        if: github.repository == 'apache/ozone'
         run: ./.github/close-pending.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`close-pending` workflow currently [does not execute the script](https://github.com/apache/ozone/runs/1788356301?check_suite_focus=true) due to mismatch in [repository name](https://github.com/apache/ozone/actions/runs/519574297/workflow#L29).

This PR just updates the workflow with the new repo name.

https://issues.apache.org/jira/browse/HDDS-4765