### PR TITLE
HDDS-4761. Implement increment count optimization in DeletedBlockLog V2

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
@@ -79,6 +79,8 @@ public class DeletedBlockLogImplV2
   private final Lock lock;
   // Maps txId to set of DNs which are successful in committing the transaction
   private Map<Long, Set<UUID>> transactionToDNsCommitMap;
+  // Maps txId to its retry counts;
+  private Map<Long, Integer> transactionRetryCountMap;
   // The access to DeletedBlocksTXTable is protected by
   // DeletedBlockLogStateManager.
   private final DeletedBlockLogStateManager deletedBlockLogStateManager;
@@ -101,6 +103,7 @@ public class DeletedBlockLogImplV2
 
     // maps transaction to dns which have committed it.
     transactionToDNsCommitMap = new ConcurrentHashMap<>();
+    transactionRetryCountMap = new ConcurrentHashMap<>();
     this.deletedBlockLogStateManager = DeletedBlockLogStateManagerImpl
         .newBuilder()
         .setConfiguration(conf)
@@ -145,8 +148,25 @@ public class DeletedBlockLogImplV2
   public void incrementCount(List<Long> txIDs) throws IOException {
     lock.lock();
     try {
-      deletedBlockLogStateManager
-          .increaseRetryCountOfTransactionInDB(new ArrayList<>(txIDs));
+      ArrayList<Long> toUpdateTxIDs = new ArrayList<>();
+      for (Long txID : txIDs) {
+        int currentCount =
+            transactionRetryCountMap.getOrDefault(txID, 0);
+        if (currentCount > maxRetry) {
+          continue;
+        } else {
+          currentCount += 1;
+          if (currentCount > maxRetry) {
+            toUpdateTxIDs.add(txID);
+          }
+          transactionRetryCountMap.put(txID, currentCount);
+        }
+      }
+
+      if (!toUpdateTxIDs.isEmpty()) {
+        deletedBlockLogStateManager
+            .increaseRetryCountOfTransactionInDB(toUpdateTxIDs);
+      }
     } finally {
       lock.unlock();
     }
@@ -216,6 +236,7 @@ public class DeletedBlockLogImplV2
                 .collect(Collectors.toList());
             if (dnsWithCommittedTxn.containsAll(containerDns)) {
               transactionToDNsCommitMap.remove(txID);
+              transactionRetryCountMap.remove(txID);
               if (LOG.isDebugEnabled()) {
                 LOG.debug("Purging txId={} from block deletion log", txID);
               }
@@ -281,8 +302,9 @@ public class DeletedBlockLogImplV2
    * Called in SCMStateMachine#notifyLeaderChanged when current SCM becomes
    *  leader.
    */
-  public void clearTransactionToDNsCommitMap() {
+  public void onBecomeLeader() {
     transactionToDNsCommitMap.clear();
+    transactionRetryCountMap.clear();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -203,7 +203,7 @@ public class DeletedBlockLogStateManagerImpl
 
   public void onFlush() {
     deletingTxIDs.clear();
-    LOG.info("Clear cached deletingTxIDs.");
+    skippingRetryTxIDs.clear();
   }
 
   public static Builder newBuilder() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -187,17 +187,10 @@ public class DeletedBlockLogStateManagerImpl
         }
         continue;
       }
-      DeletedBlocksTransaction.Builder builder = block.toBuilder();
-      int currentCount = block.getCount();
-      if (currentCount > -1) {
-        builder.setCount(++currentCount);
-      }
       // if the retry time exceeds the maxRetry value
       // then set the retry value to -1, stop retrying, admins can
       // analyze those blocks and purge them manually by SCMCli.
-      if (currentCount > maxRetry) {
-        builder.setCount(-1);
-      }
+      DeletedBlocksTransaction.Builder builder = block.toBuilder().setCount(-1);
       deletedTable.putWithBatch(
           transactionBuffer.getCurrentBatchOperation(), txID, builder.build());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -186,7 +186,7 @@ public class SCMStateMachine extends BaseStateMachine {
     Preconditions.checkArgument(
         deletedBlockLog instanceof DeletedBlockLogImplV2);
     ((DeletedBlockLogImplV2) deletedBlockLog)
-          .clearTransactionToDNsCommitMap();
+          .onBecomeLeader();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -259,43 +259,6 @@ public class TestDeletedBlockLog {
   }
 
   @Test
-  public void testIncrementCountLessFrequentWritingToDB() throws Exception {
-    OzoneConfiguration testConf = OzoneConfiguration.of(conf);
-    testConf.setInt(OZONE_SCM_BLOCK_DELETION_MAX_RETRY, 120);
-
-    deletedBlockLog = new DeletedBlockLogImplV2(testConf, containerManager,
-        MockSCMHAManager.getInstance(true).getRatisServer(),
-        scm.getScmMetadataStore().getDeletedBlocksTXTable(),
-        dbTransactionBuffer, SCMContext.emptyContext());
-
-    addTransactions(generateData(30));
-
-    List<DeletedBlocksTransaction> blocks =
-        getTransactions(40 * BLOCKS_PER_TXN);
-    List<Long> txIDs = blocks.stream().map(DeletedBlocksTransaction::getTxID)
-        .collect(Collectors.toList());
-
-    for (int i = 0; i < 110; i++) {
-      incrementCount(txIDs);
-    }
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
-    for (DeletedBlocksTransaction block : blocks) {
-      // block count should not be updated as there are only 110 retries.
-      Assert.assertEquals(0, block.getCount());
-    }
-
-    for (int i = 0; i < 50; i++) {
-      incrementCount(txIDs);
-    }
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
-    for (DeletedBlocksTransaction block : blocks) {
-      // block count should be updated to -1 as retry count exceeds maxRetry
-      // (i.e. 160 > maxRetry which is 120).
-      Assert.assertEquals(-1, block.getCount());
-    }
-  }
-
-  @Test
   public void testCommitTransactions() throws Exception {
     addTransactions(generateData(50));
     List<DeletedBlocksTransaction> blocks =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Only trigger a Ratis oncall when in-memory retry count exceed max_retry. 

Relevant doc: https://docs.google.com/document/d/1hjHs2pt3fD7jRiMwu90SK4uY2hgrFIjEsygt5kJP8NY/edit?usp=sharing

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4761

## How was this patch tested?

UT
