### PR TITLE
HDDS-5099. Error with unit test for hdds.container-service TestSchemaOneBackwardsCompatibility

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -398,7 +398,7 @@ public class TestBlockDeletingService {
   @Test
   public void testBlockDeletion() throws Exception {
     DatanodeConfiguration dnConf = conf.getObject(DatanodeConfiguration.class);
-    dnConf.setBlockDeletionLimit(3);
+    dnConf.setBlockDeletionLimit(2);
     this.blockLimitPerInterval = dnConf.getBlockDeletionLimit();
     conf.setFromObject(dnConf);
     ContainerSet containerSet = new ContainerSet();
@@ -448,7 +448,8 @@ public class TestBlockDeletingService {
       deleteAndWait(svc, 1);
 
       GenericTestUtils.waitFor(() ->
-              containerData.get(0).getBytesUsed() < 3, 100, 3000);
+              containerData.get(0).getBytesUsed() == containerSpace /
+                      3, 100, 3000);
       // After first interval 2 blocks will be deleted. Hence, current space
       // used by the container should be less than the space used by the
       // container initially(before running deletion services).
@@ -711,8 +712,8 @@ public class TestBlockDeletingService {
       deleteAndWait(service, 1);
 
       GenericTestUtils.waitFor(() ->
-              blockLimitPerInterval*blockSpace ==
-                      (totalContainerSpace-
+              blockLimitPerInterval * blockSpace ==
+                      (totalContainerSpace -
                               currentBlockSpace(containerData, containerCount)),
               100, 3000);
 
@@ -726,8 +727,8 @@ public class TestBlockDeletingService {
 
       long totalContainerBlocks = blocksPerContainer*containerCount;
       GenericTestUtils.waitFor(() ->
-              totalContainerBlocks*blockSpace ==
-                      (totalContainerSpace-
+              totalContainerBlocks * blockSpace ==
+                      (totalContainerSpace -
                               currentBlockSpace(containerData, containerCount)),
               100, 3000);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -447,6 +447,8 @@ public class TestBlockDeletingService {
       // An interval will delete 1 * 2 blocks
       deleteAndWait(svc, 1);
 
+      GenericTestUtils.waitFor(() ->
+              containerData.get(0).getBytesUsed() < 3, 100, 3000);
       // After first interval 2 blocks will be deleted. Hence, current space
       // used by the container should be less than the space used by the
       // container initially(before running deletion services).
@@ -456,8 +458,8 @@ public class TestBlockDeletingService {
 
       // After deletion of all 3 blocks, space used by the containers
       // should be zero.
-      containerSpace = containerData.get(0).getBytesUsed();
-      Assert.assertTrue(containerSpace == 0);
+      GenericTestUtils.waitFor(() ->
+              containerData.get(0).getBytesUsed() == 0, 100, 3000);
 
       // Check finally DB counters.
       // Not checking bytes used, as handler is a mock call.
@@ -629,8 +631,11 @@ public class TestBlockDeletingService {
       // Hence, space used by the container of whose block has been
       // deleted should be zero.
       deleteAndWait(service, 1);
-      Assert.assertTrue((containerData.get(0).getBytesUsed() == 0)
-          || containerData.get(1).getBytesUsed() == 0);
+
+      GenericTestUtils.waitFor(() ->
+              (containerData.get(0).getBytesUsed() == 0 ||
+                      containerData.get(1).getBytesUsed() == 0),
+              100, 3000);
 
       Assert.assertFalse((containerData.get(0).getBytesUsed() == 0) && (
           containerData.get(1).getBytesUsed() == 0));
@@ -639,8 +644,10 @@ public class TestBlockDeletingService {
       // containers should be zero.
       deleteAndWait(service, 2);
 
-      Assert.assertTrue((containerData.get(0).getBytesUsed() == 0) && (
-          containerData.get(1).getBytesUsed() == 0));
+      GenericTestUtils.waitFor(() ->
+              (containerData.get(0).getBytesUsed() ==
+                      0 && containerData.get(1).getBytesUsed() == 0),
+              100, 3000);
     } finally {
       service.shutdown();
     }
@@ -702,9 +709,12 @@ public class TestBlockDeletingService {
       // Deleted space of 10 blocks should be equal to (initial total space
       // of container - current total space of container).
       deleteAndWait(service, 1);
-      Assert.assertEquals(blockLimitPerInterval * blockSpace,
-          (totalContainerSpace - currentBlockSpace(containerData,
-              containerCount)));
+
+      GenericTestUtils.waitFor(() ->
+              blockLimitPerInterval*blockSpace ==
+                      (totalContainerSpace-
+                              currentBlockSpace(containerData, containerCount)),
+              100, 3000);
 
       // There is only 5 blocks left to runDeletingTasks
 
@@ -713,9 +723,13 @@ public class TestBlockDeletingService {
       // - current total space of container(it will be zero as all blocks
       // in all the containers are deleted)).
       deleteAndWait(service, 2);
-      Assert.assertEquals(blocksPerContainer * containerCount * blockSpace,
-          (totalContainerSpace - currentBlockSpace(containerData,
-              containerCount)));
+
+      GenericTestUtils.waitFor(() ->
+              blocksPerContainer*containerCount*blockSpace ==
+                      (totalContainerSpace-
+                              currentBlockSpace(containerData, containerCount)),
+              100, 3000);
+
     } finally {
       service.shutdown();
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -724,8 +724,9 @@ public class TestBlockDeletingService {
       // in all the containers are deleted)).
       deleteAndWait(service, 2);
 
+      long totalContainerBlocks = blocksPerContainer*containerCount;
       GenericTestUtils.waitFor(() ->
-              blocksPerContainer*containerCount*blockSpace ==
+              totalContainerBlocks*blockSpace ==
                       (totalContainerSpace-
                               currentBlockSpace(containerData, containerCount)),
               100, 3000);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -249,6 +249,14 @@ public class TestSchemaOneBackwardsCompatibility {
 
     runBlockDeletingService(keyValueHandler);
 
+    GenericTestUtils.waitFor(() -> {
+      try {
+        return (newKvData().getBytesUsed() != initialTotalSpace);
+      } catch (IOException ex) {
+      }
+      return false;
+    }, 100, 3000);
+
     long currentTotalSpace = newKvData().getBytesUsed();
     long numberOfBlocksDeleted =
         (initialTotalSpace - currentTotalSpace) / blockSpace;
@@ -264,6 +272,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
     try(ReferenceCountedDB refCountedDB = BlockUtils.getDB(newKvData(), conf)) {
       // Test results via block iteration.
+
       assertEquals(expectedDeletingBlocks,
               countDeletingBlocks(refCountedDB));
       assertEquals(expectedDeletedBlocks,
@@ -279,6 +288,8 @@ public class TestSchemaOneBackwardsCompatibility {
               refCountedDB.getStore().getMetadataTable();
       assertEquals(expectedRegularBlocks + expectedDeletingBlocks,
               (long)metadataTable.get(OzoneConsts.BLOCK_COUNT));
+    //} catch(IOException ex) {
+      // Exception thrown as expected.
     }
   }
 
@@ -327,6 +338,14 @@ public class TestSchemaOneBackwardsCompatibility {
       long blockSpace = initialTotalSpace / TestDB.KEY_COUNT;
 
       runBlockDeletingService(keyValueHandler);
+
+      GenericTestUtils.waitFor(() -> {
+        try {
+          return (newKvData().getBytesUsed() != initialTotalSpace);
+        } catch (IOException ex) {
+        }
+        return false;
+      }, 100, 3000);
 
       long currentTotalSpace = newKvData().getBytesUsed();
 
@@ -494,6 +513,7 @@ public class TestSchemaOneBackwardsCompatibility {
     service.runDeletingTasks();
     GenericTestUtils
         .waitFor(() -> service.getTimesOfProcessed() == 1, 100, 3000);
+
   }
 
   private ContainerSet makeContainerSet() throws Exception {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -288,8 +288,6 @@ public class TestSchemaOneBackwardsCompatibility {
               refCountedDB.getStore().getMetadataTable();
       assertEquals(expectedRegularBlocks + expectedDeletingBlocks,
               (long)metadataTable.get(OzoneConsts.BLOCK_COUNT));
-    //} catch(IOException ex) {
-      // Exception thrown as expected.
     }
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
@@ -84,9 +83,11 @@ public class BlockDeletingServiceTestImpl
     @Override
     public synchronized void run() {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Running background service : {}", "BlockDeletingServiceTestImpl");
+        LOG.debug("Running background service : {}",
+                "BlockDeletingServiceTestImpl");
       }
-      long serviceTimeoutInNanos = TimeDuration.valueOf(SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
+      long serviceTimeoutInNanos = TimeDuration.valueOf(
+              SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
               .toLong(TimeUnit.NANOSECONDS);
       BackgroundTaskQueue tasks = getTasks();
       if (tasks.isEmpty()) {
@@ -115,17 +116,19 @@ public class BlockDeletingServiceTestImpl
             long endTime = System.nanoTime();
             if (endTime - startTime > serviceTimeoutInNanos) {
               LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
-                      "BlockDeletingServiceTestImpl", endTime - startTime, serviceTimeoutInNanos);
+                      "BlockDeletingServiceTestImpl", endTime - startTime,
+                      serviceTimeoutInNanos);
             }
           }
-        }, getExecutorService()) );
+        }, getExecutorService()));
       }
       try {
         CompletableFuture
-                .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
+                .allOf(futureList.toArray(
+                        new CompletableFuture[futureList.size()]))
                 .get();
       } catch (Exception e) {
-        Assert.fail("testAllocateBlockInParallel failed");
+        Assert.fail("BlockDeletingServiceTestImpl failed");
       }
     }
   }
@@ -133,7 +136,7 @@ public class BlockDeletingServiceTestImpl
   // Override the implementation to start a single on-call control thread.
   @Override
   public void start() {
-    PeriodicalTask svc = new PeriodicalTaskTestImpl();
+    PeriodicalTask svc = new PeriodicalTask(); //new PeriodicalTaskTestImpl();
     // In test mode, relies on a latch countdown to runDeletingTasks tasks.
     Runnable r = () -> {
       while (true) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -25,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
@@ -84,9 +83,11 @@ public class BlockDeletingServiceTestImpl
     @Override
     public synchronized void run() {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Running background service : {}", "BlockDeletingServiceTestImpl");
+        LOG.debug("Running background service : {}",
+                "BlockDeletingServiceTestImpl");
       }
-      long serviceTimeoutInNanos = TimeDuration.valueOf(SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
+      long serviceTimeoutInNanos = TimeDuration.valueOf(
+              SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
               .toLong(TimeUnit.NANOSECONDS);
       BackgroundTaskQueue tasks = getTasks();
       if (tasks.isEmpty()) {
@@ -115,17 +116,19 @@ public class BlockDeletingServiceTestImpl
             long endTime = System.nanoTime();
             if (endTime - startTime > serviceTimeoutInNanos) {
               LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
-                      "BlockDeletingServiceTestImpl", endTime - startTime, serviceTimeoutInNanos);
+                      "BlockDeletingServiceTestImpl", endTime - startTime,
+                      serviceTimeoutInNanos);
             }
           }
-        }, getExecutorService()) );
+        }, getExecutorService()));
       }
       try {
         CompletableFuture
-                .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
+                .allOf(futureList.toArray(
+                        new CompletableFuture[futureList.size()]))
                 .get();
       } catch (Exception e) {
-        Assert.fail("testAllocateBlockInParallel failed");
+        Assert.fail("BlockDeletingServiceTestImpl failed");
       }
     }
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -80,7 +80,6 @@ public class BlockDeletingServiceTestImpl
           break;
         }
         Future<?> future = this.getExecutorService().submit(svc);
