### PR TITLE
HDDS-3752. Patch for o3fs issue with not listing bucket contents WITHOUT trailin…

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -766,6 +766,17 @@ public class BasicOzoneFileSystem extends FileSystem {
   }
 
   @Override
+  protected Path fixRelativePart(Path p) {
+    String pathPatternString = p.toUri().getPath();
+    if (pathPatternString.isEmpty()) {
+      return new Path("/");
+    }
+    else {
+      return p.isUriPathAbsolute() ? p : new Path(this.getWorkingDirectory(), p);
+    }
+  }
+   
+  @Override
   public FileStatus[] globStatus(Path pathPattern) throws IOException {
     incrementCounter(Statistic.INVOCATION_GLOB_STATUS);
     return super.globStatus(pathPattern);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -770,9 +770,8 @@ public class BasicOzoneFileSystem extends FileSystem {
     String pathPatternString = p.toUri().getPath();
     if (pathPatternString.isEmpty()) {
       return new Path("/");
-    }
-    else {
-      return p.isUriPathAbsolute() ? p : new Path(this.getWorkingDirectory(), p);
+    } else {
+      return super.fixRelativePart(p);
     }
   }
    


### PR DESCRIPTION
...Originally when _**ls -R** o3fs://bucket.vol_ issued, resulted in _No such file/directory_ error.  Fixed path so that contents of bucket listed when command issued without trailing slash.  Patch affects one file, the _BasicOzoneFileSystem_ filesystem abstraction.  Patch overrides the _fixRelativePart_ method to allow Path to be resolved correctly for _OzoneFileSystem_ implementation.

## What changes were proposed in this pull request?
Patch fixed issue with _OzoneFileSystem_ implementation of _FileSystem_ for _**o3fs**_ space when _-ls_ command request without trailing slash of 2nd level bucket (vol/bucket).  Problem is that request interpreted as a 'relative' address resolving to the 'working directory' which is evaluated to an error '_Directory or File Not Found_'.  

Patch to _BasicOzoneFileSystem_ overrides the _fixRelativePart_ method to resolve the Path to the correct Path (adding a trailing slash).  _BasicOzoneFileSystem_ implementation of _FileSystem_ then correctly evaluates the path.  


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-3752

## How was this patch tested?
Passed unit and integration tests.

Manual testing:
Tested though ozone fs cli commands (see attached images).
Pre-patch:
![ozonefs_prepatch_error](https://user-images.githubusercontent.com/81126310/112779346-c6d3c100-9003-11eb-90b8-253f470bd39d.png)

**Fix with patch**:
![ozonefs_patch_fix_test](https://user-images.githubusercontent.com/81126310/112779367-d81ccd80-9003-11eb-891c-3bb6c96f5e68.png)

