### PR TITLE
HDDS-4774. Disable Prevote in Ratis for Ozone by default.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -244,6 +244,9 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     // Set the maximum cache segments
     RaftServerConfigKeys.Log.setSegmentCacheNumMax(properties, 2);
 
+    // Disable the pre vote feature in Ratis
+    RaftServerConfigKeys.LeaderElection.setPreVote(properties, false);
+
     // Set the ratis storage directory
     Collection<String> storageDirPaths =
             HddsServerUtil.getOzoneDatanodeRatisDirectory(conf);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -411,6 +411,8 @@ public final class OzoneManagerRatisServer {
     String storageDir = OzoneManagerRatisServer.getOMRatisDirectory(conf);
     RaftServerConfigKeys.setStorageDir(properties,
         Collections.singletonList(new File(storageDir)));
+    // Disable the pre vote feature in Ratis
+    RaftServerConfigKeys.LeaderElection.setPreVote(properties, false);
 
     // Set RAFT segment size
     final int raftSegmentSize = (int) conf.getStorageSize(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Pre-vote and Leader Lease are new features in Ratis which may not be required/not tested enough with ozone currently. The idea here is to disable these by default in ozone.

Leader lease is yet be committed : https://issues.apache.org/jira/browse/RATIS-1273

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4774

## How was this patch tested?
Config change. No tests needed.
