### PR TITLE
HDDS-3974. StateContext#addPipelineActionIfAbsent does not work as expected

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -411,12 +411,22 @@ public class StateContext {
     }
   }
 
-  boolean isSamePipelineAction(PipelineAction action1, PipelineAction action2) {
-    return action1.getAction() == action2.getAction()
-        && action1.hasClosePipeline()
-        && action2.hasClosePipeline()
-        && action1.getClosePipeline().getPipelineID()
-        .equals(action2.getClosePipeline().getPipelineID());
+  /**
+   * Helper function for addPipelineActionIfAbsent that check if inputs are the
+   * same close pipeline action.
+   *
+   * Important Note: Make sure to double check for correctness before using this
+   * helper function for other purposes!
+   *
+   * @return true if a1 and a2 are the same close pipeline action,
+   *         false otherwise
+   */
+  boolean isSameClosePipelineAction(PipelineAction a1, PipelineAction a2) {
+    return a1.getAction() == a2.getAction()
+        && a1.hasClosePipeline()
+        && a2.hasClosePipeline()
+        && a1.getClosePipeline().getPipelineID()
+        .equals(a2.getClosePipeline().getPipelineID());
   }
 
   /**
@@ -438,7 +448,7 @@ public class StateContext {
         final Queue<PipelineAction> actionsForEndpoint =
             pipelineActions.get(endpoint);
         if (actionsForEndpoint.stream().noneMatch(
-            action -> isSamePipelineAction(action, pipelineAction))) {
+            action -> isSameClosePipelineAction(action, pipelineAction))) {
           actionsForEndpoint.add(pipelineAction);
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -473,19 +473,6 @@ public class StateContext {
   }
 
   /**
-   * Clear all pending pipeline actions of an endpoint.
-   */
-  @VisibleForTesting
-  void clearPendingPipelineAction(InetSocketAddress endpoint) {
-    synchronized (pipelineActions) {
-      Queue<PipelineAction> actions = this.pipelineActions.get(endpoint);
-      if (actions != null) {
-        actions.clear();
-      }
-    }
-  }
-
-  /**
    * Returns the next task to get executed by the datanode state machine.
    * @return A callable that will be executed by the
    * {@link DatanodeStateMachine}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -429,16 +429,20 @@ public class StateContext {
       for (InetSocketAddress endpoint : endpoints) {
         Queue<PipelineAction> actionsForEndpoint =
             this.pipelineActions.get(endpoint);
+        boolean actionAbsent = true;
         for (PipelineAction pipelineActionIter : actionsForEndpoint) {
           if (pipelineActionIter.getAction() == pipelineAction.getAction()
               && pipelineActionIter.hasClosePipeline()
               && pipelineAction.hasClosePipeline()
               && pipelineActionIter.getClosePipeline().getPipelineID()
               .equals(pipelineAction.getClosePipeline().getPipelineID())) {
-            return;
+            actionAbsent = false;
+            break;
           }
         }
-        actionsForEndpoint.add(pipelineAction);
+        if (actionAbsent) {
+          actionsForEndpoint.add(pipelineAction);
+        }
       }
     }
   }
@@ -465,6 +469,19 @@ public class StateContext {
         }
       }
       return pipelineActionList;
+    }
+  }
+
+  /**
+   * Clear all pending pipeline actions of an endpoint.
+   */
+  @VisibleForTesting
+  void clearPendingPipelineAction(InetSocketAddress endpoint) {
+    synchronized (pipelineActions) {
+      Queue<PipelineAction> actions = this.pipelineActions.get(endpoint);
+      if (actions != null) {
+        actions.clear();
+      }
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -411,6 +411,14 @@ public class StateContext {
     }
   }
 
+  boolean isSamePipelineAction(PipelineAction action1, PipelineAction action2) {
+    return action1.getAction() == action2.getAction()
+        && action1.hasClosePipeline()
+        && action2.hasClosePipeline()
+        && action1.getClosePipeline().getPipelineID()
+        .equals(action2.getClosePipeline().getPipelineID());
+  }
+
   /**
    * Add PipelineAction to PipelineAction queue if it's not present.
    *
@@ -427,20 +435,10 @@ public class StateContext {
        * multiple times here.
        */
       for (InetSocketAddress endpoint : endpoints) {
-        Queue<PipelineAction> actionsForEndpoint =
-            this.pipelineActions.get(endpoint);
-        boolean actionAbsent = true;
-        for (PipelineAction pipelineActionIter : actionsForEndpoint) {
-          if (pipelineActionIter.getAction() == pipelineAction.getAction()
-              && pipelineActionIter.hasClosePipeline()
-              && pipelineAction.hasClosePipeline()
-              && pipelineActionIter.getClosePipeline().getPipelineID()
-              .equals(pipelineAction.getClosePipeline().getPipelineID())) {
-            actionAbsent = false;
-            break;
-          }
-        }
-        if (actionAbsent) {
+        final Queue<PipelineAction> actionsForEndpoint =
+            pipelineActions.get(endpoint);
+        if (actionsForEndpoint.stream().noneMatch(
+            action -> isSamePipelineAction(action, pipelineAction))) {
           actionsForEndpoint.add(pipelineAction);
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -431,11 +431,11 @@ public class StateContext {
             this.pipelineActions.get(endpoint);
         for (PipelineAction pipelineActionIter : actionsForEndpoint) {
           if (pipelineActionIter.getAction() == pipelineAction.getAction()
-              && pipelineActionIter.hasClosePipeline() && pipelineAction
-              .hasClosePipeline()
+              && pipelineActionIter.hasClosePipeline()
+              && pipelineAction.hasClosePipeline()
               && pipelineActionIter.getClosePipeline().getPipelineID()
               .equals(pipelineAction.getClosePipeline().getPipelineID())) {
-            break;
+            return;
           }
         }
         actionsForEndpoint.add(pipelineAction);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -408,7 +408,7 @@ public class TestStateContext {
 
     pipelineActions = stateContext.getPendingPipelineAction(scm2, 10);
     assertEquals(1, pipelineActions.size());
-    // The pipeline action should have been removed from scm2, but still in scm1
+    // The pipeline action is dequeued from scm2 now, but still in scm1
 
     // The same pipeline action will not be added if it already exists
     stateContext.addPipelineActionIfAbsent(pipelineAction);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -406,21 +406,15 @@ public class TestStateContext {
     // Add PipelineAction. Should be added to all endpoints.
     stateContext.addPipelineActionIfAbsent(pipelineAction);
 
-    pipelineActions = stateContext.getPendingPipelineAction(scm1, 10);
-    assertEquals(1, pipelineActions.size());
     pipelineActions = stateContext.getPendingPipelineAction(scm2, 10);
     assertEquals(1, pipelineActions.size());
-
-    // Deliberately remove the pipeline action from scm2, but keep it in scm1
-    stateContext.clearPendingPipelineAction(scm2);
-    pipelineActions = stateContext.getPendingPipelineAction(scm2, 10);
-    assertEquals(0, pipelineActions.size());
+    // The pipeline action should have been removed from scm2, but still in scm1
 
     // The same pipeline action will not be added if it already exists
     stateContext.addPipelineActionIfAbsent(pipelineAction);
     pipelineActions = stateContext.getPendingPipelineAction(scm1, 10);
     assertEquals(1, pipelineActions.size());
-    // Pipeline action will be added back to the scm2
+    // The pipeline action should have been be added back to the scm2
     pipelineActions = stateContext.getPendingPipelineAction(scm2, 10);
     assertEquals(1, pipelineActions.size());
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-3974

The `break` in the loop doesn't actually prevent the pipeline action from being added twice. Should be fixed.