### PR TITLE
HDDS-5080. enable s3 test suite for secure-ha

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -33,6 +33,7 @@ execute_robot_test ${SCM} freon
 
 execute_robot_test ${SCM} basic/links.robot
 
+execute_robot_test ${SCM} s3
 stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -61,7 +61,7 @@ Setup v4 headers
     Run Keyword if      '${SECURITY_ENABLED}' == 'false'    Setup dummy credentials for S3
 
 Setup secure v4 headers
-    ${result} =         Execute                    ozone s3 getsecret
+    ${result} =         Execute                    ozone s3 getsecret ${OM_HA_PARAM}
     ${accessKey} =      Get Regexp Matches         ${result}     (?<=awsAccessKey=).*
     ${accessKey} =      Get Variable Value         ${accessKey}  sdsdasaasdasd
     ${secret} =         Get Regexp Matches         ${result}     (?<=awsSecret=).*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable s3 test suite for ozone secure-ha. In this way, the s3 test suite will run in SCM/OM HA Secure env.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5080

## How was this patch tested?

Added s3 test suite to run in secure-ha.
