### PR TITLE
HDDS-5087. Ozone RPC client leaks KeyProvider instances.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.http.HttpConfig;
 import org.apache.ratis.proto.RaftProtos.ReplicationLevel;
 import org.apache.ratis.util.TimeDuration;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class contains constants for configuration keys used in Ozone.
  */
@@ -439,6 +441,11 @@ public final class OzoneConfigKeys {
       "ozone.om.keyname.character.check.enabled";
   public static final boolean OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT =
       false;
+
+  public static final String OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY =
+      "ozone.client.key.provider.cache.expiry";
+  public static final long OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT =
+      TimeUnit.DAYS.toMillis(10); // 10 days
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2770,4 +2770,13 @@
       during OzoneManager init/SCM bootstrap.
     </description>
   </property>
+
+  <property>
+    <name>ozone.client.key.provider.cache.expiry</name>
+    <tag>OZONE, CLIENT, SECURITY</tag>
+    <value>10d</value>
+    <description>Ozone client security key provider cache expiration time.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -116,6 +116,10 @@ import org.apache.hadoop.security.token.Token;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY;
@@ -124,10 +128,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
 
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
-import org.apache.ratis.thirdparty.com.google.common.cache.Cache;
-import org.apache.ratis.thirdparty.com.google.common.cache.CacheBuilder;
-import org.apache.ratis.thirdparty.com.google.common.cache.RemovalListener;
-import org.apache.ratis.thirdparty.com.google.common.cache.RemovalNotification;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1380,5 +1380,10 @@ public class RpcClient implements ClientProtocol {
   @VisibleForTesting
   public OzoneManagerProtocol getOzoneManagerClient() {
     return ozoneManagerClient;
+  }
+
+  @VisibleForTesting
+  public Cache<URI, KeyProvider> getKeyProviderCache() {
+    return keyProviderCache;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -493,4 +493,11 @@ public class TestOzoneAtRestEncryption {
         offset + " and length " + readData.length,
         inputDataForComparison, readData);
   }
+
+  @Test
+  public void testGetKeyProvider() throws Exception {
+    KeyProvider kp1 = store.getKeyProvider();
+    KeyProvider kp2 = store.getKeyProvider();
+    Assert.assertEquals(kp1, kp2);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
@@ -31,6 +32,7 @@ import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
 
+import com.google.common.cache.Cache;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
@@ -76,6 +78,7 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client.
@@ -497,7 +500,22 @@ public class TestOzoneAtRestEncryption {
   @Test
   public void testGetKeyProvider() throws Exception {
     KeyProvider kp1 = store.getKeyProvider();
+    KeyProvider kpSpy = Mockito.spy(kp1);
+    Assert.assertNotEquals(kpSpy, kp1);
+    Cache<URI, KeyProvider> cacheSpy =
+        ((RpcClient)store.getClientProxy()).getKeyProviderCache();
+    cacheSpy.put(store.getKeyProviderUri(), kpSpy);
     KeyProvider kp2 = store.getKeyProvider();
-    Assert.assertEquals(kp1, kp2);
+    Assert.assertEquals(kpSpy, kp2);
+
+    // Verify the spied key provider is closed upon ozone client close
+    ozClient.close();
+    Mockito.verify(kpSpy).close();
+
+    KeyProvider kp3 = ozClient.getObjectStore().getKeyProvider();
+    Assert.assertNotEquals(kp3, kpSpy);
+    // Restore ozClient and store
+    TestOzoneRpcClient.setOzClient(OzoneClientFactory.getRpcClient(conf));
+    TestOzoneRpcClient.setStore(ozClient.getObjectStore());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Maintain a KeyProvider cache for Ozone RPC client and ensure Key provider is closed upon removal from the cache. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5087

## How was this patch tested?
UT added.