### PR TITLE
HDDS-4867. Ozone admin datanode list should report dead and stale nodes

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import picocli.CommandLine;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -82,7 +83,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
         .map(p -> new DatanodeWithAttributes(
             DatanodeDetails.getFromProtoBuf(p.getNodeID()),
             p.getNodeOperationalStates(0), p.getNodeStates(0)))
-        .sorted()
+        .sorted((o1, o2) -> o1.healthState.compareTo(o2.healthState))
         .collect(Collectors.toList());
   }
 
@@ -119,7 +120,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
     System.out.println("Related pipelines:\n" + pipelineListInfo);
   }
 
-  private static class DatanodeWithAttributes implements Comparable {
+  private static class DatanodeWithAttributes {
     private DatanodeDetails datanodeDetails;
     private HddsProtos.NodeOperationalState operationalState;
     private HddsProtos.NodeState healthState;
@@ -142,12 +143,6 @@ public class ListInfoSubcommand extends ScmSubcommand {
 
     public HddsProtos.NodeState getHealthState() {
       return healthState;
-    }
-
-    @Override
-    public int compareTo(Object o) {
-      DatanodeWithAttributes other = (DatanodeWithAttributes)o;
-      return healthState.compareTo(other.getHealthState());
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -76,12 +76,13 @@ public class ListInfoSubcommand extends ScmSubcommand {
   private List<DatanodeWithAttributes> getAllNodes(ScmClient scmClient)
       throws IOException {
     List<HddsProtos.Node> nodes = scmClient.queryNode(null,
-        HddsProtos.NodeState.HEALTHY, HddsProtos.QueryScope.CLUSTER, "");
+        null, HddsProtos.QueryScope.CLUSTER, "");
 
     return nodes.stream()
         .map(p -> new DatanodeWithAttributes(
             DatanodeDetails.getFromProtoBuf(p.getNodeID()),
             p.getNodeOperationalStates(0), p.getNodeStates(0)))
+        .sorted()
         .collect(Collectors.toList());
   }
 
@@ -114,10 +115,11 @@ public class ListInfoSubcommand extends ScmSubcommand {
         + "/" + datanode.getHostName() + "/" + relatedPipelineNum +
         " pipelines)");
     System.out.println("Operational State: " + dna.getOpState());
+    System.out.println("Health State: " + dna.getHealthState());
     System.out.println("Related pipelines:\n" + pipelineListInfo);
   }
 
-  private static class DatanodeWithAttributes {
+  private static class DatanodeWithAttributes implements Comparable {
     private DatanodeDetails datanodeDetails;
     private HddsProtos.NodeOperationalState operationalState;
     private HddsProtos.NodeState healthState;
@@ -140,6 +142,12 @@ public class ListInfoSubcommand extends ScmSubcommand {
 
     public HddsProtos.NodeState getHealthState() {
       return healthState;
+    }
+
+    @Override
+    public int compareTo(Object o) {
+      DatanodeWithAttributes other = (DatanodeWithAttributes)o;
+      return healthState.compareTo(other.getHealthState());
     }
   }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import picocli.CommandLine;
 
 import java.io.IOException;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -65,7 +65,8 @@ public class TestListInfoSubcommand {
   }
 
   @Test
-  public void testDataNodeOperationalStateIncludedInOutput() throws Exception {
+  public void testDataNodeOperationalStateAndHealthIncludedInOutput()
+      throws Exception {
     ScmClient scmClient = mock(ScmClient.class);
     Mockito.when(scmClient.queryNode(any(HddsProtos.NodeOperationalState.class),
         any(HddsProtos.NodeState.class), any(HddsProtos.QueryScope.class),
@@ -89,12 +90,22 @@ public class TestListInfoSubcommand {
         "^Operational State:\\s+DECOMMISSIONING$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
+    for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
+      p = Pattern.compile(
+          "^Health State:\\s+"+state+"$", Pattern.MULTILINE);
+      m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+      assertTrue(m.find());
+    }
+    // Ensure the nodes are ordered by health state HEALTHY, STALE, DEAD
+    p = Pattern.compile(".+HEALTHY.+STALE.+DEAD.+", Pattern.DOTALL);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
   }
 
   private List<HddsProtos.Node> getNodeDetails() {
     List<HddsProtos.Node> nodes = new ArrayList<>();
 
-    for (int i=0; i<2; i++) {
+    for (int i=0; i<3; i++) {
       HddsProtos.DatanodeDetailsProto.Builder dnd =
           HddsProtos.DatanodeDetailsProto.newBuilder();
       dnd.setHostName("host" + i);
@@ -109,11 +120,16 @@ public class TestListInfoSubcommand {
       if (i == 0) {
         builder.addNodeOperationalStates(
             HddsProtos.NodeOperationalState.IN_SERVICE);
-      } else {
+        builder.addNodeStates(HddsProtos.NodeState.STALE);
+      } else if (i == 1) {
         builder.addNodeOperationalStates(
             HddsProtos.NodeOperationalState.DECOMMISSIONING);
+        builder.addNodeStates(HddsProtos.NodeState.DEAD);
+      } else {
+        builder.addNodeOperationalStates(
+            HddsProtos.NodeOperationalState.IN_SERVICE);
+        builder.addNodeStates(HddsProtos.NodeState.HEALTHY);
       }
-      builder.addNodeStates(HddsProtos.NodeState.HEALTHY);
       builder.setNodeID(dnd.build());
       nodes.add(builder.build());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change adds the health state to the "ozone admin datanode list" command and ensures that all nodes registered in SCM are returned in the output. Previously, the health state was not displayed and only healthy nodes were shown. Any stale or dead nodes were omitted.

The new output looks like:

```
$ ozone admin datanode list
Datanode: 839e594c-2dd8-4d19-a932-acb2c7acebb9 (/default-rack/172.22.0.4/ozone_datanode_4.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY   ******** Newly added line
Related pipelines:
93c1ecce-e0ed-49ab-be6d-e0c0ec07e3e9/ONE/RATIS/OPEN/Leader
fde8dd62-c677-4a05-89f0-a7d0eb450736/THREE/RATIS/OPEN/Leader
```

The output is also sorted so healthy DNs are listed first, then stale and then dead at the bottom.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4867

## How was this patch tested?

Unit test and confirmed with Docker Compose:

```
$ ozone admin datanode list
Datanode: 839e594c-2dd8-4d19-a932-acb2c7acebb9 (/default-rack/172.22.0.4/ozone_datanode_4.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Related pipelines:
93c1ecce-e0ed-49ab-be6d-e0c0ec07e3e9/ONE/RATIS/OPEN/Leader
fde8dd62-c677-4a05-89f0-a7d0eb450736/THREE/RATIS/OPEN/Leader

Datanode: 8afd6d3e-09e6-40f2-b15e-6809304a9792 (/default-rack/172.22.0.5/ozone_datanode_1.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Related pipelines:
4de5a0ef-c13b-4254-b4a6-d4eae3a5bb35/ONE/RATIS/OPEN/Leader
fde8dd62-c677-4a05-89f0-a7d0eb450736/THREE/RATIS/OPEN/Follower

Datanode: 4dc7f867-b1b7-423f-8eb2-3bb46f221bbb (/default-rack/172.22.0.6/ozone_datanode_3.ozone_default/2 pipelines)
Operational State: IN_SERVICE
Health State: HEALTHY
Related pipelines:
fde8dd62-c677-4a05-89f0-a7d0eb450736/THREE/RATIS/OPEN/Follower
a99d5f34-e36a-47b6-8816-744bc719716d/ONE/RATIS/OPEN/Leader

Datanode: a086be73-8450-4506-9446-2d54a96951ff (/default-rack/172.22.0.7/ozone_datanode_2.ozone_default/0 pipelines)
Operational State: IN_SERVICE
Health State: DEAD
Related pipelines:
No related pipelines or the node is not in Healthy state.
```
