### PR TITLE
HDDS-5145. Extend Pipline/ReplicationConfig refactor with ECReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -91,4 +91,12 @@ public class ECReplicationConfig implements ReplicationConfig {
   public int hashCode() {
     return Objects.hash(data, parity);
   }
+
+  public static HddsProtos.ECReplicationConfig getProtoOrNull(
+      ReplicationConfig replicationConfig) {
+    if (replicationConfig instanceof ECReplicationConfig) {
+      return ((ECReplicationConfig) replicationConfig).toProto();
+    }
+    return null;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -92,11 +92,4 @@ public class ECReplicationConfig implements ReplicationConfig {
     return Objects.hash(data, parity);
   }
 
-  public static HddsProtos.ECReplicationConfig getProtoOrNull(
-      ReplicationConfig replicationConfig) {
-    if (replicationConfig instanceof ECReplicationConfig) {
-      return ((ECReplicationConfig) replicationConfig).toProto();
-    }
-    return null;
-  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -34,6 +34,7 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -330,16 +331,18 @@ public final class Pipeline {
     HddsProtos.Pipeline.Builder builder = HddsProtos.Pipeline.newBuilder()
         .setId(id.getProtobuf())
         .setType(replicationConfig.getReplicationType())
-        .setFactor(ReplicationConfig.getLegacyFactor(replicationConfig))
-        .setEcReplicationConfig(
-            org.apache.hadoop.hdds.client.ECReplicationConfig
-                .getProtoOrNull(replicationConfig))
         .setState(PipelineState.getProtobuf(state))
         .setLeaderID(leaderId != null ? leaderId.toString() : "")
         .setCreationTimeStamp(creationTimestamp.toEpochMilli())
         .addAllMembers(members)
         .addAllMemberReplicaIndexes(memberReplicaIndexes);
 
+    if (replicationConfig instanceof ECReplicationConfig) {
+      builder.setEcReplicationConfig(((ECReplicationConfig) replicationConfig)
+          .toProto());
+    } else {
+      builder.setFactor(ReplicationConfig.getLegacyFactor(replicationConfig));
+    }
     if (leaderId != null) {
       HddsProtos.UUID uuid128 = HddsProtos.UUID.newBuilder()
           .setMostSigBits(leaderId.getMostSignificantBits())

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -83,6 +84,24 @@ public final class MockPipeline {
         .setId(PipelineID.randomId())
         .setReplicationConfig(
             new RatisReplicationConfig(ReplicationFactor.THREE))
+        .setNodes(nodes)
+        .build();
+  }
+
+  public static Pipeline createEcPipeline() {
+
+    List<DatanodeDetails> nodes = new ArrayList<>();
+    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+
+    return Pipeline.newBuilder()
+        .setState(Pipeline.PipelineState.OPEN)
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(
+            new ECReplicationConfig(3, 2))
         .setNodes(nodes)
         .build();
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -54,13 +54,14 @@ public class TestPipeline {
   public void getProtobufMessageEC() throws IOException {
     Pipeline subject = MockPipeline.createPipeline(3);
 
-    //when EC config is empty
+    //when EC config is empty/null
     HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(1);
-    Assert.assertNull(protobufMessage);
+    Assert.assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
 
+
+    //when EC config is NOT empty
     subject = MockPipeline.createEcPipeline();
 
-    //when EC config is empty
     protobufMessage = subject.getProtobufMessage(1);
     Assert.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
     Assert

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -47,5 +48,23 @@ public class TestPipeline {
     for (HddsProtos.DatanodeDetailsProto dn : protoV1.getMembersList()) {
       assertPorts(dn, ALL_PORTS);
     }
+  }
+
+  @Test
+  public void getProtobufMessageEC() throws IOException {
+    Pipeline subject = MockPipeline.createPipeline(3);
+
+    //when EC config is empty
+    HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(1);
+    Assert.assertNull(protobufMessage);
+
+    subject = MockPipeline.createEcPipeline();
+
+    //when EC config is empty
+    protobufMessage = subject.getProtobufMessage(1);
+    Assert.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
+    Assert
+        .assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
+
   }
 }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -114,6 +114,7 @@ message Pipeline {
     optional uint64 creationTimeStamp = 8;
     optional UUID suggestedLeaderID = 9;
     repeated uint32 memberReplicaIndexes = 10;
+    optional ECReplicationConfig ecReplicationConfig = 11;
     // TODO(runzhiwang): when leaderID is gone, specify 6 as the index of leaderID128
     optional UUID leaderID128 = 100;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -186,7 +186,8 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
             request.getNumBlocks(),
             ReplicationConfig.fromProto(
                 request.getType(),
-                request.getFactor()),
+                request.getFactor(),
+                request.getEcReplicationConfig()),
             request.getOwner(),
             ExcludeList.getFromProtoBuf(request.getExcludeList()));
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-5047 / #2096 started to use `ReplicationConfig` in `Pipeline` and pipeline related SCM service on master. `ReplicationConfig` was introduced in HDDS-5011, but it has two versions one for master #(2089) and one for the EC branch.(#2068)

Merging master after HDDS-5047 requires small modification in the code to make HDDS-5047 compatible the ec version of HDDS-5011:

During the proto serialization / deserialization we should use optional ECReplicationConfig (if exists).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5145

## How was this patch tested?

With CI, The EC branch has compilation failure without this patch.