### PR TITLE
HDDS-4642. SCM security protocol support for query CRLs and latest CR…

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocol/SCMSecurityProtocol.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
 import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
@@ -131,5 +132,19 @@ public interface SCMSecurityProtocol {
    * @throws IOException
    */
   List<String> listCACertificate() throws IOException;
+
+  /**
+   * Get the CRLInfo based on the CRL Id.
+   * @param crlIds - crl ids
+   * @return list of CRLInfo
+   * @throws IOException
+   */
+  List<CRLInfo> getCrls(List<Long> crlIds) throws IOException;
+
+  /**
+   * Get the latest CRL id.
+   * @return latest CRL id.
+   */
+  long getLatestCrlId() throws IOException;
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/protocolPB/SCMSecurityProtocolClientSideTranslatorPB.java
@@ -18,12 +18,16 @@ package org.apache.hadoop.hdds.protocolPB;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.CRLInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.OzoneManagerDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmNodeDetailsProto;
@@ -32,8 +36,10 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetSCM
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCACertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCrlsRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetDataNodeCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCACertificateRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetLatestCrlIdRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecurityRequest.Builder;
@@ -41,6 +47,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMSecuri
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.proxy.SCMSecurityProtocolFailoverProxyProvider;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
@@ -317,6 +324,36 @@ public class SCMSecurityProtocolClientSideTranslatorPB implements
     return submitRequest(Type.ListCACertificate,
         builder -> builder.setListCACertificateRequestProto(proto))
         .getListCertificateResponseProto().getCertificatesList();
+  }
+
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    SCMGetCrlsRequestProto protoIns = SCMGetCrlsRequestProto
+        .newBuilder()
+        .addAllCrlId(crlIds)
+        .build();
+    List<CRLInfoProto> crlInfoProtoList = submitRequest(Type.GetCrls,
+        builder -> builder.setGetCrlsRequest(protoIns))
+        .getGetCrlsResponseProto().getCrlInfosList();
+    List<CRLInfo> result = new ArrayList<>();
+    for (CRLInfoProto crlProto : crlInfoProtoList) {
+      try {
+        CRLInfo crlInfo = CRLInfo.fromProtobuf(crlProto);
+        result.add(crlInfo);
+      } catch (CRLException | CertificateException e) {
+        throw new SCMSecurityException("Fail to parse CRL info", e);
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public long getLatestCrlId() throws IOException {
+    SCMGetLatestCrlIdRequestProto protoIns =  SCMGetLatestCrlIdRequestProto
+        .getDefaultInstance();
+    return submitRequest(Type.GetLatestCrlId,
+        builder -> builder.setGetLatestCrlIdRequest(protoIns))
+        .getGetLatestCrlIdResponseProto().getCrlId();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateServer.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateApprover.ApprovalType;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -137,6 +138,20 @@ public interface CertificateServer {
    * @param scmMetadataStore
    */
   void reinitialize(SCMMetadataStore scmMetadataStore);
+
+  /**
+   * Get the CRLInfo based on the CRL Ids.
+   * @param crlIds - list of crl ids
+   * @return CRLInfo
+   * @throws IOException
+   */
+  List<CRLInfo> getCrls(List<Long> crlIds) throws IOException;
+
+  /**
+   * Get the latest CRL id.
+   * @return latest CRL id.
+   */
+  long getLatestCrlId();
 
   /**
    * Make it explicit what type of CertificateServer we are creating here.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -141,6 +142,20 @@ public interface CertificateStore {
    * @param metadataStore SCMMetaStore.
    */
   void reinitialize(SCMMetadataStore metadataStore);
+
+  /**
+   * Get the CRLInfo based on the CRL Ids.
+   * @param crlIds - list of crl ids
+   * @return CRLInfo
+   * @throws IOException
+   */
+  List<CRLInfo> getCrls(List<Long> crlIds) throws IOException;
+
+  /**
+   * Get the latest CRL id.
+   * @return latest CRL id.
+   */
+  long getLatestCrlId();
 
   /**
    * Different kind of Certificate stores.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultCAServer.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.PKIProfile;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.SelfSignedCertificate;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
@@ -331,6 +332,22 @@ public class DefaultCAServer implements CertificateServer {
   @Override
   public void reinitialize(SCMMetadataStore scmMetadataStore) {
     store.reinitialize(scmMetadataStore);
+  }
+
+  /**
+   * Get the CRLInfo based on the CRL Ids.
+   * @param crlIds - list of crl ids
+   * @return CRLInfo
+   * @throws IOException
+   */
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    return store.getCrls(crlIds);
+  }
+
+  @Override
+  public long getLatestCrlId() {
+    return store.getLatestCrlId();
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 
 import java.io.IOException;
@@ -260,5 +261,21 @@ public interface CertificateClient {
    * @throws IOException
    */
   List<String> updateCAList() throws IOException;
+
+
+  /**
+   * Get the CRLInfo based on the CRL Ids.
+   * @param crlIds - list of crl ids
+   * @return list of CRLInfo
+   * @throws IOException
+   */
+  List<CRLInfo> getCrls(List<Long> crlIds) throws IOException;
+
+  /**
+   * Get the latest CRL id.
+   * @return latest CRL id.
+   * @throws IOException
+   */
+  long getLatestCrlId() throws IOException;
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -46,7 +46,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
-import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
@@ -68,6 +68,8 @@ import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateExcepti
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CRYPTO_SIGNATURE_VERIFICATION_ERROR;
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CRYPTO_SIGN_ERROR;
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CSR_ERROR;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClient;
+
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.slf4j.Logger;
 
@@ -284,6 +286,33 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     return this.getCertificateFromScm(certId);
   }
 
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    try {
+      SCMSecurityProtocol scmSecurityProtocolClient = getScmSecurityClient(
+          securityConfig.getConfiguration());
+      return scmSecurityProtocolClient.getCrls(crlIds);
+    } catch (Exception e) {
+      getLogger().error("Error while getting CRL with " +
+          "CRL ids:{} from scm.", crlIds, e);
+      throw new CertificateException("Error while getting CRL with " +
+          "CRL ids:" + crlIds, e);
+    }
+  }
+
+  @Override
+  public long getLatestCrlId() throws IOException {
+    try {
+      SCMSecurityProtocol scmSecurityProtocolClient = getScmSecurityClient(
+          securityConfig.getConfiguration());
+      return scmSecurityProtocolClient.getLatestCrlId();
+    } catch (Exception e) {
+      getLogger().error("Error while getting latest CRL id from scm.", e);
+      throw new CertificateException("Error while getting latest CRL id from" +
+          " scm.", e);
+    }
+  }
+
   /**
    * Get certificate from SCM and store it in local file system.
    * @param certId
@@ -296,7 +325,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         certId);
     try {
       SCMSecurityProtocol scmSecurityProtocolClient =
-          HddsServerUtil.getScmSecurityClient(
+          getScmSecurityClient(
           (OzoneConfiguration) securityConfig.getConfiguration());
       String pemEncodedCert =
           scmSecurityProtocolClient.getCertificate(certId);
@@ -899,8 +928,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     lock.lock();
     try {
       SCMSecurityProtocol scmSecurityProtocolClient =
-          HddsServerUtil.getScmSecurityClient(
-              securityConfig.getConfiguration());
+          getScmSecurityClient(securityConfig.getConfiguration());
       pemEncodedCACerts =
           scmSecurityProtocolClient.listCACertificate();
       return pemEncodedCACerts;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
@@ -90,4 +91,14 @@ public class MockCAStore implements CertificateStore {
 
   @Override
   public void reinitialize(SCMMetadataStore metadataStore) {}
+
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public long getLatestCrlId() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerSecurityProtocol.proto
@@ -51,6 +51,8 @@ message SCMSecurityRequest {
     optional SCMListCertificateRequestProto listCertificateRequest = 7;
     optional SCMGetSCMCertRequestProto getSCMCertificateRequest = 8;
     optional SCMListCACertificateRequestProto listCACertificateRequestProto = 9;
+    optional SCMGetCrlsRequestProto getCrlsRequest = 10;
+    optional SCMGetLatestCrlIdRequestProto getLatestCrlIdRequest = 11;
 
 }
 
@@ -71,6 +73,10 @@ message SCMSecurityResponse {
 
     optional SCMListCertificateResponseProto listCertificateResponseProto = 7;
 
+    optional SCMGetCrlsResponseProto getCrlsResponseProto = 8;
+
+    optional SCMGetLatestCrlIdResponseProto getLatestCrlIdResponseProto = 9;
+
 }
 
 enum Type {
@@ -82,6 +88,8 @@ enum Type {
     GetSCMCertificate = 6;
     GetRootCACertificate = 7;
     ListCACertificate = 8;
+    GetCrls = 9;
+    GetLatestCrlId = 10;
 }
 
 enum Status {
@@ -180,6 +188,27 @@ message SCMGetRootCACertificateRequestProto {
 }
 
 message SCMListCACertificateRequestProto {
+}
+
+/**
+* Proto request to get CRL.
+*/
+message SCMGetCrlsRequestProto {
+    repeated int64 crlId = 1;
+}
+
+message SCMGetCrlsResponseProto {
+    repeated CRLInfoProto crlInfos = 1;
+}
+
+/**
+* Proto request to get latest CRL id.
+*/
+message SCMGetLatestCrlIdRequestProto {
+}
+
+message SCMGetLatestCrlIdResponseProto {
+    optional int64 crlId = 1;
 }
 
 service SCMSecurityProtocolService {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -24,7 +24,11 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertResponseProto.ResponseCode;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCertificateRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCrlsRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCrlsResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetDataNodeCertRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetLatestCrlIdRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetLatestCrlIdResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetOMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetSCMCertRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMListCertificateRequestProto;
@@ -37,6 +41,7 @@ import org.apache.hadoop.hdds.scm.ha.RetriableWithNoFailoverException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 
@@ -127,6 +132,17 @@ public class SCMSecurityProtocolServerSideTranslatorPB
       case ListCACertificate:
         return scmSecurityResponse.setListCertificateResponseProto(
             listCACertificate()).build();
+      case GetCrls:
+        return SCMSecurityResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setGetCrlsResponseProto(getCrls(request.getGetCrlsRequest()))
+            .build();
+      case GetLatestCrlId:
+        return SCMSecurityResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setGetLatestCrlIdResponseProto(getLatestCrlId(
+                request.getGetLatestCrlIdRequest()))
+            .build();
       default:
         throw new IllegalArgumentException(
             "Unknown request type: " + request.getCmdType());
@@ -281,7 +297,31 @@ public class SCMSecurityProtocolServerSideTranslatorPB
             .addAllCertificates(certs);
     return builder.build();
 
+  }
 
+  public SCMGetCrlsResponseProto getCrls(
+      SCMGetCrlsRequestProto request) throws IOException {
+    List<CRLInfo> crls = impl.getCrls(request.getCrlIdList());
+    SCMGetCrlsResponseProto.Builder builder =
+        SCMGetCrlsResponseProto.newBuilder();
+    for (CRLInfo crl : crls) {
+      try {
+        builder.addCrlInfos(crl.getProtobuf());
+      } catch (SCMSecurityException e) {
+        LOG.error("Fail in parsing CRL info", e);
+        throw new SCMSecurityException("Fail in parsing CRL info", e);
+      }
+    }
+    return builder.build();
+  }
+
+  public SCMGetLatestCrlIdResponseProto getLatestCrlId(
+      SCMGetLatestCrlIdRequestProto request) throws IOException {
+    SCMGetLatestCrlIdResponseProto.Builder builder =
+        SCMGetLatestCrlIdResponseProto
+            .newBuilder().
+            setCrlId(impl.getLatestCrlId());
+    return builder.build();
   }
 
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -336,4 +336,27 @@ public final class SCMCertStore implements CertificateStore {
 
     }
   }
+
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    List<CRLInfo> results = new ArrayList<>();
+    for (Long crlId : crlIds) {
+      try {
+        CRLInfo crlInfo =
+            scmMetadataStore.getCRLInfoTable().get(crlId);
+        results.add(crlInfo);
+      } catch (IOException e) {
+        LOG.error("Fail to get CRLs from SCM metadata store for crlId: "
+            + crlId, e);
+        throw new SCMSecurityException("Fail to get CRLs from SCM metadata " +
+            "store for crlId: " + crlId, e);
+      }
+    }
+    return results;
+  }
+
+  @Override
+  public long getLatestCrlId() {
+    return crlSequenceId.get();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos;
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -320,6 +321,16 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
       return CertificateCodec.getPEMEncodedString(rootCACertificate);
     }
     return null;
+  }
+
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    return scmCertificateServer.getCrls(crlIds);
+  }
+
+  @Override
+  public long getLatestCrlId() {
+    return scmCertificateServer.getLatestCrlId();
   }
 
   public RPC.Server getRpcServer() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/CertificateClientTestImpl.java
@@ -25,6 +25,7 @@ import java.security.cert.CertStore;
 import java.security.cert.X509Certificate;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -32,6 +33,7 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.SelfSignedCertificate;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 
@@ -212,4 +214,15 @@ public class CertificateClientTestImpl implements CertificateClient {
   public List<String> updateCAList() throws IOException  {
     return null;
   }
+
+  @Override
+  public List<CRLInfo> getCrls(List<Long> crlIds) throws IOException {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public long getLatestCrlId() throws IOException {
+    return 0;
+  }
+
 }


### PR DESCRIPTION
…L id for OM and Datanode.

Add getCrls() and getLatestCrlId() for OM/DN to use.

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4642

## How was this patch tested?

UT.
