### PR TITLE
HDDS-5063. Remove hadoop- prefixes from release artifacts (release br…

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-tar-stitching
@@ -38,8 +38,8 @@ function run()
   fi
 }
 
-run tar -c -f "hadoop-ozone-${VERSION}.tar" "ozone-${VERSION}"
-run gzip -f "hadoop-ozone-${VERSION}.tar"
+run tar -c -f "ozone-${VERSION}.tar" "ozone-${VERSION}"
+run gzip -f "ozone-${VERSION}.tar"
 echo
-echo "Ozone dist tar available at: ${BASEDIR}/hadoop-ozone-${VERSION}.tar.gz"
+echo "Ozone dist tar available at: ${BASEDIR}/ozone-${VERSION}.tar.gz"
 echo

--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -334,7 +334,7 @@
                   <archiveBaseDirectory>../..</archiveBaseDirectory>
                   <appendAssemblyId>false</appendAssemblyId>
                   <attach>false</attach>
-                  <finalName>hadoop-ozone-${project.version}-src</finalName>
+                  <finalName>ozone-${project.version}-src</finalName>
                   <outputDirectory>target</outputDirectory>
                   <basedir>${project.basedir}/../..</basedir>
                   <!-- Not using descriptorRef and hadoop-assembly dependency -->


### PR DESCRIPTION

## What changes were proposed in this pull request?

When we create a release artifact today it has the `hadoop-` prefix in the names. Would be better to remove to avoid confusion.

Note: full `hadoop-` prefix is removed by #2104 (thanks to @ChenSammi ), this patch is a very small subset of that patch just to fix the tar file name on the release branch.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5063

## How was this patch tested?

```
mvn clean install -Dmaven.javadoc.skip=true -Dskip.npx -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname=$CODESIGNINGKEY
cd hadoop-ozone/dist/target
tar tzf ozone-1.1.0-SNAPSHOT.tar.gz
#check the root dir prefix in the output
tar tzf ozone-1.1.0-SNAPSHOT-src.tar.gz
#check the root dir prefix in the output
```