### PR TITLE
HDDS-4982.Solve intellj warnings on DBTransactionBuffer

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/DBTransactionBuffer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/DBTransactionBuffer.java
@@ -25,11 +25,11 @@ import java.io.IOException;
 /**
  * DB transaction that abstracts the updates to the underlying datastore.
  */
-public interface DBTransactionBuffer<KEY, VALUE> extends Closeable {
+public interface DBTransactionBuffer extends Closeable {
 
-  void addToBuffer(Table<KEY, VALUE> table, KEY key, VALUE value) throws
-      IOException;
+  <KEY, VALUE> void addToBuffer(Table<KEY, VALUE> table, KEY key, VALUE value)
+      throws IOException;
 
-  void removeFromBuffer(Table<KEY, VALUE> table, KEY key) throws
-      IOException;
+  <KEY, VALUE> void removeFromBuffer(Table<KEY, VALUE> table, KEY key)
+      throws IOException;
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBTransactionBufferImpl.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBTransactionBufferImpl.java
@@ -31,13 +31,13 @@ public class SCMDBTransactionBufferImpl implements DBTransactionBuffer {
   }
 
   @Override
-  public void addToBuffer(Table table, Object key, Object value)
-      throws IOException {
+  public <KEY, VALUE> void addToBuffer(
+      Table<KEY, VALUE> table, KEY key, VALUE value) throws IOException {
     table.put(key, value);
   }
 
   @Override
-  public void removeFromBuffer(Table table, Object key)
+  public <KEY, VALUE>void removeFromBuffer(Table<KEY, VALUE> table, KEY key)
       throws IOException {
     table.delete(key);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHADBTransactionBuffer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHADBTransactionBuffer.java
@@ -48,13 +48,13 @@ public class MockSCMHADBTransactionBuffer implements SCMHADBTransactionBuffer {
   }
 
   @Override
-  public void addToBuffer(Table table, Object key, Object value)
-      throws IOException {
+  public <KEY, VALUE> void addToBuffer(
+      Table<KEY, VALUE> table, KEY key, VALUE value) throws IOException {
     table.putWithBatch(getCurrentBatchOperation(), key, value);
   }
 
   @Override
-  public void removeFromBuffer(Table table, Object key)
+  public <KEY, VALUE> void removeFromBuffer(Table<KEY, VALUE> table, KEY key)
       throws IOException {
     table.deleteWithBatch(getCurrentBatchOperation(), key);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferImpl.java
@@ -54,13 +54,13 @@ public class SCMHADBTransactionBufferImpl implements SCMHADBTransactionBuffer {
   }
 
   @Override
-  public void addToBuffer(Table table, Object key, Object value)
-      throws IOException {
+  public <KEY, VALUE> void addToBuffer(
+      Table<KEY, VALUE> table, KEY key, VALUE value) throws IOException {
     table.putWithBatch(getCurrentBatchOperation(), key, value);
   }
 
   @Override
-  public void removeFromBuffer(Table table, Object key)
+  public <KEY, VALUE> void removeFromBuffer(Table<KEY, VALUE> table, KEY key)
       throws IOException {
     table.deleteWithBatch(getCurrentBatchOperation(), key);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
The root cause of this warning is due to misleadingly using generic classes instead of generic methods.
The generic class specifies the real type when instantiating,  and the generic method specifies the real type when it is being called.
There are two methods under DBTransactionBuffer, the method` addToBuffer` and `removeFromBuffer`.
According to where these methods call, they are actually designed to write keys into separate tables or remove them. 
The key and value of different table are different, and so are the types. This is where generic methods work.
Thus I modified the generic methods and erased the generic class.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4982

## How was this patch tested?
CI
