### PR TITLE
HDDS-5011. Introduce Java based ReplicationConfig implementation

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.client;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+
+import java.util.Objects;
+
+/**
+ * Replication configuration for EC replication.
+ */
+public class RatisReplicationConfig
+    implements ReplicationConfig {
+
+  private final ReplicationFactor replicationFactor;
+
+  public RatisReplicationConfig(ReplicationFactor replicationFactor) {
+    this.replicationFactor = replicationFactor;
+  }
+
+  @Override
+  public ReplicationType getReplicationType() {
+    return ReplicationType.RATIS;
+  }
+
+  public ReplicationFactor getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    RatisReplicationConfig that = (RatisReplicationConfig) o;
+    return replicationFactor == that.replicationFactor;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(replicationFactor);
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -35,9 +35,23 @@ public class RatisReplicationConfig
     this.replicationFactor = replicationFactor;
   }
 
+  public static boolean hasFactor(ReplicationConfig replicationConfig,
+      ReplicationFactor factor) {
+    if (replicationConfig instanceof RatisReplicationConfig) {
+      return ((RatisReplicationConfig) replicationConfig).getReplicationFactor()
+          .equals(factor);
+    }
+    return false;
+  }
+
   @Override
   public ReplicationType getReplicationType() {
     return ReplicationType.RATIS;
+  }
+
+  @Override
+  public int getRequiredNodes() {
+    return replicationFactor.getNumber();
   }
 
   public ReplicationFactor getReplicationFactor() {
@@ -54,6 +68,11 @@ public class RatisReplicationConfig
     }
     RatisReplicationConfig that = (RatisReplicationConfig) o;
     return replicationFactor == that.replicationFactor;
