### PR TITLE
HDDS-4983. Display key offset for each block in command key info

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
@@ -47,12 +47,12 @@ public class OzoneKeyLocation {
    * Constructs OzoneKeyLocation.
    */
   public OzoneKeyLocation(long containerID, long localID,
-                          long length, long offset) {
+                          long length, long offset, long keyOffset) {
     this.containerID = containerID;
     this.localID = localID;
     this.length = length;
     this.offset = offset;
-    this.keyOffset = length + offset;
+    this.keyOffset = keyOffset;
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
@@ -42,7 +42,7 @@ public class OzoneKeyLocation {
   /**
    * KeyOffset of this key.
    */
-  private final long KeyOffset;
+  private final long keyOffset;
   /**
    * Constructs OzoneKeyLocation.
    */
@@ -52,7 +52,7 @@ public class OzoneKeyLocation {
     this.localID = localID;
     this.length = length;
     this.offset = offset;
-    this.KeyOffset = length + offset;
+    this.keyOffset = length + offset;
   }
 
   /**
@@ -86,6 +86,6 @@ public class OzoneKeyLocation {
   /**
    * Returns the KeyOffset of this Key.
    */
-  public long getKeyOffset() { return KeyOffset; }
+  public long getKeyOffset() { return keyOffset; }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
@@ -39,16 +39,20 @@ public class OzoneKeyLocation {
    * Offset of this key.
    */
   private final long offset;
-
+  /**
+   * KeyOffset of this key.
+   */
+  private final long KeyOffset;
   /**
    * Constructs OzoneKeyLocation.
    */
   public OzoneKeyLocation(long containerID, long localID,
-                  long length, long offset) {
+                          long length, long offset) {
     this.containerID = containerID;
     this.localID = localID;
     this.length = length;
     this.offset = offset;
+    this.KeyOffset = length + offset;
   }
 
   /**
@@ -78,5 +82,10 @@ public class OzoneKeyLocation {
   public long getOffset() {
     return offset;
   }
+
+  /**
+   * Returns the KeyOffset of this Key.
+   */
+  public long getKeyOffset() { return KeyOffset; }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
@@ -86,6 +86,8 @@ public class OzoneKeyLocation {
   /**
    * Returns the KeyOffset of this Key.
    */
-  public long getKeyOffset() { return keyOffset; }
+  public long getKeyOffset() {
+    return keyOffset;
+  }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -860,15 +860,13 @@ public class RpcClient implements ClientProtocol {
 
     List<OzoneKeyLocation> ozoneKeyLocations = new ArrayList<>();
     long lastKeyOffset = 0L;
-    long lastLength = 0L;
     List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo
         .getLatestVersionLocations().getBlocksLatestVersionOnly();
     for (OmKeyLocationInfo info: omKeyLocationInfos) {
       ozoneKeyLocations.add(new OzoneKeyLocation(info.getContainerID(),
           info.getLocalID(), info.getLength(), info.getOffset(),
-          lastKeyOffset + lastLength));
-      lastKeyOffset = lastLength + lastKeyOffset;
-      lastLength = info.getLength();
+          lastKeyOffset));
+      lastKeyOffset += info.getLength();
     }
     return new OzoneKeyDetails(keyInfo.getVolumeName(), keyInfo.getBucketName(),
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -861,8 +861,8 @@ public class RpcClient implements ClientProtocol {
     List<OzoneKeyLocation> ozoneKeyLocations = new ArrayList<>();
     long lastKeyOffset = 0L;
     long lastLength = 0L;
-    List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo.getLatestVersionLocations()
-        .getBlocksLatestVersionOnly();
+    List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo
+        .getLatestVersionLocations().getBlocksLatestVersionOnly();
     for (OmKeyLocationInfo info: omKeyLocationInfos) {
       ozoneKeyLocations.add(new OzoneKeyLocation(info.getContainerID(),
           info.getLocalID(), info.getLength(), info.getOffset(),

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -80,6 +80,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteList;
@@ -858,9 +859,15 @@ public class RpcClient implements ClientProtocol {
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
 
     List<OzoneKeyLocation> ozoneKeyLocations = new ArrayList<>();
-    keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly().forEach(
-        (a) -> ozoneKeyLocations.add(new OzoneKeyLocation(a.getContainerID(),
-            a.getLocalID(), a.getLength(), a.getOffset())));
+    long lastKeyOffset = 0L;
+    long lastLength = 0L;
+    List<OmKeyLocationInfo> OmKeyLocationInfos = keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
+    for (OmKeyLocationInfo info: OmKeyLocationInfos) {
+      ozoneKeyLocations.add(new OzoneKeyLocation(info.getContainerID(),
+          info.getLocalID(), info.getLength(), info.getOffset(), lastKeyOffset + lastLength));
+      lastKeyOffset = lastLength + lastKeyOffset;
+      lastLength = info.getLength();
+    }
     return new OzoneKeyDetails(keyInfo.getVolumeName(), keyInfo.getBucketName(),
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
         keyInfo.getModificationTime(), ozoneKeyLocations, ReplicationType

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -861,8 +861,8 @@ public class RpcClient implements ClientProtocol {
     List<OzoneKeyLocation> ozoneKeyLocations = new ArrayList<>();
     long lastKeyOffset = 0L;
     long lastLength = 0L;
-    List<OmKeyLocationInfo> OmKeyLocationInfos = keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
-    for (OmKeyLocationInfo info: OmKeyLocationInfos) {
+    List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
+    for (OmKeyLocationInfo info: omKeyLocationInfos) {
       ozoneKeyLocations.add(new OzoneKeyLocation(info.getContainerID(),
           info.getLocalID(), info.getLength(), info.getOffset(), lastKeyOffset + lastLength));
       lastKeyOffset = lastLength + lastKeyOffset;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -861,10 +861,12 @@ public class RpcClient implements ClientProtocol {
     List<OzoneKeyLocation> ozoneKeyLocations = new ArrayList<>();
     long lastKeyOffset = 0L;
     long lastLength = 0L;
-    List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo.getLatestVersionLocations().getBlocksLatestVersionOnly();
+    List<OmKeyLocationInfo> omKeyLocationInfos = keyInfo.getLatestVersionLocations()
+        .getBlocksLatestVersionOnly();
     for (OmKeyLocationInfo info: omKeyLocationInfos) {
       ozoneKeyLocations.add(new OzoneKeyLocation(info.getContainerID(),
-          info.getLocalID(), info.getLength(), info.getOffset(), lastKeyOffset + lastLength));
+          info.getLocalID(), info.getLength(), info.getOffset(),
+          lastKeyOffset + lastLength));
       lastKeyOffset = lastLength + lastKeyOffset;
       lastLength = info.getLength();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

add keyOffset in the key info result

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4983

## How was this patch tested?
example:sh key info /vol1/bucket1/key3

```
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "key3",
  "dataSize" : 644930593,
  "creationTime" : "2021-04-20T09:22:15.206Z",
  "modificationTime" : "2021-04-20T09:22:20.869Z",
  "replicationType" : "RATIS",
  "replicationFactor" : 3,
  "ozoneKeyLocations" : [ {
    "containerID" : 3,
    "localID" : 107544261427200003,
    "length" : 268435456,
    "offset" : 0,
    "keyOffset" : 0
  }, {
    "containerID" : 4,
    "localID" : 107544261427200004,
    "length" : 268435456,
    "offset" : 0,
    "keyOffset" : 268435456
  }, {
    "containerID" : 5,
    "localID" : 107544261427200005,
    "length" : 108059681,
    "offset" : 0,
    "keyOffset" : 536870912
  } ],
  "metadata" : { },
  "fileEncryptionInfo" : null
}
```