### PR TITLE
HDDS-4978. [SCM HA Security] Ozone services should be disabled in SCM HA enabled and security enabled cluster

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -490,6 +490,14 @@ public final class ScmConfigKeys {
   public static final boolean HDDS_DATANODE_UPGRADE_LAYOUT_INLINE_DEFAULT =
       true;
 
+
+  // Temporary config which will be used only for test only purposes until
+  // SCM HA Security work is completed. This config should not be modified by
+  // users.
+  public static final String OZONE_SCM_HA_SECURITY_ENABLE =
+      "hdds.scm.ha.security.enable";
+  public static final boolean OZONE_SCM_HA_SECURITY_ENABLE_DEFAULT = false;
+
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -494,9 +494,9 @@ public final class ScmConfigKeys {
   // Temporary config which will be used only for test only purposes until
   // SCM HA Security work is completed. This config should not be modified by
   // users.
-  public static final String OZONE_SCM_HA_SECURITY_ENABLE =
+  public static final String OZONE_SCM_HA_SECURITY_SUPPORTED =
       "hdds.scm.ha.security.enable";
-  public static final boolean OZONE_SCM_HA_SECURITY_ENABLE_DEFAULT = false;
+  public static final boolean OZONE_SCM_HA_SECURITY_SUPPORTED_DEFAULT = false;
 
   /**
    * Never constructed.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -69,6 +69,7 @@ import com.google.common.base.Preconditions;
 import com.sun.jmx.mbeanserver.Introspector;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getX509Certificate;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
+import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY;
 import static org.apache.hadoop.util.ExitUtil.terminate;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -158,6 +159,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public Void call() throws Exception {
+    checkSecurityAndSCMHAEnabled(conf);
     if (printBanner) {
       StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
           HddsDatanodeService.class, args, LOG);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -159,7 +159,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public Void call() throws Exception {
-    checkSecurityAndSCMHAEnabled(conf);
     if (printBanner) {
       StringUtils.startupShutdownMessage(HddsVersionInfo.HDDS_VERSION_INFO,
           HddsDatanodeService.class, args, LOG);
@@ -189,6 +188,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   public void start(OzoneConfiguration configuration) {
     setConfiguration(configuration);
+    checkSecurityAndSCMHAEnabled(conf);
     start();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
@@ -313,10 +314,13 @@ public final class HAUtils {
   }
 
   public static void checkSecurityAndSCMHAEnabled(OzoneConfiguration conf) {
-    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+    boolean enable =
+        conf.getBoolean(ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE,
+            ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE_DEFAULT);
+    if (OzoneSecurityUtil.isSecurityEnabled(conf) && !enable) {
       List<SCMNodeInfo> scmNodeInfo = SCMNodeInfo.buildNodeInfo(conf);
       if (scmNodeInfo.size() > 1) {
-        System.out.println("Ozone Services cannot be started on a secure SCM " +
+        System.err.println("Ozone Services cannot be started on a secure SCM " +
             "HA enabled cluster");
         System.exit(1);
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
+import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider;
@@ -32,6 +33,7 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
 import org.slf4j.Logger;
@@ -45,6 +47,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
@@ -307,5 +310,16 @@ public final class HAUtils {
       }
     }
     return false;
+  }
+
+  public static void checkSecurityAndSCMHAEnabled(OzoneConfiguration conf) {
+    if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+      List<SCMNodeInfo> scmNodeInfo = SCMNodeInfo.buildNodeInfo(conf);
+      if (scmNodeInfo.size() > 1) {
+        System.out.println("Ozone Services cannot be started on a secure SCM " +
+            "HA enabled cluster");
+        System.exit(1);
+      }
+    }
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -315,8 +315,8 @@ public final class HAUtils {
 
   public static void checkSecurityAndSCMHAEnabled(OzoneConfiguration conf) {
     boolean enable =
-        conf.getBoolean(ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE,
-            ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE_DEFAULT);
+        conf.getBoolean(ScmConfigKeys.OZONE_SCM_HA_SECURITY_SUPPORTED,
+            ScmConfigKeys.OZONE_SCM_HA_SECURITY_SUPPORTED_DEFAULT);
     if (OzoneSecurityUtil.isSecurityEnabled(conf) && !enable) {
       List<SCMNodeInfo> scmNodeInfo = SCMNodeInfo.buildNodeInfo(conf);
       if (scmNodeInfo.size() > 1) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -136,6 +136,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConsts.CRL_SEQUENCE_ID_KEY;
 
@@ -257,6 +258,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     Objects.requireNonNull(configurator, "configurator cannot not be null");
     Objects.requireNonNull(conf, "configuration cannot not be null");
+
+    checkSecurityAndSCMHAEnabled(conf);
 
     scmHANodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
 
@@ -803,6 +806,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
    */
   public static boolean scmInit(OzoneConfiguration conf,
       String clusterId) throws IOException {
+    checkSecurityAndSCMHAEnabled(conf);
     SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf);
     StorageState state = scmStorageConfig.getState();
     final SCMHANodeDetails haDetails = SCMHANodeDetails.loadSCMHAConfig(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -84,7 +84,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
-        OMConfigKeys.OZONE_OM_HA_PREFIX
+        OMConfigKeys.OZONE_OM_HA_PREFIX,
+        ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE
         // TODO HDDS-2856
     ));
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -85,7 +85,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
         OMConfigKeys.OZONE_OM_HA_PREFIX,
-        ScmConfigKeys.OZONE_SCM_HA_SECURITY_ENABLE
+        ScmConfigKeys.OZONE_SCM_HA_SECURITY_SUPPORTED
         // TODO HDDS-2856
     ));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerStarter.java
