### PR TITLE
HDDS-5058. Make getScmInfo retry for a duration.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.util.TimeDuration;
 
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -509,6 +510,11 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_HA_SECURITY_SUPPORTED =
       "hdds.scm.ha.security.enable";
   public static final boolean OZONE_SCM_HA_SECURITY_SUPPORTED_DEFAULT = false;
+
+  public static final String OZONE_SCM_INFO_WAIT_DURATION = "ozone.scm.info" +
+      ".wait.duration";
+  public static final long OZONE_SCM_INFO_WAIT_DURATION_DEFAULT =
+      10 * 60;
 
   /**
    * Never constructed.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.util.TimeDuration;
 
-import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2751,4 +2751,13 @@
       filesystem semantics.
     </description>
   </property>
+
+  <property>
+    <name>ozone.scm.info.wait.duration</name>
+    <tag>OZONE, SCM, OM</tag>
+    <value>10m</value>
+    <description> Maximum amount of duration OM/SCM waits to get Scm Info
+      during OzoneManager init/SCM bootstrap.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMClientConfig.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMClientConfig.java
@@ -68,7 +68,7 @@ public class SCMClientConfig {
       tags = {OZONE, SCM, CLIENT},
       timeUnit = TimeUnit.MILLISECONDS,
       description = "SCM Client timeout on waiting for the next connection " +
-          "retry to other SCM IP. The default value is set to 2 minutes. "
+          "retry to other SCM IP. The default value is set to 2 seconds. "
   )
   private long retryInterval = 2 * 1000;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocolPB.ScmBlockLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider;
+import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
@@ -63,7 +64,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.TRANSACTION_INFO_KEY;
@@ -79,8 +83,23 @@ public final class HAUtils {
 
   public static ScmInfo getScmInfo(OzoneConfiguration conf)
       throws IOException {
+    OzoneConfiguration configuration = new OzoneConfiguration(conf);
     try {
-      return getScmBlockClient(conf).getScmInfo();
+      long duration = conf.getTimeDuration(OZONE_SCM_INFO_WAIT_DURATION,
+          OZONE_SCM_INFO_WAIT_DURATION_DEFAULT, TimeUnit.SECONDS);
+      SCMClientConfig scmClientConfig =
+          configuration.getObject(SCMClientConfig.class);
+      int retryCount =
+         (int) (duration / (scmClientConfig.getRetryInterval()/1000));
+
+      // If duration is set to lesser value, fall back to actual default
+      // retry count.
+      if (retryCount > scmClientConfig.getRetryCount()) {
+        scmClientConfig.setRetryCount(retryCount);
+        configuration.setFromObject(scmClientConfig);
+      }
+
+      return getScmBlockClient(configuration).getScmInfo();
     } catch (IOException e) {
       throw e;
     } catch (Exception e) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -90,7 +90,7 @@ public final class HAUtils {
       SCMClientConfig scmClientConfig =
           configuration.getObject(SCMClientConfig.class);
       int retryCount =
-         (int) (duration / (scmClientConfig.getRetryInterval()/1000));
+          (int) (duration / (scmClientConfig.getRetryInterval()/1000));
 
       // If duration is set to lesser value, fall back to actual default
       // retry count.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -403,7 +403,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // For testing purpose only, not hit scm from om as Hadoop UGI can't login
     // two principals in the same JVM.
     if (!testSecureOmFlag) {
-      ScmInfo scmInfo = getScmInfo(configuration);
+      ScmInfo scmInfo = HAUtils.getScmInfo(configuration);
       if (!(scmInfo.getClusterId().equals(omStorage.getClusterID()) && scmInfo
           .getScmId().equals(omStorage.getScmId()))) {
         logVersionMismatch(conf, scmInfo);
@@ -930,7 +930,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     StorageState state = omStorage.getState();
     if (state != StorageState.INITIALIZED) {
       try {
-        ScmInfo scmInfo = getScmInfo(conf);
+        ScmInfo scmInfo = HAUtils.getScmInfo(conf);
         String clusterId = scmInfo.getClusterId();
         String scmId = scmInfo.getScmId();
         if (clusterId == null || clusterId.isEmpty()) {
@@ -1006,11 +1006,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           response);
       throw new RuntimeException("OM security initialization failed.");
     }
-  }
-
-  private static ScmInfo getScmInfo(OzoneConfiguration conf)
-      throws IOException {
-    return HAUtils.getScmInfo(conf);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira proposes to add a ceration duration to try getScmInfo, instead of retry forever with fixed sleep.

In a few docker tests CI run, we have seen this issue, after 15 retries Om init failed, as SCM is started later.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5058

## How was this patch tested?

Manually tested with docker compose env.
