### PR TITLE
HDDS-5131. Use timeout in github actions

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -162,7 +162,7 @@ jobs:
         continue-on-error: true
   integration:
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 100
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -24,6 +24,7 @@ env:
 jobs:
   compile:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -70,6 +71,7 @@ jobs:
         if: always()
   basic:
     runs-on: ubuntu-18.04
+    timeout-minutes: 40
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -115,6 +117,7 @@ jobs:
   acceptance:
     needs: compile
     runs-on: ubuntu-18.04
+    timeout-minutes: 120
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -159,6 +162,7 @@ jobs:
         continue-on-error: true
   integration:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -190,6 +194,7 @@ jobs:
         continue-on-error: true
   coverage:
     runs-on: ubuntu-18.04
+    timeout-minutes: 30
     if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
     needs:
       - acceptance
@@ -235,6 +240,7 @@ jobs:
   kubernetes:
     needs: compile
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: Checkout project


### PR DESCRIPTION
## What changes were proposed in this pull request?

Default timeout for one GitHub action job is 6 hours. It turned out that in some unfortunate case the acceptance tests were pending at this time, for example in https://github.com/apache/ozone/runs/2053572861?check_suite_focus=true

We need to turn on stricter timeouts for each of our jobs to avoid unnecessary build time usage.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5131

## How was this patch tested?

Executed the full build on my fork.

https://github.com/elek/ozone/actions/runs/776651574