### PR TITLE
HDDS-5101. Fix Maxkeys is invalid when delimiter is not null

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -166,8 +166,8 @@ public class BucketEndpoint extends EndpointBase {
           if (!dirName.equals(prevDir)) {
             response.addPrefix(prefix + dirName + delimiter);
             prevDir = dirName;
-            count++;
           }
+          count++;
         } else if (relativeKeyName.endsWith(delimiter)) {
           // means or key is same as prefix with delimiter at end and ends with
           // delimiter. ex: dir/, where prefix is dir and delimiter is /

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketGet.java
@@ -238,22 +238,18 @@ public class TestBucketGet {
             "test/", null, null, null, null, null).getEntity();
 
     Assert.assertEquals(0, getBucketResponse.getContents().size());
-    Assert.assertEquals(2, getBucketResponse.getCommonPrefixes().size());
+    Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
     Assert.assertEquals("test/dir1/",
         getBucketResponse.getCommonPrefixes().get(0).getPrefix());
-    Assert.assertEquals("test/dir2/",
-        getBucketResponse.getCommonPrefixes().get(1).getPrefix());
 
     getBucketResponse =
         (ListObjectResponse) getBucket.list("b1", "/", null, null, maxKeys,
             "test/", null, getBucketResponse.getNextToken(), null, null, null)
             .getEntity();
-    Assert.assertEquals(1, getBucketResponse.getContents().size());
+    Assert.assertEquals(0, getBucketResponse.getContents().size());
     Assert.assertEquals(1, getBucketResponse.getCommonPrefixes().size());
-    Assert.assertEquals("test/dir3/",
+    Assert.assertEquals("test/dir2/",
         getBucketResponse.getCommonPrefixes().get(0).getPrefix());
-    Assert.assertEquals("test/file8",
-        getBucketResponse.getContents().get(0).getKey());
 
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5101?filter=-2

When get keys from s3g, the keys in my cluster is 
 `
main/chunk/00000000
main/chunk/00000001
...
main/chunk/99999999`
if delimiter is not null, until all keys are queried, the count is always 1 ,so the max-keys is invalid.
![image](https://user-images.githubusercontent.com/32935220/114648151-ec094480-9d10-11eb-8f06-09f7453e1c18.png)


