### PR TITLE
HDDS-5003. Introduce EC replication type

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -237,6 +237,9 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
             case STAND_ALONE:
               client = new XceiverClientGrpc(pipeline, conf, caCert);
               break;
+            case EC:
+              client = new XceiverClientGrpc(pipeline, conf, caCert);
+              break;
             case CHAINED:
             default:
               throw new IOException("not implemented" + pipeline.getType());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationType.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationType.java
@@ -26,7 +26,8 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 public enum ReplicationType {
   RATIS,
   STAND_ALONE,
-  CHAINED;
+  CHAINED,
+  EC;
 
   public static ReplicationType fromProto(
       HddsProtos.ReplicationType replicationType) {
@@ -40,6 +41,8 @@ public enum ReplicationType {
       return ReplicationType.STAND_ALONE;
     case CHAINED:
       return ReplicationType.CHAINED;
+    case EC:
+      return ReplicationType.EC;
     default:
       throw new IllegalArgumentException(
           "Unsupported ProtoBuf replication type: " + replicationType);

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -250,6 +250,7 @@ enum ReplicationType {
     RATIS = 1;
     STAND_ALONE = 2;
     CHAINED = 3;
+    EC = 4;
 }
 
 enum ReplicationFactor {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -65,7 +65,7 @@ public class PutKeyHandler extends KeyHandler {
 
   @Option(names = {"-t", "--type"},
       description = "Replication type of the new key. (use RATIS or " +
-          "STAND_ALONE) Default is specified in the cluster-wide config.")
+          "STAND_ALONE or EC) Default is specified in the cluster-wide config.")
   private ReplicationType replicationType;
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce the EC replication type. This is required by multiple other patches, it can be easier to add it as a separated patch.

For example having this EC in the enum the EcPipelineProvider can be started to implement (though ReplicationConfig is also required long-term.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5003

## How was this patch tested?

It's a simple change, any incompatibilities should be detected by unit tests.

Also tested with end2end key creation with https://github.com/elek/ozone/tree/ec (where this is the first commit)