### PR TITLE
HDDS-4998. [SCM HA Security] Make storeValidCertificate method idempotent

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -55,6 +55,14 @@ public interface CertificateStore {
       X509Certificate certificate, NodeType role) throws IOException;
 
   /**
+   * Check certificate serialID exists or not. If exists throws an exception.
+   * @param serialID
+   * @throws IOException
+   */
+  void checkValidCertID(BigInteger serialID) throws IOException;
+
+
+  /**
    * Adds the certificates to be revoked to a new CRL and moves all the
    * certificates in a transactional manner from valid certificate to
    * revoked certificate state. Returns an empty {@code Optional} instance if

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.PKIProfile;
@@ -158,6 +157,8 @@ public class DefaultApprover extends BaseApprover {
   }
 
   public long generateSerialId() {
+    // TODO: to make generation of serialId distributed.
+    // This issue will be fixed in HDDS-4999.
     return Time.monotonicNowNanos();
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
@@ -19,6 +19,8 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.PKIProfile;
@@ -48,6 +50,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.util.Date;
+import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -89,7 +92,8 @@ public class DefaultApprover extends BaseApprover {
       Date validTill,
       PKCS10CertificationRequest certificationRequest,
       String scmId,
-      String clusterId) throws IOException, OperatorCreationException {
+      String clusterId) throws IOException,
+      OperatorCreationException {
 
     AlgorithmIdentifier sigAlgId = new
         DefaultSignatureAlgorithmIdentifierFinder().find(
@@ -135,7 +139,7 @@ public class DefaultApprover extends BaseApprover {
         new X509v3CertificateBuilder(
             caCertificate.getSubject(),
             // Serial is not sequential but it is monotonically increasing.
-            BigInteger.valueOf(Time.monotonicNowNanos()),
+            BigInteger.valueOf(generateSerialId()),
             validFrom,
             validTill,
             x500Name, keyInfo);
@@ -153,6 +157,11 @@ public class DefaultApprover extends BaseApprover {
 
     return certificateGenerator.build(sigGen);
 
+  }
+
+  public synchronized long generateSerialId() {
+   return Time.monotonicNowNanos() + RandomUtils.nextLong(0,
+       Time.monotonicNowNanos());
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/DefaultApprover.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
-import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -50,7 +49,6 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.util.Date;
-import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -159,9 +157,8 @@ public class DefaultApprover extends BaseApprover {
 
   }
 
-  public synchronized long generateSerialId() {
-   return Time.monotonicNowNanos() + RandomUtils.nextLong(0,
-       Time.monotonicNowNanos());
+  public long generateSerialId() {
+    return Time.monotonicNowNanos();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -43,6 +43,11 @@ public class MockCAStore implements CertificateStore {
   }
 
   @Override
+  public void checkValidCertID(BigInteger serialID) throws IOException {
+
+  }
+
+  @Override
   public Optional<Long> revokeCertificates(
       List<BigInteger> serialIDs,
       X509CertificateHolder caCertificateHolder,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make storeValidCertificate idempotent.

Steps done:
1. Move checkValidCertID to the caller.
2. Perform signAndStoreCertificate under lock. (As doing sign only under lock, so it is not a huge overhead, as anyway writing to DB is done already under lock. And this approach will change in HDDS-4998. This is a temporary fix, until we have proper solution which can work across SCM nodes. This is required because without this for the secure cluster with ratis enabled after a restartt SCM will fail to start.)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4998

## How was this patch tested?

Existing tests.
