### PR TITLE
HDDS-5176. Increase default block cache capacity for Datanodes

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -321,7 +321,7 @@ public final class OzoneConfigKeys {
   public static final String HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE =
       "hdds.datanode.metadata.rocksdb.cache.size";
   public static final String
-      HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT = "64MB";
+      HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT = "1GB";
 
   public static final String OZONE_SECURITY_ENABLED_KEY =
       "ozone.security.enabled";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently Ozone datanodes use a default block cache capacity of 64MB. We can increase the default block cache capacity to a higher value like 512MB..1GB.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5176

## How was this patch tested?

Existing UT.