### PR TITLE
HDDS-4823. Make SCM Generic config support HA Style.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -180,7 +180,7 @@ public class SCMHANodeDetails {
         }
 
         String rpcAddrKey = ConfUtils.addKeySuffixes(
-            OZONE_SCM_ADDRESS_KEY, localScmNodeId, nodeId);
+            OZONE_SCM_ADDRESS_KEY, serviceId, nodeId);
         String rpcAddrStr = conf.get(rpcAddrKey);
         if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
           throwConfException("Configuration does not have any value set for " +
@@ -195,7 +195,7 @@ public class SCMHANodeDetails {
 
         InetSocketAddress addr = null;
         try {
-          addr = NetUtils.createSocketAddr(rpcAddrStr);
+          addr = NetUtils.createSocketAddr(rpcAddrStr, ratisPort);
         } catch (Exception e) {
           LOG.error("Couldn't create socket address for SCM {} : {}", nodeId,
               rpcAddrStr, e);
@@ -248,10 +248,6 @@ public class SCMHANodeDetails {
       return null;
     }
   }
-
-
-
-
 
   public static SCMNodeDetails getHASCMNodeDetails(OzoneConfiguration conf,
       String localScmServiceId, String localScmNodeId,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHANodeDetails.java
@@ -37,10 +37,26 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DB_DIRS;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTPS_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTPS_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INTERNAL_SERVICE_ID;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY;
 
 public class SCMHANodeDetails {
@@ -49,6 +65,28 @@ public class SCMHANodeDetails {
 
   private final SCMNodeDetails localNodeDetails;
   private final List<SCMNodeDetails> peerNodeDetails;
+
+  private static String[] nodeSpecificConfigKeys = new String[] {
+      OZONE_SCM_DATANODE_ADDRESS_KEY,
+      OZONE_SCM_DATANODE_PORT_KEY,
+      OZONE_SCM_DATANODE_BIND_HOST_KEY,
+      OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+      OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+      OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
+      OZONE_SCM_CLIENT_ADDRESS_KEY,
+      OZONE_SCM_CLIENT_PORT_KEY,
+      OZONE_SCM_CLIENT_BIND_HOST_KEY,
+      OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+      OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+      OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY,
+      OZONE_SCM_RATIS_PORT_KEY,
+      OZONE_SCM_HTTP_BIND_HOST_KEY,
+      OZONE_SCM_HTTPS_BIND_HOST_KEY,
+      OZONE_SCM_HTTP_ADDRESS_KEY,
+      OZONE_SCM_HTTPS_ADDRESS_KEY,
+      OZONE_SCM_DB_DIRS,
+      OZONE_SCM_ADDRESS_KEY
+  };
 
   public SCMHANodeDetails(SCMNodeDetails localNodeDetails,
       List<SCMNodeDetails> peerNodeDetails) {
@@ -148,7 +186,6 @@ public class SCMHANodeDetails {
           throwConfException("Configuration does not have any value set for " +
               "%s. SCM RPC Address should be set for all nodes in a SCM " +
               "service.", rpcAddrKey);
-          return null;
         }
         isSCMddressSet = true;
 
@@ -189,6 +226,10 @@ public class SCMHANodeDetails {
             localScmServiceId, localScmNodeId,
             NetUtils.getHostPortString(localRpcAddress), localRatisPort);
 
+        // Set SCM node specific config keys.
+        ConfUtils.setNodeSpecificConfigs(nodeSpecificConfigKeys, conf,
+            localScmServiceId, localScmNodeId, LOG);
+
         return new SCMHANodeDetails(getHASCMNodeDetails(conf, localScmServiceId,
             localScmNodeId, localRpcAddress, localRatisPort), peerNodesList);
 
@@ -197,17 +238,20 @@ public class SCMHANodeDetails {
                 "match local node's address. Please configure the system " +
                 "with %s and %s", OZONE_SCM_ADDRESS_KEY,
             OZONE_SCM_SERVICE_IDS_KEY, OZONE_SCM_ADDRESS_KEY);
-        return null;
       }
     }
 
     if (!isSCMddressSet) {
-      // If HA config is not set properly, fall back to default configuration
+      // If HA config is not set, fall back to default configuration
       return loadDefaultConfig(conf);
     } else {
       return null;
     }
   }
+
+
+
+
 
   public static SCMNodeDetails getHASCMNodeDetails(OzoneConfiguration conf,
       String localScmServiceId, String localScmNodeId,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -24,6 +24,24 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DB_DIRS;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
+
 public class TestSCMHAConfiguration {
   private OzoneConfiguration conf;
 
@@ -69,46 +87,47 @@ public class TestSCMHAConfiguration {
     int port = 9880;
     int i = 1;
     for (String nodeId : nodes) {
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost:"+port++);
-      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
           scmServiceId, nodeId), port);
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
           scmServiceId, nodeId), "172.28.9.1");
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost:"+port++);
-      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
           scmServiceId, nodeId), port);
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY,
-          scmServiceId, nodeId), "172.28.9.1");
+      conf.set(ConfUtils.addKeySuffixes(
+          OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId, nodeId),
+          "172.28.9.1");
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost:"+port++);
-      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY,
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_PORT_KEY,
           scmServiceId, nodeId), port);
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_BIND_HOST_KEY,
           scmServiceId, nodeId), "172.28.9.1");
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost:"+port++);
-      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY,
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
           scmServiceId, nodeId), port);
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_BIND_HOST_KEY,
           scmServiceId, nodeId), "172.28.9.1");
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost:"+port++);
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_BIND_HOST_KEY,
           scmServiceId, nodeId), "172.28.9.1");
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DB_DIRS,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_DB_DIRS,
           scmServiceId, nodeId), "/var/scm-metadata"+ i++);
 
