### PR TITLE
HDDS-3805. [OFS] Remove usage of OzoneClientAdapter interface

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -81,7 +81,9 @@ public class ObjectStore {
     proxy = null;
   }
 
-  @VisibleForTesting
+  /**
+   * Returns the ClientProtocol of the ObjectStore.
+   */
   public ClientProtocol getClientProxy() {
     return proxy;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -121,7 +121,7 @@ public class TestRootedOzoneFileSystem {
   private static FileSystem fs;
   private static RootedOzoneFileSystem ofs;
   private static ObjectStore objectStore;
-  private static BasicRootedOzoneClientAdapterImpl impl;
+  private static BasicRootedOzoneFileSystemHelper helper;
   private static Trash trash;
 
   private static String volumeName;
@@ -164,7 +164,7 @@ public class TestRootedOzoneFileSystem {
         TrashPolicy.class);
     trash = new Trash(conf);
     ofs = (RootedOzoneFileSystem) fs;
-    impl = ofs.getImpl();
+    helper = ofs.getHelper();
   }
 
   @AfterClass
@@ -696,7 +696,7 @@ public class TestRootedOzoneFileSystem {
    */
   private List<FileStatus> callAdapterListStatus(String pathStr,
       boolean recursive, String startPath, long numEntries) throws IOException {
-    return impl.listStatus(pathStr, recursive, startPath, numEntries,
+    return helper.listStatus(pathStr, recursive, startPath, numEntries,
         ofs.getUri(), ofs.getWorkingDirectory(), ofs.getUsername())
         .stream().map(ofs::convertFileStatus).collect(Collectors.toList());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -121,7 +121,7 @@ public class TestRootedOzoneFileSystem {
   private static FileSystem fs;
   private static RootedOzoneFileSystem ofs;
   private static ObjectStore objectStore;
-  private static BasicRootedOzoneClientAdapterImpl adapter;
+  private static BasicRootedOzoneClientAdapterImpl impl;
   private static Trash trash;
 
   private static String volumeName;
@@ -164,7 +164,7 @@ public class TestRootedOzoneFileSystem {
         TrashPolicy.class);
     trash = new Trash(conf);
     ofs = (RootedOzoneFileSystem) fs;
-    adapter = (BasicRootedOzoneClientAdapterImpl) ofs.getAdapter();
+    impl = ofs.getImpl();
   }
 
   @AfterClass
@@ -696,7 +696,7 @@ public class TestRootedOzoneFileSystem {
    */
   private List<FileStatus> callAdapterListStatus(String pathStr,
       boolean recursive, String startPath, long numEntries) throws IOException {
-    return adapter.listStatus(pathStr, recursive, startPath, numEntries,
+    return impl.listStatus(pathStr, recursive, startPath, numEntries,
         ofs.getUri(), ofs.getWorkingDirectory(), ofs.getUsername())
         .stream().map(ofs::convertFileStatus).collect(Collectors.toList());
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -228,11 +228,6 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     bucket.renameKey(key, newKeyName);
   }
 
-  @Override
-  public void rename(String pathStr, String newPath) throws IOException {
-    throw new IOException("Please use renameKey instead for o3fs.");
-  }
-
   /**
    * Helper method to create an directory specified by key name in bucket.
    *

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -98,8 +98,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   private URI uri;
   private String userName;
   private Path workingDir;
-  private OzoneClientAdapter adapter;
-  private BasicRootedOzoneClientAdapterImpl adapterImpl;
+  // Using impl directly rather than OzoneClientAdapter in OFS.
+  private BasicRootedOzoneClientAdapterImpl impl;
 
   private static final String URI_EXCEPTION_TEXT =
       "URL should be one of the following formats: " +
@@ -145,8 +145,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       LOG.trace("Ozone URI for OFS initialization is " + uri);
 
       ConfigurationSource source = getConfSource();
-      this.adapter = createAdapter(source, omHostOrServiceId, omPort);
-      this.adapterImpl = (BasicRootedOzoneClientAdapterImpl) this.adapter;
+      this.impl = new BasicRootedOzoneClientAdapterImpl(
+          omHostOrServiceId, omPort, source);
 
       try {
         this.userName =
@@ -163,15 +163,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
   }
 
-  protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
-      String omHost, int omPort) throws IOException {
-    return new BasicRootedOzoneClientAdapterImpl(omHost, omPort, conf);
-  }
-
   @Override
   public void close() throws IOException {
     try {
-      adapter.close();
+      impl.close();
     } finally {
       super.close();
     }
@@ -194,7 +189,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     LOG.trace("open() path: {}", path);
     final String key = pathToKey(path);
     return new FSDataInputStream(
-        new OzoneFSInputStream(adapter.readFile(key), statistics));
+        new OzoneFSInputStream(impl.readFile(key), statistics));
   }
 
   protected void incrementCounter(Statistic statistic) {
@@ -234,7 +229,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   private FSDataOutputStream createOutputStream(String key, short replication,
       boolean overwrite, boolean recursive) throws IOException {
-    return new FSDataOutputStream(adapter.createFile(key,
+    return new FSDataOutputStream(impl.createFile(key,
         replication, overwrite, recursive), statistics);
   }
 
@@ -249,7 +244,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     private final String srcPath;
     private final String dstPath;
     private final OzoneBucket bucket;
-    private final BasicRootedOzoneClientAdapterImpl adapterImpl;
 
     RenameIterator(Path srcPath, Path dstPath)
         throws IOException {
@@ -259,16 +253,14 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       LOG.trace("rename from:{} to:{}", this.srcPath, this.dstPath);
       // Initialize bucket here to reduce number of RPC calls
       OFSPath ofsPath = new OFSPath(srcPath);
-      // TODO: Refactor later.
-      adapterImpl = (BasicRootedOzoneClientAdapterImpl) adapter;
-      this.bucket = adapterImpl.getBucket(ofsPath, false);
+      this.bucket = impl.getBucket(ofsPath, false);
     }
 
     @Override
     boolean processKeyPath(List<String> keyPathList) throws IOException {
       for (String keyPath : keyPathList) {
         String newPath = dstPath.concat(keyPath.substring(srcPath.length()));
-        adapterImpl.rename(this.bucket, keyPath, newPath);
+        impl.rename(this.bucket, keyPath, newPath);
       }
       return true;
     }
@@ -411,7 +403,6 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   private class DeleteIterator extends OzoneListingIterator {
     private final boolean recursive;
     private final OzoneBucket bucket;
-    private final BasicRootedOzoneClientAdapterImpl adapterImpl;
 
     DeleteIterator(Path f, boolean recursive)
         throws IOException {
@@ -424,15 +415,13 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       }
       // Initialize bucket here to reduce number of RPC calls
       OFSPath ofsPath = new OFSPath(f);
-      // TODO: Refactor later.
-      adapterImpl = (BasicRootedOzoneClientAdapterImpl) adapter;
-      this.bucket = adapterImpl.getBucket(ofsPath, false);
+      this.bucket = impl.getBucket(ofsPath, false);
     }
 
     @Override
     boolean processKeyPath(List<String> keyPathList) {
       LOG.trace("Deleting keys: {}", keyPathList);
-      boolean succeed = adapterImpl.deleteObjects(this.bucket, keyPathList);
+      boolean succeed = impl.deleteObjects(this.bucket, keyPathList);
       // if recursive delete is requested ignore the return value of
       // deleteObject and issue deletes for other keys.
       return recursive || succeed;
@@ -505,8 +494,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
         String volumeName = ofsPath.getVolumeName();
         if (recursive) {
           // Delete all buckets first
-          OzoneVolume volume =
-              adapterImpl.getObjectStore().getVolume(volumeName);
+          OzoneVolume volume = impl.getVolumeDetails(volumeName);
           Iterator<? extends OzoneBucket> it = volume.listBuckets("");
           String prefixVolumePathStr = addTrailingSlashIfNeeded(f.toString());
           while (it.hasNext()) {
@@ -516,7 +504,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
           }
         }
         try {
-          adapterImpl.getObjectStore().deleteVolume(volumeName);
+          impl.deleteVolume(volumeName);
           return true;
         } catch (OMException ex) {
           // volume is not empty
@@ -532,8 +520,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
       // Handle delete bucket
       if (ofsPath.isBucket()) {
-        OzoneVolume volume =
-            adapterImpl.getObjectStore().getVolume(ofsPath.getVolumeName());
+        OzoneVolume volume = impl.getVolumeDetails(ofsPath.getVolumeName());
         try {
           volume.deleteBucket(ofsPath.getBucketName());
           return result;
@@ -549,7 +536,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     } else {
       LOG.debug("delete: Path is a file: {}", f);
-      result = adapter.deleteObject(key);
+      result = impl.deleteObject(key);
     }
 
     if (result) {
@@ -586,7 +573,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     if (!key.isEmpty() && !o3Exists(f)) {
       LOG.debug("Creating new fake directory at {}", f);
       String dirKey = addTrailingSlashIfNeeded(key);
-      adapter.createDirectory(dirKey);
+      impl.createDirectory(dirKey);
     }
   }
 
@@ -619,7 +606,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
     do {
       tmpStatusList =
-          adapter.listStatus(pathToKey(f), false, startPath,
+          impl.listStatus(pathToKey(f), false, startPath,
               numEntries, uri, workingDir, getUsername())
               .stream()
               .map(this::convertFileStatus)
@@ -653,7 +640,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public Token<?> getDelegationToken(String renewer) throws IOException {
-    return adapter.getDelegationToken(renewer);
+    return impl.getDelegationToken(renewer);
   }
 
   /**
@@ -664,7 +651,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    */
   @Override
   public String getCanonicalServiceName() {
-    return adapter.getCanonicalServiceName();
+    return impl.getCanonicalServiceName();
   }
 
   /**
@@ -697,7 +684,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public Collection<FileStatus> getTrashRoots(boolean allUsers) {
     // Since get all trash roots for one or more users requires listing all
     // volumes and buckets, we will let adapter impl handle it.
-    return adapterImpl.getTrashRoots(allUsers, this);
+    return impl.getTrashRoots(allUsers, this);
   }
 
   /**
@@ -708,7 +695,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
    * @throws IOException
    */
   private boolean mkdir(Path path) throws IOException {
-    return adapter.createDirectory(pathToKey(path));
+    return impl.createDirectory(pathToKey(path));
   }
 
   @Override
@@ -742,7 +729,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     FileStatus fileStatus = null;
     try {
       fileStatus = convertFileStatus(
-          adapter.getFileStatus(key, uri, qualifiedPath, getUsername()));
+          impl.getFileStatus(key, uri, qualifiedPath, getUsername()));
     } catch (OMException ex) {
       if (ex.getResult().equals(OMException.ResultCodes.KEY_NOT_FOUND) ||
           ex.getResult().equals(OMException.ResultCodes.BUCKET_NOT_FOUND) ||
@@ -766,7 +753,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
 
   @Override
   public short getDefaultReplication() {
-    return adapter.getDefaultReplication();
+    return impl.getDefaultReplication();
   }
 
   @Override
@@ -912,7 +899,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       if (status.isDirectory()) {
         this.pathKey = addTrailingSlashIfNeeded(pathKey);
       }
-      keyIterator = adapter.listKeys(pathKey);
+      keyIterator = impl.listKeys(pathKey);
     }
 
     /**
@@ -989,8 +976,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     }
   }
 
-  public OzoneClientAdapter getAdapter() {
-    return adapter;
+  public BasicRootedOzoneClientAdapterImpl getImpl() {
+    return impl;
   }
 
   public boolean isEmpty(CharSequence cs) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystemHelper.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystemHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -6,9 +6,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -83,16 +84,21 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .BUCKET_NOT_FOUND;
 
 /**
- * Basic Implementation of the RootedOzoneFileSystem calls.
- * <p>
+ * Helper implementation of RootedOzoneFileSystem (OFS) calls.
+ *
+ * Previously BasicRootedOzoneClientAdapterImpl. Might be merged with
+ * BasicRootedOzoneFileSystem in the future.
+ *
  * This is the minimal version which doesn't include any statistics.
- * <p>
+ *
  * For full featured version use RootedOzoneClientAdapterImpl.
  */
-public class BasicRootedOzoneClientAdapterImpl {
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class BasicRootedOzoneFileSystemHelper {
 
   static final Logger LOG =
-      LoggerFactory.getLogger(BasicRootedOzoneClientAdapterImpl.class);
+      LoggerFactory.getLogger(BasicRootedOzoneFileSystemHelper.class);
 
   private ObjectStore objectStore;
   private ClientProtocol proxy;
@@ -106,7 +112,7 @@ public class BasicRootedOzoneClientAdapterImpl {
    *
    * @throws IOException In case of a problem.
    */
-  public BasicRootedOzoneClientAdapterImpl() throws IOException {
+  public BasicRootedOzoneFileSystemHelper() throws IOException {
     this(createConf());
   }
 
@@ -121,12 +127,12 @@ public class BasicRootedOzoneClientAdapterImpl {
     }
   }
 
-  public BasicRootedOzoneClientAdapterImpl(OzoneConfiguration conf)
+  public BasicRootedOzoneFileSystemHelper(OzoneConfiguration conf)
       throws IOException {
     this(null, -1, conf);
   }
 
-  public BasicRootedOzoneClientAdapterImpl(String omHost, int omPort,
+  public BasicRootedOzoneFileSystemHelper(String omHost, int omPort,
       ConfigurationSource hadoopConf) throws IOException {
 
     ClassLoader contextClassLoader =

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -46,9 +46,6 @@ public interface OzoneClientAdapter {
 
   void renameKey(String key, String newKeyName) throws IOException;
 
-  // Users should use rename instead of renameKey in OFS.
-  void rename(String pathStr, String newPath) throws IOException;
-
   boolean createDirectory(String keyName) throws IOException;
 
   boolean deleteObject(String keyName);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneClientAdapterImpl.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
  * Implementation of the RootedOzoneFileSystem calls.
  */
 public class RootedOzoneClientAdapterImpl
-    extends BasicRootedOzoneClientAdapterImpl {
+    extends BasicRootedOzoneFileSystemHelper {
 
   private OzoneFSStorageStatistics storageStatistics;
 

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getAdapter().getKeyProvider();
+    return getImpl().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getAdapter().getKeyProviderUri();
+    return getImpl().getKeyProviderUri();
   }
 
   @Override
@@ -84,12 +83,5 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);
     }
-  }
-
-  @Override
-  protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
-      String omHost, int omPort) throws IOException {
-    return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
-        storageStatistics);
   }
 }

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -50,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getImpl().getKeyProvider();
+    return getHelper().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getImpl().getKeyProviderUri();
+    return getHelper().getKeyProviderUri();
   }
 
   @Override

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.KeyProviderTokenIssuer;
 import org.apache.hadoop.fs.FileSystem;
@@ -51,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getAdapter().getKeyProvider();
+    return getImpl().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getAdapter().getKeyProviderUri();
+    return getImpl().getKeyProviderUri();
   }
 
   @Override
@@ -84,12 +83,5 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
     if (storageStatistics != null) {
       storageStatistics.incrementCounter(statistic, count);
     }
-  }
-
-  @Override
-  protected OzoneClientAdapter createAdapter(ConfigurationSource conf,
-      String omHost, int omPort) throws IOException {
-    return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
-        storageStatistics);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -50,12 +50,12 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
 
   @Override
   public KeyProvider getKeyProvider() throws IOException {
-    return getImpl().getKeyProvider();
+    return getHelper().getKeyProvider();
   }
 
   @Override
   public URI getKeyProviderUri() throws IOException {
-    return getImpl().getKeyProviderUri();
+    return getHelper().getKeyProviderUri();
   }
 
   @Override


### PR DESCRIPTION
3rd time's the charm

## What changes were proposed in this pull request?

Use ClientProtocol directly in Adapter and FS. Completely remove the usage of OzoneClientAdapter interface in OFS.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3805

## How was this patch tested?

All existing UTs/robots should pass as-is.

## What is the difference of this PR since #1363?

1. Rebased to the latest master branch
2. Renamed internal class `BasicRootedOzoneClientAdapterImpl` to `BasicRootedOzoneFileSystemHelper` as [suggested](https://github.com/apache/ozone/pull/1363#issuecomment-694144300).