### PR TITLE
HDDS-5033. SCM may not be able to know full port list of Datanode after Datanode is started.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -199,14 +199,14 @@ public class DatanodeDetails extends NodeImpl implements
    *
    * @param port DataNode port
    */
-  public void setPort(Port port) {
+  public synchronized void setPort(Port port) {
     // If the port is already in the list remove it first and add the
     // new/updated port value.
     ports.remove(port);
     ports.add(port);
   }
 
-  public void setPort(Name name, int port) {
+  public synchronized void setPort(Name name, int port) {
     setPort(new Port(name, port));
   }
 
@@ -215,7 +215,7 @@ public class DatanodeDetails extends NodeImpl implements
    *
    * @return DataNode Ports
    */
-  public List<Port> getPorts() {
+  public synchronized List<Port> getPorts() {
     return ports;
   }
 
@@ -266,7 +266,7 @@ public class DatanodeDetails extends NodeImpl implements
    *
    * @return Port
    */
-  public Port getPort(Port.Name name) {
+  public synchronized Port getPort(Port.Name name) {
     for (Port port : ports) {
       if (port.getName().equals(name)) {
         return port;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -92,11 +92,6 @@ public class OzoneContainer {
   private final ReplicationServer replicationServer;
   private DatanodeDetails datanodeDetails;
 
-  /**
-   * If SCM HA is enabled, OzoneContainer#start() will be called multi-times
-   * from VersionEndpointTask. The first call should do the initializing job,
-   * the successive calls should wait until OzoneContainer is initialized.
-   */
   enum InitializingStatus {
     UNINITIALIZED, INITIALIZING, INITIALIZED
   }
@@ -268,6 +263,9 @@ public class OzoneContainer {
    * @throws IOException
    */
   public void start(String clusterId) throws IOException {
+    // If SCM HA is enabled, OzoneContainer#start() will be called multi-times
+    // from VersionEndpointTask. The first call should do the initializing job,
+    // the successive calls should wait until OzoneContainer is initialized.
     if (!initializingStatus.compareAndSet(
         InitializingStatus.UNINITIALIZED, InitializingStatus.INITIALIZING)) {
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -62,6 +62,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT;
+
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,9 +88,18 @@ public class OzoneContainer {
   private List<ContainerDataScanner> dataScanners;
   private final BlockDeletingService blockDeletingService;
   private final GrpcTlsConfig tlsClientConfig;
-  private final AtomicBoolean isStarted;
+  private final AtomicReference<InitializingStatus> initializingStatus;
   private final ReplicationServer replicationServer;
   private DatanodeDetails datanodeDetails;
+
+  /**
+   * If SCM HA is enabled, OzoneContainer#start() will be called multi-times
+   * from VersionEndpointTask. The first call should do the initializing job,
+   * the successive calls should wait until OzoneContainer is initialized.
+   */
+  enum InitializingStatus {
+    UNINITIALIZED, INITIALIZING, INITIALIZED
+  }
 
   /**
    * Construct OzoneContainer object.
@@ -170,7 +180,8 @@ public class OzoneContainer {
     tlsClientConfig = RatisHelper.createTlsClientConfig(
         secConf, certClient != null ? certClient.getCACertificate() : null);
 
-    isStarted = new AtomicBoolean(false);
+    initializingStatus =
+        new AtomicReference<>(InitializingStatus.UNINITIALIZED);
   }
 
   public GrpcTlsConfig getTlsClientConfig() {
@@ -257,10 +268,21 @@ public class OzoneContainer {
    * @throws IOException
    */
   public void start(String clusterId) throws IOException {
-    if (!isStarted.compareAndSet(false, true)) {
+    if (!initializingStatus.compareAndSet(
+        InitializingStatus.UNINITIALIZED, InitializingStatus.INITIALIZING)) {
+
+      // wait OzoneContainer to finish its initializing.
+      while (initializingStatus.get() != InitializingStatus.INITIALIZED) {
+        try {
+          Thread.sleep(1);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
       LOG.info("Ignore. OzoneContainer already started.");
       return;
     }
+
     LOG.info("Attempting to start container services.");
     startContainerScrub();
 
@@ -272,6 +294,9 @@ public class OzoneContainer {
     hddsDispatcher.init();
     hddsDispatcher.setClusterId(clusterId);
     blockDeletingService.start();
+
+    // mark OzoneContainer as INITIALIZED.
+    initializingStatus.set(InitializingStatus.INITIALIZED);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When SCM HA is enabled, after restart DN, the SCM may not know the full ports of that DN.

**The issue is:** 
SCMNodeManager just record the DatanodeDetails once during register. But for DN, it won’t record the admin, server, client port into DatanodeDetails until its ratis server is up. Thus there is contention here: if the register request is reported before ratis server is up, SCM won’t know full port list of that DN.

**The solution is**
If SCM HA is enabled, OzoneContainer#start() will be called multi-times from VersionEndpointTask. The first call should do the initializing job, the successive calls should wait until OzoneContainer is initialized.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5033

## How was this patch tested?

CI and integration test inside tencent.
