### PR TITLE
HDDS-4976. Add container replica related commands to debug

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.container.keyvalue;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
@@ -251,6 +252,7 @@ public class KeyValueContainerData extends ContainerData {
    * @return Protocol Buffer Message
    */
   @Override
+  @JsonIgnore
   public ContainerDataProto getProtoBufMessage() {
     ContainerDataProto.Builder builder = ContainerDataProto.newBuilder();
     builder.setContainerID(this.getContainerID());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/OzoneDebug.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.debug;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import picocli.CommandLine;
 
 /**
@@ -32,8 +33,17 @@ import picocli.CommandLine;
         mixinStandardHelpOptions = true)
 public class OzoneDebug extends GenericCli {
 
+  private OzoneConfiguration ozoneConf;
+
   public OzoneDebug() {
     super(OzoneDebug.class);
+  }
+
+  public OzoneConfiguration getOzoneConf() {
+    if (ozoneConf == null) {
+      ozoneConf = createOzoneConfiguration();
+    }
+    return ozoneConf;
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ExportSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ExportSubcommand.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import org.apache.hadoop.ozone.container.replication.ContainerReplicationSource;
+import org.apache.hadoop.ozone.container.replication.OnDemandContainerReplicationSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.util.concurrent.Callable;
+
+@Command(
+    name = "export",
+    description = "Export one container to a tarball")
+public class ExportSubcommand implements Callable<Void> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ExportSubcommand.class);
+
+  @ParentCommand
+  private ContainerCommands parent;
+
+  @CommandLine.Option(names = {"--container"},
+      required = true,
+      description = "Container Id")
+  private long containerId;
+
+  @CommandLine.Option(names = {"--dest"},
+      defaultValue = "/tmp",
+      description = "Destination directory")
+  private String destination;
+
+  @Override
+  public Void call() throws Exception {
+    parent.loadContainersFromVolumes();
+
+    final ContainerReplicationSource replicationSource =
+        new OnDemandContainerReplicationSource(parent.getController());
+
+    LOG.info("Starting to replication");
+
+    replicationSource.prepare(containerId);
+    LOG.info("Preparation is done");
+
+    final File destinationFile =
+        new File(destination, "container-" + containerId + ".tar.gz");
+    try (FileOutputStream fos = new FileOutputStream(destinationFile)) {
+      replicationSource.copyData(containerId, fos);
+    }
+    LOG.info("Container is exported to {}", destinationFile);
+
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InfoSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/InfoSubcommand.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.util.concurrent.Callable;
+
+import static org.apache.hadoop.ozone.debug.container.ContainerCommands.outputContainer;
+
+@Command(
+    name = "info",
+    description = "Show container info of a container replica on datanode")
+public class InfoSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private ContainerCommands parent;
+
+  @CommandLine.Option(names = {"--container"},
+      required = true,
+      description = "Container Id")
+  private long containerId;
+
+  @Override
+  public Void call() throws Exception {
+    parent.loadContainersFromVolumes();
+
+    Container container = parent.getController().getContainer(containerId);
+    if (container != null) {
+      outputContainer(container.getContainerData());
+    }
+
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ListSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ListSubcommand.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.debug.container;
+
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+
+import static org.apache.hadoop.ozone.debug.container.ContainerCommands.outputContainer;
+
+@Command(
+    name = "list",
+    description = "Show container info of all container replicas on datanode")
+public class ListSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private ContainerCommands parent;
+
+  @Override
+  public Void call() throws Exception {
+    parent.loadContainersFromVolumes();
+
+    Iterator<Container<?>> containerIt = parent.getController().getContainers();
+    while (containerIt.hasNext()) {
+      Container container = containerIt.next();
+      outputContainer(container.getContainerData());
+    }
+
+    return null;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Contains all of the datanode container replica related commands.
+ */
+package org.apache.hadoop.ozone.debug.container;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a subcommand to debug to get datanode local container info,
get as much information as possible, a bit different from `admin container info`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4976

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

manual tests
