### PR TITLE
HDDS-5064. Fix project name in NOTICE.txt

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Apache Hadoop
+Apache Ozone
 Copyright 2006 and onwards The Apache Software Foundation.
 
 This product includes software developed at

--- a/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/NOTICE.txt
@@ -1,4 +1,4 @@
-Apache Hadoop
+Apache Ozone
 Copyright 2006 and onwards The Apache Software Foundation.
 
 This product includes software developed at


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5064

## What changes were proposed in this pull request?

Fixing the name of the project (use Apache Ozone instead of Apache Hadoop) to avoid any confusions.

## How was this patch tested?

```
cd hadoop-ozone/dist
mvn clean install -Dmaven.javadoc.skip=true  -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname=$CODESIGNINGKEY
cd target
tar -O -xf hadoop-ozone-1.1.0-SNAPSHOT.tar.gz ozone-1.1.0-SNAPSHOT/NOTICE.txt | head
tar -O -xf hadoop-ozone-1.1.0-SNAPSHOT-src.tar.gz hadoop-ozone-1.1.0-SNAPSHOT-src/NOTICE.txt
```