### PR TITLE
HDDS-4987. Import container should not delete container contents if container already exists

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -466,7 +466,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
                 + " as the container descriptor (%s) has already been exist.",
             getContainerData().getContainerID(),
             getContainerFile().getAbsolutePath());
-        throw new IOException(errorMessage);
+        throw new StorageContainerException(errorMessage,
+            CONTAINER_ALREADY_EXISTS);
       }
       //copy the values from the input stream to the final destination
       // directory.
@@ -496,11 +497,17 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       KeyValueContainerUtil.parseKVContainerData(containerData, config);
 
     } catch (Exception ex) {
+      if (ex instanceof StorageContainerException &&
+          ((StorageContainerException) ex).getResult() ==
+              CONTAINER_ALREADY_EXISTS) {
+        throw ex;
+      }
       //delete all the temporary data in case of any exception.
       try {
         FileUtils.deleteDirectory(new File(containerData.getMetadataPath()));
         FileUtils.deleteDirectory(new File(containerData.getChunksPath()));
-        FileUtils.deleteDirectory(getContainerFile());
+        FileUtils.deleteDirectory(
+            new File(getContainerData().getContainerPath()));
       } catch (Exception deleteex) {
         LOG.error(
             "Can not cleanup destination directories after a container import"

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -206,8 +206,32 @@ public class TestKeyValueContainer {
       fail("Container is imported twice. Previous files are overwritten");
     } catch (IOException ex) {
       //all good
+      assertTrue(container.getContainerFile().exists());
     }
 
+    //Import failure should cleanup the container directory
+    containerData =
+        new KeyValueContainerData(containerId + 1,
+            keyValueContainerData.getLayOutVersion(),
+            keyValueContainerData.getMaxSize(), UUID.randomUUID().toString(),
+            datanodeId.toString());
+    container = new KeyValueContainer(containerData, CONF);
+
+    containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
+        .getVolumesList(), 1);
+    hddsVolumeDir = containerVolume.getHddsRootDir().toString();
+    container.populatePathFields(scmId, containerVolume, hddsVolumeDir);
+    try (FileInputStream fis = new FileInputStream(folderToExport)) {
+      fis.close();
+      container.importContainerData(fis, packer);
+      fail("Container import should fail");
+    } catch (Exception ex) {
+      assertTrue(ex instanceof IOException);
+    } finally {
+      File directory =
+          new File(container.getContainerData().getContainerPath());
+      assertFalse(directory.exists());
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -221,7 +221,8 @@ public class TestKeyValueContainer {
         .getVolumesList(), 1);
     hddsVolumeDir = containerVolume.getHddsRootDir().toString();
     container.populatePathFields(scmId, containerVolume, hddsVolumeDir);
-    try (FileInputStream fis = new FileInputStream(folderToExport)) {
+    try {
+      FileInputStream fis = new FileInputStream(folderToExport);
       fis.close();
       container.importContainerData(fis, packer);
       fail("Container import should fail");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-4987

Import container should also delete the whole container directory in case of import failure. 