### PR TITLE
HDDS-5093. [FSO] Reducing time of ozonefs acceptance testmatrix

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -54,20 +54,21 @@ stop_docker_env
 # running FS tests with different config requires restart of the cluster
 export OZONE_KEEP_RESULTS=true
 export OZONE_OM_METADATA_LAYOUT OZONE_OM_ENABLE_FILESYSTEM_PATHS
-for OZONE_OM_METADATA_LAYOUT in SIMPLE PREFIX; do
-  if [[ $OZONE_OM_METADATA_LAYOUT == "PREFIX" ]]; then
-    OZONE_OM_ENABLE_FILESYSTEM_PATHS=true
-  else
-    OZONE_OM_ENABLE_FILESYSTEM_PATHS=false
-  fi
 
-  start_docker_env
-  for scheme in ofs o3fs; do
-    for bucket in link bucket; do
-      execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${OZONE_OM_METADATA_LAYOUT}-${scheme}-${bucket} ozonefs/ozonefs.robot
-    done
-  done
-  stop_docker_env
-done
+execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-simple-ofs-bucket ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:link -N ozonefs-simple-o3fs-link ozonefs/ozonefs.robot
+
+stop_docker_env
+
+## Restarting the cluster with prefix layout enabled
+OZONE_OM_METADATA_LAYOUT=PREFIX
+OZONE_OM_ENABLE_FILESYSTEM_PATHS=true
+start_docker_env
+
+execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-prefix-ofs-link ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-prefix-o3fs-bucket ozonefs/ozonefs.robot
+execute_robot_test scm -v BUCKET:bucket -N s3-prefix-bucket s3/objectputget.robot
+
+stop_docker_env
 
 generate_report

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -64,7 +64,6 @@ start_docker_env
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-prefix-ofs-link ozonefs/ozonefs.robot
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-prefix-o3fs-bucket ozonefs/ozonefs.robot
-execute_robot_test scm -v BUCKET:bucket -N s3-prefix-bucket s3/objectputget.robot
 
 stop_docker_env
 

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -49,18 +49,15 @@ execute_robot_test scm freon
 
 execute_robot_test scm cli
 
-stop_docker_env
-
-# running FS tests with different config requires restart of the cluster
-export OZONE_KEEP_RESULTS=true
-export OZONE_OM_METADATA_LAYOUT OZONE_OM_ENABLE_FILESYSTEM_PATHS
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-simple-ofs-bucket ozonefs/ozonefs.robot
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:link -N ozonefs-simple-o3fs-link ozonefs/ozonefs.robot
 
+# running FS tests with different config requires restart of the cluster
+export OZONE_KEEP_RESULTS=true
 stop_docker_env
 
-## Restarting the cluster with prefix layout enabled
+## Restarting the cluster with prefix-layout enabled (FSO)
 OZONE_OM_METADATA_LAYOUT=PREFIX
 OZONE_OM_ENABLE_FILESYSTEM_PATHS=true
 start_docker_env


### PR DESCRIPTION
## What changes were proposed in this pull request?

Today we execute ozonefs/ozonefs.robot with compose/ozone/test.sh with multiple matrix parameters:

```
for scheme in ofs o3fs; do
    for bucket in link bucket; do
       #test ozonefs/ozonefs.robot
   done
done
```

HDDS-2939 doubles these 4 executions with introducing the layout parameter (simple vs prefix). At the same time the execution time of acceptance (unsecure) tests are increased from 37 minutes to 57 minutes.

I would suggest suggesting to use only selected tests from this 2 x 2 x 2 matrix.

For example:

```
bucket / o3fs / prefix
link / ofs / simple
bucket / ofs / prefix
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5093

## How was this patch tested?

CI tests. Checked the artifacts (new test names are included) and compared the time. 
Build times: 55 min (before patch) ,47 min (after this patch), 41 min (master)

But this specific PR build seems to be slower (compared the numbers and the same freon tests were slower on the branch compared to the master) 