### PR TITLE
HDDS-5086. Add pre-finalize validation action for SCM HA.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutVersionManager.java
@@ -46,7 +46,7 @@ public class HDDSLayoutVersionManager extends
   private static final Logger LOG =
       LoggerFactory.getLogger(HDDSLayoutVersionManager.class);
   private static final String[] HDDS_CLASS_UPGRADE_PACKAGES = new String[]{
-      "org.apache.hadoop.hdds.server.scm",
+      "org.apache.hadoop.hdds.scm.server",
       "org.apache.hadoop.ozone.container"};
 
   public HDDSLayoutVersionManager(int layoutVersion) throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.scm.server.upgrade;
+
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature.SCM_HA;
+import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.UNFINALIZED_STATE_VALIDATION;
+import static org.apache.hadoop.ozone.upgrade.UpgradeActionHdds.Component.SCM;
+
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.upgrade.HDDSUpgradeAction;
+import org.apache.hadoop.ozone.upgrade.UpgradeActionHdds;
+import org.apache.hadoop.ozone.upgrade.UpgradeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@UpgradeActionHdds(feature = SCM_HA, component = SCM,
+    type = UNFINALIZED_STATE_VALIDATION)
+public class ScmHAUnfinalizedStateValidationAction
+    implements HDDSUpgradeAction<StorageContainerManager> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ScmHAUnfinalizedStateValidationAction.class);
+
+  @Override
+  public void execute(StorageContainerManager scm) throws Exception {
+    boolean isHAEnabled =
+        scm.getConfiguration().getBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,
+        ScmConfigKeys.OZONE_SCM_HA_ENABLE_DEFAULT);
+
+    if (isHAEnabled) {
+      throw new UpgradeException(String.format("Configuration %s cannot be " +
+          "used until SCM upgrade has been finalized",
+          ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY),
+          UpgradeException.ResultCodes.PREFINALIZE_STATE_VALIDATION_FAILED);
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.scm.upgrade;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
@@ -1,0 +1,45 @@
+package org.apache.hadoop.hdds.scm.upgrade;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ScmConfig;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.upgrade.UpgradeException;
+import org.apache.hadoop.test.LambdaTestUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.UUID;
+
+public class TestSCMHAUnfinalized {
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private StorageContainerManager scm;
+
+  @Before
+  public void setup() {
+  }
+
+  @Test
+  public void testSCMHAConfigsUsedUnfinalized() throws Exception {
+    // Build unfinalized SCM with HA configuration enabled.
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,true);
+    conf.setInt(ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION,
+        HDDSLayoutFeature.INITIAL_VERSION.layoutVersion());
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,
+        temporaryFolder.newFolder().getAbsolutePath());
+
+    StorageContainerManager.scmInit(conf, UUID.randomUUID().toString());
+    scm = new StorageContainerManager(conf);
+
+    LambdaTestUtils.intercept(UpgradeException.class, scm::start);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/upgrade/TestSCMHAUnfinalized.java
@@ -1,7 +1,6 @@
 package org.apache.hadoop.hdds.scm.upgrade;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -31,7 +30,7 @@ public class TestSCMHAUnfinalized {
   public void testSCMHAConfigsUsedUnfinalized() throws Exception {
     // Build unfinalized SCM with HA configuration enabled.
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY,true);
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
     conf.setInt(ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION,
         HDDSLayoutFeature.INITIAL_VERSION.layoutVersion());
     conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure that if a pre-finalized cluster (whose metadata layout version is behind SCM HA) is started with an SCM HA enabled configuration, SCM will fail to start with an error.

## What is the link to the Apache JIRA

HDDS-5086

## How was this patch tested?

Unit test added.
