### PR TITLE
HDDS-4802. Fix an internal variable always not null in PipelinePlacementPolicy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -237,8 +237,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
   // Fall back logic for node pick up.
   DatanodeDetails fallBackPickNodes(
-      List<DatanodeDetails> nodeSet, List<DatanodeDetails> excludedNodes)
-      throws SCMException{
+      List<DatanodeDetails> nodeSet, List<DatanodeDetails> excludedNodes) {
     DatanodeDetails node;
     if (excludedNodes == null || excludedNodes.isEmpty()) {
       node = chooseNode(nodeSet);
@@ -246,14 +245,6 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
       List<DatanodeDetails> inputNodes = nodeSet.stream()
           .filter(p -> !excludedNodes.contains(p)).collect(Collectors.toList());
       node = chooseNode(inputNodes);
-    }
-
-    if (node == null) {
-      String msg = String.format("Unable to find fall back node in" +
-          " pipeline allocation. nodeSet size: %d", nodeSet.size());
-      LOG.warn(msg);
-      throw new SCMException(msg,
-          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
     return node;
   }
@@ -332,9 +323,18 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
         }
       }
 
-      results.add(pick);
-      exclude.add(pick);
-      LOG.debug("Remaining node chosen: {}", pick);
+      if (pick != null) {
+        results.add(pick);
+        exclude.add(pick);
+        LOG.debug("Remaining node chosen: {}", pick);
+      } else {
+        String msg = String.format("Unable to find suitable node in " +
+            "pipeline allocation. healthyNodes size: %d, " +
+            "excludeNodes size: %d", healthyNodes.size(), exclude.size());
+        LOG.warn(msg);
+        throw new SCMException(msg,
+            SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+      }
     }
 
     if (results.size() < nodesRequired) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -250,7 +250,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
     if (node == null) {
       String msg = String.format("Unable to find fall back node in" +
-          " pipeline allocation. nodeSet size: {}", nodeSet.size());
+          " pipeline allocation. nodeSet size: %d", nodeSet.size());
       LOG.warn(msg);
       throw new SCMException(msg,
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
@@ -332,11 +332,9 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
         }
       }
 
-      if (pick != null) {
-        results.add(pick);
-        exclude.add(pick);
-        LOG.debug("Remaining node chosen: {}", pick);
-      }
+      results.add(pick);
+      exclude.add(pick);
+      LOG.debug("Remaining node chosen: {}", pick);
     }
 
     if (results.size() < nodesRequired) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -234,24 +234,16 @@ public class TestPipelinePlacementPolicy {
     List<DatanodeDetails> healthyNodes = overWriteLocationInNodes(
         nodeManager.getNodes(NodeStatus.inServiceHealthy()));
     DatanodeDetails node;
-    try {
-      node = placementPolicy.fallBackPickNodes(healthyNodes, null);
-      Assert.assertNotNull(node);
-    } catch (SCMException e) {
-      Assert.fail("Should not reach here.");
-    }
+
+    // test no nodes are excluded
+    node = placementPolicy.fallBackPickNodes(healthyNodes, null);
+    Assert.assertNotNull(node);
 
     // when input nodeSet are all excluded.
     List<DatanodeDetails> exclude = healthyNodes;
-    try {
-      node = placementPolicy.fallBackPickNodes(healthyNodes, exclude);
-      Assert.assertNull(node);
-    } catch (SCMException e) {
-      Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
-          e.getResult());
-    } catch (Exception ex) {
-      Assert.fail("Should not reach here.");
-    }
+    node = placementPolicy.fallBackPickNodes(healthyNodes, exclude);
+    Assert.assertNull(node);
+
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`pick` always not null. `fallBackPickNodes` will throw exception if unable to find fall back node.

it's not a good way that throw exception in `fallBackPickNodes`. we can move the check logic to the end.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4802

## How was this patch tested?

Update related tests.