-
         try {
           // for tests, we only wait for 3s for completion
           future.get(3, TimeUnit.SECONDS);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -16,17 +16,28 @@
  */
 package org.apache.hadoop.ozone.container.testutils;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.ratis.util.TimeDuration;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A test class implementation for {@link BlockDeletingService}.
@@ -41,6 +52,9 @@ public class BlockDeletingServiceTestImpl
   private CountDownLatch latch;
   private Thread testingThread;
   private AtomicInteger numOfProcessed = new AtomicInteger(0);
+  private static final Logger LOG =
+          LoggerFactory.getLogger(BlockDeletingServiceTestImpl.class);
+
 
   public BlockDeletingServiceTestImpl(OzoneContainer container,
       int serviceInterval, ConfigurationSource conf) {
@@ -66,10 +80,60 @@ public class BlockDeletingServiceTestImpl
     return numOfProcessed.get();
   }
 
+  public class PeriodicalTaskTestImpl extends PeriodicalTask {
+    @Override
+    public synchronized void run() {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Running background service : {}", "BlockDeletingServiceTestImpl");
+      }
+      long serviceTimeoutInNanos = TimeDuration.valueOf(SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
+              .toLong(TimeUnit.NANOSECONDS);
+      BackgroundTaskQueue tasks = getTasks();
+      if (tasks.isEmpty()) {
+        // No task found, or some problems to init tasks
+        // return and retry in next interval.
+        return;
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Number of background tasks to execute : {}", tasks.size());
+      }
+      List<CompletableFuture<?> >futureList =
+              new ArrayList<>();
+
+      while (tasks.size() > 0) {
+        BackgroundTask task = tasks.poll();
+        futureList.add(CompletableFuture.runAsync(() -> {
+          long startTime = System.nanoTime();
+          try {
+            BackgroundTaskResult result = task.call();
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("task execution result size {}", result.getSize());
+            }
+          } catch (Exception e) {
+            LOG.warn("Background task execution failed", e);
+          } finally {
+            long endTime = System.nanoTime();
+            if (endTime - startTime > serviceTimeoutInNanos) {
+              LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
+                      "BlockDeletingServiceTestImpl", endTime - startTime, serviceTimeoutInNanos);
+            }
+          }
+        }, getExecutorService()) );
+      }
+      try {
+        CompletableFuture
+                .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
+                .get();
+      } catch (Exception e) {
+        Assert.fail("testAllocateBlockInParallel failed");
+      }
+    }
+  }
+
   // Override the implementation to start a single on-call control thread.
   @Override
   public void start() {
-    PeriodicalTask svc = new PeriodicalTask();
+    PeriodicalTask svc = new PeriodicalTaskTestImpl();
     // In test mode, relies on a latch countdown to runDeletingTasks tasks.
     Runnable r = () -> {
       while (true) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
@@ -83,11 +84,9 @@ public class BlockDeletingServiceTestImpl
     @Override
     public synchronized void run() {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Running background service : {}",
-                "BlockDeletingServiceTestImpl");
+        LOG.debug("Running background service : {}", "BlockDeletingServiceTestImpl");
       }
-      long serviceTimeoutInNanos = TimeDuration.valueOf(
-              SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
+      long serviceTimeoutInNanos = TimeDuration.valueOf(SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
               .toLong(TimeUnit.NANOSECONDS);
       BackgroundTaskQueue tasks = getTasks();
       if (tasks.isEmpty()) {
@@ -116,19 +115,17 @@ public class BlockDeletingServiceTestImpl
             long endTime = System.nanoTime();
             if (endTime - startTime > serviceTimeoutInNanos) {
               LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
-                      "BlockDeletingServiceTestImpl", endTime - startTime,
-                      serviceTimeoutInNanos);
+                      "BlockDeletingServiceTestImpl", endTime - startTime, serviceTimeoutInNanos);
             }
           }
-        }, getExecutorService()));
+        }, getExecutorService()) );
       }
       try {
         CompletableFuture
-                .allOf(futureList.toArray(
-                        new CompletableFuture[futureList.size()]))
+                .allOf(futureList.toArray(new CompletableFuture[futureList.size()]))
                 .get();
       } catch (Exception e) {
-        Assert.fail("BlockDeletingServiceTestImpl failed");
+        Assert.fail("testAllocateBlockInParallel failed");
       }
     }
   }
