### PR TITLE
HDDS-4937. Enhance SCMServerProtocol with using ReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationType.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationType.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 public enum ReplicationType {
   RATIS,
   STAND_ALONE,
-  CHAINED;
+  CHAINED,
+  EC;
 
   public static ReplicationType fromProto(
       HddsProtos.ReplicationType replicationType) {
@@ -36,6 +37,8 @@ public enum ReplicationType {
     switch (replicationType) {
     case RATIS:
       return ReplicationType.RATIS;
+    case EC:
+      return ReplicationType.EC;
     case STAND_ALONE:
       return ReplicationType.STAND_ALONE;
     case CHAINED:

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ECReplicationConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ECReplicationConfig.java
@@ -1,0 +1,32 @@
+package org.apache.hadoop.hdds.scm.protocol;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+public class ECReplicationConfig implements ReplicationConfig {
+
+  private int data;
+
+  private int parity;
+
+  public ECReplicationConfig(int data, int parity) {
+    this.data = data;
+    this.parity = parity;
+  }
+
+  public ECReplicationConfig(HddsProtos.ECReplicationConfig ecReplicationConfig) {
+    this.data = ecReplicationConfig.getData();
+    this.parity = ecReplicationConfig.getParity();
+  }
+
+  @Override
+  public HddsProtos.ReplicationType getReplicationType() {
+    return HddsProtos.ReplicationType.EC;
+  }
+
+  public HddsProtos.ECReplicationConfig toProto() {
+    return HddsProtos.ECReplicationConfig.newBuilder()
+        .setData(data)
+        .setParity(parity)
+        .build();
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/RatisReplicationConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/RatisReplicationConfig.java
@@ -1,0 +1,39 @@
+package org.apache.hadoop.hdds.scm.protocol;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+
+public class RatisReplicationConfig
+    implements ReplicationConfig {
+
+  private final ReplicationFactor replicationFactor;
+
+  public RatisReplicationConfig(ReplicationFactor replicationFactor) {
+    this.replicationFactor = replicationFactor;
+  }
+
+  public RatisReplicationConfig(HddsProtos.RatisReplicationConfig ratisReplicationConfig) {
+    replicationFactor = ratisReplicationConfig.getFactor();
+  }
+
+  public static ReplicationConfig fromProto(HddsProtos.RatisReplicationConfig ratisReplicationConfig) {
+    return null;
+  }
+
+  @Override
+  public ReplicationType getReplicationType() {
+    return ReplicationType.RATIS;
+  }
+
+  public ReplicationFactor getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  public HddsProtos.RatisReplicationConfig toProto() {
+    return HddsProtos.RatisReplicationConfig.newBuilder()
+        .setFactor(replicationFactor)
+        .build();
+  }
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ReplicationConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ReplicationConfig.java
@@ -1,0 +1,23 @@
+package org.apache.hadoop.hdds.scm.protocol;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+public interface ReplicationConfig {
+
+  public static ReplicationConfig fromTypeAndFactor(
+      HddsProtos.ReplicationType type,
+      HddsProtos.ReplicationFactor factor
+  ) {
+    switch (type) {
+    case RATIS:
+      return new RatisReplicationConfig(factor);
+    case STAND_ALONE:
+      return new StandaloneReplicationConfig(factor);
+    default:
+      throw new UnsupportedOperationException(
+          "Not supported replication: " + type);
+    }
+  }
+
+  HddsProtos.ReplicationType getReplicationType();
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -17,20 +17,20 @@
  */
 package org.apache.hadoop.hdds.scm.protocol;
 
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.scm.ScmConfig;
-import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
-import org.apache.hadoop.security.KerberosInfo;
-import org.apache.hadoop.hdds.scm.ScmInfo;
-import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
-import org.apache.hadoop.ozone.common.BlockGroup;
-import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
-
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.scm.ScmInfo;
+import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.ozone.common.BlockGroup;
+import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
+import org.apache.hadoop.security.KerberosInfo;
 
 /**
  * ScmBlockLocationProtocol is used by an HDFS node to find the set of nodes
@@ -58,8 +58,26 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * @return allocated block accessing info (key, pipeline).
    * @throws IOException
    */
-  List<AllocatedBlock> allocateBlock(long size, int numBlocks,
+  @Deprecated
+  default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
       ReplicationType type, ReplicationFactor factor, String owner,
+      ExcludeList excludeList) throws IOException {
+    return allocateBlock(size, numBlocks, ReplicationConfig.fromTypeAndFactor(type, factor), owner, excludeList);
+  }
+
+  /**
+   * Asks SCM where a block should be allocated. SCM responds with the
+   * set of datanodes that should be used creating this block.
+   * @param size - size of the block.
+   * @param numBlocks - number of blocks.
+   * @param replicationConfig - replicationConfiguration
+   * @param excludeList List of datanodes/containers to exclude during block
+   *                    allocation.
+   * @return allocated block accessing info (key, pipeline).
+   * @throws IOException
+   */
+  List<AllocatedBlock> allocateBlock(long size, int numBlocks,
+      ReplicationConfig replicationConfig, String owner,
       ExcludeList excludeList) throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/StandaloneReplicationConfig.java
@@ -1,0 +1,22 @@
+package org.apache.hadoop.hdds.scm.protocol;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+
+public class StandaloneReplicationConfig implements ReplicationConfig {
+
+  private final ReplicationFactor replicationFactor;
+
+  public StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
+    this.replicationFactor = replicationFactor;
+  }
+
+  public ReplicationFactor getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  @Override
+  public ReplicationType getReplicationType() {
+    return ReplicationType.STAND_ALONE;
+  }
+}

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -154,6 +154,9 @@ message DatanodeBlockID {
   required int64 containerID = 1;
   required int64 localID = 2;
   optional uint64 blockCommitSequenceId = 3 [default = 0];
+  //for EC we record the index of the
+  //container/block inside the EC replication group.
+  optional int32 replicationIndex = 4;
 }
 
 message KeyValue {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -228,11 +228,23 @@ enum ReplicationType {
     RATIS = 1;
     STAND_ALONE = 2;
     CHAINED = 3;
+    EC = 4;
 }
 
+//Deprected: we should use replication config implementations everywhere
 enum ReplicationFactor {
     ONE = 1;
     THREE = 3;
+}
+
+//replicaiton config for Ratis replication. Will replace pure ReplicationType everywhere
+message RatisReplicationConfig {
+    required ReplicationFactor factor = 1;
+}
+
+message ECReplicationConfig {
+    required int32 data = 1;
+    required int32 parity = 2;
 }
 
 enum ScmOps {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -242,6 +242,10 @@ message RatisReplicationConfig {
     required ReplicationFactor factor = 1;
 }
 
+message StandaloneReplicationConfig {
+    required ReplicationFactor factor = 1;
+}
+
 message ECReplicationConfig {
     required int32 data = 1;
     required int32 parity = 2;

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -206,6 +206,10 @@ message ContainerReplicaProto {
   optional int64 deleteTransactionId = 11;
   optional uint64 blockCommitSequenceId = 12;
   optional string originNodeId = 13;
+  //the index of this replica in the replication group.
+  //this will be different for each instance in case of EC
+  //but the same (0) for all instances for standard Ratis
+  optional int32 replicationIndex = 14;
 }
 
 message CommandStatusReportsProto {

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -129,13 +129,14 @@ message AllocateScmBlockRequestProto {
   //deprecated, use RatisReplicationConfig
   required ReplicationType type = 3;
   
-  required hadoop.hdds.ReplicationFactor factor = 4;
+  optional hadoop.hdds.ReplicationFactor factor = 4;
   required string owner = 5;
   optional ExcludeListProto excludeList = 7;
 
-  //based on replication type, at least one should be included
+  //based on replication type, at least one of these should be included
   optional hadoop.hdds.RatisReplicationConfig ratisReplicationConfig = 8;
   optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 9;
+  optional hadoop.hdds.StandaloneReplicationConfig standaloneReplicationConfig = 10;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -126,7 +126,7 @@ message AllocateScmBlockRequestProto {
   required uint64 size = 1;
   required uint32 numBlocks = 2;
 
-  //deprected, use RatisReplicationConfig
+  //deprecated, use RatisReplicationConfig
   required ReplicationType type = 3;
   
   required hadoop.hdds.ReplicationFactor factor = 4;

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -135,7 +135,7 @@ message AllocateScmBlockRequestProto {
 
   //based on replication type, at least one should be included
   optional hadoop.hdds.RatisReplicationConfig ratisReplicationConfig = 8;
-  optional hadoop.hdds.EcReplicationConfig ecReplicationConfig = 8;
+  optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 9;
 }
 
 /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerProtocol.proto
@@ -125,10 +125,17 @@ enum Status {
 message AllocateScmBlockRequestProto {
   required uint64 size = 1;
   required uint32 numBlocks = 2;
+
+  //deprected, use RatisReplicationConfig
   required ReplicationType type = 3;
+  
   required hadoop.hdds.ReplicationFactor factor = 4;
   required string owner = 5;
   optional ExcludeListProto excludeList = 7;
+
+  //based on replication type, at least one should be included
+  optional hadoop.hdds.RatisReplicationConfig ratisReplicationConfig = 8;
+  optional hadoop.hdds.EcReplicationConfig ecReplicationConfig = 8;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/BlockManager.java
@@ -21,9 +21,9 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.protocol.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.ozone.common.BlockGroup;
@@ -45,8 +45,8 @@ public interface BlockManager extends Closeable,
    * @return AllocatedBlock
    * @throws IOException
    */
-  AllocatedBlock allocateBlock(long size, HddsProtos.ReplicationType type,
-      HddsProtos.ReplicationFactor factor, String owner,
+  AllocatedBlock allocateBlock(long size, ReplicationConfig replicationConfig,
+      String owner,
       ExcludeList excludeList) throws IOException;
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -18,30 +18,30 @@
 
 package org.apache.hadoop.ozone.scm.pipeline;
 
+import java.io.IOException;
+import java.util.Optional;
+
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineMetrics;
+import org.apache.hadoop.hdds.scm.protocol.RatisReplicationConfig;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Optional;
-
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
 
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
@@ -107,8 +107,7 @@ public class TestSCMPipelineMetrics {
   public void testNumBlocksAllocated() throws IOException {
     AllocatedBlock block =
         cluster.getStorageContainerManager().getScmBlockManager()
-            .allocateBlock(5, HddsProtos.ReplicationType.RATIS,
-                HddsProtos.ReplicationFactor.ONE, "Test", new ExcludeList());
+            .allocateBlock(5, new RatisReplicationConfig(ReplicationFactor.ONE), "Test", new ExcludeList());
     MetricsRecordBuilder metrics =
         getMetrics(SCMPipelineMetrics.class.getSimpleName());
     Pipeline pipeline = block.getPipeline();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -19,7 +19,12 @@
 
 package org.apache.hadoop.ozone.om;
 
-import org.apache.commons.lang3.StringUtils;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -30,26 +35,19 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.DeleteBlockResult;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.hdds.scm.protocol.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 import org.apache.hadoop.util.Time;
+
+import org.apache.commons.lang3.StringUtils;
+import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result;
+import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.success;
+import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.unknownFailure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
-import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
-import static org.apache.hadoop.hdds.protocol.proto
-    .ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result;
-import static org.apache.hadoop.hdds.protocol.proto
-    .ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.success;
-import static org.apache.hadoop.hdds.protocol.proto
-    .ScmBlockLocationProtocolProtos.DeleteScmBlockResult.Result.unknownFailure;
 
 /**
  * This is a testing client that allows us to intercept calls from OzoneManager
@@ -116,7 +114,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
    */
   @Override
   public List<AllocatedBlock> allocateBlock(long size, int num,
-      HddsProtos.ReplicationType type, HddsProtos.ReplicationFactor factor,
+      ReplicationConfig config,
       String owner, ExcludeList excludeList) throws IOException {
     DatanodeDetails datanodeDetails = randomDatanodeDetails();
     Pipeline pipeline = createPipeline(datanodeDetails);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkSCM.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.hdds.scm.protocol.RatisReplicationConfig;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -119,7 +120,7 @@ public class BenchMarkSCM {
   public void allocateBlockBenchMark(BenchMarkSCM state,
       Blackhole bh) throws IOException {
     BenchMarkSCM.blockManager
-        .allocateBlock(50, ReplicationType.RATIS, ReplicationFactor.THREE,
+        .allocateBlock(50, new RatisReplicationConfig(ReplicationFactor.THREE),
             "Genesis", new ExcludeList());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-4882 a new ReplicationConfig is introduced. This patch shows how can it be used between OM and SCM on the protocol.

This patch is not a full refactor of SCM it focuses on the SCM protocol side only. Pipeline manager can be improved in follow-up patches...

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4937

## How was this patch tested?

CI