### PR TITLE
HDDS-4842. Add timestamp to Revoked Certs table in SCM DB

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -89,11 +89,21 @@ public interface SCMMetadataStore extends DBStoreHAManager {
   Table<BigInteger, X509Certificate> getValidSCMCertsTable();
 
   /**
+   * This method is Deprecated in favor of getRevokedCertsV2Table().
    * A Table that maintains all revoked certificates until they expire.
    *
    * @return Table.
    */
-  Table<BigInteger, CertInfo> getRevokedCertsTable();
+  @Deprecated
+  Table<BigInteger, X509Certificate> getRevokedCertsTable();
+
+  /**
+   * A Table that maintains all revoked certificates and the time of
+   * revocation until they expire.
+   *
+   * @return Table.
+   */
+  Table<BigInteger, CertInfo> getRevokedCertsV2Table();
 
   /**
    * A table that maintains X509 Certificate Revocation Lists and its metadata.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStore.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.utils.DBStoreHAManager;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
@@ -92,7 +93,7 @@ public interface SCMMetadataStore extends DBStoreHAManager {
    *
    * @return Table.
    */
-  Table<BigInteger, X509Certificate> getRevokedCertsTable();
+  Table<BigInteger, CertInfo> getRevokedCertsTable();
 
   /**
    * A table that maintains X509 Certificate Revocation Lists and its metadata.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.Comparator;
@@ -33,9 +34,10 @@ import java.util.Objects;
  * Class that wraps Certificate Info.
  */
 public class CertInfo implements Comparator<CertInfo>,
-    Comparable<CertInfo> {
+    Comparable<CertInfo>, Serializable {
 
   private X509Certificate x509Certificate;
+  // Timestamp when the certificate got persisted in the DB.
   private long timestamp;
 
   private CertInfo(X509Certificate x509Certificate, long timestamp) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/CertInfo.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.security.x509.certificate;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Comparator;
+import java.util.Objects;
+
+/**
+ * Class that wraps Certificate Info.
+ */
+public class CertInfo implements Comparator<CertInfo>,
+    Comparable<CertInfo> {
+
+  private X509Certificate x509Certificate;
+  private long timestamp;
+
+  private CertInfo(X509Certificate x509Certificate, long timestamp) {
+    this.x509Certificate = x509Certificate;
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Constructor for CertInfo. Needed for serialization findbugs.
+   */
+  public CertInfo() {
+  }
+
+  public static CertInfo fromProtobuf(HddsProtos.CertInfoProto info)
+      throws IOException, CertificateException {
+    CertInfo.Builder builder = new CertInfo.Builder();
+    return builder
+        .setX509Certificate(
+            CertificateCodec.getX509Certificate(info.getX509Certificate()))
+        .setTimestamp(info.getTimestamp())
+        .build();
+  }
+
+  public HddsProtos.CertInfoProto getProtobuf() throws SCMSecurityException {
+    HddsProtos.CertInfoProto.Builder builder =
+        HddsProtos.CertInfoProto.newBuilder();
+
+    return builder.setX509Certificate(
+        CertificateCodec.getPEMEncodedString(getX509Certificate()))
+        .setTimestamp(getTimestamp())
+        .build();
+  }
+
+  public X509Certificate getX509Certificate() {
+    return x509Certificate;
+  }
+
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Compares this object with the specified object for order.  Returns a
+   * negative integer, zero, or a positive integer as this object is less
+   * than, equal to, or greater than the specified object.
+   *
+   * @param o the object to be compared.
+   * @return a negative integer, zero, or a positive integer as this object
+   * is less than, equal to, or greater than the specified object.
+   * @throws NullPointerException if the specified object is null
+   * @throws ClassCastException   if the specified object's type prevents it
+   *                              from being compared to this object.
+   */
+  @Override
+  public int compareTo(@NotNull CertInfo o) {
+    return this.compare(this, o);
+  }
+
+  /**
+   * Compares its two arguments for order.  Returns a negative integer,
+   * zero, or a positive integer as the first argument is less than, equal
+   * to, or greater than the second.<p>
+   * <p>
+   *
+   * @param o1 the first object to be compared.
+   * @param o2 the second object to be compared.
+   * @return a negative integer, zero, or a positive integer as the
+   * first argument is less than, equal to, or greater than the
+   * second.
+   * @throws NullPointerException if an argument is null and this
+   *                              comparator does not permit null arguments
+   * @throws ClassCastException   if the arguments' types prevent them from
+   *                              being compared by this comparator.
+   */
+  @Override
+  public int compare(CertInfo o1, CertInfo o2) {
+    return Long.compare(o1.getTimestamp(), o2.getTimestamp());
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    CertInfo that = (CertInfo) o;
+
+    return this.getX509Certificate().equals(that.getX509Certificate()) &&
+        this.getTimestamp() == that.getTimestamp();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getX509Certificate(), getTimestamp());
+  }
+
+  @Override
+  public String toString() {
+    return "CertInfo{" +
+        "x509Certificate=" + x509Certificate.toString() +
+        ", timestamp=" + timestamp +
+        '}';
+  }
+
+  /**
+   * Builder class for CertInfo.
+   */
+  @SuppressWarnings("checkstyle:hiddenfield")
+  public static class Builder {
+    private X509Certificate x509Certificate;
+    private long timestamp;
+
+    public Builder setX509Certificate(X509Certificate x509Certificate) {
+      this.x509Certificate = x509Certificate;
+      return this;
+    }
+
+    public Builder setTimestamp(long timestamp) {
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    public CertInfo build() {
+      return new CertInfo(x509Certificate, timestamp);
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -81,6 +81,7 @@ public interface CertificateStore {
    * Otherwise, returns the newly generated CRL sequence ID.
    * @throws IOException - on failure.
    */
+  @Replicate
   Optional<Long> revokeCertificates(List<BigInteger> serialIDs,
                                     X509CertificateHolder caCertificateHolder,
                                     CRLReason reason,

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
@@ -103,6 +104,17 @@ public interface CertificateStore {
    * @throws IOException - on failure.
    */
   X509Certificate getCertificateByID(BigInteger serialID, CertType certType)
+      throws IOException;
+
+  /**
+   * Retrieves a {@link CertInfo} for a revoked certificate based on the Serial
+   * number of that certificate. This API can be used to get more information
+   * like the timestamp when the certificate was persisted in the DB.
+   * @param serialID - ID of the certificate.
+   * @return CertInfo
+   * @throws IOException - on failure.
+   */
+  CertInfo getRevokedCertificateInfoByID(BigInteger serialID)
       throws IOException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/package-info.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains the common routines used for maintaining
+ * X509 Certificates.
+ */
+package org.apache.hadoop.hdds.security.x509.certificate;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
@@ -70,6 +71,12 @@ public class MockCAStore implements CertificateStore {
   @Override
   public X509Certificate getCertificateByID(BigInteger serialID,
                                             CertType certType)
+      throws IOException {
+    return null;
+  }
+
+  @Override
+  public CertInfo getRevokedCertificateInfoByID(BigInteger serialID)
       throws IOException {
     return null;
   }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -324,3 +324,11 @@ message CRLInfoProto {
     required string x509CRL = 1;
     required uint64 creationTimestamp = 2;
 }
+
+/**
+ * Information for X509 Certificate.
+ */
+message CertInfoProto {
+    required string x509Certificate = 1;
+    required uint64 timestamp = 2;
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/CertInfoCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/CertInfoCodec.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.apache.hadoop.hdds.scm.metadata;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
+import org.apache.hadoop.hdds.utils.db.Codec;
+
+import java.io.IOException;
+import java.security.cert.CertificateException;
+
+/**
+ * Codec to serialize / deserialize CertInfo.
+ */
+public class CertInfoCodec implements Codec<CertInfo> {
+
+
+  @Override
+  public byte[] toPersistedFormat(CertInfo certInfo) throws IOException {
+    return certInfo.getProtobuf().toByteArray();
+  }
+
+  @Override
+  public CertInfo fromPersistedFormat(byte[] rawData) throws IOException {
+
+    Preconditions.checkNotNull(rawData,
+        "Null byte array can't be converted to real object.");
+    try {
+      return CertInfo.fromProtobuf(
+          HddsProtos.CertInfoProto.PARSER.parseFrom(rawData));
+    } catch (CertificateException e) {
+      throw new IllegalArgumentException(
+          "Can't encode the the raw data from the byte array", e);
+    }
+  }
+
+  @Override
+  public CertInfo copyObject(CertInfo object) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -66,6 +67,10 @@ public class SCMDBDefinition implements DBDefinition {
           X509Certificate.class,
           new X509CertificateCodec());
 
+  /**
+   * This column family is Deprecated in favor of REVOKED_CERTS_V2.
+   */
+  @Deprecated
   public static final DBColumnFamilyDefinition<BigInteger, X509Certificate>
       REVOKED_CERTS =
       new DBColumnFamilyDefinition<>(
@@ -74,6 +79,15 @@ public class SCMDBDefinition implements DBDefinition {
           new BigIntegerCodec(),
           X509Certificate.class,
           new X509CertificateCodec());
+
+  public static final DBColumnFamilyDefinition<BigInteger, CertInfo>
+      REVOKED_CERTS_V2 =
+      new DBColumnFamilyDefinition<>(
+          "revokedCertsV2",
+          BigInteger.class,
+          new BigIntegerCodec(),
+          CertInfo.class,
+          new CertInfoCodec());
 
   public static final DBColumnFamilyDefinition<PipelineID, Pipeline>
       PIPELINES =
@@ -141,7 +155,7 @@ public class SCMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_BLOCKS, VALID_CERTS,
-        VALID_SCM_CERTS, REVOKED_CERTS, PIPELINES, CONTAINERS, TRANSACTIONINFO,
-        CRLS, CRL_SEQUENCE_ID, SEQUENCE_ID};
+        VALID_SCM_CERTS, REVOKED_CERTS_V2, PIPELINES, CONTAINERS,
+        TRANSACTIONINFO, CRLS, CRL_SEQUENCE_ID, SEQUENCE_ID};
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMDBDefinition.java
@@ -155,7 +155,7 @@ public class SCMDBDefinition implements DBDefinition {
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
     return new DBColumnFamilyDefinition[] {DELETED_BLOCKS, VALID_CERTS,
-        VALID_SCM_CERTS, REVOKED_CERTS_V2, PIPELINES, CONTAINERS,
+        VALID_SCM_CERTS, REVOKED_CERTS, REVOKED_CERTS_V2, PIPELINES, CONTAINERS,
         TRANSACTIONINFO, CRLS, CRL_SEQUENCE_ID, SEQUENCE_ID};
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -44,6 +44,7 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRLS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS_V2;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.TRANSACTIONINFO;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_CERTS;
@@ -67,7 +68,9 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
   private Table<BigInteger, X509Certificate> validSCMCertsTable;
 
-  private Table<BigInteger, CertInfo> revokedCertsTable;
+  private Table<BigInteger, X509Certificate> revokedCertsTable;
+
+  private Table<BigInteger, CertInfo> revokedCertsV2Table;
 
   private Table<ContainerID, ContainerInfo> containerTable;
 
@@ -136,9 +139,13 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
       checkTableStatus(validSCMCertsTable, VALID_SCM_CERTS.getName());
 
-      revokedCertsTable = REVOKED_CERTS_V2.getTable(store);
+      revokedCertsTable = REVOKED_CERTS.getTable(store);
 
-      checkTableStatus(revokedCertsTable, REVOKED_CERTS_V2.getName());
+      checkTableStatus(revokedCertsTable, REVOKED_CERTS.getName());
+
+      revokedCertsV2Table = REVOKED_CERTS_V2.getTable(store);
+
+      checkTableStatus(revokedCertsV2Table, REVOKED_CERTS_V2.getName());
 
       pipelineTable = PIPELINES.getTable(store);
 
@@ -180,7 +187,6 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
     return deletedBlocksTable;
   }
 
-
   @Override
   public Table<BigInteger, X509Certificate> getValidCertsTable() {
     return validCertsTable;
@@ -192,8 +198,13 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   }
 
   @Override
-  public Table<BigInteger, CertInfo> getRevokedCertsTable() {
+  public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
     return revokedCertsTable;
+  }
+
+  @Override
+  public Table<BigInteger, CertInfo> getRevokedCertsV2Table() {
+    return revokedCertsV2Table;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/SCMMetadataStoreImpl.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.DeletedBlocksTransaction;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -43,7 +44,7 @@ import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRLS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CRL_SEQUENCE_ID;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.DELETED_BLOCKS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.PIPELINES;
-import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS;
+import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.REVOKED_CERTS_V2;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.TRANSACTIONINFO;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_CERTS;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.VALID_SCM_CERTS;
@@ -66,7 +67,7 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
   private Table<BigInteger, X509Certificate> validSCMCertsTable;
 
-  private Table<BigInteger, X509Certificate> revokedCertsTable;
+  private Table<BigInteger, CertInfo> revokedCertsTable;
 
   private Table<ContainerID, ContainerInfo> containerTable;
 
@@ -135,9 +136,9 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
 
       checkTableStatus(validSCMCertsTable, VALID_SCM_CERTS.getName());
 
-      revokedCertsTable = REVOKED_CERTS.getTable(store);
+      revokedCertsTable = REVOKED_CERTS_V2.getTable(store);
 
-      checkTableStatus(revokedCertsTable, REVOKED_CERTS.getName());
+      checkTableStatus(revokedCertsTable, REVOKED_CERTS_V2.getName());
 
       pipelineTable = PIPELINES.getTable(store);
 
@@ -191,7 +192,7 @@ public class SCMMetadataStoreImpl implements SCMMetadataStore {
   }
 
   @Override
-  public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
+  public Table<BigInteger, CertInfo> getRevokedCertsTable() {
     return revokedCertsTable;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CRLApprover;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
@@ -174,8 +175,12 @@ public final class SCMCertStore implements CertificateStore {
           // only if the revocation time has passed.
           if (now.after(revocationTime) || now.equals(revocationTime)) {
             for (X509Certificate cert : certsToRevoke) {
+              CertInfo certInfo = new CertInfo.Builder()
+                  .setX509Certificate(cert)
+                  .setTimestamp(now.getTime())
+                  .build();
               scmMetadataStore.getRevokedCertsTable()
-                  .putWithBatch(batch, cert.getSerialNumber(), cert);
+                  .putWithBatch(batch, cert.getSerialNumber(), certInfo);
               scmMetadataStore.getValidCertsTable()
                   .deleteWithBatch(batch, cert.getSerialNumber());
             }
@@ -214,63 +219,74 @@ public final class SCMCertStore implements CertificateStore {
     if (certType == VALID_CERTS) {
       return scmMetadataStore.getValidCertsTable().get(serialID);
     } else {
-      return scmMetadataStore.getRevokedCertsTable().get(serialID);
+      CertInfo certInfo = getRevokedCertificateInfoByID(serialID);
+      return certInfo != null ? certInfo.getX509Certificate() : null;
     }
+  }
+
+  @Override
+  public CertInfo getRevokedCertificateInfoByID(BigInteger serialID)
+      throws IOException {
+    return scmMetadataStore.getRevokedCertsTable().get(serialID);
   }
 
   @Override
   public List<X509Certificate> listCertificate(NodeType role,
       BigInteger startSerialID, int count, CertType certType)
       throws IOException {
-
+    List<X509Certificate> results = new ArrayList<>();
+    String errorMessage = "Fail to list certificate from SCM metadata store";
     Preconditions.checkNotNull(startSerialID);
 
     if (startSerialID.longValue() == 0) {
       startSerialID = null;
     }
 
-    List<? extends Table.KeyValue<BigInteger, X509Certificate>> certs =
-        getCertTableList(role, certType, startSerialID, count);
+    if (certType == VALID_CERTS) {
+      List<? extends Table.KeyValue<BigInteger, X509Certificate>> certs =
+          getValidCertTableList(role, startSerialID, count);
 
-    List<X509Certificate> results = new ArrayList<>(certs.size());
+      for (Table.KeyValue<BigInteger, X509Certificate> kv : certs) {
+        try {
+          X509Certificate cert = kv.getValue();
+          results.add(cert);
+        } catch (IOException e) {
+          LOG.error(errorMessage, e);
+          throw new SCMSecurityException(errorMessage);
+        }
+      }
+    } else {
+      List<? extends Table.KeyValue<BigInteger, CertInfo>> certs =
+          scmMetadataStore.getRevokedCertsTable().getRangeKVs(
+          startSerialID, count);
 
-    for (Table.KeyValue<BigInteger, X509Certificate> kv : certs) {
-      try {
-        X509Certificate cert = kv.getValue();
-        results.add(cert);
-      } catch (IOException e) {
-        LOG.error("Fail to list certificate from SCM metadata store", e);
-        throw new SCMSecurityException(
-            "Fail to list certificate from SCM metadata store.");
+      for (Table.KeyValue<BigInteger, CertInfo> kv : certs) {
+        try {
+          CertInfo certInfo = kv.getValue();
+          X509Certificate cert = certInfo != null ?
+              certInfo.getX509Certificate() : null;
+          results.add(cert);
+        } catch (IOException e) {
+          LOG.error(errorMessage, e);
+          throw new SCMSecurityException(errorMessage);
+        }
       }
     }
     return results;
   }
 
   private List<? extends Table.KeyValue<BigInteger, X509Certificate>>
-      getCertTableList(NodeType role, CertType certType,
-      BigInteger startSerialID, int count)
+      getValidCertTableList(NodeType role, BigInteger startSerialID, int count)
       throws IOException {
     // Implemented for role SCM and CertType VALID_CERTS.
-    // TODO: Implement for role OM/Datanode and for SCM for CertType
-    //  REVOKED_CERTS.
+    // TODO: Implement for role OM/Datanode
 
     if (role == SCM) {
-      if (certType == VALID_CERTS) {
-        return scmMetadataStore.getValidSCMCertsTable().getRangeKVs(
-            startSerialID, count);
-      } else {
-        return scmMetadataStore.getRevokedCertsTable().getRangeKVs(
-            startSerialID, count);
-      }
+      return scmMetadataStore.getValidSCMCertsTable().getRangeKVs(
+          startSerialID, count);
     } else {
-      if (certType == VALID_CERTS) {
-        return scmMetadataStore.getValidCertsTable().getRangeKVs(
-            startSerialID, count);
-      } else {
-        return scmMetadataStore.getRevokedCertsTable().getRangeKVs(
-            startSerialID, count);
-      }
+      return scmMetadataStore.getValidCertsTable().getRangeKVs(
+          startSerialID, count);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -179,7 +179,7 @@ public final class SCMCertStore implements CertificateStore {
                   .setX509Certificate(cert)
                   .setTimestamp(now.getTime())
                   .build();
-              scmMetadataStore.getRevokedCertsTable()
+              scmMetadataStore.getRevokedCertsV2Table()
                   .putWithBatch(batch, cert.getSerialNumber(), certInfo);
               scmMetadataStore.getValidCertsTable()
                   .deleteWithBatch(batch, cert.getSerialNumber());
@@ -227,7 +227,7 @@ public final class SCMCertStore implements CertificateStore {
   @Override
   public CertInfo getRevokedCertificateInfoByID(BigInteger serialID)
       throws IOException {
-    return scmMetadataStore.getRevokedCertsTable().get(serialID);
+    return scmMetadataStore.getRevokedCertsV2Table().get(serialID);
   }
 
   @Override
@@ -257,7 +257,7 @@ public final class SCMCertStore implements CertificateStore {
       }
     } else {
       List<? extends Table.KeyValue<BigInteger, CertInfo>> certs =
-          scmMetadataStore.getRevokedCertsTable().getRangeKVs(
+          scmMetadataStore.getRevokedCertsV2Table().getRangeKVs(
           startSerialID, count);
 
       for (Table.KeyValue<BigInteger, CertInfo> kv : certs) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.scm.metadata.PipelineCodec;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
@@ -99,7 +100,7 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
   }
 
   @Override
-  public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
+  public Table<BigInteger, CertInfo> getRevokedCertsTable() {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMStoreImplWithOldPipelineIDKeyFormat.java
@@ -100,7 +100,12 @@ public class TestSCMStoreImplWithOldPipelineIDKeyFormat
   }
 
   @Override
-  public Table<BigInteger, CertInfo> getRevokedCertsTable() {
+  public Table<BigInteger, X509Certificate> getRevokedCertsTable() {
+    return null;
+  }
+
+  @Override
+  public Table<BigInteger, CertInfo> getRevokedCertsV2Table() {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CRLApprover;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultCRLApprover;
@@ -147,9 +148,12 @@ public class TestSCMCertStore {
         scmCertStore.getCertificateByID(serialID,
             VALID_CERTS));
 
-    assertNotNull(
-        scmCertStore.getCertificateByID(serialID,
-            CertificateStore.CertType.REVOKED_CERTS));
+    CertInfo certInfo = scmCertStore.getRevokedCertificateInfoByID(serialID);
+
+    assertNotNull(certInfo);
+    assertNotNull(certInfo.getX509Certificate());
+    assertTrue("Timestamp should be greater than 0",
+        certInfo.getTimestamp() > 0L);
 
     // CRL Info table should have a CRL with sequence id
     assertNotNull(scmMetadataStore.getCRLInfoTable()
@@ -254,8 +258,7 @@ public class TestSCMCertStore {
             VALID_CERTS));
 
     assertNull(
-        scmCertStore.getCertificateByID(serialID,
-            CertificateStore.CertType.REVOKED_CERTS));
+        scmCertStore.getRevokedCertificateInfoByID(serialID));
   }
 
   private X509Certificate generateX509Cert() throws Exception {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMCertStore.java
@@ -229,7 +229,7 @@ public class TestSCMCertStore {
 
     // Revoked certs table should have 3 certs
     assertEquals(3L,
-        getTableSize(scmMetadataStore.getRevokedCertsTable().iterator()));
+        getTableSize(scmMetadataStore.getRevokedCertsV2Table().iterator()));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add timestamp to REVOKED_CERTS table in SCM db. 

Instead of modifying the definition of the existing column family, this patch introduces a new column family to make it easier for the finalize upgrade action to support upgrades from older versions.

The changes required to make it backward compatible is tracked here - https://issues.apache.org/jira/browse/HDDS-5088
The changes required to make the persistence happen via Ratis is tracked here - https://issues.apache.org/jira/browse/HDDS-5095

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4842

## How was this patch tested?

Unit tests
