### PR TITLE
HDDS-5126. Recon should check new containers of a container report with batch

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -103,6 +103,16 @@ public interface StorageContainerLocationProtocol extends Closeable {
       List<Long> containerIDs) throws IOException;
 
   /**
+   * Ask SCM which containers of the given list exist.
+   *
+   * @param containerIDs - IDs of a batch of containers.
+   * @return List of ContainerWithPipeline that exist in SCM
+   * - the container info with the pipeline.
+   */
+  List<ContainerWithPipeline> getExistContainerWithPipelinesInBatch(
+      List<Long> containerIDs);
+
+  /**
    * Ask SCM a list of containers with a range of container names
    * and the limit of count.
    * Search container names between start name(exclusive), and

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -28,17 +28,18 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ClosePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeAdminErrorResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeUsageInfoRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeUsageInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DeactivatePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeAdminErrorResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
@@ -87,7 +88,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
-
 import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
@@ -264,6 +264,47 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
       cps.add(ContainerWithPipeline.fromProtobuf(cp));
     }
 
+    return cps;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public List<ContainerWithPipeline> getExistContainerWithPipelinesInBatch(
+      List<Long> containerIDs) {
+    for (Long containerID: containerIDs) {
+      Preconditions.checkState(containerID >= 0,
+          "Container ID cannot be negative");
+    }
+
+    GetExistContainerWithPipelinesInBatchRequestProto request =
+        GetExistContainerWithPipelinesInBatchRequestProto.newBuilder()
+            .setTraceID(TracingUtil.exportCurrentSpan())
+            .addAllContainerIDs(containerIDs)
+            .build();
+    ScmContainerLocationResponse response = null;
+    List<ContainerWithPipeline> cps = new ArrayList<>();
+    try {
+      response = submitRequest(Type.GetExistContainerWithPipelinesInBatch,
+          (builder) -> builder
+              .setGetExistContainerWithPipelinesInBatchRequest(request));
+    } catch (IOException ex){
+      return cps;
+    }
+
+    List<HddsProtos.ContainerWithPipeline> protoCps = response
+        .getGetExistContainerWithPipelinesInBatchResponse()
+        .getContainerWithPipelinesList();
+
+    for (HddsProtos.ContainerWithPipeline cp : protoCps) {
+      try {
+        cps.add(ContainerWithPipeline.fromProtobuf(cp));
+      } catch (IOException uex) {
+          // "fromProtobuf" may throw an exception
+          // do nothing , just go ahead
+      }
+    }
     return cps;
   }
 

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -67,6 +67,7 @@ message ScmContainerLocationRequest {
   optional RecommissionNodesRequestProto recommissionNodesRequest = 28;
   optional StartMaintenanceNodesRequestProto startMaintenanceNodesRequest = 29;
   optional DatanodeUsageInfoRequestProto DatanodeUsageInfoRequest = 30;
+  optional GetExistContainerWithPipelinesInBatchRequestProto getExistContainerWithPipelinesInBatchRequest = 31;
 }
 
 message ScmContainerLocationResponse {
@@ -105,6 +106,8 @@ message ScmContainerLocationResponse {
   optional RecommissionNodesResponseProto recommissionNodesResponse = 28;
   optional StartMaintenanceNodesResponseProto startMaintenanceNodesResponse = 29;
   optional DatanodeUsageInfoResponseProto DatanodeUsageInfoResponse = 30;
+  optional GetExistContainerWithPipelinesInBatchResponseProto getExistContainerWithPipelinesInBatchResponse = 31;
+
   enum Status {
     OK = 1;
     CONTAINER_ALREADY_EXISTS = 2;
@@ -140,6 +143,7 @@ enum Type {
   RecommissionNodes = 23;
   StartMaintenanceNodes = 24;
   DatanodeUsageInfo = 25;
+  GetExistContainerWithPipelinesInBatch = 26;
 }
 
 /**
@@ -193,6 +197,11 @@ message GetContainerWithPipelineBatchRequestProto {
   optional string traceID = 2;
 }
 
+message GetExistContainerWithPipelinesInBatchRequestProto {
+  repeated int64 containerIDs = 1;
+  optional string traceID = 2;
+}
+
 message GetSafeModeRuleStatusesRequestProto {
 }
 
@@ -207,6 +216,10 @@ message GetSafeModeRuleStatusesResponseProto {
 }
 
 message GetContainerWithPipelineBatchResponseProto {
+  repeated ContainerWithPipeline containerWithPipelines = 1;
+}
+
+message GetExistContainerWithPipelinesInBatchResponseProto {
   repeated ContainerWithPipeline containerWithPipelines = 1;
 }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -42,6 +42,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineBatchResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
@@ -184,6 +186,15 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setGetContainerWithPipelineBatchResponse(
                 getContainerWithPipelineBatch(
                     request.getGetContainerWithPipelineBatchRequest(),
+                    request.getVersion()))
+            .build();
+      case GetExistContainerWithPipelinesInBatch:
+        return ScmContainerLocationResponse.newBuilder()
+            .setCmdType(request.getCmdType())
+            .setStatus(Status.OK)
+            .setGetExistContainerWithPipelinesInBatchResponse(
+                getExistContainerWithPipelinesInBatch(
+                    request.getGetExistContainerWithPipelinesInBatchRequest(),
                     request.getVersion()))
             .build();
       case ListContainer:
@@ -374,6 +385,20 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         .getContainerWithPipelineBatch(request.getContainerIDsList());
     GetContainerWithPipelineBatchResponseProto.Builder builder =
         GetContainerWithPipelineBatchResponseProto.newBuilder();
+    for (ContainerWithPipeline container : containers) {
+      builder.addContainerWithPipelines(container.getProtobuf(clientVersion));
+    }
+    return builder.build();
+  }
+
+  public GetExistContainerWithPipelinesInBatchResponseProto
+      getExistContainerWithPipelinesInBatch(
+      GetExistContainerWithPipelinesInBatchRequestProto request,
+      int clientVersion) throws IOException {
+    List<ContainerWithPipeline> containers = impl
+        .getExistContainerWithPipelinesInBatch(request.getContainerIDsList());
+    GetExistContainerWithPipelinesInBatchResponseProto.Builder builder =
+        GetExistContainerWithPipelinesInBatchResponseProto.newBuilder();
     for (ContainerWithPipeline container : containers) {
       builder.addContainerWithPipelines(container.getProtobuf(clientVersion));
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -314,6 +314,22 @@ public class SCMClientProtocolServer implements
 
     return cpList;
   }
+
+  @Override
+  public List<ContainerWithPipeline> getExistContainerWithPipelinesInBatch(
+      List<Long> containerIDs) {
+    List<ContainerWithPipeline> cpList = new ArrayList<>();
+    for (Long containerID : containerIDs) {
+      try {
+        ContainerWithPipeline cp = getContainerWithPipelineCommon(containerID);
+        cpList.add(cp);
+      } catch (IOException ex) {
+        //not found , just go ahead
+      }
+    }
+    return cpList;
+  }
+
   /**
    * Check if container reported replicas are equal or greater than required
    * replication factor.

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconContainerReportHandler.java
@@ -18,12 +18,9 @@
 
 package org.apache.hadoop.ozone.recon.scm;
 
-import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
 import org.apache.hadoop.hdds.scm.container.ContainerReportHandler;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -48,26 +45,11 @@ public class ReconContainerReportHandler extends ContainerReportHandler {
   @Override
   public void onMessage(final ContainerReportFromDatanode reportFromDatanode,
                         final EventPublisher publisher) {
-
-    final ContainerReportsProto containerReport =
-        reportFromDatanode.getReport();
     ReconContainerManager containerManager =
         (ReconContainerManager) getContainerManager();
-
-    List<ContainerReplicaProto> reportsList = containerReport.getReportsList();
-    for (ContainerReplicaProto containerReplicaProto : reportsList) {
-      final ContainerID id = ContainerID.valueOf(
-          containerReplicaProto.getContainerID());
-      try {
-        containerManager.checkAndAddNewContainer(id,
-            containerReplicaProto.getState(),
-            reportFromDatanode.getDatanodeDetails());
-      } catch (IOException ioEx) {
-        LOG.error("Exception while checking and adding new container.", ioEx);
-      }
-      LOG.debug("Got container report for containerID {} ",
-          containerReplicaProto.getContainerID());
-    }
+    List<ContainerReplicaProto> containerReplicaProtoList =
+        reportFromDatanode.getReport().getReportsList();
+    containerManager.checkAndAddNewContainerBatch(containerReplicaProtoList);
     super.onMessage(reportFromDatanode, publisher);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconIncrementalContainerReportHandler.java
@@ -77,7 +77,7 @@ public class ReconIncrementalContainerReportHandler
         try {
           containerManager.checkAndAddNewContainer(id, replicaProto.getState(),
               report.getDatanodeDetails());
-        } catch (IOException ioEx) {
+        } catch (Exception ioEx) {
           LOG.error("Exception while checking and adding new container.", ioEx);
           return;
         }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
@@ -52,4 +52,12 @@ public interface StorageContainerServiceProvider {
    */
   ContainerWithPipeline getContainerWithPipeline(long containerId)
       throws IOException;
