### PR TITLE
HDDS-4861. [SCM HA Security] Implement generate SCM certificate.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -67,7 +67,7 @@ public interface SCMSecurityProtocol {
   /**
    * Get signed certificate for SCM.
    *
-   * @param scmNodeDetails       - SCM Node Details.
+   * @param scmNodeDetails  - SCM Node Details.
    * @param certSignReq     - Certificate signing request.
    * @return String         - pem encoded SCM signed
    *                          certificate.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.security.KerberosInfo;
 
@@ -60,6 +61,18 @@ public interface SCMSecurityProtocol {
    *                          certificate.
    */
   String getOMCertificate(OzoneManagerDetailsProto omDetails,
+      String certSignReq) throws IOException;
+
+
+  /**
+   * Get signed certificate for SCM.
+   *
+   * @param scmNodeDetails       - SCM Node Details.
+   * @param certSignReq     - Certificate signing request.
+   * @return String         - pem encoded SCM signed
+   *                          certificate.
+   */
+  String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -25,7 +25,9 @@ import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGenerateSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCACertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
@@ -127,6 +129,26 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   public String getOMCertificate(OzoneManagerDetailsProto omDetails,
       String certSignReq) throws IOException {
     return getOMCertChain(omDetails, certSignReq).getX509Certificate();
+  }
+
+  /**
+   * Get SCM signed certificate and root CA certificate for SCM Peer node.
+   *
+   * @param scmNodeDetails  - SCM Node Details.
+   * @param certSignReq     - Certificate signing request.
+   * @return String         - pem encoded SCM signed
+   *                          certificate.
+   */
+  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+      String certSignReq) throws IOException {
+    SCMGenerateSCMCertRequestProto request =
+        SCMGenerateSCMCertRequestProto.newBuilder()
+        .setCSR(certSignReq)
+        .setScmDetails(scmNodeDetails)
+        .build();
+    return submitRequest(Type.GeneratePeerSCMCertificate,
+        builder -> builder.setGeneratePeerSCMCertificateRequest(request))
+        .getGetCertResponseProto().getX509Certificate();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -132,7 +132,7 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   /**
-   * Get SCM signed certificate and root CA certificate for SCM Peer node.
+   * Get SCM signed certificate and root CA certificate for SCM node.
    *
    * @param scmNodeDetails  - SCM Node Details.
    * @param certSignReq     - Certificate signing request.
@@ -146,8 +146,8 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
         .setCSR(certSignReq)
         .setScmDetails(scmNodeDetails)
         .build();
-    return submitRequest(Type.GeneratePeerSCMCertificate,
-        builder -> builder.setGeneratePeerSCMCertificateRequest(request))
+    return submitRequest(Type.GetSCMCertificate,
+        builder -> builder.setGetSCMCertificateRequest(request))
         .getGetCertResponseProto().getX509Certificate();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -141,7 +141,7 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    */
   public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException {
-   return getSCMCertChain(scmNodeDetails, certSignReq).getX509Certificate();
+    return getSCMCertChain(scmNodeDetails, certSignReq).getX509Certificate();
   }
 
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
-import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGenerateSCMCertRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCACertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
@@ -132,7 +132,7 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
   }
 
   /**
-   * Get SCM signed certificate and root CA certificate for SCM node.
+   * Get signed certificate for SCM node.
    *
    * @param scmNodeDetails  - SCM Node Details.
    * @param certSignReq     - Certificate signing request.
@@ -141,14 +141,29 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
    */
   public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
       String certSignReq) throws IOException {
-    SCMGenerateSCMCertRequestProto request =
-        SCMGenerateSCMCertRequestProto.newBuilder()
-        .setCSR(certSignReq)
-        .setScmDetails(scmNodeDetails)
-        .build();
+   return getSCMCertChain(scmNodeDetails, certSignReq).getX509Certificate();
+  }
+
+
+  /**
+   * Get signed certificate for SCM node and root CA certificate.
+   *
+   * @param scmNodeDetails   - SCM Node Details.
+   * @param certSignReq      - Certificate signing request.
+   * @return SCMGetCertResponseProto  - SCMGetCertResponseProto which holds
+   * signed certificate and root CA certificate.
+   */
+  public SCMGetCertResponseProto getSCMCertChain(
+      ScmNodeDetailsProto scmNodeDetails, String certSignReq)
+      throws IOException {
+    SCMGetSCMCertRequestProto request =
+        SCMGetSCMCertRequestProto.newBuilder()
+            .setCSR(certSignReq)
+            .setScmDetails(scmNodeDetails)
+            .build();
     return submitRequest(Type.GetSCMCertificate,
         builder -> builder.setGetSCMCertificateRequest(request))
-        .getGetCertResponseProto().getX509Certificate();
+        .getGetCertResponseProto();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType;
@@ -82,7 +83,7 @@ public interface CertificateServer {
    */
   Future<X509CertificateHolder> requestCertificate(
       PKCS10CertificationRequest csr,
-      CertificateApprover.ApprovalType type)
+      CertificateApprover.ApprovalType type, NodeType nodeType)
       throws SCMSecurityException;
 
 
@@ -96,7 +97,7 @@ public interface CertificateServer {
    * @throws SCMSecurityException - on Error.
    */
   Future<X509CertificateHolder> requestCertificate(String csr,
-      ApprovalType type) throws IOException;
+      ApprovalType type, NodeType nodeType) throws IOException;
 
   /**
    * Revokes a Certificate issued by this CertificateServer.
@@ -122,7 +123,7 @@ public interface CertificateServer {
    * @return
    * @throws IOException
    */
-  List<X509Certificate> listCertificate(HddsProtos.NodeType type,
+  List<X509Certificate> listCertificate(NodeType type,
       long startSerialId, int count, boolean isRevoked) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -77,6 +77,7 @@ public interface CertificateServer {
    *
    * @param csr  - Certificate Signing Request.
    * @param type - An Enum which says what kind of approval process to follow.
+   * @param nodeType: OM/SCM/DN
    * @return A future that will have this certificate when this request is
    * approved.
    * @throws SCMSecurityException - on Error.
@@ -92,6 +93,7 @@ public interface CertificateServer {
    *
    * @param csr - Certificate Signing Request as a PEM encoded String.
    * @param type - An Enum which says what kind of approval process to follow.
+   * @param nodeType: OM/SCM/DN
    * @return A future that will have this certificate when this request is
    * approved.
    * @throws SCMSecurityException - on Error.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -46,6 +46,12 @@ public interface CertificateStore {
   void storeValidCertificate(BigInteger serialID,
                              X509Certificate certificate) throws IOException;
 
+  /**
+   * Writes a new SCM certificate that was issued to the persistent store.
+   * @param serialID - Certificate Serial Number.
+   * @param certificate - Certificate to persist.
+   * @throws IOException - on Failure.
+   */
   void storeValidScmCertificate(BigInteger serialID,
       X509Certificate certificate) throws IOException;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -46,6 +46,9 @@ public interface CertificateStore {
   void storeValidCertificate(BigInteger serialID,
                              X509Certificate certificate) throws IOException;
 
+  void storeValidScmCertificate(BigInteger serialID,
+      X509Certificate certificate) throws IOException;
+
   /**
    * Moves a certificate in a transactional manner from valid certificate to
    * revoked certificate state.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.validator.routines.DomainValidator;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.DefaultProfile;
@@ -206,7 +207,7 @@ public class DefaultCAServer implements CertificateServer {
   @Override
   public Future<X509CertificateHolder> requestCertificate(
       PKCS10CertificationRequest csr,
-      CertificateApprover.ApprovalType approverType) {
+      CertificateApprover.ApprovalType approverType, NodeType nodeType) {
     LocalDate beginDate = LocalDate.now().atStartOfDay().toLocalDate();
     LocalDateTime temp = LocalDateTime.of(beginDate, LocalTime.MIDNIGHT);
     LocalDate endDate =
@@ -231,12 +232,12 @@ public class DefaultCAServer implements CertificateServer {
       case TESTING_AUTOMATIC:
         X509CertificateHolder xcert;
         try {
-          xcert = signAndStoreCertificate(beginDate, endDate, csr);
+          xcert = signAndStoreCertificate(beginDate, endDate, csr, nodeType);
         } catch (SCMSecurityException e) {
           // Certificate with conflicting serial id, retry again may resolve
           // this issue.
           LOG.error("Certificate storage failed, retrying one more time.", e);
-          xcert = signAndStoreCertificate(beginDate, endDate, csr);
+          xcert = signAndStoreCertificate(beginDate, endDate, csr, nodeType);
         }
 
         xcertHolder.complete(xcert);
@@ -252,23 +253,34 @@ public class DefaultCAServer implements CertificateServer {
   }
 
   private X509CertificateHolder signAndStoreCertificate(LocalDate beginDate,
-      LocalDate endDate, PKCS10CertificationRequest csr) throws IOException,
+      LocalDate endDate, PKCS10CertificationRequest csr, NodeType nodeType)
+      throws IOException,
       OperatorCreationException, CertificateException {
     X509CertificateHolder xcert = approver.sign(config,
         getCAKeys().getPrivate(),
         getCACertificate(), java.sql.Date.valueOf(beginDate),
         java.sql.Date.valueOf(endDate), csr, scmID, clusterID);
-    store.storeValidCertificate(xcert.getSerialNumber(),
-        CertificateCodec.getX509Certificate(xcert));
+    if (nodeType.equals(NodeType.SCM)) {
+      // If scm cert store in scm cert table and valid cert table.
+      // This is to help to return scm certs when get certs call.
+      store.storeValidScmCertificate(xcert.getSerialNumber(),
+          CertificateCodec.getX509Certificate(xcert));
+    } else {
+      // As we don't have different table for other roles, other role
+      // certificates will go to validCertsTable.
+      store.storeValidCertificate(xcert.getSerialNumber(),
+          CertificateCodec.getX509Certificate(xcert));
+    }
     return xcert;
   }
 
   @Override
   public Future<X509CertificateHolder> requestCertificate(String csr,
-      CertificateApprover.ApprovalType type) throws IOException {
+      CertificateApprover.ApprovalType type, NodeType nodeType)
+      throws IOException {
     PKCS10CertificationRequest request =
         getCertificationRequest(csr);
-    return requestCertificate(request, type);
+    return requestCertificate(request, type, nodeType);
   }
 
   @Override
@@ -300,7 +312,7 @@ public class DefaultCAServer implements CertificateServer {
    * @throws IOException
    */
   @Override
-  public List<X509Certificate> listCertificate(HddsProtos.NodeType role,
+  public List<X509Certificate> listCertificate(NodeType role,
       long startSerialId, int count, boolean isRevoked) throws IOException {
     return store.listCertificate(role, BigInteger.valueOf(startSerialId), count,
         isRevoked? CertificateStore.CertType.REVOKED_CERTS :

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -22,7 +22,6 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.validator.routines.DomainValidator;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -261,8 +260,8 @@ public class DefaultCAServer implements CertificateServer {
         getCACertificate(), java.sql.Date.valueOf(beginDate),
         java.sql.Date.valueOf(endDate), csr, scmID, clusterID);
     if (nodeType.equals(NodeType.SCM)) {
-      // If scm cert store in scm cert table and valid cert table.
-      // This is to help to return scm certs when get certs call.
+      // If the role is SCM, store certificate in scm cert table and valid cert
+      // table. This is to help to return scm certs during getCertificate call.
       store.storeValidScmCertificate(xcert.getSerialNumber(),
           CertificateCodec.getX509Certificate(xcert));
     } else {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -38,6 +38,7 @@ public class MockCAStore implements CertificateStore {
 
   }
 
+  @Override
   public void storeValidScmCertificate(BigInteger serialID,
       X509Certificate certificate)
       throws IOException {

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -38,6 +38,12 @@ public class MockCAStore implements CertificateStore {
 
   }
 
+  public void storeValidScmCertificate(BigInteger serialID,
+      X509Certificate certificate)
+      throws IOException {
+
+  }
+
   @Override
   public void revokeCertificate(BigInteger serialID) throws IOException {
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
@@ -43,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.function.Consumer;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
 import static org.junit.Assert.*;
 
 /**
@@ -165,7 +167,7 @@ public class TestDefaultCAServer {
         CertificateServer.CAType.SELF_SIGNED_CA);
 
     Future<X509CertificateHolder> holder = testCA.requestCertificate(csrString,
-        CertificateApprover.ApprovalType.TESTING_AUTOMATIC);
+        CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
     // Right now our calls are synchronous. Eventually this will have to wait.
     assertTrue(holder.isDone());
     assertNotNull(holder.get());
@@ -207,7 +209,7 @@ public class TestDefaultCAServer {
         CertificateServer.CAType.SELF_SIGNED_CA);
 
     Future<X509CertificateHolder> holder = testCA.requestCertificate(csrString,
-        CertificateApprover.ApprovalType.TESTING_AUTOMATIC);
+        CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
     // Right now our calls are synchronous. Eventually this will have to wait.
     assertTrue(holder.isDone());
     assertNotNull(holder.get());
@@ -243,7 +245,7 @@ public class TestDefaultCAServer {
         () -> {
           Future<X509CertificateHolder> holder =
               testCA.requestCertificate(csrString,
-                  CertificateApprover.ApprovalType.TESTING_AUTOMATIC);
+                  CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
           holder.isDone();
           holder.get();
         });

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
@@ -45,6 +44,7 @@ import java.util.function.Consumer;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.OM;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType.SCM;
 import static org.junit.Assert.*;
 
 /**
@@ -167,7 +167,7 @@ public class TestDefaultCAServer {
         CertificateServer.CAType.SELF_SIGNED_CA);
 
     Future<X509CertificateHolder> holder = testCA.requestCertificate(csrString,
-        CertificateApprover.ApprovalType.TESTING_AUTOMATIC, OM);
+        CertificateApprover.ApprovalType.TESTING_AUTOMATIC, SCM);
     // Right now our calls are synchronous. Eventually this will have to wait.
     assertTrue(holder.isDone());
     assertNotNull(holder.get());

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -73,6 +73,12 @@ message OzoneManagerDetailsProto {
     repeated Port ports = 4;
 }
 
+message ScmNodeDetailsProto {
+    required string scmNodeId = 1;     // SCM Node Id.
+    required string clusterId = 2;     // Cluster Id of SCM cluster.
+    required string hostName = 3;      // Hostname of SCM.
+}
+
 message Port {
     required string name = 1;
     required uint32 value = 2;

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
@@ -49,6 +49,8 @@ message SCMSecurityRequest {
     optional SCMGetCertificateRequestProto getCertificateRequest = 5;
     optional SCMGetCACertificateRequestProto getCACertificateRequest = 6;
     optional SCMListCertificateRequestProto listCertificateRequest = 7;
+    optional SCMGenerateSCMCertRequestProto
+    generatePeerSCMCertificateRequest = 8;
 
 }
 
@@ -77,6 +79,7 @@ enum Type {
     GetCertificate = 3;
     GetCACertificate = 4;
     ListCertificate = 5;
+    GeneratePeerSCMCertificate = 6;
 }
 
 enum Status {
@@ -97,6 +100,11 @@ message SCMGetDataNodeCertRequestProto {
 */
 message SCMGetOMCertRequestProto {
     required OzoneManagerDetailsProto omDetails = 1;
+    required string CSR = 2;
+}
+
+message SCMGenerateSCMCertRequestProto {
+    required ScmNodeDetailsProto scmDetails = 1;
     required string CSR = 2;
 }
 

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
@@ -49,8 +49,7 @@ message SCMSecurityRequest {
     optional SCMGetCertificateRequestProto getCertificateRequest = 5;
     optional SCMGetCACertificateRequestProto getCACertificateRequest = 6;
     optional SCMListCertificateRequestProto listCertificateRequest = 7;
-    optional SCMGenerateSCMCertRequestProto
-    generatePeerSCMCertificateRequest = 8;
+    optional SCMGenerateSCMCertRequestProto getSCMCertificateRequest = 8;
 
 }
 
@@ -79,7 +78,7 @@ enum Type {
     GetCertificate = 3;
     GetCACertificate = 4;
     ListCertificate = 5;
-    GeneratePeerSCMCertificate = 6;
+    GetSCMCertificate = 6;
 }
 
 enum Status {

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
@@ -49,7 +49,7 @@ message SCMSecurityRequest {
     optional SCMGetCertificateRequestProto getCertificateRequest = 5;
     optional SCMGetCACertificateRequestProto getCACertificateRequest = 6;
     optional SCMListCertificateRequestProto listCertificateRequest = 7;
-    optional SCMGenerateSCMCertRequestProto getSCMCertificateRequest = 8;
+    optional SCMGetSCMCertRequestProto getSCMCertificateRequest = 8;
 
 }
 
@@ -102,7 +102,7 @@ message SCMGetOMCertRequestProto {
     required string CSR = 2;
 }
 
-message SCMGenerateSCMCertRequestProto {
+message SCMGetSCMCertRequestProto {
     required ScmNodeDetailsProto scmDetails = 1;
     required string CSR = 2;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -57,6 +57,15 @@ public class SCMDBDefinition implements DBDefinition {
           new X509CertificateCodec());
 
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
+      VALID_SCM_CERTS =
+      new DBColumnFamilyDefinition<>(
+          "validSCMCerts",
+          BigInteger.class,
+          new BigIntegerCodec(),
+          X509Certificate.class,
+          new X509CertificateCodec());
+
+  public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       REVOKED_CERTS =
       new DBColumnFamilyDefinition<>(
           "revokedCerts",
@@ -105,6 +114,6 @@ public class SCMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_BLOCKS, VALID_CERTS,
-        REVOKED_CERTS, PIPELINES, CONTAINERS, TRANSACTIONINFO};
+        VALID_SCM_CERTS, REVOKED_CERTS, PIPELINES, CONTAINERS, TRANSACTIONINFO};
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -78,6 +78,12 @@ public interface SCMMetadataStore extends DBStoreHAManager {
   Table<BigInteger, X509Certificate> getValidCertsTable();
 
 
+  /**
+   * A table that maintains all the valid certificates of SCM nodes issued by
+   * the SCM CA.
+   *
+   * @return Table
+   */
   Table<BigInteger, X509Certificate> getValidSCMCertsTable();
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -77,6 +77,9 @@ public interface SCMMetadataStore extends DBStoreHAManager {
    */
   Table<BigInteger, X509Certificate> getValidCertsTable();
 
+
+  Table<BigInteger, X509Certificate> getValidSCMCertsTable();
+
   /**
    * A Table that maintains all revoked certificates until they expire.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -41,6 +41,8 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.TRANSACTIONINFO;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_CERTS;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_SCM_CERTS;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,8 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   private Table<Long, DeletedBlocksTransaction> deletedBlocksTable;
 
   private Table<BigInteger, X509Certificate> validCertsTable;
+
+  private Table<BigInteger, X509Certificate> validSCMCertsTable;
 
   private Table<BigInteger, X509Certificate> revokedCertsTable;
 
@@ -96,6 +100,10 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
       checkTableStatus(validCertsTable, VALID_CERTS.getName());
 
+      validSCMCertsTable = VALID_SCM_CERTS.getTable(store);
+
+      checkTableStatus(validSCMCertsTable, VALID_SCM_CERTS.getName());
+
       revokedCertsTable = REVOKED_CERTS.getTable(store);
 
       checkTableStatus(revokedCertsTable, REVOKED_CERTS.getName());
@@ -136,6 +144,11 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   @Override
   public Table<BigInteger, X509Certificate> getValidCertsTable() {
     return validCertsTable;
+  }
+
+  @Override
+  public Table<BigInteger, X509Certificate> getValidSCMCertsTable() {
+    return validSCMCertsTable;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGenerateSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto.ResponseCode;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
@@ -112,6 +113,13 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .setListCertificateResponseProto(
                 listCertificate(request.getListCertificateRequest()))
             .build();
+      case GeneratePeerSCMCertificate:
+        return SCMSecurityResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setGetCertResponseProto(generateSCMPeerNodeCertificate(
+                request.getGeneratePeerSCMCertificateRequest()))
+            .build();
       default:
         throw new IllegalArgumentException(
             "Unknown request type: " + request.getCmdType());
@@ -134,6 +142,31 @@ public class SCMSecurityProtocolServerSideTranslatorPB
 
     String certificate = impl
         .getDataNodeCertificate(request.getDatanodeDetails(),
+            request.getCSR());
+    SCMGetCertResponseProto.Builder builder =
+        SCMGetCertResponseProto
+            .newBuilder()
+            .setResponseCode(ResponseCode.success)
+            .setX509Certificate(certificate)
+            .setX509CACertificate(impl.getCACertificate());
+
+    return builder.build();
+
+  }
+
+  /**
+   * Get signed certificate for SCM.
+   *
+   * @param request - SCMGenerateSCMCertRequestProto
+   * @return SCMGetCertResponseProto.
+   */
+
+  public SCMGetCertResponseProto generateSCMPeerNodeCertificate(
+      SCMGenerateSCMCertRequestProto request)
+      throws IOException {
+
+    String certificate = impl
+        .generateSCMCertificate(request.getScmDetails(),
             request.getCSR());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -113,12 +113,12 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .setListCertificateResponseProto(
                 listCertificate(request.getListCertificateRequest()))
             .build();
-      case GeneratePeerSCMCertificate:
+      case GetSCMCertificate:
         return SCMSecurityResponse.newBuilder()
             .setCmdType(request.getCmdType())
             .setStatus(Status.OK)
-            .setGetCertResponseProto(generateSCMPeerNodeCertificate(
-                request.getGeneratePeerSCMCertificateRequest()))
+            .setGetCertResponseProto(getSCMCertificate(
+                request.getGetSCMCertificateRequest()))
             .build();
       default:
         throw new IllegalArgumentException(
@@ -161,13 +161,12 @@ public class SCMSecurityProtocolServerSideTranslatorPB
    * @return SCMGetCertResponseProto.
    */
 
-  public SCMGetCertResponseProto generateSCMPeerNodeCertificate(
+  public SCMGetCertResponseProto getSCMCertificate(
       SCMGenerateSCMCertRequestProto request)
       throws IOException {
 
-    String certificate = impl
-        .generateSCMCertificate(request.getScmDetails(),
-            request.getCSR());
+    String certificate = impl.getSCMCertificate(request.getScmDetails(),
+        request.getCSR());
     SCMGetCertResponseProto.Builder builder =
         SCMGetCertResponseProto
             .newBuilder()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -21,12 +21,12 @@ import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
-import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGenerateSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto.ResponseCode;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetDataNodeCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetOMCertRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest;
@@ -157,12 +157,12 @@ public class SCMSecurityProtocolServerSideTranslatorPB
   /**
    * Get signed certificate for SCM.
    *
-   * @param request - SCMGenerateSCMCertRequestProto
+   * @param request - SCMGetSCMCertRequestProto
    * @return SCMGetCertResponseProto.
    */
 
   public SCMGetCertResponseProto getSCMCertificate(
-      SCMGenerateSCMCertRequestProto request)
+      SCMGetSCMCertRequestProto request)
       throws IOException {
 
     String certificate = impl.getSCMCertificate(request.getScmDetails(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -33,7 +33,9 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB;
@@ -69,9 +71,11 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
   private final RPC.Server rpcServer;
   private final InetSocketAddress rpcAddress;
   private final ProtocolMessageMetrics metrics;
+  private final StorageContainerManager storageContainerManager;
 
   SCMSecurityProtocolServer(OzoneConfiguration conf,
-      CertificateServer certificateServer) throws IOException {
+      CertificateServer certificateServer, StorageContainerManager scm) throws IOException {
+    this.storageContainerManager = scm;
     this.certificateServer = certificateServer;
     final int handlerCount =
         conf.getInt(ScmConfigKeys.OZONE_SCM_SECURITY_HANDLER_COUNT_KEY,
@@ -115,18 +119,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
     LOGGER.info("Processing CSR for dn {}, UUID: {}", dnDetails.getHostName(),
         dnDetails.getUuid());
     Objects.requireNonNull(dnDetails);
-    Future<X509CertificateHolder> future =
-        certificateServer.requestCertificate(certSignReq,
-            KERBEROS_TRUSTED);
-
-    try {
-      return CertificateCodec.getPEMEncodedString(future.get());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      throw new IOException("getDataNodeCertificate operation failed. ", e);
-    } catch (ExecutionException e) {
-      throw new IOException("getDataNodeCertificate operation failed. ", e);
-    }
+    return getEncodedCertToString(certSignReq, NodeType.DATANODE);
   }
 
   /**
@@ -142,17 +135,57 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
     LOGGER.info("Processing CSR for om {}, UUID: {}", omDetails.getHostName(),
         omDetails.getUuid());
     Objects.requireNonNull(omDetails);
+    return getEncodedCertToString(certSignReq, NodeType.OM);
+  }
+
+
+  /**
+   * Get signed certificate for SCM Node.
+   *
+   * @param scmNodeDetails   - SCM Node Details.
+   * @param certSignReq - Certificate signing request.
+   * @return String         - SCM signed pem encoded certificate.
+   */
+  @Override
+  public String getSCMCertificate(ScmNodeDetailsProto scmNodeDetails,
+      String certSignReq) throws IOException {
+    Objects.requireNonNull(scmNodeDetails);
+    LOGGER.info("Processing CSR for scm {}, nodeId: {}",
+        scmNodeDetails.getHostName(), scmNodeDetails.getScmNodeId());
+
+    // Check clusterID
+    if (storageContainerManager.getClusterId().equals(
+        scmNodeDetails.getClusterId())) {
+      throw new IOException("SCM ClusterId mismatch. Peer SCM ClusterId " +
+          scmNodeDetails.getClusterId() + ", primary SCM ClusterId "
+          + storageContainerManager.getClusterId());
+    }
+
+    return getEncodedCertToString(certSignReq, NodeType.SCM);
+
+  }
+
+  /**
+   *  Request certificate for the specified role.
+   * @param certSignReq - Certificate signing request.
+   * @param nodeType - role OM/SCM/DATANODE
+   * @return String         - SCM signed pem encoded certificate.
+   * @throws IOException
+   */
+  private String getEncodedCertToString(String certSignReq, NodeType nodeType)
+      throws IOException {
     Future<X509CertificateHolder> future =
         certificateServer.requestCertificate(certSignReq,
-            KERBEROS_TRUSTED);
-
+            KERBEROS_TRUSTED, nodeType);
     try {
       return CertificateCodec.getPEMEncodedString(future.get());
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      throw new IOException("getOMCertificate operation failed. ", e);
+      throw new IOException("generate" + nodeType.toString() + "Certificate " +
+          "operation failed. ", e);
     } catch (ExecutionException e) {
-      throw new IOException("getOMCertificate operation failed. ", e);
+      throw new IOException("generate" + nodeType.toString() + "Certificate " +
+          "operation failed.", e);
     }
   }
 
@@ -205,7 +238,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
    * @throws IOException
    */
   @Override
-  public List<String> listCertificate(HddsProtos.NodeType role,
+  public List<String> listCertificate(NodeType role,
       long startSerialId, int count, boolean isRevoked) throws IOException {
     List<X509Certificate> certificates =
         certificateServer.listCertificate(role, startSerialId, count,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -31,7 +31,6 @@ import java.util.concurrent.Future;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
@@ -74,7 +73,8 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
   private final StorageContainerManager storageContainerManager;
 
   SCMSecurityProtocolServer(OzoneConfiguration conf,
-      CertificateServer certificateServer, StorageContainerManager scm) throws IOException {
+      CertificateServer certificateServer, StorageContainerManager scm)
+      throws IOException {
     this.storageContainerManager = scm;
     this.certificateServer = certificateServer;
     final int handlerCount =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -539,7 +539,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     certificateServer.init(new SecurityConfig(conf),
         CertificateServer.CAType.SELF_SIGNED_CA);
     securityProtocolServer = new SCMSecurityProtocolServer(conf,
-        certificateServer);
+        certificateServer, this);
 
     grpcTlsConfig = createTlsClientConfigForSCM(new SecurityConfig(conf),
             certificateServer);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -93,6 +93,11 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
   }
 
   @Override
+  public Table<BigInteger, X509Certificate> getValidSCMCertsTable() {
+    return null;
+  }
+
+  @Override
   public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
     return null;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMSecurityProtocolServer.java
@@ -41,7 +41,7 @@ public class TestSCMSecurityProtocolServer {
     config = new OzoneConfiguration();
     config.set(OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
         OZONE_SCM_SECURITY_SERVICE_BIND_HOST_DEFAULT + ":0");
-    securityProtocolServer = new SCMSecurityProtocolServer(config, null);
+    securityProtocolServer = new SCMSecurityProtocolServer(config, null, null);
   }
 
   @After


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to implement generatePeerSCMCertificate which will be called during bootStrap and also during init by primary SCM. This is similar to how OM and DN gets certificate.

During implementation as the validCerTable key is SerialId which is BigInteger, created a new table validScmCertsTable to store scm certs. This is being done so that we can implement querySCMCertificates which can return all SCM certs.

Also, I see there is a TODO for list Certs based on role. Not sure if there is a way in the current code to return certs from the table. If there is any approach, will rework this PR based on review comments.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4861

## How was this patch tested?


