### PR TITLE
HDDS-5128. Return specific error messages for S3-SDK

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -21,6 +21,7 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
 import java.io.IOException;
@@ -76,7 +77,7 @@ public class OzoneClientProducer {
   private ContainerRequestContext context;
 
   @Produces
-  public OzoneClient createClient() throws OS3Exception, IOException {
+  public OzoneClient createClient() throws WebApplicationException, IOException {
     client = getClient(ozoneConfiguration);
     return client;
   }
@@ -87,7 +88,7 @@ public class OzoneClientProducer {
   }
 
   private OzoneClient getClient(OzoneConfiguration config)
-      throws OS3Exception {
+      throws WebApplicationException {
     OzoneClient ozoneClient = null;
     try {
       SignatureInfo signatureInfo = signatureProcessor.parseSignature();
@@ -134,14 +135,14 @@ public class OzoneClientProducer {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Error during Client Creation: ", ex);
       }
-      throw ex;
+      throw wrapOS3Exception(ex);
     } catch (Throwable t) {
       // For any other critical errors during object creation throw Internal
       // error.
       if (LOG.isDebugEnabled()) {
         LOG.debug("Error during Client Creation: ", t);
       }
-      throw INTERNAL_ERROR;
+      throw wrapOS3Exception(INTERNAL_ERROR);
     }
     return ozoneClient;
   }
@@ -162,7 +163,7 @@ public class OzoneClientProducer {
   private void validateAccessId(String awsAccessId) throws Exception {
     if (awsAccessId == null || awsAccessId.equals("")) {
       LOG.error("Malformed s3 header. awsAccessID: ", awsAccessId);
-      throw MALFORMED_HEADER;
+      throw wrapOS3Exception(MALFORMED_HEADER);
     }
   }
 
@@ -173,5 +174,10 @@ public class OzoneClientProducer {
   @VisibleForTesting
   public void setSignatureParser(SignatureProcessor awsSignatureProcessor) {
     this.signatureProcessor = awsSignatureProcessor;
+  }
+
+  private WebApplicationException wrapOS3Exception(OS3Exception os3Exception) {
+    return new WebApplicationException(os3Exception,
+        os3Exception.getHttpCode());
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -77,7 +77,8 @@ public class OzoneClientProducer {
   private ContainerRequestContext context;
 
   @Produces
-  public OzoneClient createClient() throws WebApplicationException, IOException {
+  public OzoneClient createClient() throws WebApplicationException,
+      IOException {
     client = getClient(ozoneConfiguration);
     return client;
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -29,7 +29,6 @@ import java.util.Collection;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.signature.AWSSignatureProcessor;
 
 import static org.apache.hadoop.ozone.s3.signature.SignatureParser.AUTHORIZATION_HEADER;

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.s3;
 
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -128,7 +129,7 @@ public class TestOzoneClientProducer {
       producer.createClient();
       fail("testGetClientFailure");
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof OS3Exception);
+      Assert.assertTrue(ex instanceof WebApplicationException);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Return WebApplicationException instead of OS3Exception in OzoneClientProducer.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5128

## How was this patch tested?

Test passed with S3-SDK requests. Can test with the following Steps:
1. Remove credentials. 
```
mv ~/.aws ~/.aws_bak
unset AWS_ACCESS_KEY_ID
unset AWS_SECRET_ACCESS_KEY
```
2. List objects using S3 SDK via S3gateway.
```
AmazonS3 s3 = AmazonS3ClientBuilder.standard()
        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("http://localhost:9878", Regions.DEFAULT_REGION.getName()))
        .withPathStyleAccessEnabled(true)
        .build();
ListObjectsV2Result result = s3.listObjectsV2(bucket_name);
```
3. Before the patch the error message is as follows:
```
Server Error (Service: Amazon S3; Status Code: 500; Error Code: 500 Server Error; Request ID: null; S3 Extended Request ID: null; Proxy: null)
```
4. After the patch the error would be as follows:
```
The authorization header you provided is invalid. (Service: Amazon S3; Status Code: 404; Error Code: AuthorizationHeaderMalformed; Request ID: 2102408b-f97b-477f-8510-07e7008792be; S3 Extended Request ID: null; Proxy: null)
```