### PR TITLE
HDDS-5110. TestStorageContainerManagerHttpServer fails in CI

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestStorageContainerManagerHttpServer.java
@@ -100,6 +100,8 @@ public class TestStorageContainerManagerHttpServer {
     conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
     conf.set(ScmConfigKeys.OZONE_SCM_HTTP_ADDRESS_KEY, "localhost:0");
     conf.set(ScmConfigKeys.OZONE_SCM_HTTPS_ADDRESS_KEY, "localhost:0");
+    conf.set(ScmConfigKeys.OZONE_SCM_HTTP_BIND_HOST_KEY, "localhost");
+    conf.set(ScmConfigKeys.OZONE_SCM_HTTPS_BIND_HOST_KEY, "localhost");
 
     StorageContainerManagerHttpServer server = null;
     try {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHttpServer.java
@@ -98,6 +98,8 @@ public class TestOzoneManagerHttpServer {
     conf.set(OzoneConfigKeys.OZONE_HTTP_POLICY_KEY, policy.name());
     conf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "localhost:0");
     conf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "localhost:0");
+    conf.set(OMConfigKeys.OZONE_OM_HTTP_BIND_HOST_KEY, "localhost");
+    conf.set(OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY, "localhost");
 
     OzoneManagerHttpServer server = null;
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestStorageContainerManagerHttpServer` (and presumably `TestOzoneManagerHttpServer`) recently started failing after changing from Docker-based builder env to Github runner (in e8d001f5130e5da4f193f94e41b4b697fc9ae63f).  The problem is intermittent, but happens quite frequently in CI.

https://issues.apache.org/jira/browse/HDDS-5110

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/2360374629

50x repeated run of `TestStorageContainerManagerHttpServer` (with JUnit5):
https://github.com/adoroszlai/hadoop-ozone/runs/2360503963#step:4:3982