### PR TITLE
HDDS-4851. More compatibility problem with DatanodeDetails.Port.Name.REPLICATION

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFileStatus.java
@@ -23,7 +23,6 @@ import java.util.Objects;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneFileStatusProto.Builder;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 
 /**
@@ -94,14 +93,13 @@ public class OzoneFileStatus {
     return !isDirectory();
   }
 
-  public OzoneFileStatusProto getProtobuf() {
-
+  public OzoneFileStatusProto getProtobuf(int clientVersion) {
     Builder builder = OzoneFileStatusProto.newBuilder()
         .setBlockSize(blockSize)
         .setIsDirectory(isDirectory);
     //key info can be null for the fake root entry.
     if (keyInfo != null) {
-      builder.setKeyInfo(keyInfo.getProtobuf(CURRENT_VERSION));
+      builder.setKeyInfo(keyInfo.getProtobuf(clientVersion));
     }
     return builder.build();
   }

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -17,15 +17,6 @@
 version: "3.4"
 
 services:
-  old_client_0_5_0:
-    image: apache/ozone:0.5.0
-    env_file:
-      - docker-config
-    volumes:
-      - ../..:/opt/ozone
-    environment:
-      HADOOP_OPTS:
-    command: ["sleep","1000000"]
   old_client_1_0_0:
     image: apache/ozone:1.0.0
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -80,7 +80,7 @@ create_results_dir
 # current cluster with various clients
 COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} test_cross_compatibility
 
-for cluster_version in 1.0.0 0.5.0; do
+for cluster_version in 1.0.0; do
   # shellcheck source=/dev/null
   source "${COMPOSE_DIR}/../upgrade/versions/ozone-${cluster_version}.sh"
   # shellcheck source=/dev/null

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -19,8 +19,15 @@ Resource            ../ozone-lib/shell.robot
 Test Timeout        5 minutes
 
 *** Variables ***
-${KEY_NAME_SUFFIX}    ${EMPTY}
+${SUFFIX}    ${EMPTY}
 
 *** Test Cases ***
 Key Can Be Read
-    Key Should Match Local File    /vol1/bucket1/key-${KEY_NAME_SUFFIX}    /etc/passwd
+    Key Should Match Local File    /vol1/bucket1/key-${SUFFIX}    /etc/passwd
+
+Dir Can Be Listed
+    Execute    ozone fs -ls o3fs://bucket1.vol1/dir-${SUFFIX}
+
+File Can Be Get
+    Execute    ozone fs -get o3fs://bucket1.vol1/dir-${SUFFIX}/passwd /tmp/passwd-${SUFFIX}
+    [teardown]    Execute    rm /tmp/passwd-${SUFFIX}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/write.robot
@@ -19,8 +19,14 @@ Resource            ../ozone-lib/shell.robot
 Test Timeout        5 minutes
 
 *** Variables ***
-${KEY_NAME_SUFFIX}    ${EMPTY}
+${SUFFIX}    ${EMPTY}
 
 *** Test Cases ***
 Key Can Be Written
-    Create Key    /vol1/bucket1/key-${KEY_NAME_SUFFIX}    /etc/passwd
+    Create Key    /vol1/bucket1/key-${SUFFIX}    /etc/passwd
+
+Dir Can Be Created
+    Execute    ozone fs -mkdir o3fs://bucket1.vol1/dir-${SUFFIX}
+
+File Can Be Put
+    Execute    ozone fs -put /etc/passwd o3fs://bucket1.vol1/dir-${SUFFIX}/

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -183,8 +183,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         responseBuilder.setDbUpdatesResponse(dbUpdatesResponse);
         break;
       case GetFileStatus:
-        GetFileStatusResponse getFileStatusResponse =
-            getOzoneFileStatus(request.getGetFileStatusRequest());
+        GetFileStatusResponse getFileStatusResponse = getOzoneFileStatus(
+            request.getGetFileStatusRequest(), request.getVersion());
         responseBuilder.setGetFileStatusResponse(getFileStatusResponse);
         break;
       case LookupFile:
@@ -194,7 +194,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         break;
       case ListStatus:
         ListStatusResponse listStatusResponse =
-            listStatus(request.getListStatusRequest());
+            listStatus(request.getListStatusRequest(), request.getVersion());
         responseBuilder.setListStatusResponse(listStatusResponse);
         break;
       case GetAcl:
@@ -529,7 +529,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private GetFileStatusResponse getOzoneFileStatus(
-      GetFileStatusRequest request) throws IOException {
+      GetFileStatusRequest request, int clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -539,7 +539,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .build();
 
     GetFileStatusResponse.Builder rb = GetFileStatusResponse.newBuilder();
-    rb.setStatus(impl.getFileStatus(omKeyArgs).getProtobuf());
+    rb.setStatus(impl.getFileStatus(omKeyArgs).getProtobuf(clientVersion));
 
     return rb.build();
   }
@@ -560,7 +560,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
   }
 
   private ListStatusResponse listStatus(
-      ListStatusRequest request) throws IOException {
+      ListStatusRequest request, int clientVersion) throws IOException {
     KeyArgs keyArgs = request.getKeyArgs();
     OmKeyArgs omKeyArgs = new OmKeyArgs.Builder()
         .setVolumeName(keyArgs.getVolumeName())
@@ -575,7 +575,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         listStatusResponseBuilder =
         ListStatusResponse.newBuilder();
     for (OzoneFileStatus status : statuses) {
-      listStatusResponseBuilder.addStatuses(status.getProtobuf());
+      listStatusResponseBuilder.addStatuses(status.getProtobuf(clientVersion));
     }
     return listStatusResponseBuilder.build();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-4731 missed some places related to file status where client version needs to be considered for protobuf conversion.  These can be reproduced by `ozone fs` operations:

```
$ ozone fs -mkdir o3fs://bucket1.vol1/dir/
$ ozone fs -ls o3fs://bucket1.vol1/dir/
$ ozone fs -put /etc/passwd o3fs://bucket1.vol1/dir/
-put: No enum constant org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.REPLICATION
$ ozone fs -ls o3fs://bucket1.vol1/dir/
-ls: No enum constant org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.REPLICATION
```

https://issues.apache.org/jira/browse/HDDS-4851

## How was this patch tested?

Added acceptance test cases.  0.5.0 client had to be removed from the test due to another incompatibility:

```
Message missing required fields: getFileStatusResponse.status.status, ...
```