### PR TITLE
HDDS-4259. Edit URI_EXCEPTION_TEXT in BasicOzoneFileSystem to include omServiceId

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -108,7 +108,8 @@ public class BasicOzoneFileSystem extends FileSystem {
       "should be one of the following formats: " +
       "o3fs://bucket.volume/key  OR " +
       "o3fs://bucket.volume.om-host.example.com/key  OR " +
-      "o3fs://bucket.volume.om-host.example.com:5678/key";
+      "o3fs://bucket.volume.om-host.example.com:5678/key  OR " +
+      "o3fs://bucket.volume.omServiceId/key";
 
   @Override
   public void initialize(URI name, Configuration conf) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include the omServiceId as part of the example syntax when HA is enabled: `o3fs://bucket.volume.omServiceId/key`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4259

## How was this patch tested?

Tested using: 

> hadoop-ozone/dev-support/checks/rat.sh
> hadoop-ozone/dev-support/checks/checkstyle.sh