### PR TITLE
HDDS-4766: Recon resets the Operational State of datanodes to IN_SERVICE

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -417,16 +417,17 @@ public class SCMNodeManager implements NodeManager {
         || scmStatus.getOpStateExpiryEpochSeconds()
         != reportedDn.getPersistedOpStateExpiryEpochSec()) {
       LOG.info("Scheduling a command to update the operationalState " +
-          "persisted on the datanode as the reported value ({}, {}) does not " +
+          "persisted on {} as the reported value does not " +
           "match the value stored in SCM ({}, {})",
-          reportedDn.getPersistedOpState(),
-          reportedDn.getPersistedOpStateExpiryEpochSec(),
+          reportedDn,
           scmStatus.getOperationalState(),
           scmStatus.getOpStateExpiryEpochSeconds());
-      commandQueue.addCommand(reportedDn.getUuid(),
+
+      onMessage(new CommandForDatanode(reportedDn.getUuid(),
           new SetNodeOperationalStateCommand(
               Time.monotonicNow(), scmStatus.getOperationalState(),
-              scmStatus.getOpStateExpiryEpochSeconds()));
+              scmStatus.getOpStateExpiryEpochSeconds())
+      ), null);
     }
     DatanodeDetails scmDnd = nodeStateManager.getNode(reportedDn);
     scmDnd.setPersistedOpStateExpiryEpochSec(

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.collect.ImmutableSet;
+
+import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type.reregisterCommand;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -129,6 +131,10 @@ public class ReconNodeManager extends SCMNodeManager {
   public List<SCMCommand> processHeartbeat(DatanodeDetails datanodeDetails) {
     // Update heartbeat map with current time
     datanodeHeartbeatMap.put(datanodeDetails.getUuid(), Time.now());
-    return super.processHeartbeat(datanodeDetails);
+
+    List<SCMCommand> cmds = super.processHeartbeat(datanodeDetails);
+    return cmds.stream()
+        .filter(c -> ALLOWED_COMMANDS.contains(c.getType()))
+        .collect(toList());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a datanode is decommission or put to maintenance, its new state is persisted into the datanode.yaml file. When running on a cluster with Recon enabled, we can see conflicting commands are received repeatedly on the Datanode, eg:

```
datanode_3  | 2021-01-29 16:26:20,009 [EndpointStateMachine task thread for scm/172.24.0.6:9861 - 0 ] INFO endpoint.HeartbeatEndpointTask: Received SCM set operational state command. State: DECOMMISSIONED Expiry: 0 id 3645344
datanode_3  | 2021-01-29 16:26:50,012 [EndpointStateMachine task thread for recon/172.24.0.3:9891 - 0 ] INFO commands.SetNodeOperationalStateCommand: Create a new command to set op state IN_SERVICE 0 id is 3675347
```

This is happening because Recon delegates processing the DN heartbeats received by ReconNodeManager to an instance of SCMNodeManager running inside Recon. SCMNodeManager checks the reported state of the datanode matches the SCM memory state, and if they don't match, it issues a command to the DN to update its state.

In this case, Recon always tries to set the DN state back to IN_SERVICE.

Recon sub-classes the SCMNodeManager where this event is produced. Recon filters events it is allowed to send via the onMessage interface on SCMNodeManager, but the newly added event for decommission did not use that interface and hence bypassed the filter.

This change pushes the even over the onMessage interface to avoid this problem.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4766

## How was this patch tested?

Existing tests and manually verified in a Docker cluster.
