### PR TITLE
HDDS-5184. Use separate DB profile for Datanodes.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.utils.db;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.utils.db.DBProfile;
+import org.rocksdb.BlockBasedTableConfig;
+import org.rocksdb.DBOptions;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.LRUCache;
+import org.rocksdb.util.SizeUnit;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT;
+
+/**
+ * The class manages DBProfiles for Datanodes. Since ColumnFamilyOptions need to
+ * be shared across containers the options are maintained in the profile itself.
+ */
+public abstract class DatanodeDBProfile {
+
+  /**
+   * Returns DBOptions to be used for rocksDB in datanodes.
+   */
+  public abstract DBOptions getDBOptions();
+
+  /**
+   * Returns ColumnFamilyOptions to be used for rocksDB column families in
+   * datanodes.
+   */
+  public abstract ColumnFamilyOptions getColumnFamilyOptions(
+      ConfigurationSource config);
+
+
+
+  public static class SSD extends DatanodeDBProfile {
+    private static final StorageBasedProfile SSD_STORAGE_BASED_PROFILE =
+        new StorageBasedProfile(DBProfile.SSD);
+
+    @Override
+    public DBOptions getDBOptions() {
+      return SSD_STORAGE_BASED_PROFILE.getDBOptions();
+    }
+
+    @Override
+    public ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      return SSD_STORAGE_BASED_PROFILE.getColumnFamilyOptions(config);
+    }
+  }
+
+
+
+  public static class Disk extends DatanodeDBProfile {
+    private static final StorageBasedProfile DISK_STORAGE_BASED_PROFILE =
+        new StorageBasedProfile(DBProfile.DISK);
+
+    @Override
+    public DBOptions getDBOptions() {
+      return DISK_STORAGE_BASED_PROFILE.getDBOptions();
+    }
+
+    @Override
+    public ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      return DISK_STORAGE_BASED_PROFILE.getColumnFamilyOptions(config);
+    }
+  }
+
+
+
+  private static final class StorageBasedProfile {
+    private final AtomicReference<ColumnFamilyOptions> CF_OPTIONS =
+        new AtomicReference<>();
+    private final DBProfile baseProfile;
+
+    private StorageBasedProfile(DBProfile profile) {
+      baseProfile = profile;
+    }
+
+    private DBOptions getDBOptions() {
+      return baseProfile.getDBOptions();
+    }
+
+    private ColumnFamilyOptions getColumnFamilyOptions(
+        ConfigurationSource config) {
+      CF_OPTIONS.updateAndGet(op -> op != null ? op :
+          baseProfile.getColumnFamilyOptions()
+              .setTableFormatConfig(getBlockBasedTableConfig(config)));
+      return CF_OPTIONS.get();
+    }
+
+    private BlockBasedTableConfig getBlockBasedTableConfig(
+        ConfigurationSource config) {
+      BlockBasedTableConfig blockBasedTableConfig =
+          baseProfile.getBlockBasedTableConfig();
+      if (config == null) {
+        return blockBasedTableConfig;
+      }
+
+      long cacheSize = (long) config
+          .getStorageSize(HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE,
+              HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT,
+              StorageUnit.BYTES);
+      blockBasedTableConfig
+          .setBlockCache(new LRUCache(cacheSize * SizeUnit.MB));
+      return blockBasedTableConfig;
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -50,6 +50,21 @@ public abstract class DatanodeDBProfile {
   public abstract ColumnFamilyOptions getColumnFamilyOptions(
       ConfigurationSource config);
 
+  /**
+   * Returns DatanodeDBProfile for corresponding storage type.
+   */
+  public static DatanodeDBProfile getProfile(DBProfile dbProfile) {
+    switch (dbProfile) {
+    case SSD:
+      return new SSD();
+    case DISK:
+      return new Disk();
+    default:
+      throw new IllegalArgumentException(
+          "DatanodeDBProfile does not exist for " + dbProfile);
+    }
+  }
+
 
 
   public static class SSD extends DatanodeDBProfile {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -89,7 +89,7 @@ public abstract class DatanodeDBProfile {
 
 
   private static final class StorageBasedProfile {
-    private final AtomicReference<ColumnFamilyOptions> CF_OPTIONS =
+    private final AtomicReference<ColumnFamilyOptions> cfOptions =
         new AtomicReference<>();
     private final DBProfile baseProfile;
 
@@ -103,10 +103,10 @@ public abstract class DatanodeDBProfile {
 
     private ColumnFamilyOptions getColumnFamilyOptions(
         ConfigurationSource config) {
-      CF_OPTIONS.updateAndGet(op -> op != null ? op :
+      cfOptions.updateAndGet(op -> op != null ? op :
           baseProfile.getColumnFamilyOptions()
               .setTableFormatConfig(getBlockBasedTableConfig(config)));
-      return CF_OPTIONS.get();
+      return cfOptions.get();
     }
 
     private BlockBasedTableConfig getBlockBasedTableConfig(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -136,8 +136,7 @@ public abstract class DatanodeDBProfile {
           .getStorageSize(HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE,
               HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT,
               StorageUnit.BYTES);
-      blockBasedTableConfig
-          .setBlockCache(new LRUCache(cacheSize * SizeUnit.MB));
+      blockBasedTableConfig.setBlockCache(new LRUCache(cacheSize));
       return blockBasedTableConfig;
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/DatanodeDBProfile.java
@@ -25,7 +25,6 @@ import org.rocksdb.BlockBasedTableConfig;
 import org.rocksdb.DBOptions;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.LRUCache;
-import org.rocksdb.util.SizeUnit;
 
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -65,8 +64,9 @@ public abstract class DatanodeDBProfile {
     }
   }
 
-
-
+  /**
+   * DBProfile for SSD datanode disks.
+   */
   public static class SSD extends DatanodeDBProfile {
     private static final StorageBasedProfile SSD_STORAGE_BASED_PROFILE =
         new StorageBasedProfile(DBProfile.SSD);
@@ -83,8 +83,9 @@ public abstract class DatanodeDBProfile {
     }
   }
 
-
-
+  /**
+   * DBProfile for HDD datanode disks.
+   */
   public static class Disk extends DatanodeDBProfile {
     private static final StorageBasedProfile DISK_STORAGE_BASED_PROFILE =
         new StorageBasedProfile(DBProfile.DISK);
@@ -101,8 +102,9 @@ public abstract class DatanodeDBProfile {
     }
   }
 
-
-
+  /**
+   * Base profile for datanode storage disks.
+   */
   private static final class StorageBasedProfile {
     private final AtomicReference<ColumnFamilyOptions> cfOptions =
         new AtomicReference<>();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/package-info.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/db/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package contains files related to db use in datanodes.
+ */
+package org.apache.hadoop.ozone.container.common.utils.db;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -21,18 +21,15 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.*;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfoList;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
-import org.rocksdb.BlockBasedTableConfig;
-import org.rocksdb.BloomFilter;
+import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
 import org.rocksdb.ColumnFamilyOptions;
 import org.rocksdb.DBOptions;
-import org.rocksdb.LRUCache;
 import org.rocksdb.Statistics;
 import org.rocksdb.StatsLevel;
 import org.slf4j.Logger;
@@ -40,18 +37,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DB_PROFILE;
 import static org.apache.hadoop.hdds.utils.db.DBStoreBuilder.HDDS_DEFAULT_DB_PROFILE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_STORE_ROCKSDB_STATISTICS_OFF;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT;
 
 /**
  * Implementation of the {@link DatanodeStore} interface that contains
@@ -74,9 +66,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   private final long containerID;
   private final ColumnFamilyOptions cfOptions;
 
-  private final DBProfile dbProfile;
-  private static final Map<ConfigurationSource, ColumnFamilyOptions>
-      OPTIONS_CACHE = new ConcurrentHashMap<>();
+  private static DatanodeDBProfile dbProfile;
   private final boolean openReadOnly;
 
   /**
@@ -89,16 +79,14 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       AbstractDatanodeDBDefinition dbDef, boolean openReadOnly)
       throws IOException {
 
-    dbProfile = config.getEnum(HDDS_DB_PROFILE,
-        HDDS_DEFAULT_DB_PROFILE);
+    dbProfile = config.getEnum(HDDS_DB_PROFILE, HDDS_DEFAULT_DB_PROFILE)
+        == DBProfile.DISK ? new DatanodeDBProfile.Disk() :
+        new DatanodeDBProfile.SSD();
 
     // The same config instance is used on each datanode, so we can share the
     // corresponding column family options, providing a single shared cache
     // for all containers on a datanode.
-    if (!OPTIONS_CACHE.containsKey(config)) {
-      OPTIONS_CACHE.put(config, buildColumnFamilyOptions(config));
-    }
-    cfOptions = OPTIONS_CACHE.get(config);
+    cfOptions = dbProfile.getColumnFamilyOptions(config);
 
     this.dbDef = dbDef;
     this.containerID = containerID;
@@ -214,13 +202,7 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
   }
 
   @VisibleForTesting
-  public static Map<ConfigurationSource, ColumnFamilyOptions>
-      getColumnFamilyOptionsCache() {
-    return Collections.unmodifiableMap(OPTIONS_CACHE);
-  }
-
-  @VisibleForTesting
-  public DBProfile getDbProfile() {
+  public DatanodeDBProfile getDbProfile() {
     return dbProfile;
   }
 
@@ -234,22 +216,6 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       LOG.error(String.format(logMessage, name));
       throw new IOException(String.format(errMsg, name));
     }
-  }
-
-  private ColumnFamilyOptions buildColumnFamilyOptions(
-      ConfigurationSource config) {
-    long cacheSize = (long) config.getStorageSize(
-        HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE,
-        HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT,
-        StorageUnit.BYTES);
-
-    BlockBasedTableConfig tableConfig = new BlockBasedTableConfig();
-    tableConfig.setBlockCache(new LRUCache(cacheSize))
-        .setPinL0FilterAndIndexBlocksInCache(true)
-        .setFilterPolicy(new BloomFilter());
-
-    return dbProfile.getColumnFamilyOptions()
-        .setTableFormatConfig(tableConfig);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -79,9 +79,8 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       AbstractDatanodeDBDefinition dbDef, boolean openReadOnly)
       throws IOException {
 
-    dbProfile = config.getEnum(HDDS_DB_PROFILE, HDDS_DEFAULT_DB_PROFILE)
-        == DBProfile.DISK ? new DatanodeDBProfile.Disk() :
-        new DatanodeDBProfile.SSD();
+    dbProfile = DatanodeDBProfile
+        .getProfile(config.getEnum(HDDS_DB_PROFILE, HDDS_DEFAULT_DB_PROFILE));
 
     // The same config instance is used on each datanode, so we can share the
     // corresponding column family options, providing a single shared cache

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -369,6 +370,10 @@ public class RDBStore implements DBStore {
     return tableNames;
   }
 
+  public List<ColumnFamilyHandle> getColumnFamilyHandles() {
+    return Collections.unmodifiableList(columnFamilyHandles);
+  }
+
   @Override
   public CodecRegistry getCodecRegistry() {
     return codecRegistry;
@@ -422,6 +427,15 @@ public class RDBStore implements DBStore {
   @VisibleForTesting
   public RocksDB getDb() {
     return db;
+  }
+
+  public String getProperty(String property) throws RocksDBException {
+    return db.getProperty(property);
+  }
+
+  public String getProperty(ColumnFamilyHandle handle, String property)
+      throws RocksDBException {
+    return db.getProperty(handle, property);
   }
 
   public RDBMetrics getMetrics() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently datanodes shares a common DB profile with other components like SCM and OM etc. The jira aims to create a different profile for datanodes which also makes sure that column family options are shared by containers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5184

## How was this patch tested?

Existing UT, PR adds a UT to test columnfamilyoptions are shared.