### PR TITLE
HDDS-5166. Remove duplicate assignment of OZONE_OPTS for freon and sh

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -132,7 +132,6 @@ function ozonecmd_case
     freon)
       OZONE_CLASSNAME=org.apache.hadoop.ozone.freon.Freon
       OZONE_FREON_OPTS="${OZONE_FREON_OPTS}"
-      OZONE_OPTS="${OZONE_OPTS} ${OZONE_FREON_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     genesis)
@@ -168,7 +167,6 @@ function ozonecmd_case
       OZONE_CLASSNAME=org.apache.hadoop.ozone.shell.OzoneShell
       ozone_deprecate_envvar HDFS_OM_SH_OPTS OZONE_SH_OPTS
       OZONE_SH_OPTS="${OZONE_SH_OPTS} -Dhadoop.log.file=ozone-shell.log -Dlog4j.configuration=file:${ozone_shell_log4j}"
-      OZONE_OPTS="${OZONE_OPTS} ${OZONE_SH_OPTS}"
       OZONE_RUN_ARTIFACT_NAME="hadoop-ozone-tools"
     ;;
     s3)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The option of "OZONE_OPTS" was assigned twice for Freon and SH, so the error of "duplicate jdwp options" prompts. Need the remove the duplicate assignment of "OZONE_OPTS".

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5166

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Manually test. The following command works normal now.
```
 export OZONE_FREON_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5011
 bin/ozone freon randomkeys --num-of-volumes=1 --num-of-buckets 1 --num-of-keys 10  --replication-type=RATIS --factor=THREE

 export OZONE_SH_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5011
 bin/ozone sh volume ls /
```
