### PR TITLE
HDDS-5022. SCM get roles command should provide Ratis Leader/Follower…

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -23,6 +23,7 @@ import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -45,7 +46,7 @@ public interface SCMRatisServer {
   /**
    * Returns roles of ratis peers.
    */
-  List<String> getRatisRoles();
+  List<String> getRatisRoles() throws UnknownHostException;
 
   /**
    * Returns NotLeaderException with useful info.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -18,24 +18,29 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.Iterator;
+import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
@@ -223,12 +228,18 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   }
 
   @Override
-  public List<String> getRatisRoles() {
-    return division.getGroup().getPeers().stream()
-        .map(peer -> peer.getAddress() == null ? "" : peer.getAddress())
-        .collect(Collectors.toList());
+  public List<String> getRatisRoles() throws UnknownHostException {
+    Collection<RaftPeer> peers = division.getGroup().getPeers();
+    List<String> ratisRoles = new ArrayList<>();
+    for (RaftPeer peer : peers) {
+      InetAddress peerInetAddress = InetAddress.getByName(HddsUtils.getHostName(peer.getAddress()).get());
+      boolean isLocal = NetUtils.isLocalAddress(peerInetAddress);
+      ratisRoles.add((peer.getAddress() == null ? "" : peer.getAddress()
+              .concat(isLocal ? ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
+                      ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))));
+    }
+    return ratisRoles;
   }
-
   /**
    * {@inheritDoc}
    */

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/scmha.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/scmha.robot
@@ -25,4 +25,4 @@ Test Timeout        5 minutes
 *** Test Cases ***
 Run scm roles
     ${output} =         Execute          ozone admin scm roles
-                        Should contain   ${output}  [scm:9865]
+                        Should Match Regexp   ${output}  [scm:9865:(LEADER|FOLLOWER)]


### PR DESCRIPTION
… information.

## What changes were proposed in this pull request?
"ozone admin scm roles" command currently returns scm role info like this: [scm1:9865, scm2:9865, scm3:9865]. This change is to add: LEADER and FOLLOWER info in the return. The new result from the command is now look like this: [scm3:9865:FOLLOWER, scm2:9865:FOLLOWER, scm1:9865:LEADER] 

## What is the link to the Apache JIRA

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)

https://issues.apache.org/jira/browse/HDDS-5022

## How was this patch tested?

Manually tested locally by creating a SCM HA cluster with 3 SCM nodes and executed command: ozone admin scm roles from one of the SCM node. With this change, the command result was: [scm3:9865:FOLLOWER, scm2:9865:FOLLOWER, scm1:9865:LEADER].
