### PR TITLE
HDDS-5042.[FSO] Improve KeyDeletingService to cleanup FSO files

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.fs.ozone;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -31,9 +32,11 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.om.DirectoryDeletingService;
+import org.apache.hadoop.ozone.om.KeyDeletingService;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.test.GenericTestUtils;
 import org.junit.After;
@@ -314,5 +317,61 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
       Assert.assertTrue(ex.getMessage().contains("No such file or directory"));
     }
   }
+
+  @Test
+  public void testDeleteSubFiles() throws Exception {
+
+    Table<String, OmKeyInfo> deletedDirTable =
+        cluster.getOzoneManager().getMetadataManager().getDeletedDirTable();
+    Table<String, OmKeyInfo> keyTable =
+        cluster.getOzoneManager().getMetadataManager().getKeyTable();
+    Table<String, OmDirectoryInfo> dirTable =
+        cluster.getOzoneManager().getMetadataManager().getDirectoryTable();
+    Table<String, RepeatedOmKeyInfo> deletedKeyTable =
+        cluster.getOzoneManager().getMetadataManager().getDeletedTable();
+
+    Path root = new Path("/rootDir2");
+    // Create  parent dir from root.
+    fs.mkdirs(root);
+
+    // Added 10 sub files inside root dir
+    for (int i = 0; i<10; i++) {
+      Path path = new Path(root, "testKey" + i);
+      try (FSDataOutputStream stream = fs.create(path)) {
+        stream.write(1);
+      }
+    }
+
+    // Before delete
+    assertTableRowCount(deletedDirTable, 0);
+    assertTableRowCount(keyTable, 10);
+    assertTableRowCount(dirTable, 1);
+
+    fs.delete(root, true);
+
+    DirectoryDeletingService dirDeletingService =
+        (DirectoryDeletingService) cluster.getOzoneManager().getKeyManager()
+            .getDirDeletingService();
+
+    KeyDeletingService keyDeletingService =
+        (KeyDeletingService) cluster.getOzoneManager().getKeyManager()
+            .getDeletingService();
+
+    // Just After delete
+    assertTableRowCount(deletedDirTable, 1);
+    assertTableRowCount(keyTable, 0);
+    assertTableRowCount(dirTable, 0);
+    assertTableRowCount(deletedKeyTable, 10);
+
+    // Eventually keys would get cleaned up from deletedTables too
+    assertTableRowCount(deletedDirTable, 0);
+    assertTableRowCount(deletedKeyTable, 0);
+
+    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 10);
+    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 1);
+    // verify whether KeyDeletingService has purged the keys
+    Assert.assertEquals(10, keyDeletingService.getDeletedKeyCount().get());
+  }
+
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
@@ -350,7 +350,7 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(keyTable, 10);
     assertTableRowCount(dirTable, 1);
-    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
+    long prevDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
 
     fs.delete(root, true);
 
@@ -369,7 +369,8 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
     assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 10);
     assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 1);
     // verify whether KeyDeletingService has purged the keys
-    Assert.assertEquals(10, keyDeletingService.getDeletedKeyCount().get());
+    long currentDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
+    Assert.assertEquals(currentDeletedKeyCount, prevDeletedKeyCount + 10);
   }
 
   @Test
@@ -404,7 +405,7 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(keyTable, 10);
     assertTableRowCount(dirTable, 1);
-    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
+    long prevDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
 
     for (int i = 0; i<10; i++) {
       Path path = new Path(root, "testKey" + i);
@@ -427,6 +428,7 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
     assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
     assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 0);
     // verify whether KeyDeletingService has purged the keys
-    Assert.assertEquals(10, keyDeletingService.getDeletedKeyCount().get());
+    long currentDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
+    Assert.assertEquals(currentDeletedKeyCount, prevDeletedKeyCount + 10);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSOBucket.java
@@ -342,20 +342,21 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
       }
     }
 
