### PR TITLE
HDDS-4872. Upgrade UsageInfoSubcommand with options to show most and least used datanodes.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -297,7 +297,7 @@ public interface ScmClient extends Closeable {
       throws IOException;
 
   /**
-   * Gets usage information of most or least used datanodes.
+   * Get usage information of most or least used datanodes.
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -288,12 +288,12 @@ public interface ScmClient extends Closeable {
    *
    * @param ipaddress datanode ipaddress String
    * @param uuid datanode uuid String
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMused, and remaining space.
    * @throws IOException
    */
-  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(String ipaddress,
-                                                  String uuid)
+  List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(String ipaddress,
+                                                               String uuid)
       throws IOException;
 
   /**
@@ -301,11 +301,11 @@ public interface ScmClient extends Closeable {
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException
    */
-  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException;
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -295,4 +295,17 @@ public interface ScmClient extends Closeable {
   List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(String ipaddress,
                                                   String uuid)
       throws IOException;
+
+  /**
+   * Gets usage information of most or least used datanodes.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @param count Integer number of nodes to get info for
+   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * capacity, SCMUsed, and remaining space.
+   * @throws IOException
+   */
+  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+      boolean mostUsed, int count) throws IOException;
+
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -245,23 +245,22 @@ public interface StorageContainerLocationProtocol extends Closeable {
    *
    * @param ipaddress datanode IP address String
    * @param uuid datanode UUID String
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMused, and remaining space.
    * @throws IOException
    */
-  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(String ipaddress,
-                                                          String uuid)
-      throws IOException;
+  List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
+      String ipaddress, String uuid) throws IOException;
 
   /**
    * Get usage information of most or least used datanodes.
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException
    */
-  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -252,4 +252,16 @@ public interface StorageContainerLocationProtocol extends Closeable {
   List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(String ipaddress,
                                                           String uuid)
       throws IOException;
+
+  /**
+   * Gets usage information of most or least used datanodes.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @param count Integer number of nodes to get info for
+   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * capacity, SCMUsed, and remaining space.
+   * @throws IOException
+   */
+  List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+      boolean mostUsed, int count) throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -243,8 +243,8 @@ public interface StorageContainerLocationProtocol extends Closeable {
   /**
    * Get Datanode usage information by ip or uuid.
    *
-   * @param ipaddress - datanode IP address String
-   * @param uuid - datanode UUID String
+   * @param ipaddress datanode IP address String
+   * @param uuid datanode UUID String
    * @return List of DatanodeUsageInfo. Each element contains info such as
    * capacity, SCMused, and remaining space.
    * @throws IOException
@@ -254,7 +254,7 @@ public interface StorageContainerLocationProtocol extends Closeable {
       throws IOException;
 
   /**
-   * Gets usage information of most or least used datanodes.
+   * Get usage information of most or least used datanodes.
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -637,6 +637,32 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
     return response.getInfoList();
   }
 
+  /**
+   * Get usage information of most or least used datanodes.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @param count Integer number of nodes to get info for
+   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * capacity, SCMUsed, and remaining space.
+   * @throws IOException
+   */
+  @Override
+  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+      boolean mostUsed, int count) throws IOException {
+    DatanodeUsageInfoRequestProto request =
+        DatanodeUsageInfoRequestProto.newBuilder()
+            .setMostUsed(mostUsed)
+            .setCount(count)
+            .build();
+
+    DatanodeUsageInfoResponseProto response =
+        submitRequest(Type.DatanodeUsageInfo,
+            builder -> builder.setDatanodeUsageInfoRequest(request))
+        .getDatanodeUsageInfoResponse();
+
+    return response.getInfoList();
+  }
+
   @Override
   public Object getUnderlyingProxyObject() {
     return rpcProxy;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -616,12 +616,12 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    *
    * @param ipaddress Address String
    * @param uuid UUID String
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException
    */
   @Override
-  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       String ipaddress, String uuid) throws IOException {
 
     DatanodeUsageInfoRequestProto request =
@@ -642,12 +642,12 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException
    */
   @Override
-  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException {
     DatanodeUsageInfoRequestProto request =
         DatanodeUsageInfoRequestProto.newBuilder()

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -614,8 +614,8 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   /**
    * Builds request for datanode usage information and receives response.
    *
-   * @param ipaddress - Address String
-   * @param uuid - UUID String
+   * @param ipaddress Address String
+   * @param uuid UUID String
    * @return List of DatanodeUsageInfo. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -259,6 +259,8 @@ message NodeQueryResponseProto {
 message DatanodeUsageInfoRequestProto {
   optional string ipaddress = 1;
   optional string uuid = 2;
+  optional bool mostUsed = 3;
+  optional uint32 count = 4;
 }
 
 message DatanodeUsageInfoResponseProto {

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -254,7 +254,7 @@ message NodeQueryResponseProto {
 }
 
 /*
-  Usage info request message containing ip and uuid.
+  Datanode usage info request message.
 */
 message DatanodeUsageInfoRequestProto {
   optional string ipaddress = 1;

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -264,7 +264,7 @@ message DatanodeUsageInfoRequestProto {
 }
 
 message DatanodeUsageInfoResponseProto {
-  repeated DatanodeUsageInfo info = 1;
+  repeated DatanodeUsageInfoProto info = 1;
 }
 
 /*

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -156,7 +156,7 @@ message NodePool {
     repeated Node nodes = 1;
 }
 
-message DatanodeUsageInfo {
+message DatanodeUsageInfoProto {
     optional int64 capacity = 1;
     optional int64 used = 2;
     optional int64 remaining = 3;

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -160,6 +160,7 @@ message DatanodeUsageInfo {
     optional int64 capacity = 1;
     optional int64 used = 2;
     optional int64 remaining = 3;
+    optional DatanodeDetailsProto node = 4;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
@@ -151,16 +151,11 @@ public class SCMNodeStat implements NodeStat {
   public int compareByRemainingRatio(SCMNodeStat other) {
     Preconditions.checkNotNull(other, "Argument cannot be null");
 
-    double thisCapacity = this.getCapacity().get().doubleValue();
-    double otherCapacity = other.getCapacity().get().doubleValue();
-
     // if capacity is zero, replace with 1 for division to work
-    if (thisCapacity == 0) {
-      thisCapacity = 1;
-    }
-    if (otherCapacity == 0) {
-      otherCapacity = 1;
-    }
+    double thisCapacity = Math.max(this.getCapacity().get().doubleValue(), 1d);
+    double otherCapacity = Math.max(
+        other.getCapacity().get().doubleValue(), 1d);
+
     double thisRemainingRatio = this.getRemaining().get() / thisCapacity;
     double otherRemainingRatio = other.getRemaining().get() / otherCapacity;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
@@ -138,4 +138,32 @@ public class SCMNodeStat implements NodeStat {
   public int hashCode() {
     return Long.hashCode(capacity.get() ^ scmUsed.get() ^ remaining.get());
   }
+
+  /**
+   * Compares this SCMNodeStat with other on the basis of remaining to
+   * capacity ratio.
+   *
+   * @param other The SCMNodeStat object to compare with this object.
+   * @return A value greater than 0 if this has lesser remaining ratio than the
+   * specified other, a value lesser than 0 if this has greater remaining ratio
+   * than the specified other, and 0 if remaining ratios are equal.
+   */
+  public int compareByRemainingRatio(SCMNodeStat other) {
+    Preconditions.checkNotNull(other, "Argument cannot be null");
+
+    double thisCapacity = this.getCapacity().get().doubleValue();
+    double otherCapacity = other.getCapacity().get().doubleValue();
+
+    // if capacity is zero, replace with 1 for division to work
+    if (thisCapacity == 0) {
+      thisCapacity = 1;
+    }
+    if (otherCapacity == 0) {
+      otherCapacity = 1;
+    }
+    double thisRemainingRatio = this.getRemaining().get() / thisCapacity;
+    double otherRemainingRatio = other.getRemaining().get() / otherCapacity;
+
+    return Double.compare(otherRemainingRatio, thisRemainingRatio);
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -1,0 +1,172 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.node;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+
+import java.util.Comparator;
+
+public class DatanodeUsageInfo {
+
+  private DatanodeDetails datanodeDetails;
+  private SCMNodeStat scmNodeStat;
+
+  /**
+   * Constructs a DatanodeUsageInfo with DatanodeDetails and SCMNodeStat.
+   *
+   * @param datanodeDetails DatanodeDetails
+   * @param scmNodeStat SCMNodeStat
+   */
+  public DatanodeUsageInfo(
+      DatanodeDetails datanodeDetails,
+      SCMNodeStat scmNodeStat) {
+    this.datanodeDetails = datanodeDetails;
+    this.scmNodeStat = scmNodeStat;
+  }
+
+  /**
+   * Compares two DatanodeUsageInfo on the basis of used space.
+   *
+   * @param first DatanodeUsageInfo
+   * @param second DatanodeUsageInfo
+   * @return a value greater than 0 if first is more used, a value
+   * lesser than 0 if second is more used, and 0 if both are equally used or
+   * first.equals(second) is true
+   */
+  private static int compare(DatanodeUsageInfo first,
+                             DatanodeUsageInfo second) {
+    if (first.equals(second)) {
+      return 0;
+    }
+    double remaining = first.scmNodeStat.getRemaining().get().doubleValue();
+    double capacity = first.scmNodeStat.getCapacity().get().doubleValue();
+    double ratioRemaining = remaining / capacity;
+
+    double secondRemaining = second.scmNodeStat
+        .getRemaining().get().doubleValue();
+    double secondCapacity = second.scmNodeStat
+        .getCapacity().get().doubleValue();
+    double secondRatioRemaining = secondRemaining / secondCapacity;
+
+    return Double.compare(secondRatioRemaining, ratioRemaining);
+  }
+
+  /**
+   * Sets DatanodeDetails of this DatanodeUsageInfo.
+   *
+   * @param datanodeDetails the DatanodeDetails to use
+   */
+  public void setDatanodeDetails(
+      DatanodeDetails datanodeDetails) {
+    this.datanodeDetails = datanodeDetails;
+  }
+
+  /**
+   * Sets SCMNodeStat of this DatanodeUsageInfo.
+   *
+   * @param scmNodeStat the SCMNodeStat to use.
+   */
+  public void setScmNodeStat(
+      SCMNodeStat scmNodeStat) {
+    this.scmNodeStat = scmNodeStat;
+  }
+
+  /**
+   * Gets DatanodeDetails of this DatanodeUsageInfo.
+   *
+   * @return DatanodeDetails
+   */
+  public DatanodeDetails getDatanodeDetails() {
+    return datanodeDetails;
+  }
+
+  /**
+   * Gets SCMNodeStat of this DatanodeUsageInfo.
+   *
+   * @return SCMNodeStat
+   */
+  public SCMNodeStat getScmNodeStat() {
+    return scmNodeStat;
+  }
+
+  /**
+   * Gets Comparator that compares two DatanodeUsageInfo on the basis of
+   * used space. The comparison function returns a value greater than 0 if
+   * first DatanodeUsageInfo is more used, a value lesser than 0 if second
+   * DatanodeUsageInfo is more used, and 0 if both are equally used or first
+   * .equals(second) is true
+   *
+   * @return Comparator to compare two DatanodeUsageInfo.
+   */
+  public static Comparator<DatanodeUsageInfo> getUsageComparator() {
+    return DatanodeUsageInfo::compare;
+  }
+
+  /**
+   * Checks if the specified Object o is equal to this DatanodeUsageInfo.
+   *
+   * @param o Object to check
+   * @return true if both refer to the same object or if both have the same
+   * DatanodeDetails, false otherwise
+   */
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DatanodeUsageInfo that = (DatanodeUsageInfo) o;
+    return datanodeDetails.equals(that.datanodeDetails);
+  }
+
+  @Override
+  public int hashCode() {
+    return datanodeDetails.hashCode();
+  }
+
+  /**
+   * Converts an object of type DatanodeUsageInfo to Protobuf type
+   * HddsProtos.DatanodeUsageInfoProto.
+   *
+   * @return Protobuf HddsProtos.DatanodeUsageInfo
+   */
+  public HddsProtos.DatanodeUsageInfoProto toProto() {
+    return toProtoBuilder().build();
+  }
+
+  private HddsProtos.DatanodeUsageInfoProto.Builder toProtoBuilder() {
+    HddsProtos.DatanodeUsageInfoProto.Builder builder =
+        HddsProtos.DatanodeUsageInfoProto.newBuilder();
+
+    if (datanodeDetails != null) {
+      builder.setNode(
+          datanodeDetails.toProto(datanodeDetails.getCurrentVersion()));
+    }
+    if (scmNodeStat != null) {
+      builder.setCapacity(scmNodeStat.getCapacity().get());
+      builder.setUsed(scmNodeStat.getScmUsed().get());
+      builder.setRemaining(scmNodeStat.getRemaining().get());
+    }
+    return builder;
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -43,30 +43,23 @@ public class DatanodeUsageInfo {
   }
 
   /**
-   * Compares two DatanodeUsageInfo on the basis of used space.
+   * Compares two DatanodeUsageInfo on the basis of remaining space to capacity
+   * ratio.
    *
    * @param first DatanodeUsageInfo
    * @param second DatanodeUsageInfo
-   * @return a value greater than 0 if first is more used, a value
-   * lesser than 0 if second is more used, and 0 if both are equally used or
-   * first.equals(second) is true
+   * @return a value greater than 0 if second has higher remaining to
+   * capacity ratio, a value lesser than 0 if first has higher remaining to
+   * capacity ratio, and 0 if both have equal ratios or first.equals(second)
+   * is true
    */
-  private static int compare(DatanodeUsageInfo first,
+  private static int compareByRemainingRatio(DatanodeUsageInfo first,
                              DatanodeUsageInfo second) {
     if (first.equals(second)) {
       return 0;
     }
-    double remaining = first.scmNodeStat.getRemaining().get().doubleValue();
-    double capacity = first.scmNodeStat.getCapacity().get().doubleValue();
-    double ratioRemaining = remaining / capacity;
-
-    double secondRemaining = second.scmNodeStat
-        .getRemaining().get().doubleValue();
-    double secondCapacity = second.scmNodeStat
-        .getCapacity().get().doubleValue();
-    double secondRatioRemaining = secondRemaining / secondCapacity;
-
-    return Double.compare(secondRatioRemaining, ratioRemaining);
+    return first.getScmNodeStat()
+        .compareByRemainingRatio(second.getScmNodeStat());
   }
 
   /**
@@ -109,15 +102,16 @@ public class DatanodeUsageInfo {
 
   /**
    * Gets Comparator that compares two DatanodeUsageInfo on the basis of
-   * used space. The comparison function returns a value greater than 0 if
-   * first DatanodeUsageInfo is more used, a value lesser than 0 if second
-   * DatanodeUsageInfo is more used, and 0 if both are equally used or first
-   * .equals(second) is true
+   * remaining space to capacity ratio.
    *
-   * @return Comparator to compare two DatanodeUsageInfo.
+   * @return Comparator to compare two DatanodeUsageInfo. The comparison
+   * function returns a value greater than 0 if second DatanodeUsageInfo has
+   * greater remaining space to capacity ratio, a value lesser than 0 if
+   * first DatanodeUsageInfo has greater remaining space to capacity ratio,
+   * and 0 if both have equal ratios or first.equals(second) is true
    */
-  public static Comparator<DatanodeUsageInfo> getUsageComparator() {
-    return DatanodeUsageInfo::compare;
+  public static Comparator<DatanodeUsageInfo> getMostUsedByRemainingRatio() {
+    return DatanodeUsageInfo::compareByRemainingRatio;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -17,17 +17,17 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.net.NetworkTopology;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.ozone.protocol.StorageContainerNodeProtocol;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
@@ -116,6 +116,17 @@ public interface NodeManager extends StorageContainerNodeProtocol,
    * @return a map of individual node stats (live/stale but not dead).
    */
   Map<DatanodeDetails, SCMNodeStat> getNodeStats();
+
+  /**
+   * Gets a sorted list of most or least used DatanodeUsageInfo containing
+   * healthy, in-service nodes. If the specified mostUsed is true, the returned
+   * list is in descending order of usage. Otherwise, the returned list is in
+   * ascending order of usage.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @return List of DatanodeUsageInfo
+   */
+  List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(boolean mostUsed);
 
   /**
    * Return the node stat of the specified datanode.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -17,26 +17,15 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
-import javax.management.ObjectName;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Collections;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
-import java.util.stream.Collectors;
-
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
@@ -67,14 +56,24 @@ import org.apache.hadoop.ozone.protocol.commands.RegisteredCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.ozone.protocol.commands.SetNodeOperationalStateCommand;
 import org.apache.hadoop.util.ReflectionUtils;
-
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import org.apache.hadoop.util.Time;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.management.ObjectName;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
 
 /**
  * Maintains information about the Datanodes on SCM side.
@@ -529,6 +528,40 @@ public class SCMNodeManager implements NodeManager {
       }
     }
     return nodeStats;
+  }
+
+  /**
+   * Gets a sorted list of most or least used DatanodeUsageInfo containing
+   * healthy, in-service nodes. If the specified mostUsed is true, the returned
+   * list is in descending order of usage. Otherwise, the returned list is in
+   * ascending order of usage.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @return List of DatanodeUsageInfo
+   */
+  public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(
+      boolean mostUsed) {
+    List<DatanodeDetails> healthyNodes =
+        getNodes(NodeOperationalState.IN_SERVICE, NodeState.HEALTHY);
+
+    List<DatanodeUsageInfo> datanodeUsageInfoList =
+        new ArrayList<>(healthyNodes.size());
+
+    // create a DatanodeUsageInfo from each DatanodeDetails and add it to the
+    // list
+    for (DatanodeDetails node : healthyNodes) {
+      SCMNodeStat stat = getNodeStatInternal(node);
+      datanodeUsageInfoList.add(new DatanodeUsageInfo(node, stat));
+    }
+
+    // sort the list according to appropriate comparator
+    if (mostUsed) {
+      datanodeUsageInfoList.sort(
+          DatanodeUsageInfo.getUsageComparator().reversed());
+    } else {
+      datanodeUsageInfoList.sort(DatanodeUsageInfo.getUsageComparator());
+    }
+    return datanodeUsageInfoList;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -557,9 +557,10 @@ public class SCMNodeManager implements NodeManager {
     // sort the list according to appropriate comparator
     if (mostUsed) {
       datanodeUsageInfoList.sort(
-          DatanodeUsageInfo.getUsageComparator().reversed());
+          DatanodeUsageInfo.getMostUsedByRemainingRatio().reversed());
     } else {
-      datanodeUsageInfoList.sort(DatanodeUsageInfo.getUsageComparator());
+      datanodeUsageInfoList.sort(
+          DatanodeUsageInfo.getMostUsedByRemainingRatio());
     }
     return datanodeUsageInfoList;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -567,7 +567,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public DatanodeUsageInfoResponseProto getDatanodeUsageInfo(
       StorageContainerLocationProtocolProtos.DatanodeUsageInfoRequestProto
       request) throws IOException {
-    List<HddsProtos.DatanodeUsageInfo> infoList;
+    List<HddsProtos.DatanodeUsageInfoProto> infoList;
 
     // get info by ip or uuid
     if (request.hasUuid() || request.hasIpaddress()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.protocol;
 
-import com.google.common.base.Strings;
 import com.google.protobuf.ProtocolMessageEnum;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
@@ -568,21 +567,17 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public DatanodeUsageInfoResponseProto getDatanodeUsageInfo(
       StorageContainerLocationProtocolProtos.DatanodeUsageInfoRequestProto
       request) throws IOException {
-    String ipaddress = null;
-    String uuid = null;
-    if (request.hasIpaddress()) {
-      ipaddress = request.getIpaddress();
-    }
-    if (request.hasUuid()) {
-      uuid = request.getUuid();
-    }
-    if (Strings.isNullOrEmpty(ipaddress) && Strings.isNullOrEmpty(uuid)) {
-      throw new IOException("No ip or uuid specified");
+    List<HddsProtos.DatanodeUsageInfo> infoList;
+
+    // get info by ip or uuid
+    if (request.hasUuid() || request.hasIpaddress()) {
+      infoList = impl.getDatanodeUsageInfo(request.getIpaddress(),
+          request.getUuid());
+    } else {  // get most or least used nodes
+      infoList = impl.getDatanodeUsageInfo(request.getMostUsed(),
+          request.getCount());
     }
 
-    List<HddsProtos.DatanodeUsageInfo> infoList;
-    infoList = impl.getDatanodeUsageInfo(ipaddress,
-        uuid);
     return DatanodeUsageInfoResponseProto.newBuilder()
         .addAllInfo(infoList)
         .build();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.scm.net.Node;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -265,6 +266,21 @@ public class MockNodeManager implements NodeManager {
   @Override
   public Map<DatanodeDetails, SCMNodeStat> getNodeStats() {
     return nodeMetricMap;
+  }
+
+  /**
+   * Gets a sorted list of most or least used DatanodeUsageInfo containing
+   * healthy, in-service nodes. If the specified mostUsed is true, the returned
+   * list is in descending order of usage. Otherwise, the returned list is in
+   * ascending order of usage.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @return List of DatanodeUsageInfo
+   */
+  @Override
+  public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(
+      boolean mostUsed) {
+    return null;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
@@ -208,6 +209,20 @@ public class SimpleMockNodeManager implements NodeManager {
 
   @Override
   public Map<DatanodeDetails, SCMNodeStat> getNodeStats() {
+    return null;
+  }
+
+  /**
+   * Gets a sorted list of most or least used DatanodeUsageInfo containing
+   * healthy, in-service nodes. If the specified mostUsed is true, the returned
+   * list is in descending order of usage. Otherwise, the returned list is in
+   * ascending order of usage.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @return List of DatanodeUsageInfo
+   */
+  @Override
+  public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(boolean mostUsed) {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
         .StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -157,6 +158,20 @@ public class ReplicationNodeManagerMock implements NodeManager {
    */
   @Override
   public Map<DatanodeDetails, SCMNodeStat> getNodeStats() {
+    return null;
+  }
+
+  /**
+   * Gets a sorted list of most or least used DatanodeUsageInfo containing
+   * healthy, in-service nodes. If the specified mostUsed is true, the returned
+   * list is in descending order of usage. Otherwise, the returned list is in
+   * ascending order of usage.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @return List of DatanodeUsageInfo
+   */
+  @Override
+  public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(boolean mostUsed) {
     return null;
   }
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -537,12 +537,12 @@ public class ContainerOperationClient implements ScmClient {
    *
    * @param ipaddress datanode ipaddress String
    * @param uuid datanode uuid String
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMused, and remaining space.
    * @throws IOException
    */
   @Override
-  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       String ipaddress, String uuid) throws IOException {
     return storageContainerLocationClient.getDatanodeUsageInfo(ipaddress,
         uuid);
@@ -553,12 +553,12 @@ public class ContainerOperationClient implements ScmClient {
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for
-   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * @return List of DatanodeUsageInfoProto. Each element contains info such as
    * capacity, SCMUsed, and remaining space.
    * @throws IOException
    */
   @Override
-  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+  public List<HddsProtos.DatanodeUsageInfoProto> getDatanodeUsageInfo(
       boolean mostUsed, int count) throws IOException {
     return storageContainerLocationClient.getDatanodeUsageInfo(mostUsed, count);
   }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -548,4 +548,19 @@ public class ContainerOperationClient implements ScmClient {
         uuid);
   }
 
+  /**
+   * Gets usage information of most or least used datanodes.
+   *
+   * @param mostUsed true if most used, false if least used
+   * @param count Integer number of nodes to get info for
+   * @return List of DatanodeUsageInfo. Each element contains info such as
+   * capacity, SCMUsed, and remaining space.
+   * @throws IOException
+   */
+  @Override
+  public List<HddsProtos.DatanodeUsageInfo> getDatanodeUsageInfo(
+      boolean mostUsed, int count) throws IOException {
+    return storageContainerLocationClient.getDatanodeUsageInfo(mostUsed, count);
+  }
+
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -535,8 +535,8 @@ public class ContainerOperationClient implements ScmClient {
   /**
    * Get Datanode Usage information by ipaddress or uuid.
    *
-   * @param ipaddress - datanode ipaddress String
-   * @param uuid - datanode uuid String
+   * @param ipaddress datanode ipaddress String
+   * @param uuid datanode uuid String
    * @return List of DatanodeUsageInfo. Each element contains info such as
    * capacity, SCMused, and remaining space.
    * @throws IOException
@@ -549,7 +549,7 @@ public class ContainerOperationClient implements ScmClient {
   }
 
   /**
-   * Gets usage information of most or least used datanodes.
+   * Get usage information of most or least used datanodes.
    *
    * @param mostUsed true if most used, false if least used
    * @param count Integer number of nodes to get info for

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
@@ -73,6 +73,9 @@ public class UsageInfoSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     List<HddsProtos.DatanodeUsageInfo> infoList = null;
+    if (count < 1) {
+      throw new IOException("count must be greater than 0");
+    }
     if (!Strings.isNullOrEmpty(exclusiveArguments.ipaddress) ||
         !Strings.isNullOrEmpty(exclusiveArguments.uuid)) {
       infoList = scmClient.getDatanodeUsageInfo(exclusiveArguments.ipaddress,
@@ -97,6 +100,7 @@ public class UsageInfoSubcommand extends ScmSubcommand {
     NumberFormat percentFormat = NumberFormat.getPercentInstance();
     percentFormat.setMinimumFractionDigits(5);
 
+    System.out.printf("Usage info for %s:%n", info.getNode().getUuid());
     System.out.printf("%-10s: %20sB %n", "Capacity", info.getCapacity());
     System.out.printf("%-10s: %20sB (%s) %n", "SCMUsed", info.getUsed(),
         percentFormat.format(usedRatio));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce `--most-used` and `--least-used` options in `UsageInfoSubcommand` to get the usage info of most used and least used datanodes, respectively. `--count` option can be used to specify number of nodes along with `--most-used` or `--least-used`.

All options except `--count` are now exclusive.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4872

## How was this patch tested?

Tested using docker-compose. Screenshots have been attached below.

<img width="798" alt="test1" src="https://user-images.githubusercontent.com/34305492/109654699-827e0e00-7b88-11eb-91f5-eef3fe050d4b.png">
<img width="945" alt="test2" src="https://user-images.githubusercontent.com/34305492/109654728-8ad64900-7b88-11eb-98b5-2c2ac3544a3a.png">
<img width="945" alt="test3" src="https://user-images.githubusercontent.com/34305492/109654772-96c20b00-7b88-11eb-9c75-68f8b45d2c0d.png">
<img width="945" alt="image" src="https://user-images.githubusercontent.com/34305492/109654829-ab9e9e80-7b88-11eb-8ac8-dbab46b94a7a.png">
