### PR TITLE
HDDS-5165. OM DB checkpoint servlet not accessible in a secure cluster

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -71,6 +71,7 @@ public class DBCheckpointServlet extends HttpServlet {
   private Collection<String> ozAdmins;
   private String reconSPN;
 
+  @SuppressWarnings("checkstyle:hiddenfield")
   public void initialize(DBStore store, DBCheckpointMetrics metrics,
                          boolean omAclEnabled, Collection<String> ozoneAdmins,
                          boolean isSpnegoEnabled, OzoneConfiguration conf)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
@@ -60,7 +60,6 @@ public class SCMDBCheckpointServlet extends DBCheckpointServlet {
         scm.getMetrics().getDBCheckpointMetrics(),
         false,
         Collections.emptyList(),
-        false,
-        scm.getConfiguration());
+        false);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -59,6 +59,8 @@ public class SCMDBCheckpointServlet extends DBCheckpointServlet {
     initialize(scm.getScmMetadataStore().getStore(),
         scm.getMetrics().getDBCheckpointMetrics(),
         false,
-        Collections.emptyList());
+        Collections.emptyList(),
+        false,
+        scm.getConfiguration());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -119,8 +119,7 @@ public class TestSCMDbCheckpointServlet {
           scmMetrics.getDBCheckpointMetrics(),
           false,
           Collections.emptyList(),
-          false,
-          scm.getConfiguration());
+          false);
 
       HttpServletRequest requestMock = mock(HttpServletRequest.class);
       HttpServletResponse responseMock = mock(HttpServletResponse.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -54,7 +54,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Class used for testing the OM DB Checkpoint provider servlet.
+ * Class used for testing the SCM DB Checkpoint provider servlet.
  */
 public class TestSCMDbCheckpointServlet {
   private MiniOzoneCluster cluster = null;
@@ -75,7 +75,7 @@ public class TestSCMDbCheckpointServlet {
    * <p>
    * Ozone is made active by setting OZONE_ENABLED = true
    *
-   * @throws IOException
+   * @throws Exception
    */
   @Before
   public void init() throws Exception {
@@ -118,7 +118,9 @@ public class TestSCMDbCheckpointServlet {
           scm.getScmMetadataStore().getStore(),
           scmMetrics.getDBCheckpointMetrics(),
           false,
-          Collections.emptyList());
+          Collections.emptyList(),
+          false,
+          scm.getConfiguration());
 
       HttpServletRequest requestMock = mock(HttpServletRequest.class);
       HttpServletResponse responseMock = mock(HttpServletResponse.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om;
 
 import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
@@ -33,7 +32,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Principal;
-import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
@@ -48,7 +46,6 @@ import static org.apache.hadoop.hdds.recon.ReconConfig.ConfigStrings.OZONE_RECON
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HTTP_SECURITY_ENABLED_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OPEN_KEY_EXPIRE_THRESHOLD_SECONDS;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
@@ -92,7 +89,7 @@ public class TestOMDbCheckpointServlet {
    * <p>
    * Ozone is made active by setting OZONE_ENABLED = true
    *
-   * @throws IOException
+   * @throws Exception
    */
   @BeforeClass
   public static void init() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -52,11 +52,11 @@ import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FL
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.om.OMDBCheckpointServlet.writeDBCheckpointToStream;
 
-import org.junit.AfterClass;
+import org.junit.After;
 import org.junit.Assert;
 
 import static org.junit.Assert.assertNotNull;
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -74,10 +74,10 @@ import static org.mockito.Mockito.when;
  * Class used for testing the OM DB Checkpoint provider servlet.
  */
 public class TestOMDbCheckpointServlet {
-  private static OzoneConfiguration conf;
-  private static File tempFile;
-  private static ServletOutputStream servletOutputStream;
-  private static MiniOzoneCluster cluster = null;
+  private OzoneConfiguration conf;
+  private File tempFile;
+  private ServletOutputStream servletOutputStream;
+  private MiniOzoneCluster cluster = null;
   private OMMetrics omMetrics = null;
   private HttpServletRequest requestMock = null;
   private HttpServletResponse responseMock = null;
@@ -95,8 +95,8 @@ public class TestOMDbCheckpointServlet {
    *
    * @throws Exception
    */
-  @BeforeClass
-  public static void init() throws Exception {
+  @Before
+  public void init() throws Exception {
     conf = new OzoneConfiguration();
 
     tempFile = File.createTempFile("testDoGet_" + System
@@ -124,22 +124,18 @@ public class TestOMDbCheckpointServlet {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
-  public static void shutdown() throws InterruptedException {
+  @After
+  public void shutdown() throws InterruptedException {
     if (cluster != null) {
       cluster.shutdown();
     }
     FileUtils.deleteQuietly(tempFile);
   }
 
-  private static void setCluster(MiniOzoneCluster cluster) {
-    TestOMDbCheckpointServlet.cluster = cluster;
-  }
-
   private void setupCluster() throws Exception {
-    setCluster(MiniOzoneCluster.newBuilder(conf)
+    cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(1)
-        .build());
+        .build();
     cluster.waitForClusterToBeReady();
     omMetrics = cluster.getOzoneManager().getMetrics();
 
@@ -209,7 +205,6 @@ public class TestOMDbCheckpointServlet {
 
   @Test
   public void testSpnegoEnabled() throws Exception {
-    cluster.shutdown();
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     conf.set(OZONE_ADMINISTRATORS, "");
     conf.set(OZONE_OM_HTTP_AUTH_TYPE, "kerberos");
@@ -296,7 +291,7 @@ public class TestOMDbCheckpointServlet {
 
 class TestDBCheckpoint implements DBCheckpoint {
 
-  private Path checkpointFile;
+  private final Path checkpointFile;
 
   TestDBCheckpoint(Path checkpointFile) {
     this.checkpointFile = checkpointFile;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -20,13 +20,17 @@ package org.apache.hadoop.ozone.om;
 
 import javax.servlet.ServletException;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.recon.ReconConfig;
 import org.apache.hadoop.hdds.utils.DBCheckpointServlet;
 import org.apache.hadoop.ozone.OzoneConsts;
 
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 
 /**
  * Provides the current checkpoint Snapshot of the OM DB. (tar.gz)
@@ -59,12 +63,22 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     }
 
     try {
+      OzoneConfiguration conf = om.getConfiguration();
+      // Only Ozone Admins and Recon are allowed
+      Collection<String> allowedUsers = om.getOzoneAdmins(conf);
+      ReconConfig reconConfig = conf.getObject(ReconConfig.class);
+      String reconPrincipal = reconConfig.getKerberosPrincipal();
+      if (!reconPrincipal.isEmpty()) {
+        UserGroupInformation ugi =
+            UserGroupInformation.createRemoteUser(reconPrincipal);
+        allowedUsers.add(ugi.getShortUserName());
+      }
+
       initialize(om.getMetadataManager().getStore(),
           om.getMetrics().getDBCheckpointMetrics(),
           om.getAclsEnabled(),
-          om.getOzoneAdmins(om.getConfiguration()),
-          om.isSpnegoEnabled(),
-          om.getConfiguration());
+          allowedUsers,
+          om.isSpnegoEnabled());
     } catch (IOException e) {
       LOG.error("Error in getOzoneAdmins: {}", e.getMessage());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -62,7 +62,9 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
       initialize(om.getMetadataManager().getStore(),
           om.getMetrics().getDBCheckpointMetrics(),
           om.getAclsEnabled(),
-          om.getOzoneAdmins(om.getConfiguration()));
+          om.getOzoneAdmins(om.getConfiguration()),
+          om.isSpnegoEnabled(),
+          om.getConfiguration());
     } catch (IOException e) {
       LOG.error("Error in getOzoneAdmins: {}", e.getMessage());
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -215,6 +215,7 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
@@ -291,6 +292,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private final Runnable shutdownHook;
   private final File omMetaDir;
   private final boolean isAclEnabled;
+  private final boolean isSpnegoEnabled;
   private IAccessAuthorizer accessAuthorizer;
   private JvmPauseMonitor jvmPauseMonitor;
   private final SecurityConfig secConfig;
@@ -377,6 +379,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     omMetaDir = OMStorage.getOmDbDir(configuration);
     this.isAclEnabled = conf.getBoolean(OZONE_ACL_ENABLED,
         OZONE_ACL_ENABLED_DEFAULT);
+    this.isSpnegoEnabled = conf.get(OZONE_OM_HTTP_AUTH_TYPE, "simple")
+        .equals("kerberos");
     this.scmBlockSize = (long) conf.getStorageSize(OZONE_SCM_BLOCK_SIZE,
         OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
     this.preallocateBlocksMax = conf.getInt(
@@ -1792,6 +1796,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   public boolean getAclsEnabled() {
     return isAclEnabled;
+  }
+
+  /**
+   * Return true if SPNEGO auth is enabled for OM HTTP server, otherwise false.
+   *
+   * @return boolean
+   */
+  public boolean isSpnegoEnabled() {
+    return isSpnegoEnabled;
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update OM DB checkpoint servlet to enforce access restrictions only when both ACL and SPNGEO auth are enabled. Also, updated the rules to allow recon by default.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5165

## How was this patch tested?

Unit tests and tested in a real cluster.
