### PR TITLE
HDDS-4971. Define Ozone specific trash-interval and checkpoint interval

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2517,4 +2517,13 @@
     </description>
   </property>
 
+  <property>
+    <name>ozone.fs.trash.checkpoint.interval</name>
+    <tag>OZONE, OM</tag>
+    <value>0</value>
+    <description>
+      The interval after which trash checkpoints would get created.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2507,4 +2507,14 @@
       filesystem semantics.
     </description>
   </property>
+
+  <property>
+    <name>ozone.fs.trash.interval</name>
+    <tag>OZONE, OM</tag>
+    <value>0</value>
+    <description>
+      The interval after which keys in trash would get deleted permanently.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2507,23 +2507,4 @@
       filesystem semantics.
     </description>
   </property>
-
-  <property>
-    <name>ozone.fs.trash.interval</name>
-    <tag>OZONE, OM</tag>
-    <value>0</value>
-    <description>
-      The interval after which keys in trash would get deleted permanently.
-    </description>
-  </property>
-
-  <property>
-    <name>ozone.fs.trash.checkpoint.interval</name>
-    <tag>OZONE, OM</tag>
-    <value>0</value>
-    <description>
-      The interval after which trash checkpoints would get created.
-    </description>
-  </property>
-
 </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -234,4 +234,14 @@ public final class OMConfigKeys {
       false;
 
   public static final String OZONE_OM_HA_PREFIX = "ozone.om.ha";
+
+  public static final String OZONE_FS_TRASH_INTERVAL_KEY =
+      "ozone.fs.trash.interval";
+
+  public static final long  OZONE_FS_TRASH_INTERVAL_DEFAULT = 0;
+
+  public static final String OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY =
+      "ozone.fs.trash.checkpoint.interval";
+
+  public static final long  OZONE_FS_TRASH_CHECKPOINT_INTERVAL_DEFAULT = 0;
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -133,7 +133,8 @@ public class TestOzoneFileSystem {
 
   private void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setInt(FS_TRASH_INTERVAL_KEY, 1);
+    conf.setInt(FS_TRASH_INTERVAL_KEY, 2);
+    conf.setInt(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, 1);
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
@@ -798,10 +799,11 @@ public class TestOzoneFileSystem {
     String testKeyName = "testKey2";
     Path path = new Path(OZONE_URI_DELIMITER, testKeyName);
     ContractTestUtils.touch(fs, path);
-    Assert.assertTrue(trash.getConf().getClass(
-        "fs.trash.classname", TrashPolicy.class).
+    Assert.assertTrue(trash.getConf().getClass("fs.trash.classname",
+        TrashPolicy.class).
         isAssignableFrom(TrashPolicyOzone.class));
-    Assert.assertEquals(trash.getConf().getInt(FS_TRASH_INTERVAL_KEY, 0), 1);
+    Assert.assertEquals(1, trash.getConf().
+        getInt(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, 0));
     // Call moveToTrash. We can't call protected fs.rename() directly
     trash.moveToTrash(path);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -799,8 +799,8 @@ public class TestOzoneFileSystem {
     String testKeyName = "testKey2";
     Path path = new Path(OZONE_URI_DELIMITER, testKeyName);
     ContractTestUtils.touch(fs, path);
-    Assert.assertTrue(trash.getConf().getClass("fs.trash.classname",
-        TrashPolicy.class).
+    Assert.assertTrue(trash.getConf().getClass(
+        "fs.trash.classname", TrashPolicy.class).
         isAssignableFrom(TrashPolicyOzone.class));
     Assert.assertEquals(1, trash.getConf().
         getInt(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, 0));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -67,6 +67,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
         OMConfigKeys.OZONE_OM_NODES_KEY,
+        OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY,
+        OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1270,8 +1270,13 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @throws IOException
    */
   private void startTrashEmptier(Configuration conf) throws IOException {
+    long hadoopTrashInterval =
+        conf.getLong(FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT);
+    // check whether user has configured ozone specific trash-interval
+    // if not fall back to hadoop configuration
     long trashInterval =
-            conf.getLong(FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT);
+            conf.getLong(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY,
+                hadoopTrashInterval);
     if (trashInterval == 0) {
       LOG.info("Trash Interval set to 0. Files deleted will not move to trash");
       return;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -82,11 +82,22 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
   public void initialize(Configuration conf, FileSystem fs) {
     this.fs = fs;
     this.configuration = conf;
+    float hadoopTrashInterval = conf.getFloat(
+        FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT);
+    // check whether user has configured ozone specific trash-interval
+    // if not fall back to hadoop configuration
     this.deletionInterval = (long)(conf.getFloat(
-        FS_TRASH_INTERVAL_KEY, FS_TRASH_INTERVAL_DEFAULT)
+        OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, hadoopTrashInterval)
         * MSECS_PER_MINUTE);
+    float hadoopCheckpointInterval = conf.getFloat(
+        FS_TRASH_CHECKPOINT_INTERVAL_KEY,
+        FS_TRASH_CHECKPOINT_INTERVAL_DEFAULT);
+    // check whether user has configured ozone specific
+    // trash- checkpoint-interval
+    // if not fall back to hadoop configuration
     this.emptierInterval = (long)(conf.getFloat(
-        FS_TRASH_CHECKPOINT_INTERVAL_KEY, FS_TRASH_CHECKPOINT_INTERVAL_DEFAULT)
+        OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
+        hadoopCheckpointInterval)
         * MSECS_PER_MINUTE);
     if (deletionInterval < 0) {
       LOG.warn("Invalid value {} for deletion interval,"


### PR DESCRIPTION
## What changes were proposed in this pull request?
This change adds 2 new configs in ozone. One thing to note here is that ozone trash is not fully independent from the hadoop-configurations i.e (`fs.trash.interval`) . This config (`fs.trash.interval`) will still control enabling/disabling of trash feature whereas the newly added configs (`ozone.fs.trash.interval` & `ozone.fs.trash.checkpoint.interval` ) would set values if trash is enabled . These will add flexibility if ozone user wants to set ozone specific interval period. 
 
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4971

## How was this patch tested?
Unit test
