### PR TITLE
HDDS-5062. Add a config to bypass clusterId validation for bootstrapping SCM.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -313,6 +313,23 @@ public final class ScmConfigKeys {
    */
   public static final String OZONE_SCM_PRIMORDIAL_NODE_ID_KEY =
       "ozone.scm.primordial.node.id";
+
+  /**
+   * The config when set to true skips the clusterId validation from leader
+   * scm during bootstrap. In SCM HA, the primary node starts up the ratis
+   * server while other bootstrapping nodes will get added to the ratis group.
+   * Now, if all the bootstrapping SCM get stopped post the group formation,
+   * the primary node will now step down from leadership as it will loose
+   * majority. If the bootstrapping nodes are now bootstrapped again,
+   * the bootstrapping node will try to first validate the cluster id from the
+   * leader SCM with the persisted cluster id , but as there is no leader
+   * existing, bootstrapping will keep on failing and retrying until
+   * it shuts down.
+   */
+  public static final String OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_KEY =
+      "ozone.scm.skip.bootstrap.validation";
+  public static final boolean OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_DEFAULT =
+      false;
   // The path where datanode ID is to be written to.
   // if this value is not set then container startup will fail.
   public static final String OZONE_SCM_DATANODE_ID_DIR =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1957,6 +1957,15 @@
     </description>
   </property>
   <property>
+    <name>ozone.scm.skip.bootstrap.validation</name>
+    <value>false</value>
+    <tag>OZONE, SCM, HA</tag>
+    <description>
+      optional config, the config when set to true skips the clusterId
+      validation from leader scm during bootstrap
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.ratis.enable</name>
     <value>false</value>
     <tag>OZONE, SCM, HA, RATIS</tag>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -811,13 +811,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       LOG.error("Bootstrap is not supported without SCM HA.");
       return false;
     }
-    SCMHANodeDetails scmhaNodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
-
-    loginAsSCMUserIfSecurityEnabled(scmhaNodeDetails, conf);
-    // The node here will try to fetch the cluster id from any of existing
-    // running SCM instances.
-
     String primordialSCM = SCMHAUtils.getPrimordialSCM(conf);
+    SCMHANodeDetails scmhaNodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
     String selfNodeId = scmhaNodeDetails.getLocalNodeDetails().getNodeId();
     if (primordialSCM != null && SCMHAUtils.isPrimordialSCM(conf, selfNodeId)) {
       LOG.info(
@@ -826,15 +821,27 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               + "Ignoring it.", primordialSCM, selfNodeId);
       return true;
     }
+    SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf);
+    final String persistedClusterId = scmStorageConfig.getClusterID();
+    StorageState state = scmStorageConfig.getState();
+    if (state == StorageState.INITIALIZED && conf
+        .getBoolean(ScmConfigKeys.OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_KEY,
+            ScmConfigKeys.OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_DEFAULT)) {
+      LOG.info("Skipping clusterId validation during bootstrap command.  "
+              + "ClusterId id {}, SCM id {}", persistedClusterId,
+          scmStorageConfig.getScmId());
+      return true;
+    }
+
+    loginAsSCMUserIfSecurityEnabled(scmhaNodeDetails, conf);
+    // The node here will try to fetch the cluster id from any of existing
+    // running SCM instances.
     OzoneConfiguration config =
         SCMHAUtils.removeSelfId(conf,
             scmhaNodeDetails.getLocalNodeDetails().getNodeId());
     final ScmInfo scmInfo = HAUtils.getScmInfo(config);
-    SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf);
-    final String persistedClusterId = scmStorageConfig.getClusterID();
     final String fetchedId = scmInfo.getClusterId();
     Preconditions.checkNotNull(fetchedId);
-    StorageState state = scmStorageConfig.getState();
     if (state == StorageState.INITIALIZED) {
       Preconditions.checkNotNull(scmStorageConfig.getScmId());
       if (!fetchedId.equals(persistedClusterId)) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -42,7 +42,6 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.File;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -233,19 +233,16 @@ public class TestStorageContainerManagerHA {
 
   @Test
   public void testBootStrapSCM() throws Exception {
-    StorageContainerManager scm1 = cluster.getStorageContainerManagers().get(0);
     StorageContainerManager scm2 = cluster.getStorageContainerManagers().get(1);
     OzoneConfiguration conf2 = scm2.getConfiguration();
-    conf2.set(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY,
-        scm1.getSCMNodeId());
-    conf2.set(ScmConfigKeys.OZONE_SCM_PRIMORDIAL_NODE_ID_KEY,
-        scm1.getSCMNodeId());
     boolean isDeleted = scm2.getScmStorageConfig().getVersionFile().delete();
     Assert.assertTrue(isDeleted);
     final SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf2);
     scmStorageConfig.setClusterId(UUID.randomUUID().toString());
     scmStorageConfig.getCurrentDir().delete();
     scmStorageConfig.initialize();
+    conf2.setBoolean(ScmConfigKeys.OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_KEY,
+        false);
     Assert.assertFalse(StorageContainerManager.scmBootstrap(conf2));
     conf2.setBoolean(ScmConfigKeys.OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_KEY,
         true);


### PR DESCRIPTION

## What changes were proposed in this pull request?
IN SCM HA, the primary node starts up the ratis server while other bootstrapping nodes will get added to the ratis group. Now, if all the bootstrapping SCM's get stopped, the primary node will now step down from leadership as it will loose majority. If the bootstrapping nodes are now bootstrapped again,  the bootsrapping node will try to first validate the cluster id from the leader SCM with the persisted cluster id , but as there is no leader existing, bootstrapping wil keep on failing and retrying until it shuts down. 

The issue can be very easily simulated in kubernetes deployments, where bootstrap and init cmds are run repeatedly on every restart.

The Jira aims to bypass the cluster id validation if a bootstrapping node already has a cluster id.
## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5062

## How was this patch tested?
Added unit test
