### PR TITLE
HDDS-5116. Secure datanode/OM may exit if it cannot connect to SCM.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2766,8 +2766,8 @@
     <name>ozone.scm.info.wait.duration</name>
     <tag>OZONE, SCM, OM</tag>
     <value>10m</value>
-    <description> Maximum amount of duration OM/SCM waits to get Scm Info
-      during OzoneManager init/SCM bootstrap.
+    <description> Maximum amount of duration OM/SCM waits to get Scm Info/Scm
+      signed cert during OzoneManager init/SCM bootstrap.
     </description>
   </property>
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -342,7 +342,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       PKCS10CertificationRequest csr = getCSR(config);
       // TODO: For SCM CA we should fetch certificate from multiple SCMs.
       SCMSecurityProtocolClientSideTranslatorPB secureScmClient =
-          HddsServerUtil.getScmSecurityClient(config);
+          HddsServerUtil.getScmSecurityClientWithMaxRetry(config);
       SCMGetCertResponseProto response = secureScmClient.
           getDataNodeCertificateChain(
               datanodeDetails.getProtoBufMessage(),

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -223,7 +223,7 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
           }
         }
 
-        // For AccessControl Exception where Client is not authentica
+        // For AccessControl Exception where Client is not authenticated.
         if (HAUtils.isAccessControlException(exception)) {
           return RetryAction.FAIL;
         }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -69,6 +69,7 @@ import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateExcepti
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CRYPTO_SIGN_ERROR;
 import static org.apache.hadoop.hdds.security.x509.exceptions.CertificateException.ErrorCode.CSR_ERROR;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClient;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmSecurityClientWithMaxRetry;
 
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.slf4j.Logger;
@@ -325,7 +326,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
         certId);
     try {
       SCMSecurityProtocol scmSecurityProtocolClient =
-          getScmSecurityClient(
+          getScmSecurityClientWithMaxRetry(
           (OzoneConfiguration) securityConfig.getConfiguration());
       String pemEncodedCert =
           scmSecurityProtocolClient.getCertificate(certId);
@@ -928,7 +929,8 @@ public abstract class DefaultCertificateClient implements CertificateClient {
     lock.lock();
     try {
       SCMSecurityProtocol scmSecurityProtocolClient =
-          getScmSecurityClient(securityConfig.getConfiguration());
+          getScmSecurityClientWithMaxRetry(
+              (OzoneConfiguration) securityConfig.getConfiguration());
       pemEncodedCACerts =
           scmSecurityProtocolClient.listCACertificate();
       return pemEncodedCACerts;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -445,7 +445,7 @@ public final class HAUtils {
       if (!caListUpToDate) {
         LOG.info("Expected CA list size {}, where as received CA List size " +
             "{}. Retry to fetch CA List after {} seconds", expectedCount,
-            caCertPemList.size(), waitTime/1000);
+            caCertPemList.size(), retryTime);
         try {
           Thread.sleep(retryTime);
         } catch (InterruptedException ex) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -443,7 +443,8 @@ public final class HddsServerUtil {
   }
 
   public static SCMSecurityProtocolClientSideTranslatorPB
-  getScmSecurityClientWithMaxRetry(OzoneConfiguration conf) throws IOException {
+      getScmSecurityClientWithMaxRetry(OzoneConfiguration conf)
+      throws IOException {
     // Certificate from SCM is required for DN startup to succeed, so retry
     // for ever. In this way DN start up is resilient to SCM service running
     // status.
@@ -460,7 +461,8 @@ public final class HddsServerUtil {
   }
 
   public static SCMSecurityProtocolClientSideTranslatorPB
-  getScmSecurityClientWithFixedDuration(OzoneConfiguration conf) throws IOException {
+      getScmSecurityClientWithFixedDuration(OzoneConfiguration conf)
+      throws IOException {
     // As for OM during init, we need to wait for specific duration so that
     // we can give response to user performed operation init in a definite
     // period, instead of stuck for ever.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -435,8 +435,6 @@ public final class HddsServerUtil {
    */
   public static SCMSecurityProtocolClientSideTranslatorPB getScmSecurityClient(
       ConfigurationSource conf) throws IOException {
-    // Certificate from SCM is required for DN startup to succeed, so retry
-    // for ever.
     return new SCMSecurityProtocolClientSideTranslatorPB(
         new SCMSecurityProtocolFailoverProxyProvider(conf,
             UserGroupInformation.getCurrentUser()));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslator
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
+import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMSecurityProtocolFailoverProxyProvider;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
@@ -80,6 +81,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_R
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_RPC_RETRY_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
@@ -432,41 +435,55 @@ public final class HddsServerUtil {
    */
   public static SCMSecurityProtocolClientSideTranslatorPB getScmSecurityClient(
       ConfigurationSource conf) throws IOException {
+    // Certificate from SCM is required for DN startup to succeed, so retry
+    // for ever.
     return new SCMSecurityProtocolClientSideTranslatorPB(
         new SCMSecurityProtocolFailoverProxyProvider(conf,
             UserGroupInformation.getCurrentUser()));
   }
 
+  public static SCMSecurityProtocolClientSideTranslatorPB
+  getScmSecurityClientWithMaxRetry(OzoneConfiguration conf) throws IOException {
+    // Certificate from SCM is required for DN startup to succeed, so retry
+    // for ever. In this way DN start up is resilient to SCM service running
+    // status.
+    OzoneConfiguration configuration = new OzoneConfiguration(conf);
+    SCMClientConfig scmClientConfig =
+        conf.getObject(SCMClientConfig.class);
+    int retryCount = Integer.MAX_VALUE;
+    scmClientConfig.setRetryCount(retryCount);
+    configuration.setFromObject(scmClientConfig);
 
-  /**
-   * Retrieve the socket address that should be used by clients to connect
-   * to the SCM for
-   * {@link org.apache.hadoop.hdds.protocol.SCMSecurityProtocol}. If
-   * {@link ScmConfigKeys#OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY} is not defined
-   * then {@link ScmConfigKeys#OZONE_SCM_CLIENT_ADDRESS_KEY} is used. If neither
-   * is defined then {@link ScmConfigKeys#OZONE_SCM_NAMES} is used.
-   *
-   * @param conf
-   * @return Target {@code InetSocketAddress} for the SCM block client endpoint.
-   * @throws IllegalArgumentException if configuration is not defined or invalid
-   */
-  public static InetSocketAddress getScmAddressForSecurityProtocol(
-      ConfigurationSource conf) {
-    Optional<String> host = getHostNameFromConfigKeys(conf,
-        ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY,
-        ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY);
+    return new SCMSecurityProtocolClientSideTranslatorPB(
+        new SCMSecurityProtocolFailoverProxyProvider(configuration,
+            UserGroupInformation.getCurrentUser()));
+  }
 
-    if (!host.isPresent()) {
-      // Fallback to Ozone SCM name
-      host = Optional.of(getSingleSCMAddress(conf).getHostName());
+  public static SCMSecurityProtocolClientSideTranslatorPB
+  getScmSecurityClientWithFixedDuration(OzoneConfiguration conf) throws IOException {
+    // As for OM during init, we need to wait for specific duration so that
+    // we can give response to user performed operation init in a definite
+    // period, instead of stuck for ever.
+    OzoneConfiguration configuration = new OzoneConfiguration(conf);
+    long duration = conf.getTimeDuration(OZONE_SCM_INFO_WAIT_DURATION,
+        OZONE_SCM_INFO_WAIT_DURATION_DEFAULT, TimeUnit.SECONDS);
+    SCMClientConfig scmClientConfig =
+        conf.getObject(SCMClientConfig.class);
+    int retryCount =
+        (int) (duration / (scmClientConfig.getRetryInterval()/1000));
+
+    // If duration is set to lesser value, fall back to actual default
+    // retry count.
+    if (retryCount > scmClientConfig.getRetryCount()) {
+      scmClientConfig.setRetryCount(retryCount);
+      configuration.setFromObject(scmClientConfig);
     }
 
-    final int port = getPortNumberFromConfigKeys(conf,
-        ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY)
-        .orElse(ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT);
-
-    return NetUtils.createSocketAddr(host.get() + ":" + port);
+    return new SCMSecurityProtocolClientSideTranslatorPB(
+        new SCMSecurityProtocolFailoverProxyProvider(configuration,
+            UserGroupInformation.getCurrentUser()));
   }
+
   /**
    * Create a scm block client, used by putKey() and getKey().
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -142,7 +142,7 @@ public final class HASecurityUtils {
 
       // Create SCM security client.
       SCMSecurityProtocolClientSideTranslatorPB secureScmClient =
-          HddsServerUtil.getScmSecurityClient(config);
+          HddsServerUtil.getScmSecurityClientWithFixedDuration(config);
 
       // Get SCM sub CA cert.
       SCMGetCertResponseProto response = secureScmClient.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
@@ -108,7 +108,6 @@ public class SCMSnapshotProvider {
     if (client == null) {
       client = new InterSCMGrpcClient(
           peerNodesMap.get(leaderSCMNodeID).getInetAddress().getHostAddress(),
-          peerNodesMap.get(leaderSCMNodeID).
           conf);
     }
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
@@ -108,6 +108,7 @@ public class SCMSnapshotProvider {
     if (client == null) {
       client = new InterSCMGrpcClient(
           peerNodesMap.get(leaderSCMNodeID).getInetAddress().getHostAddress(),
+          peerNodesMap.get(leaderSCMNodeID).
           conf);
     }
     try {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1458,7 +1458,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         omDetailsProtoBuilder.build();
     LOG.info("OzoneManager ports added:{}", omDetailsProto.getPortsList());
     SCMSecurityProtocolClientSideTranslatorPB secureScmClient =
-        HddsServerUtil.getScmSecurityClient(config);
+        HddsServerUtil.getScmSecurityClientWithFixedDuration(config);
 
     SCMGetCertResponseProto response = secureScmClient.
         getOMCertChain(omDetailsProto, getEncodedString(csr));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Following changes are done:
1. For Datanode used max retryCount so that Datanode will retry for ever during startup to get Signed Cert from SCM.
2. For OM/SCM used fixed duration to give response to end-user performing init/bootstrap.
3. Updated to use max retryCount for fetching CAList which is required during DN/OM startup.
4. Updated to use max retry count for get certificate From SCM which is used in BlockToken Verification/OMToken Verification when cert is not there in its local cache.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5116

## How was this patch tested?

Tested manually, started OM/DN before SCM Startup and they are retrying more than default 15 retry count.

docker-compose up --build om1 datanode1

After some time greater than default retry completed start scm
docker-compose up --build scm1.org scm2.org scm3.org

`om1_1        | 2021-04-20 07:15:09,675 [main] INFO retry.RetryInvocationHandler: com.google.protobuf.ServiceException: java.net.NoRouteToHostException: No Route to Host from  om1/172.25.0.111 to scm1.org:9863 failed on socket timeout exception: java.net.NoRouteToHostException: No route to host; For more details see:  http://wiki.apache.org/hadoop/NoRouteToHost, while invoking $Proxy31.send over nodeId=scm1,nodeAddress=scm1.org/172.25.0.116:9863 after 45 failover attempts. Trying to failover after sleeping for 2000ms.`



`datanode1_1  | 2021-04-20 07:15:35,048 [main] INFO retry.RetryInvocationHandler: com.google.protobuf.ServiceException: java.net.ConnectException: Call From 9cb343c107ed/172.25.0.102 to scm3.org:9961 failed on connection exception: java.net.ConnectException: Connection refused; For more details see:  http://wiki.apache.org/hadoop/ConnectionRefused, while invoking $Proxy17.submitRequest over nodeId=scm3,nodeAddress=scm3.org/172.25.0.118:9961 after 35 failover attempts. Trying to failover after sleeping for 2000ms.`


And once SCM is booted up DN and OM are able to successfully startup.
