### PR TITLE
HDDS-5182. Acceptance test may exit with 0 in case of error

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -324,7 +324,7 @@ run_test_script() {
   #required to read the .env file from the right location
   cd "${d}" || return
 
-  ret=0
+  local ret=0
   if ! ./test.sh; then
     ret=1
     echo "ERROR: Test execution of ${d} is FAILED!!!!"
@@ -336,7 +336,7 @@ run_test_script() {
 }
 
 run_test_scripts() {
-  ret=0
+  local ret=0
 
   for t in "$@"; do
     d="$(dirname "${t}")"


### PR DESCRIPTION
## What changes were proposed in this pull request?

If any acceptance test fails, `test-all.sh` (and in turn `acceptance.sh`) should exit with error code (1).  But if a successful test is run after a failing one, it will now wrongly exit with success (0).

```
$ export OZONE_TEST_SELECTOR='failing1\|ozone-csi'
$ ./hadoop-ozone/dev-support/checks/acceptance.sh
...
$ echo $?
0
```

The problem is that the variable `ret` in the functions `run_test_scripts` and `run_test_script` are intended to be independent, but are the same (global) one.

https://issues.apache.org/jira/browse/HDDS-5182

## How was this patch tested?

```
$ export OZONE_TEST_SELECTOR='failing1\|ozone-csi'
$ ./hadoop-ozone/dev-support/checks/acceptance.sh
...
$ echo $?
1
```