### PR TITLE
HDDS-4798. Check before updating container's BCSID

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -128,8 +128,10 @@ public class BlockManagerImpl implements BlockManager {
               .initBatchOperation()) {
         db.getStore().getBlockDataTable().putWithBatch(
             batch, Long.toString(data.getLocalID()), data);
-        db.getStore().getMetadataTable().putWithBatch(
-            batch, OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID, bcsId);
+        if (bcsId != 0) {
+          db.getStore().getMetadataTable().putWithBatch(
+              batch, OzoneConsts.BLOCK_COMMIT_SEQUENCE_ID, bcsId);
+        }
 
         // Set Bytes used, this bytes used will be updated for every write and
         // only get committed for every put block. In this way, when datanode
@@ -151,7 +153,9 @@ public class BlockManagerImpl implements BlockManager {
         db.getStore().getBatchHandler().commitBatchOperation(batch);
       }
 
-      container.updateBlockCommitSequenceId(bcsId);
+      if (bcsId != 0) {
+        container.updateBlockCommitSequenceId(bcsId);
+      }
       // Increment block count finally here for in-memory.
       if (incrKeyCount) {
         container.getContainerData().incrKeyCount();


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Check if the BlockData's BCSID equals 0 before updating container's BCSID

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4798

## How was this patch tested?

Unit Test.
