### PR TITLE
HDDS-4780. Disable spotbugs for (the empty) hadoop-ozone-datanode project

### DIFF
--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -26,6 +26,10 @@
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
 
+  <properties>
+    <spotbugs.skip>true</spotbugs.skip>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4780

## What changes were proposed in this pull request?

Execution the spotbugs check script fails locally. If some other resource files are already generated in an empty project, spotbugs expected real source files:

```
[INFO] --------------< org.apache.hadoop:hadoop-ozone-datanode >---------------
[INFO] Building Apache Hadoop Ozone Datanode 1.1.0-SNAPSHOT             [32/40]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
...
[INFO] 
[INFO] --- maven-compiler-plugin:3.1:testCompile (default-testCompile) @ hadoop-ozone-datanode ---
[INFO] No sources to compile
[INFO] 
[INFO] --- spotbugs-maven-plugin:3.1.12:spotbugs (default-cli) @ hadoop-ozone-datanode ---
[INFO] Fork Value is true
     [java] Exception in thread "main" java.io.IOException: No files to analyze could be opened
     [java] 	at edu.umd.cs.findbugs.FindBugs2.execute(FindBugs2.java:274)
     [java] 	at edu.umd.cs.findbugs.FindBugs.runMain(FindBugs.java:401)
     [java] 	at edu.umd.cs.findbugs.FindBugs2.main(FindBugs2.java:1185)
[INFO] 
```

It's more safe to turn off explicitly the spotbugs check for the empty `hadoop-ozone-datanode` project (note: source code of the datanode is in the `hadoop-hdds-container-service` project) 

## How was this patch tested?

`mvn spotbugs:check` and `./hadoop-ozone/dev-support/checks/findbugs.sh` from my local working directory.