### PR TITLE
HDDS-5192. Intermittent failure in TestOzoneRpcClient due to volume name conflict

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1846,14 +1846,14 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testListVolume() throws IOException {
     String volBase = "vol-list-";
-    //Create 10 volume vol-<random>-a-0-<random> to vol-<random>-a-9-<random>
-    String volBaseNameA = volBase + "-a-";
+    //Create 10 volume vol-list-a-0-<random> to vol-list-a-9-<random>
+    String volBaseNameA = volBase + "a-";
     for(int i = 0; i < 10; i++) {
       store.createVolume(
           volBaseNameA + i + "-" + RandomStringUtils.randomNumeric(5));
     }
-    //Create 10 volume vol-<random>-b-0-<random> to vol-<random>-b-9-<random>
-    String volBaseNameB = volBase + "-b-";
+    //Create 10 volume vol-list-b-0-<random> to vol-list-b-9-<random>
+    String volBaseNameB = volBase + "b-";
     for(int i = 0; i < 10; i++) {
       store.createVolume(
           volBaseNameB + i + "-" + RandomStringUtils.randomNumeric(5));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -1845,7 +1845,7 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testListVolume() throws IOException {
-    String volBase = "vol-" + RandomStringUtils.randomNumeric(3);
+    String volBase = "vol-list-";
     //Create 10 volume vol-<random>-a-0-<random> to vol-<random>-a-9-<random>
     String volBaseNameA = volBase + "-a-";
     for(int i = 0; i < 10; i++) {
@@ -1964,7 +1964,7 @@ public abstract class TestOzoneRpcClientAbstract {
   @Test
   public void testListBucketsOnEmptyVolume()
       throws IOException {
-    String volume = "vol-" + RandomStringUtils.randomNumeric(5);
+    String volume = "vol-empty";
     store.createVolume(volume);
     OzoneVolume vol = store.getVolume(volume);
     Iterator<? extends OzoneBucket> buckets = vol.listBuckets("");


### PR DESCRIPTION
## What changes were proposed in this pull request?

The name of volume created in `testListBucketsOnEmptyVolume` or `testListKeyOnEmptyBucket` might contain the prefix used in `testListVolume`:

```
... Creating Volume: vol-71454, ...
...
... Creating Volume: vol-714-a-0-78727, ...
```

which leads to unexpected number of volumes with that prefix:

```
Tests run: 80, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 175.065 s <<< FAILURE! - in org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClient
testListVolume  Time elapsed: 0.086 s  <<< FAILURE!
java.lang.AssertionError: expected:<20> but was:<21>
  ...
  at org.apache.hadoop.ozone.client.rpc.TestOzoneRpcClientAbstract.testListVolume(TestOzoneRpcClientAbstract.java:1867)
```

This fix simply changes to fix volume name for `testListBucketsOnEmptyVolume` and a different fix prefix for `testListVolume`, thus avoiding conflict.

https://issues.apache.org/jira/browse/HDDS-5192

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/2521726183