### PR TITLE
HDDS-4778. Add transactionId into deletingTxIDs when remove it from DB

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -165,6 +165,7 @@ public class DeletedBlockLogStateManagerImpl
   @Override
   public void removeTransactionsFromDB(ArrayList<Long> txIDs)
       throws IOException {
+    deletingTxIDs.addAll(txIDs);
     for (Long txID : txIDs) {
       deletedTable.deleteWithBatch(
           transactionBuffer.getCurrentBatchOperation(), txID);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add transactionId into deletingTxIDs when remove it from DB

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4778

## How was this patch tested?

