### PR TITLE
HDDS-4879. Support reserved space for single dir

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -203,6 +203,8 @@ public final class ScmConfigKeys {
       "hdds.rest.http-address";
   public static final String HDDS_REST_HTTP_ADDRESS_DEFAULT = "0.0.0.0:9880";
   public static final String HDDS_DATANODE_DIR_KEY = "hdds.datanode.dir";
+  public static final String HDDS_DATANODE_DIR_DU_RESERVED =
+      "hdds.datanode.dir.du.reserved";
   public static final String HDDS_REST_CSRF_ENABLED_KEY =
       "hdds.rest.rest-csrf.enabled";
   public static final boolean HDDS_REST_CSRF_ENABLED_DEFAULT = false;

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -145,6 +145,14 @@
     </description>
   </property>
   <property>
+    <name>hdds.datanode.dir.du.reserved</name>
+    <value/>
+    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
+    <description>Reserved space in bytes per volume. Always leave this much space free for non dfs use.
+       Such as /dir1:100, /dir2:200, means dir1 reserves 100 bytes and dir2 reserves 200 bytes.
+    </description>
+  </property>
+  <property>
     <name>hdds.datanode.volume.choosing.policy</name>
     <value/>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -149,7 +149,7 @@
     <value/>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
     <description>Reserved space in bytes per volume. Always leave this much space free for non dfs use.
-       Such as /dir1:100, /dir2:200, means dir1 reserves 100 bytes and dir2 reserves 200 bytes.
+       Such as /dir1:100B, /dir2:200MB, means dir1 reserves 100 bytes and dir2 reserves 200 MB.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.ozone.container.common.volume;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckParams;
 
@@ -94,12 +95,19 @@ public final class VolumeInfo {
     for (String reserve : reserveList) {
       String[] words = reserve.split(":");
       if (words.length < 2) {
-        throw new IllegalArgumentException(
-            "Reserved space should config in pair");
+        LOG.error("Reserved space should config in pair, but current is {}",
+            reserve);
+        continue;
       }
 
       if (words[0].trim().equals(rootDir)) {
-        return Long.parseLong(words[1].trim());
+        try {
+          StorageSize size = StorageSize.parse(words[1].trim());
+          return (long) size.getUnit().toBytes(size.getValue());
+        } catch (Exception e) {
+          LOG.error("Failed to parse StorageSize:{}", words[1].trim(), e);
+          return 0;
+        }
       }
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -93,13 +93,19 @@ public final class VolumeInfo {
   private long getReserved(ConfigurationSource conf) {
     Collection<String> reserveList = conf.getTrimmedStringCollection(
         HDDS_DATANODE_DIR_DU_RESERVED);
-    Map<String, Long> reserveMap = new HashMap<>();
     for (String reserve : reserveList) {
       String[] words = reserve.split(":");
-      reserveMap.put(words[0], Long.parseLong(words[1].trim()));
+      if (words.length < 2) {
+        throw new IllegalArgumentException(
+            "Reserved space should config in pair");
+      }
+
+      if (words[0].trim().equals(rootDir)) {
+        return Long.parseLong(words[1].trim());
+      }
     }
 
-    return reserveMap.containsKey(rootDir) ? reserveMap.get(rootDir) : 0;
+    return 0;
   }
 
   private VolumeInfo(Builder b) throws IOException {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsagePersistence;
 import org.apache.hadoop.hdds.fs.SpaceUsageSource;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 
@@ -51,6 +52,7 @@ public class TestHddsVolume {
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
+  private static final int RESERVED_SPACE = 100;
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -61,6 +63,8 @@ public class TestHddsVolume {
   @Before
   public void setup() throws Exception {
     File rootDir = new File(folder.getRoot(), HddsVolume.HDDS_VOLUME_DIR);
+    CONF.set(ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED, folder.getRoot() +
+        ":" + RESERVED_SPACE);
     volumeBuilder = new HddsVolume.Builder(folder.getRoot().getPath())
         .datanodeUuid(DATANODE_UUID)
         .conf(CONF)
@@ -146,7 +150,10 @@ public class TestHddsVolume {
 
     // Volume.getAvailable() should succeed even when usage thread
     // is shutdown.
-    assertEquals(spaceUsage.getAvailable(), volume.getAvailable());
+    assertEquals(spaceUsage.getCapacity(),
+        volume.getCapacity() + RESERVED_SPACE);
+    assertEquals(spaceUsage.getAvailable(),
+        volume.getAvailable() + RESERVED_SPACE);
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.fs.SpaceUsagePersistence;
@@ -52,7 +53,7 @@ public class TestHddsVolume {
   private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
-  private static final int RESERVED_SPACE = 100;
+  private static final String RESERVED_SPACE = "100B";
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
@@ -150,10 +151,13 @@ public class TestHddsVolume {
 
     // Volume.getAvailable() should succeed even when usage thread
     // is shutdown.
+    StorageSize size = StorageSize.parse(RESERVED_SPACE);
+    long reservedSpaceInBytes = (long) size.getUnit().toBytes(size.getValue());
+
     assertEquals(spaceUsage.getCapacity(),
-        volume.getCapacity() + RESERVED_SPACE);
+        volume.getCapacity() + reservedSpaceInBytes);
     assertEquals(spaceUsage.getAvailable(),
-        volume.getAvailable() + RESERVED_SPACE);
+        volume.getAvailable() + reservedSpaceInBytes);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
HDFS support reserved space for all dirs: https://github.com/apache/hadoop/blob/trunk/hadoop-hdfs-project/hadoop-hdfs/src/main/java/org/apache/hadoop/hdfs/server/datanode/fsdataset/impl/ReservedSpaceCalculator.java

But we also need to support reserved space for single dir, because different dir maybe need different reserved space, for example, maybe only one dir needs reserved space.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4879

## How was this patch tested?

new ut
