### PR TITLE
HDDS-4984. Support async profiler 2.0

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
@@ -75,16 +75,16 @@ import org.slf4j.LoggerFactory;
  * //  --ttsp            time-to-safepoint profiling
  * Example:
  * - To collect 30 second CPU profile of current process (returns FlameGraph
- * html)
+ * svg)
  * curl "http://localhost:10002/prof"
  * - To collect 1 minute CPU profile of current process and output in tree
  * format (html)
  * curl "http://localhost:10002/prof?output=tree&duration=60"
  * - To collect 30 second heap allocation profile of current process (returns
- * FlameGraph html)
+ * FlameGraph svg)
  * curl "http://localhost:10002/prof?event=alloc"
  * - To collect lock contention profile of current process (returns
- * FlameGraph html)
+ * FlameGraph svg)
  * curl "http://localhost:10002/prof?event=lock"
  * Following event types are supported (default is 'cpu') (NOTE: not all
  * OS'es support all events)
@@ -379,7 +379,9 @@ public class ProfileServlet extends HttpServlet {
               + "ready..");
     } else {
       if (safeFileName.endsWith(".html")) {
-        resp.setContentType("image/html+xml");
+        resp.setContentType("text/html");
+      } else if (safeFileName.endsWith(".svg")) {
+        resp.setContentType("image/svg+xml");
       } else if (safeFileName.endsWith(".tree")) {
         resp.setContentType("text/html");
       }
@@ -442,10 +444,10 @@ public class ProfileServlet extends HttpServlet {
       try {
         return Output.valueOf(outputArg.trim().toUpperCase());
       } catch (IllegalArgumentException e) {
-        return Output.HTML;
+        return Output.SVG;
       }
     }
-    return Output.HTML;
+    return Output.SVG;
   }
 
   private void setResponseHeader(final HttpServletResponse response) {
@@ -511,6 +513,7 @@ public class ProfileServlet extends HttpServlet {
     TRACES,
     FLAT,
     COLLAPSED,
+    SVG,
     TREE,
     JFR,
     HTML

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
@@ -187,10 +187,13 @@ public class ProfileServlet extends HttpServlet {
   @VisibleForTesting
   protected static String generateFileName(Integer pid, Output output,
       Event event) {
+    String outputFormat = output.name().toLowerCase();
+    if(output == Output.FLAMEGRAPH) {
+      outputFormat = "html";
+    }
     return FILE_PREFIX + pid + "-" +
         event.name().toLowerCase() + "-" + ID_GEN.incrementAndGet()
-        + "." +
-        output.name().toLowerCase();
+        + "." + outputFormat;
   }
 
   @VisibleForTesting
@@ -516,7 +519,7 @@ public class ProfileServlet extends HttpServlet {
     SVG,
     TREE,
     JFR,
-    HTML
+    FLAMEGRAPH
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
@@ -46,32 +46,43 @@ import org.slf4j.LoggerFactory;
  * Source: https://github.com/apache/hive/blob/master/common/src/java/org
  * /apache/hive/http/ProfileServlet.java
  * <p>
- * Following options from async-profiler can be specified as query paramater.
+ * Following options from async-profiler can be specified as query parameter.
  * //  -e event          profiling event: cpu|alloc|lock|cache-misses etc.
- * //  -d duration       run profiling for <duration> seconds (integer)
- * //  -i interval       sampling interval in nanoseconds (long)
- * //  -j jstackdepth    maximum Java stack depth (integer)
- * //  -b bufsize        frame buffer size (long)
+ * //  -d duration       run profiling for <duration> seconds
+ * //  -f filename       dump output to <filename>
+ * //  -i interval       sampling interval in nanoseconds
+ * //  -j jstackdepth    maximum Java stack depth
  * //  -t                profile different threads separately
  * //  -s                simple class names instead of FQN
- * //  -o fmt[,fmt...]   output format:
- * summary|traces|flat|collapsed|svg|tree|jfr
- * //  --width px        SVG width pixels (integer)
- * //  --height px       SVG frame height pixels (integer)
- * //  --minwidth px     skip frames smaller than px (double)
+ * //  -g                print method signatures
+ * //  -a                annotate Java method names
+ * //  -o fmt            output format: flat|traces|collapsed|flamegraph|tree|jfr
+ * //  -I include        output only stack traces containing the specified pattern
+ * //  -X exclude        exclude stack traces with the specified pattern
+ * //  -v, --version     display version string
+ * //  --title string    FlameGraph title
+ * //  --minwidth pct    skip frames smaller than pct%
  * //  --reverse         generate stack-reversed FlameGraph / Call tree
+ * //  --alloc bytes     allocation profiling interval in bytes
+ * //  --lock duration   lock profiling threshold in nanoseconds
+ * //  --total           accumulate the total value (time, bytes, etc.)
+ * //  --all-user        only include user-mode events
+ * //  --cstack mode     how to traverse C stack: fp|lbr|no
+ * //  --begin function  begin profiling when function is executed
+ * //  --end function    end profiling when function is executed
+ * //  --ttsp            time-to-safepoint profiling
  * Example:
  * - To collect 30 second CPU profile of current process (returns FlameGraph
- * svg)
+ * html)
  * curl "http://localhost:10002/prof"
  * - To collect 1 minute CPU profile of current process and output in tree
  * format (html)
  * curl "http://localhost:10002/prof?output=tree&duration=60"
  * - To collect 30 second heap allocation profile of current process (returns
- * FlameGraph svg)
+ * FlameGraph html)
  * curl "http://localhost:10002/prof?event=alloc"
  * - To collect lock contention profile of current process (returns
- * FlameGraph svg)
+ * FlameGraph html)
  * curl "http://localhost:10002/prof?event=lock"
  * Following event types are supported (default is 'cpu') (NOTE: not all
  * OS'es support all events)
@@ -365,8 +376,8 @@ public class ProfileServlet extends HttpServlet {
           "This page will auto-refresh every 2 second until output file is "
               + "ready..");
     } else {
-      if (safeFileName.endsWith(".svg")) {
-        resp.setContentType("image/svg+xml");
+      if (safeFileName.endsWith(".html")) {
+        resp.setContentType("image/html+xml");
       } else if (safeFileName.endsWith(".tree")) {
         resp.setContentType("text/html");
       }
@@ -429,10 +440,10 @@ public class ProfileServlet extends HttpServlet {
       try {
         return Output.valueOf(outputArg.trim().toUpperCase());
       } catch (IllegalArgumentException e) {
-        return Output.SVG;
+        return Output.HTML;
       }
     }
-    return Output.SVG;
+    return Output.HTML;
   }
 
   private void setResponseHeader(final HttpServletResponse response) {
@@ -498,9 +509,9 @@ public class ProfileServlet extends HttpServlet {
     TRACES,
     FLAT,
     COLLAPSED,
-    SVG,
     TREE,
-    JFR
+    JFR,
+    HTML
   }
 
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
@@ -56,8 +56,10 @@ import org.slf4j.LoggerFactory;
  * //  -s                simple class names instead of FQN
  * //  -g                print method signatures
  * //  -a                annotate Java method names
- * //  -o fmt            output format: flat|traces|collapsed|flamegraph|tree|jfr
- * //  -I include        output only stack traces containing the specified pattern
+ * //  -o fmt            output format:
+ * flat|traces|collapsed|flamegraph|tree|jfr
+ * //  -I include        output only stack traces
+ * containing the specified pattern
  * //  -X exclude        exclude stack traces with the specified pattern
  * //  -v, --version     display version string
  * //  --title string    FlameGraph title

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -42,7 +42,8 @@ public class TestProfileServlet {
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithNewLine() throws IOException {
     ProfileServlet.validateFileName(
-        "test\n" + ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
+        "test\n" + ProfileServlet.generateFileName(1, Output.HTML,
+            Event.ALLOC));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -33,7 +33,8 @@ public class TestProfileServlet {
   public void testNameValidation() throws IOException {
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
-
+    ProfileServlet.validateFileName(
+            ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(23, Output.COLLAPSED,
             Event.L1_DCACHE_LOAD_MISSES));
@@ -44,12 +45,17 @@ public class TestProfileServlet {
     ProfileServlet.validateFileName(
         "test\n" + ProfileServlet.generateFileName(1, Output.HTML,
             Event.ALLOC));
+    ProfileServlet.validateFileName(
+            "test\n" + ProfileServlet.generateFileName(1, Output.SVG,
+            Event.ALLOC));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithSlash() throws IOException {
     ProfileServlet.validateFileName(
         "../" + ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
+    ProfileServlet.validateFileName(
+        "../" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -34,7 +34,7 @@ public class TestProfileServlet {
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(1, Output.FLAMEGRAPH, Event.ALLOC));
     ProfileServlet.validateFileName(
-            ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+        ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(23, Output.COLLAPSED,
             Event.L1_DCACHE_LOAD_MISSES));
@@ -46,14 +46,14 @@ public class TestProfileServlet {
         "test\n" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
             Event.ALLOC));
     ProfileServlet.validateFileName(
-            "test\n" + ProfileServlet.generateFileName(1, Output.SVG,
-            Event.ALLOC));
+        "test\n" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithSlash() throws IOException {
     ProfileServlet.validateFileName(
-        "../" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH, Event.ALLOC));
+        "../" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
+            Event.ALLOC));
     ProfileServlet.validateFileName(
         "../" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -32,7 +32,7 @@ public class TestProfileServlet {
   @Test
   public void testNameValidation() throws IOException {
     ProfileServlet.validateFileName(
-        ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+        ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
 
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(23, Output.COLLAPSED,
@@ -42,13 +42,13 @@ public class TestProfileServlet {
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithNewLine() throws IOException {
     ProfileServlet.validateFileName(
-        "test\n" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+        "test\n" + ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithSlash() throws IOException {
     ProfileServlet.validateFileName(
-        "../" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+        "../" + ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -32,7 +32,7 @@ public class TestProfileServlet {
   @Test
   public void testNameValidation() throws IOException {
     ProfileServlet.validateFileName(
-        ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
+        ProfileServlet.generateFileName(1, Output.FLAMEGRAPH, Event.ALLOC));
     ProfileServlet.validateFileName(
             ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
     ProfileServlet.validateFileName(
@@ -43,7 +43,7 @@ public class TestProfileServlet {
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithNewLine() throws IOException {
     ProfileServlet.validateFileName(
-        "test\n" + ProfileServlet.generateFileName(1, Output.HTML,
+        "test\n" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
             Event.ALLOC));
     ProfileServlet.validateFileName(
             "test\n" + ProfileServlet.generateFileName(1, Output.SVG,
@@ -53,7 +53,7 @@ public class TestProfileServlet {
   @Test(expected = IllegalArgumentException.class)
   public void testNameValidationWithSlash() throws IOException {
     ProfileServlet.validateFileName(
-        "../" + ProfileServlet.generateFileName(1, Output.HTML, Event.ALLOC));
+        "../" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH, Event.ALLOC));
     ProfileServlet.validateFileName(
         "../" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to the update of Async profiler 2.0, the output format is changed from svg to html.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4984

## How was this patch tested?

Local test.
