### PR TITLE
HDDS-4896. Need a tool to upgrade current non-HA SCM node to single node HA cluster

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -292,6 +292,17 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_NODE_ID_KEY =
       "ozone.scm.node.id";
 
+  // optional config, if being set will cause scm --init to only take effect on
+  // the specific node and ignore scm --bootstrap cmd.
+  // Similarly, scm --init will be ignored on the non-primordial scm nodes.
+  // If a cluster is upgraded from non-ratis to ratis based SCM, if the config
+  // is set , this will be the primary SCM node which will initialize the ratis
+  // ring.
+
+  // If the config is not set, scm --init needs to re-run for switching from
+  // non-ratis based SCM to ratis-based SCM.
+  public static final String OZONE_SCM_PRIMORDIAL_NODE_ID_KEY =
+      "ozone.scm.primordial.node.id";
   // The path where datanode ID is to be written to.
   // if this value is not set then container startup will fail.
   public static final String OZONE_SCM_DATANODE_ID_DIR =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -292,15 +292,18 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_NODE_ID_KEY =
       "ozone.scm.node.id";
 
-  // optional config, if being set will cause scm --init to only take effect on
-  // the specific node and ignore scm --bootstrap cmd.
-  // Similarly, scm --init will be ignored on the non-primordial scm nodes.
-  // If a cluster is upgraded from non-ratis to ratis based SCM, if the config
-  // is set , this will be the primary SCM node which will initialize the ratis
-  // ring.
-
-  // If the config is not set, scm --init needs to re-run for switching from
-  // non-ratis based SCM to ratis-based SCM.
+  /**
+   * Optional config, if being set will cause scm --init to only take effect on
+   * the specific node and ignore scm --bootstrap cmd.
+   * Similarly, scm --init will be ignored on the non-primordial scm nodes.
+   * With the config set, applications/admins can safely execute init and
+   * bootstrap commands safely on all scm instances, for example kubernetes
+   * deployments.
+   *
+   * If a cluster is upgraded from non-ratis to ratis based SCM, scm --init
+   * needs to re-run for switching from
+   * non-ratis based SCM to ratis-based SCM on the primary node.
+   */
   public static final String OZONE_SCM_PRIMORDIAL_NODE_ID_KEY =
       "ozone.scm.primordial.node.id";
   // The path where datanode ID is to be written to.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -56,6 +56,16 @@ public final class SCMHAUtils {
         ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT);
   }
 
