### PR TITLE
HDDS-5023. Datanodes should always use MLV 0 when no VERSION file is present.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
@@ -63,6 +63,28 @@ public class DatanodeLayoutStorage extends Storage {
     return new Properties();
   }
 
+  /**
+   * Older versions of the code did not write a VERSION file to disk for the
+   * datanode. Therefore, When a datanode starts up and does not find a metadata
+   * layout version written to disk, it does not know whether
+   * it is being installed on a new system, or as part of an upgrade to an
+   * existing system.
+   *
+   * It should assume that it is being installed as part of
+   * an upgrade and use the lowest metadata layout version available. If it
+   * is being started as part of a new system, then SCM will tell it to
+   * finalize to match the SCM MLV, otherwise it will remain pre-finalized
+   * until SCM tells it to finalize.
+   *
+   * This is only an issue when upgrading from software layout versions
+   * {@link HDDSLayoutFeature#INITIAL_VERSION} to
+   * {@link HDDSLayoutFeature#DATANODE_SCHEMA_V2}. After this, the upgrade
+   * framework will write a VERSION file for the datanode and future software
+   * versions will always know the MLV to use.
+   *
+   * @return The layout version that should be used for the datanode if no
+   * layout version is found on disk.
+   */
   private static int getDefaultLayoutVersion() {
     int softwareLayoutVersion = maxLayoutVersion();
     int defaultLayoutVersion = softwareLayoutVersion;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
@@ -84,17 +84,12 @@ public class DatanodeLayoutStorage extends Storage {
    * layout version is found on disk.
    */
   private static int getDefaultLayoutVersion(OzoneConfiguration conf) {
-    int softwareLayoutVersion = maxLayoutVersion();
-    int defaultLayoutVersion = softwareLayoutVersion;
+    int defaultLayoutVersion = maxLayoutVersion();
 
-    if (softwareLayoutVersion ==
-        HDDSLayoutFeature.DATANODE_SCHEMA_V2.layoutVersion()) {
-
-      File dnIdFile = new File(HddsServerUtil.getDatanodeIdFilePath(conf));
-      if (dnIdFile.exists()) {
-        defaultLayoutVersion =
-            HDDSLayoutFeature.INITIAL_VERSION.layoutVersion();
-      }
+    File dnIdFile = new File(HddsServerUtil.getDatanodeIdFilePath(conf));
+    if (dnIdFile.exists()) {
+      defaultLayoutVersion =
+          HDDSLayoutFeature.INITIAL_VERSION.layoutVersion();
     }
 
     return defaultLayoutVersion;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.ozone.common.Storage;
 
 /**
@@ -42,7 +43,7 @@ public class DatanodeLayoutStorage extends Storage {
   public DatanodeLayoutStorage(OzoneConfiguration conf, String dataNodeId)
       throws IOException {
     super(NodeType.DATANODE, ServerUtils.getOzoneMetaDirPath(conf),
-        DATANODE_LAYOUT_VERSION_DIR, dataNodeId, maxLayoutVersion());
+        DATANODE_LAYOUT_VERSION_DIR, dataNodeId, getDefaultLayoutVersion());
   }
 
   public DatanodeLayoutStorage(OzoneConfiguration conf, String dataNodeId,
@@ -60,5 +61,17 @@ public class DatanodeLayoutStorage extends Storage {
   @Override
   protected Properties getNodeProperties() {
     return new Properties();
+  }
+
+  private static int getDefaultLayoutVersion() {
+    int softwareLayoutVersion = maxLayoutVersion();
+    int defaultLayoutVersion = softwareLayoutVersion;
+
+    if (softwareLayoutVersion ==
+        HDDSLayoutFeature.DATANODE_SCHEMA_V2.layoutVersion()) {
+      defaultLayoutVersion = HDDSLayoutFeature.INITIAL_VERSION.layoutVersion();
+    }
+
+    return defaultLayoutVersion;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/DatanodeLayoutStorage.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.common.Storage;
 
 /**
@@ -35,7 +36,6 @@ import org.apache.hadoop.ozone.common.Storage;
  * StorageDirectories used by the DataNode.
  */
 public class DatanodeLayoutStorage extends Storage {
-
   /**
    * Construct DataNodeStorageConfig.
    * @throws IOException if any directories are inaccessible.
@@ -43,7 +43,7 @@ public class DatanodeLayoutStorage extends Storage {
   public DatanodeLayoutStorage(OzoneConfiguration conf, String dataNodeId)
       throws IOException {
     super(NodeType.DATANODE, ServerUtils.getOzoneMetaDirPath(conf),
-        DATANODE_LAYOUT_VERSION_DIR, dataNodeId, getDefaultLayoutVersion());
+        DATANODE_LAYOUT_VERSION_DIR, dataNodeId, getDefaultLayoutVersion(conf));
   }
 
   public DatanodeLayoutStorage(OzoneConfiguration conf, String dataNodeId,
@@ -66,32 +66,35 @@ public class DatanodeLayoutStorage extends Storage {
   /**
    * Older versions of the code did not write a VERSION file to disk for the
    * datanode. Therefore, When a datanode starts up and does not find a metadata
-   * layout version written to disk, it does not know whether
+   * layout version written to disk, it must figure out whether
    * it is being installed on a new system, or as part of an upgrade to an
-   * existing system.
+   * existing system. To do this, it will use the presence of the datanode.id
+   * file to indicate that it is being started as part of an upgrade and
+   * should start with the initial layout version. Otherwise, it will use the
+   * latest layout version.
    *
-   * It should assume that it is being installed as part of
-   * an upgrade and use the lowest metadata layout version available. If it
-   * is being started as part of a new system, then SCM will tell it to
-   * finalize to match the SCM MLV, otherwise it will remain pre-finalized
-   * until SCM tells it to finalize.
-   *
-   * This is only an issue when upgrading from software layout versions
+   * This is only an issue when upgrading from software layout version
    * {@link HDDSLayoutFeature#INITIAL_VERSION} to
    * {@link HDDSLayoutFeature#DATANODE_SCHEMA_V2}. After this, the upgrade
    * framework will write a VERSION file for the datanode and future software
-   * versions will always know the MLV to use.
+   * versions will always know the MLV to use. The result of this method will
+   * not be used in this case.
    *
    * @return The layout version that should be used for the datanode if no
    * layout version is found on disk.
    */
-  private static int getDefaultLayoutVersion() {
+  private static int getDefaultLayoutVersion(OzoneConfiguration conf) {
     int softwareLayoutVersion = maxLayoutVersion();
     int defaultLayoutVersion = softwareLayoutVersion;
 
     if (softwareLayoutVersion ==
         HDDSLayoutFeature.DATANODE_SCHEMA_V2.layoutVersion()) {
-      defaultLayoutVersion = HDDSLayoutFeature.INITIAL_VERSION.layoutVersion();
+
+      File dnIdFile = new File(HddsServerUtil.getDatanodeIdFilePath(conf));
+      if (dnIdFile.exists()) {
+        defaultLayoutVersion =
+            HDDSLayoutFeature.INITIAL_VERSION.layoutVersion();
+      }
     }
 
     return defaultLayoutVersion;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since older versions of the code did not have a VERSION file for datanodes, use the presence of the datanode.id file to determine whether the datanode is being started on a fresh install and should use the latest layout version, or being started as part of an upgrade and should use the initial layout version.

## What is the link to the Apache JIRA

HDDS-5023

## How was this patch tested?

Added fix to HDDS-4181 acceptance tests, and the MLV tests there verified that pre-finalize datanodes are using the correct MLV when pre-finalized.
