### PR TITLE
HDDS-5153. Decommissioning a dead node should complete immediately

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -268,11 +269,18 @@ public class NodeDecommissionManager {
       throws NodeNotFoundException, InvalidNodeStateException {
     NodeStatus nodeStatus = getNodeStatus(dn);
     NodeOperationalState opState = nodeStatus.getOperationalState();
+    HddsProtos.NodeState health = nodeStatus.getHealth();
     if (opState == NodeOperationalState.IN_SERVICE) {
-      LOG.info("Starting Decommission for node {}", dn);
-      nodeManager.setNodeOperationalState(
-          dn, NodeOperationalState.DECOMMISSIONING);
-      monitor.startMonitoring(dn);
+      if (health != HddsProtos.NodeState.DEAD) {
+        LOG.info("Starting Decommission for node {}", dn);
+        nodeManager.setNodeOperationalState(
+            dn, NodeOperationalState.DECOMMISSIONING);
+        monitor.startMonitoring(dn);
+      } else {
+        LOG.info("{} is dead. Moving to decommissioned immediately", dn);
+        nodeManager.setNodeOperationalState(
+            dn, NodeOperationalState.DECOMMISSIONED);
+      }
     } else if (nodeStatus.isDecommission()) {
       LOG.info("Start Decommission called on node {} in state {}. Nothing to "+
           "do.", dn, opState);
@@ -354,11 +362,18 @@ public class NodeDecommissionManager {
       maintenanceEnd =
           (System.currentTimeMillis() / 1000L) + (endInHours * 60L * 60L);
     }
+    HddsProtos.NodeState health = nodeStatus.getHealth();
     if (opState == NodeOperationalState.IN_SERVICE) {
-      nodeManager.setNodeOperationalState(
-          dn, NodeOperationalState.ENTERING_MAINTENANCE, maintenanceEnd);
-      monitor.startMonitoring(dn);
-      LOG.info("Starting Maintenance for node {}", dn);
+      if (health != HddsProtos.NodeState.DEAD) {
+        nodeManager.setNodeOperationalState(
+            dn, NodeOperationalState.ENTERING_MAINTENANCE, maintenanceEnd);
+        monitor.startMonitoring(dn);
+        LOG.info("Starting Maintenance for node {}", dn);
+      }  else {
+        LOG.info("{} is dead. Moving to maintenance immediately", dn);
+        nodeManager.setNodeOperationalState(
+            dn, NodeOperationalState.IN_MAINTENANCE);
+      }
     } else if (nodeStatus.isMaintenance()) {
       LOG.info("Starting Maintenance called on node {} with state {}. "+
           "Nothing to do.", dn, opState);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
+import org.apache.hadoop.hdds.scm.container.SimpleMockNodeManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -177,6 +178,22 @@ public class TestNodeDecommissionManager {
   }
 
   @Test
+  public void testDeadNodeDecommissionsImmediately()
+      throws NodeNotFoundException, InvalidNodeStateException {
+    List<DatanodeDetails> dns = generateDatanodes();
+    DatanodeDetails dn = dns.get(1);
+
+    SimpleMockNodeManager mockNM = new SimpleMockNodeManager();
+    mockNM.register(dn, NodeStatus.inServiceDead());
+    NodeDecommissionManager decomMgr = new NodeDecommissionManager(conf, mockNM,
+        null, SCMContext.emptyContext(), new EventQueue(), null);
+
+    decomMgr.startDecommission(dns.get(1));
+    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
+        mockNM.getNodeStatus(dns.get(1)).getOperationalState());
+  }
+
+  @Test
   public void testNodesCanBePutIntoMaintenanceAndRecommissioned()
       throws InvalidHostStringException, NodeNotFoundException {
     List<DatanodeDetails> dns = generateDatanodes();
@@ -217,6 +234,22 @@ public class TestNodeDecommissionManager {
         nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(10)).getOperationalState());
+  }
+
+  @Test
+  public void testDeadNodeGoesToMaintenanceImmediately()
+      throws NodeNotFoundException, InvalidNodeStateException {
+    List<DatanodeDetails> dns = generateDatanodes();
+    DatanodeDetails dn = dns.get(1);
+
+    SimpleMockNodeManager mockNM = new SimpleMockNodeManager();
+    mockNM.register(dn, NodeStatus.inServiceDead());
+    NodeDecommissionManager decomMgr = new NodeDecommissionManager(conf, mockNM,
+        null, SCMContext.emptyContext(), new EventQueue(), null);
+
+    decomMgr.startMaintenance(dns.get(1), 0);
+    assertEquals(HddsProtos.NodeOperationalState.IN_MAINTENANCE,
+        mockNM.getNodeStatus(dns.get(1)).getOperationalState());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

If you run the decommission or "enter maintenance" command on a node which is already dead, then it should immediately go to the DECOMMISSIONED or IN_MAINTENANCE state. As the node is already dead, there is no way to replicate its containers in a controlled way, and hence the decommission process does not need to run.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5153

## How was this patch tested?

New unit tests
