### PR TITLE
HDDS-4844. Fixing build issue for some platforms.

### DIFF
--- a/tools/fault-injection-service/CMakeLists.txt
+++ b/tools/fault-injection-service/CMakeLists.txt
@@ -82,6 +82,7 @@ include_directories("${CMAKE_CURRENT_BINARY_DIR}"
 #add_compile_options("-fpermissive")
 
 # Build server
+find_package(Threads)
 add_executable(failure_injector_svc_server 
     ${FS_DIR}/failure_injector_fs.cc ${FS_DIR}/failure_injector.cc
     ${SRV_DIR}/failure_injector_svc_server.cc ${SRV_DIR}/run_grpc_service.cc 

--- a/tools/fault-injection-service/README.md
+++ b/tools/fault-injection-service/README.md
@@ -27,8 +27,43 @@ Dependencies
 	built/installed from sources
 - cppunit & cppunit-devel
 
+Building Dependencies
+======================
+
+Building libfuse3 from the sources
+------------------------------------
+    - You can get it from https://github.com/libfuse/libfuse/releases/
+        * https://github.com/libfuse/libfuse/releases/tag/fuse-3.10.2
+    - follow the README.md for building libfuse
+    - you may need to get "meson-0.42.0" or above to build this.
+
+CMAKE
+======
+    - this will need cmake-3.14.0 or higher
+    - if required build from the sources. (tested with cmake-3.14.0 and
+       cmake-3.6.2)
+    
+Building grpc from the sources
+------------------------------------
+    - https://grpc.io/docs/languages/cpp/quickstart/
+    - sudo apt install -y build-essential autoconf libtool pkg-config
+    - git clone --recurse-submodules -b v1.35.0 https://github.com/grpc/grpc
+    - Follow build instructions
+        - mkdir -p cmake/build
+        - pushd cmake/build
+        - cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF\
+                 -DCMAKE_INSTALL_PREFIX=$MY_INSTALL_DIR  ../..
+        - make -j
+        - make install 
+
+Finally
+-------
+    - Make sure all the dependencies are in $PATH.
+    - This build was last tested on (debian 4.18.5-1.el7.elrepo.x86_64
+       GNU/Linux) and Ubuntu 18:0.1.0.0-4.
+
 Installation                                                                    
------------- 
+=============
 mkdir Build 
 cd Build
 do 'cmake ..'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing a minor build issue that can cause failure on some platforms while unable to find Threads library.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4844

## How was this patch tested?

Build on the Ubuntu and Debian platform after making the changes.
This does not affect the Ozone build of CI tests.