### PR TITLE
HDDS-4897. [SCM HA Security] Create SCM CertClient and use it during startup and bootStrap

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -38,6 +38,7 @@ public final class OzoneConsts {
 
   public static final String STORAGE_DIR = "scm";
   public static final String SCM_ID = "scmUuid";
+  public static final String PRIMARY_SCM_NODE_ID = "primaryScmNodeId";
   public static final String CLUSTER_ID_PREFIX = "CID-";
 
   public static final String OZONE_SIMPLE_ROOT_USER = "root";

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
@@ -305,10 +305,8 @@ public class DefaultProfile implements PKIProfile {
    */
   @Override
   public KeyUsage getKeyUsage() {
-    // Adding to same profile
-    // TODO: Create a new profile for RootCA which issues certificate?
     return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment
-        | KeyUsage.dataEncipherment | KeyUsage.keyAgreement | KeyUsage.keyCertSign | KeyUsage.cRLSign);
+        | KeyUsage.dataEncipherment | KeyUsage.keyAgreement);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/PKIProfiles/DefaultProfile.java
@@ -153,6 +153,7 @@ public class DefaultProfile implements PKIProfile {
           GeneralNames.getInstance(ext.getParsedValue()).toString());
       return false;
     }
+
     GeneralNames generalNames = GeneralNames.getInstance(ext.getParsedValue());
     for (GeneralName name : generalNames.getNames()) {
       try {
@@ -304,8 +305,10 @@ public class DefaultProfile implements PKIProfile {
    */
   @Override
   public KeyUsage getKeyUsage() {
+    // Adding to same profile
+    // TODO: Create a new profile for RootCA which issues certificate?
     return new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment
-        | KeyUsage.dataEncipherment | KeyUsage.keyAgreement);
+        | KeyUsage.dataEncipherment | KeyUsage.keyAgreement | KeyUsage.keyCertSign | KeyUsage.cRLSign);
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.security.x509.certificate.client;
+
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
+import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.GETCERT;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.RECOVER;
+import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.SUCCESS;
+
+/**
+ * SCM Certificate Client which is used for generate public, private Key and
+ * generate CSR.
+ */
+public class SCMCertificateClient extends DefaultCertificateClient {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SCMCertificateClient.class);
+
+  public static final String COMPONENT_NAME = "scm";
+
+  public SCMCertificateClient(SecurityConfig securityConfig,
+      String certSerialId) {
+    super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
+  }
+
+  public SCMCertificateClient(SecurityConfig securityConfig) {
+    super(securityConfig, LOG, null, COMPONENT_NAME);
+  }
+
+  @Override
+  protected InitResponse handleCase(DefaultCertificateClient.InitCase init) throws
+      CertificateException {
+    // This is similar to OM, where it overrides handleCase method from
+    // DefaultCertClient.
+    switch (init) {
+    case NONE:
+      LOG.info("Creating keypair for client as keypair and certificate not " +
+          "found.");
+      bootstrapClientKeys();
+      return GETCERT;
+    case CERT:
+      LOG.error("Private key not found, while certificate is still present." +
+          "Delete keypair and try again.");
+      return FAILURE;
+    case PUBLIC_KEY:
+      LOG.error("Found public key but private key and certificate missing.");
+      return FAILURE;
+    case PRIVATE_KEY:
+      LOG.info("Found private key but public key and certificate is missing.");
+      // TODO: Recovering public key from private might be possible in some
+      //  cases.
+      return FAILURE;
+    case PUBLICKEY_CERT:
+      LOG.error("Found public key and certificate but private key is " +
+          "missing.");
+      return FAILURE;
+    case PRIVATEKEY_CERT:
+      LOG.info("Found private key and certificate but public key missing.");
+      if (recoverPublicKey()) {
+        return SUCCESS;
+      } else {
+        LOG.error("Public key recovery failed.");
+        return FAILURE;
+      }
+    case PUBLICKEY_PRIVATEKEY:
+      LOG.info("Found private and public key but certificate is missing.");
+      if (validateKeyPair(getPublicKey())) {
+        return RECOVER;
+      } else {
+        LOG.error("Keypair validation failed.");
+        return FAILURE;
+      }
+    case ALL:
+      LOG.info("Found certificate file along with KeyPair.");
+      if (validateKeyPairAndCertificate()) {
+        return SUCCESS;
+      } else {
+        return FAILURE;
+      }
+    default:
+      LOG.error("Unexpected case: {} (private/public/cert)",
+          Integer.toBinaryString(init.ordinal()));
+      return FAILURE;
+    }
+  }
+
+  /**
+   * Returns a CSR builder that can be used to creates a Certificate signing
+   * request.
+   *
+   * @return CertificateSignRequest.Builder
+   */
+  @Override
+  public CertificateSignRequest.Builder getCSRBuilder()
+      throws CertificateException {
+    return super.getCSRBuilder()
+        .setDigitalEncryption(true)
+        .setDigitalSignature(true)
+        // Set CA to true, as this will be used to sign certs for OM/DN.
+        .setCA(true);
+  }
+
+
+  @Override
+  public Logger getLogger() {
+    return LOG;
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.DefaultCertificateClient.InitCase;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.slf4j.Logger;
@@ -50,8 +51,8 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   }
 
   @Override
-  protected InitResponse handleCase(DefaultCertificateClient.InitCase init) throws
-      CertificateException {
+  protected InitResponse handleCase(InitCase init)
+      throws CertificateException {
     // This is similar to OM, where it overrides handleCase method from
     // DefaultCertClient.
     switch (init) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
@@ -95,7 +95,7 @@ public final class HASecurityUtils {
         client.getPrivateKey());
 
     // Get host name.
-    String hostname = scmAddress.getHostName();
+    String hostname = scmAddress.getAddress().getHostName();
     String ip = scmAddress.getAddress().getHostAddress();
 
     String subject;
@@ -120,6 +120,7 @@ public final class HASecurityUtils {
 
     HddsProtos.ScmNodeDetailsProto scmNodeDetailsProto =
         HddsProtos.ScmNodeDetailsProto.newBuilder()
+            .setClusterId(clusterId)
             .setHostName(scmAddress.getHostName())
             .setScmNodeId(fetchedSCMId).build();
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
@@ -37,6 +37,9 @@ import static org.apache.hadoop.hdds.security.x509.certificates.utils.Certificat
 
 public class HASecurityUtils {
 
+  private HASecurityUtils() {
+  }
+
   public static final Logger LOG =
       LoggerFactory.getLogger(HASecurityUtils.class);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
@@ -35,7 +35,7 @@ import java.security.KeyPair;
 
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
 
-public class HASecurityUtils {
+public final class HASecurityUtils {
 
   private HASecurityUtils() {
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HASecurityUtils.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.utils;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
+import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient;
+import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+
+import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
+
+public class HASecurityUtils {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(HASecurityUtils.class);
+
+  /**
+   * Initialize Security which generates public, private key pair and get SCM
+   * signed certificate and persist to local disk.
+   * @param clusterId
+   * @param fetchedScmId
+   * @param conf
+   * @param scmAddress
+   * @throws IOException
+   */
+  public static void initializeSecurity(String clusterId,
+      String fetchedScmId, OzoneConfiguration conf,
+      InetSocketAddress scmAddress)
+      throws IOException {
+    LOG.info("Initializing secure StorageContainerManager.");
+
+    CertificateClient certClient =
+        new SCMCertificateClient(new SecurityConfig(conf));
+    CertificateClient.InitResponse response = certClient.init();
+    LOG.info("Init response: {}", response);
+    switch (response) {
+    case SUCCESS:
+      LOG.info("Initialization successful.");
+      break;
+    case GETCERT:
+      getSCMSignedCert(certClient, conf, fetchedScmId, clusterId, scmAddress);
+      LOG.info("Successfully stored SCM signed certificate.");
+      break;
+    case FAILURE:
+      LOG.error("SCM security initialization failed.");
+      throw new RuntimeException("OM security initialization failed.");
+    case RECOVER:
+      LOG.error("SCM security initialization failed. SCM certificate is " +
+          "missing.");
+      throw new RuntimeException("SCM security initialization failed.");
+    default:
+      LOG.error("SCM security initialization failed. Init response: {}",
+          response);
+      throw new RuntimeException("SCM security initialization failed.");
+    }
+  }
+
+  /**
+   * Get SCM signed certificate and store it using certificate client.
+   */
+  private static void getSCMSignedCert(CertificateClient client,
+      OzoneConfiguration config, String fetchedSCMId, String clusterId,
+      InetSocketAddress scmAddress) throws IOException {
+    CertificateSignRequest.Builder builder = client.getCSRBuilder();
+    KeyPair keyPair = new KeyPair(client.getPublicKey(),
+        client.getPrivateKey());
+
+    // Get host name.
+    String hostname = scmAddress.getHostName();
+    String ip = scmAddress.getAddress().getHostAddress();
+
+    String subject;
+    if (builder.hasDnsName()) {
+      subject = UserGroupInformation.getCurrentUser().getShortUserName()
+          + "@" + hostname;
+    } else {
+      // With only IP in alt.name, certificate validation would fail if subject
+      // isn't a hostname either, so omit username.
+      subject = hostname;
+    }
+
+    builder.setKey(keyPair)
+        .setConfiguration(config)
+        .setScmID(fetchedSCMId)
+        .setClusterID(clusterId)
+        .setSubject(subject);
+
+
+    LOG.info("Creating csr for SCM->hostName:{},ip:{},scmId:{},clusterId:{}," +
+            "subject:{}", hostname, ip, fetchedSCMId, clusterId, subject);
+
+    HddsProtos.ScmNodeDetailsProto scmNodeDetailsProto =
+        HddsProtos.ScmNodeDetailsProto.newBuilder()
+            .setHostName(scmAddress.getHostName())
+            .setScmNodeId(fetchedSCMId).build();
+
+    PKCS10CertificationRequest csr = builder.build();
+
+    SCMSecurityProtocolClientSideTranslatorPB secureScmClient =
+        HddsServerUtil.getScmSecurityClient(config);
+
+    SCMGetCertResponseProto response = secureScmClient.
+        getSCMCertChain(scmNodeDetailsProto, getEncodedString(csr));
+    String pemEncodedCert = response.getX509Certificate();
+
+    try {
+
+      // Store SCM CA certificate.
+      if (response.hasX509CACertificate()) {
+        String pemEncodedRootCert = response.getX509CACertificate();
+        client.storeCertificate(pemEncodedRootCert, true, true);
+        client.storeCertificate(pemEncodedCert, true);
+      } else {
+        throw new RuntimeException("Unable to retrieve SCM certificate chain");
+      }
+    } catch (IOException e) {
+      LOG.error("Error while storing SCM signed certificate.", e);
+      throw new RuntimeException(e);
+    }
+
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -154,7 +154,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
         scmNodeDetails.getHostName(), scmNodeDetails.getScmNodeId());
 
     // Check clusterID
-    if (storageContainerManager.getClusterId().equals(
+    if (!storageContainerManager.getClusterId().equals(
         scmNodeDetails.getClusterId())) {
       throw new IOException("SCM ClusterId mismatch. Peer SCM ClusterId " +
           scmNodeDetails.getClusterId() + ", primary SCM ClusterId "

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
+import static org.apache.hadoop.ozone.OzoneConsts.PRIMARY_SCM_NODE_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_ID;
 import static org.apache.hadoop.ozone.OzoneConsts.STORAGE_DIR;
 
@@ -56,6 +57,27 @@ public class SCMStorageConfig extends Storage {
     } else {
       getStorageInfo().setProperty(SCM_ID, scmId);
     }
+  }
+
+  /**
+   * Set primary SCM node ID.
+   * @param scmId
+   * @throws IOException
+   */
+  public void setPrimaryScmNodeId(String scmId) throws IOException {
+    if (getState() == StorageState.INITIALIZED) {
+      throw new IOException("SCM is already initialized.");
+    } else {
+      getStorageInfo().setProperty(PRIMARY_SCM_NODE_ID, scmId);
+    }
+  }
+
+  /**
+   * Retrieves the primary SCM node ID from the version file.
+   * @return Primary SCM node ID.
+   */
+  public String getPrimaryScmNodeId() {
+    return getStorageInfo().getProperty(PRIMARY_SCM_NODE_ID);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -565,7 +565,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     // For primary do this during SCM startup, as it requires SCM Security
     // protocol server, Ratis Server and SCMMetadataStore setup.
-    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+
+    if (OzoneSecurityUtil.isSecurityEnabled(conf) &&
+        scmStorageConfig.getPrimaryScmNodeId().equals(scmStorageConfig.getScmId())) {
       HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
           scmStorageConfig.getScmId(), conf,
           scmHANodeDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
@@ -824,6 +826,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
         scmStorageConfig.initialize();
 
+
+        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
+        scmStorageConfig.initialize();
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"
                 + "; cid={}; layoutVersion={}; scmId={}",
             scmStorageConfig.getStorageDir(), scmStorageConfig.getClusterID(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -566,7 +566,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     // For primary do this during SCM startup, as it requires SCM Security
     // protocol server, Ratis Server and SCMMetadataStore setup.
     if (OzoneSecurityUtil.isSecurityEnabled(conf) &&
-        scmStorageConfig.getPrimaryScmNodeId().equals(scmStorageConfig.getScmId())) {
+        scmStorageConfig.getPrimaryScmNodeId().equals(
+            scmStorageConfig.getScmId())) {
       HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
           scmStorageConfig.getScmId(), conf,
           scmHANodeDetails.getLocalNodeDetails()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -813,9 +813,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               haDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
         }
 
-        scmStorageConfig.initialize();
-
-
         scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
         scmStorageConfig.initialize();
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -565,12 +565,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     // For primary do this during SCM startup, as it requires SCM Security
     // protocol server, Ratis Server and SCMMetadataStore setup.
-
     if (OzoneSecurityUtil.isSecurityEnabled(conf) &&
         scmStorageConfig.getPrimaryScmNodeId().equals(scmStorageConfig.getScmId())) {
       HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
           scmStorageConfig.getScmId(), conf,
-          scmHANodeDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
+          scmHANodeDetails.getLocalNodeDetails()
+              .getBlockProtocolServerAddress());
     }
 
     grpcTlsConfig = createTlsClientConfigForSCM(new SecurityConfig(conf),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -563,6 +563,14 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     securityProtocolServer = new SCMSecurityProtocolServer(conf,
         certificateServer, this);
 
+    // For primary do this during SCM startup, as it requires SCM Security
+    // protocol server, Ratis Server and SCMMetadataStore setup.
+    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+      HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
+          scmStorageConfig.getScmId(), conf,
+          scmHANodeDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
+    }
+
     grpcTlsConfig = createTlsClientConfigForSCM(new SecurityConfig(conf),
             certificateServer);
   }
@@ -769,9 +777,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         scmStorageConfig.initialize();
 
         if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
-          HASecurityUtils.initializeSecurity(fetchedId,
-              scmInfo.getScmId(), conf,
-              scmhaNodeDetails.getLocalNodeDetails()
+          HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
+              fetchedId, conf, scmhaNodeDetails.getLocalNodeDetails()
                   .getBlockProtocolServerAddress());
         }
 
@@ -814,7 +821,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               scmStorageConfig.getScmId(), conf,
               haDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
         }
+
         scmStorageConfig.initialize();
+
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"
                 + "; cid={}; layoutVersion={}; scmId={}",
             scmStorageConfig.getStorageDir(), scmStorageConfig.getClusterID(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
 import org.apache.hadoop.hdds.scm.ScmInfo;
+import org.apache.hadoop.hdds.utils.HASecurityUtils;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmConfig;
@@ -765,10 +766,15 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         // It will write down the cluster Id fetched from already
         // running SCM as well as the local SCM Id.
 
-        // SCM Node info containing hostname to scm Id mappings
-        // will be persisted into the version file once this node gets added
-        // to existing SCM ring post node regular start up.
         scmStorageConfig.initialize();
+
+        if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+          HASecurityUtils.initializeSecurity(fetchedId,
+              scmInfo.getScmId(), conf,
+              scmhaNodeDetails.getLocalNodeDetails()
+                  .getBlockProtocolServerAddress());
+        }
+
       } catch (IOException ioe) {
         LOG.error("Could not initialize SCM version file", ioe);
         return false;
@@ -796,12 +802,19 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           Preconditions.checkNotNull(UUID.fromString(clusterId));
           scmStorageConfig.setClusterId(clusterId);
         }
-        scmStorageConfig.initialize();
+
         if (SCMHAUtils.isSCMHAEnabled(conf)) {
           SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
               scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
               conf);
         }
+
+        if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+          HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
+              scmStorageConfig.getScmId(), conf,
+              haDetails.getLocalNodeDetails().getBlockProtocolServerAddress());
+        }
+        scmStorageConfig.initialize();
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"
                 + "; cid={}; layoutVersion={}; scmId={}",
             scmStorageConfig.getStorageDir(), scmStorageConfig.getClusterID(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -562,18 +562,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         CertificateServer.CAType.SELF_SIGNED_CA);
     securityProtocolServer = new SCMSecurityProtocolServer(conf,
         certificateServer, this);
-
-    // For primary do this during SCM startup, as it requires SCM Security
-    // protocol server, Ratis Server and SCMMetadataStore setup.
-    if (OzoneSecurityUtil.isSecurityEnabled(conf) &&
-        scmStorageConfig.getPrimaryScmNodeId().equals(
-            scmStorageConfig.getScmId())) {
-      HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
-          scmStorageConfig.getScmId(), conf,
-          scmHANodeDetails.getLocalNodeDetails()
-              .getBlockProtocolServerAddress());
-    }
-
     grpcTlsConfig = createTlsClientConfigForSCM(new SecurityConfig(conf),
             certificateServer);
   }
@@ -1025,6 +1013,18 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     } catch (Exception ex) {
       // SCM HttpServer start-up failure should be non-fatal
       LOG.error("SCM HttpServer failed to start.", ex);
+    }
+
+
+    // For primary do this during SCM startup, as it requires SCM Security
+    // protocol server, Ratis Server and SCMMetadataStore setup.
+    if (OzoneSecurityUtil.isSecurityEnabled(configuration) &&
+        scmStorageConfig.getPrimaryScmNodeId().equals(
+            scmStorageConfig.getScmId())) {
+      HASecurityUtils.initializeSecurity(scmStorageConfig.getClusterID(),
+          scmStorageConfig.getScmId(), configuration,
+          scmHANodeDetails.getLocalNodeDetails()
+              .getBlockProtocolServerAddress());
     }
 
     setStartTime();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to implement
1. Create CertClient, which generates a public key, private key, and generates CSR with ClusterID, SCM1ID.
2. Use SCM SecurityFailOverProxyProvider to getSCMCertificate and RootCA certificate and store it to a local disk.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4897

## How was this patch tested?
Need changes in DefaultProfile to make this work, as right now BasicConstraint is not validated in DefaultProfile, so when the new RootCA server starts, will use a new profile/make changes to make the CSR and request certificate work. Will add tests in further jira.