### PR TITLE
HDDS-4687. Disable compression for closed-container replication

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
@@ -55,7 +54,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.commons.compress.compressors.CompressorStreamFactory.GZIP;
 
 /**
  * Test the tar/untar for a given container.
@@ -169,9 +167,7 @@ public class TestTarContainerPacker {
     //THEN: check the result
     TarArchiveInputStream tarStream = null;
     try (FileInputStream input = new FileInputStream(targetFile.toFile())) {
-      CompressorInputStream uncompressed = new CompressorStreamFactory()
-          .createCompressorInputStream(GZIP, input);
-      tarStream = new TarArchiveInputStream(uncompressed);
+      tarStream = new TarArchiveInputStream(input);
 
       TarArchiveEntry entry;
       Map<String, TarArchiveEntry> entries = new HashMap<>();
@@ -351,9 +347,7 @@ public class TestTarContainerPacker {
       throws Exception {
     File targetFile = TEMP_DIR.resolve("container.tar.gz").toFile();
     try (FileOutputStream output = new FileOutputStream(targetFile);
-         CompressorOutputStream gzipped = new CompressorStreamFactory()
-             .createCompressorOutputStream(GZIP, output);
-         ArchiveOutputStream archive = new TarArchiveOutputStream(gzipped)) {
+         ArchiveOutputStream archive = new TarArchiveOutputStream(output)) {
       TarContainerPacker.includeFile(file, entryName, archive);
     }
     return targetFile;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestTarContainerPacker.java
@@ -40,9 +40,6 @@ import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
-import org.apache.commons.compress.compressors.CompressorException;
-import org.apache.commons.compress.compressors.CompressorInputStream;
-import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.test.LambdaTestUtils;
@@ -137,7 +134,7 @@ public class TestTarContainerPacker {
   }
 
   @Test
-  public void pack() throws IOException, CompressorException {
+  public void pack() throws IOException {
 
     //GIVEN
     OzoneConfiguration conf = new OzoneConfiguration();


### PR DESCRIPTION
## What changes were proposed in this pull request?

During the measurement of closed container replication I found that the biggest bottleneck is the read side. 5 Gb container is replicated under ~3 minutes but ~2:30 was the downloading part.

Closed containers are replicated via GRPC. The source side creates an `OutputStream` on-the-fly (`OnDemandContainerReplicationSource.java`) and stream all the container content as a "tar.gz" archive to the client.

It turned out that the compression (the .gz part) is quite expensive:

I created a CLI tool to export containers to tar files (same logic as the replication but without streaming via GRPC, just saving to a file).

I have seen the 2:30 time to create the archive:

```
2021-01-13 05:51:25,302 [main] INFO debug.ExportContainer: Preparation is done
2021-01-13 05:53:53,472 [main] INFO debug.ExportContainer: Container is exported to /tmp/container-3.tar.gz
```

But when I removed the compression in `TarContainerPacker.java`, the speed was significant better (25 sec instead of the 150 sec)

```
2021-01-13 06:11:46,254 [main] INFO debug.ExportContainer: Preparation is done
2021-01-13 06:12:11,512 [main] INFO debug.ExportContainer: Container is exported to /tmp/container-3.tar
```

As a result I suggest turning off the compression for closed container replication.

More details: https://github.com/elek/ozone-notes/tree/master/20210113-closed-container-replication

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4687

## How was this patch tested?

Tested in real kubernetes cluster: 

 * data is generated with the freon data generator 
 * containers were replicated with the freon container replicator (time is checked from the log)
