### PR TITLE
HDDS-4772. Upgrade Ratis Thirdparty to 0.6.0 for fixing ozone codebase build error

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -118,6 +118,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.apache.ratis</groupId>
     </dependency>
     <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-thirdparty-misc</artifactId>
+      <version>${ratis.thirdparty.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_annotations</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <ratis.version>1.1.0-eb66796d-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>0.6.0-SNAPSHOT</ratis.thirdparty.version>
+    <ratis.thirdparty.version>0.6.0</ratis.thirdparty.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade ratis-thirdparty to recently released 0.6.0, because 0.6.0-SNAPSHOT is no longer in the [apache repo](https://repository.apache.org/content/repositories/snapshots).

```
Failure to find org.apache.ratis:ratis-thirdparty-misc:jar:0.6.0-SNAPSHOT in 
https://repository.apache.org/content/repositories/snapshots was cached in the local repository, 
resolution will not be reattempted until the update interval of apache.snapshots.https has elapsed or updates are forced
```

### Links

https://github.com/apache/incubator-ratis/pull/412

https://github.com/apache/incubator-ratis-thirdparty

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4772

## How was this patch tested?

CI checks.