### PR TITLE
HDDS-4825. Trash checkpoints are not getting deleted from multiple buckets.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1195,15 +1195,27 @@ public class TestRootedOzoneFileSystem {
   /**
    * 1.Move a Key to Trash
    * 2.Verify that the key gets deleted by the trash emptier.
+   * 3.Create a second Key in different bucket and verify deletion.
    * @throws Exception
    */
   @Test
   public void testTrash() throws Exception {
     String testKeyName = "keyToBeDeleted";
-    Path path = new Path(bucketPath, testKeyName);
-    try (FSDataOutputStream stream = fs.create(path)) {
+    Path keyPath1 = new Path(bucketPath, testKeyName);
+    try (FSDataOutputStream stream = fs.create(keyPath1)) {
       stream.write(1);
     }
+    // create second bucket and write a key in it.
+    OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(cluster);
+    String volumeName2 = bucket2.getVolumeName();
+    Path volumePath2 = new Path(OZONE_URI_DELIMITER, volumeName2);
+    String bucketName2 = bucket2.getName();
+    Path bucketPath2 = new Path(volumePath2, bucketName2);
+    Path keyPath2 = new Path(bucketPath2, testKeyName + "1");
+    try (FSDataOutputStream stream = fs.create(keyPath2)) {
+      stream.write(1);
+    }
+
     Assert.assertTrue(trash.getConf().getClass(
         "fs.trash.classname", TrashPolicy.class).
         isAssignableFrom(TrashPolicyOzone.class));
@@ -1215,20 +1227,26 @@ public class TestRootedOzoneFileSystem {
     long prevNumTrashFileRenames = getOMMetrics().getNumTrashFilesRenames();
 
     // Call moveToTrash. We can't call protected fs.rename() directly
-    trash.moveToTrash(path);
+    trash.moveToTrash(keyPath1);
+    // for key in second bucket
+    trash.moveToTrash(keyPath2);
 
-    // Construct paths
+    // Construct paths for first key
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
     Path trashRoot = new Path(bucketPath, TRASH_PREFIX);
     Path userTrash = new Path(trashRoot, username);
-    Path userTrashCurrent = new Path(userTrash, "Current");
-    String key = path.toString().substring(1);
-    Path trashPath = new Path(userTrashCurrent, key);
+    Path trashPath = getTrashKeyPath(keyPath1, userTrash);
 
-    // Wait until the TrashEmptier purges the key
+    // Construct paths for second key in different bucket
+    Path trashRoot2 = new Path(bucketPath2, TRASH_PREFIX);
+    Path userTrash2 = new Path(trashRoot2, username);
+    Path trashPath2 = getTrashKeyPath(keyPath2, userTrash2);
+
+
+    // Wait until the TrashEmptier purges the keys
     GenericTestUtils.waitFor(()-> {
       try {
-        return !ofs.exists(trashPath);
+        return !ofs.exists(trashPath) && !ofs.exists(trashPath2);
       } catch (IOException e) {
         LOG.error("Delete from Trash Failed", e);
         Assert.fail("Delete from Trash Failed");
@@ -1249,7 +1267,14 @@ public class TestRootedOzoneFileSystem {
             > prevNumTrashFileDeletes, 100, 180000);
     // Cleanup
     ofs.delete(trashRoot, true);
+    ofs.delete(trashRoot2, true);
 
+  }
+
+  private Path getTrashKeyPath(Path keyPath, Path userTrash) {
+    Path userTrashCurrent = new Path(userTrash, "Current");
+    String key = keyPath.toString().substring(1);
+    return new Path(userTrashCurrent, key);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1260,6 +1260,18 @@ public class TestRootedOzoneFileSystem {
     Assert.assertTrue(getOMMetrics()
         .getNumTrashFilesRenames() > prevNumTrashFileRenames);
 
+    // wait for deletion of checkpoint dir
+    GenericTestUtils.waitFor(()-> {
+      try {
+        return ofs.listStatus(userTrash).length==0 &&
+            ofs.listStatus(userTrash2).length==0;
+      } catch (IOException e) {
+        LOG.error("Delete from Trash Failed", e);
+        Assert.fail("Delete from Trash Failed");
+        return false;
+      }
+    }, 1000, 120000);
+
     // This condition should succeed once the checkpoint directory is deleted
     GenericTestUtils.waitFor(
         () -> getOMMetrics().getNumTrashDeletes() > prevNumTrashDeletes

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -190,12 +190,12 @@ public class TrashOzoneFileSystem extends FileSystem {
    * converts OzoneFileStatus object to FileStatus.
    */
   private FileStatus convertToFileStatus(OzoneFileStatus status) {
-    String ofsPathPrefix = OZONE_URI_DELIMITER +
+    Path temp = new Path(OZONE_URI_DELIMITER +
         status.getKeyInfo().getVolumeName() +
         OZONE_URI_DELIMITER +
-        status.getKeyInfo().getBucketName();
-    Path temp = new Path(ofsPathPrefix +
-        OZONE_URI_DELIMITER + status.getKeyInfo().getKeyName());
+        status.getKeyInfo().getBucketName() +
+        OZONE_URI_DELIMITER +
+        status.getKeyInfo().getKeyName());
     return new FileStatus(
         status.getKeyInfo().getDataSize(),
         status.isDirectory(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -75,8 +75,6 @@ public class TrashOzoneFileSystem extends FileSystem {
 
   private final String userName;
 
-  private String ofsPathPrefix;
-
   private final AtomicLong runCount;
 
   private static final ClientId CLIENT_ID = ClientId.randomId();
@@ -192,6 +190,10 @@ public class TrashOzoneFileSystem extends FileSystem {
    * converts OzoneFileStatus object to FileStatus.
    */
   private FileStatus convertToFileStatus(OzoneFileStatus status) {
+    String ofsPathPrefix = OZONE_URI_DELIMITER +
+        status.getKeyInfo().getVolumeName() +
+        OZONE_URI_DELIMITER +
+        status.getKeyInfo().getBucketName();
     Path temp = new Path(ofsPathPrefix +
         OZONE_URI_DELIMITER + status.getKeyInfo().getKeyName());
     return new FileStatus(
@@ -243,8 +245,6 @@ public class TrashOzoneFileSystem extends FileSystem {
         .setBucketName(bucket)
         .setKeyName(key)
         .build();
-    this.ofsPathPrefix = OZONE_URI_DELIMITER +
-        volume + OZONE_URI_DELIMITER + bucket;
     return keyArgs;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Trash checkpoints are not getting deleted from multiple buckets . Since the trash emptier is multi-threaded and share the same fs instance,` ofsPathPrefix` which is used as an instance variable in `TrashOzoneFilesystem` is getting set my  multiple threads at once (each thread operates on a bucket) and wrong bucket name is obtained . This change resolves this issue by removing ` ofsPathPrefix` as an instance variable for TrashOzoneFilesystem which is unneccessary.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4825

## How was this patch tested?
Added unit tests where deletion from multiple buckets is ensured.
