### PR TITLE
HDDS-4769. Simplify insert operation of ContainerAttribute

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -84,7 +84,8 @@ public class ContainerAttribute<T> {
   }
 
   /**
-   * Insert or update the value in the Attribute map.
+   * Insert the value in the Attribute map, keep the original value if it exists
+   * already.
    *
    * @param key - The key to the set where the ContainerID should exist.
    * @param value - Actual Container ID.
@@ -97,14 +98,11 @@ public class ContainerAttribute<T> {
     if (attributeMap.containsKey(key)) {
       if (attributeMap.get(key).add(value)) {
         return true; //we inserted the value as it doesn’t exist in the set.
-      } else { // Failure indicates that this ContainerID exists in the Set
-        if (!attributeMap.get(key).remove(value)) {
-          LOG.error("Failure to remove the object from the Map.Key:{}, " +
-              "ContainerID: {}", key, value);
-          throw new SCMException("Failure to remove the object from the Map",
-              FAILED_TO_CHANGE_CONTAINER_STATE);
-        }
-        attributeMap.get(key).add(value);
+      } else {
+        // Failure indicates that this ContainerID exists in the Set, since
+        // ContainerID contains no information other than id, we keep the the
+        // old value.
+        LOG.debug("ContainerID: {} already exists in Map.Key :{}.", value, key);
         return true;
       }
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -94,23 +94,8 @@ public class ContainerAttribute<T> {
   public boolean insert(T key, ContainerID value) throws SCMException {
     Preconditions.checkNotNull(key);
     Preconditions.checkNotNull(value);
-
-    if (attributeMap.containsKey(key)) {
-      if (attributeMap.get(key).add(value)) {
-        return true; //we inserted the value as it doesn’t exist in the set.
-      } else { // Failure indicates that this ContainerID exists in the Set
-        return updateContainerID(key, value);
-      }
-    } else {
-      // This key does not exist, we need to allocate this key in the map.
-      // TODO: Replace TreeSet with FoldedTreeSet from HDFS Utils.
-      // Skipping for now, since FoldedTreeSet does not have implementations
-      // for headSet and TailSet. We need those calls.
-      this.attributeMap.put(key, new TreeSet<>());
-      // This should not fail, we just allocated this object.
-      attributeMap.get(key).add(value);
-      return true;
-    }
+    attributeMap.computeIfAbsent(key, any -> new TreeSet<>()).add(value);
+    return true;
   }
 
   /**
@@ -245,20 +230,5 @@ public class ContainerAttribute<T> {
       }
       throw ex;
     }
-  }
-
-  /**
-   * Update the ContainerID for the specified key.
-   *
-   * @param key - Key to update.
-   * @param value - ContainerID.
-   * @return true or false
-   */
-  private boolean updateContainerID(T key, ContainerID value) {
-    // Since ContainerID contains no information other than id, we keep the the
-    // old value.
-    LOG.debug("Updating ContainerID: {} in Map.Key :{} by keeping old value.",
-        value, key);
-    return true;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -98,12 +98,8 @@ public class ContainerAttribute<T> {
     if (attributeMap.containsKey(key)) {
       if (attributeMap.get(key).add(value)) {
         return true; //we inserted the value as it doesn’t exist in the set.
-      } else {
-        // Failure indicates that this ContainerID exists in the Set, since
-        // ContainerID contains no information other than id, we keep the the
-        // old value.
-        LOG.debug("ContainerID: {} already exists in Map.Key :{}.", value, key);
-        return true;
+      } else { // Failure indicates that this ContainerID exists in the Set
+        return updateContainerID(key, value);
       }
     } else {
       // This key does not exist, we need to allocate this key in the map.
@@ -249,5 +245,20 @@ public class ContainerAttribute<T> {
       }
       throw ex;
     }
+  }
+
+  /**
+   * Update the ContainerID for the specified key.
+   *
+   * @param key - Key to update.
+   * @param value - ContainerID.
+   * @return true or false
+   */
+  private boolean updateContainerID(T key, ContainerID value) {
+    // Since ContainerID contains no information other than id, we keep the the
+    // old value.
+    LOG.debug("Updating ContainerID: {} in Map.Key :{} by keeping old value.",
+        value, key);
+    return true;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
@@ -27,7 +27,6 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.NavigableSet;
 
 /**
  * Test ContainerAttribute management.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerAttribute.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.NavigableSet;
 
 /**
  * Test ContainerAttribute management.
@@ -45,7 +46,7 @@ public class TestContainerAttribute {
         containerAttribute.getCollection(1).size());
     Assert.assertTrue(containerAttribute.getCollection(1).contains(id));
 
-    // Insert again and verify that it overwrites an existing value.
+    // Insert again and verify that the new ContainerId is inserted.
     ContainerID newId =
         new ContainerID(42);
     containerAttribute.insert(1, newId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Keep the original value in ContainerAttribute when inserting ContainerId.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4769

## How was this patch tested?

Unit test in TestContainerAttribute.testInsert() validates the correctness.
