### PR TITLE
HDDS-5183. For AccessControlException do not perform failover.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.ratis.protocol.exceptions.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -288,7 +290,10 @@ public final class SCMHAUtils {
 
   public static RetryPolicy.RetryAction getRetryAction(int failovers, int retry,
       Exception e, int maxRetryCount, long retryInterval) {
-    if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
+    // For AccessControl Exception where Client is not authenticated.
+    if (isAccessControlException(e)) {
+      return RetryPolicy.RetryAction.FAIL;
+    } else if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
       if (retry < maxRetryCount) {
         return new RetryPolicy.RetryAction(
             RetryPolicy.RetryAction.RetryDecision.RETRY, retryInterval);
@@ -306,5 +311,25 @@ public final class SCMHAUtils {
         return RetryPolicy.RetryAction.FAIL;
       }
     }
+  }
+
+  /**
+   * Unwrap exception to check if it is some kind of access control problem.
+   * {@link AccessControlException}
+   */
+  public static boolean isAccessControlException(Exception ex) {
+    if (ex instanceof ServiceException) {
+      Throwable t = ex.getCause();
+      if (t instanceof RemoteException) {
+        t = ((RemoteException) t).unwrapRemoteException();
+      }
+      while (t != null) {
+        if (t instanceof AccessControlException) {
+          return true;
+        }
+        t = t.getCause();
+      }
+    }
+    return false;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -77,15 +77,26 @@ public class SCMContainerLocationFailoverProxyProvider implements
 
   private final UserGroupInformation ugi;
 
-
-  public SCMContainerLocationFailoverProxyProvider(ConfigurationSource conf) {
+  /**
+   * Construct SCMContainerLocationFailoverProxyProvider.
+   * If userGroupInformation is not null, use the passed ugi, else obtain
+   * from {@link UserGroupInformation#getCurrentUser()}
+   * @param conf
+   * @param userGroupInformation
+   */
+  public SCMContainerLocationFailoverProxyProvider(ConfigurationSource conf,
+      UserGroupInformation userGroupInformation) {
     this.conf = conf;
 
-    try {
-      this.ugi = UserGroupInformation.getCurrentUser();
-    } catch (IOException ex) {
-      LOG.error("Unable to fetch user credentials from UGI", ex);
-      throw new RuntimeException(ex);
+    if (userGroupInformation == null) {
+      try {
+        this.ugi = UserGroupInformation.getCurrentUser();
+      } catch (IOException ex) {
+        LOG.error("Unable to fetch user credentials from UGI", ex);
+        throw new RuntimeException(ex);
+      }
+    } else {
+      this.ugi = userGroupInformation;
     }
     this.scmVersion = RPC.getProtocolVersion(
         StorageContainerLocationProtocolPB.class);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolPB;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
-import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.FailoverProxyProvider;
 import org.apache.hadoop.io.retry.RetryPolicies;
@@ -268,11 +267,6 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
             LOG.debug("RetryProxy: SCM {}: {}", getCurrentProxySCMNodeId(),
                 exception.getMessage());
           }
-        }
-
-        // For AccessControl Exception where Client is not authenticated.
-        if (HAUtils.isAccessControlException(exception)) {
-          return RetryAction.FAIL;
         }
 
         if (!SCMHAUtils.checkRetriableWithNoFailoverException(exception)) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -16,8 +16,8 @@
  */
 package org.apache.hadoop.hdds.utils;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.HddsConfigKeys;
-import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.function.SupplierWithIOException;
@@ -44,13 +44,12 @@ import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.ipc.RemoteException;
-import org.apache.hadoop.security.AccessControlException;
 
 import java.io.File;
 import java.io.IOException;
@@ -142,7 +141,20 @@ public final class HAUtils {
   public static StorageContainerLocationProtocol getScmContainerClient(
       ConfigurationSource conf) {
     SCMContainerLocationFailoverProxyProvider proxyProvider =
-        new SCMContainerLocationFailoverProxyProvider(conf);
+        new SCMContainerLocationFailoverProxyProvider(conf, null);
+    StorageContainerLocationProtocol scmContainerClient =
+        TracingUtil.createProxy(
+            new StorageContainerLocationProtocolClientSideTranslatorPB(
+                proxyProvider), StorageContainerLocationProtocol.class, conf);
+    return scmContainerClient;
+  }
+
+  @VisibleForTesting
+  public static StorageContainerLocationProtocol getScmContainerClient(
+      ConfigurationSource conf, UserGroupInformation userGroupInformation) {
+    SCMContainerLocationFailoverProxyProvider proxyProvider =
+        new SCMContainerLocationFailoverProxyProvider(conf,
+            userGroupInformation);
     StorageContainerLocationProtocol scmContainerClient =
         TracingUtil.createProxy(
             new StorageContainerLocationProtocolClientSideTranslatorPB(
@@ -331,27 +343,6 @@ public final class HAUtils {
     }
     return metadataDir;
   }
-
-  /**
-   * Unwrap exception to check if it is some kind of access control problem.
-   * {@link AccessControlException}
-   */
-  public static boolean isAccessControlException(Exception ex) {
-    if (ex instanceof ServiceException) {
-      Throwable t = ex.getCause();
-      if (t instanceof RemoteException) {
-        t = ((RemoteException) t).unwrapRemoteException();
-      }
-      while (t != null) {
-        if (t instanceof AccessControlException) {
-          return true;
-        }
-        t = t.getCause();
-      }
-    }
-    return false;
-  }
-
   /**
    * Build CA list which need to be passed to client.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -117,6 +117,7 @@ import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.lock.LockManager;
+import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
@@ -1452,7 +1453,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   public void checkAdminAccess(String remoteUser) throws IOException {
     if (remoteUser != null && !scmAdminUsernames.contains(remoteUser) &&
         !scmAdminUsernames.contains(OZONE_ADMINISTRATORS_WILDCARD)) {
-      throw new IOException(
+      throw new AccessControlException(
           "Access denied for user " + remoteUser + ". Superuser privilege " +
               "is required.");
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -338,7 +338,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         address);
 
     SCMContainerLocationFailoverProxyProvider proxyProvider =
-        new SCMContainerLocationFailoverProxyProvider(conf);
+        new SCMContainerLocationFailoverProxyProvider(conf, null);
 
     return new StorageContainerLocationProtocolClientSideTranslatorPB(
         proxyProvider);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.scm.ha.HASecurityUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMHANodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
+import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -51,6 +52,7 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.keys.HDDSKeyGenerator;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
+import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ipc.Client;
@@ -322,6 +324,40 @@ public final class TestSecureOzoneCluster {
           finalScmSecurityProtocolClient::getCACertificate);
       LambdaTestUtils.intercept(IOException.class, cannotAuthMessage,
           () -> finalScmSecurityProtocolClient.getCertificate("1"));
+    } finally {
+      if (scm != null) {
+        scm.stop();
+      }
+    }
+  }
+
+  @Test
+  public void testAdminAccessControlException() throws Exception {
+    initSCM();
+    scm = TestUtils.getScmSimple(conf);
+    //Reads the SCM Info from SCM instance
+    try {
+      scm.start();
+
+      //case 1: Run admin command with non-admin user.
+      UserGroupInformation ugi =
+          UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+          testUserPrincipal, testUserKeytab.getCanonicalPath());
+      StorageContainerLocationProtocol scmRpcClient =
+          HAUtils.getScmContainerClient(conf, ugi);
+      LambdaTestUtils.intercept(IOException.class, "Access denied",
+          scmRpcClient::forceExitSafeMode);
+
+
+      // Case 2: User without Kerberos credentials should fail.
+      ugi = UserGroupInformation.createRemoteUser("test");
+      ugi.setAuthenticationMethod(AuthMethod.TOKEN);
+      scmRpcClient =
+          HAUtils.getScmContainerClient(conf, ugi);
+
+      String cannotAuthMessage = "Client cannot authenticate via:[KERBEROS]";
+      LambdaTestUtils.intercept(IOException.class, cannotAuthMessage,
+          scmRpcClient::forceExitSafeMode);
     } finally {
       if (scm != null) {
         scm.stop();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -119,7 +119,7 @@ public class TestFailoverWithSCMHA {
         .contains("Performing failover to suggested leader"));
     scm = getLeader(cluster);
     SCMContainerLocationFailoverProxyProvider proxyProvider =
-        new SCMContainerLocationFailoverProxyProvider(conf);
+        new SCMContainerLocationFailoverProxyProvider(conf, null);
     GenericTestUtils.setLogLevel(SCMContainerLocationFailoverProxyProvider.LOG,
         Level.DEBUG);
     logCapture = GenericTestUtils.LogCapturer


### PR DESCRIPTION
## What changes were proposed in this pull request?

For AccessControlException do not perform failover, as even with retry it would yield the same result.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5183

## How was this patch tested?

Added tests and also ran a sample test in docker.


```
bash-4.2$ ozone admin scm roles --service-id=scmservice
Exception encountered while connecting to the server
org.apache.hadoop.security.AccessControlException: Client cannot authenticate via:[KERBEROS]
	at org.apache.hadoop.security.SaslRpcClient.selectSaslClient(SaslRpcClient.java:173)
	at org.apache.hadoop.security.SaslRpcClient.saslConnect(SaslRpcClient.java:390)
	at org.apache.hadoop.ipc.Client$Connection.setupSaslConnection(Client.java:622)
	at org.apache.hadoop.ipc.Client$Connection.access$2300(Client.java:413)
	at org.apache.hadoop.ipc.Client$Connection$2.run(Client.java:822)
	at org.apache.hadoop.ipc.Client$Connection$2.run(Client.java:818)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1762)
	at org.apache.hadoop.ipc.Client$Connection.setupIOstreams(Client.java:818)
	at org.apache.hadoop.ipc.Client$Connection.access$3800(Client.java:413)
	at org.apache.hadoop.ipc.Client.getConnection(Client.java:1636)
	at org.apache.hadoop.ipc.Client.call(Client.java:1452)
	at org.apache.hadoop.ipc.Client.call(Client.java:1405)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:233)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Invoker.invoke(ProtobufRpcEngine.java:118)
	at com.sun.proxy.$Proxy20.submitRequest(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invokeMethod(RetryInvocationHandler.java:422)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeMethod(RetryInvocationHandler.java:165)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invoke(RetryInvocationHandler.java:157)
	at org.apache.hadoop.io.retry.RetryInvocationHandler$Call.invokeOnce(RetryInvocationHandler.java:95)
	at org.apache.hadoop.io.retry.RetryInvocationHandler.invoke(RetryInvocationHandler.java:359)
	at com.sun.proxy.$Proxy20.submitRequest(Unknown Source)
	at org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB.submitRequest(SCMSecurityProtocolClientSideTranslatorPB.java:104)
	at org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB.listCACertificate(SCMSecurityProtocolClientSideTranslatorPB.java:324)
	at org.apache.hadoop.hdds.utils.HAUtils.lambda$buildCAList$2(HAUtils.java:414)
	at org.apache.hadoop.hdds.utils.HAUtils.waitForCACerts(HAUtils.java:439)
	at org.apache.hadoop.hdds.utils.HAUtils.buildCAList(HAUtils.java:413)
	at org.apache.hadoop.hdds.utils.HAUtils.buildCAX509List(HAUtils.java:492)
	at org.apache.hadoop.hdds.scm.cli.ContainerOperationClient.newXCeiverClientManager(ContainerOperationClient.java:102)
	at org.apache.hadoop.hdds.scm.cli.ContainerOperationClient.<init>(ContainerOperationClient.java:76)
	at org.apache.hadoop.hdds.scm.cli.ScmOption.createScmClient(ScmOption.java:62)
	at org.apache.hadoop.hdds.scm.cli.ScmSubcommand.call(ScmSubcommand.java:38)
	at org.apache.hadoop.hdds.scm.cli.ScmSubcommand.call(ScmSubcommand.java:29)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
	at picocli.CommandLine.access$1100(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
	at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2152)
	at picocli.CommandLine.parseWithHandlers(CommandLine.java:2530)
	at picocli.CommandLine.parseWithHandler(CommandLine.java:2465)
	at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:96)
	at org.apache.hadoop.hdds.cli.OzoneAdmin.lambda$execute$0(OzoneAdmin.java:76)
	at org.apache.hadoop.hdds.tracing.TracingUtil.executeInNewSpan(TracingUtil.java:159)
	at org.apache.hadoop.hdds.cli.OzoneAdmin.execute(OzoneAdmin.java:74)
	at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:87)
	at org.apache.hadoop.hdds.cli.OzoneAdmin.main(OzoneAdmin.java:68)
Can't create SCM client
bash-4.2$ kinit -kt /etc/security/keytabs/HTTP.keytab HTTP/scm2.org@EXAMPLE.COM
bash-4.2$ ozone admin safemode exit
Access denied for user HTTP/scm2.org@EXAMPLE.COM. Superuser privilege is required.
````

