### PR TITLE
HDDS-4989. Decommission CLI should return details of nodes which fail

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/DatanodeAdminError.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/DatanodeAdminError.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+/**
+ * Simple class to wrap a datanode admin host and error message.
+ */
+public class DatanodeAdminError {
+
+  private String hostname;
+  private String error;
+
+  public DatanodeAdminError(String host, String error) {
+    this.hostname = host;
+    this.error = error;
+  }
+
+  public String getHostname() {
+    return hostname;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.client;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -177,17 +178,23 @@ public interface ScmClient extends Closeable {
    * by their hostname and optionally port in the format foo.com:port.
    * @param hosts A list of hostnames, optionally with port
    * @throws IOException
+   * @return A list of DatanodeAdminError for any hosts which failed to
+   *         decommission
    */
-  void decommissionNodes(List<String> hosts) throws IOException;
+  List<DatanodeAdminError> decommissionNodes(List<String> hosts)
+      throws IOException;
 
   /**
    * Allows a list of hosts in maintenance or decommission states to be placed
    * back in service. The hosts are identified by their hostname and optionally
    * port in the format foo.com:port.
    * @param hosts A list of hostnames, optionally with port
+   * @return A list of DatanodeAdminError for any hosts which failed to
+   *         recommission
    * @throws IOException
    */
-  void recommissionNodes(List<String> hosts) throws IOException;
+  List<DatanodeAdminError> recommissionNodes(List<String> hosts)
+      throws IOException;
 
   /**
    * Place the list of datanodes into maintenance mode. If a non-zero endDtm
@@ -199,10 +206,12 @@ public interface ScmClient extends Closeable {
    * @param hosts A list of hostnames, optionally with port
    * @param endHours The number of hours from now which maintenance will end or
    *                 zero if maintenance must be manually ended.
+   * @return A list of DatanodeAdminError for any hosts which failed to
+   *         end maintenance.
    * @throws IOException
    */
-  void startMaintenanceNodes(List<String> hosts, int endHours)
-      throws IOException;
+  List<DatanodeAdminError> startMaintenanceNodes(List<String> hosts,
+      int endHours) throws IOException;
 
   /**
    * Creates a specified replication pipeline.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.protocol;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -148,12 +149,14 @@ public interface StorageContainerLocationProtocol extends Closeable {
       HddsProtos.NodeState state, HddsProtos.QueryScope queryScope,
       String poolName, int clientVersion) throws IOException;
 
-  void decommissionNodes(List<String> nodes) throws IOException;
-
-  void recommissionNodes(List<String> nodes) throws IOException;
-
-  void startMaintenanceNodes(List<String> nodes, int endInHours)
+  List<DatanodeAdminError> decommissionNodes(List<String> nodes)
       throws IOException;
+
+  List<DatanodeAdminError> recommissionNodes(List<String> nodes)
+      throws IOException;
+
+  List<DatanodeAdminError> startMaintenanceNodes(List<String> nodes,
+      int endInHours) throws IOException;
 
   /**
    * Close a container.

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -273,8 +273,14 @@ message DecommissionNodesRequestProto {
   repeated string hosts = 1;
 }
 
+
+message DatanodeAdminErrorResponseProto {
+  required string host = 1;
+  required string error = 2;
+}
+
 message DecommissionNodesResponseProto {
-  // empty response
+  repeated DatanodeAdminErrorResponseProto failedHosts = 1;
 }
 
 /*
@@ -285,7 +291,7 @@ message RecommissionNodesRequestProto {
 }
 
 message RecommissionNodesResponseProto {
-  // empty response
+  repeated DatanodeAdminErrorResponseProto failedHosts = 1;
 }
 
 /*
@@ -297,7 +303,7 @@ message StartMaintenanceNodesRequestProto {
 }
 
 message StartMaintenanceNodesResponseProto {
-  // empty response
+  repeated DatanodeAdminErrorResponseProto failedHosts = 1;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -21,6 +21,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ReplicationManager;
@@ -34,6 +35,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -213,9 +215,10 @@ public class NodeDecommissionManager {
     return monitor;
   }
 
-  public synchronized void decommissionNodes(List nodes)
-      throws InvalidHostStringException {
+  public synchronized List<DatanodeAdminError> decommissionNodes(
+      List<String> nodes) throws InvalidHostStringException {
     List<DatanodeDetails> dns = mapHostnamesToDatanodes(nodes);
+    List<DatanodeAdminError> errors = new ArrayList<>();
     for (DatanodeDetails dn : dns) {
       try {
         startDecommission(dn);
@@ -227,13 +230,13 @@ public class NodeDecommissionManager {
         // log a warning and ignore the exception
         LOG.warn("The host {} was not found in SCM. Ignoring the request to "+
             "decommission it", dn.getHostName());
+        errors.add(new DatanodeAdminError(dn.getHostName(),
+            "The host was not found in SCM"));
       } catch (InvalidNodeStateException e) {
-        // TODO - decide how to handle this. We may not want to fail all nodes
-        //        only one is in a bad state, as some nodes may have been OK
-        //        and already processed. Perhaps we should return a list of
-        //        error and feed that all the way back to the client?
+        errors.add(new DatanodeAdminError(dn.getHostName(), e.getMessage()));
       }
     }
+    return errors;
   }
 
   /**
@@ -272,9 +275,10 @@ public class NodeDecommissionManager {
     }
   }
 
-  public synchronized void recommissionNodes(List nodes)
-      throws InvalidHostStringException {
+  public synchronized List<DatanodeAdminError> recommissionNodes(
+      List<String> nodes) throws InvalidHostStringException {
     List<DatanodeDetails> dns = mapHostnamesToDatanodes(nodes);
+    List<DatanodeAdminError> errors = new ArrayList<>();
     for (DatanodeDetails dn : dns) {
       try {
         recommission(dn);
@@ -286,8 +290,11 @@ public class NodeDecommissionManager {
         // log a warning and ignore the exception
         LOG.warn("Host {} was not found in SCM. Ignoring the request to "+
             "recommission it.", dn.getHostName());
+        errors.add(new DatanodeAdminError(dn.getHostName(),
+            "The host was not found in SCM"));
       }
     }
+    return errors;
   }
 
   public synchronized void recommission(DatanodeDetails dn)
@@ -305,9 +312,10 @@ public class NodeDecommissionManager {
     }
   }
 
-  public synchronized void startMaintenanceNodes(List nodes, int endInHours)
-      throws InvalidHostStringException {
+  public synchronized List<DatanodeAdminError> startMaintenanceNodes(
+      List<String> nodes, int endInHours) throws InvalidHostStringException {
     List<DatanodeDetails> dns = mapHostnamesToDatanodes(nodes);
+    List<DatanodeAdminError> errors = new ArrayList<>();
     for (DatanodeDetails dn : dns) {
       try {
         startMaintenance(dn, endInHours);
@@ -320,12 +328,10 @@ public class NodeDecommissionManager {
         LOG.warn("The host {} was not found in SCM. Ignoring the request to "+
             "start maintenance on it", dn.getHostName());
       } catch (InvalidNodeStateException e) {
-        // TODO - decide how to handle this. We may not want to fail all nodes
-        //        only one is in a bad state, as some nodes may have been OK
-        //        and already processed. Perhaps we should return a list of
-        //        error and feed that all the way back to the client?
+        errors.add(new DatanodeAdminError(dn.getHostName(), e.getMessage()));
       }
     }
+    return errors;
   }
 
   // TODO - If startMaintenance is called on a host already in maintenance,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ClosePipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeAdminErrorResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeUsageInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DeactivatePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DeactivatePipelineResponseProto;
@@ -74,6 +75,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartReplicationManagerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StopReplicationManagerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StopReplicationManagerResponseProto;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
@@ -550,23 +552,51 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
 
   public DecommissionNodesResponseProto decommissionNodes(
       DecommissionNodesRequestProto request) throws IOException {
-    impl.decommissionNodes(request.getHostsList());
-    return DecommissionNodesResponseProto.newBuilder()
-        .build();
+    List<DatanodeAdminError> errors =
+        impl.decommissionNodes(request.getHostsList());
+    DecommissionNodesResponseProto.Builder response =
+        DecommissionNodesResponseProto.newBuilder();
+    for (DatanodeAdminError e : errors) {
+      DatanodeAdminErrorResponseProto.Builder error =
+          DatanodeAdminErrorResponseProto.newBuilder();
+      error.setHost(e.getHostname());
+      error.setError(e.getError());
+      response.addFailedHosts(error);
+    }
+    return response.build();
   }
 
   public RecommissionNodesResponseProto recommissionNodes(
       RecommissionNodesRequestProto request) throws IOException {
-    impl.recommissionNodes(request.getHostsList());
-    return RecommissionNodesResponseProto.newBuilder().build();
+    List<DatanodeAdminError> errors =
+        impl.recommissionNodes(request.getHostsList());
+    RecommissionNodesResponseProto.Builder response =
+        RecommissionNodesResponseProto.newBuilder();
+    for (DatanodeAdminError e : errors) {
+      DatanodeAdminErrorResponseProto.Builder error =
+          DatanodeAdminErrorResponseProto.newBuilder();
+      error.setHost(e.getHostname());
+      error.setError(e.getError());
+      response.addFailedHosts(error);
+    }
+    return response.build();
   }
 
   public StartMaintenanceNodesResponseProto startMaintenanceNodes(
       StartMaintenanceNodesRequestProto request) throws IOException {
-    impl.startMaintenanceNodes(request.getHostsList(),
+    List<DatanodeAdminError> errors =
+        impl.startMaintenanceNodes(request.getHostsList(),
         (int)request.getEndInHours());
-    return StartMaintenanceNodesResponseProto.newBuilder()
-        .build();
+    StartMaintenanceNodesResponseProto.Builder response =
+        StartMaintenanceNodesResponseProto.newBuilder();
+    for (DatanodeAdminError e : errors) {
+      DatanodeAdminErrorResponseProto.Builder error =
+          DatanodeAdminErrorResponseProto.newBuilder();
+      error.setHost(e.getHostname());
+      error.setError(e.getError());
+      response.addFailedHosts(error);
+    }
+    return response.build();
   }
 
   public DatanodeUsageInfoResponseProto getDatanodeUsageInfo(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ScmOps;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.ScmUtils;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -440,11 +441,12 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public void decommissionNodes(List<String> nodes) throws IOException {
+  public List<DatanodeAdminError> decommissionNodes(List<String> nodes)
+      throws IOException {
     String remoteUser = getRpcRemoteUsername();
     try {
       getScm().checkAdminAccess(remoteUser);
-      scm.getScmDecommissionManager().decommissionNodes(nodes);
+      return scm.getScmDecommissionManager().decommissionNodes(nodes);
     } catch (Exception ex) {
       LOG.error("Failed to decommission nodes", ex);
       throw ex;
@@ -452,11 +454,12 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public void recommissionNodes(List<String> nodes) throws IOException {
+  public List<DatanodeAdminError> recommissionNodes(List<String> nodes)
+      throws IOException {
     String remoteUser = getRpcRemoteUsername();
     try {
       getScm().checkAdminAccess(remoteUser);
-      scm.getScmDecommissionManager().recommissionNodes(nodes);
+      return scm.getScmDecommissionManager().recommissionNodes(nodes);
     } catch (Exception ex) {
       LOG.error("Failed to recommission nodes", ex);
       throw ex;
@@ -464,12 +467,13 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public void startMaintenanceNodes(List<String> nodes, int endInHours)
-      throws IOException {
+  public List<DatanodeAdminError> startMaintenanceNodes(List<String> nodes,
+      int endInHours) throws IOException {
     String remoteUser = getRpcRemoteUsername();
     try {
       getScm().checkAdminAccess(remoteUser);
-      scm.getScmDecommissionManager().startMaintenanceNodes(nodes, endInHours);
+      return scm.getScmDecommissionManager()
+          .startMaintenanceNodes(nodes, endInHours);
     } catch (Exception ex) {
       LOG.error("Failed to place nodes into maintenance mode", ex);
       throw ex;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.HddsTestUtils;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -229,18 +230,18 @@ public class TestNodeDecommissionManager {
         nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
 
     // Try to go from maint to decom:
-    try {
-      decom.startDecommission(dns.get(1));
-      fail("Expected InvalidNodeStateException");
-    } catch (InvalidNodeStateException e) {
-    }
+    List<String> dn = new ArrayList<>();
+    dn.add(dns.get(1).getIpAddress());
+    List<DatanodeAdminError> errors = decom.decommissionNodes(dn);
+    assertEquals(1, errors.size());
+    assertEquals(dns.get(1).getHostName(), errors.get(0).getHostname());
 
     // Try to go from decom to maint:
-    try {
-      decom.startMaintenance(dns.get(2), 100);
-      fail("Expected InvalidNodeStateException");
-    } catch (InvalidNodeStateException e) {
-    }
+    dn = new ArrayList<>();
+    dn.add(dns.get(2).getIpAddress());
+    errors = decom.startMaintenanceNodes(dn, 100);
+    assertEquals(1, errors.size());
+    assertEquals(dns.get(2).getHostName(), errors.get(0).getHostname());
 
     // Ensure the states are still as before
     assertEquals(HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE,
@@ -248,8 +249,6 @@ public class TestNodeDecommissionManager {
     assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONING,
         nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
   }
-
-
 
   private SCMNodeManager createNodeManager(OzoneConfiguration config)
       throws IOException, AuthenticationException {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.protocol.SCMSecurityProtocol;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
@@ -280,19 +281,22 @@ public class ContainerOperationClient implements ScmClient {
   }
 
   @Override
-  public void decommissionNodes(List<String> hosts) throws IOException {
-    storageContainerLocationClient.decommissionNodes(hosts);
-  }
-
-  @Override
-  public void recommissionNodes(List<String> hosts) throws IOException {
-    storageContainerLocationClient.recommissionNodes(hosts);
-  }
-
-  @Override
-  public void startMaintenanceNodes(List<String> hosts, int endHours)
+  public List<DatanodeAdminError> decommissionNodes(List<String> hosts)
       throws IOException {
-    storageContainerLocationClient.startMaintenanceNodes(hosts, endHours);
+    return storageContainerLocationClient.decommissionNodes(hosts);
+  }
+
+  @Override
+  public List<DatanodeAdminError> recommissionNodes(List<String> hosts)
+      throws IOException {
+    return storageContainerLocationClient.recommissionNodes(hosts);
+  }
+
+  @Override
+  public List<DatanodeAdminError> startMaintenanceNodes(List<String> hosts,
+      int endHours) throws IOException {
+    return storageContainerLocationClient.startMaintenanceNodes(
+        hosts, endHours);
   }
 
   /**

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/MaintenanceSubCommand.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
@@ -51,9 +52,20 @@ public class MaintenanceSubCommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     if (hosts.size() > 0) {
-      scmClient.startMaintenanceNodes(hosts, endInHours);
+      List<DatanodeAdminError> errors =
+          scmClient.startMaintenanceNodes(hosts, endInHours);
       System.out.println("Entering maintenance mode on datanode(s):\n" +
           String.join("\n", hosts));
+      if (errors.size() > 0) {
+        for (DatanodeAdminError error : errors) {
+          System.err.println("Error: " + error.getHostname() +": "
+              + error.getError());
+        }
+        // Throwing the exception will cause a non-zero exit status for the
+        // command.
+        throw new IOException(
+            "Some nodes could not start the maintenance workflow");
+      }
     } else {
       GenericCli.missingSubcommand(spec);
     }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.mockito.Mockito;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests to validate the the DecommissionSubCommand class includes the
+ * correct output when executed against a mock client.
+ */
+public class TestDecommissionSubCommand {
+
+  private DecommissionSubCommand cmd;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  @Before
+  public void setup() throws UnsupportedEncodingException {
+    cmd = new DecommissionSubCommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testNoErrorsWhenDecommissioning() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.decommissionNodes(anyListOf(String.class)))
+        .thenAnswer(invocation -> new ArrayList<DatanodeAdminError>());
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    cmd.execute(scmClient);
+
+    Pattern p = Pattern.compile(
+        "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+  @Test
+  public void testErrorsReportedWhenDecommissioning() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.decommissionNodes(anyListOf(String.class)))
+        .thenAnswer(invocation -> {
+          ArrayList<DatanodeAdminError> e = new ArrayList<>();
+          e.add(new DatanodeAdminError("host1", "host1 error"));
+          return e;
+        });
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    try {
+      cmd.execute(scmClient);
+      fail("Should not succeed without an exception");
+    } catch (IOException e) {
+       // Expected
+    }
+
+    Pattern p = Pattern.compile(
+        "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
+    m = p.matcher(errContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+}

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.mockito.Mockito;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests to validate the the DecommissionSubCommand class includes the
+ * correct output when executed against a mock client.
+ */
+public class TestMaintenanceSubCommand {
+
+  private MaintenanceSubCommand cmd;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  @Before
+  public void setup() throws UnsupportedEncodingException {
+    cmd = new MaintenanceSubCommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testNoErrorsWhenEnteringMaintenance() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.startMaintenanceNodes(
+        anyListOf(String.class), anyInt()))
+        .thenAnswer(invocation -> new ArrayList<DatanodeAdminError>());
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    cmd.execute(scmClient);
+
+    Pattern p = Pattern.compile(
+        "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
+        Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+  @Test
+  public void testErrorsReportedWhenEnteringMaintenance() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.startMaintenanceNodes(
+        anyListOf(String.class), anyInt()))
+        .thenAnswer(invocation -> {
+          ArrayList<DatanodeAdminError> e = new ArrayList<>();
+          e.add(new DatanodeAdminError("host1", "host1 error"));
+          return e;
+        });
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    try {
+      cmd.execute(scmClient);
+      fail("Should not succeed without an exception");
+    } catch (IOException e) {
+      // Expected
+    }
+
+    Pattern p = Pattern.compile(
+        "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
+        Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
+    m = p.matcher(errContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+}

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.datanode;
+
+import org.apache.hadoop.hdds.scm.DatanodeAdminError;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.mockito.Mockito;
+import picocli.CommandLine;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.anyListOf;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests to validate the the RecommissionSubCommand class includes the
+ * correct output when executed against a mock client.
+ */
+public class TestRecommissionSubCommand {
+
+  private RecommissionSubCommand cmd;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  @Before
+  public void setup() throws UnsupportedEncodingException {
+    cmd = new RecommissionSubCommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testNoErrorsWhenRecommissioning() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.recommissionNodes(anyListOf(String.class)))
+        .thenAnswer(invocation -> new ArrayList<DatanodeAdminError>());
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    cmd.execute(scmClient);
+
+    Pattern p = Pattern.compile(
+        "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+  @Test
+  public void testErrorsReportedWhenRecommissioning() throws IOException  {
+    ScmClient scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.recommissionNodes(anyListOf(String.class)))
+        .thenAnswer(invocation -> {
+          ArrayList<DatanodeAdminError> e = new ArrayList<>();
+          e.add(new DatanodeAdminError("host1", "host1 error"));
+          return e;
+        });
+
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("host1", "host2");
+    try {
+      cmd.execute(scmClient);
+      fail("Should not succeed without an exception");
+    } catch (IOException e) {
+      // Expected
+    }
+
+    Pattern p = Pattern.compile(
+        "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
+    Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host1$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^host2$", Pattern.MULTILINE);
+    m = p.matcher(outContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+
+    p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
+    m = p.matcher(errContent.toString(DEFAULT_ENCODING));
+    assertTrue(m.find());
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

With the current decommission / recommission / maintenance mode commands, you can pass a list of hosts to perform the operation on. If any of these hosts fail to enter the decommission / maintenance workflow, the command gives no feedback about the error. Some of the hosts can silently fail and the only way to know is to inspect the SCM log.

The most common way a host can fail, is if a node which is undergoing maintenance is instructed to go to decommission and vice versa as this is a transition which is not allowed.

This change will allow any failed nodes to feed back to the client. If the client detects that any of the nodes have failed, details will be written to stderr and the command exit code will be non-zero.

Note that even though the exit code is non-zero, the command may have partially worked.

Also note that the errors which are fed back are only around transitioning the node into the admin workflow - it is still possible for it to fail later for other reasons which will not be fed back to the client. This is because the client does not wait for the process to complete, but exits after confirmation the command has been processed by scm.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4989

## How was this patch tested?

New unit tests and validated manually using docker
