### PR TITLE
HDDS-5026. Cancel failing PR workflow runs

### DIFF
--- a/.github/workflows/cancel-ci.yaml
+++ b/.github/workflows/cancel-ci.yaml
@@ -30,5 +30,12 @@ jobs:
           cancelFutureDuplicates: true
           token: ${{ secrets.GITHUB_TOKEN }}
           sourceRunId: ${{ github.event.workflow_run.id }}
-          notifyPRCancel: true
           skipEventTypes: '["push", "schedule"]'
+      - uses: potiuk/cancel-workflow-runs@a81b3c4d59c61e27484cfacdc13897dd908419c9
+        name: "Cancel failing PR builds"
+        with:
+          cancelMode: failedJobs
+          token: ${{ secrets.GITHUB_TOKEN }}
+          skipEventTypes: '["push", "schedule"]'
+          jobNameRegexps: '["^.*$"]'
+          workflowFileName: post-commit.yml


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently most CI checks run to completion even if other checks fail.  HDDS-4933 added cancellation for concurrent builds of the same check (eg. _acceptance_).  This change extends the separate _Cancelling_ workflow introduced in HDDS-4988, to abort PR builds with any checks already failing.  (Eg. avoid waiting 1.5 hours for acceptance if checkstyle has error).

https://issues.apache.org/jira/browse/HDDS-5026

## How was this patch tested?

Tested similar change in my fork.