### PR TITLE
HDDS-4985. [SCM HA Security] When Ratis enable, SCM secure cluster is not working.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAInvocationHandler.java
@@ -90,7 +90,8 @@ public class SCMHAInvocationHandler implements InvocationHandler {
     long startTime = Time.monotonicNowNanos();
     Preconditions.checkNotNull(ratisHandler);
     final SCMRatisResponse response =  ratisHandler.submitRequest(
-        SCMRatisRequest.of(requestType, method.getName(), args));
+        SCMRatisRequest.of(requestType, method.getName(),
+            method.getParameterTypes(), args));
     LOG.info("Invoking method {} on target {}, cost {}us",
         method, ratisHandler, (Time.monotonicNowNanos() - startTime) / 1000.0);
     if (response.isSuccess()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -19,9 +19,7 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.Map;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
@@ -152,12 +150,8 @@ public class SCMStateMachine extends BaseStateMachine {
             request.getType());
       }
 
-      final List<Class<?>> argumentTypes = new ArrayList<>();
-      for(Object args : request.getArguments()) {
-        argumentTypes.add(args.getClass());
-      }
       final Object result = handler.getClass().getMethod(
-          request.getOperation(), argumentTypes.toArray(new Class<?>[0]))
+          request.getOperation(), request.getParameterTypes())
           .invoke(handler, request.getArguments());
       return SCMRatisResponse.encode(result);
     } catch (NoSuchMethodException | SecurityException ex) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
@@ -40,7 +40,8 @@ public class TestSCMRatisRequest {
     PipelineID pipelineID = PipelineID.randomId();
     Object[] args = new Object[] {pipelineID.getProtobuf()};
     String operation = "test";
-    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation, args);
+    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
+        new Class[]{pipelineID.getProtobuf().getClass()}, args);
     Assert.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
     Assert.assertEquals(args[0],
@@ -52,7 +53,8 @@ public class TestSCMRatisRequest {
     PipelineID pipelineID = PipelineID.randomId();
     // Non proto args
     Object[] args = new Object[] {pipelineID};
-    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, "test", args);
+    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, "test",
+        new Class[]{pipelineID.getClass()}, args);
     // Should throw exception there.
     request.encode();
   }
@@ -73,7 +75,8 @@ public class TestSCMRatisRequest {
     pids.add(PipelineID.randomId().getProtobuf());
     Object[] args = new Object[] {pids};
     String operation = "test";
-    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation, args);
+    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
+        new Class[]{pids.getClass()}, args);
     Assert.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
     Assert.assertEquals(args[0],
@@ -84,7 +87,8 @@ public class TestSCMRatisRequest {
   public void testEncodeAndDecodeOfLong() throws Exception {
     final Long value = 10L;
     String operation = "test";
-    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation, value);
+    SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
+        new Class[]{value.getClass()}, value);
     Assert.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
     Assert.assertEquals(value,

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -104,5 +104,6 @@ services:
       KERBEROS_KEYTABS: scm HTTP testuser testuser2
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
+      OZONE-SITE.XML_ozone.scm.ratis.enable: "${OZONE_SCM_RATIS_ENABLE:-false}"
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -27,39 +27,42 @@ export SECURITY_ENABLED=true
 
 : ${OZONE_BUCKET_KEY_NAME:=key1}
 
-start_docker_env
+for enable in true false; do
 
-execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
+  start_docker_env 3 "${enable}"
 
-execute_robot_test scm kinit.robot
+  execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
-execute_robot_test scm basic
+  execute_robot_test scm kinit.robot
 
-execute_robot_test scm security
+  execute_robot_test scm basic
 
-for scheme in ofs o3fs; do
-  for bucket in link bucket; do
-    execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${scheme}-${bucket} ozonefs/ozonefs.robot
+  execute_robot_test scm security
+
+  for scheme in ofs o3fs; do
+    for bucket in link bucket; do
+      execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${scheme}-${bucket} ozonefs/ozonefs.robot
+    done
   done
+
+  for bucket in link generated; do
+    execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
+  done
+
+  #expects 4 pipelines, should be run before
+  #admincli which creates STANDALONE pipeline
+  execute_robot_test scm recon
+
+  execute_robot_test scm admincli
+  execute_robot_test scm spnego
+
+  # test replication
+  docker-compose up -d --scale datanode=2
+  execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
+  docker-compose up -d --scale datanode=3
+  execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
+
+  stop_docker_env
+
+  generate_report
 done
-
-for bucket in link generated; do
-  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
-done
-
-#expects 4 pipelines, should be run before 
-#admincli which creates STANDALONE pipeline
-execute_robot_test scm recon
-
-execute_robot_test scm admincli
-execute_robot_test scm spnego
-
-# test replication
-docker-compose up -d --scale datanode=2
-execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
-docker-compose up -d --scale datanode=3
-execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
-
-stop_docker_env
-
-generate_report

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -138,6 +138,8 @@ start_docker_env(){
 
   create_results_dir
   export OZONE_SAFEMODE_MIN_DATANODES="${datanode_count}"
+
+  export OZONE_SCM_RATIS_ENABLE=${2:-false}
   docker-compose --no-ansi down
   if ! { docker-compose --no-ansi up -d --scale datanode="${datanode_count}" \
       && wait_for_safemode_exit \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use actual method parameter type when invoking a method, instead of deriving it from actual argument. (This will help when the actual arg param type is subclass, where as method param type is superclass. If we don't use actual method param type during invoke, we get MethodNotFoundException.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4985

## How was this patch tested?

Updated docker ozone-secure to run with ratis enabled.
