### PR TITLE
HDDS-5185. Update commons-io to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1035,7 +1035,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.5</version>
+        <version>2.8.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `commons-io` version to latest.

https://issues.apache.org/jira/browse/HDDS-5185

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/809654660