### PR TITLE
HDDS-5053. RocksDB block cache is not shared by Datanode containers

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -1,0 +1,119 @@
+package org.apache.hadoop.ozone.container.common.utils.db;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.utils.db.DBProfile;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.DBOptions;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.LRUCache;
+import org.rocksdb.util.SizeUnit;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT;
+
+public abstract class DatanodeDBProfile {
+
+  /**
+   * Returns DBOptions to be used for rocksDB in datanodes.
+   */
+  public abstract DBOptions getDBOptions();
+
+  /**
+   * Returns ColumnFamilyOptions to be used for rocksDB column families in
+   * datanodes.
+   */
+  public abstract ColumnFamilyOptions getColumnFamilyOptions(
+      ConfigurationSource config);
+
+
+
+  public static class SSD extends DatanodeDBProfile {
+    private static final StorageBasedProfile ssdStorageBasedProfile =
+        new StorageBasedProfile(DBProfile.SSD);
+
+    @Override
+    public DBOptions getDBOptions() {
+      return ssdStorageBasedProfile.getDBOptions();
+    }
+
+    @Override
+    public ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      return ssdStorageBasedProfile.getColumnFamilyOptions(config);
+    }
+  }
+
+
+
+  public static class Disk extends DatanodeDBProfile {
+    private static final StorageBasedProfile diskStorageBasedProfile =
+        new StorageBasedProfile(DBProfile.DISK);
+
+    @Override
+    public DBOptions getDBOptions() {
+      return diskStorageBasedProfile.getDBOptions();
+    }
+
+    @Override
+    public ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      return diskStorageBasedProfile.getColumnFamilyOptions(config);
+    }
+  }
+
+
+
+  private static class StorageBasedProfile {
+    private static final AtomicReference<DBOptions> dbOptions =
+        new AtomicReference<>();
+    private static final AtomicReference<ColumnFamilyOptions> cfOptions =
+        new AtomicReference<>();
+    private final DBProfile baseProfile;
+
+    public StorageBasedProfile(DBProfile profile) {
+      baseProfile = profile;
+    }
+
+    private DBOptions getDBOptions() {
+      dbOptions
+          .updateAndGet(op -> op != null ? op : baseProfile.getDBOptions());
+      return dbOptions.get();
+    }
+
+    private ColumnFamilyOptions getColumnFamilyOptions() {
+      return getColumnFamilyOptions(null);
+    }
+
+    private BlockBasedTableConfig getBlockBasedTableConfig() {
+      return getBlockBasedTableConfig(null);
+    }
+
+    private ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      cfOptions.updateAndGet(op -> op != null ? op :
+          baseProfile.getColumnFamilyOptions()
+              .setTableFormatConfig(getBlockBasedTableConfig(config)));
+      return cfOptions.get();
+    }
+
+    private BlockBasedTableConfig getBlockBasedTableConfig(
+        ConfigurationSource config) {
+      BlockBasedTableConfig blockBasedTableConfig =
+          baseProfile.getBlockBasedTableConfig();
+      if (config == null) {
+        return blockBasedTableConfig;
+      }
+
+      long cacheSize = (long) config
+          .getStorageSize(HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE,
+              HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT,
+              StorageUnit.BYTES);
+      blockBasedTableConfig
+          .setBlockCache(new LRUCache(cacheSize * SizeUnit.MB));
+      return blockBasedTableConfig;
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -31,72 +31,60 @@ public abstract class DatanodeDBProfile {
 
 
   public static class SSD extends DatanodeDBProfile {
-    private static final StorageBasedProfile ssdStorageBasedProfile =
+    private static final StorageBasedProfile SSD_STORAGE_BASED_PROFILE =
         new StorageBasedProfile(DBProfile.SSD);
 
     @Override
     public DBOptions getDBOptions() {
-      return ssdStorageBasedProfile.getDBOptions();
+      return SSD_STORAGE_BASED_PROFILE.getDBOptions();
     }
 
     @Override
     public ColumnFamilyOptions getColumnFamilyOptions(
         ConfigurationSource config) {
-      return ssdStorageBasedProfile.getColumnFamilyOptions(config);
+      return SSD_STORAGE_BASED_PROFILE.getColumnFamilyOptions(config);
     }
   }
 
 
 
   public static class Disk extends DatanodeDBProfile {
-    private static final StorageBasedProfile diskStorageBasedProfile =
+    private static final StorageBasedProfile DISK_STORAGE_BASED_PROFILE =
         new StorageBasedProfile(DBProfile.DISK);
 
     @Override
     public DBOptions getDBOptions() {
-      return diskStorageBasedProfile.getDBOptions();
+      return DISK_STORAGE_BASED_PROFILE.getDBOptions();
     }
 
     @Override
     public ColumnFamilyOptions getColumnFamilyOptions(
         ConfigurationSource config) {
-      return diskStorageBasedProfile.getColumnFamilyOptions(config);
+      return DISK_STORAGE_BASED_PROFILE.getColumnFamilyOptions(config);
     }
   }
 
 
 
   private static class StorageBasedProfile {
-    private static final AtomicReference<DBOptions> dbOptions =
-        new AtomicReference<>();
-    private static final AtomicReference<ColumnFamilyOptions> cfOptions =
+    private static final AtomicReference<ColumnFamilyOptions> CF_OPTIONS =
         new AtomicReference<>();
     private final DBProfile baseProfile;
 
-    public StorageBasedProfile(DBProfile profile) {
+    private StorageBasedProfile(DBProfile profile) {
       baseProfile = profile;
     }
 
     private DBOptions getDBOptions() {
-      dbOptions
-          .updateAndGet(op -> op != null ? op : baseProfile.getDBOptions());
-      return dbOptions.get();
-    }
-
-    private ColumnFamilyOptions getColumnFamilyOptions() {
-      return getColumnFamilyOptions(null);
-    }
-
-    private BlockBasedTableConfig getBlockBasedTableConfig() {
-      return getBlockBasedTableConfig(null);
+      return baseProfile.getDBOptions();
     }
 
     private ColumnFamilyOptions getColumnFamilyOptions(
         ConfigurationSource config) {
-      cfOptions.updateAndGet(op -> op != null ? op :
+      CF_OPTIONS.updateAndGet(op -> op != null ? op :
           baseProfile.getColumnFamilyOptions()
               .setTableFormatConfig(getBlockBasedTableConfig(config)));
-      return cfOptions.get();
+      return CF_OPTIONS.get();
     }
 
     private BlockBasedTableConfig getBlockBasedTableConfig(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.container.common.utils.db;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -66,7 +84,7 @@ public abstract class DatanodeDBProfile {
 
 
 
-  private static class StorageBasedProfile {
+  private static final class StorageBasedProfile {
     private static final AtomicReference<ColumnFamilyOptions> CF_OPTIONS =
         new AtomicReference<>();
     private final DBProfile baseProfile;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/package-info.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains files related to db use in datanodes.
+ */
+package org.apache.hadoop.ozone.container.common.utils.db;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.container.keyvalue;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.BlockID;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 
@@ -31,13 +30,13 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
+import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume
     .RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
-import org.apache.hadoop.ozone.container.metadata.AbstractDatanodeStore;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
@@ -52,6 +51,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.DBOptions;
 
 import java.io.File;
 
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -430,30 +431,18 @@ public class TestKeyValueContainer {
   }
 
   @Test
-  public void testContainersShareColumnFamilyOptions() throws Exception {
-    // Get a read only view (not a copy) of the options cache.
-    Map<ConfigurationSource, ColumnFamilyOptions> cachedOptions =
-        AbstractDatanodeStore.getColumnFamilyOptionsCache();
+  public void testContainersShareColumnFamilyOptions() {
+    for (Supplier<DatanodeDBProfile> dbProfileSupplier : new Supplier[] {
+        DatanodeDBProfile.Disk::new, DatanodeDBProfile.SSD::new }) {
+      ColumnFamilyOptions columnFamilyOptions1 = dbProfileSupplier.get()
+          .getColumnFamilyOptions(new OzoneConfiguration());
+      ColumnFamilyOptions columnFamilyOptions2 = dbProfileSupplier.get()
+          .getColumnFamilyOptions(new OzoneConfiguration());
+      Assert.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
 
-    // Create Container 1
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
-    Assert.assertEquals(1, cachedOptions.size());
-    ColumnFamilyOptions options1 = cachedOptions.get(CONF);
-    Assert.assertNotNull(options1);
-
-    // Create Container 2
-    keyValueContainerData = new KeyValueContainerData(2L,
-        layout,
-        (long) StorageUnit.GB.toBytes(5), UUID.randomUUID().toString(),
-        datanodeId.toString());
-    keyValueContainer = new KeyValueContainer(keyValueContainerData, CONF);
-    keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
-
-    Assert.assertEquals(1, cachedOptions.size());
-    ColumnFamilyOptions options2 = cachedOptions.get(CONF);
-    Assert.assertNotNull(options2);
-
-    // Column family options object should be reused.
-    Assert.assertSame(options1, options2);
+      DBOptions dbOptions1 = dbProfileSupplier.get().getDBOptions();
+      DBOptions dbOptions2 = dbProfileSupplier.get().getDBOptions();
+      Assert.assertEquals(dbOptions1, dbOptions2);
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -51,7 +51,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 import org.rocksdb.ColumnFamilyOptions;
-import org.rocksdb.DBOptions;
 
 import java.io.File;
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -439,10 +439,6 @@ public class TestKeyValueContainer {
       ColumnFamilyOptions columnFamilyOptions2 = dbProfileSupplier.get()
           .getColumnFamilyOptions(new OzoneConfiguration());
       Assert.assertEquals(columnFamilyOptions1, columnFamilyOptions2);
-
-      DBOptions dbOptions1 = dbProfileSupplier.get().getDBOptions();
-      DBOptions dbOptions2 = dbProfileSupplier.get().getDBOptions();
-      Assert.assertEquals(dbOptions1, dbOptions2);
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

RocksDB block cache is not being shared by Datanode containers. The DN process uses around 20 GB of RSS after startup and does not release the memory even though rocksdb is closed for every container.
Replacing the OPTIONS_CACHE in AbstractDatanodeStore with static ColumnFamilyOptions brings the RSS down to ~3.5 GB after startup.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5053

## How was this patch tested?

Cluster deployment
