### PR TITLE
HDDS-5059. Increase number of client retries/ failovers to OMs

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -366,7 +366,7 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_KEY =
       "ozone.client.failover.max.attempts";
   public static final int OZONE_CLIENT_FAILOVER_MAX_ATTEMPTS_DEFAULT =
-      15;
+      500;
   public static final String OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY =
       "ozone.client.wait.between.retries.millis";
   public static final long OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2357,12 +2357,14 @@
   </property>
   <property>
     <name>ozone.client.failover.max.attempts</name>
-    <value>15</value>
+    <value>100</value>
     <description>
       Expert only. Ozone RpcClient attempts talking to each OzoneManager
       ipc.client.connect.max.retries (default = 10) number of times before
       failing over to another OzoneManager, if available. This parameter
-      represents the number of times the client will failover before giving up.
+      represents the number of times the client will failover before giving
+      up. This value is kept high so that client does not give up trying to
+      connect to OMs easily.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2357,7 +2357,7 @@
   </property>
   <property>
     <name>ozone.client.failover.max.attempts</name>
-    <value>100</value>
+    <value>500</value>
     <description>
       Expert only. Ozone RpcClient attempts talking to each OzoneManager
       ipc.client.connect.max.retries (default = 10) number of times before

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -87,8 +87,6 @@ public class OMFailoverProxyProvider implements
 
   private final String omServiceId;
 
-  private List<String> retryExceptions = new ArrayList<>();
-
   // OMFailoverProxyProvider, on encountering certain exception, tries each OM
   // once in a round robin fashion. After that it waits for configured time
   // before attempting to contact all the OMs again. For other exceptions
@@ -235,17 +233,18 @@ public class OMFailoverProxyProvider implements
           int failovers, boolean isIdempotentOrAtMostOnce)
           throws Exception {
 
+        String omNodeId = getCurrentProxyOMNodeId();
+
         if (LOG.isDebugEnabled()) {
           if (exception.getCause() != null) {
-            LOG.debug("RetryProxy: OM {}: {}: {}", getCurrentProxyOMNodeId(),
+            LOG.debug("RetryProxy: OM {}: {}: {}", omNodeId,
                 exception.getCause().getClass().getSimpleName(),
                 exception.getCause().getMessage());
           } else {
-            LOG.debug("RetryProxy: OM {}: {}", getCurrentProxyOMNodeId(),
+            LOG.debug("RetryProxy: OM {}: {}", omNodeId,
                 exception.getMessage());
           }
         }
-        retryExceptions.add(getExceptionMsg(exception, failovers));
 
         if (exception instanceof ServiceException) {
           OMNotLeaderException notLeaderException =
@@ -267,7 +266,7 @@ public class OMFailoverProxyProvider implements
             // Retry on same OM again as leader OM is not ready.
             // Failing over to same OM so that wait time between retries is
             // incremented
-            performFailoverIfRequired(getCurrentProxyOMNodeId());
+            performFailoverIfRequired(omNodeId);
             return getRetryAction(RetryDecision.FAILOVER_AND_RETRY, failovers);
           }
         }
@@ -287,15 +286,8 @@ public class OMFailoverProxyProvider implements
         if (failovers < maxFailovers) {
           return new RetryAction(fallbackAction, getWaitTime());
         } else {
-          StringBuilder allRetryExceptions = new StringBuilder();
-          allRetryExceptions.append("\n");
-          retryExceptions.stream().forEach(e -> allRetryExceptions.append(e)
-              .append("\n"));
-          LOG.error("Failed to connect to OMs: {}. Attempted {} failovers. " +
-                  "Got following exceptions during retries: {}",
-              getOMProxyInfos(), maxFailovers,
-              allRetryExceptions.toString());
-          retryExceptions.clear();
+          LOG.error("Failed to connect to OMs: {}. Attempted {} failovers.",
+              getOMProxyInfos(), maxFailovers);
           return RetryAction.FAIL;
         }
       }
@@ -499,23 +491,6 @@ public class OMFailoverProxyProvider implements
   @VisibleForTesting
   public List<OMProxyInfo> getOMProxyInfos() {
     return new ArrayList<OMProxyInfo>(omProxyInfos.values());
-  }
-
-  private static String getExceptionMsg(Exception e, int retryAttempt) {
-    StringBuilder exceptionMsg = new StringBuilder()
-        .append("Retry Attempt ")
-        .append(retryAttempt)
-        .append(" Exception - ");
-    if (e.getCause() == null) {
-      exceptionMsg.append(e.getClass().getCanonicalName())
-          .append(": ")
-          .append(e.getMessage());
-    } else {
-      exceptionMsg.append(e.getCause().getClass().getCanonicalName())
-          .append(": ")
-          .append(e.getCause().getMessage());
-    }
-    return exceptionMsg.toString();
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in an OM HA setup, client by default does 15 failovers before giving up. If there are 3 OMs and a leader has not been elected yet, then the client will try each OM in a round robin way, wait for 2 secs and then try all the OMs again. This gives the client around 10 seconds before it exhausts all its failover attempts and fails. 

This Jira proposes to increase the failover attempts to 100.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5059

## How was this patch tested?

Existing unit tests