+  }
+
+  @Override
+  public String toString() {
+    return "RATIS/" + replicationFactor;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.client;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+/**
+ * Replication configuration for any ReplicationType with all the required
+ * parameters..
+ */
+public interface ReplicationConfig {
+
+  /**
+   * Helper method to create proper replication method from old-style
+   * factor+type definition.
+   * <p>
+   * Note: it's never used for EC replication where config is created.
+   */
+  static ReplicationConfig fromTypeAndFactor(
+      HddsProtos.ReplicationType type,
+      HddsProtos.ReplicationFactor factor
+  ) {
+    switch (type) {
+    case RATIS:
+      return new RatisReplicationConfig(factor);
+    case STAND_ALONE:
+      return new StandaloneReplicationConfig(factor);
+    default:
+      throw new UnsupportedOperationException(
+          "Not supported replication: " + type);
+    }
+  }
+
+  /**
+   * Helper method to serialize from proto.
+   * <p>
+   * This uses either the old type/factor or the new ecConfig depends on the
+   * type.
+   * <p>
+   * Note: It will support all the available replication types (including EC).
+   * <p>
+   * Separated to remain be synced with the EC feature branch, as later it
+   * will have different signature.
+   */
+  static ReplicationConfig fromProto(
+      HddsProtos.ReplicationType type,
+      HddsProtos.ReplicationFactor factor) {
+    switch (type) {
+    case RATIS:
+    case STAND_ALONE:
+      return fromTypeAndFactor(type, factor);
+    default:
+      throw new UnsupportedOperationException(
+          "Not supported replication: " + type);
+    }
+  }
+
+  /**
+   * Replication type supported by the replication config.
+   */
+  HddsProtos.ReplicationType getReplicationType();
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -71,9 +71,28 @@ public interface ReplicationConfig {
     }
   }
 
+  static HddsProtos.ReplicationFactor getLegacyFactor(
+      ReplicationConfig replicationConfig) {
+    if (replicationConfig instanceof RatisReplicationConfig) {
+      return ((RatisReplicationConfig) replicationConfig)
+          .getReplicationFactor();
+    } else if (replicationConfig instanceof StandaloneReplicationConfig) {
+      return ((StandaloneReplicationConfig) replicationConfig)
+          .getReplicationFactor();
+    }
+    throw new UnsupportedOperationException(
+        "factor is not valid property of replication " + replicationConfig
+            .getReplicationType());
+  }
+
   /**
    * Replication type supported by the replication config.
    */
   HddsProtos.ReplicationType getReplicationType();
+
+  /**
+   * Number of required nodes for this replication.
+   */
+  int getRequiredNodes();
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.client;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+
+import java.util.Objects;
+
+/**
+ * Replication configuration for STANDALONE replication.
+ */
+public class StandaloneReplicationConfig implements ReplicationConfig {
+
+  private final ReplicationFactor replicationFactor;
+
+  public StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
+    this.replicationFactor = replicationFactor;
+  }
+
+  public ReplicationFactor getReplicationFactor() {
+    return replicationFactor;
+  }
+
+  @Override
+  public ReplicationType getReplicationType() {
+    return ReplicationType.STAND_ALONE;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    StandaloneReplicationConfig that = (StandaloneReplicationConfig) o;
+    return replicationFactor == that.replicationFactor;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(replicationFactor);
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -39,6 +39,11 @@ public class StandaloneReplicationConfig implements ReplicationConfig {
   }
 
   @Override
+  public int getRequiredNodes() {
+    return replicationFactor.getNumber();
+  }
+
+  @Override
   public ReplicationType getReplicationType() {
     return ReplicationType.STAND_ALONE;
   }
@@ -53,6 +58,11 @@ public class StandaloneReplicationConfig implements ReplicationConfig {
     }
     StandaloneReplicationConfig that = (StandaloneReplicationConfig) o;
     return replicationFactor == that.replicationFactor;
+  }
+
+  @Override
+  public String toString() {
+    return "STANDALONE/" + replicationFactor;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocol/TestReplicationConfig.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocol/TestReplicationConfig.java
@@ -33,7 +33,7 @@ public class TestReplicationConfig {
   @Test
   public void deserializeRatis() {
     final ReplicationConfig replicationConfig = ReplicationConfig
-        .fromProto(ReplicationType.RATIS, ReplicationFactor.THREE);
+        .fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.THREE);
 
     Assert
         .assertEquals(RatisReplicationConfig.class,
@@ -50,7 +50,7 @@ public class TestReplicationConfig {
   @Test
   public void deserializeStandalone() {
     final ReplicationConfig replicationConfig = ReplicationConfig
-        .fromProto(ReplicationType.STAND_ALONE, ReplicationFactor.ONE);
+        .fromTypeAndFactor(ReplicationType.STAND_ALONE, ReplicationFactor.ONE);
 
     Assert
         .assertEquals(StandaloneReplicationConfig.class,

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocol/TestReplicationConfig.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/protocol/TestReplicationConfig.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.protocol;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test replicationConfig.
+ */
+public class TestReplicationConfig {
+
+  @Test
+  public void deserializeRatis() {
+    final ReplicationConfig replicationConfig = ReplicationConfig
+        .fromProto(ReplicationType.RATIS, ReplicationFactor.THREE);
+
+    Assert
+        .assertEquals(RatisReplicationConfig.class,
+            replicationConfig.getClass());
+
+    RatisReplicationConfig ratisReplicationConfig =
+        (RatisReplicationConfig) replicationConfig;
+    Assert.assertEquals(ReplicationType.RATIS,
+        ratisReplicationConfig.getReplicationType());
+    Assert.assertEquals(ReplicationFactor.THREE,
+        ratisReplicationConfig.getReplicationFactor());
+  }
+
+  @Test
+  public void deserializeStandalone() {
+    final ReplicationConfig replicationConfig = ReplicationConfig
+        .fromProto(ReplicationType.STAND_ALONE, ReplicationFactor.ONE);
+
+    Assert
+        .assertEquals(StandaloneReplicationConfig.class,
+            replicationConfig.getClass());
+
+    StandaloneReplicationConfig standalone =
+        (StandaloneReplicationConfig) replicationConfig;
+    Assert.assertEquals(ReplicationType.STAND_ALONE,
+        standalone.getReplicationType());
+    Assert.assertEquals(ReplicationFactor.ONE,
+        standalone.getReplicationFactor());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch introduces the usage of `ReplicationConfig` on mater instead of using `replicationType` and `replicationFactor`. It is required by EC (see #2068 and #1973)

Using java based `ReplicationFactor` requires further changes in SCM (and OM) and we decidede to make the generic part of the refactor on master (it doesn't introduce any new logic only the java representation of the data is changing)  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5011

## How was this patch tested?

It contains unit tests. It introduces only new Java classes, therefore it's safe to include.