-      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,
+      conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_ADDRESS_KEY,
           scmServiceId, nodeId), "localhost");
 
-      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+      conf.setInt(ConfUtils.addKeySuffixes(OZONE_SCM_RATIS_PORT_KEY,
           scmServiceId, nodeId), port++);
     }
 
@@ -119,65 +138,65 @@ public class TestSCMHAConfiguration {
 
     // Validate configs.
     Assert.assertEquals("localhost:"+port++,
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
         scmServiceId, "scm1")));
     Assert.assertEquals(port,
-        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
         scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, scmServiceId,
-        "scm1")));
+    Assert.assertEquals("172.28.9.1",
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
+            scmServiceId, "scm1")));
 
 
     Assert.assertEquals("localhost:"+port++,
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+        conf.get(ConfUtils.addKeySuffixes(
+            OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY, scmServiceId, "scm1")));
+    Assert.assertEquals(port,
+        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+            scmServiceId, "scm1"), 9999));
+    Assert.assertEquals("172.28.9.1",
+        conf.get(ConfUtils.addKeySuffixes(
+            OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId, "scm1")));
+
+
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_ADDRESS_KEY,
             scmServiceId, "scm1")));
     Assert.assertEquals(port,
-        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_PORT_KEY,
             scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId,
+    Assert.assertEquals("172.28.9.1", conf.get(
+        ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_BIND_HOST_KEY, scmServiceId,
         "scm1")));
 
-
     Assert.assertEquals("localhost:"+port++,
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_ADDRESS_KEY,
             scmServiceId, "scm1")));
     Assert.assertEquals(port,
-        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY,
+        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
             scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY, scmServiceId,
-        "scm1")));
-
-    Assert.assertEquals("localhost:"+port++,
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
-            scmServiceId, "scm1")));
-    Assert.assertEquals(port,
-        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY,
-            scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY, scmServiceId,
+    Assert.assertEquals("172.28.9.1", conf.get(
+        ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_BIND_HOST_KEY, scmServiceId,
         "scm1")));
 
 
     Assert.assertEquals("localhost:"+port++,
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_ADDRESS_KEY,
         scmServiceId, "scm1")));
     Assert.assertEquals("172.28.9.1",
-        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY,
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_BIND_HOST_KEY,
         scmServiceId, "scm1")));
 
     Assert.assertEquals("localhost", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_ADDRESS_KEY, scmServiceId,
+        OZONE_SCM_ADDRESS_KEY, scmServiceId,
         "scm1")));
 
