### PR TITLE
HDDS-4790. Add a tool to parse entries in the prefix format

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -713,8 +713,10 @@ public class SCMPipelineManager implements PipelineManager {
     pipelineFactory.shutdown();
     lock.writeLock().lock();
     try {
-      pipelineStore.close();
-      pipelineStore = null;
+      if (pipelineStore != null) {
+        pipelineStore.close();
+        pipelineStore = null;
+      }
     } catch (Exception ex) {
       LOG.error("Pipeline  store close failed", ex);
     } finally {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -28,7 +28,7 @@ import java.util.*;
  * in the user given path and a pointer to its parent directory element in the
  * path. Also, it stores directory node related metdata details.
  */
-public class OmDirectoryInfo extends WithObjectID {
+public class OmDirectoryInfo extends WithParentObjectId {
   private long parentObjectID; // pointer to parent directory
 
   private String name; // directory name

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDirectoryInfo.java
@@ -29,8 +29,6 @@ import java.util.*;
  * path. Also, it stores directory node related metdata details.
  */
 public class OmDirectoryInfo extends WithParentObjectId {
-  private long parentObjectID; // pointer to parent directory
-
   private String name; // directory name
 
   private long creationTime;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -42,7 +42,7 @@ import com.google.common.base.Preconditions;
  * This is returned from OM to client, and client use class to talk to
  * datanode. Also, this is the metadata written to om.db on server side.
  */
-public final class OmKeyInfo extends WithObjectID {
+public final class OmKeyInfo extends WithParentObjectId {
   private final String volumeName;
   private final String bucketName;
   // name of key client specified

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -56,29 +56,6 @@ public final class OmKeyInfo extends WithParentObjectId {
   private FileEncryptionInfo encInfo;
 
   /**
-   * A pointer to parent directory used for path traversal. ParentID will be
-   * used only when the key is created into a FileSystemOptimized(FSO) bucket.
-   * <p>
-   * For example, if a key "a/b/key1" created into a FSOBucket then each
-   * path component will be assigned an ObjectId and linked to its parent path
-   * component using parent's objectID.
-   * <p>
-   * Say, Bucket's ObjectID = 512, which is the parent for its immediate child
-   * element.
-   * <p>
-   * ------------------------------------------|
-   * PathComponent |   ObjectID   |   ParentID |
-   * ------------------------------------------|
-   *      a        |     1024     |     512    |
-   * ------------------------------------------|
-   *      b        |     1025     |     1024   |
-   * ------------------------------------------|
-   *     key1      |     1026     |     1025   |
-   * ------------------------------------------|
-   */
-  private long parentObjectID;
-
-  /**
    * Represents leaf node name. This also will be used when the keyName is
    * created on a FileSystemOptimized(FSO) bucket. For example, the user given
    * keyName is "a/b/key1" then the fileName stores "key1".

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
@@ -22,9 +22,28 @@ package org.apache.hadoop.ozone.om.helpers;
  * Object ID with additional parent ID field.
  */
 public class WithParentObjectId extends WithObjectID {
-
   /**
    * Object ID with additional parent ID field.
+   *
+   * A pointer to parent directory used for path traversal. ParentID will be
+   * used only when the key is created into a FileSystemOptimized(FSO) bucket.
+   * <p>
+   * For example, if a key "a/b/key1" created into a FSOBucket then each
+   * path component will be assigned an ObjectId and linked to its parent path
+   * component using parent's objectID.
+   * <p>
+   * Say, Bucket's ObjectID = 512, which is the parent for its immediate child
+   * element.
+   * <p>
+   * ------------------------------------------|
+   * PathComponent |   ObjectID   |   ParentID |
+   * ------------------------------------------|
+   *      a        |     1024     |     512    |
+   * ------------------------------------------|
+   *      b        |     1025     |     1024   |
+   * ------------------------------------------|
+   *     key1      |     1026     |     1025   |
+   * ------------------------------------------|
    */
   @SuppressWarnings("visibilitymodifier")
   protected long parentObjectID;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithParentObjectId.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+/**
+ * Object ID with additional parent ID field.
+ */
+public class WithParentObjectId extends WithObjectID {
+
+  /**
+   * Object ID with additional parent ID field.
+   */
+  @SuppressWarnings("visibilitymodifier")
+  protected long parentObjectID;
+
+  public long getParentObjectID() {
+    return parentObjectID;
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -101,7 +101,7 @@ public class TestOzoneFileSystemPrefixParser {
         OMStorage.getOmDbDir(configuration).getPath(),
         dir.getParent().getParent().toString());
 
-    assertPrefixStats(parser, 1, 1, 3, 0, 1 ,1);
+    assertPrefixStats(parser, 1, 1, 3, 0, 1, 1);
   }
 
   @Test
@@ -119,7 +119,7 @@ public class TestOzoneFileSystemPrefixParser {
         OMStorage.getOmDbDir(configuration).getPath(),
         file.toString());
 
-    assertPrefixStats(parser, 1, 1, 2, 1, 1 ,1);
+    assertPrefixStats(parser, 1, 1, 2, 1, 1, 1);
   }
 
   private void assertPrefixStats(PrefixParser parser, int volumeCount,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.debug.PrefixParser;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OMStorage;
+import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+
+/**
+ * Test Ozone Prefix Parser
+ */
+public class TestOzoneFileSystemPrefixParser {
+
+  private MiniOzoneCluster cluster = null;
+
+  private FileSystem fs;
+
+  private String volumeName;
+
+  private String bucketName;
+
+  private OzoneConfiguration configuration;
+
+  @Before
+  public void init() throws Exception {
+    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+    configuration = new OzoneConfiguration();
+
+    TestOMRequestUtils.configureFSOptimizedPaths(configuration,
+        true, OMConfigKeys.OZONE_OM_LAYOUT_VERSION_V1);
+
+    cluster = MiniOzoneCluster.newBuilder(configuration)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a bucket to be used by OzoneFileSystem
+    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+
+    String rootPath = String
+        .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,
+            volumeName);
+      fs = FileSystem.get(new URI(rootPath + "/test.txt"), configuration);
+  }
+
+  @After
+  public void teardown() throws IOException {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(fs);
+  }
+
+  @Test
+  public void testPrefixParsing() throws Exception {
+    Path dir = new Path("/a/b/c/d/e");
+    fs.mkdirs(dir);
+
+    Path file = new Path("/a/b/c/file1");
+    try(FSDataOutputStream os = fs.create(file)) {
+
+    }
+
+    cluster.stop();
+    PrefixParser parser = new PrefixParser();
+
+    parser.parse(volumeName, bucketName,
+        OMStorage.getOmDbDir(configuration).getPath(), "/a/b/c");
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.net.URI;
 
 /**
- * Test Ozone Prefix Parser
+ * Test Ozone Prefix Parser.
  */
 public class TestOzoneFileSystemPrefixParser {
 
@@ -74,7 +74,7 @@ public class TestOzoneFileSystemPrefixParser {
     String rootPath = String
         .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,
             volumeName);
-      fs = FileSystem.get(new URI(rootPath + "/test.txt"), configuration);
+    fs = FileSystem.get(new URI(rootPath + "/test.txt"), configuration);
   }
 
   @After
@@ -89,17 +89,16 @@ public class TestOzoneFileSystemPrefixParser {
   public void testPrefixParsing() throws Exception {
     Path dir = new Path("/a/b/c/d/e");
     fs.mkdirs(dir);
-
     Path file = new Path("/a/b/c/file1");
-    try(FSDataOutputStream os = fs.create(file)) {
-
-    }
+    FSDataOutputStream os = fs.create(file);
+    os.close();
 
     cluster.stop();
     PrefixParser parser = new PrefixParser();
 
     parser.parse(volumeName, bucketName,
-        OMStorage.getOmDbDir(configuration).getPath(), "/a/b/c");
+        OMStorage.getOmDbDir(configuration).getPath(),
+        dir.getParent().getParent().toString());
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemPrefixParser.java
@@ -86,7 +86,7 @@ public class TestOzoneFileSystemPrefixParser {
   }
 
   @Test
-  public void testPrefixParsing() throws Exception {
+  public void testPrefixParseDir() throws Exception {
     Path dir = new Path("/a/b/c/d/e");
     fs.mkdirs(dir);
     Path file = new Path("/a/b/c/file1");
@@ -101,4 +101,19 @@ public class TestOzoneFileSystemPrefixParser {
         dir.getParent().getParent().toString());
   }
 
+  @Test
+  public void testPrefixParseFile() throws Exception {
+    Path dir = new Path("/a/b/c/d/e");
+    fs.mkdirs(dir);
+    Path file = new Path("/a/b/c/file1");
+    FSDataOutputStream os = fs.create(file);
+    os.close();
+
+    cluster.stop();
+    PrefixParser parser = new PrefixParser();
+
+    parser.parse(volumeName, bucketName,
+        OMStorage.getOmDbDir(configuration).getPath(),
+        file.toString());
+  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -59,7 +59,7 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
     NON_EXISTENT_DIRECTORY,
   }
 
-  private final int parserStats[] = new int[Types.values().length];
+  private final int[] parserStats = new int[Types.values().length];
 
   @Spec
   private CommandSpec spec;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -65,12 +65,12 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
 
   @CommandLine.Option(names = {"--bucket"},
       required = true,
-      description = "bucket in /vol/bucket format")
+      description = "bucket name")
   private String bucket;
 
   @CommandLine.Option(names = {"--volume"},
       required = true,
-      description = "volume in /vol/bucket format")
+      description = "volume name")
   private String volume;
 
   public String getDbPath() {
@@ -129,15 +129,27 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
 
     Iterator<Path> pathIterator =  p.iterator();
     while(pathIterator.hasNext()) {
-      Path ss = pathIterator.next();
+      Path elem = pathIterator.next();
       String path =
-          metadataManager.getOzonePathKey(lastObjectId, ss.toString());
+          metadataManager.getOzonePathKey(lastObjectId, elem.toString());
       OmDirectoryInfo directoryInfo =
           metadataManager.getDirectoryTable().get(path);
-      effectivePath = getEffectivePath(effectivePath, ss.toString());
+
+      org.apache.hadoop.fs.Path tmpPath =
+          getEffectivePath(effectivePath, elem.toString());
+      if (directoryInfo == null) {
+        System.out.println("Given path contains a file at:" +
+            tmpPath);
+        System.out.println("Dumping files and dirs at level:" +
+            tmpPath.getParent());
+        System.out.println();
+        break;
+      }
+
+      effectivePath = tmpPath;
 
       dumpInfo("Intermediate Dir", effectivePath,
-          directoryInfo, directoryInfo.getName());
+          directoryInfo, path);
       lastObjectId = directoryInfo.getObjectID();
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import java.nio.file.Path;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.Spec;
+
+/**
+ * Tool that parses OM db file for prefix table.
+ */
+@CommandLine.Command(
+    name = "prefix",
+    description = "Parse prefix contents")
+@MetaInfServices(SubcommandWithParent.class)
+public class PrefixParser implements Callable<Void>, SubcommandWithParent {
+
+  @Spec
+  private CommandSpec spec;
+
+  @CommandLine.Option(names = {"--db"},
+      required = true,
+      description = "Database File Path")
+  private String dbPath;
+
+  @CommandLine.Option(names = {"--path"},
+      required = true,
+      description = "prefixFile Path")
+  private String filePath;
+
+  @CommandLine.Option(names = {"--bucket"},
+      required = true,
+      description = "bucket in /vol/bucket format")
+  private String bucket;
+
+  @CommandLine.Option(names = {"--volume"},
+      required = true,
+      description = "volume in /vol/bucket format")
+  private String volume;
+
+  public String getDbPath() {
+    return dbPath;
+  }
+
+  public void setDbPath(String dbPath) {
+    this.dbPath = dbPath;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneDebug.class;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    parse(volume, bucket, dbPath, filePath);
+    return null;
+  }
+
+  public static void main(String [] args) throws Exception {
+    new PrefixParser().call();
+  }
+
+  public void parse(String volume, String bucket, String dbPath,
+                    String filePath) throws Exception {
+    if (!Files.exists(Paths.get(dbPath))) {
+      System.out.println("DB path not exist:" + dbPath);
+      return;
+    }
+
+    System.out.println("FilePath is:" + filePath);
+    System.out.println("Db Path is:" + dbPath);
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, dbPath);
+    OzoneManagerRatisUtils.setBucketFSOptimized(true);
+
+    OmMetadataManagerImpl metadataManager =
+        new OmMetadataManagerImpl(conf);
+    metadataManager.start(conf);
+
+    org.apache.hadoop.fs.Path effectivePath =
+        new org.apache.hadoop.fs.Path("/");
+
+    Path p = Paths.get(filePath);
+
+    // First get the info about the bucket
+    String bucketKey = metadataManager.getBucketKey(volume, bucket);
+    OmBucketInfo info = metadataManager.getBucketTable().get(bucketKey);
+    long lastObjectId = info.getObjectID();
+    WithParentObjectId objectBucketId = new WithParentObjectId();
+    objectBucketId.setObjectID(lastObjectId);
+    dumpInfo("Bucket", effectivePath, objectBucketId, bucketKey);
+
+    Iterator<Path> pathIterator =  p.iterator();
+    while(pathIterator.hasNext()) {
+      Path ss = pathIterator.next();
+      String path =
+          metadataManager.getOzonePathKey(lastObjectId, ss.toString());
+      OmDirectoryInfo directoryInfo =
+          metadataManager.getDirectoryTable().get(path);
+      effectivePath = getEffectivePath(effectivePath, ss.toString());
+
+      dumpInfo("Intermediate Dir", effectivePath,
+          directoryInfo, directoryInfo.getName());
+      lastObjectId = directoryInfo.getObjectID();
+    }
+
+    // at the last level, now parse both file and dir table
+    dumpTableInfo("Directory", effectivePath,
+        metadataManager.getDirectoryTable(), lastObjectId);
+
+    dumpTableInfo("File", effectivePath,
+        metadataManager.getKeyTable(), lastObjectId);
+  }
+
+  private void dumpTableInfo(String type,
+      org.apache.hadoop.fs.Path effectivePath,
+      Table<String, ? extends WithParentObjectId> table, long lastObjectId)
+      throws IOException {
+    MetadataKeyFilters.KeyPrefixFilter filter = getPrefixFilter(lastObjectId);
+
+    List<? extends Table.KeyValue
+        <String, ? extends WithParentObjectId>> infoList =
+        table.getRangeKVs(null, 1000, filter);
+
+    for (Table.KeyValue
+        <String, ? extends WithParentObjectId> info : infoList) {
+      Path key = Paths.get(info.getKey());
+      dumpInfo(type, getEffectivePath(effectivePath,
+          key.getName(1).toString()), info.getValue(), info.getKey());
+    }
+  }
+
+  private org.apache.hadoop.fs.Path getEffectivePath(
+      org.apache.hadoop.fs.Path currentPath, String name) {
+   return new org.apache.hadoop.fs.Path(currentPath, name);
+  }
+
+  private void dumpInfo(String level, org.apache.hadoop.fs.Path effectivePath,
+                        WithParentObjectId id,  String key) {
+    System.out.println("Type:" + level);
+    System.out.println("Path: " + effectivePath);
+    System.out.println("DB Path: " + key);
+    System.out.println("Object Id: " + id.getObjectID());
+    System.out.println("Parent object Id: " + id.getParentObjectID());
+    System.out.println();
+
+  }
+
+  private static MetadataKeyFilters.KeyPrefixFilter getPrefixFilter(long id) {
+    return (new MetadataKeyFilters.KeyPrefixFilter())
+        .addFilter(Long.toString(id));
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.*;
@@ -154,12 +155,11 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
       throws IOException {
     MetadataKeyFilters.KeyPrefixFilter filter = getPrefixFilter(lastObjectId);
 
-    List<? extends Table.KeyValue
+    List<? extends KeyValue
         <String, ? extends WithParentObjectId>> infoList =
         table.getRangeKVs(null, 1000, filter);
 
-    for (Table.KeyValue
-      <String, ? extends WithParentObjectId> info : infoList) {
+    for (KeyValue<String, ? extends WithParentObjectId> info :infoList) {
       Path key = Paths.get(info.getKey());
       dumpInfo(type, getEffectivePath(effectivePath,
           key.getName(1).toString()), info.getValue(), info.getKey());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -91,22 +91,22 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
     return null;
   }
 
-  public static void main(String [] args) throws Exception {
+  public static void main(String[] args) throws Exception {
     new PrefixParser().call();
   }
 
-  public void parse(String volume, String bucket, String dbPath,
-                    String filePath) throws Exception {
-    if (!Files.exists(Paths.get(dbPath))) {
-      System.out.println("DB path not exist:" + dbPath);
+  public void parse(String vol, String buck, String db,
+                    String file) throws Exception {
+    if (!Files.exists(Paths.get(db))) {
+      System.out.println("DB path not exist:" + db);
       return;
     }
 
-    System.out.println("FilePath is:" + filePath);
-    System.out.println("Db Path is:" + dbPath);
+    System.out.println("FilePath is:" + file);
+    System.out.println("Db Path is:" + db);
 
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, dbPath);
+    conf.set(OMConfigKeys.OZONE_OM_DB_DIRS, db);
     OzoneManagerRatisUtils.setBucketFSOptimized(true);
 
     OmMetadataManagerImpl metadataManager =
@@ -116,10 +116,10 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
     org.apache.hadoop.fs.Path effectivePath =
         new org.apache.hadoop.fs.Path("/");
 
-    Path p = Paths.get(filePath);
+    Path p = Paths.get(file);
 
     // First get the info about the bucket
-    String bucketKey = metadataManager.getBucketKey(volume, bucket);
+    String bucketKey = metadataManager.getBucketKey(vol, buck);
     OmBucketInfo info = metadataManager.getBucketTable().get(bucketKey);
     long lastObjectId = info.getObjectID();
     WithParentObjectId objectBucketId = new WithParentObjectId();
@@ -159,7 +159,7 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
         table.getRangeKVs(null, 1000, filter);
 
     for (Table.KeyValue
-        <String, ? extends WithParentObjectId> info : infoList) {
+      <String, ? extends WithParentObjectId> info : infoList) {
       Path key = Paths.get(info.getKey());
       dumpInfo(type, getEffectivePath(effectivePath,
           key.getName(1).toString()), info.getValue(), info.getKey());
@@ -168,7 +168,7 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
 
   private org.apache.hadoop.fs.Path getEffectivePath(
       org.apache.hadoop.fs.Path currentPath, String name) {
-   return new org.apache.hadoop.fs.Path(currentPath, name);
+    return new org.apache.hadoop.fs.Path(currentPath, name);
   }
 
   private void dumpInfo(String level, org.apache.hadoop.fs.Path effectivePath,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a tool to parse entries in the prefix format


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4790

## How was this patch tested?
Added a new unit test

` Type:Bucket
Path: /
DB Path: /pnfrljixwf/jprltiklhg
Object Id: 9223372036854776576
Parent object Id: 0

Type:Intermediate Dir
Path: /a
DB Path: 9223372036854776576/a
Object Id: 9223372036854777089
Parent object Id: 9223372036854776576

Type:Intermediate Dir
Path: /a/b
DB Path: 9223372036854777089/b
Object Id: 9223372036854777090
Parent object Id: 9223372036854777089

Type:Intermediate Dir
Path: /a/b/c
DB Path: 9223372036854777090/c
Object Id: 9223372036854777091
Parent object Id: 9223372036854777090

Type:Directory
Path: /a/b/c/d
DB Path: 9223372036854777091/d
Object Id: 9223372036854777092
Parent object Id: 9223372036854777091

Type:File
Path: /a/b/c/file1
DB Path: 9223372036854777091/file1
Object Id: 9223372036854777601
Parent object Id: 9223372036854777091 `