### PR TITLE
HDDS-5066. Use fixed version from pnpm to build recon

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -23,6 +23,9 @@
   <name>Apache Ozone Recon</name>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-ozone-recon</artifactId>
+  <properties>
+    <pnpm.version>5.18.9</pnpm.version>
+  </properties>
   <build>
     <resources>
       <resource>
@@ -104,12 +107,12 @@
             </configuration>
           </execution>
           <execution>
-            <id>set pnpm store path</id>
+            <id>set pnpm@${pnpm.version} store path</id>
             <goals>
               <goal>npx</goal>
             </goals>
             <configuration>
-              <arguments>pnpm config set store-dir ~/.pnpm-store</arguments>
+              <arguments>pnpm@${pnpm.version} config set store-dir ~/.pnpm-store</arguments>
             </configuration>
           </execution>
           <execution>
@@ -118,7 +121,7 @@
               <goal>npx</goal>
             </goals>
             <configuration>
-              <arguments>pnpm install --frozen-lockfile</arguments>
+              <arguments>pnpm@${pnpm.version} install --frozen-lockfile</arguments>
             </configuration>
           </execution>
           <execution>
@@ -127,7 +130,7 @@
               <goal>npx</goal>
             </goals>
             <configuration>
-              <arguments>pnpm run build</arguments>
+              <arguments>pnpm@${pnpm.version} run build</arguments>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon build is broken since yesterday due to a new pnpm@6.0.0 release

```
[INFO] Running 'npx pnpm config set store-dir ~/.pnpm-store' in /home/elek/projects/ozone/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web
[INFO] npx: installed 1 in 1.057s
[INFO] ERROR: This version of pnpm requires at least Node.js v12.17
[INFO] The current version of Node.js is v12.14.1
[INFO] Visit https://r.pnpm.io/comp to see the list of past pnpm versions with respective Node.js version support.
```

This is because the frontend maven plugin uses [npx](https://www.npmjs.com/package/npx) which downloads the required tools (`pnpm` in our case) on-demand if they are not available locally.

This download uses the latest version (by default).  

I recommend using a fixed version from `pnpm` to avoid any unexpected error when external tools is updated.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5066

## How was this patch tested?

The problem was reproducible with simple build. Tested with local build.