### PR TITLE
HDDS-5124. Use OzoneConsts.OZONE_TIME_ZONE instead of "GMT"

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
@@ -339,7 +340,7 @@ public class ObjectEndpoint extends EndpointBase {
       ResponseBuilder responseBuilder, OzoneKeyDetails key) {
 
     ZonedDateTime lastModificationTime = key.getModificationTime()
-        .atZone(ZoneId.of("GMT"));
+        .atZone(ZoneId.of(OzoneConsts.OZONE_TIME_ZONE));
 
     responseBuilder
         .header(LAST_MODIFIED,

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RFC1123Util.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/RFC1123Util.java
@@ -23,6 +23,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.SignStyle;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.hadoop.ozone.OzoneConsts;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.DAY_OF_WEEK;
@@ -92,7 +93,7 @@ public final class RFC1123Util {
         .appendValue(SECOND_OF_MINUTE, 2)
         .optionalEnd()
         .appendLiteral(' ')
-        .appendOffset("+HHMM", "GMT")
+        .appendOffset("+HHMM", OzoneConsts.OZONE_TIME_ZONE)
         .toFormatter();
   }
 }


### PR DESCRIPTION
## What is the link to the Apache JIRA
jira: HDDS-5124. Use existing constants for org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint#addLastModifiedDate
https://issues.apache.org/jira/browse/HDDS-5124?filter=-2

The "GMT" already defined in OzoneConsts, so why not user it.
we can use Ozone.Consts.OZONE_TIME_ZONE instead of "GMT"