### PR TITLE
HDDS-4850. Intermittent failure in ozonesecure due to unable to allocate block

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -51,15 +51,14 @@ done
 #admincli which creates STANDALONE pipeline
 execute_robot_test scm recon
 
-# test replication; must be run before admincli,
-# which stops replication manager
+execute_robot_test scm admincli
+execute_robot_test scm spnego
+
+# test replication
 docker-compose up -d --scale datanode=2
 execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
 docker-compose up -d --scale datanode=3
 execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
-
-execute_robot_test scm admincli
-execute_robot_test scm spnego
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/replicationmanager.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/replicationmanager.robot
@@ -30,15 +30,15 @@ Check replicationmanager with explicit host
                         Should contain   ${output}   ReplicationManager
                         Should contain   ${output}   Running
 
-Start replicationmanager
-    ${output} =         Execute          ozone admin replicationmanager start
-                        Should contain   ${output}   Starting ReplicationManager
-                        Wait Until Keyword Succeeds    30sec    5sec    Execute          ozone admin replicationmanager status | grep -q 'is Running'
-
 Stop replicationmanager
     ${output} =         Execute          ozone admin replicationmanager stop
                         Should contain   ${output}   Stopping ReplicationManager
                         Wait Until Keyword Succeeds    30sec    5sec    Execute          ozone admin replicationmanager status | grep -q 'is Not Running'
+
+Start replicationmanager
+    ${output} =         Execute          ozone admin replicationmanager start
+                        Should contain   ${output}   Starting ReplicationManager
+                        Wait Until Keyword Succeeds    30sec    5sec    Execute          ozone admin replicationmanager status | grep -q 'is Running'
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin replicationmanager


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-4834 added a new test case in `ozonesecure`, which apparently causes flakiness in later container-related test.

This PR moves the replication test, which requires datanode restart, to the end of the test suite.  Hopefully this fixes the flakiness.

https://issues.apache.org/jira/browse/HDDS-4850

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/584182478

acceptance (secure) 10x:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/584359630
https://github.com/adoroszlai/hadoop-ozone/actions/runs/584573002