### PR TITLE
HDDS-5027. [SCM HA Security] Handle leader changes during bootstrap.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -45,6 +45,11 @@ public interface CertificateStore {
 
   /**
    * Writes a new certificate that was issued to the persistent store.
+   *
+   * Note: Don't rename this method, as it is used in
+   * SCMHAInvocationHandler#invokeRatis. If for any case renaming this
+   * method name is required, change it over there.
+   *
    * @param serialID - Certificate Serial Number.
    * @param certificate - Certificate to persist.
    * @param role - OM/DN/SCM.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
@@ -28,6 +28,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
 import org.apache.ratis.protocol.RaftClientReply;
@@ -229,6 +230,11 @@ public final class MockSCMHAManager implements SCMHAManager {
     @Override
     public boolean addSCM(AddSCMRequest request) throws IOException {
       return false;
+    }
+
+    @Override
+    public GrpcTlsConfig getGrpcTlsConfig() {
+      return null;
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServer.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
 
@@ -57,4 +58,7 @@ public interface SCMRatisServer {
   boolean addSCM(AddSCMRequest request) throws IOException;
 
   SCMStateMachine getSCMStateMachine();
+
+  GrpcTlsConfig getGrpcTlsConfig();
+
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -59,6 +59,9 @@ import org.apache.ratis.server.RaftServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.scm.ha.HASecurityUtils.createSCMRatisTLSConfig;
+import static org.apache.hadoop.hdds.scm.ha.HASecurityUtils.createSCMServerTlsParameters;
+
 /**
  * TODO.
  */
@@ -93,10 +96,9 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     // scm boots up, it has peer info embedded in the raft log and will
     // trigger leader election.
 
-    grpcTlsConfig = HASecurityUtils.createSCMRatisTLSConfig(new SecurityConfig(conf),
-            scm.getScmCertificateClient());
-    Parameters parameters =
-        HASecurityUtils.createSCMServerTlsParameters(grpcTlsConfig);
+    grpcTlsConfig = createSCMRatisTLSConfig(new SecurityConfig(conf),
+        scm.getScmCertificateClient());
+    Parameters parameters = createSCMServerTlsParameters(grpcTlsConfig);
 
     this.server = newRaftServer(scm.getScmId(), conf)
         .setStateMachine(stateMachine)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/SCMSecurityProtocolServerSideTranslatorPB.java
@@ -77,10 +77,14 @@ public class SCMSecurityProtocolServerSideTranslatorPB
   @Override
   public SCMSecurityResponse submitRequest(RpcController controller,
       SCMSecurityRequest request) throws ServiceException {
-    if (!scm.checkLeader()) {
-      throw new ServiceException(scm.getScmHAManager()
-          .getRatisServer()
-          .triggerNotLeaderException());
+    // For request type GetSCMCertificate we don't need leader check. As
+    // primary SCM may not be leader SCM.
+    if (!request.getCmdType().equals(GetSCMCertificate)) {
+      if (!scm.checkLeader()) {
+        throw new ServiceException(scm.getScmHAManager()
+            .getRatisServer()
+            .triggerNotLeaderException());
+      }
     }
     return dispatcher.processRequest(request, this::processRequest,
         request.getCmdType(), request.getTraceID());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.container.ContainerStateManagerV2;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
+import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
 import org.junit.Assert;
@@ -90,6 +91,11 @@ public class TestReplicationAnnotation {
       public SCMStateMachine getSCMStateMachine() {
         return null;
       }
+
+      @Override
+      public GrpcTlsConfig getGrpcTlsConfig() {
+        return null;
+      }
     };
   }
 
@@ -125,7 +131,7 @@ public class TestReplicationAnnotation {
     try {
       certificateStore.storeValidCertificate(BigInteger.valueOf(100L),
           KeyStoreTestUtil.generateCertificate("CN=Test", keyPair, 30,
-          "SHA256withRSA"), HddsProtos.NodeType.SCM);
+          "SHA256withRSA"), HddsProtos.NodeType.DATANODE);
       Assert.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException ignore) {
       Assert.assertNotNull(ignore.getMessage() != null);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This Jira is to handle when primary SCM is not leader SCM and bootstrap is failing due to this.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5027

## How was this patch tested?
Existing docker ozonesecure-ha, as modified code to use RatisClient for propagation of SCM certs.