### PR TITLE
HDDS-5122. SCM Reinitialization can end up leaking Ratis Segmented RaftLogWorker threads

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -74,10 +74,10 @@ public final class SCMHAUtils {
   }
 
   public static boolean isPrimordialSCM(ConfigurationSource conf,
-      String selfNodeId) {
+      String selfNodeId, String hostname) {
     String primordialNode = getPrimordialSCM(conf);
-    return isSCMHAEnabled(conf) && primordialNode != null && primordialNode
-        .equals(selfNodeId);
+    return isSCMHAEnabled(conf) && primordialNode != null && (primordialNode
+        .equals(selfNodeId) || primordialNode.equals(hostname));
   }
   /**
    * Get a collection of all scmNodeIds for the given scmServiceId.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -74,10 +74,10 @@ public final class SCMHAUtils {
   }
 
   public static boolean isPrimordialSCM(ConfigurationSource conf,
-      String selfNodeId, String hostname) {
+      String selfNodeId, String hostName) {
     String primordialNode = getPrimordialSCM(conf);
     return isSCMHAEnabled(conf) && primordialNode != null && (primordialNode
-        .equals(selfNodeId) || primordialNode.equals(hostname));
+        .equals(selfNodeId) || primordialNode.equals(hostName));
   }
   /**
    * Get a collection of all scmNodeIds for the given scmServiceId.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -39,6 +39,7 @@ public final class OzoneConsts {
 
   public static final String STORAGE_DIR = "scm";
   public static final String SCM_ID = "scmUuid";
+  public static final String SCM_HA = "scmHA";
   public static final String CLUSTER_ID_PREFIX = "CID-";
   public static final String SCM_CERT_SERIAL_ID = "scmCertSerialId";
   public static final String PRIMARY_SCM_NODE_ID = "primaryScmNodeId";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -251,6 +251,19 @@ public abstract class Storage {
   }
 
   /**
+   * Creates the Version file even if it exits,
+   * otherwise returns with IOException.
+   * @throws IOException
+   */
+  public void forceInitialize() throws IOException {
+    if (state != StorageState.INITIALIZED) {
+      initialize();
+    } else {
+      storageInfo.writeTo(getVersionFile());
+    }
+  }
+
+  /**
    * Persists current StorageInfo to file system..
    * @throws IOException
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -251,7 +251,7 @@ public abstract class Storage {
   }
 
   /**
-   * Creates the Version file even if it exists
+   * Creates the Version file even if it exists.
    * @throws IOException
    */
   public void forceInitialize() throws IOException {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Storage.java
@@ -251,8 +251,7 @@ public abstract class Storage {
   }
 
   /**
-   * Creates the Version file even if it exits,
-   * otherwise returns with IOException.
+   * Creates the Version file even if it exists
    * @throws IOException
    */
   public void forceInitialize() throws IOException {

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1949,6 +1949,8 @@
       optional config, if being set will cause scm --init to only take effect on
       the specific node and ignore scm --bootstrap cmd.
       Similarly, scm --init will be ignored on the non-primordial scm nodes.
+      The config can either be set equal to the hostname or the node id of any
+      of the scm nodes.
       With the config set, applications/admins can safely execute init and
       bootstrap commands safely on all scm instances.
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -141,10 +141,13 @@ public class SCMRatisServerImpl implements SCMRatisServer {
           .equals(buildRaftGroupId(clusterId))) {
         LOG.info("Ratis group with group Id {} already exists.",
             group.getGroupId());
+        // start the server to transition the server to Running state to ensure
+        // all the log worker threads get stopped during close()
+        server.start();
         return;
       } else {
         // close the server instance so that pending locks on raft storage
-        // directory gets released if any and further initiliaze can succeed.
+        // directory gets released if any and further initialize can succeed.
         server.close();
         initialize(clusterId, scmId, details, conf);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -22,13 +22,11 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.Iterator;
 import java.util.Collection;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.HddsUtils;
@@ -56,6 +54,7 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -125,37 +124,6 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   @Override
   public GrpcTlsConfig getGrpcTlsConfig() {
     return grpcTlsConfig;
-  }
-
-  public static void reinitialize(String clusterId, String scmId,
-      SCMNodeDetails details, OzoneConfiguration conf) throws IOException {
-    RaftServer server = null;
-    try {
-      server = newRaftServer(scmId, conf).build();
-      RaftGroup group = null;
-      Iterator<RaftGroup> iter = server.getGroups().iterator();
-      if (iter.hasNext()) {
-        group = iter.next();
-      }
-      if (group != null && group.getGroupId()
-          .equals(buildRaftGroupId(clusterId))) {
-        LOG.info("Ratis group with group Id {} already exists.",
-            group.getGroupId());
-        // start the server to transition the server to Running state to ensure
-        // all the log worker threads get stopped during close()
-        server.start();
-        return;
-      } else {
-        // close the server instance so that pending locks on raft storage
-        // directory gets released if any and further initialize can succeed.
-        server.close();
-        initialize(clusterId, scmId, details, conf);
-      }
-    } finally {
-      if (server != null) {
-        server.close();
-      }
-    }
   }
 
   private static void waitForLeaderToBeReady(RaftServer server,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -54,7 +54,6 @@ import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.protocol.SetConfigurationRequest;
 import org.apache.ratis.server.RaftServer;
-import org.apache.ratis.server.RaftServerConfigKeys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
@@ -28,8 +28,11 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
-import static org.apache.hadoop.ozone.OzoneConsts.*;
-
+import static org.apache.hadoop.ozone.OzoneConsts.SCM_HA;
+import static org.apache.hadoop.ozone.OzoneConsts.STORAGE_DIR;
+import static org.apache.hadoop.ozone.OzoneConsts.PRIMARY_SCM_NODE_ID;
+import static org.apache.hadoop.ozone.OzoneConsts.SCM_CERT_SERIAL_ID;
+import static org.apache.hadoop.ozone.OzoneConsts.SCM_ID;
 /**
  * SCMStorageConfig is responsible for management of the
  * StorageDirectories used by the SCM.
@@ -59,7 +62,6 @@ public class SCMStorageConfig extends Storage {
 
   public void setSCMHAFlag(boolean flag) {
     if (!isSCMHAEnabled()) {
-      Preconditions.checkNotNull(flag);
       getStorageInfo().setProperty(SCM_HA, Boolean.toString(flag));
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.server;
 
-import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.server.ServerUtils;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMStorageConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.server;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.server.ServerUtils;
@@ -27,11 +28,7 @@ import java.io.IOException;
 import java.util.Properties;
 import java.util.UUID;
 
-import static org.apache.hadoop.ozone.OzoneConsts.PRIMARY_SCM_NODE_ID;
-import static org.apache.hadoop.ozone.OzoneConsts.SCM_CERT_SERIAL_ID;
-import static org.apache.hadoop.ozone.OzoneConsts.SCM_ID;
-import static org.apache.hadoop.ozone.OzoneConsts.STORAGE_DIR;
-
+import static org.apache.hadoop.ozone.OzoneConsts.*;
 
 /**
  * SCMStorageConfig is responsible for management of the
@@ -60,12 +57,27 @@ public class SCMStorageConfig extends Storage {
     }
   }
 
+  public void setSCMHAFlag(boolean flag) {
+    if (!isSCMHAEnabled()) {
+      Preconditions.checkNotNull(flag);
+      getStorageInfo().setProperty(SCM_HA, Boolean.toString(flag));
+    }
+  }
+
   /**
    * Retrieves the SCM ID from the version file.
    * @return SCM_ID
    */
   public String getScmId() {
     return getStorageInfo().getProperty(SCM_ID);
+  }
+
+  /**
+   * Retrieves the SCM HA flag from the version file.
+   * @return SCM_ID
+   */
+  public boolean isSCMHAEnabled() {
+    return Boolean.valueOf(getStorageInfo().getProperty(SCM_HA));
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -943,16 +943,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
     } else {
       clusterId = scmStorageConfig.getClusterID();
-      if (!scmStorageConfig.checkPrimarySCMIdInitialized()) {
-        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
-        scmStorageConfig.forceInitialize();
-      }
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();
       if (SCMHAUtils.isSCMHAEnabled(conf) && !isSCMHAEnabled) {
         SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
             scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
             conf);
         scmStorageConfig.setSCMHAFlag(true);
+        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
         scmStorageConfig.forceInitialize();
         LOG.debug("Enabled SCM HA");
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -943,14 +943,18 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
     } else {
       clusterId = scmStorageConfig.getClusterID();
+      if (!scmStorageConfig.checkPrimarySCMIdInitialized()) {
+        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
+        scmStorageConfig.forceInitialize();
+      }
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();
       if (SCMHAUtils.isSCMHAEnabled(conf) && !isSCMHAEnabled) {
         SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
             scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
             conf);
         scmStorageConfig.setSCMHAFlag(true);
-        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
         scmStorageConfig.forceInitialize();
+        LOG.debug("Enabled SCM HA");
       }
       LOG.info("SCM already initialized. Reusing existing cluster id for sd={}"
               + ";cid={}; layoutVersion={}; HAEnabled={}",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -283,7 +283,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       String errMsg = "Please make sure you have run \'ozone scm --init\' " +
           "command to generate all the required metadata to " +
           scmStorageConfig.getStorageDir();
-      if (SCMHAUtils.isSCMHAEnabled(conf)) {
+      if (SCMHAUtils.isSCMHAEnabled(conf) && !scmStorageConfig
+          .isSCMHAEnabled()) {
         errMsg += " or make sure you have run \'ozone scm --bootstrap\' cmd to "
             + "add the SCM to existing SCM HA group";
       }
@@ -819,11 +820,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     String primordialSCM = SCMHAUtils.getPrimordialSCM(conf);
     SCMHANodeDetails scmhaNodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
     String selfNodeId = scmhaNodeDetails.getLocalNodeDetails().getNodeId();
-    if (primordialSCM != null && SCMHAUtils.isPrimordialSCM(conf, selfNodeId)) {
+    final String selfHostName =
+        scmhaNodeDetails.getLocalNodeDetails().getHostName();
+    if (primordialSCM != null && SCMHAUtils
+        .isPrimordialSCM(conf, selfNodeId, selfHostName)) {
       LOG.info(
           "SCM bootstrap command can only be executed in non-Primordial SCM "
-              + "{}, self id {} "
-              + "Ignoring it.", primordialSCM, selfNodeId);
+              + "{}, self id {} " + "Ignoring it.", primordialSCM, selfNodeId);
       return true;
     }
     SCMStorageConfig scmStorageConfig = new SCMStorageConfig(conf);
@@ -871,6 +874,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               getScmAddress(scmhaNodeDetails, conf), false);
         }
         scmStorageConfig.setPrimaryScmNodeId(scmInfo.getScmId());
+        scmStorageConfig.setSCMHAFlag(true);
         scmStorageConfig.initialize();
         LOG.info("SCM BootStrap  is successful for ClusterID {}, SCMID {}",
             scmInfo.getClusterId(), scmStorageConfig.getScmId());
@@ -897,9 +901,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     StorageState state = scmStorageConfig.getState();
     final SCMHANodeDetails haDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
     String primordialSCM = SCMHAUtils.getPrimordialSCM(conf);
-    String selfNodeId = haDetails.getLocalNodeDetails().getNodeId();
+    final String selfNodeId = haDetails.getLocalNodeDetails().getNodeId();
+    final String selfHostName = haDetails.getLocalNodeDetails().getHostName();
     if (primordialSCM != null && !SCMHAUtils
-        .isPrimordialSCM(conf, selfNodeId)) {
+        .isPrimordialSCM(conf, selfNodeId, selfHostName)) {
       LOG.info(
           "SCM init command can only be executed in Primordial SCM {}, "
               + "self id {} "
@@ -918,6 +923,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
               scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
               conf);
+          scmStorageConfig.setSCMHAFlag(true);
         }
 
         if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
@@ -937,13 +943,20 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
     } else {
       clusterId = scmStorageConfig.getClusterID();
-      LOG.info("SCM already initialized. Reusing existing cluster id for sd={}"
-              + ";cid={};layoutVersion={}", scmStorageConfig.getStorageDir(),
-          clusterId, scmStorageConfig.getLayoutVersion());
-      if (SCMHAUtils.isSCMHAEnabled(conf)) {
-        SCMRatisServerImpl.reinitialize(clusterId, scmStorageConfig.getScmId(),
-            haDetails.getLocalNodeDetails(), conf);
+      final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();
+      if (SCMHAUtils.isSCMHAEnabled(conf) && !isSCMHAEnabled) {
+        SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
+            scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
+            conf);
+        scmStorageConfig.setSCMHAFlag(true);
+        scmStorageConfig.setPrimaryScmNodeId(scmStorageConfig.getScmId());
+        scmStorageConfig.forceInitialize();
       }
+      LOG.info("SCM already initialized. Reusing existing cluster id for sd={}"
+              + ";cid={}; layoutVersion={}; HAEnabled={}",
+          scmStorageConfig.getStorageDir(), clusterId,
+          scmStorageConfig.getLayoutVersion(),
+          scmStorageConfig.isSCMHAEnabled());
       return true;
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -485,6 +485,7 @@ public class TestStorageContainerManager {
     StorageContainerManager.scmInit(conf, testClusterId);
     Assert.assertEquals(NodeType.SCM, scmStore.getNodeType());
     Assert.assertEquals(testClusterId, scmStore.getClusterID());
+    Assert.assertFalse(scmStore.isSCMHAEnabled());
   }
 
   @Test
@@ -499,6 +500,8 @@ public class TestStorageContainerManager {
     final UUID clusterId = UUID.randomUUID();
     // This will initialize SCM
     StorageContainerManager.scmInit(conf, clusterId.toString());
+    SCMStorageConfig scmStore = new SCMStorageConfig(conf);
+    Assert.assertTrue(scmStore.isSCMHAEnabled());
     validateRatisGroupExists(conf, clusterId.toString());
   }
 
@@ -519,6 +522,7 @@ public class TestStorageContainerManager {
       StorageContainerManager.scmInit(conf, clusterId.toString());
       SCMStorageConfig scmStore = new SCMStorageConfig(conf);
       Assert.assertNotEquals(clusterId.toString(), scmStore.getClusterID());
+      Assert.assertFalse(scmStore.isSCMHAEnabled());
     } finally {
       cluster.shutdown();
     }
@@ -591,6 +595,8 @@ public class TestStorageContainerManager {
       StorageContainerManager.scmInit(conf, clusterId);
       // Ratis group with cluster id exists now
       validateRatisGroupExists(conf, clusterId);
+      SCMStorageConfig scmStore = new SCMStorageConfig(conf);
+      Assert.assertTrue(scmStore.isSCMHAEnabled());
     } finally {
       cluster.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed SCM reinitialization logic 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5122

## How was this patch tested?

Modified UTs
