### PR TITLE
HDDS-4553. ChunkInputStream should release buffer as soon as last byte in the buffer is read

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.hdds.scm.storage;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.CanUnbuffer;
 import org.apache.hadoop.fs.Seekable;

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -647,7 +647,7 @@ public class ChunkInputStream extends InputStream
 
 
   /**
-   * Release a buffers upto the given index.
+   * Release the buffers upto the given index.
    * @param releaseUptoBufferIndex bufferIndex (inclusive) upto which the
    *                               buffers must be released
    */

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -410,10 +410,7 @@ public class ChunkInputStream extends InputStream
     } else if (readChunkResponse.hasDataBuffers()) {
       List<ByteString> buffersList = readChunkResponse.getDataBuffers()
           .getBuffersList();
-      return buffersList.stream()
-          .map(ByteString::asReadOnlyByteBuffer)
-          .collect(Collectors.toList())
-          .toArray(new ByteBuffer[0]);
+      return BufferUtils.getReadOnlyByteBuffersArray(buffersList);
     } else {
       throw new IOException("Unexpected error while reading chunk data " +
           "from container. No data returned.");

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyChunkInputStream.java
@@ -50,7 +50,7 @@ public class DummyChunkInputStream extends ChunkInputStream {
   }
 
   @Override
-  protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo) {
+  protected ByteBuffer[] readChunk(ChunkInfo readChunkInfo) {
     int offset = (int) readChunkInfo.getOffset();
     int remainingToRead = (int) readChunkInfo.getLen();
 
@@ -72,7 +72,8 @@ public class DummyChunkInputStream extends ChunkInputStream {
       remainingToRead -= bufferLen;
     }
 
-    return BufferUtils.getReadOnlyByteBuffers(readByteBuffers);
+    return BufferUtils.getReadOnlyByteBuffers(readByteBuffers)
+        .toArray(new ByteBuffer[0]);
   }
 
   @Override

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -229,8 +229,9 @@ public class TestChunkInputStream {
     ChunkInputStream subject = new ChunkInputStream(chunkInfo, null,
         clientFactory, pipelineRef::get, false, null) {
       @Override
-      protected List<ByteBuffer> readChunk(ChunkInfo readChunkInfo) {
-        return ByteString.copyFrom(chunkData).asReadOnlyByteBufferList();
+      protected ByteBuffer[] readChunk(ChunkInfo readChunkInfo) {
+        return ByteString.copyFrom(chunkData).asReadOnlyByteBufferList()
+            .toArray(new ByteBuffer[0]);
       }
     };
 

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/TestChunkInputStream.java
@@ -172,16 +172,26 @@ public class TestChunkInputStream {
     // buffers and the chunkPosition should be reset to -1.
     Assert.assertEquals(-1, chunkStream.getChunkPosition());
 
-    // Seek to a position within the current buffers. Current buffers contain
-    // data from index 20 to 59. ChunkPosition should still not be used to
-    // set the position.
-    seekAndVerify(35);
+    // Only the last BYTES_PER_CHECKSUM will be cached in the buffers as
+    // buffers are released after each checksum boundary is read. So the
+    // buffers should contain data from index 40 to 59.
+    // Seek to a position within the cached buffers. ChunkPosition should
+    // still not be used to set the position.
+    seekAndVerify(45);
     Assert.assertEquals(-1, chunkStream.getChunkPosition());
 
-    // Seek to a position outside the current buffers. In this case, the
+    // Seek to a position outside the current cached buffers. In this case, the
     // chunkPosition should be updated to the seeked position.
     seekAndVerify(75);
     Assert.assertEquals(75, chunkStream.getChunkPosition());
+
+    // Read upto checksum boundary should result in all the buffers being
+    // released and hence chunkPosition updated with current position of chunk.
+    seekAndVerify(25);
+    b = new byte[15];
+    chunkStream.read(b, 0, 15);
+    matchWithInputData(b, 25, 15);
+    Assert.assertEquals(40, chunkStream.getChunkPosition());
   }
 
   @Test

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
@@ -21,7 +21,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.stream.Collectors;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.io.IOException;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
@@ -218,13 +218,21 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
 
   @Override
   public ByteString toByteStringImpl(Function<ByteBuffer, ByteString> f) {
-    return buffers.stream().map(f).reduce(ByteString.EMPTY, ByteString::concat);
+    ByteString result = ByteString.EMPTY;
+    for (ByteBuffer buffer : buffers) {
+      result = result.concat(f.apply(buffer));
+    }
+    return result;
   }
 
   @Override
   public List<ByteString> toByteStringListImpl(
       Function<ByteBuffer, ByteString> f) {
-    return buffers.stream().map(f).collect(Collectors.toList());
+    List<ByteString> byteStringList = new ArrayList<>();
+    for (ByteBuffer buffer : buffers) {
+      byteStringList.add(f.apply(buffer));
+    }
+    return byteStringList;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.ozone.common;
 
 import com.google.common.base.Preconditions;
-import java.util.stream.Collectors;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 
 import java.io.IOException;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/IncrementalChunkBuffer.java
@@ -271,13 +271,21 @@ final class IncrementalChunkBuffer implements ChunkBuffer {
 
   @Override
   public ByteString toByteStringImpl(Function<ByteBuffer, ByteString> f) {
-    return buffers.stream().map(f).reduce(ByteString.EMPTY, ByteString::concat);
+    ByteString result = ByteString.EMPTY;
+    for (ByteBuffer buffer : buffers) {
+      result = result.concat(f.apply(buffer));
+    }
+    return result;
   }
 
   @Override
   public List<ByteString> toByteStringListImpl(
       Function<ByteBuffer, ByteString> f) {
-    return buffers.stream().map(f).collect(Collectors.toList());
+    List<ByteString> byteStringList = new ArrayList<>();
+    for (ByteBuffer buffer : buffers) {
+      byteStringList.add(f.apply(buffer));
+    }
+    return byteStringList;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -76,9 +76,13 @@ public final class BufferUtils {
    */
   public static ByteBuffer[] getReadOnlyByteBuffers(
       ByteBuffer[] byteBuffers) {
+    if (byteBuffers == null) {
+      return null;
+    }
     ByteBuffer[] readOnlyBuffers = new ByteBuffer[byteBuffers.length];
     for (int i = 0; i < byteBuffers.length; i++) {
-      readOnlyBuffers[i] = byteBuffers[i].asReadOnlyBuffer();
+      readOnlyBuffers[i] = byteBuffers[i] == null ?
+          null : byteBuffers[i].asReadOnlyBuffer();
     }
     return readOnlyBuffers;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -72,6 +72,18 @@ public final class BufferUtils {
   }
 
   /**
+   * Return a read only copy of ByteBuffer array.
+   */
+  public static ByteBuffer[] getReadOnlyByteBuffers(
+      ByteBuffer[] byteBuffers) {
+    ByteBuffer[] readOnlyBuffers = new ByteBuffer[byteBuffers.length];
+    for (int i = 0; i < byteBuffers.length; i++) {
+      readOnlyBuffers[i] = byteBuffers[i].asReadOnlyBuffer();
+    }
+    return readOnlyBuffers;
+  }
+
+  /**
    * Return a read only ByteBuffer array for the input ByteStrings list.
    */
   public static ByteBuffer[] getReadOnlyByteBuffersArray(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/utils/BufferUtils.java
@@ -71,8 +71,20 @@ public final class BufferUtils {
     return buffers;
   }
 
+  /**
+   * Return a read only ByteBuffer array for the input ByteStrings list.
+   */
+  public static ByteBuffer[] getReadOnlyByteBuffersArray(
+      List<ByteString> byteStrings) {
+    return getReadOnlyByteBuffers(byteStrings).toArray(new ByteBuffer[0]);
+  }
+
   public static ByteString concatByteStrings(List<ByteString> byteStrings) {
-    return byteStrings.stream().reduce(ByteString::concat).orElse(null);
+    ByteString result = ByteString.EMPTY;
+    for (ByteString byteString : byteStrings) {
+      result = result.concat(byteString);
+    }
+    return result;
   }
 
   /**
@@ -95,5 +107,11 @@ public final class BufferUtils {
    */
   public static int getNumberOfBins(long numElements, long maxElementsPerBin) {
     return (int) Math.ceil((double) numElements / (double) maxElementsPerBin);
+  }
+
+  public static void clearBuffers(ByteBuffer[] byteBuffers) {
+    for (ByteBuffer buffer : byteBuffers) {
+      buffer.clear();
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -152,7 +152,7 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     long len = info.getLen();
     long offset = info.getOffset();
-    long bufferCapacity = getBufferCapacityForChunkRead(info,
+    long bufferCapacity =  ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -153,30 +153,8 @@ public class FilePerBlockStrategy implements ChunkManager {
 
     long len = info.getLen();
     long offset = info.getOffset();
-
-    long bufferCapacity = 0;
-    if (info.isReadDataIntoSingleBuffer()) {
-      // Older client - read all chunk data into one single buffer.
-      bufferCapacity = len;
-    } else {
-      // Set buffer capacity to checksum boundary size so that each buffer
-      // corresponds to one checksum. If checksum is NONE, then set buffer
-      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
-      ChecksumData checksumData = info.getChecksumData();
-
-      if (checksumData != null) {
-        if (checksumData.getChecksumType() ==
-            ContainerProtos.ChecksumType.NONE) {
-          bufferCapacity = defaultReadBufferCapacity;
-        } else {
-          bufferCapacity = checksumData.getBytesPerChecksum();
-        }
-      }
-    }
-    // If the buffer capacity is 0, set all the data into one ByteBuffer
-    if (bufferCapacity == 0) {
-      bufferCapacity = len;
-    }
+    long bufferCapacity = getBufferCapacityForChunkRead(info,
+        defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
         bufferCapacity);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
-import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -228,30 +228,8 @@ public class FilePerChunkStrategy implements ChunkManager {
     }
 
     long len = info.getLen();
-
-    long bufferCapacity = 0;
-    if (info.isReadDataIntoSingleBuffer()) {
-      // Older client - read all chunk data into one single buffer.
-      bufferCapacity = len;
-    } else {
-      // Set buffer capacity to checksum boundary size so that each buffer
-      // corresponds to one checksum. If checksum is NONE, then set buffer
-      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
-      ChecksumData checksumData = info.getChecksumData();
-
-      if (checksumData != null) {
-        if (checksumData.getChecksumType() ==
-            ContainerProtos.ChecksumType.NONE) {
-          bufferCapacity = defaultReadBufferCapacity;
-        } else {
-          bufferCapacity = checksumData.getBytesPerChecksum();
-        }
-      }
-    }
-    // If the buffer capacity is 0, set all the data into one ByteBuffer
-    if (bufferCapacity == 0) {
-      bufferCapacity = len;
-    }
+    long bufferCapacity = getBufferCapacityForChunkRead(info,
+        defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
         bufferCapacity);
@@ -296,7 +274,7 @@ public class FilePerChunkStrategy implements ChunkManager {
         if (ex.getResult() != UNABLE_TO_FIND_CHUNK) {
           throw ex;
         }
-        dataBuffers = null;
+        BufferUtils.clearBuffers(dataBuffers);
       }
     }
     throw new StorageContainerException(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -227,7 +227,7 @@ public class FilePerChunkStrategy implements ChunkManager {
     }
 
     long len = info.getLen();
-    long bufferCapacity = getBufferCapacityForChunkRead(info,
+    long bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -104,7 +104,7 @@ public interface ChunkManager {
     // no-op
   }
 
-  default long getBufferCapacityForChunkRead(ChunkInfo chunkInfo,
+  static long getBufferCapacityForChunkRead(ChunkInfo chunkInfo,
       long defaultReadBufferCapacity) {
     long bufferCapacity = 0;
     if (chunkInfo.isReadDataIntoSingleBuffer()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/ChunkManager.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.ozone.container.keyvalue.interfaces;
  */
 
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -100,5 +102,34 @@ public interface ChunkManager {
   default void finishWriteChunks(KeyValueContainer kvContainer,
       BlockData blockData) throws IOException {
     // no-op
+  }
+
+  default long getBufferCapacityForChunkRead(ChunkInfo chunkInfo,
+      long defaultReadBufferCapacity) {
+    long bufferCapacity = 0;
+    if (chunkInfo.isReadDataIntoSingleBuffer()) {
+      // Older client - read all chunk data into one single buffer.
+      bufferCapacity = chunkInfo.getLen();
+    } else {
+      // Set buffer capacity to checksum boundary size so that each buffer
+      // corresponds to one checksum. If checksum is NONE, then set buffer
+      // capacity to default (OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY = 64KB).
+      ChecksumData checksumData = chunkInfo.getChecksumData();
+
+      if (checksumData != null) {
+        if (checksumData.getChecksumType() ==
+            ContainerProtos.ChecksumType.NONE) {
+          bufferCapacity = defaultReadBufferCapacity;
+        } else {
+          bufferCapacity = checksumData.getBytesPerChecksum();
+        }
+      }
+    }
+    // If the buffer capacity is 0, set all the data into one ByteBuffer
+    if (bufferCapacity == 0) {
+      bufferCapacity = chunkInfo.getLen();
+    }
+
+    return bufferCapacity;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -56,12 +56,12 @@ public class TestChunkInputStream extends TestInputStreamBase {
     // To read 1 byte of chunk data, ChunkInputStream should get one full
     // checksum boundary worth of data from Container and store it in buffers.
     chunk0Stream.read(new byte[1]);
-    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1,
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
         BYTES_PER_CHECKSUM);
 
     // Read > checksum boundary of data from chunk0
     int readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
-    byte[] readData = readDataFromChunk(chunk0Stream, readDataLen, 0);
+    byte[] readData = readDataFromChunk(chunk0Stream, 0, readDataLen);
     validateData(inputData, 0, readData);
 
     // The first checksum boundary size of data was already existing in the
@@ -69,52 +69,138 @@ public class TestChunkInputStream extends TestInputStreamBase {
     // boundary size of data will be fetched again to read the remaining data.
     // Hence there should be 1 checksum boundary size of data stored in the
     // ChunkStreams buffers at the end of the read.
-    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1,
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
         BYTES_PER_CHECKSUM);
 
     // Seek to a position in the third checksum boundary (so that current
     // buffers do not have the seeked position) and read > BYTES_PER_CHECKSUM
     // bytes of data. This should result in 2 * BYTES_PER_CHECKSUM amount of
-    // data being read into the buffers. There should be 2 buffers each with
-    // BYTES_PER_CHECKSUM capacity.
+    // data being read into the buffers. There should be 2 buffers in the
+    // stream but the the first buffer should be released after it is read
+    // and the second buffer should have BYTES_PER_CHECKSUM capacity.
     readDataLen = BYTES_PER_CHECKSUM + (BYTES_PER_CHECKSUM / 2);
     int offset = 2 * BYTES_PER_CHECKSUM + 1;
-    readData = readDataFromChunk(chunk0Stream, readDataLen, offset);
+    readData = readDataFromChunk(chunk0Stream, offset, readDataLen);
     validateData(inputData, offset, readData);
-    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 2,
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 2, 1,
         BYTES_PER_CHECKSUM);
 
 
-    // Read the full chunk data -1 and verify that all chunk data is read into
-    // buffers. We read CHUNK_SIZE - 1 as otherwise the buffers will be
+    // Read the full chunk data - 1 and verify that all chunk data is read into
+    // buffers. We read CHUNK_SIZE - 1 as otherwise all the buffers will be
     // released once all chunk data is read.
-    readData = readDataFromChunk(chunk0Stream, CHUNK_SIZE - 1, 0);
+    readData = readDataFromChunk(chunk0Stream, 0, CHUNK_SIZE - 1);
     validateData(inputData, 0, readData);
+    int expectedNumBuffers = CHUNK_SIZE / BYTES_PER_CHECKSUM;
     checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(),
-        CHUNK_SIZE / BYTES_PER_CHECKSUM, BYTES_PER_CHECKSUM);
+        expectedNumBuffers, expectedNumBuffers - 1, BYTES_PER_CHECKSUM);
 
     // Read the last byte of chunk and verify that the buffers are released.
     chunk0Stream.read(new byte[1]);
     Assert.assertNull("ChunkInputStream did not release buffers after " +
         "reaching EOF.", chunk0Stream.getCachedBuffers());
+  }
 
+  /**
+   * Test that ChunkInputStream buffers are released as soon as the last byte
+   * of the buffer is read.
+   */
+  @Test
+  public void testBufferRelease() throws Exception {
+    String keyName = getNewKeyName();
+    int dataLength = CHUNK_SIZE;
+    byte[] inputData = writeRandomBytes(keyName, dataLength);
+
+    KeyInputStream keyInputStream = getKeyInputStream(keyName);
+
+    BlockInputStream block0Stream = keyInputStream.getBlockStreams().get(0);
+    block0Stream.initialize();
+
+    ChunkInputStream chunk0Stream = block0Stream.getChunkStreams().get(0);
+
+    // Read checksum boundary - 1 bytes of data
+    int readDataLen = BYTES_PER_CHECKSUM - 1;
+    byte[] readData = readDataFromChunk(chunk0Stream, 0, readDataLen);
+    validateData(inputData, 0, readData);
+
+    // There should be 1 byte of data remaining in the buffer which is not
+    // yet read. Hence, the buffer should not be released.
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(),
+        1, 0, BYTES_PER_CHECKSUM);
+    Assert.assertEquals(1, chunk0Stream.getCachedBuffers()[0].remaining());
+
+    // Reading the last byte in the buffer should result in all the buffers
+    // being released.
+    readData = readDataFromChunk(chunk0Stream, 1);
+    validateData(inputData, readDataLen, readData);
+    Assert.assertNull("Chunk stream buffers not released after last byte is " +
+        "read", chunk0Stream.getCachedBuffers());
+
+    // Read more data to get the data till the next checksum boundary.
+    readDataLen = BYTES_PER_CHECKSUM / 2;
+    readData = readDataFromChunk(chunk0Stream, readDataLen);
+    // There should be one buffer and the buffer should not be released as
+    // there is data pending to be read from the buffer
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
+        BYTES_PER_CHECKSUM);
+    ByteBuffer lastCachedBuffer = chunk0Stream.getCachedBuffers()[0];
+    Assert.assertEquals(BYTES_PER_CHECKSUM - readDataLen,
+        lastCachedBuffer.remaining());
+
+    // Read more than the remaining data in buffer (but less than the next
+    // checksum boundary).
+    int position = (int) chunk0Stream.getPos();
+    readDataLen = lastCachedBuffer.remaining() + BYTES_PER_CHECKSUM / 2;
+    readData = readDataFromChunk(chunk0Stream, readDataLen);
+    validateData(inputData, position, readData);
+    // After reading the remaining data in the buffer, the buffer should be
+    // released and next checksum size of data must be read into the buffers
+    checkBufferSizeAndCapacity(chunk0Stream.getCachedBuffers(), 1, 0,
+        BYTES_PER_CHECKSUM);
+    // Verify that the previously cached buffer is released by comparing it
+    // with the current cached buffer
+    Assert.assertNotEquals(lastCachedBuffer,
+        chunk0Stream.getCachedBuffers()[0]);
   }
 
   private byte[] readDataFromChunk(ChunkInputStream chunkInputStream,
-      int readDataLength, int offset) throws IOException {
+      int offset, int readDataLength) throws IOException {
     byte[] readData = new byte[readDataLength];
     chunkInputStream.seek(offset);
     chunkInputStream.read(readData, 0, readDataLength);
     return readData;
   }
 
-  private void checkBufferSizeAndCapacity(List<ByteBuffer> buffers,
-      int expectedNumBuffers, long expectedBufferCapacity) {
+  private byte[] readDataFromChunk(ChunkInputStream chunkInputStream,
+      int readDataLength) throws IOException {
+    byte[] readData = new byte[readDataLength];
+    chunkInputStream.read(readData, 0, readDataLength);
+    return readData;
+  }
+
+  /**
+   * Verify number of buffers and their capacities
+   * @param buffers chunk stream buffers
+   * @param expectedNumBuffers expected number of buffers
+   * @param numReleasedBuffers first numReleasedBuffers are expected to
+   *                           be released and hence null
+   * @param expectedBufferCapacity expected buffer capacity of unreleased
+   *                               buffers
+   */
+  private void checkBufferSizeAndCapacity(ByteBuffer[] buffers,
+      int expectedNumBuffers, int numReleasedBuffers,
+      long expectedBufferCapacity) {
     Assert.assertEquals("ChunkInputStream does not have expected number of " +
-        "ByteBuffers", expectedNumBuffers, buffers.size());
-    for (ByteBuffer buffer : buffers) {
-      Assert.assertEquals("ChunkInputStream ByteBuffer capacity is wrong",
-          expectedBufferCapacity, buffer.capacity());
+        "ByteBuffers", expectedNumBuffers, buffers.length);
+    for (int i = 0; i < buffers.length; i++) {
+      if (i <= numReleasedBuffers - 1) {
+        // This buffer should have been released and hence null
+        Assert.assertNull("ChunkInputStream Buffer not released after being " +
+            "read", buffers[i]);
+      } else {
+        Assert.assertEquals("ChunkInputStream ByteBuffer capacity is wrong",
+            expectedBufferCapacity, buffers[i].capacity());
+      }
     }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestChunkInputStream.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.client.rpc.read;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.scm.storage.ChunkInputStream;
 import org.apache.hadoop.ozone.client.io.KeyInputStream;
@@ -179,7 +178,7 @@ public class TestChunkInputStream extends TestInputStreamBase {
   }
 
   /**
-   * Verify number of buffers and their capacities
+   * Verify number of buffers and their capacities.
    * @param buffers chunk stream buffers
    * @param expectedNumBuffers expected number of buffers
    * @param numReleasedBuffers first numReleasedBuffers are expected to


### PR DESCRIPTION
## What changes were proposed in this pull request?

We currently wait for reading up till the Chunk EOF before releasing the buffers in ChunkInputStream (or when the stream is closed). Let's say a client reads first 3 MB of a chunk  of size 4MB and does not close the stream immediately. This would lead to the 3MB of data being cached in the ChunkInputStream buffers till the stream is closed.

After HDDS-4552, a chunk read from DN would return the chunk data as an array of ByteBuffers. After each ByteBuffer is read, it can be released. This would greatly help with optimizing memory usage of ChunkInputStream.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4553

## How was this patch tested?

Added unit tests