### PR TITLE
HDDS-5144. Allow SHA in SNAPSHOT version

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -211,7 +211,7 @@ share/ozone/lib/ratis-netty.jar
 share/ozone/lib/ratis-proto.jar
 share/ozone/lib/ratis-server-api.jar
 share/ozone/lib/ratis-server.jar
-share/ozone/lib/ratis-thirdparty-misc-a398b19-SNAPSHOT.jar
+share/ozone/lib/ratis-thirdparty-misc.jar
 share/ozone/lib/ratis-tools.jar
 share/ozone/lib/re2j.jar
 share/ozone/lib/rocksdbjni.jar

--- a/hadoop-ozone/dist/src/main/license/update-jar-report.sh
+++ b/hadoop-ozone/dist/src/main/license/update-jar-report.sh
@@ -30,4 +30,4 @@ cd "$OZONE_DIST_DIR"
 
 #sed expression removes the version. Usually license is not changed with version bumps
 #jacoco and test dependencies are excluded
-find . -type f -name "*.jar" | cut -c3- | perl -wpl -e 's/-[0-9]+(.[0-9]+)*(-SNAPSHOT)?+//g' | grep -v jacoco | grep -v hadoop-hdds-test-utils | sort > "$SCRIPTDIR"/$REPORT_NAME
+find . -type f -name "*.jar" | cut -c3- | perl -wpl -e 's/-[0-9]+(.[0-9]+)*(-([0-9a-f]+-)?SNAPSHOT)?+//g' | grep -v jacoco | grep -v hadoop-hdds-test-utils | sort > "$SCRIPTDIR"/$REPORT_NAME


### PR DESCRIPTION
## What changes were proposed in this pull request?

Newly introduced dependency check is [failing](https://github.com/apache/ozone/runs/2465470137#step:5:17) on `master` because Ratis SNAPSHOT jars have SHA, but it is missing in the baseline list of jars.  Since version numbers in general are intended to be ignored for the dependency check, we need to remove the SHA, too.

```
Changed jars:

--- /dev/fd/63	2021-04-29 09:44:00.396023295 +0000
+++ /dev/fd/62	2021-04-29 09:44:00.396023295 +0000
@@ -203,16 +203,16 @@
 share/ozone/lib/protobuf-java-util.jar
 share/ozone/lib/protobuf-java.jar
 share/ozone/lib/protobuf-java.jar
-share/ozone/lib/ratis-client.jar
-share/ozone/lib/ratis-common.jar
-share/ozone/lib/ratis-grpc.jar
-share/ozone/lib/ratis-metrics.jar
-share/ozone/lib/ratis-netty.jar
-share/ozone/lib/ratis-proto.jar
-share/ozone/lib/ratis-server-api.jar
-share/ozone/lib/ratis-server.jar
+share/ozone/lib/ratis-client-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-common-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-grpc-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-metrics-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-netty-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-proto-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-server-api-ff8aa66-SNAPSHOT.jar
+share/ozone/lib/ratis-server-ff8aa66-SNAPSHOT.jar
 share/ozone/lib/ratis-thirdparty-misc-a398b19-SNAPSHOT.jar
-share/ozone/lib/ratis-tools.jar
+share/ozone/lib/ratis-tools-ff8aa66-SNAPSHOT.jar
 share/ozone/lib/re2j.jar
 share/ozone/lib/rocksdbjni.jar
 share/ozone/lib/simpleclient.jar
```

https://issues.apache.org/jira/browse/HDDS-5144

## How was this patch tested?

```
mvn -DskipTests clean verify
hadoop-ozone/dev-support/checks/dependency.sh
```