-    Assert.assertEquals("/var/scm-metadata1", conf.get(ConfUtils.addKeySuffixes(
-        ScmConfigKeys.OZONE_SCM_DB_DIRS, scmServiceId,
+    Assert.assertEquals("/var/scm-metadata1",
+        conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_DB_DIRS, scmServiceId,
         "scm1")));
 
     Assert.assertEquals(port++,
-        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_RATIS_PORT_KEY,
         scmServiceId, "scm1"), 9999));
 
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,5 +54,132 @@ public class TestSCMHAConfiguration {
     scmhaConfiguration = conf.getObject(
         SCMHAConfiguration.class);
     Assert.assertEquals(true, scmhaConfiguration.getRaftLogPurgeEnabled());
+  }
+
+
+  @Test
+  public void testSCMHAConfig() throws Exception {
+    String scmServiceId = "scmserviceId";
+    conf.set(ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY, scmServiceId);
+
+    String[] nodes = new String[] {"scm1", "scm2", "scm3"};
+    conf.set(ScmConfigKeys.OZONE_SCM_NODES_KEY+"."+scmServiceId, "scm1,scm2,scm3");
+    conf.set(ScmConfigKeys.OZONE_SCM_NODE_ID_KEY, "scm1");
+
+    int port = 9880;
+    int i = 1;
+    for (String nodeId : nodes) {
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost:"+port++);
+      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+          scmServiceId, nodeId), port);
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
+          scmServiceId, nodeId), "172.28.9.1");
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost:"+port++);
+      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+          scmServiceId, nodeId), port);
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY,
+          scmServiceId, nodeId), "172.28.9.1");
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost:"+port++);
+      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY,
+          scmServiceId, nodeId), port);
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY,
+          scmServiceId, nodeId), "172.28.9.1");
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost:"+port++);
+      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY,
+          scmServiceId, nodeId), port);
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY,
+          scmServiceId, nodeId), "172.28.9.1");
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost:"+port++);
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY,
+          scmServiceId, nodeId), "172.28.9.1");
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DB_DIRS,
+          scmServiceId, nodeId), "/var/scm-metadata"+ i++);
+
+      conf.set(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,
+          scmServiceId, nodeId), "localhost");
+
+      conf.setInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+          scmServiceId, nodeId), port++);
+    }
+
+
+    SCMHANodeDetails.loadSCMHAConfig(conf);
+
+    port = 9880;
+
+    // Validate configs.
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
+        scmServiceId, "scm1")));
+    Assert.assertEquals(port,
+        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
+        scmServiceId, "scm1"), 9999));
+    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY, scmServiceId,
+        "scm1")));
+
+
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
+            scmServiceId, "scm1")));
+    Assert.assertEquals(port,
+        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
+            scmServiceId, "scm1"), 9999));
+    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId,
+        "scm1")));
+
+
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY,
+            scmServiceId, "scm1")));
+    Assert.assertEquals(port,
+        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_CLIENT_PORT_KEY,
+            scmServiceId, "scm1"), 9999));
+    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_CLIENT_BIND_HOST_KEY, scmServiceId,
+        "scm1")));
+
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_ADDRESS_KEY,
+            scmServiceId, "scm1")));
+    Assert.assertEquals(port,
+        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY,
+            scmServiceId, "scm1"), 9999));
+    Assert.assertEquals("172.28.9.1", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_DATANODE_BIND_HOST_KEY, scmServiceId,
+        "scm1")));
+
+
+    Assert.assertEquals("localhost:"+port++,
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY,
+        scmServiceId, "scm1")));
+    Assert.assertEquals("172.28.9.1",
+        conf.get(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY,
+        scmServiceId, "scm1")));
+
+    Assert.assertEquals("localhost", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_ADDRESS_KEY, scmServiceId,
+        "scm1")));
+
+    Assert.assertEquals("/var/scm-metadata1", conf.get(ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_DB_DIRS, scmServiceId,
+        "scm1")));
+
+    Assert.assertEquals(port++,
+        conf.getInt(ConfUtils.addKeySuffixes(ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+        scmServiceId, "scm1"), 9999));
+
+
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -81,7 +81,8 @@ public class TestSCMHAConfiguration {
     conf.set(ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY, scmServiceId);
 
     String[] nodes = new String[] {"scm1", "scm2", "scm3"};
-    conf.set(ScmConfigKeys.OZONE_SCM_NODES_KEY+"."+scmServiceId, "scm1,scm2,scm3");
+    conf.set(ScmConfigKeys.OZONE_SCM_NODES_KEY+"."+scmServiceId,
+        "scm1,scm2,scm3");
     conf.set(ScmConfigKeys.OZONE_SCM_NODE_ID_KEY, "scm1");
 
     int port = 9880;
@@ -151,9 +152,8 @@ public class TestSCMHAConfiguration {
     Assert.assertEquals("localhost:"+port++,
         conf.get(ConfUtils.addKeySuffixes(
             OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY, scmServiceId, "scm1")));
-    Assert.assertEquals(port,
-        conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
-            scmServiceId, "scm1"), 9999));
+    Assert.assertEquals(port, conf.getInt(ConfUtils.addKeySuffixes(
+        OZONE_SCM_SECURITY_SERVICE_PORT_KEY, scmServiceId, "scm1"), 9999));
     Assert.assertEquals("172.28.9.1",
         conf.get(ConfUtils.addKeySuffixes(
             OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId, "scm1")));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/ha/ConfUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/ha/ConfUtils.java
