### PR TITLE
HDDS-5089. On-demand disk checker for hdds volume

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.DataNodeLayoutVersion;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -233,5 +235,14 @@ public final class HddsVolumeUtil {
       return false;
     }
 
+  }
+
+  public static void onFailure(HddsVolume volume) {
+    if (volume != null) {
+      VolumeSet volumeSet = volume.getVolumeSet();
+      if (volumeSet != null && volumeSet instanceof MutableVolumeSet) {
+        ((MutableVolumeSet) volumeSet).checkVolumeAsync(volume);
+      }
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -78,6 +78,7 @@ public class HddsVolume
   private final VolumeInfo volumeInfo;
   private VolumeState state;
   private final VolumeIOStats volumeIOStats;
+  private final VolumeSet volumeSet;
 
   // VERSION file properties
   private String storageID;       // id of the file system
@@ -115,6 +116,7 @@ public class HddsVolume
     private String clusterID;
     private boolean failedVolume = false;
     private SpaceUsageCheckFactory usageCheckFactory;
+    private VolumeSet volumeSet;
 
     public Builder(String rootDirStr) {
       this.volumeRootStr = rootDirStr;
@@ -153,6 +155,11 @@ public class HddsVolume
       return this;
     }
 
+    public Builder volumeSet(VolumeSet volSet) {
+      this.volumeSet = volSet;
+      return this;
+    }
+
     public HddsVolume build() throws IOException {
       return new HddsVolume(this);
     }
@@ -172,6 +179,7 @@ public class HddsVolume
           .usageCheckFactory(b.usageCheckFactory)
           .build();
       this.committedBytes = new AtomicLong(0);
+      this.volumeSet = b.volumeSet;
 
       LOG.info("Creating Volume: {} of storage type : {} and capacity : {}",
           hddsRootDir, b.storageType, volumeInfo.getCapacity());
@@ -186,6 +194,7 @@ public class HddsVolume
       storageID = UUID.randomUUID().toString();
       state = VolumeState.FAILED;
       committedBytes = null;
+      volumeSet = null;
     }
   }
 
@@ -393,6 +402,10 @@ public class HddsVolume
 
   public VolumeIOStats getVolumeIOStats() {
     return volumeIOStats;
+  }
+
+  public VolumeSet getVolumeSet() {
+    return volumeSet;
   }
 
   public void failVolume() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -161,7 +161,7 @@ public class MutableVolumeSet implements VolumeSet {
   }
 
   @VisibleForTesting
