### PR TITLE
HDDS-4887. Useless message about node schema location

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
@@ -44,6 +44,8 @@ import java.util.Map;
 import  org.apache.hadoop.hdds.scm.net.NodeSchema.LayerType;
 import org.yaml.snakeyaml.Yaml;
 
+import static org.apache.commons.collections.EnumerationUtils.toList;
+
 /**
  * A Network topology layer schema loading tool that loads user defined network
  * layer schema data from a XML configuration file.
@@ -123,8 +125,10 @@ public final class NodeSchemaLoader {
           try (InputStream stream = classloader
               .getResourceAsStream(schemaFilePath)) {
             if (stream != null) {
-              LOG.info("Loading file from {}", classloader
-                  .getResources(schemaFilePath));
+              if (LOG.isInfoEnabled()) {
+                LOG.info("Loading schema from {}",
+                    toList(classloader.getResources(schemaFilePath)));
+              }
               return loadSchemaFromStream(schemaFilePath, stream);
             }
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Convert classloader URL enumeration to list for more user-friendly output in log.

https://issues.apache.org/jira/browse/HDDS-4887

## How was this patch tested?

Started `ozone` compose cluster, verified message in log:

```
[main] INFO net.NodeSchemaLoader: Loading schema from [file:/etc/hadoop/network-topology-default.xml, jar:file:/opt/hadoop/share/ozone/lib/hadoop-hdds-common-1.1.0-SNAPSHOT.jar!/network-topology-default.xml]
```