### PR TITLE
HDDS-4853. libexec/entrypoint.sh might copy from wrong path

### DIFF
--- a/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
+++ b/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
@@ -102,7 +102,7 @@ CONF_DESTINATION_DIR="${HADOOP_CONF_DIR:-/opt/hadoop/etc/hadoop}"
 #Try to copy the defaults
 set +e
 if [[ -d "/opt/ozone/etc/hadoop" ]]; then
-   cp /opt/hadoop/etc/hadoop/* "$CONF_DESTINATION_DIR/" > /dev/null 2>&1
+   cp /opt/ozone/etc/hadoop/* "$CONF_DESTINATION_DIR/" > /dev/null 2>&1
 elif [[ -d "/opt/hadoop/etc/hadoop" ]]; then
    cp /opt/hadoop/etc/hadoop/* "$CONF_DESTINATION_DIR/" > /dev/null 2>&1
 fi


### PR DESCRIPTION
## What changes were proposed in this pull request?

I think it may be the previous mistake that caused the copy path error, so I modified the copy path.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4853

## How was this patch tested?

no test.
