### PR TITLE
HDDS-5147. Intermittent test failure in TestContainerDeletionChoosingPolicy#testRandomChoosingPolicy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -177,8 +177,6 @@ public class BlockDeletingService extends BackgroundService {
             .filter(e -> isDeletionAllowed(e.getValue().getContainerData(),
                 deletionPolicy)).collect(Collectors
             .toMap(Map.Entry::getKey, e -> e.getValue().getContainerData()));
-    System.out.println("size " + containerDataMap.size());
-    System.out.println("blockLimit " + blockLimit);
     return deletionPolicy
         .chooseContainerForBlockDeletion(blockLimit, containerDataMap);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -177,6 +177,8 @@ public class BlockDeletingService extends BackgroundService {
             .filter(e -> isDeletionAllowed(e.getValue().getContainerData(),
                 deletionPolicy)).collect(Collectors
             .toMap(Map.Entry::getKey, e -> e.getValue().getContainerData()));
+    System.out.println("size " + containerDataMap.size());
+    System.out.println("blockLimit " + blockLimit);
     return deletionPolicy
         .chooseContainerForBlockDeletion(blockLimit, containerDataMap);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -103,7 +103,7 @@ public class TestContainerDeletionChoosingPolicy {
           layout,
           ContainerTestHelper.CONTAINER_MAX_SIZE, UUID.randomUUID().toString(),
           UUID.randomUUID().toString());
-      data.incrPendingDeletionBlocks(random.nextInt(numContainers) + 1);
+      data.incrPendingDeletionBlocks(20);
       data.closeContainer();
       KeyValueContainer container = new KeyValueContainer(data, conf);
       containerSet.addContainer(container);
@@ -125,22 +125,22 @@ public class TestContainerDeletionChoosingPolicy {
     }
     Assert.assertTrue(totPendingBlocks >= blockLimitPerInterval);
 
-
-    // test random choosing
-    List<ContainerBlockInfo> result1 = blockDeletingService
-        .chooseContainerForBlockDeletion(numContainers, deletionPolicy);
-    List<ContainerBlockInfo> result2 = blockDeletingService
-        .chooseContainerForBlockDeletion(numContainers, deletionPolicy);
-
-    boolean hasShuffled = false;
-    for (int i = 0; i < numContainers; i++) {
-      if (result1.get(i).getContainerData().getContainerID() != result2.get(i)
-          .getContainerData().getContainerID()) {
-        hasShuffled = true;
-        break;
+    // test random choosing. We choose 100 times the 3 datanodes twice.
+    //We expect different order at least once.
+    for (int j = 0; j < 100; j++) {
+      List<ContainerBlockInfo> result1 = blockDeletingService
+              .chooseContainerForBlockDeletion(50, deletionPolicy);
+      List<ContainerBlockInfo> result2 = blockDeletingService
+              .chooseContainerForBlockDeletion(50, deletionPolicy);
+      boolean hasShuffled = false;
+      for (int i = 0; i < result1.size(); i++) {
+        if (result1.get(i).getContainerData().getContainerID() != result2.get(i)
+                .getContainerData().getContainerID()) {
+          return;
+        }
       }
     }
-    Assert.assertTrue("Chosen container results were same", hasShuffled);
+    Assert.fail("Chosen container results were same 100 times");
 
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerDeletionChoosingPolicy.java
@@ -97,7 +97,6 @@ public class TestContainerDeletionChoosingPolicy {
     containerSet = new ContainerSet();
 
     int numContainers = 10;
-    Random random = new Random();
     for (int i = 0; i < numContainers; i++) {
       KeyValueContainerData data = new KeyValueContainerData(i,
           layout,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `TestContainerDeletionChoosingPolicy#testRandomChoosingPolicy` is reported to be intermittent.

> Observed in this CI run: https://github.com/apache/ozone/pull/2179/checks?check_run_id=2423463857

> Bundle is attached to issue.

It seems that #1885 introduced a few problems. (It was new to me, so I try to explain here the changes)

```
-data.incrPendingDeletionBlocks(random.nextInt(numContainers) + 1);
+data.incrPendingDeletionBlocks(20);
```
It's better to use fixed size of containers as it's very hard to predict the test behaviors without that.


```
 for (int i = 0; i < result1.size(); i++) {
```

That's the root cause of the problem. As we have block size based selection, the container size may be less than the requested block size.


```
List<ContainerBlockInfo> result1 = blockDeletingService
              .chooseContainerForBlockDeletion(50, deletionPolicy);
```

Here we should use block number s(50) instead of the container numbers (was 10 earlier)

```
for (int j = 0; j < 100; j++) {
```

As result1 and result2 returns with 3 containers it's better to check multiple times the randomness.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5147

## How was this patch tested?

Unit test is passed 7000 times locally. Without the patch it fails during the first 50-100 executions.