### PR TITLE
HDDS-4845. Update NodeStatus OperationalState for Datanodes in Recon

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -155,6 +155,10 @@ public class SCMNodeManager implements NodeManager {
     }
   }
 
+  protected NodeStateManager getNodeStateManager() {
+    return nodeStateManager;
+  }
+
   /**
    * Returns all datanode that are in the given state. This function works by
    * taking a snapshot of the current collection and then returning the list
@@ -399,6 +403,12 @@ public class SCMNodeManager implements NodeManager {
     return commandQueue.getCommand(datanodeDetails.getUuid());
   }
 
+  boolean opStateDiffers(DatanodeDetails dnDetails, NodeStatus nodeStatus) {
+    return nodeStatus.getOperationalState() != dnDetails.getPersistedOpState()
+        || nodeStatus.getOpStateExpiryEpochSeconds()
+        != dnDetails.getPersistedOpStateExpiryEpochSec();
+  }
+
   /**
    * If the operational state or expiry reported in the datanode heartbeat do
    * not match those store in SCM, queue a command to update the state persisted
@@ -410,12 +420,10 @@ public class SCMNodeManager implements NodeManager {
    * @param reportedDn The DatanodeDetails taken from the node heartbeat.
    * @throws NodeNotFoundException
    */
-  private void updateDatanodeOpState(DatanodeDetails reportedDn)
+  protected void updateDatanodeOpState(DatanodeDetails reportedDn)
       throws NodeNotFoundException {
     NodeStatus scmStatus = getNodeStatus(reportedDn);
-    if (scmStatus.getOperationalState() != reportedDn.getPersistedOpState()
-        || scmStatus.getOpStateExpiryEpochSeconds()
-        != reportedDn.getPersistedOpStateExpiryEpochSec()) {
+    if (opStateDiffers(reportedDn, scmStatus)) {
       LOG.info("Scheduling a command to update the operationalState " +
           "persisted on {} as the reported value does not " +
           "match the value stored in SCM ({}, {})",
@@ -802,7 +810,7 @@ public class SCMNodeManager implements NodeManager {
    */
   @Override
   public void onMessage(CommandForDatanode commandForDatanode,
-      EventPublisher ignored) {
+                        EventPublisher ignored) {
     addDatanodeCommand(commandForDatanode.getDatanodeId(),
         commandForDatanode.getCommand());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -53,6 +53,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.Timeout;
+import org.slf4j.event.Level;
 
 /**
  * Recon's passive SCM integration tests.
@@ -139,6 +140,7 @@ public class TestReconAsPassiveScm {
 
     GenericTestUtils.LogCapturer logCapturer =
         GenericTestUtils.LogCapturer.captureLogs(ReconNodeManager.LOG);
+    GenericTestUtils.setLogLevel(ReconNodeManager.LOG, Level.DEBUG);
     reconScm.getEventQueue().fireEvent(CLOSE_CONTAINER,
         containerInfo.containerID());
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto.Type;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -111,13 +112,12 @@ public class ReconNodeManager extends SCMNodeManager {
   @Override
   public void onMessage(CommandForDatanode commandForDatanode,
                         EventPublisher ignored) {
-    if (ALLOWED_COMMANDS.contains(
-        commandForDatanode.getCommand().getType())) {
+    final Type cmdType = commandForDatanode.getCommand().getType();
+    if (ALLOWED_COMMANDS.contains(cmdType)) {
       super.onMessage(commandForDatanode, ignored);
     } else {
-      LOG.info("Ignoring unsupported command {} for Datanode {}.",
-          commandForDatanode.getCommand().getType(),
-          commandForDatanode.getDatanodeId());
+      LOG.debug("Ignoring unsupported command {} for Datanode {}.",
+          cmdType, commandForDatanode.getDatanodeId());
     }
   }
 
@@ -136,5 +136,15 @@ public class ReconNodeManager extends SCMNodeManager {
     return cmds.stream()
         .filter(c -> ALLOWED_COMMANDS.contains(c.getType()))
         .collect(toList());
+  }
+
+  @Override
+  protected void updateDatanodeOpState(DatanodeDetails reportedDn)
+      throws NodeNotFoundException {
+    super.updateDatanodeOpState(reportedDn);
+    // Update NodeOperationalState in NodeStatus to keep it consistent for Recon
+    super.getNodeStateManager().setNodeOperationalState(reportedDn,
+        reportedDn.getPersistedOpState(),
+        reportedDn.getPersistedOpStateExpiryEpochSec());
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4845

Possibly due to Recon ignoring `setNodeOperationalStateCommand` ([HDDS-4766](https://github.com/apache/ozone/pull/1857/files#diff-9ef008cf91342ca17b33f4edf0f8ecf1bff0b3c954f04dda9a02d6ae9d9e9d16R426)), `NodeStatus` isn't being updated for its `operationalState` and `opStateExpiryEpochSeconds` fields (but `DatanodeInfo`'s `persistedOpState` and `persistedOpStateExpiryEpochSec` are correct):

<img width="1181" alt="discrepancy" src="https://user-images.githubusercontent.com/50227127/108457235-0a7a2480-7227-11eb-9ed8-fba5b956a145.png">


## How was this patch tested?

- Tested manually so far with temporarily inserted assertions.
- Updated UT.