### PR TITLE
HDDS-4995. Skip CI for draft pull requests

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -15,6 +15,7 @@
 name: build-branch
 on:
   pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
   push:
   schedule:
     - cron: 30 0,12 * * *
@@ -23,6 +24,7 @@ env:
 jobs:
   compile:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         java: [ 8, 11 ]
@@ -66,6 +68,7 @@ jobs:
         if: always()
   bats:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -89,6 +92,7 @@ jobs:
         continue-on-error: true
   rat:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -108,6 +112,7 @@ jobs:
         continue-on-error: true
   author:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -125,6 +130,7 @@ jobs:
         continue-on-error: true
   unit:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -144,6 +150,7 @@ jobs:
         continue-on-error: true
   checkstyle:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -163,6 +170,7 @@ jobs:
         continue-on-error: true
   findbugs:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
@@ -183,6 +191,7 @@ jobs:
   acceptance:
     needs: compile
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         suite:
@@ -228,6 +237,7 @@ jobs:
         continue-on-error: true
   integration:
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
         profile:
@@ -294,6 +304,7 @@ jobs:
   kubernetes:
     needs: compile
     runs-on: ubuntu-18.04
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project
         uses: actions/checkout@v2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Github pull requests can be created as (or converted to) draft. This is useful for gathering early feedback from other contributors about proof-of-concept code. Such code may not even compile, and style issues are usually ignored.

Since further commits are generally expected in this case, I think it makes sense to skip CI build/test until the PR is marked as "ready for review".  The goal is to save CI cycles for other issues.

If CI feedback is desired, the author should enable workflows in their fork so we can check push builds there.

https://issues.apache.org/jira/browse/HDDS-4995

## How was this patch tested?

Tested with a draft PR in my fork: https://github.com/adoroszlai/hadoop-ozone/pull/12

Builds:
 * commit 1
   * push: https://github.com/adoroszlai/hadoop-ozone/actions/runs/665327555 (cancelled manually)
   * PR: https://github.com/adoroszlai/hadoop-ozone/actions/runs/665361303
 * commit 2
   * push: https://github.com/adoroszlai/hadoop-ozone/actions/runs/665365286 (cancelled manually)
   * PR: https://github.com/adoroszlai/hadoop-ozone/actions/runs/665366214
 * "ready for review"
   * https://github.com/adoroszlai/hadoop-ozone/actions/runs/665370947 (cancelled manually)

Also with this PR:
 * draft: https://github.com/apache/ozone/actions/runs/665634620
 * "ready for review": https://github.com/apache/ozone/actions/runs/665636793