### PR TITLE
HDDS-5149 when source datanode download container tar from target datanode,but the target datanode container file missing,import error

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -53,7 +53,6 @@ import static java.util.stream.Collectors.toList;
  */
 public class TarContainerPacker
     implements ContainerPacker<KeyValueContainerData> {
-
   private static final Logger LOG =
       LoggerFactory.getLogger(TarContainerPacker.class);
 
@@ -157,30 +156,25 @@ public class TarContainerPacker
     try (OutputStream compressed = compress(output);
          ArchiveOutputStream archiveOutput = tar(compressed)) {
 
-      if (containerData.getDbFile().exists()) {
-        includePath(containerData.getDbFile().toPath(), DB_DIR_NAME,
-            archiveOutput);
-      } else {
-        LOG.warn("DBfile {} not exist",
-            containerData.getDbFile().toPath().toString());
+      if (!containerData.getDbFile().exists()) {
+        LOG.warn("DBfile {} not exist", containerData.getDbFile().toPath().toString());
+        return;
+      } else if (!new File(containerData.getChunksPath()).exists()) {
+        LOG.warn("Chunkfile {} not exist", containerData.getDbFile().toPath().toString());
+        return;
+      } else if (!container.getContainerFile().exists()) {
+        LOG.warn("Containerfile {} not exist", containerData.getDbFile().toPath().toString());
         return;
       }
 
-      if (new File(containerData.getChunksPath()).exists()) {
-        includePath(Paths.get(containerData.getChunksPath()), CHUNKS_DIR_NAME,
-            archiveOutput);
-      } else {
-        LOG.warn("Chunkfile {} not exist", containerData.getChunksPath());
-        return;
-      }
+      includePath(containerData.getDbFile().toPath(), DB_DIR_NAME,
+          archiveOutput);
 
-      if (container.getContainerFile().exists()) {
-        includeFile(container.getContainerFile(), CONTAINER_FILE_NAME,
-            archiveOutput);
-      } else {
-        LOG.warn("Containerfile {} not exist",
-            container.getContainerFile().toPath().toString());
-      }
+      includePath(Paths.get(containerData.getChunksPath()), CHUNKS_DIR_NAME,
+          archiveOutput);
+
+      includeFile(container.getContainerFile(), CONTAINER_FILE_NAME,
+          archiveOutput);
     } catch (CompressorException e) {
       throw new IOException(
           "Can't compress the container: " + containerData.getContainerID(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/TarContainerPacker.java
@@ -157,13 +157,16 @@ public class TarContainerPacker
          ArchiveOutputStream archiveOutput = tar(compressed)) {
 
       if (!containerData.getDbFile().exists()) {
-        LOG.warn("DBfile {} not exist", containerData.getDbFile().toPath().toString());
+        LOG.warn("DBfile {} not exist",
+            containerData.getDbFile().toPath().toString());
         return;
       } else if (!new File(containerData.getChunksPath()).exists()) {
-        LOG.warn("Chunkfile {} not exist", containerData.getDbFile().toPath().toString());
+        LOG.warn("Chunkfile {} not exist",
+            containerData.getDbFile().toPath().toString());
         return;
       } else if (!container.getContainerFile().exists()) {
-        LOG.warn("Containerfile {} not exist", containerData.getDbFile().toPath().toString());
+        LOG.warn("Containerfile {} not exist",
+            containerData.getDbFile().toPath().toString());
         return;
       }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -121,10 +121,16 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
         LOG.info("Container {} is downloaded with size {}, starting to import.",
                 containerID, bytes);
         task.setTransferredBytes(bytes);
-
-        importContainer(containerID, path);
-        LOG.info("Container {} is replicated successfully", containerID);
-        task.setStatus(Status.DONE);
+        // if tar is null, the tar size is 45 bytes
+        if (bytes <= 45) {
+          task.setStatus(Status.FAILED);
+          LOG.warn("Container {} is downloaded with size {}, " +
+              "if size less than 45 bytes the tar file is null", containerID, bytes);
+        } else {
+          importContainer(containerID, path);
+          LOG.info("Container {} is replicated successfully", containerID);
+          task.setStatus(Status.DONE);
+        }
       } catch (Exception e) {
         LOG.error("Container {} replication was unsuccessful.", containerID, e);
         task.setStatus(Status.FAILED);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -125,7 +125,8 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
         if (bytes <= 45) {
           task.setStatus(Status.FAILED);
           LOG.warn("Container {} is downloaded with size {}, " +
-              "if size less than 45 bytes the tar file is null", containerID, bytes);
+              "if size less than 45 bytes the tar file is null",
+              containerID, bytes);
         } else {
           importContainer(containerID, path);
           LOG.info("Container {} is replicated successfully", containerID);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -252,8 +252,10 @@ public class TestKeyValueContainer {
     TarContainerPacker packer = new TarContainerPacker();
 
     //if missing chunksfile
-    Files.delete(new File(keyValueContainer.getContainerData().getChunksPath()).toPath());
-    Assert.assertFalse(new File(keyValueContainer.getContainerData().getChunksPath()).exists());
+    File chunkfile = new File(keyValueContainer.
+        getContainerData().getChunksPath());
+    Files.delete(chunkfile.toPath());
+    Assert.assertFalse(chunkfile.exists());
     //export the container
     try (FileOutputStream fos = new FileOutputStream(folderToExport)) {
       keyValueContainer


### PR DESCRIPTION
## What changes were proposed in this pull request?
fix if the metadatafile or chunksfile missing import export container error

## What is the link to the Apache JIRA
https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5149?filter=addedrecently

## How was this patch tested?
unittest