-  HddsVolumeChecker getVolumeChecker() {
+  public HddsVolumeChecker getVolumeChecker() {
     return volumeChecker;
   }
 
@@ -284,6 +284,19 @@ public class MutableVolumeSet implements VolumeSet {
     // 2. Handle Ratis log disk failure.
   }
 
+  public void checkVolumeAsync(HddsVolume volume) {
+    volumeChecker.checkVolume(
+        volume, (healthyVolumes, failedVolumes) -> {
+          if (failedVolumes.size() > 0) {
+            LOG.warn("checkVolumeAsync callback got {} failed volumes: {}",
+                failedVolumes.size(), failedVolumes);
+          } else {
+            LOG.debug("checkVolumeAsync: no volume failures detected");
+          }
+          handleVolumeFailures(failedVolumes);
+        });
+  }
+
   /**
    * If Version file exists and the {@link #clusterID} is not set yet,
    * assign it the value from Version file. Otherwise, check that the given
@@ -349,7 +362,8 @@ public class MutableVolumeSet implements VolumeSet {
         .datanodeUuid(datanodeUuid)
         .clusterID(clusterID)
         .usageCheckFactory(usageCheckFactory)
-        .storageType(storageType);
+        .storageType(storageType)
+        .volumeSet(this);
     return volumeBuilder.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -64,6 +64,8 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.ERROR_IN_DB_SYNC;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.INVALID_CONTAINER_STATE;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
+import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -225,6 +227,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       }
 
     } catch (IOException ex) {
+      onFailure(containerData.getVolume());
       throw new StorageContainerException("Error while creating/ updating " +
           ".container file. ContainerID: " + containerId, ex,
           CONTAINER_FILES_CREATE_ERROR);
@@ -259,6 +262,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } catch (IOException ex) {
       // TODO : An I/O error during delete can leave partial artifacts on the
       // disk. We will need the cleaner thread to cleanup this information.
+      onFailure(containerData.getVolume());
       String errMsg = String.format("Failed to cleanup container. ID: %d",
           containerId);
       LOG.error(errMsg, ex);
@@ -377,6 +381,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       throw ex;
     } catch (IOException ex) {
       LOG.error("Error in DB compaction while closing container", ex);
+      onFailure(containerData.getVolume());
       throw new StorageContainerException(ex, ERROR_IN_COMPACT_DB);
     }
   }
@@ -393,6 +398,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       throw ex;
     } catch (IOException ex) {
       LOG.error("Error in DB sync while closing container", ex);
+      onFailure(containerData.getVolume());
       throw new StorageContainerException(ex, ERROR_IN_DB_SYNC);
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -125,7 +125,8 @@ public class KeyValueHandler extends Handler {
     super(config, datanodeId, contSet, volSet, metrics, icrSender);
     containerType = ContainerType.KeyValueContainer;
     blockManager = new BlockManagerImpl(config);
-    chunkManager = ChunkManagerFactory.createChunkManager(config, blockManager);
+    chunkManager = ChunkManagerFactory.createChunkManager(config, blockManager,
+        volSet);
     try {
       volumeChoosingPolicy = conf.getClass(
           HDDS_DATANODE_VOLUME_CHOOSING_POLICY, RoundRobinVolumeChoosingPolicy

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_READ_METADATA_DB;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
+import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
 
 /**
  * Utils functions to help block functions.
@@ -121,6 +122,7 @@ public final class BlockUtils {
           .getContainerDBType(), containerData.getDbFile().getAbsolutePath(),
               containerData.getSchemaVersion(), conf);
     } catch (IOException ex) {
+      onFailure(containerData.getVolume());
       String message = String.format("Error opening DB. Container:%s " +
           "ContainerPath:%s", containerData.getContainerID(), containerData
           .getDbFile().getPath());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
-import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -54,6 +54,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.IO_EXCEPTION;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_ALGORITHM;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
+import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,27 +93,27 @@ public final class ChunkUtils {
    * @param data - The data buffer.
    * @param offset
    * @param len
-   * @param volumeIOStats statistics collector
+   * @param volume for statistics and checker
    * @param sync whether to do fsync or not
    */
   public static void writeData(File file, ChunkBuffer data,
-      long offset, long len, VolumeIOStats volumeIOStats, boolean sync)
+      long offset, long len, HddsVolume volume, boolean sync)
       throws StorageContainerException {
 
-    writeData(data, file.getName(), offset, len, volumeIOStats,
+    writeData(data, file.getName(), offset, len, volume,
         d -> writeDataToFile(file, d, offset, sync));
   }
 
   public static void writeData(FileChannel file, String filename,
-      ChunkBuffer data, long offset, long len, VolumeIOStats volumeIOStats
-  ) throws StorageContainerException {
+      ChunkBuffer data, long offset, long len, HddsVolume volume)
+      throws StorageContainerException {
 
-    writeData(data, filename, offset, len, volumeIOStats,
+    writeData(data, filename, offset, len, volume,
         d -> writeDataToChannel(file, d, offset));
   }
 
   private static void writeData(ChunkBuffer data, String filename,
-      long offset, long len, VolumeIOStats volumeIOStats,
+      long offset, long len, HddsVolume volume,
       ToLongFunction<ChunkBuffer> writer) throws StorageContainerException {
 
     validateBufferSize(len, data.remaining());
@@ -122,14 +123,17 @@ public final class ChunkUtils {
     try {
       bytesWritten = writer.applyAsLong(data);
     } catch (UncheckedIOException e) {
+      onFailure(volume);
       throw wrapInStorageContainerException(e.getCause());
     }
 
     final long endTime = Time.monotonicNow();
     long elapsed = endTime - startTime;
-    volumeIOStats.incWriteTime(elapsed);
-    volumeIOStats.incWriteOpCount();
-    volumeIOStats.incWriteBytes(bytesWritten);
+    if (volume != null) {
+      volume.getVolumeIOStats().incWriteTime(elapsed);
+      volume.getVolumeIOStats().incWriteOpCount();
+      volume.getVolumeIOStats().incWriteBytes(bytesWritten);
+    }
 
     LOG.debug("Written {} bytes at offset {} to {} in {} ms",
         bytesWritten, offset, filename, elapsed);
@@ -170,9 +174,13 @@ public final class ChunkUtils {
    * Reads data from an existing chunk file into a list of ByteBuffers.
    *
    * @param file file where data lives
+   * @param buffers
+   * @param offset
+   * @param len
+   * @param volume for statistics and checker
    */
   public static void readData(File file, ByteBuffer[] buffers,
-      long offset, long len, VolumeIOStats volumeIOStats)
+      long offset, long len, HddsVolume volume)
       throws StorageContainerException {
 
     final Path path = file.toPath();
@@ -186,18 +194,22 @@ public final class ChunkUtils {
 
           return channel.position(offset).read(buffers);
         } catch (IOException e) {
+          onFailure(volume);
           throw new UncheckedIOException(e);
         }
       });
     } catch (UncheckedIOException e) {
+      onFailure(volume);
       throw wrapInStorageContainerException(e.getCause());
     }
 
     // Increment volumeIO stats here.
     long endTime = Time.monotonicNow();
-    volumeIOStats.incReadTime(endTime - startTime);
-    volumeIOStats.incReadOpCount();
-    volumeIOStats.incReadBytes(bytesRead);
+    if (volume != null) {
+      volume.getVolumeIOStats().incReadTime(endTime - startTime);
+      volume.getVolumeIOStats().incReadOpCount();
+      volume.getVolumeIOStats().incReadBytes(bytesRead);
+    }
 
     LOG.debug("Read {} bytes starting at offset {} from {}",
         bytesRead, offset, file);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerDispatcher.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
@@ -56,9 +57,12 @@ public class ChunkManagerDispatcher implements ChunkManager {
   private final Map<ChunkLayOutVersion, ChunkManager> handlers
       = new EnumMap<>(ChunkLayOutVersion.class);
 
-  ChunkManagerDispatcher(boolean sync, BlockManager manager) {
-    handlers.put(FILE_PER_CHUNK, new FilePerChunkStrategy(sync, manager));
-    handlers.put(FILE_PER_BLOCK, new FilePerBlockStrategy(sync, manager));
+  ChunkManagerDispatcher(boolean sync, BlockManager manager,
+                         VolumeSet volSet) {
+    handlers.put(FILE_PER_CHUNK,
+        new FilePerChunkStrategy(sync, manager, volSet));
+    handlers.put(FILE_PER_BLOCK,
+        new FilePerBlockStrategy(sync, manager, volSet));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.keyvalue.impl;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration;
@@ -48,7 +49,7 @@ public final class ChunkManagerFactory {
    * @return
    */
   public static ChunkManager createChunkManager(ConfigurationSource conf,
-      BlockManager manager) {
+      BlockManager manager, VolumeSet volSet) {
     boolean sync =
         conf.getBoolean(OzoneConfigKeys.DFS_CONTAINER_CHUNK_WRITE_SYNC_KEY,
             OzoneConfigKeys.DFS_CONTAINER_CHUNK_WRITE_SYNC_DEFAULT);
@@ -75,6 +76,6 @@ public final class ChunkManagerFactory {
       return new ChunkManagerDummyImpl();
     }
 
-    return new ChunkManagerDispatcher(sync, manager);
+    return new ChunkManagerDispatcher(sync, manager, volSet);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.BlockManager;
 import org.apache.hadoop.ozone.container.keyvalue.interfaces.ChunkManager;
@@ -58,6 +58,7 @@ import java.util.concurrent.ExecutionException;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion.FILE_PER_BLOCK;
 import static org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage.COMMIT_DATA;
+import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.validateChunkForOverwrite;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.verifyChunkFileExists;
 
@@ -72,11 +73,14 @@ public class FilePerBlockStrategy implements ChunkManager {
   private final boolean doSyncWrite;
   private final OpenFiles files = new OpenFiles();
   private final long defaultReadBufferCapacity;
+  private final VolumeSet volumeSet;
 
-  public FilePerBlockStrategy(boolean sync, BlockManager manager) {
+  public FilePerBlockStrategy(boolean sync, BlockManager manager,
+                              VolumeSet volSet) {
     doSyncWrite = sync;
     this.defaultReadBufferCapacity = manager == null ? 0 :
         manager.getDefaultReadBufferCapacity();
+    this.volumeSet = volSet;
   }
 
   private static void checkLayoutVersion(Container container) {
@@ -121,11 +125,17 @@ public class FilePerBlockStrategy implements ChunkManager {
     }
 
     HddsVolume volume = containerData.getVolume();
-    VolumeIOStats volumeIOStats = volume.getVolumeIOStats();
 
-    FileChannel channel = files.getChannel(chunkFile, doSyncWrite);
+    FileChannel channel = null;
+    try {
+      channel = files.getChannel(chunkFile, doSyncWrite);
+    } catch (IOException e) {
+      onFailure(volume);
+      throw e;
+    }
+
     ChunkUtils.writeData(channel, chunkFile.getName(), data, offset, len,
-        volumeIOStats);
+        volume);
 
     containerData.updateWriteStats(len, overwrite);
   }
@@ -146,7 +156,6 @@ public class FilePerBlockStrategy implements ChunkManager {
         .getContainerData();
 
     HddsVolume volume = containerData.getVolume();
-    VolumeIOStats volumeIOStats = volume.getVolumeIOStats();
 
     File chunkFile = getChunkFile(container, blockID, info);
 
@@ -158,7 +167,7 @@ public class FilePerBlockStrategy implements ChunkManager {
     ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
         bufferCapacity);
 
-    ChunkUtils.readData(chunkFile, dataBuffers, offset, len, volumeIOStats);
+    ChunkUtils.readData(chunkFile, dataBuffers, offset, len, volume);
 
     return ChunkBuffer.wrap(Lists.newArrayList(dataBuffers));
   }
@@ -179,8 +188,13 @@ public class FilePerBlockStrategy implements ChunkManager {
   public void finishWriteChunks(KeyValueContainer container,
       BlockData blockData) throws IOException {
     File chunkFile = getChunkFile(container, blockData.getBlockID(), null);
-    files.close(chunkFile);
-    verifyChunkFileExists(chunkFile);
+    try {
+      files.close(chunkFile);
+      verifyChunkFileExists(chunkFile);
+    } catch (IOException e) {
+      onFailure(container.getContainerData().getVolume());
+      throw e;
+    }
   }
 
   private void deleteChunk(Container container, BlockID blockID,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -185,9 +185,9 @@ public class TestBlockDeletingService {
       int numOfChunksPerBlock) throws IOException {
     ChunkManager chunkManager;
     if (layout == FILE_PER_BLOCK) {
-      chunkManager = new FilePerBlockStrategy(true, null);
+      chunkManager = new FilePerBlockStrategy(true, null, null);
     } else {
-      chunkManager = new FilePerChunkStrategy(true, null);
+      chunkManager = new FilePerChunkStrategy(true, null, null);
     }
     byte[] arr = randomAlphanumeric(1048576).getBytes(UTF_8);
     ChunkBuffer buffer = ChunkBuffer.wrap(ByteBuffer.wrap(arr));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -143,7 +143,8 @@ public class TestContainerPersistence {
     containerSet = new ContainerSet();
     volumeSet = new MutableVolumeSet(DATANODE_UUID, conf);
     blockManager = new BlockManagerImpl(conf);
-    chunkManager = ChunkManagerFactory.createChunkManager(conf, blockManager);
+    chunkManager = ChunkManagerFactory.createChunkManager(conf, blockManager,
+        null);
 
     for (String dir : conf.getStrings(ScmConfigKeys.HDDS_DATANODE_DIR_KEY)) {
       StorageLocation location = StorageLocation.parse(dir);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ChunkLayoutTestInfo.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/ChunkLayoutTestInfo.java
@@ -64,7 +64,7 @@ public enum ChunkLayoutTestInfo {
   FILE_PER_CHUNK {
     @Override
     public ChunkManager createChunkManager(boolean sync, BlockManager manager) {
-      return new FilePerChunkStrategy(sync, manager);
+      return new FilePerChunkStrategy(sync, manager, null);
     }
 
     @Override
@@ -81,7 +81,7 @@ public enum ChunkLayoutTestInfo {
   FILE_PER_BLOCK {
     @Override
     public ChunkManager createChunkManager(boolean sync, BlockManager manager) {
-      return new FilePerBlockStrategy(sync, null);
+      return new FilePerBlockStrategy(sync, null, null);
     }
 
     @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerExcep
 import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
-import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.test.GenericTestUtils;
 
 import org.apache.commons.io.FileUtils;
@@ -73,8 +72,7 @@ public class TestChunkUtils {
       long len = data.limit();
       long offset = 0;
       File file = tempFile.toFile();
-      VolumeIOStats stats = new VolumeIOStats();
-      ChunkUtils.writeData(file, data, offset, len, stats, true);
+      ChunkUtils.writeData(file, data, offset, len, null, true);
       int threads = 10;
       ExecutorService executor = new ThreadPoolExecutor(threads, threads,
           0, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
@@ -85,7 +83,7 @@ public class TestChunkUtils {
         executor.execute(() -> {
           try {
             ByteBuffer[] readBuffers = BufferUtils.assignByteBuffers(len, len);
-            ChunkUtils.readData(file, readBuffers, offset, len, stats);
+            ChunkUtils.readData(file, readBuffers, offset, len, null);
 
             // There should be only one element in readBuffers
             Assert.assertEquals(1, readBuffers.length);
@@ -163,13 +161,12 @@ public class TestChunkUtils {
     Path tempFile = Files.createTempFile(PREFIX, "serial");
     try {
       File file = tempFile.toFile();
-      VolumeIOStats stats = new VolumeIOStats();
       long len = data.limit();
       long offset = 0;
-      ChunkUtils.writeData(file, data, offset, len, stats, true);
+      ChunkUtils.writeData(file, data, offset, len, null, true);
 
       ByteBuffer[] readBuffers = BufferUtils.assignByteBuffers(len, len);
-      ChunkUtils.readData(file, readBuffers, offset, len, stats);
+      ChunkUtils.readData(file, readBuffers, offset, len, null);
 
       // There should be only one element in readBuffers
       Assert.assertEquals(1, readBuffers.length);
@@ -206,12 +203,11 @@ public class TestChunkUtils {
     int offset = 0;
     File nonExistentFile = new File("nosuchfile");
     ByteBuffer[] bufs = BufferUtils.assignByteBuffers(len, len);
-    VolumeIOStats stats = new VolumeIOStats();
 
     // when
     StorageContainerException e = LambdaTestUtils.intercept(
         StorageContainerException.class,
-        () -> ChunkUtils.readData(nonExistentFile, bufs, offset, len, stats));
+        () -> ChunkUtils.readData(nonExistentFile, bufs, offset, len, null));
 
     // then
     Assert.assertEquals(UNABLE_TO_FIND_CHUNK, e.getResult());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/TestFilePerChunkStrategy.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.ozone.common.ChunkBuffer;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
-import org.apache.hadoop.ozone.container.common.volume.VolumeIOStats;
 import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils;
@@ -114,7 +113,7 @@ public class TestFilePerChunkStrategy extends CommonChunkManagerTestCases {
         container.getContainerData(), blockID, chunkInfo);
     ChunkUtils.writeData(file,
         ChunkBuffer.wrap(getData()), offset, chunkInfo.getLen(),
-        new VolumeIOStats(), true);
+        null, true);
     checkChunkFileCount(1);
     assertTrue(file.exists());
     assertEquals(offset + chunkInfo.getLen(), file.length());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.hadoop.ozone.dn;
+
+import com.google.common.base.Supplier;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.test.GenericTestUtils;
+
+import java.io.File;
+import java.io.IOException;
+
+/**
+ * Utility offers low-level access methods to datanode.
+ */
+public final class DatanodeTestUtils {
+  private static final String FAILURE_SUFFIX = ".origin";
+
+  private DatanodeTestUtils() {
+  }
+
+  /**
+   * It injects disk failures to data dirs by replacing these data dirs with
+   * regular files.
+   *
+   * @param dirs data directories.
+   * @throws IOException on I/O error.
+   */
+  public static void injectDataDirFailure(File... dirs) throws IOException {
+    for (File dir : dirs) {
+      File renamedTo = new File(dir.getPath() + FAILURE_SUFFIX);
+      if (renamedTo.exists()) {
+        throw new IOException(String.format(
+            "Can not inject failure to dir: %s because %s exists.",
+            dir, renamedTo));
+      }
+      if (!dir.renameTo(renamedTo)) {
+        throw new IOException(String.format("Failed to rename %s to %s.",
+            dir, renamedTo));
+      }
+      if (!dir.createNewFile()) {
+        throw new IOException(String.format(
+            "Failed to create file %s to inject disk failure.", dir));
+      }
+    }
+  }
+
+  /**
+   * Restore the injected data dir failures.
+   *
+   * @see {@link #injectDataDirFailure}.
+   * @param dirs data directories.
+   * @throws IOException
+   */
+  public static void restoreDataDirFromFailure(File... dirs)
+      throws IOException {
+    for (File dir : dirs) {
+      File renamedDir = new File(dir.getPath() + FAILURE_SUFFIX);
+      if (renamedDir.exists()) {
+        if (dir.exists()) {
+          if (!dir.isFile()) {
+            throw new IOException(
+                "Injected failure data dir is supposed to be file: " + dir);
+          }
+          if (!dir.delete()) {
+            throw new IOException(
+                "Failed to delete injected failure data dir: " + dir);
+          }
+        }
+        if (!renamedDir.renameTo(dir)) {
+          throw new IOException(String.format(
+              "Failed to recover injected failure data dir %s to %s.",
+              renamedDir, dir));
+        }
+      }
+    }
+  }
+
+  /**
+   * Inject disk failures to data files by replacing with dirs.
+   * @param files
+   * @throws IOException
+   */
+  public static void injectDataFileFailure(File... files) throws IOException {
+    for (File file : files) {
+      if (file.exists()) {
+        File renamedTo = new File(file.getPath() + FAILURE_SUFFIX);
+        if (renamedTo.exists()) {
+          throw new IOException(String.format(
+              "Can not inject failure to file: %s because %s exists.",
+              file, renamedTo));
+        }
+        if (!file.renameTo(renamedTo)) {
+          throw new IOException(String.format("Failed to rename %s to %s.",
+              file, renamedTo));
+        }
+        if (!file.mkdir()) {
+          throw new IOException(String.format(
+              "Failed to create dir %s to inject disk failure.", file));
+        }
+      }
+    }
+  }
+
+  /**
+   * Restore the injected data files from disk failures.
+   * @see {@link #injectDataFileFailure(File...)}
+   * @param files
+   * @throws IOException
+   */
+  public static void restoreDataFileFromFailure(File... files)
+      throws IOException {
+    for (File file : files) {
+      File renamedFile = new File(file.getPath() + FAILURE_SUFFIX);
+      if (renamedFile.exists()) {
+        if (file.exists()) {
+          if (!file.isDirectory()) {
+            throw new IOException(
+                "Injected failure data file is supposed to be dir: " + file);
+          }
+          if (!file.delete()) {
+            throw new IOException(
+                "Failed to delete injected failure data file: " + file);
+          }
+        }
+        if (!renamedFile.renameTo(file)) {
+          throw new IOException(String.format(
+              "Failed to recover injected failure data file %s to %s.",
+              renamedFile, file));
+        }
+      }
+    }
+  }
+
+  /**
+   * Inject failure to container metadata dir by removing write
+   * permission on it.
+   * KeyValueContainer uses a creatTemp & rename way to update
+   * container metadata file, so we cannot use a rename or
+   * change permission way to do injection.
+   * @param dirs
+   */
+  public static void injectContainerMetaDirFailure(File... dirs) {
+    for (File dir : dirs) {
+      if (dir.exists()) {
+        dir.setWritable(false, false);
+      }
+    }
+  }
+
+  /**
+   * Restore container metadata dir from failure.
+   * @see {@link #injectContainerMetaDirFailure(File...)}
+   * @param dirs
+   */
+  public static void restoreContainerMetaDirFromFailure(File... dirs) {
+    for (File dir : dirs) {
+      if (dir.exists()) {
+        dir.setWritable(true, true);
+      }
+    }
+  }
+
+  /**
+   * Simulate a bad volume by removing write permission.
+   * @see {@link org.apache.hadoop.ozone.container.common.volume
+   * .HddsVolume#check(Boolean)}
+   * @param vol
+   */
+  public static void simulateBadVolume(HddsVolume vol) {
+    File rootDir = vol.getHddsRootDir();
+    if (rootDir.exists()) {
+      rootDir.setWritable(false);
+    }
+  }
+
+  /**
+   * Restore a simulated bad volume to normal.
+   * @see {@link #simulateBadVolume(HddsVolume)}
+   * @param vol
+   */
+  public static void restoreBadVolume(HddsVolume vol) {
+    File rootDir = vol.getHddsRootDir();
+    if (rootDir.exists()) {
+      rootDir.setWritable(true);
+    }
+  }
+
+  /**
+   * Wait for detect volume failure.
+   *
+   * @param volSet
+   * @param numOfChecks target number of checks
+   * @throws Exception
+   */
+  public static void waitForCheckVolume(MutableVolumeSet volSet,
+                                        long numOfChecks) throws Exception {
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return numOfChecks == volSet.getVolumeChecker().getNumVolumeChecks();
+      }
+    }, 100, 10000);
+  }
+
+  /**
+   * Wait for failed volume to be handled.
+   * @param volSet
+   * @param numOfFailedVolumes
+   * @throws Exception
+   */
+  public static void waitForHandleFailedVolume(
+      MutableVolumeSet volSet, int numOfFailedVolumes) throws Exception {
+    GenericTestUtils.waitFor(new Supplier<Boolean>() {
+      @Override
+      public Boolean get() {
+        return numOfFailedVolumes == volSet.getFailedVolumesList().size();
+      }
+    }, 100, 10000);
+  }
+
+  public static File getHddsVolumeClusterDir(HddsVolume vol) {
+    File hddsVolumeRootDir = vol.getHddsRootDir();
+    return new File(hddsVolumeRootDir, vol.getClusterID());
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.hadoop.ozone.dn.volume;
+
+import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.ozone.HddsDatanodeService;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.common.Storage;
+import org.apache.hadoop.ozone.container.common.interfaces.Container;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.ozone.dn.DatanodeTestUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Rule;
+import org.junit.rules.Timeout;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.client.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.client.ReplicationType.STAND_ALONE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+
+/**
+ * This class tests datanode can detect failed volumes.
+ */
+public class TestDatanodeHddsVolumeFailureDetection {
+
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+  private MiniOzoneCluster cluster;
+  private OzoneConfiguration ozoneConfig;
+  private OzoneClient ozClient = null;
+  private ScmClient scmClient;
+  private ObjectStore store = null;
+  private OzoneVolume volume;
+  private OzoneBucket bucket;
+  private List<HddsDatanodeService> datanodes;
+
+  @Before
+  public void init() throws Exception {
+    ozoneConfig = new OzoneConfiguration();
+    ozoneConfig.set(OZONE_SCM_CONTAINER_SIZE, "1GB");
+    ozoneConfig.setInt(OZONE_REPLICATION, ReplicationFactor.ONE.getValue());
+    // keep the cache size = 1, so we could trigger io exception on
+    // reading on-disk db instance
+    ozoneConfig.setInt(OZONE_CONTAINER_CACHE_SIZE, 1);
+    // shorten the gap between successive checks to ease tests
+    ozoneConfig.setTimeDuration(
+        DFSConfigKeysLegacy.DFS_DATANODE_DISK_CHECK_MIN_GAP_KEY, 5,
+        TimeUnit.SECONDS);
+    cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
+        .setNumDatanodes(1)
+        .setNumDataVolumes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    ozClient = OzoneClientFactory.getRpcClient(ozoneConfig);
+    store = ozClient.getObjectStore();
+    scmClient = new ContainerOperationClient(ozoneConfig);
+
+    String volumeName = UUID.randomUUID().toString();
+    store.createVolume(volumeName);
+    volume = store.getVolume(volumeName);
+
+    String bucketName = UUID.randomUUID().toString();
+    volume.createBucket(bucketName);
+    bucket = volume.getBucket(bucketName);
+
+    datanodes = cluster.getHddsDatanodes();
+  }
+
+  @After
+  public void shutdown() throws IOException {
+    if (ozClient != null) {
+      ozClient.close();
+    }
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testHddsVolumeFailureOnChunkFileCorrupt() throws Exception {
+    // write a file
+    String keyName = UUID.randomUUID().toString();
+    String value = "sample value";
+    OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(UTF_8).length, STAND_ALONE,
+        ONE, new HashMap<>());
+    out.write(value.getBytes(UTF_8));
+    out.close();
+    OzoneKey key = bucket.getKey(keyName);
+    Assert.assertEquals(keyName, key.getName());
+
+    // corrupt chunk file by rename file->dir
+    HddsDatanodeService dn = datanodes.get(0);
+    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+    MutableVolumeSet volSet = oc.getVolumeSet();
+    HddsVolume vol0 = volSet.getVolumesList().get(0);
+    File clusterDir = DatanodeTestUtils.getHddsVolumeClusterDir(vol0);
+    File currentDir = new File(clusterDir, Storage.STORAGE_DIR_CURRENT);
+    File containerTopDir = new File(currentDir, Storage.CONTAINER_DIR + "0");
+    File containerDir = new File(containerTopDir, "1");
+    File chunksDir = new File(containerDir, OzoneConsts.STORAGE_DIR_CHUNKS);
+    File[] chunkFiles = chunksDir.listFiles();
+    Assert.assertNotNull(chunkFiles);
+    for (File chunkFile : chunkFiles) {
+      DatanodeTestUtils.injectDataFileFailure(chunkFile);
+    }
+
+    // simulate bad volume by removing write permission on root dir
+    // refer to HddsVolume.check()
+    DatanodeTestUtils.simulateBadVolume(vol0);
+
+    // read written file to trigger checkVolumeAsync
+    OzoneInputStream is = bucket.readKey(keyName);
+    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+
+    try {
+      is.read(fileContent);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof IOException);
+    } finally {
+      is.close();
+    }
+
+    // should trigger checkVolumeAsync and
+    // a failed volume should be detected
+    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+
+    // restore for cleanup
+    DatanodeTestUtils.restoreBadVolume(vol0);
+    for (File chunkFile : chunkFiles) {
+      DatanodeTestUtils.restoreDataFileFromFailure(chunkFile);
+    }
+  }
+
+  @Test
+  public void testHddsVolumeFailureOnContainerFileCorrupt() throws Exception {
+    // create a container
+    ContainerWithPipeline container = scmClient.createContainer(HddsProtos
+        .ReplicationType.STAND_ALONE, HddsProtos.ReplicationFactor
+        .ONE, OzoneConsts.OZONE);
+
+    // corrupt container file by removing write permission on
+    // container metadata dir, since container update operation
+    // use a create temp & rename way, so we can't just rename
+    // container file to simulate corruption
+    HddsDatanodeService dn = datanodes.get(0);
+    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+    MutableVolumeSet volSet = oc.getVolumeSet();
+    HddsVolume vol0 = volSet.getVolumesList().get(0);
+    Container c1 = oc.getContainerSet().getContainer(container.
+        getContainerInfo().getContainerID());
+    File metadataDir = new File(c1.getContainerFile().getParent());
+    DatanodeTestUtils.injectContainerMetaDirFailure(metadataDir);
+
+    // simulate bad volume by removing write permission on root dir
+    // refer to HddsVolume.check()
+    DatanodeTestUtils.simulateBadVolume(vol0);
+
+    // close container to trigger checkVolumeAsync
+    try {
+      c1.close();
+      Assert.fail();
+    } catch(Exception e) {
+      Assert.assertTrue(e instanceof IOException);
+    }
+
+    // should trigger CheckVolumeAsync and
+    // a failed volume should be detected
+    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+
+    // restore for cleanup
+    DatanodeTestUtils.restoreBadVolume(vol0);
+    DatanodeTestUtils.restoreContainerMetaDirFromFailure(metadataDir);
+  }
+
+  @Test
+  public void testHddsVolumeFailureOnDbFileCorrupt() throws Exception {
+    // write a file, will create container1
+    String keyName = UUID.randomUUID().toString();
+    String value = "sample value";
+    OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(UTF_8).length, STAND_ALONE,
+        ONE, new HashMap<>());
+    out.write(value.getBytes(UTF_8));
+    out.close();
+    OzoneKey key = bucket.getKey(keyName);
+    Assert.assertEquals(keyName, key.getName());
+
+    // close container1
+    HddsDatanodeService dn = datanodes.get(0);
+    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
+    Container c1 = oc.getContainerSet().getContainer(1);
+    c1.close();
+
+    // create container2, and container1 is kicked out of cache
+    ContainerWithPipeline c2 = scmClient.createContainer(HddsProtos
+        .ReplicationType.STAND_ALONE, HddsProtos.ReplicationFactor
+        .ONE, OzoneConsts.OZONE);
+    Assert.assertTrue(c2.getContainerInfo().getState()
+        .equals(HddsProtos.LifeCycleState.OPEN));
+
+    // corrupt db by rename dir->file
+    File metadataDir = new File(c1.getContainerFile().getParent());
+    File dbDir = new File(metadataDir, "1" + OzoneConsts.DN_CONTAINER_DB);
+    DatanodeTestUtils.injectDataDirFailure(dbDir);
+
+    // simulate bad volume by removing write permission on root dir
+    // refer to HddsVolume.check()
+    MutableVolumeSet volSet = oc.getVolumeSet();
+    HddsVolume vol0 = volSet.getVolumesList().get(0);
+    DatanodeTestUtils.simulateBadVolume(vol0);
+
+    // read written file to trigger checkVolumeAsync
+    OzoneInputStream is = bucket.readKey(keyName);
+    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+
+    try {
+      is.read(fileContent);
+      Assert.fail();
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof IOException);
+    } finally {
+      is.close();
+    }
+
+    // should trigger CheckVolumeAsync and
+    // a failed volume should be detected
+    DatanodeTestUtils.waitForCheckVolume(volSet, 1L);
+    DatanodeTestUtils.waitForHandleFailedVolume(volSet, 1);
+
+    // restore all
+    DatanodeTestUtils.restoreBadVolume(vol0);
+    DatanodeTestUtils.restoreDataDirFromFailure(dbDir);
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
@@ -135,7 +135,7 @@ public class ChunkManagerDiskWrite extends BaseFreonGenerator implements
       data = randomAscii(chunkSize).getBytes(UTF_8);
 
       chunkManager = ChunkManagerFactory.createChunkManager(ozoneConfiguration,
-          null);
+          null, null);
 
       timer = getMetrics().timer("chunk-write");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -128,7 +128,7 @@ public class GeneratorDatanode extends BaseGenerator {
 
     BlockManager blockManager = new BlockManagerImpl(config);
     chunkManager = ChunkManagerFactory
-        .createChunkManager(config, blockManager);
+        .createChunkManager(config, blockManager, null);
 
     final Collection<String> storageDirs =
         MutableVolumeSet.getDatanodeStorageDirs(config);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchmarkChunkManager.java
@@ -131,7 +131,7 @@ public class BenchmarkChunkManager {
   public void writeMultipleFiles(BenchmarkState state, Blackhole sink)
       throws StorageContainerException {
 
-    ChunkManager chunkManager = new FilePerChunkStrategy(true, null);
+    ChunkManager chunkManager = new FilePerChunkStrategy(true, null, null);
     benchmark(chunkManager, FILE_PER_CHUNK, state, sink);
   }
 
@@ -139,7 +139,7 @@ public class BenchmarkChunkManager {
   public void writeSingleFile(BenchmarkState state, Blackhole sink)
       throws StorageContainerException {
 
-    ChunkManager chunkManager = new FilePerBlockStrategy(true, null);
+    ChunkManager chunkManager = new FilePerBlockStrategy(true, null, null);
     benchmark(chunkManager, FILE_PER_BLOCK, state, sink);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check hdds volume on io exceptions to detect bad disks quickly.
For now ozone only has a periodic disk checker which only check for disk errors at fixed interval.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5089

## How was this patch tested?

manual tests
a new integration test
