### PR TITLE
HDDS-5019. Inconsistent tmp bucket name on different nodes when Kerberos is enabled

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
@@ -285,7 +285,7 @@ public class OFSPath {
    */
   public static String getTempMountBucketNameOfCurrentUser()
       throws IOException {
-    String username = UserGroupInformation.getCurrentUser().getUserName();
+    String username = UserGroupInformation.getCurrentUser().getShortUserName();
     return getTempMountBucketName(username);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I setup yarn cluster on ozone, and kerberos is enable. NodeManager can't download resource package in ContainerLocalizer stage, show error like this

```
2021-03-22 19:56:42,004 WARN org.apache.hadoop.yarn.server.nodemanager.containermanager.localizer.ResourceLocalizationService: \{ ofs://test1/tmp/hadoop-yarn/staging/$user/.staging/job_1616412423610_0008/job.splitmetainfo, 1616414199202, FILE, null } failed: hadoop-yarn/staging/$user/.staging/job_1616412423610_0008/job.splitmetainfo: No such file or directory!
java.io.FileNotFoundException: hadoop-yarn/staging/$user/.staging/job_1616412423610_0008/job.splitmetainfo: No such file or directory!
```
 

The reason is that this wrong way to get user. For kerberos principal in different machine are not same, so UserGroupInformation.getCurrentUser().getUserName() are not same. Because kerberos principal's formate is "user/host@HADOOP.COM"
 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5019

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
