### PR TITLE
HDDS-4482. SCM should be able to persist CRL

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -392,4 +392,8 @@ public final class OzoneConsts {
   public static final String OM_RATIS_SNAPSHOT_DIR = "snapshot";
 
   public static final long DEFAULT_OM_UPDATE_ID = -1L;  
+
+  // CRL Sequence Id
+  public static final String CRL_SEQUENCE_ID_KEY = "CRL_SEQUENCE_ID";
+
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CRLApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CRLApprover.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.security.x509.certificate.authority;
+
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+
+import java.security.cert.CRLException;
+import java.security.cert.X509CRL;
+
+/**
+ * CRL Approver interface is used to sign CRLs.
+ */
+public interface CRLApprover {
+
+  /**
+   * Signs a CRL.
+   * @param builder - CRL builder instance with CRL info to be signed.
+   * @return Signed CRL.
+   * @throws CRLException - On Error
+   * @throws OperatorCreationException - on Error.
+   */
+  X509CRL sign(X509v2CRLBuilder builder)
+      throws CRLException, OperatorCreationException;
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -31,6 +31,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
@@ -107,11 +108,13 @@ public interface CertificateServer {
    * @param serialIDs       - List of serial IDs of Certificates to be revoked.
    * @param reason          - Reason for revocation.
    * @param securityConfig  - Security Configuration.
+   * @param revocationTime  - Revocation time for the certificates.
    * @return Future that gives a list of certificates that were revoked.
    */
   Future<Optional<Long>> revokeCertificates(
       List<BigInteger> serialIDs,
       CRLReason reason,
+      Date revocationTime,
       SecurityConfig securityConfig);
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -23,13 +23,16 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType;
+import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Future;
 
 /**
@@ -46,7 +49,7 @@ public interface CertificateServer {
    * @throws SCMSecurityException - Throws if the init fails.
    */
   void init(SecurityConfig securityConfig, CAType type)
-      throws SCMSecurityException;
+      throws IOException;
 
   /**
    * Returns the CA Certificate for this CA.
@@ -101,14 +104,15 @@ public interface CertificateServer {
   /**
    * Revokes a Certificate issued by this CertificateServer.
    *
-   * @param certificates - List of Certificates to revoke.
-   * @param reason - Reason for revocation.
-   * @param securityConfig - Security Configuration.
-   * @return Future that tells us what happened.
+   * @param serialIDs       - List of serial IDs of Certificates to be revoked.
+   * @param reason          - Reason for revocation.
+   * @param securityConfig  - Security Configuration.
+   * @return Future that gives a list of certificates that were revoked.
    */
-  Future<Boolean> revokeCertificates(List<X509Certificate> certificates,
-                                     int reason,
-                                     SecurityConfig securityConfig);
+  Future<Optional<Long>> revokeCertificates(
+      List<BigInteger> serialIDs,
+      CRLReason reason,
+      SecurityConfig securityConfig);
 
   /**
    * List certificates.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -101,26 +101,22 @@ public interface CertificateServer {
   /**
    * Revokes a Certificate issued by this CertificateServer.
    *
-   * @param certificate - Certificate to revoke
-   * @param approver - Approval process to follow.
+   * @param certificates - List of Certificates to revoke.
+   * @param reason - Reason for revocation.
+   * @param securityConfig - Security Configuration.
    * @return Future that tells us what happened.
-   * @throws SCMSecurityException - on Error.
    */
-  Future<Boolean> revokeCertificate(X509Certificate certificate,
-      ApprovalType approver) throws SCMSecurityException;
-
-  /**
-   * TODO : CRL, OCSP etc. Later. This is the start of a CertificateServer
-   * framework.
-   */
+  Future<Boolean> revokeCertificates(List<X509Certificate> certificates,
+                                     int reason,
+                                     SecurityConfig securityConfig);
 
   /**
    * List certificates.
    * @param type            - node type: OM/SCM/DN
    * @param startSerialId   - start certificate serial id
    * @param count           - max number of certificates returned in a batch
-   * @return
-   * @throws IOException
+   * @return List of X509 Certificates.
+   * @throws IOException - On Failure
    */
   List<X509Certificate> listCertificate(HddsProtos.NodeType type,
       long startSerialId, int count, boolean isRevoked) throws IOException;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -20,9 +20,12 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.bouncycastle.cert.X509CertificateHolder;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
@@ -47,12 +50,21 @@ public interface CertificateStore {
                              X509Certificate certificate) throws IOException;
 
   /**
-   * Moves a certificate in a transactional manner from valid certificate to
+   * Adds the certificates to be revoked to a new CRL and moves all the
+   * certificates in a transactional manner from valid certificate to
    * revoked certificate state.
-   * @param serialID - Serial ID of the certificate.
+   * @param certificates - List of X509 Certificates to be revoked.
+   * @param caCertificateHolder - X509 Certificate Holder of the CA.
+   * @param reason - CRLReason for revocation.
+   * @param securityConfig - Security Configuration.
+   * @param keyPair - Public and Private key of the CA.
    * @throws IOException
    */
-  void revokeCertificate(BigInteger serialID) throws IOException;
+  void revokeCertificates(List<X509Certificate> certificates,
+                          X509CertificateHolder caCertificateHolder,
+                          int reason, SecurityConfig securityConfig,
+                          KeyPair keyPair)
+      throws IOException;
 
   /**
    * Deletes an expired certificate from the store. Please note: We don't
@@ -65,7 +77,7 @@ public interface CertificateStore {
   /**
    * Retrieves a Certificate based on the Serial number of that certificate.
    * @param serialID - ID of the certificate.
-   * @param certType
+   * @param certType - Whether its Valid or Revoked certificate.
    * @return X509Certificate
    * @throws IOException
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -26,6 +26,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -52,17 +53,23 @@ public interface CertificateStore {
   /**
    * Adds the certificates to be revoked to a new CRL and moves all the
    * certificates in a transactional manner from valid certificate to
-   * revoked certificate state.
+   * revoked certificate state. Returns an empty {@code Optional} instance if
+   * the certificates were invalid / not found / already revoked and no CRL
+   * was generated. Otherwise, returns the newly generated CRL sequence ID.
    * @param serialIDs - List of Serial IDs of Certificates to be revoked.
    * @param caCertificateHolder - X509 Certificate Holder of the CA.
    * @param reason - CRLReason for revocation.
+   * @param revocationTime - Revocation Time for the certificates.
    * @param approver - CRL approver to sign the CRL.
-   * @return CRL sequence ID.
+   * @return An empty {@code Optional} instance if no CRL was generated.
+   * Otherwise, returns the newly generated CRL sequence ID.
    * @throws IOException - on failure.
    */
   Optional<Long> revokeCertificates(List<BigInteger> serialIDs,
                                     X509CertificateHolder caCertificateHolder,
-                                    CRLReason reason, CRLApprover approver)
+                                    CRLReason reason,
+                                    Date revocationTime,
+                                    CRLApprover approver)
       throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -20,14 +20,14 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * This interface allows the DefaultCA to be portable and use different DB
@@ -53,17 +53,16 @@ public interface CertificateStore {
    * Adds the certificates to be revoked to a new CRL and moves all the
    * certificates in a transactional manner from valid certificate to
    * revoked certificate state.
-   * @param certificates - List of X509 Certificates to be revoked.
+   * @param serialIDs - List of Serial IDs of Certificates to be revoked.
    * @param caCertificateHolder - X509 Certificate Holder of the CA.
    * @param reason - CRLReason for revocation.
-   * @param securityConfig - Security Configuration.
-   * @param keyPair - Public and Private key of the CA.
-   * @throws IOException
+   * @param approver - CRL approver to sign the CRL.
+   * @return CRL sequence ID.
+   * @throws IOException - on failure.
    */
-  void revokeCertificates(List<X509Certificate> certificates,
-                          X509CertificateHolder caCertificateHolder,
-                          int reason, SecurityConfig securityConfig,
-                          KeyPair keyPair)
+  Optional<Long> revokeCertificates(List<BigInteger> serialIDs,
+                                    X509CertificateHolder caCertificateHolder,
+                                    CRLReason reason, CRLApprover approver)
       throws IOException;
 
   /**
@@ -79,7 +78,7 @@ public interface CertificateStore {
    * @param serialID - ID of the certificate.
    * @param certType - Whether its Valid or Revoked certificate.
    * @return X509Certificate
-   * @throws IOException
+   * @throws IOException - on failure.
    */
   X509Certificate getCertificateByID(BigInteger serialID, CertType certType)
       throws IOException;
@@ -91,7 +90,7 @@ public interface CertificateStore {
    * @param count - max number of certs returned.
    * @param certType cert type (valid/revoked).
    * @return list of X509 certificates.
-   * @throws IOException
+   * @throws IOException - on failure.
    */
   List<X509Certificate> listCertificate(HddsProtos.NodeType role,
       BigInteger startSerialID, int count, CertType certType)

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -54,6 +54,7 @@ import java.security.spec.InvalidKeySpecException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -281,6 +282,7 @@ public class DefaultCAServer implements CertificateServer {
   public Future<Optional<Long>> revokeCertificates(
       List<BigInteger> certificates,
       CRLReason reason,
+      Date revocationTime,
       SecurityConfig securityConfig) {
     CompletableFuture<Optional<Long>> revoked = new CompletableFuture<>();
     if (CollectionUtils.isEmpty(certificates)) {
@@ -291,7 +293,7 @@ public class DefaultCAServer implements CertificateServer {
     try {
       revoked.complete(
           store.revokeCertificates(certificates,
-              getCACertificate(), reason, crlApprover)
+              getCACertificate(), reason, revocationTime, crlApprover)
       );
     } catch (IOException ex) {
       LOG.error("Revoking the certificate failed.", ex.getCause());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCRLApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCRLApprover.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.security.x509.certificate.authority;
+
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CRLCodec;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+import java.security.PrivateKey;
+import java.security.cert.CRLException;
+import java.security.cert.X509CRL;
+
+/**
+ * Default CRL Approver used by the DefaultCA.
+ */
+public class DefaultCRLApprover implements CRLApprover {
+
+  private SecurityConfig config;
+  private PrivateKey caPrivate;
+
+  public DefaultCRLApprover(SecurityConfig config, PrivateKey caPrivate) {
+    this.config = config;
+    this.caPrivate = caPrivate;
+  }
+
+  @Override
+  public X509CRL sign(X509v2CRLBuilder builder)
+      throws CRLException, OperatorCreationException {
+    JcaContentSignerBuilder contentSignerBuilder =
+        new JcaContentSignerBuilder(config.getSignatureAlgo());
+
+    contentSignerBuilder.setProvider(config.getProvider());
+    X509CRLHolder crlHolder =
+        builder.build(contentSignerBuilder.build(caPrivate));
+
+    return CRLCodec.getX509CRL(crlHolder);
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.security.x509.crl;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CRLCodec;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509CRL;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Class that wraps Certificate Revocation List Info.
+ */
+public class CRLInfo implements Comparator<CRLInfo>,
+    Comparable<CRLInfo> {
+
+  private X509CRL x509CRL;
+  private long creationTimestamp;
+
+  private CRLInfo(X509CRL x509CRL, long creationTimestamp) {
+    this.x509CRL = x509CRL;
+    this.creationTimestamp = creationTimestamp;
+  }
+
+  /**
+   * Constructor for CRLInfo. Needed for serialization findbugs.
+   */
+  public CRLInfo() {
+  }
+
+  public static CRLInfo fromProtobuf(HddsProtos.CRLInfoProto info)
+      throws IOException, CRLException, CertificateException {
+    CRLInfo.Builder builder = new CRLInfo.Builder();
+    return builder
+        .setX509CRL(CRLCodec.getX509CRL(info.getX509CRL()))
+        .setCreationTimestamp(info.getCreationTimestamp())
+        .build();
+  }
+
+  public HddsProtos.CRLInfoProto getProtobuf() throws SCMSecurityException {
+    HddsProtos.CRLInfoProto.Builder builder =
+        HddsProtos.CRLInfoProto.newBuilder();
+
+    return builder.setX509CRL(CRLCodec.getPEMEncodedString(getX509CRL()))
+        .setCreationTimestamp(getCreationTimestamp())
+        .build();
+  }
+
+  public X509CRL getX509CRL() {
+    return x509CRL;
+  }
+
+  public long getCreationTimestamp() {
+    return creationTimestamp;
+  }
+
+  /**
+   * Compares this object with the specified object for order.  Returns a
+   * negative integer, zero, or a positive integer as this object is less
+   * than, equal to, or greater than the specified object.
+   *
+   * @param o the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object
+   * is less than, equal to, or greater than the specified object.
+   * @throws NullPointerException if the specified object is null
+   * @throws ClassCastException   if the specified object's type prevents it
+   *                              from being compared to this object.
+   */
+  @Override
+  public int compareTo(@NotNull CRLInfo o) {
+    return this.compare(this, o);
+  }
+
+  /**
+   * Compares its two arguments for order.  Returns a negative integer,
+   * zero, or a positive integer as the first argument is less than, equal
+   * to, or greater than the second.<p>
+   * <p>
+   *
+   * @param o1 the first object to be compared.
+   * @param o2 the second object to be compared.
+   * @return a negative integer, zero, or a positive integer as the
+   * first argument is less than, equal to, or greater than the
+   * second.
+   * @throws NullPointerException if an argument is null and this
+   *                              comparator does not permit null arguments
+   * @throws ClassCastException   if the arguments' types prevent them from
+   *                              being compared by this comparator.
+   */
+  @Override
+  public int compare(CRLInfo o1, CRLInfo o2) {
+    return 0;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CRLInfo that = (CRLInfo) o;
+
+    return this.getX509CRL().equals(that.x509CRL) &&
+        this.creationTimestamp == that.creationTimestamp;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(x509CRL);
+  }
+
+  /**
+   * Builder class for CRLInfo.
+   */
+  @SuppressWarnings("checkstyle:hiddenfield")
+  public static class Builder {
+    private X509CRL x509CRL;
+    private long creationTimestamp;
+
+    public Builder setX509CRL(X509CRL x509CRL) {
+      this.x509CRL = x509CRL;
+      return this;
+    }
+
+    public Builder setCreationTimestamp(long creationTimestamp) {
+      this.creationTimestamp = creationTimestamp;
+      return this;
+    }
+
+    public CRLInfo build() {
+      return new CRLInfo(x509CRL, creationTimestamp);
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLInfo.java
@@ -111,7 +111,7 @@ public class CRLInfo implements Comparator<CRLInfo>,
    */
   @Override
   public int compare(CRLInfo o1, CRLInfo o2) {
-    return 0;
+    return Long.compare(o1.getCreationTimestamp(), o2.getCreationTimestamp());
   }
 
   @Override
@@ -132,7 +132,15 @@ public class CRLInfo implements Comparator<CRLInfo>,
 
   @Override
   public int hashCode() {
-    return Objects.hash(x509CRL);
+    return Objects.hash(getX509CRL(), getCreationTimestamp());
+  }
+
+  @Override
+  public String toString() {
+    return "CRLInfo{" +
+        "x509CRL=" + x509CRL.toString() +
+        ", creationTimestamp=" + creationTimestamp +
+        '}';
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/package-info.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/crl/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the common routines used for maintaining Certificate
+ * Revocation Lists.
+ */
+package org.apache.hadoop.hdds.security.x509.crl;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -20,9 +20,11 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.bouncycastle.cert.X509CertificateHolder;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
@@ -39,7 +41,10 @@ public class MockCAStore implements CertificateStore {
   }
 
   @Override
-  public void revokeCertificate(BigInteger serialID) throws IOException {
+  public void revokeCertificates(List<X509Certificate> certificates,
+                                 X509CertificateHolder caCertificateHolder,
+                                 int reason, SecurityConfig securityConfig,
+                                 KeyPair keyPair) throws IOException {
 
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +45,9 @@ public class MockCAStore implements CertificateStore {
   public Optional<Long> revokeCertificates(
       List<BigInteger> serialIDs,
       X509CertificateHolder caCertificateHolder,
-      CRLReason reason, CRLApprover approver) throws IOException {
+      CRLReason reason,
+      Date revocationTime,
+      CRLApprover approver) throws IOException {
     return Optional.empty();
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -20,14 +20,14 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  *
@@ -41,11 +41,11 @@ public class MockCAStore implements CertificateStore {
   }
 
   @Override
-  public void revokeCertificates(List<X509Certificate> certificates,
-                                 X509CertificateHolder caCertificateHolder,
-                                 int reason, SecurityConfig securityConfig,
-                                 KeyPair keyPair) throws IOException {
-
+  public Optional<Long> revokeCertificates(
+      List<BigInteger> serialIDs,
+      X509CertificateHolder caCertificateHolder,
+      CRLReason reason, CRLApprover approver) throws IOException {
+    return Optional.empty();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -45,6 +45,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -230,6 +231,7 @@ public class TestDefaultCAServer {
   public void testRevokeCertificates() throws Exception {
     String scmId =  RandomStringUtils.randomAlphabetic(4);
     String clusterId =  RandomStringUtils.randomAlphabetic(4);
+    Date now = new Date();
 
     CertificateServer testCA = new DefaultCAServer("testCA",
         clusterId, scmId, caStore);
@@ -258,7 +260,7 @@ public class TestDefaultCAServer {
     List<BigInteger> serialIDs = new ArrayList<>();
     serialIDs.add(certificate.getSerialNumber());
     Future<Optional<Long>> revoked = testCA.revokeCertificates(serialIDs,
-        CRLReason.lookup(CRLReason.keyCompromise),
+        CRLReason.lookup(CRLReason.keyCompromise), now,
         new SecurityConfig(conf));
 
     // Revoking a valid certificate complete successfully without errors.
@@ -270,7 +272,7 @@ public class TestDefaultCAServer {
         () -> {
           Future<Optional<Long>> result =
               testCA.revokeCertificates(Collections.emptyList(),
-              CRLReason.lookup(CRLReason.keyCompromise),
+              CRLReason.lookup(CRLReason.keyCompromise), now,
                   new SecurityConfig(conf));
           result.isDone();
           result.get();

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -285,3 +285,11 @@ message BlockID {
     required ContainerBlockID containerBlockID = 1;
     optional uint64 blockCommitSequenceId = 2 [default = 0];
 }
+
+/**
+ * Information for Certificate Revocation List.
+ */
+message CRLInfoProto {
+    required string x509CRL = 1;
+    required uint64 creationTimestamp = 2;
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/CRLInfoCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/CRLInfoCodec.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.scm.metadata;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.utils.db.Codec;
+
+import java.io.IOException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+
+/**
+ * Codec to serialize / deserialize CRLInfo.
+ */
+public class CRLInfoCodec implements Codec<CRLInfo> {
+
+  @Override
+  public byte[] toPersistedFormat(CRLInfo crlInfo) throws IOException {
+    return crlInfo.getProtobuf().toByteArray();
+  }
+
+  @Override
+  public CRLInfo fromPersistedFormat(byte[] rawData) throws IOException {
+
+    Preconditions.checkNotNull(rawData,
+        "Null byte array can't be converted to real object.");
+    try {
+      return CRLInfo.fromProtobuf(
+          HddsProtos.CRLInfoProto.PARSER.parseFrom(rawData));
+    } catch (CertificateException|CRLException e) {
+      throw new IllegalArgumentException(
+          "Can't encode the the raw data from the byte array", e);
+    }
+  }
+
+  @Override
+  public CRLInfo copyObject(CRLInfo object) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -24,11 +24,13 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
 import org.apache.hadoop.hdds.utils.db.LongCodec;
+import org.apache.hadoop.hdds.utils.db.StringCodec;
 
 /**
  * Class defines the structure and types of the scm.db.
@@ -73,12 +75,29 @@ public class SCMDBDefinition implements DBDefinition {
 
   public static final DBColumnFamilyDefinition<ContainerID, ContainerInfo>
       CONTAINERS =
-      new DBColumnFamilyDefinition<ContainerID, ContainerInfo>(
+      new DBColumnFamilyDefinition<>(
           "containers",
           ContainerID.class,
           new ContainerIDCodec(),
           ContainerInfo.class,
           new ContainerInfoCodec());
+
+  public static final DBColumnFamilyDefinition<Long, CRLInfo> CRL_INFO =
+      new DBColumnFamilyDefinition<>(
+          "crlInfo",
+          Long.class,
+          new LongCodec(),
+          CRLInfo.class,
+          new CRLInfoCodec());
+
+  public static final DBColumnFamilyDefinition<String, Long>
+      CRL_SEQUENCE_ID =
+      new DBColumnFamilyDefinition<>(
+          "crlSequenceId",
+          String.class,
+          new StringCodec(),
+          Long.class,
+          new LongCodec());
 
   @Override
   public String getName() {
@@ -93,6 +112,6 @@ public class SCMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_BLOCKS, VALID_CERTS,
-        REVOKED_CERTS, PIPELINES, CONTAINERS};
+        REVOKED_CERTS, PIPELINES, CONTAINERS, CRL_INFO, CRL_SEQUENCE_ID};
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -82,9 +82,9 @@ public class SCMDBDefinition implements DBDefinition {
           ContainerInfo.class,
           new ContainerInfoCodec());
 
-  public static final DBColumnFamilyDefinition<Long, CRLInfo> CRL_INFO =
+  public static final DBColumnFamilyDefinition<Long, CRLInfo> CRLS =
       new DBColumnFamilyDefinition<>(
-          "crlInfo",
+          "crls",
           Long.class,
           new LongCodec(),
           CRLInfo.class,
@@ -112,6 +112,6 @@ public class SCMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_BLOCKS, VALID_CERTS,
-        REVOKED_CERTS, PIPELINES, CONTAINERS, CRL_INFO, CRL_SEQUENCE_ID};
+        REVOKED_CERTS, PIPELINES, CONTAINERS, CRLS, CRL_SEQUENCE_ID};
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -82,6 +83,21 @@ public interface SCMMetadataStore {
    * @return Table.
    */
   Table<BigInteger, X509Certificate> getRevokedCertsTable();
+
+  /**
+   * A table that maintains X509 Certificate Revocation Lists and its metadata.
+   *
+   * @return Table.
+   */
+  Table<Long, CRLInfo> getCRLInfoTable();
+
+  /**
+   * A table that maintains the last CRL SequenceId. This helps to make sure
+   * that the CRL Sequence Ids are monotonically increasing.
+   *
+   * @return Table.
+   */
+  Table<String, Long> getCRLSequenceIdTable();
 
   /**
    * Returns the list of Certificates of a specific type.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
@@ -35,6 +36,8 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_INFO;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
@@ -57,6 +60,10 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   private Table<ContainerID, ContainerInfo> containerTable;
 
   private Table<PipelineID, Pipeline> pipelineTable;
+
+  private Table<Long, CRLInfo> crlInfoTable;
+
+  private Table<String, Long> crlSequenceIdTable;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMMetadataStoreImpl.class);
@@ -99,6 +106,10 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
       pipelineTable = PIPELINES.getTable(store);
 
       containerTable = CONTAINERS.getTable(store);
+
+      crlInfoTable = CRL_INFO.getTable(store);
+
+      crlSequenceIdTable = CRL_SEQUENCE_ID.getTable(store);
     }
   }
 
@@ -129,6 +140,27 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   @Override
   public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
     return revokedCertsTable;
+  }
+
+  /**
+   * A table that maintains X509 Certificate Revocation Lists and its metadata.
+   *
+   * @return Table.
+   */
+  @Override
+  public Table<Long, CRLInfo> getCRLInfoTable() {
+    return crlInfoTable;
+  }
+
+  /**
+   * A table that maintains the last CRL SequenceId. This helps to make sure
+   * that the CRL Sequence Ids are monotonically increasing.
+   *
+   * @return Table.
+   */
+  @Override
+  public Table<String, Long> getCRLSequenceIdTable() {
+    return crlSequenceIdTable;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -36,7 +36,7 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_INFO;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRLS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
@@ -107,7 +107,7 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
       containerTable = CONTAINERS.getTable(store);
 
-      crlInfoTable = CRL_INFO.getTable(store);
+      crlInfoTable = CRLS.getTable(store);
 
       crlSequenceIdTable = CRL_SEQUENCE_ID.getTable(store);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -91,14 +91,13 @@ public class SCMCertStore implements CertificateStore {
       CRLReason reason,
       CRLApprover crlApprover)
       throws IOException {
-    lock.lock();
     Date now = new Date();
-
     X509v2CRLBuilder builder =
         new X509v2CRLBuilder(caCertificateHolder.getIssuer(), now);
     List<X509Certificate> certsToRevoke = new ArrayList<>();
     X509CRL crl;
     Optional<Long> sequenceId = Optional.empty();
+    lock.lock();
     try {
       for (BigInteger serialID: serialIDs) {
         X509Certificate cert =
@@ -118,7 +117,6 @@ public class SCMCertStore implements CertificateStore {
         try {
           crl = crlApprover.sign(builder);
         } catch (OperatorCreationException | CRLException e) {
-          lock.unlock();
           throw new SCMSecurityException("Unable to create Certificate " +
               "Revocation List.", e);
         }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -89,6 +89,7 @@ public class SCMCertStore implements CertificateStore {
       List<BigInteger> serialIDs,
       X509CertificateHolder caCertificateHolder,
       CRLReason reason,
+      Date revocationTime,
       CRLApprover crlApprover)
       throws IOException {
     Date now = new Date();
@@ -109,7 +110,8 @@ public class SCMCertStore implements CertificateStore {
             != null) {
           LOG.warn("Trying to revoke a certificate that is already revoked.");
         } else {
-          builder.addCRLEntry(serialID, now, reason.getValue().intValue());
+          builder.addCRLEntry(serialID, revocationTime,
+              reason.getValue().intValue());
           certsToRevoke.add(cert);
         }
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -34,6 +34,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -111,19 +112,19 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.util.JvmPauseMonitor;
+import org.apache.ratis.grpc.GrpcTlsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import com.google.protobuf.BlockingService;
-import org.apache.commons.lang3.tuple.Pair;
+
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
-
-import org.apache.ratis.grpc.GrpcTlsConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
 
 /**
  * StorageContainerManager is the main entry point for the service that
@@ -568,8 +569,22 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       throw new SCMException("Cannot initialize CA without a valid metadata " +
           "store", ResultCodes.SCM_NOT_INITIALIZED);
     }
-    SCMCertStore certStore = new SCMCertStore(this.scmMetadataStore);
+    SCMCertStore certStore = new SCMCertStore(this.scmMetadataStore,
+        getLastSequenceIdForCRL());
     return new DefaultCAServer(subject, clusterID, scmID, certStore);
+  }
+
+  long getLastSequenceIdForCRL() throws IOException {
+    Long sequenceId =
+        scmMetadataStore.getCRLSequenceIdTable().get(CRL_SEQUENCE_ID_KEY);
+    // If the CRL_SEQUENCE_ID_KEY does not exist in DB return 0 so that new
+    // CRL requests can have sequence id starting from 1.
+    if (sequenceId == null) {
+      return 0L;
+    }
+    // If there exists a last sequence id in the DB, the new incoming
+    // CRL requests must have sequence ids greater than the one stored in the DB
+    return sequenceId;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.metadata.PipelineCodec;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
@@ -93,6 +94,16 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
 
   @Override
   public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
+    return null;
+  }
+
+  @Override
+  public Table<Long, CRLInfo> getCRLInfoTable() {
+    return null;
+  }
+
+  @Override
+  public Table<String, Long> getCRLSequenceIdTable() {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.server;
+
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.security.KeyPair;
+import java.security.cert.X509CRLEntry;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
+
+/**
+ * Test class for @{@link SCMCertStore}.
+ */
+public class TestSCMCertStore {
+
+  private static final String COMPONENT_NAME = "scm";
+  private static final Long INITIAL_SEQUENCE_ID = 1L;
+
+  private OzoneConfiguration config;
+  private SCMMetadataStore scmMetadataStore;
+  private SCMCertStore scmCertStore;
+  private SecurityConfig securityConfig;
+  private X509Certificate x509Certificate;
+  private KeyPair keyPair;
+
+  @Rule
+  public final TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Before
+  public void setUp() throws Exception {
+    config = new OzoneConfiguration();
+
+    config.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+        tempDir.newFolder().getAbsolutePath());
+
+    securityConfig = new SecurityConfig(config);
+  }
+
+  @Before
+  public void initDbStore() throws IOException {
+    scmMetadataStore = new SCMMetadataStoreImpl(config);
+    scmCertStore = new SCMCertStore(scmMetadataStore, INITIAL_SEQUENCE_ID);
+  }
+
+  @Before
+  public void generateCertificate() throws Exception {
+    Files.createDirectories(securityConfig.getKeyLocation(COMPONENT_NAME));
+    x509Certificate = generateX509Cert(null);
+  }
+
+  @After
+  public void destroyDbStore() throws Exception {
+    if (scmMetadataStore.getStore() != null) {
+      scmMetadataStore.getStore().close();
+    }
+  }
+
+  @Test
+  public void testRevokeCertificates() throws Exception {
+
+    BigInteger serialID = x509Certificate.getSerialNumber();
+    scmCertStore.storeValidCertificate(serialID, x509Certificate);
+
+    Assert.assertNotNull(
+        scmCertStore.getCertificateByID(serialID,
+        CertificateStore.CertType.VALID_CERTS));
+
+    X509CertificateHolder caCertificateHolder =
+        new X509CertificateHolder(generateX509Cert(keyPair).getEncoded());
+    List<X509Certificate> certs = new ArrayList<>();
+    certs.add(x509Certificate);
+    scmCertStore.revokeCertificates(certs,
+        caCertificateHolder,
+        CRLReason.unspecified, securityConfig,
+        keyPair);
+
+    Assert.assertNull(
+        scmCertStore.getCertificateByID(serialID,
+            CertificateStore.CertType.VALID_CERTS));
+
+    Assert.assertNotNull(
+        scmCertStore.getCertificateByID(serialID,
+            CertificateStore.CertType.REVOKED_CERTS));
+
+    // CRL Info table should have a CRL with sequence id
+    Assert.assertEquals(
+        INITIAL_SEQUENCE_ID + 1L,
+        (long) scmMetadataStore.getCRLInfoTable().iterator().next().getKey());
+
+    // Check the sequence ID table for latest sequence id
+    Assert.assertEquals(INITIAL_SEQUENCE_ID + 1L, (long)
+        scmMetadataStore.getCRLSequenceIdTable().get(CRL_SEQUENCE_ID_KEY));
+
+    CRLInfo crlInfo =
+        scmMetadataStore.getCRLInfoTable().iterator().next().getValue();
+
+    Set<? extends X509CRLEntry> revokedCertificates =
+        crlInfo.getX509CRL().getRevokedCertificates();
+    Assert.assertEquals(1L, revokedCertificates.size());
+    Assert.assertEquals(x509Certificate.getSerialNumber(),
+        revokedCertificates.iterator().next().getSerialNumber());
+
+    // Now trying to revoke the already revoked certificate should result in
+    // a warning message and no-op. It should not create a new CRL.
+    scmCertStore.revokeCertificates(certs,
+        caCertificateHolder,
+        CRLReason.unspecified, securityConfig,
+        keyPair);
+
+    int size = 0;
+    TableIterator<Long, ? extends Table.KeyValue<Long, CRLInfo>> iter =
+        scmMetadataStore.getCRLInfoTable().iterator();
+
+    while(iter.hasNext()) {
+      size++;
+      iter.next();
+    }
+
+    Assert.assertEquals(1, size);
+
+    // Generate 3 more certificates and revoke 2 of them
+    List<X509Certificate> newCerts = new ArrayList<>();
+    for (int i = 0; i<3; i++) {
+      X509Certificate cert = generateX509Cert(keyPair);
+      scmCertStore.storeValidCertificate(cert.getSerialNumber(), cert);
+      newCerts.add(cert);
+    }
+
+    // Add the first 2 certificates to the revocation list
+    scmCertStore.revokeCertificates(newCerts.subList(0, 2),
+        caCertificateHolder,
+        CRLReason.unspecified, securityConfig,
+        keyPair);
+
+    // This should create a CRL with sequence id INITIAL_SEQUENCE_ID + 2
+    // And contain 2 certificates in it
+    iter = scmMetadataStore.getCRLInfoTable().iterator();
+    iter.seekToLast();
+    Assert.assertEquals(INITIAL_SEQUENCE_ID + 2L, (long) iter.key());
+
+    // Check the sequence ID table for latest sequence id
+    Assert.assertEquals(INITIAL_SEQUENCE_ID + 2L, (long)
+        scmMetadataStore.getCRLSequenceIdTable().get(CRL_SEQUENCE_ID_KEY));
+
+    CRLInfo newCrlInfo = iter.value().getValue();
+    revokedCertificates = newCrlInfo.getX509CRL().getRevokedCertificates();
+    Assert.assertEquals(2L, revokedCertificates.size());
+    Assert.assertNotNull(
+        revokedCertificates.stream().filter(c ->
+            c.getSerialNumber().equals(newCerts.get(0).getSerialNumber()))
+            .findAny());
+
+    Assert.assertNotNull(
+        revokedCertificates.stream().filter(c ->
+            c.getSerialNumber().equals(newCerts.get(1).getSerialNumber()))
+            .findAny());
+
+    // Valid certs table should have 1 cert
+    size = 0;
+    TableIterator<BigInteger,
+        ? extends Table.KeyValue<BigInteger, X509Certificate>> iterator =
+        scmMetadataStore.getValidCertsTable().iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      size++;
+    }
+    Assert.assertEquals(1L, size);
+    // Make sure that the last certificate that was not revoked is the one
+    // in the valid certs table.
+    Assert.assertEquals(newCerts.get(2).getSerialNumber(),
+        scmMetadataStore.getValidCertsTable().iterator().next().getKey());
+
+    // Revoked certs table should have 3 certs
+    size = 0;
+    Iterator iterator1 = scmMetadataStore.getRevokedCertsTable().iterator();
+    while (iterator1.hasNext()) {
+      size++;
+      iterator1.next();
+    }
+    Assert.assertEquals(3L, size);
+  }
+
+  private X509Certificate generateX509Cert(KeyPair keypair) throws Exception {
+    if (keypair == null) {
+      keyPair = KeyStoreTestUtil.generateKeyPair("RSA");
+    }
+    return CertificateCodec.getX509Certificate(
+        CertificateCodec.getPEMEncodedString(
+            KeyStoreTestUtil.generateCertificate("CN=Test", keyPair, 30,
+        "SHA256withRSA")));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add a new table to persist CRL information
- Add a new table to keep track of the last CRL sequence ID
- Update the revoke certificates method to create a new CRL to revoke certificates
- Add Unit tests

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4482

## How was this patch tested?

Unit tests
