### PR TITLE
HDDS-4868. Ozone datanode initraftlog fail due to bad disk so can not communicate to SCM

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -109,7 +109,11 @@ public class VersionEndpointTask implements
           }
 
           // Start the container services after getting the version information
-          ozoneContainer.start(scmId);
+          try {
+            ozoneContainer.start(scmId);
+          } catch (IOException ex) {
+            rpcEndPoint.logIfNeeded(ex);
+          }
         }
         EndpointStateMachine.EndPointStates nextState =
             rpcEndPoint.getState().getNextState();


### PR DESCRIPTION
## What changes were proposed in this pull request?
When datanode initraftlog fail due to bad disk,the datanode can not connect to SCM,and the datanode will always throw the exception,so we should let datanode throw the runtime exception once,and SCM will remove the raftgroup 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4868

## How was this patch tested?
I will mock the datanode initraftlog fail and the process of the datanode will not always throw the exception

