### PR TITLE
HDDS-5084. Include HISTORY.md/SECURITY.md/CONTRIBUTING.md in the release artifacts.

### DIFF
--- a/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
+++ b/hadoop-ozone/dist/dev-support/bin/dist-layout-stitching
@@ -67,6 +67,9 @@ run cp -p "${ROOT}/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt" "LICENSE.
 run cp -pr "${ROOT}/hadoop-ozone/dist/src/main/license/bin/licenses" "licenses"
 run cp -p "${ROOT}/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/LICENSE" "licenses/LICENSE-ozone-recon.txt"
 run cp -p "${ROOT}/README.md" .
+run cp -p "${ROOT}/HISTORY.md" .
+run cp -p "${ROOT}/SECURITY.md" .
+run cp -p "${ROOT}/CONTRIBUTING.md" .
 
 run mkdir -p ./share/ozone/web
 run mkdir -p ./bin

--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -59,6 +59,9 @@
       <includes>
         <include>pom.xml</include>
         <include>README.md</include>
+        <include>HISTORY.md</include>
+        <include>SECURITY.md</include>
+        <include>CONTRIBUTING.md</include>
       </includes>
     </fileSet>
     <fileSet>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5084

## What changes were proposed in this pull request?

During the ozone-1.1.0 vote I realized that `HISTORY.md`/`SECURITY.md`/`CONTRIBUTING.md` files are missing from the `bin` and `src` artifacts. I think they include very useful information and would be better to include them in the release artifacts.

## How was this patch tested?

```
mvn clean install -Dmaven.javadoc.skip=true -DskipTests -Psign,dist,src -Dtar -Dgpg.keyname=$CODESIGNINGKEY
  cd hadoop-ozone/dist/target/
tar tzf hadoop-ozone-1.1.0-SNAPSHOT.tar.gz
tar tzf hadoop-ozone-1.1.0-src-SNAPSHOT.tar.gz
```  