### PR TITLE
HDDS-4983. Display key offset for each block in command key info

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -109,7 +109,11 @@ public class VersionEndpointTask implements
           }
 
           // Start the container services after getting the version information
-          ozoneContainer.start(scmId);
+          try {
+            ozoneContainer.start(scmId);
+          } catch (IOException ex) {
+            rpcEndPoint.logIfNeeded(ex);
+          }
         }
         EndpointStateMachine.EndPointStates nextState =
             rpcEndPoint.getState().getNextState();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -109,11 +109,7 @@ public class VersionEndpointTask implements
           }
 
           // Start the container services after getting the version information
-          try {
-            ozoneContainer.start(scmId);
-          } catch (IOException ex) {
-            rpcEndPoint.logIfNeeded(ex);
-          }
+          ozoneContainer.start(scmId);
         }
         EndpointStateMachine.EndPointStates nextState =
             rpcEndPoint.getState().getNextState();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyLocation.java
@@ -39,6 +39,10 @@ public class OzoneKeyLocation {
    * Offset of this key.
    */
   private final long offset;
+  /**
+   * KeyOffset of this key.
+   */
+  private final long keyOffset;
 
   /**
    * Constructs OzoneKeyLocation.
@@ -49,6 +53,7 @@ public class OzoneKeyLocation {
     this.localID = localID;
     this.length = length;
     this.offset = offset;
+    this.keyOffset = length + offset;
   }
 
   /**
@@ -77,6 +82,13 @@ public class OzoneKeyLocation {
    */
   public long getOffset() {
     return offset;
+  }
+
+  /**
+   * Returns the KeyOffset of this Key.
+   */
+  public long getKeyOffset() {
+    return keyOffset;
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

add keyOffset in the key info result

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4983

## How was this patch tested?

example:sh key info /vol1/bucket1/key1

{
"volumeName" : "vol1",
"bucketName" : "bucket1",
"name" : "key1",
"dataSize" : 16,
"creationTime" : "2021-03-12T11:23:22.125Z",
"modificationTime" : "2021-03-16T08:28:08.901Z",
"replicationType" : "RATIS",
"replicationFactor" : 3,
"ozoneKeyLocations" : [ {
"containerID" : 5,
"localID" : 105898527115771904,
"length" : 16,
"offset" : 0,
"keyOffset" : 16
} ],
"metadata" : { },
"fileEncryptionInfo" : null
}