+
+  /**
+   * Requests SCM for which containers in given ID list.
+   * @param containerIDs containerId list
+   * @return list of ContainerInfo + Pipeline info exists in SCM
+   */
+  List<ContainerWithPipeline> getExistContainerWithPipelinesInBatch(
+      List<Long> containerIDs);
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -60,4 +60,10 @@ public class StorageContainerServiceProviderImpl
       throws IOException {
     return scmClient.getContainerWithPipeline(containerId);
   }
+
+  @Override
+  public List<ContainerWithPipeline> getExistContainerWithPipelinesInBatch(
+      List<Long> containerIDs) {
+    return scmClient.getExistContainerWithPipelinesInBatch(containerIDs);
+  }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -477,7 +477,7 @@ public class TestContainerEndpoint {
   void putContainerInfos(int num) throws IOException {
     for (int i = 1; i <= num; i++) {
       final ContainerInfo info = newContainerInfo(i);
-      reconContainerManager.addNewContainer(i,
+      reconContainerManager.addNewContainer(
           new ContainerWithPipeline(info, pipeline));
     }
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -108,6 +108,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.Callable;
@@ -176,6 +177,13 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
         pipeline.getId().getProtobuf())).thenReturn(pipeline);
     when(mockScmServiceProvider.getContainerWithPipeline(containerId))
         .thenReturn(containerWithPipeline);
+    List<Long> containerIDs = new LinkedList<>();
+    containerIDs.add(containerId);
+    List<ContainerWithPipeline> cpw = new LinkedList<>();
+    cpw.add(containerWithPipeline);
+    when(mockScmServiceProvider
+        .getExistContainerWithPipelinesInBatch(containerIDs))
+        .thenReturn(cpw);
 
     InputStream inputStream =
         Thread.currentThread().getContextClassLoader().getResourceAsStream(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.ozone.recon.scm;
 
 import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
@@ -55,6 +57,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
+
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -148,10 +151,37 @@ public class AbstractReconContainerManagerTest {
             .build();
     ContainerWithPipeline containerWithPipeline =
         new ContainerWithPipeline(containerInfo, pipeline);
+
+    List<Long> containerList = new LinkedList<>();
+    List<ContainerWithPipeline> verifiedContainerPipeline =
+        new LinkedList<>();
+    LifeCycleState[] stateTypes = LifeCycleState.values();
+    int stateTypeCount = stateTypes.length;
+    for (int i = 200; i < 300; i++) {
+      containerList.add((long)i);
+      ContainerID cID = ContainerID.valueOf(i);
+      ContainerInfo cInfo =
+          new ContainerInfo.Builder()
+              .setContainerID(cID.getId())
+              .setNumberOfKeys(10)
+              .setPipelineID(pipeline.getId())
+              .setReplicationFactor(ONE)
+              .setOwner("test")
+              //add containers in all kinds of state
+              .setState(stateTypes[i % stateTypeCount])
+              .setReplicationType(STAND_ALONE)
+              .build();
+      verifiedContainerPipeline.add(
+          new ContainerWithPipeline(cInfo, pipeline));
+    }
+
     StorageContainerServiceProvider scmServiceProviderMock = mock(
         StorageContainerServiceProvider.class);
     when(scmServiceProviderMock.getContainerWithPipeline(100L))
         .thenReturn(containerWithPipeline);
+    when(scmServiceProviderMock
+        .getExistContainerWithPipelinesInBatch(containerList))
+        .thenReturn(verifiedContainerPipeline);
     return scmServiceProviderMock;
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconIncrementalContainerReportHandler.java
@@ -113,8 +113,7 @@ public class TestReconIncrementalContainerReportHandler
           containerWithPipeline.getContainerInfo().containerID();
 
       ReconContainerManager containerManager = getContainerManager();
-      containerManager.addNewContainer(containerID.getId(),
-          containerWithPipeline);
+      containerManager.addNewContainer(containerWithPipeline);
 
       DatanodeDetails datanodeDetails =
           containerWithPipeline.getPipeline().getFirstNode();


### PR DESCRIPTION

## What changes were proposed in this pull request?

in my test environment,  400000 containers exist. when bootstrap a new recon, every container will be checked and added to recondb.but , for now , recon check all the containers in a container report one by one , and each check will take a rpc call to scm. this is too slow and in my test environment , it leads to recon oom, because too many containers to be consumed are waitting in the message queue . It is better for recon to check new containers of a container report with batch.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5126

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

unit test
