### PR TITLE
HDDS-4947. Reuse compiled binaries in combined coverage calculation

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -264,14 +264,14 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
-      - name: Run a full build
-        uses: ./.github/buildenv
-        with:
-          args: ./hadoop-ozone/dev-support/checks/build.sh
       - name: Download artifacts
         uses: actions/download-artifact@v2
         with:
           path: target/artifacts
+      - name: Untar binaries
+        run: |
+          mkdir -p hadoop-ozone/dist/target
+          tar xzvf target/artifacts/ozone-bin/hadoop-ozone*.tar.gz -C hadoop-ozone/dist/target
       - name: Calculate combined coverage
         run: ./hadoop-ozone/dev-support/checks/coverage.sh
       - name: Setup java 11


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reuse [binaries created by _compile_ check](https://github.com/adoroszlai/hadoop-ozone/runs/2076199087#step:3:51) instead of [running a full build](https://github.com/apache/ozone/runs/2075932144#step:3:3997) for coverage.  This saves ~12 minutes for non-PR builds (`push`, `schedule`).

https://issues.apache.org/jira/browse/HDDS-4947

## How was this patch tested?

Regular CI after temporarily enabled _coverage_ check in forks.
https://github.com/adoroszlai/hadoop-ozone/actions/runs/638883332

Verified that combined [coverage](https://github.com/adoroszlai/hadoop-ozone/suites/2223105407/artifacts/46054459) is around the same as on [`master`](https://github.com/apache/ozone/suites/2222440551/artifacts/46051808):
1. download _coverage_ artifacts for both builds
2. unzip and open `all/index.html`