### PR TITLE
HDDS-4768. Refactor the repeated exception conversion method into a common util class

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -70,6 +70,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_R
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
+
+import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -487,4 +489,21 @@ public final class HddsServerUtil {
     }
     return metricsSystem;
   }
+
+  /**
+   * Converts RocksDB exception to IOE.
+   * @param msg  - Message to add to exception.
+   * @param e - Original Exception.
+   * @return  IOE.
+   */
+  public static IOException toIOException(String msg, RocksDBException e) {
+    String statusCode = e.getStatus() == null ? "N/A" :
+        e.getStatus().getCodeString();
+    String errMessage = e.getMessage() == null ? "Unknown error" :
+        e.getMessage();
+    String output = msg + "; status : " + statusCode
+        + "; message : " + errMessage;
+    return new IOException(output, e);
+  }
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
@@ -97,22 +97,13 @@ public class RocksDBStore implements MetadataStore {
     }
   }
 
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
-  }
-
   @Override
   public void put(byte[] key, byte[] value) throws IOException {
     try {
       db.put(writeOptions, key, value);
     } catch (RocksDBException e) {
-      throw toIOException("Failed to put key-value to metadata store", e);
+      throw HddsServerUtil.toIOException(
+          "Failed to put key-value to metadata store", e);
     }
   }
 
@@ -135,7 +126,8 @@ public class RocksDBStore implements MetadataStore {
     try {
       return db.get(key);
     } catch (RocksDBException e) {
-      throw toIOException("Failed to get the value for the given key", e);
+      throw HddsServerUtil.toIOException(
+          "Failed to get the value for the given key", e);
     }
   }
 
@@ -144,7 +136,7 @@ public class RocksDBStore implements MetadataStore {
     try {
       db.delete(key);
     } catch (RocksDBException e) {
-      throw toIOException("Failed to delete the given key", e);
+      throw HddsServerUtil.toIOException("Failed to delete the given key", e);
     }
   }
 
@@ -262,7 +254,7 @@ public class RocksDBStore implements MetadataStore {
         }
         db.write(writeOptions, writeBatch);
       } catch (RocksDBException e) {
-        throw toIOException("Batch write operation failed", e);
+        throw HddsServerUtil.toIOException("Batch write operation failed", e);
       }
     }
   }
@@ -273,7 +265,7 @@ public class RocksDBStore implements MetadataStore {
       try {
         db.compactRange();
       } catch (RocksDBException e) {
-        throw toIOException("Failed to compact db", e);
+        throw HddsServerUtil.toIOException("Failed to compact db", e);
       }
     }
   }
@@ -286,7 +278,7 @@ public class RocksDBStore implements MetadataStore {
         // be reconstructed using it.
         db.flushWal(sync);
       } catch (RocksDBException e) {
-        throw toIOException("Failed to flush db", e);
+        throw HddsServerUtil.toIOException("Failed to flush db", e);
       }
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.eclipse.jetty.util.StringUtil;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.DBOptions;
@@ -134,7 +135,8 @@ public final class DBConfigFromFile {
               env, options, cfDescs, true);
 
         } catch (RocksDBException rdEx) {
-          RDBTable.toIOException("Unable to find/open Options file.", rdEx);
+          HddsServerUtil.toIOException(
+              "Unable to find/open Options file.", rdEx);
         }
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.utils.RocksDBStoreMBean;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
 import org.apache.hadoop.metrics2.util.MBeans;
@@ -158,7 +159,7 @@ public class RDBStore implements DBStore {
           e.getCause().getClass().getCanonicalName() + " " +
               e.getCause().getMessage());
 
-      throw toIOException(msg, e);
+      throw HddsServerUtil.toIOException(msg, e);
     }
 
     if (LOG.isDebugEnabled()) {
@@ -189,23 +190,13 @@ public class RDBStore implements DBStore {
     return columnFamiliesInDb;
   }
 
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
-  }
-
   @Override
   public void compactDB() throws IOException {
     if (db != null) {
       try {
         db.compactRange();
       } catch (RocksDBException e) {
-        throw toIOException("Failed to compact db", e);
+        throw HddsServerUtil.toIOException("Failed to compact db", e);
       }
     }
   }
@@ -270,7 +261,8 @@ public class RDBStore implements DBStore {
     try {
       return db.getLongProperty("rocksdb.estimate-num-keys");
     } catch (RocksDBException e) {
-      throw toIOException("Unable to get the estimated count.", e);
+      throw HddsServerUtil.toIOException(
+          "Unable to get the estimated count.", e);
     }
   }
 
