### PR TITLE
HDDS-4858. Useless Maven cache cleanup

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -56,6 +56,12 @@ jobs:
           name: ozone-bin
           path: hadoop-ozone/dist/target/hadoop-ozone*.tar.gz
           retention-days: 1
+      - name: Delete temporary build artifacts before caching
+        run: |
+          #Never cache local artifacts
+          rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-hdds*
+          rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-ozone*
+        if: always()
   bats:
     runs-on: ubuntu-18.04
     steps:
@@ -218,12 +224,6 @@ jobs:
           name: acceptance-${{ matrix.suite }}
           path: /mnt/ozone/target/acceptance
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/hadoop/hdds
-          rm -rf ~/.m2/repository/org/apache/hadoop/ozone
-        if: always()
   integration:
     runs-on: ubuntu-18.04
     strategy:
@@ -335,9 +335,3 @@ jobs:
           name: kubernetes
           path: /mnt/ozone/target/kubernetes
         continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/hadoop/hdds
-          rm -rf ~/.m2/repository/org/apache/hadoop/ozone
-        if: always()

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -59,8 +59,8 @@ jobs:
       - name: Delete temporary build artifacts before caching
         run: |
           #Never cache local artifacts
-          rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-hdds*
-          rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-ozone*
+          rm -rf ~/.m2/repository/org/apache/hadoop/hadoop-hdds*
+          rm -rf ~/.m2/repository/org/apache/hadoop/hadoop-ozone*
         if: always()
   bats:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `Never cache local artifacts` step in Github Actions workflow.  There were 2 problems:

1. The cache and the cleanup were in different jobs.
2. The repo does not have `hdds` and `ozone` subdirectories, only ones like `hadoop-hdds-common`, etc.

https://issues.apache.org/jira/browse/HDDS-4858

## How was this patch tested?

Temporarily enabled verbose output to print items being removed:

```
2021-02-23T14:16:41.5399844Z ##[group]Run #Never cache local artifacts
2021-02-23T14:16:41.5400509Z #Never cache local artifacts
2021-02-23T14:16:41.5401104Z rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-hdds*
2021-02-23T14:16:41.5401913Z rm -rfv ~/.m2/repository/org/apache/hadoop/hadoop-ozone*
...
2021-02-23T14:16:41.5541337Z ##[endgroup]
...
2021-02-23T14:16:41.5665616Z removed directory '/home/runner/.m2/repository/org/apache/hadoop/hadoop-hdds-client/1.1.0-SNAPSHOT'
2021-02-23T14:16:41.5666912Z removed directory '/home/runner/.m2/repository/org/apache/hadoop/hadoop-hdds-client'
...
2021-02-23T14:16:41.6203996Z removed directory '/home/runner/.m2/repository/org/apache/hadoop/hadoop-ozone-dist/1.1.0-SNAPSHOT'
2021-02-23T14:16:41.6205242Z removed directory '/home/runner/.m2/repository/org/apache/hadoop/hadoop-ozone-dist'
...
```

https://github.com/adoroszlai/hadoop-ozone/runs/1961713108