### PR TITLE
HDDS-4849. Improve Ozone admin shell decommission/recommission/maintenance commands user experience

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -108,8 +108,8 @@ public class NodeDecommissionManager {
       try {
         addr = InetAddress.getByName(host.getHostname());
       } catch (UnknownHostException e) {
-        throw new InvalidHostStringException("Unable to resolve the host "
-            +host.getRawHostname(), e);
+        throw new InvalidHostStringException("Unable to resolve host "
+            + host.getRawHostname(), e);
       }
       String dnsName;
       if (useHostnames) {
@@ -119,15 +119,17 @@ public class NodeDecommissionManager {
       }
       List<DatanodeDetails> found = nodeManager.getNodesByAddress(dnsName);
       if (found.size() == 0) {
-        throw new InvalidHostStringException("The string " +
-            host.getRawHostname()+" resolved to "+dnsName +
-            " is not found in SCM");
+        throw new InvalidHostStringException("Host " + host.getRawHostname()
+            + " (" + dnsName + ") is not running any datanodes registered"
+            + " with SCM."
+            + " Please check the host name.");
       } else if (found.size() == 1) {
         if (host.getPort() != -1 &&
             !validateDNPortMatch(host.getPort(), found.get(0))) {
-          throw new InvalidHostStringException("The string "+
-              host.getRawHostname()+" matched a single datanode, but the "+
-              "given port is not used by that Datanode");
+          throw new InvalidHostStringException("Host " + host.getRawHostname()
+              + " is running a datanode registered with SCM,"
+              + " but the port number doesn't match."
+              + " Please check the port number.");
         }
         results.add(found.get(0));
       } else if (found.size() > 1) {
@@ -139,9 +141,10 @@ public class NodeDecommissionManager {
           }
         }
         if (match == null) {
-          throw new InvalidHostStringException("The string " +
-              host.getRawHostname()+ "matched multiple Datanodes, but no "+
-              "datanode port matched the given port");
+          throw new InvalidHostStringException("Host " + host.getRawHostname()
+              + " is running multiple datanodes registered with SCM,"
+              + " but no port numbers match."
+              + " Please check the port number.");
         }
         results.add(match);
       }
@@ -281,8 +284,8 @@ public class NodeDecommissionManager {
         // NodeNotFoundException here expect if the node is remove in the
         // very short window between validation and starting decom. Therefore
         // log a warning and ignore the exception
-        LOG.warn("The host {} was not found in SCM. Ignoring the request to "+
-            "recommission it", dn.getHostName());
+        LOG.warn("Host {} was not found in SCM. Ignoring the request to "+
+            "recommission it.", dn.getHostName());
       }
     }
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/DecommissionSubCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -36,11 +37,20 @@ import java.util.List;
     versionProvider = HddsVersionProvider.class)
 public class DecommissionSubCommand extends ScmSubcommand {
 
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
   @CommandLine.Parameters(description = "List of fully qualified host names")
-  private List<String> hosts = new ArrayList<String>();
+  private List<String> hosts = new ArrayList<>();
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    scmClient.decommissionNodes(hosts);
+    if (hosts.size() > 0) {
+      scmClient.decommissionNodes(hosts);
+      System.out.println("Started decommissioning datanode(s):\n" +
+          String.join("\n", hosts));
+    } else {
+      GenericCli.missingSubcommand(spec);
+    }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -114,7 +114,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
         + "/" + datanode.getHostName() + "/" + relatedPipelineNum +
         " pipelines)");
     System.out.println("Operational State: " + dna.getOpState());
-    System.out.println("Related pipelines: \n" + pipelineListInfo);
+    System.out.println("Related pipelines:\n" + pipelineListInfo);
   }
 
   private static class DatanodeWithAttributes {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -36,8 +37,11 @@ import java.util.List;
     versionProvider = HddsVersionProvider.class)
 public class MaintenanceSubCommand extends ScmSubcommand {
 
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
   @CommandLine.Parameters(description = "List of fully qualified host names")
-  private List<String> hosts = new ArrayList<String>();
+  private List<String> hosts = new ArrayList<>();
 
   @CommandLine.Option(names = {"--end"},
       description = "Automatically end maintenance after the given hours. "+
@@ -46,6 +50,12 @@ public class MaintenanceSubCommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    scmClient.startMaintenanceNodes(hosts, endInHours);
+    if (hosts.size() > 0) {
+      scmClient.startMaintenanceNodes(hosts, endInHours);
+      System.out.println("Entering maintenance mode on datanode(s):\n" +
+          String.join("\n", hosts));
+    } else {
+      GenericCli.missingSubcommand(spec);
+    }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/RecommissionSubCommand.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.cli.datanode;
 
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -27,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
+ * Recommission one or more datanodes.
  * Place decommissioned or maintenance nodes back into service.
  */
 @Command(
@@ -36,11 +38,20 @@ import java.util.List;
     versionProvider = HddsVersionProvider.class)
 public class RecommissionSubCommand extends ScmSubcommand {
 
+  @CommandLine.Spec
+  private CommandLine.Model.CommandSpec spec;
+
   @CommandLine.Parameters(description = "List of fully qualified host names")
-  private List<String> hosts = new ArrayList<String>();
+  private List<String> hosts = new ArrayList<>();
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    scmClient.recommissionNodes(hosts);
+    if (hosts.size() > 0) {
+      scmClient.recommissionNodes(hosts);
+      System.out.println("Started recommissioning datanode(s):\n" +
+          String.join("\n", hosts));
+    } else {
+      GenericCli.missingSubcommand(spec);
+    }
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4849

1. Right now running `ozone admin datanode decommission` command alone doesn't give any feedback.

With patch:

```bash
bash-4.2$ ozone admin datanode decommission
Incomplete command
Usage: ozone admin datanode decommission [-hV] [--scm=<scm>] [<hosts>...]
Decommission a datanode
      [<hosts>...]   List of fully qualified host names
  -h, --help         Show this help message and exit.
      --scm=<scm>    The destination scm (host:port)
  -V, --version      Print version information and exit.
```

2. When a decommission command is executed successfully, it lacks feedback on the client (it does log on the server side).

With patch:

```bash
bash-4.2$ ozone admin datanode decommission 172.18.0.7 172.18.0.2
Started decommissioning datanode(s):
172.18.0.7
172.18.0.2
```

3. Improve decommission failure message due to host/port resolution.

With patch:

```bash
bash-4.2$ ozone admin datanode decommission 172.18.0.71
Host 172.18.0.71 (172.18.0.71) is not running any datanodes registered with SCM. Please check the host name.

bash-4.2$ ozone admin datanode decommission 172.18.0.7:9999
Host 172.18.0.7:9999 is running a datanode registered with SCM, but the port number doesn't match. Please check the port number.
```

Same for recommission and maintenance commands.