### PR TITLE
HDDS-4754. Make scm heartbeat rpc retry interval configurable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -246,6 +246,11 @@ public final class ScmConfigKeys {
   public static final int OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT =
       15;
 
+  public static final String OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL =
+      "ozone.scm.heartbeat.rpc-retry-interval";
+  public static final String OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL_DEFAULT =
+      "1s";
+
   /**
    * Defines how frequently we will log the missing of heartbeat to a specific
    * SCM. In the default case we will write a warning message for each 10

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -969,7 +969,17 @@
     <tag>OZONE, MANAGEMENT</tag>
     <description>
       Retry count for the RPC from Datanode to SCM. The rpc-retry-interval
-      is 1s. Make sure rpc-retry-count * (rpc-timeout + rpc-retry-interval)
+      is 1s by default. Make sure rpc-retry-count * (rpc-timeout +
+      rpc-retry-interval) is less than hdds.heartbeat.interval.
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.heartbeat.rpc-retry-interval</name>
+    <value>1s</value>
+    <tag>OZONE, MANAGEMENT</tag>
+    <description>
+      Retry interval for the RPC from Datanode to SCM.
+      Make sure rpc-retry-count * (rpc-timeout + rpc-retry-interval)
       is less than hdds.heartbeat.interval.
     </description>
   </property>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import static java.util.Collections.unmodifiableList;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcTimeOutInMilliseconds;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryCount;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmRpcRetryInterval;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -151,8 +152,8 @@ public class SCMConnectionManager
 
       RetryPolicy retryPolicy =
           RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getScmRpcRetryCount(conf),
-              1000, TimeUnit.MILLISECONDS);
+              getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
+              TimeUnit.MILLISECONDS);
 
       StorageContainerDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
           StorageContainerDatanodeProtocolPB.class, version,
@@ -196,8 +197,8 @@ public class SCMConnectionManager
 
       RetryPolicy retryPolicy =
           RetryPolicies.retryUpToMaximumCountWithFixedSleep(
-              getScmRpcRetryCount(conf),
-              1000, TimeUnit.MILLISECONDS);
+              getScmRpcRetryCount(conf), getScmRpcRetryInterval(conf),
+              TimeUnit.MILLISECONDS);
       ReconDatanodeProtocolPB rpcProxy = RPC.getProtocolProxy(
           ReconDatanodeProtocolPB.class, version,
           address, UserGroupInformation.getCurrentUser(), hadoopConfig,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -67,6 +67,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_T
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
@@ -337,6 +339,18 @@ public final class HddsServerUtil {
   public static int getScmRpcRetryCount(ConfigurationSource conf) {
     return conf.getInt(OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT,
         OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT);
+  }
+
+  /**
+   * Fixed datanode rpc retry interval, which is used by datanode to connect
+   * the SCM.
+   *
+   * @param conf - Ozone Config
+   * @return - Rpc retry interval.
+   */
+  public static long getScmRpcRetryInterval(ConfigurationSource conf) {
+    return conf.getTimeDuration(OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL,
+        OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Background:
The current retry policy of DN is to retry sending with a 1s interval. Given at some time-point, all the DNs lost connection with the SCM at the same time, due to the restart of SCM, all DNs will send container report to SCM nearly at the same time, which is a ContainerReport Storm.

Solution:
Manually adjust the rpc-retry-interval with rpc-retry-count could mitigate extreme cases such as OOM, when facing up a huge cluster.
Make the rpc-retry-interval configurable. 


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4754


## How was this patch tested?
CI
