### PR TITLE
HDDS-5006. Use Log4j to print error messages for Datanode startup

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -587,4 +587,15 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
   public void setCertificateClient(CertificateClient client) {
     dnCertClient = client;
   }
+
+  @Override
+  public void printError(Throwable error) {
+    if (error.getMessage() == null || error.getMessage().length() == 0) {
+      //message could be null in case of NPE. This is unexpected so we can
+      //print out the stack trace.
+      LOG.error("Exception in HddsDatanodeService.", error);
+    } else {
+      LOG.error(error.getMessage().split("\n")[0]);
+    }
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -590,12 +590,6 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
   @Override
   public void printError(Throwable error) {
-    if (error.getMessage() == null || error.getMessage().length() == 0) {
-      //message could be null in case of NPE. This is unexpected so we can
-      //print out the stack trace.
-      LOG.error("Exception in HddsDatanodeService.", error);
-    } else {
-      LOG.error(error.getMessage().split("\n")[0]);
-    }
+    LOG.error("Exception in HddsDatanodeService.", error);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use Log4j to print error messages for Datanode startup, instead of System.err

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5006

## How was this patch tested?

The updated result is as follows, which will be much easier for the users to find the root cause of Datanode failing to start:
<img width="889" alt="Screenshot 2021-03-21 at 10 27 13 PM" src="https://user-images.githubusercontent.com/14933944/111908629-e4011080-8a94-11eb-947c-e3b671bea1f5.png">