@@ -70,7 +70,7 @@ public final class ConfUtils {
   }
 
   /**
-   * Get the conf key value appended with serviceId and nodeId
+   * Get the conf key value appended with serviceId and nodeId.
    * @param conf
    * @param confKey
    * @param omServiceID

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/ha/ConfUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/ha/ConfUtils.java
@@ -17,7 +17,11 @@
 package org.apache.hadoop.ozone.ha;
 
 import com.google.common.base.Joiner;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.net.NetUtils;
+import org.slf4j.Logger;
 
 import java.net.InetSocketAddress;
 
@@ -50,7 +54,7 @@ public final class ConfUtils {
   /**
    * Concatenate list of suffix strings '.' separated.
    */
-  private static String concatSuffixes(String... suffixes) {
+  public static String concatSuffixes(String... suffixes) {
     if (suffixes == null) {
       return null;
     }
@@ -63,5 +67,46 @@ public final class ConfUtils {
    */
   public static boolean isAddressLocal(InetSocketAddress addr) {
     return NetUtils.isLocalAddress(addr.getAddress());
+  }
+
+  /**
+   * Get the conf key value appended with serviceId and nodeId
+   * @param conf
+   * @param confKey
+   * @param omServiceID
+   * @param omNodeId
+   * @return conf value.
+   */
+  public static String getConfSuffixedWithServiceId(ConfigurationSource conf,
+      String confKey, String omServiceID, String omNodeId) {
+    String suffixedConfKey = ConfUtils.addKeySuffixes(
+        confKey, omServiceID, omNodeId);
+    String confValue = conf.getTrimmed(suffixedConfKey);
+    if (StringUtils.isNotEmpty(confValue)) {
+      return confValue;
+    }
+    return null;
+  }
+
+  /**
+   * Set Node Specific config keys to generic config keys.
+   * @param nodeSpecificConfigKeys
+   * @param ozoneConfiguration
+   * @param serviceId
+   * @param nodeId
+   */
+  public static void setNodeSpecificConfigs(
+      String[] nodeSpecificConfigKeys, OzoneConfiguration ozoneConfiguration,
+      String serviceId, String nodeId, Logger logger) {
+    for (String confKey : nodeSpecificConfigKeys) {
+      String confValue = getConfSuffixedWithServiceId(
+          ozoneConfiguration, confKey, serviceId, nodeId);
+      if (confValue != null) {
+        logger.info("Setting configuration key {} with value of key {}: {}",
+            confKey, ConfUtils.addKeySuffixes(confKey, serviceId, nodeId),
+            confValue);
+        ozoneConfiguration.set(confKey, confValue);
+      }
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -189,7 +189,8 @@ public class OMHANodeDetails {
             localOMServiceId, localOMNodeId,
             NetUtils.getHostPortString(localRpcAddress), localRatisPort);
 
-        setOMNodeSpecificConfigs(conf, localOMServiceId, localOMNodeId);
+        ConfUtils.setNodeSpecificConfigs(genericConfigKeys, conf,
+            localOMServiceId, localOMNodeId, LOG);
         return new OMHANodeDetails(getHAOMNodeDetails(conf, localOMServiceId,
             localOMNodeId, localRpcAddress, localRatisPort), peerNodesList);
 
@@ -291,36 +292,6 @@ public class OMHANodeDetails {
         .setHttpAddress(httpAddr)
         .setHttpsAddress(httpsAddr)
         .build();
-  }
-
-  /**
-   * Check if any of the following configuration keys have been set using OM
-   * Node ID suffixed to the key. If yes, then set the base key with the
-   * configured valued.
-   *    1. {@link OMConfigKeys#OZONE_OM_HTTP_ADDRESS_KEY}
-   *    2. {@link OMConfigKeys#OZONE_OM_HTTPS_ADDRESS_KEY}
-   *    3. {@link OMConfigKeys#OZONE_OM_HTTP_BIND_HOST_KEY}
-   *    4. {@link OMConfigKeys#OZONE_OM_HTTPS_BIND_HOST_KEY}\
-   *    5. {@link OMConfigKeys#OZONE_OM_HTTP_KERBEROS_KEYTAB_FILE}
-   *    6. {@link OMConfigKeys#OZONE_OM_HTTP_KERBEROS_PRINCIPAL_KEY}
-   *    7. {@link OMConfigKeys#OZONE_OM_KERBEROS_KEYTAB_FILE_KEY}
-   *    8. {@link OMConfigKeys#OZONE_OM_KERBEROS_PRINCIPAL_KEY}
-   *    9. {@link OMConfigKeys#OZONE_OM_DB_DIRS}
-   *    10. {@link OMConfigKeys#OZONE_OM_ADDRESS_KEY}
-   */
-  private static void setOMNodeSpecificConfigs(
-      OzoneConfiguration ozoneConfiguration, String omServiceId,
-      String omNodeId) {
-
-    for (String confKey : genericConfigKeys) {
-      String confValue = OmUtils.getConfSuffixedWithOMNodeId(
-          ozoneConfiguration, confKey, omServiceId, omNodeId);
-      if (confValue != null) {
-        LOG.info("Setting configuration key {} with value of key {}: {}",
-            confKey, ConfUtils.addKeySuffixes(confKey, omNodeId), confValue);
-        ozoneConfiguration.set(confKey, confValue);
-      }
-    }
   }
 
   private static void throwConfException(String message, String... arguments)


### PR DESCRIPTION
## What changes were proposed in this pull request?

To use a single config across the cluster, a few of the config keys in SCM need to support HA Style, and they need to be set to default config keys so that the conf can be reusable in other parts of code.

In this Jira, added the following config keys to support HA style config.

OZONE_SCM_DATANODE_ADDRESS_KEY,
OZONE_SCM_DATANODE_PORT_KEY,
OZONE_SCM_DATANODE_BIND_HOST_KEY,
OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
OZONE_SCM_CLIENT_ADDRESS_KEY,
OZONE_SCM_CLIENT_PORT_KEY,
OZONE_SCM_CLIENT_BIND_HOST_KEY,
OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
OZONE_SCM_SECURITY_SERVICE_PORT_KEY,
OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY,
OZONE_SCM_RATIS_PORT_KEY,
OZONE_SCM_HTTP_BIND_HOST_KEY,
OZONE_SCM_HTTPS_BIND_HOST_KEY,
OZONE_SCM_HTTP_ADDRESS_KEY,
OZONE_SCM_HTTPS_ADDRESS_KEY,
OZONE_SCM_DB_DIRS,
OZONE_SCM_ADDRESS_KEY



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4823

## How was this patch tested?

Added a test.
