### PR TITLE
HDDS-5159. Make periodic disk check interval configurable.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -41,8 +41,12 @@ public class DatanodeConfiguration {
       "hdds.datanode.replication.streams.limit";
   static final String CONTAINER_DELETE_THREADS_MAX_KEY =
       "hdds.datanode.container.delete.threads.max";
+  static final String PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY =
+      "hdds.datanode.periodic.disk.check.interval.minutes";
 
   static final int REPLICATION_MAX_STREAMS_DEFAULT = 10;
+
+  static final long PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT = 15;
 
   /**
    * The maximum number of replication commands a single datanode can execute
@@ -110,6 +114,15 @@ public class DatanodeConfiguration {
     this.blockLimitPerInterval = limit;
   }
 
+  @Config(key = "periodic.disk.check.interval.minutes",
+      defaultValue = "15",
+      type = ConfigType.LONG,
+      tags = { DATANODE },
+      description = "Periodic disk check run interval in minutes."
+  )
+  private long periodicDiskCheckIntervalMinutes =
+      PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
+
   @PostConstruct
   public void validate() {
     if (replicationMaxStreams < 1) {
@@ -124,6 +137,15 @@ public class DatanodeConfiguration {
               " and was set to {}. Defaulting to {}",
           containerDeleteThreads, CONTAINER_DELETE_THREADS_DEFAULT);
       containerDeleteThreads = CONTAINER_DELETE_THREADS_DEFAULT;
+    }
+
+    if (periodicDiskCheckIntervalMinutes < 1) {
+      LOG.warn(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY +
+              " must be greater than zero and was set to {}. Defaulting to {}",
+          periodicDiskCheckIntervalMinutes,
+          PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT);
+      periodicDiskCheckIntervalMinutes =
+          PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
     }
   }
 
@@ -143,4 +165,12 @@ public class DatanodeConfiguration {
     return containerDeleteThreads;
   }
 
+  public long getPeriodicDiskCheckIntervalMinutes() {
+    return periodicDiskCheckIntervalMinutes;
+  }
+
+  public void setPeriodicDiskCheckIntervalMinutes(
+      long periodicDiskCheckIntervalMinutes) {
+    this.periodicDiskCheckIntervalMinutes = periodicDiskCheckIntervalMinutes;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume.VolumeState;
 import org.apache.hadoop.util.DiskChecker;
@@ -88,8 +89,6 @@ public class MutableVolumeSet implements VolumeSet {
   private final ScheduledFuture<?> periodicDiskChecker;
   private final SpaceUsageCheckFactory usageCheckFactory;
 
-  private static final long DISK_CHECK_INTERVAL_MINUTES = 15;
-
   /**
    * A Reentrant Read Write Lock to synchronize volume operations in VolumeSet.
    * Any update to {@link #volumeMap}, {@link #failedVolumeMap}, or
@@ -123,6 +122,11 @@ public class MutableVolumeSet implements VolumeSet {
             t.setDaemon(true);
             return t;
         });
+
+    DatanodeConfiguration dnConf =
+        conf.getObject(DatanodeConfiguration.class);
+    long periodicDiskCheckIntervalMinutes =
+        dnConf.getPeriodicDiskCheckIntervalMinutes();
     this.periodicDiskChecker =
       diskCheckerservice.scheduleWithFixedDelay(() -> {
         try {
@@ -130,7 +134,7 @@ public class MutableVolumeSet implements VolumeSet {
         } catch (IOException e) {
           LOG.warn("Exception while checking disks", e);
         }
-      }, DISK_CHECK_INTERVAL_MINUTES, DISK_CHECK_INTERVAL_MINUTES,
+      }, periodicDiskCheckIntervalMinutes, periodicDiskCheckIntervalMinutes,
         TimeUnit.MINUTES);
 
     usageCheckFactory = SpaceUsageCheckFactory.create(conf);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -24,6 +24,9 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_DELETE_THREADS_MAX_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_MAX_STREAMS_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_STREAMS_LIMIT_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
+
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -36,9 +39,12 @@ public class TestDatanodeConfiguration {
     // GIVEN
     int validReplicationLimit = 123;
     int validDeleteThreads = 42;
+    long validDiskCheckIntervalMinutes = 60;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, validReplicationLimit);
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
+    conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
+        validDiskCheckIntervalMinutes);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -46,6 +52,8 @@ public class TestDatanodeConfiguration {
     // THEN
     assertEquals(validReplicationLimit, subject.getReplicationMaxStreams());
     assertEquals(validDeleteThreads, subject.getContainerDeleteThreads());
+    assertEquals(validDiskCheckIntervalMinutes,
+        subject.getPeriodicDiskCheckIntervalMinutes());
   }
 
   @Test
@@ -53,9 +61,12 @@ public class TestDatanodeConfiguration {
     // GIVEN
     int invalidReplicationLimit = -5;
     int invalidDeleteThreads = 0;
+    long invalidDiskCheckIntervalMinutes = -1;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, invalidReplicationLimit);
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, invalidDeleteThreads);
+    conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
+        invalidDiskCheckIntervalMinutes);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -65,6 +76,8 @@ public class TestDatanodeConfiguration {
         subject.getReplicationMaxStreams());
     assertEquals(CONTAINER_DELETE_THREADS_DEFAULT,
         subject.getContainerDeleteThreads());
+    assertEquals(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT,
+        subject.getPeriodicDiskCheckIntervalMinutes());
   }
 
   @Test
@@ -80,6 +93,8 @@ public class TestDatanodeConfiguration {
         subject.getReplicationMaxStreams());
     assertEquals(CONTAINER_DELETE_THREADS_DEFAULT,
         subject.getContainerDeleteThreads());
+    assertEquals(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT,
+        subject.getPeriodicDiskCheckIntervalMinutes());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make datanode periodic disk check interval configurable, originally it is fixed 15min.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5159

## How was this patch tested?

extended existing ut
manual test
