### PR TITLE
HDDS-5053. RocksDB block cache capacity is wrongly configured

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -245,7 +245,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
         StorageUnit.BYTES);
 
     BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
-    tableConfig.setBlockCache(new LRUCache(cacheSize * SizeUnit.MB))
+    tableConfig.setBlockCache(new LRUCache(cacheSize))
         .setPinL0FilterAndIndexBlocksInCache(true)
         .setFilterPolicy(new BloomFilter());
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -35,7 +35,6 @@ import org.rocksdb.DBOptions;
 import org.rocksdb.LRUCache;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
-import org.rocksdb.util.SizeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The DN process uses around 20 GB of RSS after startup and does not release the memory even though rocksdb is closed for every container.
The capacity used by AbstractDatanodeStore is default capacity * MB. Since default capacity is 64MB therefore block cache is passed a capacity of 64TB. After the fix the DN memory usage drops to ~3GB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5053

## How was this patch tested?

Cluster deployment