### PR TITLE
HDDS-4740. Admin command should take effect on all SCM instance

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -189,6 +189,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hadoop-hdds-interface-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdds-interface-admin</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.protocol;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
@@ -27,8 +28,11 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.security.KerberosInfo;
 
@@ -45,6 +49,14 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * Version 1: Initial version.
    */
   long versionID = 1L;
+
+  /**
+   * Admin command should take effect on all SCM instance.
+   */
+  Set<Type> ADMIN_COMMAND_TYPE = Collections.unmodifiableSet(EnumSet.of(
+      Type.StartReplicationManager,
+      Type.StopReplicationManager,
+      Type.ForceExitSafeMode));
 
   /**
    * Asks SCM where a container should be allocated. SCM responds with the

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMProxyInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMProxyInfo.java
@@ -28,13 +28,13 @@ import java.net.InetSocketAddress;
  * Class to store SCM proxy info.
  */
 public class SCMProxyInfo {
-  private String serviceId;
-  private String nodeId;
-  private String rpcAddrStr;
-  private InetSocketAddress rpcAddr;
-
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMProxyInfo.class);
+
+  private final String serviceId;
+  private final String nodeId;
+  private final String rpcAddrStr;
+  private final InetSocketAddress rpcAddr;
 
   public SCMProxyInfo(String serviceID, String nodeID,
                       InetSocketAddress rpcAddress) {
@@ -51,12 +51,9 @@ public class SCMProxyInfo {
     }
   }
 
+  @Override
   public String toString() {
-    return new StringBuilder()
-        .append("nodeId=")
-        .append(nodeId)
-        .append(",nodeAddress=")
-        .append(rpcAddrStr).toString();
+    return "nodeId=" + nodeId + ",nodeAddress=" + rpcAddrStr;
   }
 
   public InetSocketAddress getAddress() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -88,6 +88,8 @@ import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto.Error.errorPipelineAlreadyExists;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto.Error.success;
+import static org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol.ADMIN_COMMAND_TYPE;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -133,7 +135,9 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   @Override
   public ScmContainerLocationResponse submitRequest(RpcController controller,
       ScmContainerLocationRequest request) throws ServiceException {
-    if (!scm.getScmContext().isLeader()) {
+    // not leader or not belong to admin command.
+    if (!scm.getScmContext().isLeader()
+        && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       throw new ServiceException(scm.getScmHAManager()
                                     .getRatisServer()
                                     .triggerNotLeaderException());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scope
admin command includes rm start/stop and safe mode exit.
 
Requirement
1, When admin stops rm, rm in all SCM should stop, re-election should not trigger rm to start in the new leader.
2, When admin starts rm, only rm in leader and out of safe mode should take effect. Given leader is in safe mode, even if admin starts rm explicitly, it does not take effect.
3, This admin rm start/stop can not survive restart for a SCM instance. When admin decides to stop rm of the SCM cluster, he should pay attention if any of the SCM crashes.
 
Status
1, For now, admin rm start/stop will create/destroy the rm thread.
2, SCMContainerLocationFailoverProxyProvider has been proxied by FailoverProxyProvider, it will round robin SCMs in ozone.scm.names, until it is successfully handled. In ServerSide, whenever receiving a client request, it do isLeader check first, return nle to trigger fpp to failover to the next SCM.
3, SCMService decides the next iteration of rm to take effect or not by changing RUNNING and PAUSING.
 
Solution:
When receiving a rm stop/start request on the server side, SCM skip the isLeader check, just destroys/creates rm thread, client side fake an exception to trigger fpp to try the next SCM in a round robin way.
The Running and PAUSING status and rm start/stop can be treated separately. The admin operations and the raft status are requirements of two dimensions.
 
We can achieve above requirements:
1, When admin stops rm, rm in all SCM should stop, re-election should not trigger rm to start in the new leader.
Meet, admin rm start destroy rm thread in all SCM.
 
2, When admin starts rm, only rm in leader and out of safe mode should take effect. Given leader is in safe mode, even if admin starts it explicitly, rm does not take effect.
Meet, admin rm stop create rm thread in all SCM, but SCMStatus is decided by leader and safe mode.
 
3, This admin rm start/stop can not survive restart for a SCM instance. When admin decides to stop rm of the SCM cluster, he should pay attention if any of the SCM crashes.
Meet. The is actually a relax item. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4740

## How was this patch tested?

CI and 3 SCM cluster.