### PR TITLE
HDDS-4756. Add lock for activate/deactivate in PipelineManagerV2

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
@@ -413,8 +413,13 @@ public final class PipelineManagerV2Impl implements PipelineManager {
   @Override
   public void activatePipeline(PipelineID pipelineID)
       throws IOException {
-    stateManager.updatePipelineState(pipelineID.getProtobuf(),
-        HddsProtos.PipelineState.PIPELINE_OPEN);
+    lock.lock();
+    try {
+      stateManager.updatePipelineState(pipelineID.getProtobuf(),
+              HddsProtos.PipelineState.PIPELINE_OPEN);
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**
@@ -426,8 +431,13 @@ public final class PipelineManagerV2Impl implements PipelineManager {
   @Override
   public void deactivatePipeline(PipelineID pipelineID)
       throws IOException {
-    stateManager.updatePipelineState(pipelineID.getProtobuf(),
-        HddsProtos.PipelineState.PIPELINE_DORMANT);
+    lock.lock();
+    try {
+      stateManager.updatePipelineState(pipelineID.getProtobuf(),
+          HddsProtos.PipelineState.PIPELINE_DORMANT);
+    } finally {
+      lock.unlock();
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Problem:
In PipelineManagerV2, the activate and deactivate pipeline methods don't have the lock that originally supposed to have based on the HA design. Thus the result is that ratis operation could be requested concurrently and may lead to reading the stale version of pipeline state.

Solution:
Add lock before calling the statemanager

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4756

## How was this patch tested?
The locked version is tested based on the tps upper bound test.
The result shows that the number of ratis calls per second is declined rapidly.

