### PR TITLE
HDDS-4801. Skip coverage check for PRs and in forks

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -256,6 +256,7 @@ jobs:
         continue-on-error: true
   coverage:
     runs-on: ubuntu-18.04
+    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
     needs:
       - acceptance
       - integration
@@ -275,12 +276,10 @@ jobs:
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
       - name: Setup java 11
         uses: actions/setup-java@v1
-        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         with:
           java-version: 11
       - name: Upload coverage to Sonar
         run: ./hadoop-ozone/dev-support/checks/sonar.sh
-        if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
         env:
           SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently _coverage_ CI check:

 1. calculates combined test coverage
 2. uploads it to Sonar only for Apache Ozone repo and only for builds on push/schedule
 3. stores combined coverage in GitHub Actions artifact

Thus for PR in Apache Ozone and for all builds in forks, it only stores coverage in the artifact.  These expire in 30 days and I don't think anybody really checks them manually.

I propose to completely skip _coverage_ check for PRs and in forks, instead of only skipping upload to Sonar.  This would save ~12 minutes for such builds.

https://issues.apache.org/jira/browse/HDDS-4801

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/1849668371