+  public static String getPrimordialSCM(ConfigurationSource conf) {
+    return conf.get(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY);
+  }
+
+  public static boolean isPrimordialSCM(ConfigurationSource conf,
+      String selfNodeId) {
+    String primordialNode = getPrimordialSCM(conf);
+    return isSCMHAEnabled(conf) && primordialNode != null && primordialNode
+        .equals(selfNodeId);
+  }
   /**
    * Get a collection of all scmNodeIds for the given scmServiceId.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1927,11 +1927,11 @@
       optional config, if being set will cause scm --init to only take effect on
       the specific node and ignore scm --bootstrap cmd.
       Similarly, scm --init will be ignored on the non-primordial scm nodes.
-      If a cluster is upgraded from non-ratis to ratis based SCM, if the config
-      is set , this will be the primary SCM node which will initialize the ratis
-      ring.
+      With the config set, applications/admins can safely execute init and
+      bootstrap commands safely on all scm instances.
 
-      If the config is not set, scm --init needs to re-run for switching from
+      If a cluster is upgraded from non-ratis to ratis based SCM, scm --init
+      needs to re-run for switching from
       non-ratis based SCM to ratis-based SCM on the primary node.
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1920,6 +1920,22 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.primordial.node.id</name>
+    <value></value>
+    <tag>OZONE, SCM, HA</tag>
+    <description>
+      optional config, if being set will cause scm --init to only take effect on
+      the specific node and ignore scm --bootstrap cmd.
+      Similarly, scm --init will be ignored on the non-primordial scm nodes.
+      If a cluster is upgraded from non-ratis to ratis based SCM, if the config
+      is set , this will be the primary SCM node which will initialize the ratis
+      ring.
+
+      If the config is not set, scm --init needs to re-run for switching from
+      non-ratis based SCM to ratis-based SCM on the primary node.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.ratis.enable</name>
     <value>false</value>
     <tag>OZONE, SCM, HA, RATIS</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
@@ -138,6 +138,5 @@ public class SCMHADBTransactionBufferImpl implements SCMHADBTransactionBuffer {
 
   @Override
   public void close() throws IOException {
-    flush();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -255,7 +255,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
       // to the installed checkpoint's snapshot index.
       try {
         reloadSCMState();
-        getRatisServer().getSCMStateMachine().unpause(lastAppliedIndex, term);
+        getRatisServer().getSCMStateMachine().unpause(term, lastAppliedIndex);
         LOG.info("Reloaded SCM state with Term: {} and Index: {}", term,
             lastAppliedIndex);
       } catch (Exception ex) {
@@ -307,7 +307,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
   public void shutdown() throws IOException {
     if (ratisServer != null) {
       ratisServer.stop();
-      ratisServer.getSCMStateMachine().stop();
+      ratisServer.getSCMStateMachine().close();
       grpcServer.stop();
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -230,7 +230,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
         // Pause the State Machine so that no new transactions can be applied.
         // This action also clears the SCM Double Buffer so that if there
         // are any pending transactions in the buffer, they are discarded.
-
+        getRatisServer().getSCMStateMachine().pause();
       } catch (Exception e) {
         LOG.error("Failed to stop/ pause the services. Cannot proceed with "
             + "installing the new checkpoint.");
@@ -250,32 +250,33 @@ public class SCMHAManagerImpl implements SCMHAManager {
         LOG.error("Failed to install Snapshot from {} as SCM failed to replace"
             + " DB with downloaded checkpoint. Reloading old SCM state.", e);
       }
+      // Reload the DB store with the new checkpoint.
+      // Restart (unpause) the state machine and update its last applied index
+      // to the installed checkpoint's snapshot index.
+      try {
+        reloadSCMState();
+        getRatisServer().getSCMStateMachine().unpause(lastAppliedIndex, term);
+        LOG.info("Reloaded SCM state with Term: {} and Index: {}", term,
+            lastAppliedIndex);
+      } catch (Exception ex) {
+        String errorMsg =
+            "Failed to reload SCM state and instantiate services.";
+        exitManager.exitSystem(1, errorMsg, ex, LOG);
+      }
+
+      // Delete the backup DB
+      try {
+        if (dbBackup != null) {
+          FileUtils.deleteFully(dbBackup);
+        }
+      } catch (Exception e) {
+        LOG.error("Failed to delete the backup of the original DB {}",
+            dbBackup);
+      }
     } else {
       LOG.warn("Cannot proceed with InstallSnapshot as SCM is at TermIndex {} "
           + "and checkpoint has lower TermIndex {}. Reloading old "
           + "state of SCM.", termIndex, checkpointTrxnInfo.getTermIndex());
-    }
-
-    // Reload the DB store with the new checkpoint.
-    // Restart (unpause) the state machine and update its last applied index
-    // to the installed checkpoint's snapshot index.
-    try {
-      reloadSCMState();
-      getRatisServer().getSCMStateMachine().unpause(lastAppliedIndex, term);
-      LOG.info("Reloaded SCM state with Term: {} and Index: {}", term,
-          lastAppliedIndex);
-    } catch (Exception ex) {
-      String errorMsg = "Failed to reload SCM state and instantiate services.";
-      exitManager.exitSystem(1, errorMsg, ex, LOG);
-    }
-
-    // Delete the backup DB
-    try {
-      if (dbBackup != null) {
-        FileUtils.deleteFully(dbBackup);
-      }
-    } catch (Exception e) {
-      LOG.error("Failed to delete the backup of the original DB {}", dbBackup);
     }
 
     if (lastAppliedIndex != checkpointTrxnInfo.getTransactionIndex()) {
@@ -284,8 +285,6 @@ public class SCMHAManagerImpl implements SCMHAManager {
       return null;
     }
 
-    // TODO: We should only return the snpashotIndex to the leader.
-    //  Should be fixed after RATIS-586
     TermIndex newTermIndex = TermIndex.valueOf(term, lastAppliedIndex);
     return newTermIndex;
   }
@@ -334,7 +333,8 @@ public class SCMHAManagerImpl implements SCMHAManager {
     scm.getScmMetadataStore().stop();
   }
 
-  void startServices() throws IOException {
+  @VisibleForTesting
+   public void startServices() throws IOException {
 
    // TODO: Fix the metrics ??
     final SCMMetadataStore metadataStore = scm.getScmMetadataStore();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -101,7 +101,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       server = newRaftServer(scmId, conf).setGroup(group).build();
       server.start();
       // TODO: Timeout and sleep interval should be made configurable
-      waitforLeaderToBeReady(server, 60000, group);
+      waitForLeaderToBeReady(server, 60000, group);
     } finally {
       if (server != null) {
         server.close();
@@ -137,7 +137,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     }
   }
 
-  private static void waitforLeaderToBeReady(RaftServer server, long timeout,
+  private static void waitForLeaderToBeReady(RaftServer server, long timeout,
       RaftGroup group)
       throws IOException {
     boolean ready;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -17,19 +17,14 @@
 
 package org.apache.hadoop.hdds.scm.ha;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
-import java.util.Optional;
 import java.util.Iterator;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -275,46 +270,6 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     }
   }
 
-  @VisibleForTesting
-  public static void validateRatisGroupExists(OzoneConfiguration conf,
-      String clusterId) throws IOException {
-    final SCMHAConfiguration haConf = conf.getObject(SCMHAConfiguration.class);
-    final RaftProperties properties = RatisUtil.newRaftProperties(haConf, conf);
-    final RaftGroupId raftGroupId = buildRaftGroupId(clusterId);
-    final AtomicBoolean found = new AtomicBoolean(false);
-    RaftServerConfigKeys.storageDir(properties).parallelStream().forEach(
-        (dir) -> Optional.ofNullable(dir.listFiles()).map(Arrays::stream)
-            .orElse(Stream.empty()).filter(File::isDirectory).forEach(sub -> {
-              try {
-                LOG.info("{}: found a subdirectory {}", raftGroupId, sub);
-                RaftGroupId groupId = null;
-                try {
-                  groupId = RaftGroupId.valueOf(UUID.fromString(sub.getName()));
-                } catch (Exception e) {
-                  LOG.info("{}: The directory {} is not a group directory;"
-                      + " ignoring it. ", raftGroupId, sub.getAbsolutePath());
-                }
-                if (groupId != null) {
-                  if (groupId.equals(raftGroupId)) {
-                    LOG.info(
-                        "{} : The directory {} found a group directory for "
-                            + "cluster {}", raftGroupId, sub.getAbsolutePath(),
-                        clusterId);
-                    found.set(true);
-                  }
-                }
-              } catch (Exception e) {
-                LOG.warn(
-                    raftGroupId + ": Failed to find the group directory "
-                        + sub.getAbsolutePath() + ".", e);
-              }
-            }));
-    if (!found.get()) {
-      throw new IOException(
-          "Could not find any ratis group with id " + raftGroupId);
-    }
-  }
-
   private static RaftGroup buildRaftGroup(SCMNodeDetails details,
       String scmId, String clusterId) {
     Preconditions.checkNotNull(scmId);
@@ -333,7 +288,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     return group;
   }
 
-  private static RaftGroupId buildRaftGroupId(String clusterId) {
+  @VisibleForTesting
+  public static RaftGroupId buildRaftGroupId(String clusterId) {
     Preconditions.checkNotNull(clusterId);
     return RaftGroupId.valueOf(
         UUID.fromString(clusterId.replace(OzoneConsts.CLUSTER_ID_PREFIX, "")));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -46,7 +46,6 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.RaftServerConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -166,6 +166,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
 
   @Override
   public void start() throws IOException {
+    LOG.info("starting ratis server {}", server.getPeer().getAddress());
     server.start();
   }
 
@@ -215,6 +216,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
 
   @Override
   public void stop() throws IOException {
+    LOG.info("stopping ratis server {}", server.getPeer().getAddress());
     server.close();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -277,7 +277,8 @@ public class SCMStateMachine extends BaseStateMachine {
     getLifeCycle().transition(LifeCycle.State.PAUSED);
   }
 
-  public void stop() {
+  public void stop() throws IOException {
+    transactionBuffer.close();
     HadoopExecutors.
         shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1116,14 +1116,15 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (jvmPauseMonitor != null) {
       jvmPauseMonitor.stop();
     }
-    IOUtils.cleanupWithLogger(LOG, containerManager);
-    IOUtils.cleanupWithLogger(LOG, pipelineManager);
 
     try {
       scmHAManager.shutdown();
     } catch (Exception ex) {
       LOG.error("SCM HA Manager stop failed", ex);
     }
+
+    IOUtils.cleanupWithLogger(LOG, containerManager);
+    IOUtils.cleanupWithLogger(LOG, pipelineManager);
 
     try {
       scmMetadataStore.stop();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -81,9 +81,6 @@ public class TestSCMSnapshot {
             "index 1 {}", snapshotInfo2, snapshotInfo1),
         snapshotInfo2 > snapshotInfo1);
 
-    Table<String, TransactionInfo> trxInfo =
-        scm.getScmMetadataStore().getTransactionInfoTable();
-
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
-import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
 
 public class TestSCMSnapshot {
   private static MiniOzoneCluster cluster;
@@ -84,7 +83,6 @@ public class TestSCMSnapshot {
 
     Table<String, TransactionInfo> trxInfo =
         scm.getScmMetadataStore().getTransactionInfoTable();
-    TransactionInfo transactionInfo = trxInfo.get(TRANSACTION_INFO_KEY);
 
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -86,11 +86,6 @@ public class TestSCMSnapshot {
         scm.getScmMetadataStore().getTransactionInfoTable();
     TransactionInfo transactionInfo = trxInfo.get(TRANSACTION_INFO_KEY);
 
-    Assert.assertTrue(
-        "DB trx info:" + transactionInfo.getTransactionIndex()
-        + ", latestSnapshotInfo:" + snapshotInfo2,
-        transactionInfo.getTransactionIndex() >= snapshotInfo2);
-
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -529,7 +529,8 @@ public class TestStorageContainerManager {
       String clusterId) throws IOException {
     final SCMHAConfiguration haConf = conf.getObject(SCMHAConfiguration.class);
     final RaftProperties properties = RatisUtil.newRaftProperties(haConf, conf);
-    final RaftGroupId raftGroupId = SCMRatisServerImpl.buildRaftGroupId(clusterId);
+    final RaftGroupId raftGroupId =
+        SCMRatisServerImpl.buildRaftGroupId(clusterId);
     final AtomicBoolean found = new AtomicBoolean(false);
     RaftServerConfigKeys.storageDir(properties).parallelStream().forEach(
         (dir) -> Optional.ofNullable(dir.listFiles()).map(Arrays::stream)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys
     .HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.junit.Assert.fail;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
@@ -49,7 +50,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
+import java.util.Arrays;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -75,9 +80,7 @@ import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.apache.hadoop.hdds.scm.ha.SCMContext;
-import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
-import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
+import org.apache.hadoop.hdds.scm.ha.*;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
@@ -100,6 +103,9 @@ import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -493,7 +499,7 @@ public class TestStorageContainerManager {
     final UUID clusterId = UUID.randomUUID();
     // This will initialize SCM
     StorageContainerManager.scmInit(conf, clusterId.toString());
-    SCMRatisServerImpl.validateRatisGroupExists(conf, clusterId.toString());
+    validateRatisGroupExists(conf, clusterId.toString());
   }
 
   @Test
@@ -518,7 +524,45 @@ public class TestStorageContainerManager {
     }
   }
 
-
+  @VisibleForTesting
+  public static void validateRatisGroupExists(OzoneConfiguration conf,
+      String clusterId) throws IOException {
+    final SCMHAConfiguration haConf = conf.getObject(SCMHAConfiguration.class);
+    final RaftProperties properties = RatisUtil.newRaftProperties(haConf, conf);
+    final RaftGroupId raftGroupId = SCMRatisServerImpl.buildRaftGroupId(clusterId);
+    final AtomicBoolean found = new AtomicBoolean(false);
+    RaftServerConfigKeys.storageDir(properties).parallelStream().forEach(
+        (dir) -> Optional.ofNullable(dir.listFiles()).map(Arrays::stream)
+            .orElse(Stream.empty()).filter(File::isDirectory).forEach(sub -> {
+              try {
+                LOG.info("{}: found a subdirectory {}", raftGroupId, sub);
+                RaftGroupId groupId = null;
+                try {
+                  groupId = RaftGroupId.valueOf(UUID.fromString(sub.getName()));
+                } catch (Exception e) {
+                  LOG.info("{}: The directory {} is not a group directory;"
+                      + " ignoring it. ", raftGroupId, sub.getAbsolutePath());
+                }
+                if (groupId != null) {
+                  if (groupId.equals(raftGroupId)) {
+                    LOG.info(
+                        "{} : The directory {} found a group directory for "
+                            + "cluster {}", raftGroupId, sub.getAbsolutePath(),
+                        clusterId);
+                    found.set(true);
+                  }
+                }
+              } catch (Exception e) {
+                LOG.warn(
+                    raftGroupId + ": Failed to find the group directory "
+                        + sub.getAbsolutePath() + ".", e);
+              }
+            }));
+    if (!found.get()) {
+      throw new IOException(
+          "Could not find any ratis group with id " + raftGroupId);
+    }
+  }
   @Test
   public void testSCMReinitializationWithHAEnabled() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -536,7 +580,7 @@ public class TestStorageContainerManager {
           cluster.getStorageContainerManager().getClusterId();
       // validate there is no ratis group pre existing
       try {
-        SCMRatisServerImpl.validateRatisGroupExists(conf, clusterId);
+        validateRatisGroupExists(conf, clusterId);
         Assert.fail();
       } catch (IOException ioe) {
         // Exception is expected here
@@ -545,7 +589,7 @@ public class TestStorageContainerManager {
       // This will re-initialize SCM
       StorageContainerManager.scmInit(conf, clusterId);
       // Ratis group with cluster id exists now
-      SCMRatisServerImpl.validateRatisGroupExists(conf, clusterId);
+      validateRatisGroupExists(conf, clusterId);
     } finally {
       cluster.shutdown();
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.scm;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -231,6 +232,7 @@ public class TestSCMInstallSnapshotWithHA {
         "logIndex is less than it's lastAppliedIndex", newTermIndex);
     Assert.assertEquals(followerTermIndex,
         followerSM.getLastAppliedTermIndex());
+    Assert.assertFalse(followerSM.getLifeCycleState().isPausingOrPaused());
   }
 
   @Test
@@ -245,7 +247,7 @@ public class TestSCMInstallSnapshotWithHA {
     follower.exitSafeMode();
     // Do some transactions so that the log index increases
     writeToIncreaseLogIndex(leaderSCM, 100);
-    File oldLocation =
+    File oldDBLocation =
         follower.getScmMetadataStore().getStore().getDbLocation();
 
     SCMStateMachine sm =
@@ -259,6 +261,16 @@ public class TestSCMInstallSnapshotWithHA {
             new SCMDBDefinition());
 
     Assert.assertNotNull(leaderCheckpointLocation);
+    // Take a backup of the current DB
+    String dbBackupName =
+        "SCM_CHECKPOINT_BACKUP" + termIndex.getIndex() + "_" + System
+            .currentTimeMillis();
+    File dbDir = oldDBLocation.getParentFile();
+    File checkpointBackup = new File(dbDir, dbBackupName);
+
+    // Take a backup of the leader checkpoint
+    Files.copy(leaderCheckpointLocation.toAbsolutePath(),
+        checkpointBackup.toPath());
     // Corrupt the leader checkpoint and install that on the follower. The
     // operation should fail and  should shutdown.
     boolean delete = true;
@@ -286,6 +298,18 @@ public class TestSCMInstallSnapshotWithHA {
 
     Assert.assertTrue(logCapture.getOutput()
         .contains("Failed to reload SCM state and instantiate services."));
+    Assert.assertTrue(sm.getLifeCycleState().isPausingOrPaused());
+
+    // Verify correct reloading
+    HAUtils
+        .replaceDBWithCheckpoint(leaderCheckpointTrxnInfo.getTransactionIndex(),
+            oldDBLocation, checkpointBackup.toPath(),
+            OzoneConsts.SCM_DB_BACKUP_PREFIX);
+    scmhaManager.startServices();
+    sm.unpause(leaderCheckpointTrxnInfo.getTerm(),
+        leaderCheckpointTrxnInfo.getTransactionIndex());
+    Assert.assertTrue(sm.getLastAppliedTermIndex()
+        .equals(leaderCheckpointTrxnInfo.getTermIndex()));
   }
 
   private List<ContainerInfo> writeToIncreaseLogIndex(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -240,9 +240,17 @@ public class TestSCMInstallSnapshotWithHA {
     // Find the inactive SCM
     String followerId = getInactiveSCM(cluster).getScmId();
     StorageContainerManager follower = cluster.getSCM(followerId);
+    //cluster.startInactiveSCM(followerId);
+    follower.start();
+    follower.exitSafeMode();
     // Do some transactions so that the log index increases
     writeToIncreaseLogIndex(leaderSCM, 100);
+    File oldLocation =
+        follower.getScmMetadataStore().getStore().getDbLocation();
 
+    SCMStateMachine sm =
+        follower.getScmHAManager().getRatisServer().getSCMStateMachine();
+    TermIndex termIndex = sm.getLastAppliedTermIndex();
     DBCheckpoint leaderDbCheckpoint = leaderSCM.getScmMetadataStore().getStore()
         .getCheckpoint(false);
     Path leaderCheckpointLocation = leaderDbCheckpoint.getCheckpointLocation();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -44,6 +44,7 @@ import org.junit.Test;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -52,7 +53,6 @@ import org.junit.Rule;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.scm;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -207,5 +208,24 @@ public class TestStorageContainerManagerHA {
       sync = getLastAppliedIndex(scm) == leaderIndex;
     }
     return sync;
+  }
+
+  @Test
+  public void testPrimordialSCM() throws Exception {
+    StorageContainerManager scm1 = cluster.getStorageContainerManagers().get(0);
+    StorageContainerManager scm2 = cluster.getStorageContainerManagers().get(1);
+    OzoneConfiguration conf1 = scm1.getConfiguration();
+    OzoneConfiguration conf2 = scm2.getConfiguration();
+    conf1.set(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY,
+        scm1.getSCMNodeId());
+    conf2.set(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY,
+        scm1.getSCMNodeId());
+    Assert.assertFalse(StorageContainerManager.scmBootstrap(conf1));
+    scm1.getScmHAManager().shutdown();
+    Assert.assertTrue(
+        StorageContainerManager.scmInit(conf1, scm1.getClusterId()));
+    Assert.assertTrue(StorageContainerManager.scmBootstrap(conf2));
+    Assert.assertFalse(
+        StorageContainerManager.scmInit(conf2, scm2.getClusterId()));
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The idea here is to add  an optional config "ozone.scm.primordial.node.id".  if the config is set, it will cause scm --init to only take effect on
the specific node and ignore scm --bootstrap cmd. Similarly, scm --init will be ignored on the non-primordial scm nodes.


If the cluster is upgraded from non-ratis to ratis version , scm --init needs to re-run for switching from non-ratis based SCM to ratis-based SCM on the primary node.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4896

## How was this patch tested?
Unit tests added