### PR TITLE
Rename Apache Hadoop Ozone to Apache Ozone in pom and markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,9 @@
-Apache Hadoop Ozone Contribution guideline
+Apache Ozone Contribution guideline
 ===
 
-Ozone is a part of the Apache Hadoop project. The bug tracking system for Ozone is under the [Apache Jira project named HDDS](https://issues.apache.org/jira/projects/HDDS/).
+Ozone is an Apache project. The bug tracking system for Ozone is under the [Apache Jira project named HDDS](https://issues.apache.org/jira/projects/HDDS/).
 
-If you are familiar with contributing to Apache Hadoop, then you already know everything you need to know to start filing Ozone bugs and submitting patches.
-
-If you have never contributed to Apache Hadoop before, then you may find it useful to read [How To Contribute](https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute+to+Ozone).
-
-This document summarize the contribution process and defines the differences.  
+This document summarize the contribution process:
 
 ## What can I contribute?
 
@@ -18,7 +14,7 @@ We welcome contributions of:
    * [All open and unassigned Ozone jiras](https://s.apache.org/OzoneUnassignedJiras)
  * **Documentation Improvements**: You can submit improvements to either:
      * Ozone website. Instructions are here: [Modifying the Ozone Website](https://cwiki.apache.org/confluence/display/HADOOP/Modifying+the+Ozone+Website)
-     * Developer docs. These are markdown files [checked into the Apache Hadoop Source tree](https://github.com/apache/hadoop-ozone/tree/master/hadoop-hdds/docs/content).
+     * Developer docs. These are markdown files [checked into the Apache Ozone Source tree](https://github.com/apache/ozone/tree/master/hadoop-hdds/docs/content).
  * The [wiki pages](https://cwiki.apache.org/confluence/display/HADOOP/Ozone+Contributor+Guide): Please contact us at ozone-dev@hadoop.apache.org and we can provide you write access to the wiki.
  * **Testing**: We always need help to improve our testing
       * Unit Tests (JUnit / Java)
@@ -44,7 +40,7 @@ Requirements to compile the code:
 * Unix System
 * JDK 1.8 or higher
 * Maven 3.5 or later
-* Internet connection for first build (to fetch all Maven and Hadoop dependencies)
+* Internet connection for first build (to fetch all Maven and Ozone dependencies)
 
 Additional requirements to run your first pseudo cluster:
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,7 +15,7 @@
   limitations under the License.
 -->
 
-# History of Apache Hadoop Ozone project
+# History of Apache Ozone project
 
 Ozone development was started on a feature branch HDFS-7240 as part of the Apache Hadoop HDFS project. Based on the Jira information the first Ozone commit was the commit of [HDFS-8456 Ozone: Introduce STORAGE_CONTAINER_SERVICE as a new NodeType.](https://issues.apache.org/jira/browse/HDFS-8456) in May 2015.
 

--- a/hadoop-hdds/client/pom.xml
+++ b/hadoop-hdds/client/pom.xml
@@ -25,8 +25,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <artifactId>hadoop-hdds-client</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Client Library</description>
-  <name>Apache Hadoop HDDS Client</name>
+  <description>Apache Ozone Distributed Data Store Client Library</description>
+  <name>Apache Ozone HDDS Client</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-common</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Common</description>
-  <name>Apache Hadoop HDDS Common</name>
+  <description>Apache Ozone Distributed Data Store Common</description>
+  <name>Apache Ozone HDDS Common</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/config/pom.xml
+++ b/hadoop-hdds/config/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-config</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Config Tools</description>
-  <name>Apache Hadoop HDDS Config</name>
+  <description>Apache Ozone Distributed Data Store Config Tools</description>
+  <name>Apache Ozone HDDS Config</name>
   <packaging>jar</packaging>
 
   <properties>

--- a/hadoop-hdds/container-service/pom.xml
+++ b/hadoop-hdds/container-service/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-container-service</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Container Service</description>
-  <name>Apache Hadoop HDDS Container Service</name>
+  <description>Apache Ozone Distributed Data Store Container Service</description>
+  <name>Apache Ozone HDDS Container Service</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-server-framework</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Server Framework
+  <description>Apache Ozone Distributed Data Store Server Framework
   </description>
-  <name>Apache Hadoop HDDS Server Framework</name>
+  <name>Apache Ozone HDDS Server Framework</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/hadoop-dependency-client/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-client/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-hadoop-dependency-client</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Hadoop client dependencies
+  <description>Apache Ozone Distributed Data Store Hadoop client dependencies
   </description>
-  <name>Apache Hadoop HDDS Hadoop Client dependencies</name>
+  <name>Apache Ozone HDDS Hadoop Client dependencies</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/hadoop-dependency-server/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-server/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-hadoop-dependency-server</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Hadoop server dependencies
+  <description>Apache Ozone Distributed Data Store Hadoop server dependencies
   </description>
-  <name>Apache Hadoop HDDS Hadoop Server dependencies</name>
+  <name>Apache Ozone HDDS Hadoop Server dependencies</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/hadoop-dependency-test/pom.xml
+++ b/hadoop-hdds/hadoop-dependency-test/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-hadoop-dependency-test</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Hadoop test dependencies
+  <description>Apache Ozone Distributed Data Store Hadoop test dependencies
   </description>
-  <name>Apache Hadoop HDDS Hadoop Test dependencies</name>
+  <name>Apache Ozone HDDS Hadoop Test dependencies</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-interface-admin</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Admin interface
+  <description>Apache Ozone Distributed Data Store Admin interface
   </description>
-  <name>Apache Hadoop HDDS Admin Interface</name>
+  <name>Apache Ozone HDDS Admin Interface</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-interface-client</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Client interface
+  <description>Apache Ozone Distributed Data Store Client interface
   </description>
-  <name>Apache Hadoop HDDS Client Interface</name>
+  <name>Apache Ozone HDDS Client Interface</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -24,9 +24,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-interface-server</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Server interface
+  <description>Apache Ozone Distributed Data Store Server interface
   </description>
-  <name>Apache Hadoop HDDS Server Interface</name>
+  <name>Apache Ozone HDDS Server Interface</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -25,8 +25,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <artifactId>hadoop-hdds</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Project</description>
-  <name>Apache Hadoop HDDS</name>
+  <description>Apache Ozone Distributed Data Store Project</description>
+  <name>Apache Ozone HDDS</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/hadoop-hdds/server-scm/pom.xml
+++ b/hadoop-hdds/server-scm/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-server-scm</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Storage Container Manager Server</description>
-  <name>Apache Hadoop HDDS SCM Server</name>
+  <description>Apache Ozone Distributed Data Store Storage Container Manager Server</description>
+  <name>Apache Ozone HDDS SCM Server</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-hdds/test-utils/pom.xml
+++ b/hadoop-hdds/test-utils/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-hdds-test-utils</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Test Utils</description>
-  <name>Apache Hadoop HDDS Test Utils</name>
+  <description>Apache Ozone Distributed Data Store Test Utils</description>
+  <name>Apache Ozone HDDS Test Utils</name>
   <packaging>jar</packaging>
 
   <properties>

--- a/hadoop-hdds/tools/pom.xml
+++ b/hadoop-hdds/tools/pom.xml
@@ -25,8 +25,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <artifactId>hadoop-hdds-tools</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Distributed Data Store Tools</description>
-  <name>Apache Hadoop HDDS Tools</name>
+  <description>Apache Ozone Distributed Data Store Tools</description>
+  <name>Apache Ozone HDDS Tools</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-client</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Client</description>
-  <name>Apache Hadoop Ozone Client</name>
+  <description>Apache Ozone Client</description>
+  <name>Apache Ozone Client</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-common</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Common</description>
-  <name>Apache Hadoop Ozone Common</name>
+  <description>Apache Ozone Common</description>
+  <name>Apache Ozone Common</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/csi/pom.xml
+++ b/hadoop-ozone/csi/pom.xml
@@ -24,8 +24,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-csi</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone CSI service</description>
-  <name>Apache Hadoop Ozone CSI service</name>
+  <description>Apache Ozone CSI service</description>
+  <name>Apache Ozone CSI service</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/datanode/pom.xml
+++ b/hadoop-ozone/datanode/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-datanode</artifactId>
-  <name>Apache Hadoop Ozone Datanode</name>
+  <name>Apache Ozone Datanode</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
 

--- a/hadoop-ozone/dist/README.md
+++ b/hadoop-ozone/dist/README.md
@@ -43,7 +43,7 @@ Please refer to the Getting Started guide for a couple of options for testing Oz
 
 ### Monitoring
 
-Apache Hadoop Ozone supports Prometheus out of the box. It contains a prometheus-compatible exporter servlet. To start monitoring you need a Prometheus deployment in your Kubernetes cluster:
+Apache Ozone supports Prometheus out of the box. It contains a prometheus-compatible exporter servlet. To start monitoring you need a Prometheus deployment in your Kubernetes cluster:
 
 ```
 cd src/main/k8s/prometheus

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-dist</artifactId>
-  <name>Apache Hadoop Ozone Distribution</name>
+  <name>Apache Ozone Distribution</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/flekszible.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/flekszible.yaml
@@ -13,4 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-description: Apache Hadoop Ozone
+description: Apache Ozone

--- a/hadoop-ozone/dist/src/main/k8s/definitions/ozone/freon/flekszible.yaml
+++ b/hadoop-ozone/dist/src/main/k8s/definitions/ozone/freon/flekszible.yaml
@@ -13,4 +13,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-description: Load test tool for Apache Hadoop Ozone
+description: Load test tool for Apache Ozone

--- a/hadoop-ozone/dist/src/main/ozone/README.txt
+++ b/hadoop-ozone/dist/src/main/ozone/README.txt
@@ -12,7 +12,7 @@
   limitations under the License. See accompanying LICENSE file.
 -->
 
-This is the distribution of Apache Hadoop Ozone.
+This is the distribution of Apache Ozone.
 
 Ozone is a submodule of Hadoop with separated release cycle. For more information, check
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
@@ -34,4 +34,4 @@ S3 Gateway Web UI
                         Should contain      ${result}       Location
                         Should contain      ${result}       /static/
     ${result} =         Execute                             curl --negotiate -u : -v ${ENDPOINT_URL}/static/index.html
-                        Should contain      ${result}       Apache Hadoop Ozone S3
+                        Should contain      ${result}       Apache Ozone S3

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/pom.xml
@@ -23,8 +23,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Mini Ozone Chaos Tests</description>
-  <name>Apache Hadoop Ozone Mini Ozone Chaos Tests</name>
+  <description>Apache Ozone Mini Ozone Chaos Tests</description>
+  <name>Apache Ozone Mini Ozone Chaos Tests</name>
 
   <artifactId>mini-chaos-tests</artifactId>
   <dependencies>

--- a/hadoop-ozone/fault-injection-test/network-tests/pom.xml
+++ b/hadoop-ozone/fault-injection-test/network-tests/pom.xml
@@ -23,8 +23,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-network-tests</artifactId>
-  <description>Apache Hadoop Ozone Network Tests</description>
-  <name>Apache Hadoop Ozone Network Tests</name>
+  <description>Apache Ozone Network Tests</description>
+  <name>Apache Ozone Network Tests</name>
   <packaging>jar</packaging>
 
   <build>

--- a/hadoop-ozone/fault-injection-test/pom.xml
+++ b/hadoop-ozone/fault-injection-test/pom.xml
@@ -24,8 +24,8 @@ http://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-fault-injection-test</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Fault Injection Tests</description>
-  <name>Apache Hadoop Ozone Fault Injection Tests</name>
+  <description>Apache Ozone Fault Injection Tests</description>
+  <name>Apache Ozone Fault Injection Tests</name>
   <packaging>pom</packaging>
 
   <modules>

--- a/hadoop-ozone/insight/pom.xml
+++ b/hadoop-ozone/insight/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-insight</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Insight Tool</description>
-  <name>Apache Hadoop Ozone Insight Tool</name>
+  <description>Apache Ozone Insight Tool</description>
+  <name>Apache Ozone Insight Tool</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-integration-test</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Integration Tests</description>
-  <name>Apache Hadoop Ozone Integration Tests</name>
+  <description>Apache Ozone Integration Tests</description>
+  <name>Apache Ozone Integration Tests</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-interface-client</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Client interface</description>
-  <name>Apache Hadoop Ozone Client Interface</name>
+  <description>Apache Ozone Client interface</description>
+  <name>Apache Ozone Client Interface</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -24,8 +24,8 @@
   </parent>
   <artifactId>hadoop-ozone-interface-storage</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Storage Interface</description>
-  <name>Apache Hadoop Ozone Storage Interface</name>
+  <description>Apache Ozone Storage Interface</description>
+  <name>Apache Ozone Storage Interface</name>
   <packaging>jar</packaging>
   <dependencies>
 

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-ozone-manager</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Manager Server</description>
-  <name>Apache Hadoop Ozone Manager Server</name>
+  <description>Apache Ozone Manager Server</description>
+  <name>Apache Ozone Manager Server</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/hadoop-ozone/ozonefs-common/pom.xml
+++ b/hadoop-ozone/ozonefs-common/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-common</artifactId>
-  <name>Apache Hadoop Ozone FileSystem Common</name>
+  <name>Apache Ozone FileSystem Common</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop2/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop2/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-hadoop2</artifactId>
-  <name>Apache Hadoop Ozone FS Hadoop 2.x compatibility</name>
+  <name>Apache Ozone FS Hadoop 2.x compatibility</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/ozonefs-hadoop3/pom.xml
+++ b/hadoop-ozone/ozonefs-hadoop3/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-hadoop3</artifactId>
-  <name>Apache Hadoop Ozone FS Hadoop 3.x compatibility</name>
+  <name>Apache Ozone FS Hadoop 3.x compatibility</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem-shaded</artifactId>
-  <name>Apache Hadoop Ozone FileSystem Shaded</name>
+  <name>Apache Ozone FileSystem Shaded</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
 

--- a/hadoop-ozone/ozonefs/pom.xml
+++ b/hadoop-ozone/ozonefs/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-filesystem</artifactId>
-  <name>Apache Hadoop Ozone FileSystem</name>
+  <name>Apache Ozone FileSystem</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -20,8 +20,8 @@
   </parent>
   <artifactId>hadoop-ozone</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Project</description>
-  <name>Apache Hadoop Ozone</name>
+  <description>Apache Ozone Project</description>
+  <name>Apache Ozone</name>
   <packaging>pom</packaging>
 
   <properties>

--- a/hadoop-ozone/recon-codegen/pom.xml
+++ b/hadoop-ozone/recon-codegen/pom.xml
@@ -22,7 +22,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-ozone-reconcodegen</artifactId>
-  <name>Apache Hadoop Ozone Recon CodeGen</name>
+  <name>Apache Ozone Recon CodeGen</name>
   <dependencies>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -20,7 +20,7 @@
     <artifactId>hadoop-ozone</artifactId>
     <version>1.1.0-SNAPSHOT</version>
   </parent>
-  <name>Apache Hadoop Ozone Recon</name>
+  <name>Apache Ozone Recon</name>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-ozone-recon</artifactId>
   <build>

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/NOTICE
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/NOTICE
@@ -1,4 +1,4 @@
-Apache Hadoop Ozone Recon
+Apache Ozone Recon
 Copyright 2019 and onwards The Apache Software Foundation.
 
 This product includes software developed at

--- a/hadoop-ozone/s3gateway/pom.xml
+++ b/hadoop-ozone/s3gateway/pom.xml
@@ -22,7 +22,7 @@
     <version>1.1.0-SNAPSHOT</version>
   </parent>
   <artifactId>hadoop-ozone-s3gateway</artifactId>
-  <name>Apache Hadoop Ozone S3 Gateway</name>
+  <name>Apache Ozone S3 Gateway</name>
   <packaging>jar</packaging>
   <version>1.1.0-SNAPSHOT</version>
   <properties>

--- a/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
+++ b/hadoop-ozone/s3gateway/src/main/resources/webapps/static/index.html
@@ -23,9 +23,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="Content-Security-Policy" content="script-src 'self';">
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
-    <meta name="description" content="Apache Hadoop Ozone S3 gateway">
+    <meta name="description" content="Apache Ozone S3 gateway">
 
-    <title>S3 gateway -- Apache Hadoop Ozone</title>
+    <title>S3 gateway -- Apache Ozone</title>
 
     <link href="bootstrap-3.4.1/css/bootstrap.min.css" rel="stylesheet">
     <link href="hadoop.css" rel="stylesheet">
@@ -63,7 +63,7 @@
 
     <h1>S3 gateway</h1>
 
-    <p>This is an endpoint of Apache Hadoop Ozone S3 gateway. Use it with any
+    <p>This is an endpoint of Apache Ozone S3 gateway. Use it with any
         AWS S3 compatible tool
         with setting this url as an endpoint</p>
 

--- a/hadoop-ozone/tools/pom.xml
+++ b/hadoop-ozone/tools/pom.xml
@@ -24,8 +24,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   </parent>
   <artifactId>hadoop-ozone-tools</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Tools</description>
-  <name>Apache Hadoop Ozone Tools</name>
+  <description>Apache Ozone Tools</description>
+  <name>Apache Ozone Tools</name>
   <packaging>jar</packaging>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
   <groupId>org.apache.hadoop</groupId>
   <artifactId>hadoop-main-ozone</artifactId>
   <version>1.1.0-SNAPSHOT</version>
-  <description>Apache Hadoop Ozone Main</description>
-  <name>Apache Hadoop Ozone Main</name>
+  <description>Apache Ozone Main</description>
+  <name>Apache Ozone Main</name>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace mentioning of `Apache Hadoop Ozone` with `Apache Ozone` in pom.xml files and markdown files.

## How was this patch tested?

:eye: 