### PR TITLE
HDDS-4996. Upgrade kotlin-stdlib

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -172,6 +172,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>jaeger-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.opentracing</groupId>
       <artifactId>opentracing-util</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1345,6 +1345,17 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>io.jaegertracing</groupId>
         <artifactId>jaeger-client</artifactId>
         <version>${jaeger.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.4.31</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade `kotlin-stdlib`, transitive dependency via `jaeger-client`, to 1.4.31 (latest release).

https://issues.apache.org/jira/browse/HDDS-4996

## How was this patch tested?

Verified Jaeger tracing still works OK:

```
cd hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/compose/ozone
export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
docker-compose up -d --scale datanode=3
# wait
docker-compose exec scm ozone freon ockg -n1 -t1
open http://localhost:16686/
```

Verified JARs in Ozone package:

```
$ ls -1 hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/share/ozone/lib/*kotlin*
hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/share/ozone/lib/kotlin-stdlib-1.4.31.jar
hadoop-ozone/dist/target/ozone-1.1.0-SNAPSHOT/share/ozone/lib/kotlin-stdlib-common-1.4.31.jar
```