### PR TITLE
HDDS-4815. Close the corresponding ChunkInputStream when BlockInputStream is being closed.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -413,6 +413,13 @@ public class BlockInputStream extends InputStream
   public synchronized void close() {
     releaseClient();
     xceiverClientFactory = null;
+
+    final List<ChunkInputStream> inputStreams = this.chunkStreams;
+    if (inputStreams != null) {
+      for (ChunkInputStream is : inputStreams) {
+        is.close();
+      }
+    }
   }
 
   private void releaseClient() {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Close the corresponding ChunkInputStream when BlockInputStream is being closed, reverting the behavior changed by HDDS-4320.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4815

## How was this patch tested?
Manually verified using SparkSQL TPC-DS workload. Also verified by a btrace script that intercepts input stream construction/close calls and socket creation.