### PR TITLE
HDDS-4793. Allow recon access /dbCheckpoint in ozonesecure-om-ha

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
@@ -49,7 +49,7 @@ OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_ozone.security.enabled=true
 OZONE-SITE.XML_ozone.acl.enabled=true
 OZONE-SITE.XML_ozone.acl.authorizer.class=org.apache.hadoop.ozone.security.acl.OzoneNativeAuthorizer
-OZONE-SITE.XML_ozone.administrators="testuser/scm@EXAMPLE.COM,testuser/s3g@EXAMPLE.COM"
+OZONE-SITE.XML_ozone.administrators="testuser/scm@EXAMPLE.COM,testuser/s3g@EXAMPLE.COM,recon/recon@EXAMPLE.COM"
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `recon/recon@EXAMPLE.COM` to `ozone.administrators` in `ozonesecure-om-ha` as suggested by the error message:

```
om1_1 | ERROR om.OMDBCheckpointServlet: Permission denied: User principal 'recon/recon@EXAMPLE.COM' does not have access to /dbCheckpoint.
om1_1 | This can happen when Ozone Manager is started with a different user.
om1_1 | Please append 'recon/recon@EXAMPLE.COM' to OM 'ozone.administrators' config and restart OM to grant current user access to this endpoint.
```

https://issues.apache.org/jira/browse/HDDS-4793

## How was this patch tested?

```
cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/compose/ozonesecure-om-ha
KEEP_RUNNING=true ./test.sh
docker-compose logs om1 om2 om3 | grep Checkpoint
...
om1_1 | [...] INFO om.OMDBCheckpointServlet: Received request to obtain OM DB checkpoint snapshot
om1_1 | [...] INFO db.RDBCheckpointManager: Created checkpoint at /data/metadata/db.checkpoints/rdb_rdb_checkpoint_1612468871049 in 15 milliseconds
om1_1 | [...] INFO om.OMDBCheckpointServlet: Time taken to write the checkpoint to response output stream: 30 milliseconds
om1_1 | [...] INFO db.RocksDBCheckpoint: Cleaning up RocksDB checkpoint at /data/metadata/db.checkpoints/rdb_rdb_checkpoint_1612468871049
```

https://github.com/adoroszlai/hadoop-ozone/runs/1833972692