@@ -330,7 +322,7 @@ public class RDBStore implements DBStore {
       flushOptions.setWaitForFlush(true);
       db.flush(flushOptions);
     } catch (RocksDBException e) {
-      throw toIOException("Unable to Flush RocksDB data", e);
+      throw HddsServerUtil.toIOException("Unable to Flush RocksDB data", e);
     }
   }
 
@@ -342,7 +334,7 @@ public class RDBStore implements DBStore {
         // be reconstructed using it.
         db.flushWal(sync);
       } catch (RocksDBException e) {
-        throw toIOException("Failed to flush db", e);
+        throw HddsServerUtil.toIOException("Failed to flush db", e);
       }
     }
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.StringUtils;
 
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.Holder;
 import org.rocksdb.ReadOptions;
@@ -72,22 +73,6 @@ class RDBTable implements Table<byte[], byte[]> {
   }
 
   /**
-   * Converts RocksDB exception to IOE.
-   * @param msg  - Message to add to exception.
-   * @param e - Original Exception.
-   * @return  IOE.
-   */
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
-  }
-
-  /**
    * Returns the Column family Handle.
    *
    * @return ColumnFamilyHandle.
@@ -103,7 +88,7 @@ class RDBTable implements Table<byte[], byte[]> {
     } catch (RocksDBException e) {
       LOG.error("Failed to write to DB. Key: {}", new String(key,
           StandardCharsets.UTF_8));
-      throw toIOException("Failed to put key-value to metadata "
+      throw HddsServerUtil.toIOException("Failed to put key-value to metadata "
           + "store", e);
     }
   }
@@ -147,8 +132,7 @@ class RDBTable implements Table<byte[], byte[]> {
       }
       return false;
     } catch (RocksDBException e) {
-      throw toIOException(
-          "Error in accessing DB. ", e);
+      throw HddsServerUtil.toIOException("Error in accessing DB. ", e);
     }
   }
 
@@ -157,7 +141,7 @@ class RDBTable implements Table<byte[], byte[]> {
     try {
       return db.get(handle, key);
     } catch (RocksDBException e) {
-      throw toIOException(
+      throw HddsServerUtil.toIOException(
           "Failed to get the value for the given key", e);
     }
   }
@@ -196,7 +180,7 @@ class RDBTable implements Table<byte[], byte[]> {
       }
       return null;
     } catch (RocksDBException e) {
-      throw toIOException("Error in accessing DB. ", e);
+      throw HddsServerUtil.toIOException("Error in accessing DB. ", e);
     }
   }
 
@@ -205,7 +189,7 @@ class RDBTable implements Table<byte[], byte[]> {
     try {
       db.delete(handle, key);
     } catch (RocksDBException e) {
-      throw toIOException("Failed to delete the given key", e);
+      throw HddsServerUtil.toIOException("Failed to delete the given key", e);
     }
   }
 
@@ -232,7 +216,8 @@ class RDBTable implements Table<byte[], byte[]> {
     try {
       return StringUtils.bytes2String(this.getHandle().getName());
     } catch (RocksDBException rdbEx) {
-      throw toIOException("Unable to get the table name.", rdbEx);
+      throw HddsServerUtil.toIOException(
+          "Unable to get the table name.", rdbEx);
     }
   }
 
@@ -246,7 +231,7 @@ class RDBTable implements Table<byte[], byte[]> {
     try {
       return db.getLongProperty(handle, "rocksdb.estimate-num-keys");
     } catch (RocksDBException e) {
-      throw toIOException(
+      throw HddsServerUtil.toIOException(
           "Failed to get estimated key count of table " + getName(), e);
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following method was defined in `RocksDBStore.java`, `RDBStore.java`, `RDBTable.java`, this pr aims to move it to `HddsServerUtil` which is a util class for server side components.
```java
/**
 * Converts RocksDB exception to IOE.
 * @param msg  - Message to add to exception.
 * @param e - Original Exception.
 * @return  IOE.
 */
public static IOException toIOException(String msg, RocksDBException e) {
  String statusCode = e.getStatus() == null ? "N/A" :
      e.getStatus().getCodeString();
  String errMessage = e.getMessage() == null ? "Unknown error" :
      e.getMessage();
  String output = msg + "; status : " + statusCode
      + "; message : " + errMessage;
  return new IOException(output, e);
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4768

## How was this patch tested?

No need more new tests.
