### PR TITLE
HDDS-4889. Add simple CI check for docs

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -77,6 +77,7 @@ jobs:
           - author
           - bats
           - checkstyle
+          - docs
           - findbugs
           - rat
           - unit
@@ -93,7 +94,7 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}-8
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
-        if: ${{ !contains('author,bats', matrix.check) }}
+        if: ${{ !contains('author,bats,docs', matrix.check) }}
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
       - name: Summary of failures

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -45,12 +45,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Test http server os SCM with various HTTP option.
  */
 @RunWith(value = Parameterized.class)
 public class TestStorageContainerManagerHttpServer {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestStorageContainerManagerHttpServer.class);
   private static final String BASEDIR = GenericTestUtils
       .getTempPath(TestStorageContainerManagerHttpServer.class.getSimpleName());
   private static String keystoresDir;
@@ -130,13 +135,13 @@ public class TestStorageContainerManagerHttpServer {
     if (addr == null) {
       return false;
     }
+    String url = scheme + "://" + NetUtils.getHostPortString(addr) + "/jmx";
     try {
-      URL url =
-          new URL(scheme + "://" + NetUtils.getHostPortString(addr) + "/jmx");
-      URLConnection conn = connectionFactory.openConnection(url);
+      URLConnection conn = connectionFactory.openConnection(new URL(url));
       conn.connect();
       conn.getContent();
     } catch (IOException e) {
+      LOG.info("Cannot access {}", url, e);
       return false;
     }
     return true;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -45,17 +45,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Test http server os SCM with various HTTP option.
  */
 @RunWith(value = Parameterized.class)
 public class TestStorageContainerManagerHttpServer {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestStorageContainerManagerHttpServer.class);
   private static final String BASEDIR = GenericTestUtils
       .getTempPath(TestStorageContainerManagerHttpServer.class.getSimpleName());
   private static String keystoresDir;
@@ -137,13 +132,13 @@ public class TestStorageContainerManagerHttpServer {
     if (addr == null) {
       return false;
     }
-    String url = scheme + "://" + NetUtils.getHostPortString(addr) + "/jmx";
     try {
-      URLConnection conn = connectionFactory.openConnection(new URL(url));
+      URL url =
+          new URL(scheme + "://" + NetUtils.getHostPortString(addr) + "/jmx");
+      URLConnection conn = connectionFactory.openConnection(url);
       conn.connect();
       conn.getContent();
     } catch (IOException e) {
-      LOG.info("Cannot access {}", url, e);
       return false;
     }
     return true;

--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -87,6 +87,34 @@ _install_flekszible() {
   chmod +x bin/flekszible
 }
 
+install_hugo() {
+  _install_tool hugo bin
+}
+
+_install_hugo() {
+  : ${HUGO_VERSION:=0.81.0}
+
+  local os=$(uname -s)
+  local arch=$(uname -m)
+
+  mkdir bin
+
+  case "${os}" in
+    Darwin)
+      os=macOS
+      ;;
+  esac
+
+  case "${arch}" in
+    x86_64)
+      arch=64bit
+      ;;
+  esac
+
+  curl -LSs "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_${HUGO_VERSION}_${os}-${arch}.tar.gz" | tar -xz -f - -C bin hugo
+  chmod +x bin/hugo
+}
+
 install_virtualenv() {
   _install_tool virtualenv
 }

--- a/hadoop-ozone/dev-support/checks/docs.sh
+++ b/hadoop-ozone/dev-support/checks/docs.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd "${DIR}/../../.." || exit 1
+
+source "${DIR}/_lib.sh"
+install_hugo
+
+REPORT_DIR=${OUTPUT_DIR:-"${DIR}/../../../target/docs"}
+mkdir -p "${REPORT_DIR}"
+REPORT_FILE="${REPORT_DIR}/summary.txt"
+
+hadoop-hdds/docs/dev-support/bin/generate-site.sh | tee "${REPORT_DIR}/output.log"
+rc=$?
+
+grep -o 'ERROR.*' "${REPORT_DIR}/output.log" > "${REPORT_FILE}"
+
+wc -l "${REPORT_FILE}" | awk '{ print $1 }' > "${REPORT_DIR}/failures"
+
+if [[ -s "${REPORT_FILE}" ]]; then
+   exit 1
+fi
+
+exit ${rc}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently docs are implicitly built in _integration_ checks.  (They used to be built in few other checks, too, but those no longer have Hugo available.)  If there is a syntax error in the docs, all of these fail due to the same cause.  Also, one needs to dig into build logs to find any problem, because Hugo errors are not collected.

This PR adds a separate check for building `hadoop-hdds/docs` with Hugo, collecting summary of Hugo-specific failures in the regular way.

https://issues.apache.org/jira/browse/HDDS-4889

## How was this patch tested?

```
> Run hadoop-ozone/dev-support/checks/docs.sh
...
Installed hugo in /home/runner/work/hadoop-ozone/hadoop-ozone/.dev-tools/hugo
~/work/hadoop-ozone/hadoop-ozone
Start building sites … 

                   | EN | ZH  
-------------------+----+-----
  Pages            | 81 | 49  
  Paginator pages  |  0 |  0  
  Non-page files   | 22 | 22  
  Static files     | 26 | 26  
  Processed images |  0 |  0  
  Aliases          |  1 |  0  
  Sitemaps         |  2 |  1  
  Cleaned          |  0 |  0  

Total in 188 ms
```

https://github.com/adoroszlai/hadoop-ozone/runs/2344467280#step:4:1

Introduced reference to non-existing page locally, verified output:

```
$ hadoop-ozone/dev-support/checks/docs.sh
...
Error: Error building site: logged 1 error(s)

$ cat target/docs/summary.txt
ERROR 2021/04/14 17:30:42 [en] REF_NOT_FOUND: Ref "asdfJavaApi.md": "hadoop-hdds/docs/content/_index.md:33:138": page not found

$ cat target/docs/failures
1
```