### PR TITLE
HDDS-4946. Do not wait one heartbeat to move newly registered datanodes that match SCM's MLV from HEALTHY_READONLY to HEALTHY

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -180,7 +180,7 @@ public class NodeStateManager implements Runnable, Closeable {
     this.state2EventMap = new HashMap<>();
     initialiseState2EventMap();
     Set<NodeState> finalStates = new HashSet<>();
-    this.nodeHealthSM = new StateMachine<>(NodeState.HEALTHY_READONLY,
+    this.nodeHealthSM = new StateMachine<>(NodeState.HEALTHY,
         finalStates);
     initializeStateMachines();
     heartbeatCheckerIntervalMs = HddsServerUtil
@@ -301,10 +301,12 @@ public class NodeStateManager implements Runnable, Closeable {
       DatanodeInfo dnInfo = nodeStateMap.getNodeInfo(dnID);
       NodeStatus status = nodeStateMap.getNodeStatus(dnID);
 
-      updateNodeLayoutVersionState(dnInfo, layoutMatchCondition, status,
-          NodeLifeCycleEvent.LAYOUT_MATCH);
+      // State machine starts nodes as HEALTHY. If there is a layout
+      // mismatch, this node should be moved to HEALTHY_READONLY.
+      updateNodeLayoutVersionState(dnInfo, layoutMisMatchCondition, status,
+          NodeLifeCycleEvent.LAYOUT_MISMATCH);
     } catch (NodeNotFoundException ex) {
-      LOG.error("Inconsistent NodeStateMap| Datanode with ID {} was " +
+      LOG.error("Inconsistent NodeStateMap! Datanode with ID {} was " +
           "added but not found in  map: {}", dnID, nodeStateMap);
     }
     eventPublisher.fireEvent(SCMEvents.NEW_NODE, datanodeDetails);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -199,12 +199,12 @@ public class NodeStateManager implements Runnable, Closeable {
     skippedHealthChecks = 0;
     checkPaused = false; // accessed only from test functions
 
-     layoutMatchCondition =
+    layoutMatchCondition =
         (layout) -> layout.getMetadataLayoutVersion() ==
-            layoutVersionManager.getMetadataLayoutVersion();
-     layoutMisMatchCondition =
+             layoutVersionManager.getMetadataLayoutVersion();
+    layoutMisMatchCondition =
         (layout) -> layout.getMetadataLayoutVersion() !=
-            layoutVersionManager.getMetadataLayoutVersion();
+             layoutVersionManager.getMetadataLayoutVersion();
 
     scheduleNextHealthCheck();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -369,8 +369,6 @@ public class SCMNodeManager implements NodeManager {
 
         clusterMap.add(datanodeDetails);
         nodeStateManager.addNode(datanodeDetails, layoutInfo);
-        nodeStateManager.updateLastKnownLayoutVersion(datanodeDetails,
-            layoutInfo);
         // Check that datanode in nodeStateManager has topology parent set
         DatanodeDetails dn = nodeStateManager.getNode(datanodeDetails);
         Preconditions.checkState(dn.getParent() != null);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -43,6 +43,7 @@ import java.util.List;
 import java.util.UUID;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
@@ -183,8 +184,7 @@ public class TestNodeStateManager {
     eventPublisher.clearEvents();
     nsm.checkNodesHealth();
     assertEquals(NodeState.HEALTHY, nsm.getNodeStatus(dn).getHealth());
-    assertEquals(SCMEvents.READ_ONLY_HEALTHY_TO_HEALTHY_NODE,
-        eventPublisher.getLastEvent());
+    assertNull(eventPublisher.getLastEvent());
 
     // Set the heartbeat old enough to make it stale
     dni.updateLastHeartbeatTime(now - staleLimit);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -1141,9 +1141,6 @@ public class TestSCMNodeManager {
       //TODO: wait for EventQueue to be processed
       eventQueue.processAll(8000L);
 
-      assertEquals(1, nodeManager.getNodeCount(
-          NodeStatus.inServiceHealthyReadOnly()));
-      Thread.sleep(3 * 1000);
       assertEquals(1, nodeManager
           .getNodeCount(NodeStatus.inServiceHealthy()));
       assertEquals(volumeCount / 2,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -1083,9 +1083,6 @@ public class TestSCMNodeManager {
       eventQueue.processAll(8000L);
 
       assertEquals(nodeCount, nodeManager.getNodeCount(
-          NodeStatus.inServiceHealthyReadOnly()));
-      Thread.sleep(3 * 1000);
-      assertEquals(nodeCount, nodeManager.getNodeCount(
           NodeStatus.inServiceHealthy()));
       assertEquals(capacity * nodeCount, (long) nodeManager.getStats()
           .getCapacity().get());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -195,9 +195,9 @@ public class TestSCMNodeMetrics {
 
     MetricsRecordBuilder metricsSource = getMetrics(SCMNodeMetrics.SOURCE_NAME);
 
-    assertGauge("InServiceHealthyNodes", 0,
+    assertGauge("InServiceHealthyNodes", 1,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
-    assertGauge("InServiceHealthyReadonlyNodes", 1,
+    assertGauge("InServiceHealthyReadonlyNodes", 0,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));
     assertGauge("InServiceStaleNodes", 0,
         getMetrics(SCMNodeMetrics.class.getSimpleName()));

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -653,6 +653,7 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
             .setContainerReport(containerReportsProto)
             .setDatanodeDetails(extendedDatanodeDetailsProto
                 .getDatanodeDetails())
+            .setDataNodeLayoutVersion(defaultLayoutVersionProto())
             .build();
     reconScm.getDatanodeProtocolServer().sendHeartbeat(heartbeatRequestProto);
     LambdaTestUtils.await(30000, 1000, check);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, when a datanode is registered with SCM, it is added as HEALTHY_READONLY, regardless of its metadata layout version. On the next heartbeat, the layout is checked against that of SCM's to determine if it matches and can be moved to HEALTHY. This Jira will add the check for layout match when the datanode is registered, as well as on each heartbeat, so nodes whose MLV matches SCM's on registration will move directly from HEALTHY_READONLY to HEALTHY without needing to wait for a heartbeat.

## What is the link to the Apache JIRA

HDDS-4946

## How was this patch tested?

Recon `TestEndpoints` unit test updated to pass layout version on heartbeat.
`TestNodeStateManager` updated to test the new behavior.
