### PR TITLE
HDDS-4789. Improve usability of ozone s3 getsecret output

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -62,9 +62,9 @@ Setup v4 headers
 
 Setup secure v4 headers
     ${result} =         Execute                    ozone s3 getsecret
-    ${accessKey} =      Get Regexp Matches         ${result}     (?<=AWS_ACCESS_KEY_ID=).*
+    ${accessKey} =      Get Regexp Matches         ${result}     (?<=awsAccessKey=).*
     ${accessKey} =      Get Variable Value         ${accessKey}  sdsdasaasdasd
-    ${secret} =         Get Regexp Matches         ${result}     (?<=AWS_SECRET_ACCESS_KEY=).*
+    ${secret} =         Get Regexp Matches         ${result}     (?<=awsSecret=).*
     ${accessKey} =      Set Variable               ${accessKey[0]}
     ${secret} =         Set Variable               ${secret[0]}
                         Execute                    aws configure set default.s3.signature_version s3v4

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -62,9 +62,9 @@ Setup v4 headers
 
 Setup secure v4 headers
     ${result} =         Execute                    ozone s3 getsecret
-    ${accessKey} =      Get Regexp Matches         ${result}     (?<=awsAccessKey=).*
+    ${accessKey} =      Get Regexp Matches         ${result}     (?<=AWS_ACCESS_KEY_ID=).*
     ${accessKey} =      Get Variable Value         ${accessKey}  sdsdasaasdasd
-    ${secret} =         Get Regexp Matches         ${result}     (?<=awsSecret=).*
+    ${secret} =         Get Regexp Matches         ${result}     (?<=AWS_SECRET_ACCESS_KEY=).*
     ${accessKey} =      Set Variable               ${accessKey[0]}
     ${secret} =         Set Variable               ${secret[0]}
                         Execute                    aws configure set default.s3.signature_version s3v4

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
@@ -51,10 +51,8 @@ public class GetS3SecretHandler extends S3Handler {
 
     final S3SecretValue secret = client.getObjectStore().getS3Secret(userName);
     if (export) {
-      System.out
-          .println("export AWS_ACCESS_KEY_ID=" + secret.getAwsAccessKey());
-      System.out
-          .println("export AWS_SECRET_ACCESS_KEY=" + secret.getAwsSecret());
+      out().println("export AWS_ACCESS_KEY_ID=" + secret.getAwsAccessKey());
+      out().println("export AWS_SECRET_ACCESS_KEY=" + secret.getAwsSecret());
     } else {
       out().println(secret);
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
@@ -17,12 +17,15 @@
  */
 package org.apache.hadoop.ozone.shell.s3;
 
+import java.io.IOException;
+
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.security.UserGroupInformation;
-import picocli.CommandLine.Command;
 
-import java.io.IOException;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
 
 /**
  * Executes getsecret calls.
@@ -30,6 +33,11 @@ import java.io.IOException;
 @Command(name = "getsecret",
     description = "Returns s3 secret for current user")
 public class GetS3SecretHandler extends S3Handler {
+
+  @Option(names = "-e",
+      description = "Print out variables together with 'export' prefix, to "
+          + "use it from 'eval $(ozone s3 getsecret)'")
+  private boolean export;
 
   @Override
   protected boolean isApplicable() {
@@ -40,7 +48,16 @@ public class GetS3SecretHandler extends S3Handler {
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
-    out().println(client.getObjectStore().getS3Secret(userName));
+    final S3SecretValue secret =
+        client.getObjectStore().getS3Secret(userName);
+    String prefix = "";
+    if (export) {
+      prefix = "export ";
+    }
+    System.out
+        .println(prefix + "AWS_ACCESS_KEY_ID=" + secret.getAwsAccessKey());
+    System.out
+        .println(prefix + "AWS_SECRET_ACCESS_KEY=" + secret.getAwsSecret());
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/GetS3SecretHandler.java
@@ -48,16 +48,16 @@ public class GetS3SecretHandler extends S3Handler {
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
     String userName = UserGroupInformation.getCurrentUser().getUserName();
-    final S3SecretValue secret =
-        client.getObjectStore().getS3Secret(userName);
-    String prefix = "";
+
+    final S3SecretValue secret = client.getObjectStore().getS3Secret(userName);
     if (export) {
-      prefix = "export ";
+      System.out
+          .println("export AWS_ACCESS_KEY_ID=" + secret.getAwsAccessKey());
+      System.out
+          .println("export AWS_SECRET_ACCESS_KEY=" + secret.getAwsSecret());
+    } else {
+      out().println(secret);
     }
-    System.out
-        .println(prefix + "AWS_ACCESS_KEY_ID=" + secret.getAwsAccessKey());
-    System.out
-        .println(prefix + "AWS_SECRET_ACCESS_KEY=" + secret.getAwsSecret());
   }
 
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4789

## What changes were proposed in this pull request?

I am testing the S3g a lot in secure environment.

It's slightly painful to set the AWS acces key Id and secret every time.

I propose to improve the usability to print out the credentials in a read-to-use format:

```
ozone s3 getsecret 
AWS_ACCESS_KEY_ID=testuser/scm@EXAMPLE.COM
AWS_SECRET_ACCESS_KEY=...
```

Instead of:
```
ozone s3 getsecret 
awsAccessKey=testuser/scm@EXAMPLE.COM
awsSecret=...
```

The `-e` option even adds the required `export` prefixes:

```
ozone s3 getsecret -e 
export AWS_ACCESS_KEY_ID=testuser/scm@EXAMPLE.COM
export AWS_SECRET_ACCESS_KEY=...
```

Which makes the usage as easy as :

```
eval $(ozone s3 getsecret -e)
```

or for docker-compose based environments:

```
eval $(docker-compose exec scm ozone s3 getsecret -e)
```

## How was this patch tested?

From CLI and from acceptance tests