### PR TITLE
HDDS-4787. Trash emptier fails to create checkpoints in a secure setup

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -56,6 +56,7 @@ import org.apache.commons.io.IOUtils;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.fs.FileSystem.TRASH_PREFIX;
 import static org.apache.hadoop.fs.ozone.Constants.LISTING_PAGE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.Assert.assertEquals;
@@ -133,6 +134,7 @@ public class TestOzoneFileSystem {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(FS_TRASH_INTERVAL_KEY, 1);
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
+    conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
             enabledFileSystemPaths);
     cluster = MiniOzoneCluster.newBuilder(conf)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3618,11 +3618,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     Pair<String, String> resolved;
     try {
       if (isAclEnabled) {
+        InetAddress remoteIp = Server.getRemoteIp();
         resolved = resolveBucketLink(requested, new HashSet<>(),
             Server.getRemoteUser(),
-            Server.getRemoteIp(),
-            Server.getRemoteIp() != null ?
-                Server.getRemoteIp().getHostName() :
+            remoteIp,
+            remoteIp != null ? remoteIp.getHostName() :
                 omRpcAddress.getHostName());
       } else {
         resolved = resolveBucketLink(requested, new HashSet<>(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1698,16 +1698,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private void checkAcls(ResourceType resType, StoreType store,
       ACLType acl, String vol, String bucket, String key)
       throws IOException {
+    UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
+    InetAddress remoteIp = ProtobufRpcEngine.Server.getRemoteIp();
     checkAcls(resType, store, acl, vol, bucket, key,
-        ProtobufRpcEngine.Server.getRemoteUser() != null ?
-            ProtobufRpcEngine.Server.getRemoteUser() :
-            getRemoteUser(),
-        ProtobufRpcEngine.Server.getRemoteIp() != null ?
-            ProtobufRpcEngine.Server.getRemoteIp() :
-            omRpcAddress.getAddress(),
-        ProtobufRpcEngine.Server.getRemoteIp() != null ?
-            ProtobufRpcEngine.Server.getRemoteIp().getHostName() :
-            omRpcAddress.getHostName(),
+        user != null ? user : getRemoteUser(),
+        remoteIp != null ? remoteIp : omRpcAddress.getAddress(),
+        remoteIp != null ? remoteIp.getHostName() : omRpcAddress.getHostName(),
         true, getVolumeOwner(vol, acl, resType));
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -31,6 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.security.KeyPair;
 import java.security.PrivateKey;
+import java.security.PrivilegedExceptionAction;
 import java.security.PublicKey;
 import java.security.cert.CertificateException;
 import java.util.ArrayList;
@@ -1275,7 +1276,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throw new IOException("Cannot start trash emptier with negative interval."
               + " Set " + FS_TRASH_INTERVAL_KEY + " to a positive value.");
     }
-    FileSystem fs = new TrashOzoneFileSystem(this);
+
+    OzoneManager i = this;
+    FileSystem fs = SecurityUtil.doAsLoginUser(
+        new PrivilegedExceptionAction<FileSystem>() {
+          @Override
+          public FileSystem run() throws IOException {
+            return new TrashOzoneFileSystem(i);
+          }
+        });
     this.emptier = new Thread(new OzoneTrash(fs, conf, this).
       getEmptier(), "Trash Emptier");
     this.emptier.setDaemon(true);
@@ -1688,11 +1697,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   private void checkAcls(ResourceType resType, StoreType store,
       ACLType acl, String vol, String bucket, String key)
-      throws OMException {
+      throws IOException {
     checkAcls(resType, store, acl, vol, bucket, key,
-        ProtobufRpcEngine.Server.getRemoteUser(),
-        ProtobufRpcEngine.Server.getRemoteIp(),
-        ProtobufRpcEngine.Server.getRemoteIp().getHostName(),
+        ProtobufRpcEngine.Server.getRemoteUser() != null ?
+            ProtobufRpcEngine.Server.getRemoteUser() :
+            getRemoteUser(),
+        ProtobufRpcEngine.Server.getRemoteIp() != null ?
+            ProtobufRpcEngine.Server.getRemoteIp() :
+            omRpcAddress.getAddress(),
+        ProtobufRpcEngine.Server.getRemoteIp() != null ?
+            ProtobufRpcEngine.Server.getRemoteIp().getHostName() :
+            omRpcAddress.getHostName(),
         true, getVolumeOwner(vol, acl, resType));
   }
 
@@ -3605,14 +3620,20 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws IOException {
 
     Pair<String, String> resolved;
-    if (isAclEnabled) {
-      resolved = resolveBucketLink(requested, new HashSet<>(),
-              Server.getRemoteUser(),
-              Server.getRemoteIp(),
-              Server.getRemoteIp().getHostName());
-    } else {
-      resolved = resolveBucketLink(requested, new HashSet<>(),
-          null, null, null);
+    try {
+      if (isAclEnabled) {
+        resolved = resolveBucketLink(requested, new HashSet<>(),
+            Server.getRemoteUser(),
+            Server.getRemoteIp(),
+            Server.getRemoteIp() != null ?
+                Server.getRemoteIp().getHostName() :
+                omRpcAddress.getHostName());
+      } else {
+        resolved = resolveBucketLink(requested, new HashSet<>(),
+            null, null, null);
+      }
+    } catch (Throwable t) {
+      throw t;
     }
     return new ResolvedBucket(requested, resolved);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -274,7 +275,7 @@ public class TrashOzoneFileSystem extends FileSystem {
         }
       } catch (Exception e){
         LOG.error("Couldn't perform fs operation " +
-            "fs.listStatus()/fs.exists()" + e);
+            "fs.listStatus()/fs.exists()", e);
       }
     }
     return ret;
@@ -428,11 +429,17 @@ public class TrashOzoneFileSystem extends FileSystem {
               .setToKeyName(toKeyName)
               .build();
       OzoneManagerProtocolProtos.OMRequest omRequest =
-          OzoneManagerProtocolProtos.OMRequest.newBuilder()
-              .setClientId(CLIENT_ID.toString())
-              .setRenameKeyRequest(renameKeyRequest)
-              .setCmdType(OzoneManagerProtocolProtos.Type.RenameKey)
-              .build();
+          null;
+      try {
+        omRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()
+            .setClientId(CLIENT_ID.toString())
+            .setUserInfo(getUserInfo())
+            .setRenameKeyRequest(renameKeyRequest)
+            .setCmdType(OzoneManagerProtocolProtos.Type.RenameKey)
+            .build();
+      } catch (IOException e) {
+        LOG.error("Couldn't get userinfo", e);
+      }
       return omRequest;
     }
   }
@@ -490,13 +497,36 @@ public class TrashOzoneFileSystem extends FileSystem {
               .setDeleteKeys(deleteKeyArgs)
               .build();
       OzoneManagerProtocolProtos.OMRequest omRequest =
-          OzoneManagerProtocolProtos.OMRequest.newBuilder()
-              .setClientId(CLIENT_ID.toString())
-              .setDeleteKeysRequest(deleteKeysRequest)
-              .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
-              .build();
+          null;
+      try {
+        omRequest = OzoneManagerProtocolProtos.OMRequest.newBuilder()
+            .setClientId(CLIENT_ID.toString())
+            .setUserInfo(getUserInfo())
+            .setDeleteKeysRequest(deleteKeysRequest)
+            .setCmdType(OzoneManagerProtocolProtos.Type.DeleteKeys)
+            .build();
+      } catch (IOException e) {
+        LOG.error("Couldn't get userinfo", e);
+      }
       return omRequest;
     }
+  }
+
+  OzoneManagerProtocolProtos.UserInfo getUserInfo() throws IOException {
+    UserGroupInformation user = UserGroupInformation.getCurrentUser();
+    InetAddress remoteAddress = ozoneManager.getOmRpcServerAddr().getAddress();
+    OzoneManagerProtocolProtos.UserInfo.Builder userInfo =
+        OzoneManagerProtocolProtos.UserInfo.newBuilder();
+    if (user != null) {
+      userInfo.setUserName(user.getUserName());
+    }
+
+    if (remoteAddress != null) {
+      userInfo.setHostName(remoteAddress.getHostName());
+      userInfo.setRemoteAddress(remoteAddress.getHostAddress()).build();
+    }
+
+    return userInfo.build();
   }
 
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -523,7 +523,7 @@ public class TrashOzoneFileSystem extends FileSystem {
 
     if (remoteAddress != null) {
       userInfo.setHostName(remoteAddress.getHostName());
-      userInfo.setRemoteAddress(remoteAddress.getHostAddress()).build();
+      userInfo.setRemoteAddress(remoteAddress.getHostAddress());
     }
 
     return userInfo.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -143,19 +143,25 @@ public abstract class OMClientRequest implements RequestAuditor {
    * @return User Info.
    */
   public OzoneManagerProtocolProtos.UserInfo getUserIfNotExists(
-      OzoneManager ozoneManager)
-      throws IOException {
+      OzoneManager ozoneManager) {
     OzoneManagerProtocolProtos.UserInfo userInfo = getUserInfo();
     if (!userInfo.hasRemoteAddress() || !userInfo.hasUserName()){
       OzoneManagerProtocolProtos.UserInfo.Builder newuserInfo =
           OzoneManagerProtocolProtos.UserInfo.newBuilder();
-      UserGroupInformation user = UserGroupInformation.getCurrentUser();
-      InetAddress remoteAddress = ozoneManager.getOmRpcServerAddr()
-          .getAddress();
-      newuserInfo.setUserName(user.getUserName());
-      newuserInfo.setHostName(remoteAddress.getHostName());
-      newuserInfo.setRemoteAddress(remoteAddress.getHostAddress());
-      return newuserInfo.build();
+      UserGroupInformation user;
+      InetAddress remoteAddress;
+      try {
+        user = UserGroupInformation.getCurrentUser();
+        remoteAddress = ozoneManager.getOmRpcServerAddr()
+            .getAddress();
+      } catch (Exception e){
+        LOG.debug("Couldn't get om Rpc server address", e);
+        return getUserInfo();
+      }
+        newuserInfo.setUserName(user.getUserName());
+        newuserInfo.setHostName(remoteAddress.getHostName());
+        newuserInfo.setRemoteAddress(remoteAddress.getHostAddress());
+        return newuserInfo.build();
     }
     return getUserInfo();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -158,10 +158,10 @@ public abstract class OMClientRequest implements RequestAuditor {
         LOG.debug("Couldn't get om Rpc server address", e);
         return getUserInfo();
       }
-        newuserInfo.setUserName(user.getUserName());
-        newuserInfo.setHostName(remoteAddress.getHostName());
-        newuserInfo.setRemoteAddress(remoteAddress.getHostAddress());
-        return newuserInfo.build();
+      newuserInfo.setUserName(user.getUserName());
+      newuserInfo.setHostName(remoteAddress.getHostName());
+      newuserInfo.setRemoteAddress(remoteAddress.getHostAddress());
+      return newuserInfo.build();
     }
     return getUserInfo();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -78,7 +78,8 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     return getOmRequest().toBuilder()
         .setDeleteKeyRequest(deleteKeyRequest.toBuilder()
-            .setKeyArgs(newKeyArgs)).setUserInfo(getUserInfo()).build();
+            .setKeyArgs(newKeyArgs))
+        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -94,9 +94,10 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     return getOmRequest().toBuilder()
         .setRenameKeyRequest(renameKeyRequest.toBuilder()
             .setKeyArgs(newKeyArgs))
-        .setUserInfo(getUserInfo()).build();
+        .setUserInfo(getUserIfNotExists(ozoneManager)).build();
 
   }
+
 
   @Override
   @SuppressWarnings("methodlength")


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since in `TrashOzoneFilesystem` the calls are internal and not through RPC, NPE is generated during `checkacls`(), Since `Server.getRemoteIp` and other such parameters would be null, the security authorizers too generate an NPE. The fix here is if `Server.getRemoteIp()` is null replace it with ip of the node that starts OM

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4787#

## How was this patch tested?
Existing unit tests. also tried on cluster [https://github.com/sadanand48/hadoop-ozone/runs/1825648963?check_suite_focus=true](https://github.com/sadanand48/hadoop-ozone/runs/1825648963?check_suite_focus=true)