### PR TITLE
HDDS-4788. Enable mTLS for Ratis in OM HA

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/CertificateSignRequest.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificates/utils/CertificateSignRequest.java
@@ -190,12 +190,24 @@ public final class CertificateSignRequest {
       return this;
     }
 
-    // Support SAN extenion with DNS and RFC822 Name
+    // Support SAN extension with DNS and RFC822 Name
     // other name type will be added as needed.
     public CertificateSignRequest.Builder addDnsName(String dnsName) {
       Preconditions.checkNotNull(dnsName, "dnsName cannot be null");
       this.addAltName(GeneralName.dNSName, dnsName);
       return this;
+    }
+
+    public boolean hasDnsName() {
+      if (altNames == null || altNames.isEmpty()) {
+        return false;
+      }
+      for (GeneralName name : altNames) {
+        if (name.getTagNo() == GeneralName.dNSName) {
+          return true;
+        }
+      }
+      return false;
     }
 
     // IP address is subject to change which is optional for now.

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-om-ha/docker-config
@@ -39,6 +39,7 @@ OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.handler.type=distributed
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_hdds.block.token.enabled=true
+OZONE-SITE.XML_hdds.grpc.tls.enabled=true
 OZONE-SITE.XML_ozone.replication=3
 
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -33,6 +33,8 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ipc.ProtobufRpcEngine.Server;
@@ -52,8 +54,10 @@ import com.google.common.base.Strings;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ServiceException;
 import org.apache.ratis.RaftConfigKeys;
+import org.apache.ratis.conf.Parameters;
 import org.apache.ratis.conf.RaftProperties;
 import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.netty.NettyConfigKeys;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
@@ -258,10 +262,12 @@ public final class OzoneManagerRatisServer {
    * @param raftPeers peer nodes in the raft ring
    * @throws IOException
    */
+  @SuppressWarnings({"parameternumber", "java:S107"})
   private OzoneManagerRatisServer(ConfigurationSource conf,
       OzoneManager om,
       String raftGroupIdStr, RaftPeerId localRaftPeerId,
-      InetSocketAddress addr, List<RaftPeer> raftPeers)
+      InetSocketAddress addr, List<RaftPeer> raftPeers,
+      SecurityConfig secConfig, CertificateClient certClient)
       throws IOException {
     this.ozoneManager = om;
     this.omRatisAddress = addr;
@@ -282,10 +288,12 @@ public final class OzoneManagerRatisServer {
 
     this.omStateMachine = getStateMachine(conf);
 
+    Parameters parameters = createServerTlsParameters(secConfig, certClient);
     this.server = RaftServer.newBuilder()
         .setServerId(this.raftPeerId)
         .setGroup(this.raftGroup)
         .setProperties(serverProperties)
+        .setParameters(parameters)
         .setStateMachine(omStateMachine)
         .build();
   }
@@ -295,7 +303,8 @@ public final class OzoneManagerRatisServer {
    */
   public static OzoneManagerRatisServer newOMRatisServer(
       ConfigurationSource ozoneConf, OzoneManager omProtocol,
-      OMNodeDetails omNodeDetails, List<OMNodeDetails> peerNodes)
+      OMNodeDetails omNodeDetails, List<OMNodeDetails> peerNodes,
+      SecurityConfig secConfig, CertificateClient certClient)
       throws IOException {
 
     // RaftGroupId is the omServiceId
@@ -339,7 +348,7 @@ public final class OzoneManagerRatisServer {
     }
 
     return new OzoneManagerRatisServer(ozoneConf, omProtocol, omServiceId,
-        localRaftPeerId, ratisAddr, raftPeers);
+        localRaftPeerId, ratisAddr, raftPeers, secConfig, certClient);
   }
 
   public RaftGroup getRaftGroup() {
@@ -636,4 +645,22 @@ public final class OzoneManagerRatisServer {
   public RaftGroupId getRaftGroupId() {
     return raftGroupId;
   }
+
+  private static Parameters createServerTlsParameters(SecurityConfig conf,
+      CertificateClient caClient) {
+    Parameters parameters = new Parameters();
+
+    if (conf.isSecurityEnabled() && conf.isGrpcTlsEnabled()) {
+      GrpcTlsConfig config = new GrpcTlsConfig(
+          caClient.getPrivateKey(), caClient.getCertificate(),
+          caClient.getCACertificate(), true);
+      GrpcConfigKeys.Server.setTlsConf(parameters, config);
+      GrpcConfigKeys.Admin.setTlsConf(parameters, config);
+      GrpcConfigKeys.Client.setTlsConf(parameters, config);
+      GrpcConfigKeys.TLS.setConf(parameters, config);
+    }
+
+    return parameters;
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerRatisServer.java
@@ -28,6 +28,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.OMCertificateClient;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
@@ -75,6 +77,8 @@ public class TestOzoneManagerRatisServer {
   private OzoneManager ozoneManager;
   private OMNodeDetails omNodeDetails;
   private TermIndex initialTermIndex;
+  private SecurityConfig secConfig;
+  private OMCertificateClient certClient;
 
   @Before
   public void init() throws Exception {
@@ -106,8 +110,10 @@ public class TestOzoneManagerRatisServer {
     initialTermIndex = TermIndex.valueOf(0, 0);
     OMRatisSnapshotInfo omRatisSnapshotInfo = new OMRatisSnapshotInfo();
     when(ozoneManager.getSnapshotInfo()).thenReturn(omRatisSnapshotInfo);
+    secConfig = new SecurityConfig(conf);
+    certClient = new OMCertificateClient(secConfig);
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-      omNodeDetails, Collections.emptyList());
+      omNodeDetails, Collections.emptyList(), secConfig, certClient);
     omRatisServer.start();
   }
 
@@ -147,7 +153,7 @@ public class TestOzoneManagerRatisServer {
 
     // Start new Ratis server. It should pick up and load the new SnapshotInfo
     omRatisServer = OzoneManagerRatisServer.newOMRatisServer(conf, ozoneManager,
-        omNodeDetails, Collections.emptyList());
+        omNodeDetails, Collections.emptyList(), secConfig, certClient);
     omRatisServer.start();
     TermIndex lastAppliedTermIndex =
         omRatisServer.getLastAppliedTermIndex();
@@ -217,7 +223,7 @@ public class TestOzoneManagerRatisServer {
     omRatisServer.stop();
     OzoneManagerRatisServer newOmRatisServer = OzoneManagerRatisServer
         .newOMRatisServer(newConf, ozoneManager, nodeDetails,
-            Collections.emptyList());
+            Collections.emptyList(), secConfig, certClient);
     newOmRatisServer.start();
 
     UUID uuid = UUID.nameUUIDFromBytes(customOmServiceId.getBytes(UTF_8));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Let OM HA enable TLS for its internal Ratis if `SecurityConfig#isGrpcTlsEnabled` is true (ie. if `hdds.grpc.tls.enabled=true`)

To make this work in docker-compose cluster, we need a small tweak in the OM certificate request.  Normally hostname is included in the alternative names list, and subject name can be anything (in our case it's in the form of `user@host`, eg. `root@om1`).  However, if reverse lookup for OM host's IP does not work, then subject name will be the only information available for certificate verification to match DNS.  In this case we should omit the username part, because it will cause DNS match to fail.

https://issues.apache.org/jira/browse/HDDS-4788

## How was this patch tested?

Enabled `hdds.grpc.tls.enabled=true` in `ozonesecure-om-ha` cluster.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/547953101