@@ -136,7 +133,7 @@ public class BlockDeletingServiceTestImpl
   // Override the implementation to start a single on-call control thread.
   @Override
   public void start() {
-    PeriodicalTask svc = new PeriodicalTask(); //new PeriodicalTaskTestImpl();
+    PeriodicalTask svc = new PeriodicalTaskTestImpl();
     // In test mode, relies on a latch countdown to runDeletingTasks tasks.
     Runnable r = () -> {
       while (true) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/testutils/BlockDeletingServiceTestImpl.java
@@ -16,27 +16,17 @@
  */
 package org.apache.hadoop.ozone.container.testutils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.utils.BackgroundTask;
-import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
-import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.apache.ratis.util.TimeDuration;
-import org.junit.Assert;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A test class implementation for {@link BlockDeletingService}.
@@ -51,9 +41,6 @@ public class BlockDeletingServiceTestImpl
   private CountDownLatch latch;
   private Thread testingThread;
   private AtomicInteger numOfProcessed = new AtomicInteger(0);
-  private static final Logger LOG =
-          LoggerFactory.getLogger(BlockDeletingServiceTestImpl.class);
-
 
   public BlockDeletingServiceTestImpl(OzoneContainer container,
       int serviceInterval, ConfigurationSource conf) {
@@ -79,64 +66,10 @@ public class BlockDeletingServiceTestImpl
     return numOfProcessed.get();
   }
 
-  public class PeriodicalTaskTestImpl extends PeriodicalTask {
-    @Override
-    public synchronized void run() {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Running background service : {}",
-                "BlockDeletingServiceTestImpl");
-      }
-      long serviceTimeoutInNanos = TimeDuration.valueOf(
-              SERVICE_TIMEOUT_IN_MILLISECONDS, TimeUnit.MILLISECONDS)
-              .toLong(TimeUnit.NANOSECONDS);
-      BackgroundTaskQueue tasks = getTasks();
-      if (tasks.isEmpty()) {
-        // No task found, or some problems to init tasks
-        // return and retry in next interval.
-        return;
-      }
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Number of background tasks to execute : {}", tasks.size());
-      }
-      List<CompletableFuture<?> >futureList =
-              new ArrayList<>();
-
-      while (tasks.size() > 0) {
-        BackgroundTask task = tasks.poll();
-        futureList.add(CompletableFuture.runAsync(() -> {
-          long startTime = System.nanoTime();
-          try {
-            BackgroundTaskResult result = task.call();
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("task execution result size {}", result.getSize());
-            }
-          } catch (Exception e) {
-            LOG.warn("Background task execution failed", e);
-          } finally {
-            long endTime = System.nanoTime();
-            if (endTime - startTime > serviceTimeoutInNanos) {
-              LOG.warn("{} Background task execution took {}ns > {}ns(timeout)",
-                      "BlockDeletingServiceTestImpl", endTime - startTime,
-                      serviceTimeoutInNanos);
-            }
-          }
-        }, getExecutorService()));
-      }
-      try {
-        CompletableFuture
-                .allOf(futureList.toArray(
-                        new CompletableFuture[futureList.size()]))
-                .get();
-      } catch (Exception e) {
-        Assert.fail("BlockDeletingServiceTestImpl failed");
-      }
-    }
-  }
-
   // Override the implementation to start a single on-call control thread.
   @Override
   public void start() {
-    PeriodicalTask svc = new PeriodicalTaskTestImpl();
+    PeriodicalTask svc = new PeriodicalTask();
     // In test mode, relies on a latch countdown to runDeletingTasks tasks.
     Runnable r = () -> {
       while (true) {
@@ -147,6 +80,7 @@ public class BlockDeletingServiceTestImpl
           break;
         }
         Future<?> future = this.getExecutorService().submit(svc);
+
         try {
           // for tests, we only wait for 3s for completion
           future.get(3, TimeUnit.SECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes for intermittent unit test failures found in  hdds.container-service _TestSchemaOneBackwardsCompatibility_ and in _TestBlockDeletingService_.  Current implementation for unit tests uses the _BackgroundService_ for block deletion.  This service uses a thread pool executor that uses worker thread tasks that run asynchronously.  The unit test callers for this service 'start' the _PeriodicalTask_ of the _BackgroundService_ and expect the workers to finish deleting blocks when they do checks for expected results.  The thread pool executor runs the worker tasks, _however_ they do not run to completion prior to returning control to the unit test callers.  This leads to an **intermittent error** due to results not ready when the unit test caller checks for expected results.

Patch _**extends**_ the _PeriodicalTask_ for the background service and runs the worker tasks async until completion prior to returning control to the unit test caller.  This is realized in the _BlockDeletingServiceTestImpl_ _**PeriodicalTaskTestImpl**_ implementation.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5099

## How was this patch tested?

Patch was tested with unit tests : _**TestSchemaOneBackwardsCompatibility**_ and _**TestBlockDeletingService**_.

to see error, reproduce the error reliably (it is intermittent), can force failure though injecting fault into the 
_BlockDeletingService.java_ implementation - adding a small delay to the BackgroundTask call():
```
    public BackgroundTaskResult call() throws Exception {
      ContainerBackgroundTaskResult crr;
      final Container container = ozoneContainer.getContainerSet()
          .getContainer(containerData.getContainerID());
      container.writeLock();
      File dataDir = new File(containerData.getChunksPath());
      long startTime = Time.monotonicNow();
      // Scan container's db and get list of under deletion blocks
      try (ReferenceCountedDB meta = BlockUtils.getDB(containerData, conf)) {
        TimeUnit.MILLISECONDS.sleep(100); 
```
**pre-patch**

`hadoop-hdds/container-service$ mvn -Dtest=TestSchemaOneBackwardsCompatibility#testDelete test` 
![TestSchemaOneBackwardsCompatibility_prepatch](https://user-images.githubusercontent.com/81126310/116017324-86fcfb00-a5fc-11eb-8cd7-06924ea9b567.png)

`hadoop-hdds/container-service$ mvn -Dtest=TestBlockDeletingService test
`
![testBlockDeletingService_prepatch](https://user-images.githubusercontent.com/81126310/116017350-9714da80-a5fc-11eb-8f86-840727dc1c8e.png)

**after patch is applied**

`hadoop-hdds/container-service$ mvn -Dtest=TestSchemaOneBackwardsCompatibility#testDelete test` 
![TestSchemaOneBackwardsCompatibility_afterpatch](https://user-images.githubusercontent.com/81126310/116017336-8cf2dc00-a5fc-11eb-8a6d-a72d2166789b.png)

`hadoop-hdds/container-service$ mvn -Dtest=TestBlockDeletingService test`

![TestBlockDeletingService_afterpatch](https://user-images.githubusercontent.com/81126310/116017380-a85de700-a5fc-11eb-829c-bd0973a900b4.png)

