### PR TITLE
Deleting at bucket root throws NPE

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -496,6 +496,11 @@ public class BasicOzoneFileSystem extends FileSystem {
     String key = pathToKey(f);
     boolean result;
 
+    if (f.isRoot()) {
+      LOG.warn("Cannot delete root directory.");
+      return false;
+    }
+
     if (status.isDirectory()) {
       LOG.debug("delete: Path is a directory: {}", f);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4838

## How was this patch tested?

hdfs hdfs dfs -rm -r -skipTrash o3fs://bucket1.vol1/
WARN ozone.BasicOzoneFileSystem: Cannot delete root directory.
