### PR TITLE
HDDS-4760. Intermittent failure in ozone-ha acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -20,6 +20,7 @@ export COMPOSE_DIR
 
 export SECURITY_ENABLED=false
 export OZONE_REPLICATION_FACTOR=3
+export OM_SERVICE_ID=omservice
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wait for OM leader election (similar to SCM safemode exit) in acceptance tests, as even 15 retries is not enough in some cases (failover to other OM has no delay).

https://issues.apache.org/jira/browse/HDDS-4760

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/531562574

```
2021-02-02T18:34:29.2792765Z Safe mode is off
2021-02-02T18:34:40.9042608Z Found OM leader for service omservice: om2 : LEADER (om2)
...
2021-02-02T19:14:59.0717583Z Safe mode is off
2021-02-02T19:15:03.7196532Z Found OM leader for service id1: om1 : LEADER (om1)
```