### PR TITLE
HDDS-4957. Fix flaky test TestSCMInstallSnapshotWithHA#testInstallCorruptedCheckpointFailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -242,9 +242,6 @@ public class TestSCMInstallSnapshotWithHA {
     // Find the inactive SCM
     String followerId = getInactiveSCM(cluster).getScmId();
     StorageContainerManager follower = cluster.getSCM(followerId);
-    //cluster.startInactiveSCM(followerId);
-    follower.start();
-    follower.exitSafeMode();
     // Do some transactions so that the log index increases
     writeToIncreaseLogIndex(leaderSCM, 100);
     File oldDBLocation =


### PR DESCRIPTION

## What changes were proposed in this pull request?
The test assumes that a follower node must be behind the leader during the final validation assertions. Fix is to not start the follower server itself , so that it always lags behind the leader at any point of time.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4957

## How was this patch tested?
Fixed UT