+    KeyDeletingService keyDeletingService =
+        (KeyDeletingService) cluster.getOzoneManager().getKeyManager()
+            .getDeletingService();
+
     // Before delete
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(keyTable, 10);
     assertTableRowCount(dirTable, 1);
+    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
 
     fs.delete(root, true);
 
     DirectoryDeletingService dirDeletingService =
         (DirectoryDeletingService) cluster.getOzoneManager().getKeyManager()
             .getDirDeletingService();
-
-    KeyDeletingService keyDeletingService =
-        (KeyDeletingService) cluster.getOzoneManager().getKeyManager()
-            .getDeletingService();
 
     // After delete
     assertTableRowCount(keyTable, 0);
@@ -395,10 +396,15 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
       }
     }
 
+    KeyDeletingService keyDeletingService =
+        (KeyDeletingService) cluster.getOzoneManager().getKeyManager()
+            .getDeletingService();
+
     // Before delete
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(keyTable, 10);
     assertTableRowCount(dirTable, 1);
+    Assert.assertEquals(0, keyDeletingService.getDeletedKeyCount().get());
 
     for (int i = 0; i<10; i++) {
       Path path = new Path(root, "testKey" + i);
@@ -409,9 +415,6 @@ public class TestDirectoryDeletingServiceWithFSOBucket {
         (DirectoryDeletingService) cluster.getOzoneManager().getKeyManager()
             .getDirDeletingService();
 
-    KeyDeletingService keyDeletingService =
-        (KeyDeletingService) cluster.getOzoneManager().getKeyManager()
-            .getDeletingService();
 
     // After delete
     assertTableRowCount(keyTable, 0);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
@@ -239,7 +239,7 @@ public class DirectoryDeletingService extends BackgroundService {
     }
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(CURRENT_VERSION));
+          purgeFile.getProtobuf(true, CURRENT_VERSION));
     }
 
     // Add these directories to deletedDirTable, so that its sub-paths will be

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -100,6 +100,50 @@ public abstract class AbstractOMKeyDeleteResponse extends OMClientResponse {
     }
   }
 
+  /**
+   *  This method is used for FSO file deletes.
+   *  Since a common deletedTable is used ,it requires to add  key in the
+   *  full format (vol/buck/key). This method deletes the key from
+   *  file table (which is in prefix format) and adds the fullKey
+   *  into the deletedTable
+   * @param keyName     (format: objectId/key)
+   * @param fullKeyName (format: vol/buck/key)
+   * @param omKeyInfo
+   * @throws IOException
+   */
+  protected void addDeletionToBatch(
+      OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation,
+      Table<String, ?> fromTable,
+      String keyName, String fullKeyName,
+      OmKeyInfo omKeyInfo) throws IOException {
+
+    // For OmResponse with failure, this should do nothing. This method is
+    // not called in failure scenario in OM code.
+    fromTable.deleteWithBatch(batchOperation, keyName);
+
+    // If Key is not empty add this to delete table.
+    if (!isKeyEmpty(omKeyInfo)) {
+      // If a deleted key is put in the table where a key with the same
+      // name already exists, then the old deleted key information would be
+      // lost. To avoid this, first check if a key with same name exists.
+      // deletedTable in OM Metadata stores <KeyName, RepeatedOMKeyInfo>.
+      // The RepeatedOmKeyInfo is the structure that allows us to store a
+      // list of OmKeyInfo that can be tied to same key name. For a keyName
+      // if RepeatedOMKeyInfo structure is null, we create a new instance,
+      // if it is not null, then we simply add to the list and store this
+      // instance in deletedTable.
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(fullKeyName);
+      repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(
+          omKeyInfo, repeatedOmKeyInfo, omKeyInfo.getUpdateID(),
+          isRatisEnabled);
+      omMetadataManager.getDeletedTable().putWithBatch(
+          batchOperation, fullKeyName, repeatedOmKeyInfo);
+    }
+  }
+
+
   @Override
   public abstract void addToDBBatch(OMMetadataManager omMetadataManager,
         BatchOperation batchOperation) throws IOException;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseV1.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseV1.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_DIR_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
