### PR TITLE
HDDS-5186. If primordial SCM id is set, a non-HA cluster can not be initialized.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
@@ -78,8 +79,10 @@ public final class SCMHAUtils {
 
   public static boolean isPrimordialSCM(ConfigurationSource conf,
       String selfNodeId, String hostName) {
+    // This should only be called if SCM HA is enabled.
+    Preconditions.checkArgument(isSCMHAEnabled(conf));
     String primordialNode = getPrimordialSCM(conf);
-    return isSCMHAEnabled(conf) && primordialNode != null && (primordialNode
+    return primordialNode != null && (primordialNode
         .equals(selfNodeId) || primordialNode.equals(hostName));
   }
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -823,8 +823,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     String selfNodeId = scmhaNodeDetails.getLocalNodeDetails().getNodeId();
     final String selfHostName =
         scmhaNodeDetails.getLocalNodeDetails().getHostName();
-    if (primordialSCM != null && SCMHAUtils
-        .isPrimordialSCM(conf, selfNodeId, selfHostName)) {
+    if (primordialSCM != null && SCMHAUtils.isSCMHAEnabled(conf)
+        && SCMHAUtils.isPrimordialSCM(conf, selfNodeId, selfHostName)) {
       LOG.info(
           "SCM bootstrap command can only be executed in non-Primordial SCM "
               + "{}, self id {} " + "Ignoring it.", primordialSCM, selfNodeId);
@@ -904,8 +904,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     String primordialSCM = SCMHAUtils.getPrimordialSCM(conf);
     final String selfNodeId = haDetails.getLocalNodeDetails().getNodeId();
     final String selfHostName = haDetails.getLocalNodeDetails().getHostName();
-    if (primordialSCM != null && !SCMHAUtils
-        .isPrimordialSCM(conf, selfNodeId, selfHostName)) {
+    if (primordialSCM != null && SCMHAUtils.isSCMHAEnabled(conf)
+        && !SCMHAUtils.isPrimordialSCM(conf, selfNodeId, selfHostName)) {
       LOG.info(
           "SCM init command can only be executed in Primordial SCM {}, "
               + "self id {} "


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM init should work when primordial node is specified in the config and SCM HA is not enabled.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5186

## How was this patch tested?
Existing Tests
