### PR TITLE
HDDS-5181. Generate metadata directories config for production environment

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -125,7 +125,7 @@
   <property>
     <name>dfs.container.ratis.datanode.storage.dir</name>
     <value/>
-    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT, RATIS</tag>
+    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT, RATIS, META_DIR</tag>
     <description>This directory is used for storing Ratis metadata like logs. If
       this is
       not set then default metadata dirs is used. A warning will be logged if
@@ -595,7 +595,7 @@
   <property>
     <name>ozone.om.db.dirs</name>
     <value/>
-    <tag>OZONE, OM, STORAGE, PERFORMANCE</tag>
+    <tag>OZONE, OM, STORAGE, PERFORMANCE, META_DIR</tag>
     <description>
       Directory where the OzoneManager stores its metadata. This should
       be specified as a single directory. If the directory does not
@@ -637,7 +637,7 @@
   <property>
     <name>ozone.scm.db.dirs</name>
     <value/>
-    <tag>OZONE, SCM, STORAGE, PERFORMANCE</tag>
+    <tag>OZONE, SCM, STORAGE, PERFORMANCE, META_DIR</tag>
     <description>
       Directory where the StorageContainerManager stores its metadata.
       This should be specified as a single directory. If the directory
@@ -917,7 +917,7 @@
   <property>
     <name>ozone.scm.datanode.id.dir</name>
     <value/>
-    <tag>OZONE, MANAGEMENT</tag>
+    <tag>OZONE, MANAGEMENT, META_DIR</tag>
     <description>The path that datanodes will use to store the datanode ID.
       If this value is not set, then datanode ID is created under the
       metadata directory.
@@ -1655,7 +1655,7 @@
   <property>
     <name>ozone.om.ratis.storage.dir</name>
     <value/>
-    <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS</tag>
+    <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS, META_DIR</tag>
     <description>This directory is used for storing OM's Ratis metadata like
       logs. If this is not set then default metadata dirs is used. A warning
       will be logged if this not set. Ideally, this should be mapped to a
@@ -1750,7 +1750,7 @@
   <property>
     <name>ozone.om.ratis.snapshot.dir</name>
     <value/>
-    <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS</tag>
+    <tag>OZONE, OM, STORAGE, MANAGEMENT, RATIS, META_DIR</tag>
     <description>This directory is used for storing OM's snapshot
       related files like the ratisSnapshotIndex and DB checkpoint from leader
       OM.
@@ -2051,7 +2051,7 @@
   <property>
     <name>ozone.scm.ratis.storage.dir</name>
     <value/>
-    <tag>OZONE, SCM, HA, RATIS, STORAGE</tag>
+    <tag>OZONE, SCM, HA, RATIS, STORAGE, META_DIR</tag>
     <description>This directory is used for storing SCM's Ratis metadata like
       logs. If this is not set then default metadata dirs is used. A warning
       will be logged if this not set. Ideally, this should be mapped to a
@@ -2554,7 +2554,7 @@
   <property>
     <name>ozone.recon.db.dir</name>
     <value/>
-    <tag>OZONE, RECON, STORAGE, PERFORMANCE</tag>
+    <tag>OZONE, RECON, STORAGE, PERFORMANCE, META_DIR</tag>
     <description>
       Directory where the Recon Server stores its metadata. This should
       be specified as a single directory. If the directory does not
@@ -2585,18 +2585,32 @@
   </property>
   <property>
     <name>ozone.recon.om.db.dir</name>
-  <value/>
-  <tag>OZONE, RECON, STORAGE</tag>
-  <description>
-    Directory where the Recon Server stores its OM snapshot DB. This should
-    be specified as a single directory. If the directory does not
-    exist then the Recon will attempt to create it.
+    <value/>
+    <tag>OZONE, RECON, STORAGE, META_DIR</tag>
+    <description>
+      Directory where the Recon Server stores its OM snapshot DB. This should
+      be specified as a single directory. If the directory does not
+      exist then the Recon will attempt to create it.
 
-    If undefined, then the Recon will log a warning and fallback to
-    ozone.metadata.dirs. This fallback approach is not recommended for
-    production environments.
-  </description>
-</property>
+      If undefined, then the Recon will log a warning and fallback to
+      ozone.metadata.dirs. This fallback approach is not recommended for
+      production environments.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scm.db.dirs</name>
+    <value/>
+    <tag>OZONE, RECON, STORAGE, META_DIR</tag>
+    <description>
+      Directory where the Recon Server stores its SCM snapshot DB. This should
+      be specified as a single directory. If the directory does not
+      exist then the Recon will attempt to create it.
+
+      If undefined, then the Recon will log a warning and fallback to
+      ozone.metadata.dirs. This fallback approach is not recommended for
+      production environments.
+    </description>
+  </property>
   <property>
     <name>ozone.recon.om.connection.request.timeout</name>
     <value>5000</value>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -78,7 +78,6 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
-        ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR,
         ReconServerConfigKeys.OZONE_RECON_METRICS_HTTP_CONNECTION_TIMEOUT,
         ReconServerConfigKeys
             .OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genconf/GenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genconf/GenerateOzoneRequiredConfigurations.java
