### PR TITLE
HDDS-4182. Onboard HDDS-3869 into Layout version management.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -140,7 +140,7 @@ public class DatanodeStateMachine implements Closeable {
     upgradeFinalizer = new DataNodeUpgradeFinalizer(dataNodeVersionManager,
         datanodeDetails.getUuidString());
     DatanodeMetadataFeatures.
-        setHDDSLayoutVersionManager(dataNodeVersionManager);
+        initialize(dataNodeVersionManager);
 
     executorService = Executors.newFixedThreadPool(
         getEndPointTaskThreadPoolSize(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.ozone.container.replication.ReplicationSupervisor;
 import org.apache.hadoop.ozone.container.replication.SimpleContainerDownloader;
 import org.apache.hadoop.ozone.container.upgrade.DataNodeLayoutAction;
 import org.apache.hadoop.ozone.container.upgrade.DataNodeUpgradeFinalizer;
+import org.apache.hadoop.ozone.container.upgrade.DatanodeMetadataFeatures;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.util.JvmPauseMonitor;
@@ -138,6 +139,8 @@ public class DatanodeStateMachine implements Closeable {
         new HDDSLayoutVersionManager(dataNodeStorageConfig);
     upgradeFinalizer = new DataNodeUpgradeFinalizer(dataNodeVersionManager,
         datanodeDetails.getUuidString());
+    DatanodeMetadataFeatures.
+        setHDDSLayoutVersionManager(dataNodeVersionManager);
 
     executorService = Executors.newFixedThreadPool(
         getEndPointTaskThreadPoolSize(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
+import org.apache.hadoop.ozone.container.upgrade.DatanodeMetadataFeatures;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import com.google.common.base.Preconditions;
@@ -129,7 +130,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
 
       // This method is only called when creating new containers.
       // Therefore, always use the newest schema version.
-      containerData.setSchemaVersion(OzoneConsts.SCHEMA_LATEST);
+      containerData.setSchemaVersion(
+          DatanodeMetadataFeatures.getSchemaVersion());
       KeyValueContainerUtil.createContainerMetaData(containerID,
               containerMetaDataPath, chunksPath, dbFile,
               containerData.getSchemaVersion(), config);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
@@ -3,19 +3,27 @@ package org.apache.hadoop.ozone.container.upgrade;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.OzoneConsts;
 
+/**
+ * Utility class to retrieve the version of a feature that corresponds to the
+ * metadata layout version specified by the provided
+ * {@link HDDSLayoutVersionManager}.
+ */
 public final class DatanodeMetadataFeatures {
   private static HDDSLayoutVersionManager versionManager;
 
-  public static void setHDDSLayoutVersionManager(HDDSLayoutVersionManager manager) {
+  private DatanodeMetadataFeatures() { }
+
+  public static synchronized void setHDDSLayoutVersionManager(
+      HDDSLayoutVersionManager manager) {
     versionManager = manager;
   }
 
-  public static String getSchemaVersion() {
+  public static synchronized String getSchemaVersion() {
     if (versionManager == null ||
         versionManager.getMetadataLayoutVersion() < 1) {
       return OzoneConsts.SCHEMA_V1;
     } else {
-      return OzoneConsts.SCHEMA_V1;
+      return OzoneConsts.SCHEMA_V2;
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
@@ -17,8 +17,11 @@
  */
 package org.apache.hadoop.ozone.container.upgrade;
 
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.OzoneConsts;
+
+import java.io.IOException;
 
 /**
  * Utility class to retrieve the version of a feature that corresponds to the
@@ -30,14 +33,17 @@ public final class DatanodeMetadataFeatures {
 
   private DatanodeMetadataFeatures() { }
 
-  public static synchronized void setHDDSLayoutVersionManager(
+  public static synchronized void initialize(
       HDDSLayoutVersionManager manager) {
     versionManager = manager;
   }
 
-  public static synchronized String getSchemaVersion() {
-    if (versionManager == null ||
-        versionManager.getMetadataLayoutVersion() < 1) {
+  public static synchronized String getSchemaVersion() throws IOException {
+    if (versionManager == null) {
+      throw new IOException("DatanodeMetadataFeatures must be initialized " +
+          "to determine schema version");
+    } else if (versionManager.getMetadataLayoutVersion() <
+        HDDSLayoutFeature.FIRST_UPGRADE_VERSION.layoutVersion()) {
       return OzoneConsts.SCHEMA_V1;
     } else {
       return OzoneConsts.SCHEMA_V2;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
@@ -40,8 +40,9 @@ public final class DatanodeMetadataFeatures {
 
   public static synchronized String getSchemaVersion() throws IOException {
     if (versionManager == null) {
-      throw new IOException("DatanodeMetadataFeatures must be initialized " +
-          "to determine schema version");
+      // version manager can be null for testing. Use the latest version in
+      // this case.
+      return OzoneConsts.SCHEMA_V2;
     } else if (versionManager.getMetadataLayoutVersion() <
         HDDSLayoutFeature.FIRST_UPGRADE_VERSION.layoutVersion()) {
       return OzoneConsts.SCHEMA_V1;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
@@ -1,0 +1,21 @@
+package org.apache.hadoop.ozone.container.upgrade;
+
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+public final class DatanodeMetadataFeatures {
+  private static HDDSLayoutVersionManager versionManager;
+
+  public static void setHDDSLayoutVersionManager(HDDSLayoutVersionManager manager) {
+    versionManager = manager;
+  }
+
+  public static String getSchemaVersion() {
+    if (versionManager == null ||
+        versionManager.getMetadataLayoutVersion() < 1) {
+      return OzoneConsts.SCHEMA_V1;
+    } else {
+      return OzoneConsts.SCHEMA_V1;
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DatanodeMetadataFeatures.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone.container.upgrade;
 
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-3869 (Use different column families for datanode block and metadata), a new schema version for container layout was introduced. Use the non-rolling upgrade framework to make sure that this new schema version is not used before the cluster is finalized.

## What is the link to the Apache JIRA

HDDS-4182

## How was this patch tested?

With the current code, existing tests will use schema V1 after this change. After HDDS-4817, existing tests will use schema V2 as before. Moving from schema V1 to schema V2 will be tested as part of the upgrade acceptance testing added in HDDS-4181.
