### PR TITLE
HDDS-4891. Avoid latest/master in Github Actions

### DIFF
--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -21,10 +21,10 @@ on:
 jobs:
   close-pending:
     name: close-pending
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Execute close-pending script
         if: github.repository == 'apache/ozone'
         run: ./.github/close-pending.sh

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   process-comment:
     name: check-comment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - run: ./.github/process-comment.sh

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -25,7 +25,9 @@ jobs:
     name: check-comment
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@v2
-      - run: ./.github/process-comment.sh
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Execute process-comment script
+        run: ./.github/process-comment.sh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid versions `latest` (for runners) and `master` (for actions) in Github Actions workflows.

https://issues.apache.org/jira/browse/HDDS-4891

## How was this patch tested?

Tested a command comment on my fork:
https://github.com/adoroszlai/hadoop-ozone/pull/8#issuecomment-788974590
https://github.com/adoroszlai/hadoop-ozone/runs/2014250387