@@ -66,6 +66,11 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
       "template, update Kerberos principal and keytab file before use.")
   private boolean genSecurityConf;
 
+  @Option(names = "--meta-directory", description = "Generates config " +
+      "template with all metadata directories for production environment, " +
+      "update the metadata directories before use.")
+  private boolean genMetaDirectoryConf;
+
   /**
    * Entry point for using genconf tool.
    *
@@ -78,7 +83,7 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
 
   @Override
   public Void call() throws Exception {
-    generateConfigurations(path, genSecurityConf);
+    generateConfigurations(path, genSecurityConf, genMetaDirectoryConf);
     return null;
   }
 
@@ -90,7 +95,7 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
    */
   public static void generateConfigurations(String path) throws
       PicocliException, JAXBException, IOException {
-    generateConfigurations(path, false);
+    generateConfigurations(path, false, false);
   }
 
   /**
@@ -101,7 +106,7 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
    * @throws JAXBException
    */
   public static void generateConfigurations(String path,
-      boolean genSecurityConf) throws
+      boolean genSecurityConf, boolean genMetaDirectoryConf) throws
       PicocliException, JAXBException, IOException {
 
     if (!isValidPath(path)) {
@@ -127,7 +132,8 @@ public final class GenerateOzoneRequiredConfigurations extends GenericCli {
 
     for (OzoneConfiguration.Property p : allProperties) {
       if (p.getTag() != null && (p.getTag().contains("REQUIRED") ||
-          (genSecurityConf && p.getTag().contains("KERBEROS")))) {
+          (genSecurityConf && p.getTag().contains("KERBEROS")) ||
+          (genMetaDirectoryConf && p.getTag().contains("META_DIR")))) {
         // Set default value for common required configs
         if (p.getName().equalsIgnoreCase(
             OzoneConfigKeys.OZONE_METADATA_DIRS)) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
@@ -337,7 +337,8 @@ public class TestGenerateOzoneRequiredConfigurations {
   public void genconfHelp() throws Exception {
     File tempPath = getRandomTempDir();
     String[] args = new String[]{"--help"};
-    execute(args, "Usage: ozone genconf [-hV] [--security] [--verbose]");
+    execute(args, "Usage: ozone genconf [-hV] [--meta-directory] [--security]" +
+        " [--verbose]");
   }
 
   private File getRandomTempDir() throws IOException {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/genconf/TestGenerateOzoneRequiredConfigurations.java
@@ -232,6 +232,51 @@ public class TestGenerateOzoneRequiredConfigurations {
   }
 
   /**
+   * Tests a valid path and generates ozone-site.xml with meta directories by
+   * calling {@code GenerateOzoneRequiredConfigurations#generateConfigurations}.
+   * Further verifies that all properties have a default value.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testGenerateMetaDirectoryConfigurations() throws Exception {
+    int ozoneConfigurationCount, ozoneMetaDirectoryConfigurationCount;
+
+    // Generate default Ozone Configuration
+    File tempPath = getRandomTempDir();
+    String[] args = new String[]{tempPath.getAbsolutePath()};
+    execute(args, "ozone-site.xml has been generated at " +
+        tempPath.getAbsolutePath());
+
+    URL url = new File(tempPath.getAbsolutePath() + "/ozone-site.xml")
+        .toURI().toURL();
+    OzoneConfiguration oc = new OzoneConfiguration();
+    List<OzoneConfiguration.Property> allProperties =
+        oc.readPropertyFromXml(url);
+
+    for (OzoneConfiguration.Property p : allProperties) {
+      Assert.assertTrue(
+          p.getValue() != null && p.getValue().length() > 0);
+    }
+    ozoneConfigurationCount = allProperties.size();
+
+    // Generate secure Ozone Configuration
+    tempPath = getRandomTempDir();
+    args = new String[]{"--meta-directory", tempPath.getAbsolutePath()};
+    execute(args, "ozone-site.xml has been generated at " +
+        tempPath.getAbsolutePath());
+
+    url = new File(tempPath.getAbsolutePath() + "/ozone-site.xml")
+        .toURI().toURL();
+    oc = new OzoneConfiguration();
+    allProperties = oc.readPropertyFromXml(url);
+
+    ozoneMetaDirectoryConfigurationCount = allProperties.size();
+
+    Assert.assertNotEquals(ozoneConfigurationCount,
+        ozoneMetaDirectoryConfigurationCount);
+  }
+  /**
    * Generates ozone-site.xml at specified path.
    * Verify that it does not overwrite if file already exists in path.
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?

When deploying Ozone in production environment, it takes some time to find all the metadata directories config that may affect the performance. This patch added an option in `genconf` to generate all the metadata directories config for the convenience of users.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5181

## How was this patch tested?

Unit test. The usage would be as follows.
![genconf_meta_directory](https://user-images.githubusercontent.com/14933944/116889173-d8416600-ac5e-11eb-8194-1ec7fc7cc90f.png)
