### PR TITLE
HDDS-4869. Bump jackson version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <jersey2.version>2.27</jersey2.version>
 
     <!-- jackson versions -->
-    <jackson2.version>2.10.3</jackson2.version>
+    <jackson2.version>2.12.1</jackson2.version>
 
     <!-- jaegertracing veresion -->
     <jaeger.version>1.2.0</jaeger.version>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-4869

## What changes were proposed in this pull request?

> com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.
> 
> Affected versions of this package are vulnerable to Deserialization of Untrusted Data due to an incomplete black list (incomplete fix for CVE-2017-7525). It doesn't block common-configuration JNDI classes org.apache.commons.configuration.JNDIConfiguration and org.apache.commons.configuration2.JNDIConfiguration

More information: https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-559106

## How was this patch tested?

CI + checking if jackson jars are replaced:

```
cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/share/ozone/lib
s -lah *jackson*
Permissions Size User Date Modified Name
.rw-r--r--   75k elek 25 Feb 11:36  jackson-annotations-2.12.1.jar
.rw-r--r--  365k elek 25 Feb 11:36  jackson-core-2.12.1.jar
.rw-r--r--  1.5M elek 25 Feb 11:36  jackson-databind-2.12.1.jar
.rw-r--r--   61k elek 25 Feb 11:36  jackson-dataformat-cbor-2.12.1.jar
.rw-r--r--  120k elek 25 Feb 11:36  jackson-dataformat-xml-2.12.1.jar
.rw-r--r--  120k elek 25 Feb 11:36  jackson-datatype-jsr310-2.12.1.jar
.rw-r--r--   36k elek 25 Feb 11:36  jackson-module-jaxb-annotations-2.12.1.jar
.rw-r--r--   73k elek 25 Feb 11:36  jersey-media-json-jackson-2.27.jar
```