### PR TITLE
HDDS-4763. Owner field of S3AUTHINFO type delegation token should be validated

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -472,7 +472,11 @@ public class OzoneDelegationTokenSecretManager
   private byte[] validateS3AuthInfo(OzoneTokenIdentifier identifier)
       throws InvalidToken {
     LOG.trace("Validating S3AuthInfo for identifier:{}", identifier);
-    if (!identifier.getOwner().equals(identifier.getAwsAccessId())) {
+    if (identifier.getOwner() == null) {
+      throw new InvalidToken(
+          "Owner is missing from the S3 auth token");
+    }
+    if (!identifier.getOwner().toString().equals(identifier.getAwsAccessId())) {
       LOG.error(
           "Owner and AWSAccessId is different in the S3 token. Possible "
               + " security attack: {}",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -472,6 +472,15 @@ public class OzoneDelegationTokenSecretManager
   private byte[] validateS3AuthInfo(OzoneTokenIdentifier identifier)
       throws InvalidToken {
     LOG.trace("Validating S3AuthInfo for identifier:{}", identifier);
+    if (!identifier.getOwner().equals(identifier.getAwsAccessId())) {
+      LOG.error(
+          "Owner and AWSAccessId is different in the S3 token. Possible "
+              + " security attack: {}",
+          identifier);
+      throw new InvalidToken(
+          "Invalid S3 identifier: owner=" + identifier.getOwner()
+              + ", awsAccessId=" + identifier.getAwsAccessId());
+    }
     String awsSecret;
     try {
       awsSecret = s3SecretManager.getS3UserSecretString(identifier

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneDelegationTokenSecretManager.java
@@ -18,6 +18,16 @@
 
 package org.apache.hadoop.ozone.security;
 
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
@@ -36,25 +46,15 @@ import org.apache.hadoop.security.token.SecretManager;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.test.LambdaTestUtils;
 import org.apache.hadoop.util.Time;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.Signature;
-import java.security.cert.X509Certificate;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
 
 /**
  * Test class for {@link OzoneDelegationTokenSecretManager}.
@@ -342,6 +342,7 @@ public class TestOzoneDelegationTokenSecretManager {
         "20190221/us-west-1/s3/aws4_request\n" +
         "c297c080cce4e0927779823d3fd1f5cae71481a8f7dfc7e18d91851294efc47d");
     identifier.setAwsAccessId("testuser1");
+    identifier.setOwner(new Text("testuser1"));
     secretManager.retrievePassword(identifier);
   }
 
@@ -360,6 +361,7 @@ public class TestOzoneDelegationTokenSecretManager {
         "20190221/us-west-1/s3/aws4_request\n" +
         "c297c080cce4e0927779823d3fd1f5cae71481a8f7dfc7e18d91851294efc47d");
     identifier.setAwsAccessId("testuser2");
+    identifier.setOwner(new Text("testuser2"));
     // Case 1: User don't have aws secret set.
     LambdaTestUtils.intercept(SecretManager.InvalidToken.class, " No S3 " +
             "secret found for S3 identifier",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding a check for S3AUTH token validation. 

Please see the jira for the motivation. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4763

## How was this patch tested?

Test method is explained in the Jira (with the code to test it).