### PR TITLE
HDDS-5152. Fix Suggested leader in Client.

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -200,6 +200,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hamcrest-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -60,11 +60,10 @@ public class ServerNotLeaderException extends IOException {
 
       Matcher suggestedLeaderMatcher =
           SUGGESTED_LEADER_PATTERN.matcher(message);
-      // TODO: If message contains only port or multiple ":" this will return
-      // suggested leader which will not be a valid host.
       if (suggestedLeaderMatcher.matches()) {
         if (suggestedLeaderMatcher.groupCount() == 2) {
-          if (suggestedLeaderMatcher.group(1).equals("")) {
+          if (suggestedLeaderMatcher.group(1).isEmpty()
+              || suggestedLeaderMatcher.group(2).isEmpty()) {
             this.leader = null;
           } else {
             this.leader = suggestedLeaderMatcher.group(1) +

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -61,8 +61,12 @@ public class ServerNotLeaderException extends IOException {
       Matcher suggestedLeaderMatcher =
           SUGGESTED_LEADER_PATTERN.matcher(message);
       if (suggestedLeaderMatcher.matches()) {
-        this.leader = suggestedLeaderMatcher.group(1) +
-            suggestedLeaderMatcher.group(2);
+        if (suggestedLeaderMatcher.groupCount() == 2) {
+          this.leader = suggestedLeaderMatcher.group(1) +
+              suggestedLeaderMatcher.group(2);
+        } else {
+          this.leader = null;
+        }
       } else {
         this.leader = null;
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -60,10 +60,16 @@ public class ServerNotLeaderException extends IOException {
 
       Matcher suggestedLeaderMatcher =
           SUGGESTED_LEADER_PATTERN.matcher(message);
+      // TODO: If message contains only port or multiple ":" this will return
+      // suggested leader which will not be a valid host.
       if (suggestedLeaderMatcher.matches()) {
         if (suggestedLeaderMatcher.groupCount() == 2) {
-          this.leader = suggestedLeaderMatcher.group(1) +
-              suggestedLeaderMatcher.group(2);
+          if (suggestedLeaderMatcher.group(1).equals("")) {
+            this.leader = null;
+          } else {
+            this.leader = suggestedLeaderMatcher.group(1) +
+                suggestedLeaderMatcher.group(2);
+          }
         } else {
           this.leader = null;
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -33,7 +33,8 @@ public class ServerNotLeaderException extends IOException {
   private static final Pattern CURRENT_PEER_ID_PATTERN =
       Pattern.compile("Server:(.*) is not the leader[.]+.*", Pattern.DOTALL);
   private static final Pattern SUGGESTED_LEADER_PATTERN =
-      Pattern.compile(".*Suggested leader is Server:([^.]*).*", Pattern.DOTALL);
+      Pattern.compile(".*Suggested leader is Server:([^:]*)(:[0-9]+).*",
+          Pattern.DOTALL);
 
   public ServerNotLeaderException(RaftPeerId currentPeerId) {
     super("Server:" + currentPeerId + " is not the leader. Could not " +
@@ -60,7 +61,7 @@ public class ServerNotLeaderException extends IOException {
       Matcher suggestedLeaderMatcher =
           SUGGESTED_LEADER_PATTERN.matcher(message);
       if (suggestedLeaderMatcher.matches()) {
-        this.leader = suggestedLeaderMatcher.group(1);
+        this.leader = suggestedLeaderMatcher.group(1)  + suggestedLeaderMatcher.group(2);
       } else {
         this.leader = null;
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/ServerNotLeaderException.java
@@ -61,7 +61,8 @@ public class ServerNotLeaderException extends IOException {
       Matcher suggestedLeaderMatcher =
           SUGGESTED_LEADER_PATTERN.matcher(message);
       if (suggestedLeaderMatcher.matches()) {
-        this.leader = suggestedLeaderMatcher.group(1)  + suggestedLeaderMatcher.group(2);
+        this.leader = suggestedLeaderMatcher.group(1) +
+            suggestedLeaderMatcher.group(2);
       } else {
         this.leader = null;
       }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -61,6 +61,22 @@ public class TestServerNotLeaderException {
     snle = new ServerNotLeaderException(message);
     Assert.assertEquals(null,
         snle.getSuggestedLeader());
+
+    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+        "leader.Suggested leader is Server:localhost:98634:8988 \n" +
+        "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
+        ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
+    snle = new ServerNotLeaderException(message);
+    Assert.assertEquals("localhost:98634",
+        snle.getSuggestedLeader());
+
+    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+        "leader.Suggested leader is Server:localhost \n" +
+        "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
+        ".convertToNotLeaderException(ServerNotLeaderException.java)";
+    snle = new ServerNotLeaderException(message);
+    Assert.assertEquals(null,
+        snle.getSuggestedLeader());
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -53,6 +53,14 @@ public class TestServerNotLeaderException {
     snle = new ServerNotLeaderException(message);
     Assert.assertEquals("localhost:98634",
         snle.getSuggestedLeader());
+
+    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+        "leader.Suggested leader is Server::98634 \n" +
+        "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
+        ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
+    snle = new ServerNotLeaderException(message);
+    Assert.assertEquals(null,
+        snle.getSuggestedLeader());
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -18,14 +18,18 @@
 
 package org.apache.hadoop.hdds.ratis;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
 
+/** Class to test {@link ServerNotLeaderException} parsing. **/
+
+@SuppressFBWarnings("NM_CLASS_NOT_EXCEPTION")
 public class TestServerNotLeaderException {
   @Test
-  public void testServerNotLeaderException() throws IOException {
+  public void testServerNotLeaderException() {
 
     // Test hostname with "."
     final String msg =

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.ratis;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class TestServerNotLeaderException {
+  @Test
+  public void testServerNotLeaderException() throws IOException {
+
+    // Test hostname with "."
+    final String msg =
+        "Server:cf0bc565-a41b-4784-a24d-3048d5a5b013 is not the leader. "
+            + "Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863";
+    ServerNotLeaderException snle = new ServerNotLeaderException(msg);
+    Assert.assertEquals(snle.getSuggestedLeader(), "scm5-3.scm5.root.hwx" +
+        ".site:9863");
+
+    String message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+        "leader.Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863 \n" +
+        "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
+        ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
+    snle = new ServerNotLeaderException(message);
+    Assert.assertEquals("scm5-3.scm5.root.hwx.site:9863",
+        snle.getSuggestedLeader());
+
+    // Test hostname with out "."
+    message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
+        "leader.Suggested leader is Server:localhost:98634 \n" +
+        "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
+        ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
+    snle = new ServerNotLeaderException(message);
+    Assert.assertEquals("localhost:98634",
+        snle.getSuggestedLeader());
+  }
+
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -22,8 +22,6 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.IOException;
-
 /** Class to test {@link ServerNotLeaderException} parsing. **/
 
 @SuppressFBWarnings("NM_CLASS_NOT_EXCEPTION")

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -165,8 +165,8 @@ public class SCMBlockLocationFailoverProxyProvider implements
     if (snle != null && snle.getSuggestedLeader() != null) {
       Optional<SCMProxyInfo> matchedProxyInfo =
           scmProxyInfoMap.values().stream().filter(
-          proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
-              .equals(snle.getSuggestedLeader())).findFirst();
+              proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
+                  .equals(snle.getSuggestedLeader())).findFirst();
       if (matchedProxyInfo.isPresent()) {
         newLeader = matchedProxyInfo.get().getNodeId();
         LOG.debug("Performing failover to suggested leader {}, nodeId {}",

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -41,9 +41,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.apache.hadoop.ozone.OzoneConsts.SCM_DUMMY_SERVICE_ID;
 
@@ -161,11 +163,19 @@ public class SCMBlockLocationFailoverProxyProvider implements
     ServerNotLeaderException snle =
         (ServerNotLeaderException) SCMHAUtils.getServerNotLeaderException(e);
     if (snle != null && snle.getSuggestedLeader() != null) {
-      newLeader = scmProxyInfoMap.values().stream().filter(
+      Optional<SCMProxyInfo> matchedProxyInfo =
+          scmProxyInfoMap.values().stream().filter(
           proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
-              .equals(snle.getSuggestedLeader())).findFirst().get().getNodeId();
-      LOG.debug("Performing failover to suggested leader {}, nodeId {}",
-          snle.getSuggestedLeader(), newLeader);
+              .equals(snle.getSuggestedLeader())).findFirst();
+      if (matchedProxyInfo.isPresent()) {
+        newLeader = matchedProxyInfo.get().getNodeId();
+        LOG.debug("Performing failover to suggested leader {}, nodeId {}",
+            snle.getSuggestedLeader(), newLeader);
+      } else {
+        LOG.debug("Suggested leader {} does not match with any of the " +
+                "proxyInfo adress {}", snle.getSuggestedLeader(),
+            Arrays.toString(scmProxyInfoMap.values().toArray()));
+      }
     }
     if (newLeader == null) {
       // If newLeader is not assigned, it will fail over to next proxy.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -189,20 +189,19 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
     ServerNotLeaderException snle =
         (ServerNotLeaderException) SCMHAUtils.getServerNotLeaderException(e);
     if (snle != null && snle.getSuggestedLeader() != null) {
-      if (snle != null && snle.getSuggestedLeader() != null) {
-        Optional<SCMProxyInfo> matchedProxyInfo =
-            scmProxyInfoMap.values().stream().filter(
-                proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
-                    .equals(snle.getSuggestedLeader())).findFirst();
-        if (matchedProxyInfo.isPresent()) {
-          newLeader = matchedProxyInfo.get().getNodeId();
-          LOG.debug("Performing failover to suggested leader {}, nodeId {}",
-              snle.getSuggestedLeader(), newLeader);
-        } else {
-          LOG.debug("Suggested leader {} does not match with any of the " +
-                  "proxyInfo adress {}", snle.getSuggestedLeader(),
-              Arrays.toString(scmProxyInfoMap.values().toArray()));
-        }
+      Optional< SCMProxyInfo > matchedProxyInfo =
+          scmProxyInfoMap.values().stream().filter(
+              proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
+                  .equals(snle.getSuggestedLeader())).findFirst();
+      if (matchedProxyInfo.isPresent()) {
+        newLeader = matchedProxyInfo.get().getNodeId();
+        LOG.debug("Performing failover to suggested leader {}, nodeId {}",
+            snle.getSuggestedLeader(), newLeader);
+      } else {
+        LOG.debug("Suggested leader {} does not match with any of the " +
+                "proxyInfo adress {}", snle.getSuggestedLeader(),
+            Arrays.toString(scmProxyInfoMap.values().toArray()));
+      }
     }
     if (newLeader == null) {
       // If newLeader is not assigned, it will fail over to next proxy.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -41,9 +41,11 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Failover proxy provider for SCMSecurityProtocol server.
@@ -187,11 +189,20 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
     ServerNotLeaderException snle =
         (ServerNotLeaderException) SCMHAUtils.getServerNotLeaderException(e);
     if (snle != null && snle.getSuggestedLeader() != null) {
-      newLeader = scmProxyInfoMap.values().stream().filter(
-          proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
-              .equals(snle.getSuggestedLeader())).findFirst().get().getNodeId();
-      LOG.debug("Performing failover to suggested leader {}, nodeId {}",
-          snle.getSuggestedLeader(), newLeader);
+      if (snle != null && snle.getSuggestedLeader() != null) {
+        Optional<SCMProxyInfo> matchedProxyInfo =
+            scmProxyInfoMap.values().stream().filter(
+                proxyInfo -> NetUtils.getHostPortString(proxyInfo.getAddress())
+                    .equals(snle.getSuggestedLeader())).findFirst();
+        if (matchedProxyInfo.isPresent()) {
+          newLeader = matchedProxyInfo.get().getNodeId();
+          LOG.debug("Performing failover to suggested leader {}, nodeId {}",
+              snle.getSuggestedLeader(), newLeader);
+        } else {
+          LOG.debug("Suggested leader {} does not match with any of the " +
+                  "proxyInfo adress {}", snle.getSuggestedLeader(),
+              Arrays.toString(scmProxyInfoMap.values().toArray()));
+        }
     }
     if (newLeader == null) {
       // If newLeader is not assigned, it will fail over to next proxy.


### PR DESCRIPTION
## What changes were proposed in this pull request?

When hostname is having "." the regex is not matching properly with suggested leader and fail over is failing with below exception.
```
Caused by: java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135)
	at org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider.performFailoverToAssignedLeader(SCMBlockLocationFailoverProxyProvider.java:166)
	at org.apache.hadoop.hdds.scm.proxy.SCMBlockLocationFailoverProxyProvider$1.shouldRetry(SCMBlockLocationFailoverProxyProvider.java:273)
	at 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5152

## How was this patch tested?

Added tests
