### PR TITLE
HDDS-4885. ozone admin datanode list filter by UUID broken

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -67,7 +67,7 @@ public class ListInfoSubcommand extends ScmSubcommand {
       }
       if (!Strings.isNullOrEmpty(uuid)) {
         allNodes = allNodes.filter(p ->
-            p.getDatanodeDetails().toString().equals(uuid));
+            p.getDatanodeDetails().getUuidString().equals(uuid));
       }
       allNodes.forEach(this::printDatanodeInfo);
     }

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -25,6 +25,15 @@ List datanodes
                         Should contain   ${output}   Datanode:
                         Should contain   ${output}   Related pipelines:
 
+Filter list by UUID
+    ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
+    ${output} =         Execute      ozone admin datanode list --id "${uuid}"
+    Should contain      ${output}    Datanode: ${uuid}
+    ${datanodes} =      Get Lines Containing String    ${output}    Datanode:
+    @{lines} =          Split To Lines   ${datanodes}
+    ${count} =          Get Length   ${lines}
+    Should Be Equal As Integers    ${count}    1
+
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin datanode
                         Should contain   ${output}   Incomplete command


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix UUID comparison for `ozone admin datanode list`.

https://issues.apache.org/jira/browse/HDDS-4885

## How was this patch tested?

Added acceptance test.
https://github.com/adoroszlai/hadoop-ozone/runs/2006084493#step:7:1022