### PR TITLE
HDDS-4768. Refactor the repeated exception conversion method into a common util class

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -70,6 +70,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_R
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
+
+import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -487,4 +489,21 @@ public final class HddsServerUtil {
     }
     return metricsSystem;
   }
+
+  /**
+   * Converts RocksDB exception to IOE.
+   * @param msg  - Message to add to exception.
+   * @param e - Original Exception.
+   * @return  IOE.
+   */
+  public static IOException toIOException(String msg, RocksDBException e) {
+    String statusCode = e.getStatus() == null ? "N/A" :
+        e.getStatus().getCodeString();
+    String errMessage = e.getMessage() == null ? "Unknown error" :
+        e.getMessage();
+    String output = msg + "; status : " + statusCode
+        + "; message : " + errMessage;
+    return new IOException(output, e);
+  }
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/RocksDBStore.java
@@ -45,6 +45,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.toIOException;
+
 /**
  * RocksDB implementation of ozone metadata store.
  */
@@ -95,16 +97,6 @@ public class RocksDBStore implements MetadataStore {
       LOG.debug("[Option] maxOpenFiles= {}", options.maxOpenFiles());
       LOG.debug("[Option] writeBufferSize= {}", options.writeBufferSize());
     }
-  }
-
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -20,7 +20,6 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.eclipse.jetty.util.StringUtil;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.DBOptions;
@@ -35,6 +34,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.toIOException;
 
 /**
  * A Class that controls the standard config options of RocksDB.
@@ -135,7 +136,7 @@ public final class DBConfigFromFile {
               env, options, cfDescs, true);
 
         } catch (RocksDBException rdEx) {
-          HddsServerUtil.toIOException("Unable to find/open Options file.", rdEx);
+          toIOException("Unable to find/open Options file.", rdEx);
         }
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBConfigFromFile.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.utils.db;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.eclipse.jetty.util.StringUtil;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.DBOptions;
@@ -134,7 +135,7 @@ public final class DBConfigFromFile {
               env, options, cfDescs, true);
 
         } catch (RocksDBException rdEx) {
-          RDBTable.toIOException("Unable to find/open Options file.", rdEx);
+          HddsServerUtil.toIOException("Unable to find/open Options file.", rdEx);
         }
       }
     }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -50,6 +50,8 @@ import org.rocksdb.WriteOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.toIOException;
+
 /**
  * RocksDB Store that supports creating Tables in DB.
  */
@@ -187,16 +189,6 @@ public class RDBStore implements DBStore {
           columnFamiliesInDb);
     }
     return columnFamiliesInDb;
-  }
-
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBTable.java
@@ -39,6 +39,8 @@ import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.toIOException;
+
 /**
  * RocksDB implementation of ozone metadata store. This class should be only
  * used as part of TypedTable as it's underlying implementation to access the
@@ -69,22 +71,6 @@ class RDBTable implements Table<byte[], byte[]> {
     this.handle = handle;
     this.writeOptions = writeOptions;
     this.rdbMetrics = rdbMetrics;
-  }
-
-  /**
-   * Converts RocksDB exception to IOE.
-   * @param msg  - Message to add to exception.
-   * @param e - Original Exception.
-   * @return  IOE.
-   */
-  public static IOException toIOException(String msg, RocksDBException e) {
-    String statusCode = e.getStatus() == null ? "N/A" :
-        e.getStatus().getCodeString();
-    String errMessage = e.getMessage() == null ? "Unknown error" :
-        e.getMessage();
-    String output = msg + "; status : " + statusCode
-        + "; message : " + errMessage;
-    return new IOException(output, e);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following method was defined in `RocksDBStore.java`, `RDBStore.java`, `RDBTable.java`, this pr aims to move it to `HddsServerUtil` which is a util class for server side components.
```java
/**
 * Converts RocksDB exception to IOE.
 * @param msg  - Message to add to exception.
 * @param e - Original Exception.
 * @return  IOE.
 */
public static IOException toIOException(String msg, RocksDBException e) {
  String statusCode = e.getStatus() == null ? "N/A" :
      e.getStatus().getCodeString();
  String errMessage = e.getMessage() == null ? "Unknown error" :
      e.getMessage();
  String output = msg + "; status : " + statusCode
      + "; message : " + errMessage;
  return new IOException(output, e);
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4768

## How was this patch tested?

No need more new tests.