@@ -31,6 +31,8 @@ import picocli.CommandLine.Command;
 
 import java.io.IOException;
 
+import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
+
 /**
  * This class provides a command line interface to start the OM
  * using Picocli.
@@ -122,6 +124,7 @@ public class OzoneManagerStarter extends GenericCli {
     @Override
     public void start(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
+      checkSecurityAndSCMHAEnabled(conf);
       OzoneManager om = OzoneManager.createOm(conf);
       om.start();
       om.join();
@@ -130,6 +133,7 @@ public class OzoneManagerStarter extends GenericCli {
     @Override
     public boolean init(OzoneConfiguration conf) throws IOException,
         AuthenticationException {
+      checkSecurityAndSCMHAEnabled(conf);
       return OzoneManager.omInit(conf);
     }
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon;
 
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON_KERBEROS_PRINCIPAL_KEY;
+import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
 
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
@@ -75,6 +76,7 @@ public class ReconServer extends GenericCli {
         ReconServer.class, originalArgs, LOG);
 
     configuration = createOzoneConfiguration();
+    checkSecurityAndSCMHAEnabled(configuration);
     ConfigurationProvider.setConfiguration(configuration);
 
     injector =  Guice.createInjector(new

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -31,8 +31,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 
-import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
-
 /**
  * This class is used to start/stop S3 compatible rest server.
  */
@@ -56,7 +54,6 @@ public class Gateway extends GenericCli {
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     UserGroupInformation.setConfiguration(ozoneConfiguration);
-    checkSecurityAndSCMHAEnabled(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();
     return null;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -31,6 +31,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 
+import static org.apache.hadoop.hdds.utils.HAUtils.checkSecurityAndSCMHAEnabled;
+
 /**
  * This class is used to start/stop S3 compatible rest server.
  */
@@ -54,6 +56,7 @@ public class Gateway extends GenericCli {
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     UserGroupInformation.setConfiguration(ozoneConfiguration);
+    checkSecurityAndSCMHAEnabled(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();
     return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Do not start ozone services when security and SCM HA is enabled

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4978

## How was this patch tested?
Tested it with docker-compose ozone-ha cluster by settingozone.security.enabled=true
Verified that all services failed to come up


Snippet of partial log.
```
om2_1       | Ozone Services cannot be started on a secure SCM HA enabled cluster
om2_1       | 2021-03-15 12:09:15,429 [shutdown-hook-0] INFO om.OzoneManagerStarter: SHUTDOWN_MSG:
om2_1       | /************************************************************
om2_1       | SHUTDOWN_MSG: Shutting down OzoneManager at om2/172.27.0.4
om2_1       | ************************************************************/
scm1_1      | Ozone Services cannot be started on a secure SCM HA enabled cluster
scm1_1      | 2021-03-15 12:09:15,686 [shutdown-hook-0] INFO server.StorageContainerManagerStarter: SHUTDOWN_MSG:
scm1_1      | /************************************************************
scm1_1      | SHUTDOWN_MSG: Shutting down StorageContainerManager at 2a2fc5196315/172.27.0.2
scm1_1      | ************************************************************/
````