### PR TITLE
HDDS-5075. NPE during secure SCM initialization with HA code updated to an already existing cluster

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMSecurityProtocolServer.java
@@ -316,7 +316,7 @@ public class SCMSecurityProtocolServer implements SCMSecurityProtocol {
   public String getRootCACertificate() throws IOException {
     LOGGER.debug("Getting Root CA certificate.");
     if (storageContainerManager.getScmStorageConfig()
-        .getPrimaryScmNodeId() != null) {
+        .checkPrimarySCMIdInitialized()) {
       return CertificateCodec.getPEMEncodedString(rootCACertificate);
     }
     return null;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -644,7 +644,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     // as for SCM CA is root-CA.
     securityProtocolServer = new SCMSecurityProtocolServer(conf,
         rootCertificateServer, scmCertificateServer,
-        scmCertificateClient.getCACertificate(), this);
+        scmCertificateClient != null ?
+            scmCertificateClient.getCACertificate() : null, this);
   }
 
   /** Persist primary SCM root ca cert and sub-ca certs to DB.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed the issue of SCM not coming up after the upgrade, and also SCM Client commands failing due to NPE with setX509RootCACertificate. For more info refer to Jira for stack trace.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5078

## How was this patch tested?

Tested it manually. Thank You @fapifta for reporting and also for trying out the fix.
