### PR TITLE
HDDS-5077. Include dev-support in ozone source distribution

### DIFF
--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -62,6 +62,10 @@
       </includes>
     </fileSet>
     <fileSet>
+      <directory>dev-support</directory>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+    <fileSet>
       <directory>hadoop-hdds</directory>
       <useDefaultExcludes>true</useDefaultExcludes>
       <excludes>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-5077

This should include dev-support in the ozone-src dist.