### PR TITLE
HDDS-5125. Only test ozonesecure with SCM Ratis disabled

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -104,6 +104,5 @@ services:
       KERBEROS_KEYTABS: scm HTTP testuser testuser2
       ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
-      OZONE-SITE.XML_ozone.scm.ratis.enable: "${OZONE_SCM_RATIS_ENABLE:-false}"
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -27,42 +27,39 @@ export SECURITY_ENABLED=true
 
 : ${OZONE_BUCKET_KEY_NAME:=key1}
 
-for enable in true false; do
+start_docker_env
 
-  start_docker_env 3 "${enable}"
+execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
-  execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
+execute_robot_test scm kinit.robot
 
-  execute_robot_test scm kinit.robot
+execute_robot_test scm basic
 
-  execute_robot_test scm basic
+execute_robot_test scm security
 
-  execute_robot_test scm security
-
-  for scheme in ofs o3fs; do
-    for bucket in link bucket; do
-      execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${scheme}-${bucket} ozonefs/ozonefs.robot
-    done
+for scheme in ofs o3fs; do
+  for bucket in link bucket; do
+    execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${scheme}-${bucket} ozonefs/ozonefs.robot
   done
-
-  for bucket in link generated; do
-    execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
-  done
-
-  #expects 4 pipelines, should be run before
-  #admincli which creates STANDALONE pipeline
-  execute_robot_test scm recon
-
-  execute_robot_test scm admincli
-  execute_robot_test scm spnego
-
-  # test replication
-  docker-compose up -d --scale datanode=2
-  execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
-  docker-compose up -d --scale datanode=3
-  execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
-
-  stop_docker_env
-
-  generate_report
 done
+
+for bucket in link generated; do
+  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
+done
+
+#expects 4 pipelines, should be run before
+#admincli which creates STANDALONE pipeline
+execute_robot_test scm recon
+
+execute_robot_test scm admincli
+execute_robot_test scm spnego
+
+# test replication
+docker-compose up -d --scale datanode=2
+execute_robot_test scm -v container:1 -v count:2 replication/wait.robot
+docker-compose up -d --scale datanode=3
+execute_robot_test scm -v container:1 -v count:3 replication/wait.robot
+
+stop_docker_env
+
+generate_report

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -139,7 +139,6 @@ start_docker_env(){
   create_results_dir
   export OZONE_SAFEMODE_MIN_DATANODES="${datanode_count}"
 
-  export OZONE_SCM_RATIS_ENABLE=${2:-false}
   docker-compose --no-ansi down
   if ! { docker-compose --no-ansi up -d --scale datanode="${datanode_count}" \
       && wait_for_safemode_exit \


### PR DESCRIPTION
## What changes were proposed in this pull request?

As [spotted](https://github.com/apache/ozone/pull/2052#discussion_r616570112) by @elek, `ozonesecure` acceptance test is run twice: with SCM Ratis enabled and disabled.  This doubles execution time.  Now that `ozonesecure-ha` acceptance test also has SCM HA (implies Ratis enabled), I don't think it's necessary to run `ozonesecure` (single SCM) with Ratis enabled.

https://issues.apache.org/jira/browse/HDDS-5125

## How was this patch tested?

Now _acceptance (secure)_ is only 1 hour:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/768286122