@@ -36,7 +37,8 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 /**
  * Response for DeleteKey request.
  */
-@CleanupTableInfo(cleanupTables = {FILE_TABLE, DIRECTORY_TABLE, DELETED_TABLE})
+@CleanupTableInfo(cleanupTables = {FILE_TABLE, DIRECTORY_TABLE,
+    DELETED_TABLE, DELETED_DIR_TABLE})
 public class OMKeyDeleteResponseV1 extends OMKeyDeleteResponse {
 
   private boolean isDeleteDirectory;
@@ -79,8 +81,18 @@ public class OMKeyDeleteResponseV1 extends OMKeyDeleteResponse {
           batchOperation, ozoneDbKey, omKeyInfo);
     } else {
       Table<String, OmKeyInfo> keyTable = omMetadataManager.getKeyTable();
+      OmKeyInfo omKeyInfo = getOmKeyInfo();
+      // Sets full absolute key name to OmKeyInfo, which is
+      // required for moving the sub-files to KeyDeletionService.
+      omKeyInfo.setKeyName(keyName);
+      String deletedKey = omMetadataManager
+          .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
+              omKeyInfo.getKeyName());
+      // For OmResponse with failure, this should do nothing. This method is
+      // not called in failure scenario in OM code.
+      keyTable.deleteWithBatch(batchOperation, ozoneDbKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
-              ozoneDbKey, getOmKeyInfo());
+          ozoneDbKey, deletedKey, omKeyInfo);
     }
 
     // update bucket usedBytes.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseV1.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseV1.java
@@ -88,9 +88,6 @@ public class OMKeyDeleteResponseV1 extends OMKeyDeleteResponse {
       String deletedKey = omMetadataManager
           .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
               omKeyInfo.getKeyName());
-      // For OmResponse with failure, this should do nothing. This method is
-      // not called in failure scenario in OM code.
-      keyTable.deleteWithBatch(batchOperation, ozoneDbKey);
       addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
           ozoneDbKey, deletedKey, omKeyInfo);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMPathsPurgeResponseV1.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMPathsPurgeResponseV1.java
@@ -112,8 +112,12 @@ public class OMPathsPurgeResponseV1 extends OMClientResponse {
       repeatedOmKeyInfo = OmUtils.prepareKeyForDelete(keyInfo,
           repeatedOmKeyInfo, keyInfo.getUpdateID(), isRatisEnabled);
 
+      String deletedKey = omMetadataManager
+          .getOzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),
+              keyInfo.getKeyName());
+
       omMetadataManager.getDeletedTable().putWithBatch(batchOperation,
-          keyInfo.getPath(), repeatedOmKeyInfo);
+          deletedKey, repeatedOmKeyInfo);
 
     }
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -69,10 +69,13 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     Assert.assertFalse(omMetadataManager.getKeyTable().isExist(ozoneKey));
 
+    String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+
     // As default key entry does not have any blocks, it should not be in
     // deletedKeyTable.
     Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(
-        ozoneKey));
+        deletedKey));
   }
 
   @Test
@@ -124,9 +127,11 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
     Assert.assertFalse(omMetadataManager.getKeyTable().isExist(ozoneKey));
 
+    String deletedKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
+        keyName);
+
     // Key has blocks, it should not be in deletedKeyTable.
-    Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(
-        ozoneKey));
+    Assert.assertTrue(omMetadataManager.getDeletedTable().isExist(deletedKey));
   }
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Added unit test to verify whether `KeyDeletingService` deletes FSO files. The `DirectoryDeletingService` is responsible for moving subfiles of deleted directories into the `DeletedTable`. The `DeletedTable` however expects the older key format (volume/bucket/key) . The fix in this change ensures that the right key format is written into the `DeletedTable`

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5042

## How was this patch tested?
UT