### PR TITLE
HDDS-5173. Divide snapshot related work into notifyInstallSnapshotFromLeader and reinitialize for SCMStateMachine.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
  * Grpc client to download a Rocks db checkpoint from leader node
  * in SCM HA ring.
  */
-public class InterSCMGrpcClient implements SCMSnapshotDownloader{
+public class InterSCMGrpcClient implements SCMSnapshotDownloader {
   private static final Logger LOG =
       LoggerFactory.getLogger(InterSCMGrpcClient.class);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
@@ -28,6 +28,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.Message;
@@ -125,7 +126,18 @@ public final class MockSCMHAManager implements SCMHAManager {
   }
 
   @Override
-  public TermIndex installSnapshotFromLeader(String leaderId) {
+  public DBCheckpoint downloadCheckpointFromLeader(String leaderId) {
+    return null;
+  }
+
+  @Override
+  public TermIndex verifyCheckpointFromLeader(String leaderId,
+                                              DBCheckpoint checkpoint) {
+    return null;
+  }
+
+  @Override
+  public TermIndex installCheckpoint(DBCheckpoint dbCheckpoint) {
     return null;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManager.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.ratis.server.protocol.TermIndex;
 
 import java.io.IOException;
@@ -69,10 +70,28 @@ public interface SCMHAManager {
   boolean addSCM(AddSCMRequest request) throws IOException;
 
   /**
-   * Download the SCM DB checkpoint from leader and reload the SCM state from
-   * it.
-   * @param leaderId leader id.
-   * @return
+   * Download the latest checkpoint from leader SCM.
+   *
+   * @param leaderId peerNodeID of the leader SCM
+   * @return If checkpoint is installed successfully, return the
+   *         corresponding termIndex. Otherwise, return null.
    */
-  TermIndex installSnapshotFromLeader(String leaderId);
+  DBCheckpoint downloadCheckpointFromLeader(String leaderId);
+
+  /**
+   * Verify the SCM DB checkpoint downloaded from leader.
+   *
+   * @param leaderId : leaderId
+   * @param checkpoint : checkpoint downloaded from leader.
+   * @return If the checkpoints snapshot index is greater than SCM's
+   *         last applied transaction index, return the termIndex of
+   *         the checkpoint, otherwise return null.
+   */
+  TermIndex verifyCheckpointFromLeader(String leaderId,
+                                       DBCheckpoint checkpoint);
+
+  /**
+   * Re-initialize the SCM state via this checkpoint.
+   */
+  TermIndex installCheckpoint(DBCheckpoint dbCheckpoint) throws Exception;
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotDownloader.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotDownloader.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hdds.scm.ha;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
@@ -28,7 +29,7 @@ import java.util.concurrent.CompletableFuture;
  * any chosen protocol(for now its Grpc).
  * images.
  */
-public interface SCMSnapshotDownloader {
+public interface SCMSnapshotDownloader extends Closeable {
 
   /**
    * Downloads the contents to the target file path.
@@ -38,6 +39,4 @@ public interface SCMSnapshotDownloader {
    * @throws IOException
    */
   CompletableFuture<Path> download(Path destination) throws IOException;
-
-  void close();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMSnapshotProvider.java
@@ -110,16 +110,15 @@ public class SCMSnapshotProvider {
     // the downloadClient instance will be created as and when install snapshot
     // request is received. No caching of the client as it should be a very rare
     int port = peerNodesMap.get(leaderSCMNodeID).getGrpcPort();
-    SCMSnapshotDownloader downloadClient = new InterSCMGrpcClient(
-        peerNodesMap.get(leaderSCMNodeID).getInetAddress().getHostAddress(),
-        port, conf, scmCertificateClient);
-    try {
+    String host = peerNodesMap.get(leaderSCMNodeID).getInetAddress()
+            .getHostAddress();
+
+    try (SCMSnapshotDownloader downloadClient =
+        new InterSCMGrpcClient(host, port, conf, scmCertificateClient)) {
       downloadClient.download(targetFile.toPath()).get();
     } catch (ExecutionException | InterruptedException e) {
       LOG.error("Rocks DB checkpoint downloading failed", e);
       throw new IOException(e);
-    } finally {
-      downloadClient.close();
     }
 
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -27,12 +27,14 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLog;
 import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImplV2;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
@@ -75,6 +77,11 @@ public class SCMStateMachine extends BaseStateMachine {
       new SimpleStateMachineStorage();
   private final boolean isInitialized;
   private ExecutorService installSnapshotExecutor;
+
+  // The atomic variable RaftServerImpl#inProgressInstallSnapshotRequest
+  // ensures serializable between notifyInstallSnapshotFromLeader()
+  // and reinitialize().
+  private DBCheckpoint installingDBCheckpoint;
 
   public SCMStateMachine(final StorageContainerManager scm,
       final SCMRatisServer ratisServer, SCMHADBTransactionBuffer buffer)
@@ -202,7 +209,23 @@ public class SCMStateMachine extends BaseStateMachine {
         + "term index: {}", leaderAddress, firstTermIndexInLog);
 
     CompletableFuture<TermIndex> future = CompletableFuture.supplyAsync(
-        () -> scm.getScmHAManager().installSnapshotFromLeader(leaderNodeId),
+        () -> {
+          DBCheckpoint checkpoint =
+              scm.getScmHAManager().downloadCheckpointFromLeader(leaderNodeId);
+
+          if (checkpoint == null) {
+            return null;
+          }
+
+          TermIndex termIndex =
+              scm.getScmHAManager().verifyCheckpointFromLeader(
+                  leaderNodeId, checkpoint);
+
+          if (termIndex != null) {
+            installingDBCheckpoint = checkpoint;
+          }
+          return termIndex;
+        },
         installSnapshotExecutor);
     return future;
   }
@@ -296,10 +319,27 @@ public class SCMStateMachine extends BaseStateMachine {
 
   @Override
   public void reinitialize() {
-    if (getLifeCycleState() == LifeCycle.State.PAUSED) {
-      getLifeCycle().transition(LifeCycle.State.STARTING);
-      getLifeCycle().transition(LifeCycle.State.RUNNING);
+    Preconditions.checkNotNull(installingDBCheckpoint);
+
+    TermIndex termIndex = null;
+    try {
+      termIndex =
+          scm.getScmHAManager().installCheckpoint(installingDBCheckpoint);
+    } catch (Exception e) {
+      LOG.error("Failed to reinitialize SCMStateMachine.");
+      return;
     }
+
+    // re-initialize the DoubleBuffer and update the lastAppliedIndex.
+    try {
+      transactionBuffer.init();
+      this.setLastAppliedTermIndex(termIndex);
+    } catch (IOException ioe) {
+      LOG.error("Failed to unpause ", ioe);
+    }
+
+    getLifeCycle().transition(LifeCycle.State.STARTING);
+    getLifeCycle().transition(LifeCycle.State.RUNNING);
   }
 
   @Override
@@ -312,21 +352,9 @@ public class SCMStateMachine extends BaseStateMachine {
     HadoopExecutors.
         shutdown(installSnapshotExecutor, LOG, 5, TimeUnit.SECONDS);
   }
-  /**
-   * Unpause the StateMachine, re-initialize the DoubleBuffer and update the
-   * lastAppliedIndex. This should be done after uploading new state to the
-   * StateMachine.
-   */
-  public void unpause(long newLastAppliedSnapShotTerm,
-      long newLastAppliedSnapshotIndex) {
-    getLifeCycle().startAndTransition(() -> {
-      try {
-        transactionBuffer.init();
-        this.setLastAppliedTermIndex(TermIndex
-            .valueOf(newLastAppliedSnapShotTerm, newLastAppliedSnapshotIndex));
-      } catch (IOException ioe) {
-        LOG.error("Failed to unpause ", ioe);
-      }
-    });
+
+  @VisibleForTesting
+  public void setInstallingDBCheckpoint(DBCheckpoint checkpoint) {
+    installingDBCheckpoint = checkpoint;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -222,7 +222,7 @@ public class SCMStateMachine extends BaseStateMachine {
                   leaderNodeId, checkpoint);
 
           if (termIndex != null) {
-            installingDBCheckpoint = checkpoint;
+            setInstallingDBCheckpoint(checkpoint);
           }
           return termIndex;
         },

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
 import org.apache.hadoop.hdds.scm.ha.SCMHAConfiguration;
-import org.apache.hadoop.hdds.scm.ha.SCMHAManagerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMSnapshotProvider;
 import org.apache.hadoop.hdds.scm.ha.SCMStateMachine;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -122,7 +122,6 @@ public class TestSCMInstallSnapshot {
   public void testInstallCheckPoint() throws Exception {
     DBCheckpoint checkpoint = downloadSnapshot();
     StorageContainerManager scm = cluster.getStorageContainerManager();
-    SCMHAManagerImpl scmhaManager = (SCMHAManagerImpl)scm.getScmHAManager();
     DBStore db = HAUtils
         .loadDB(conf, checkpoint.getCheckpointLocation().getParent().toFile(),
             checkpoint.getCheckpointLocation().getFileName().toString(),

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -143,7 +143,7 @@ public class TestSCMInstallSnapshot {
     Assert.assertNull(
         scm.getScmMetadataStore().getPipelineTable().get(pipelineID));
     Assert.assertFalse(scm.getContainerManager().containerExist(cid));
-    scmhaManager.installCheckpoint("scm1", checkpoint);
+    scmhaManager.installCheckpoint(checkpoint);
 
     Assert.assertNotNull(
         scm.getScmMetadataStore().getPipelineTable().get(pipelineID));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -18,12 +18,12 @@ package org.apache.hadoop.ozone.scm;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -186,8 +187,13 @@ public class TestSCMInstallSnapshotWithHA {
     TermIndex followerTermIndex = followerSM.getLastAppliedTermIndex();
     SCMHAManagerImpl scmhaManager =
         (SCMHAManagerImpl) (followerSCM.getScmHAManager());
-    TermIndex newTermIndex =
-        scmhaManager.installCheckpoint(leaderNodeId, leaderDbCheckpoint);
+
+    TermIndex newTermIndex = null;
+    try {
+      newTermIndex = scmhaManager.installCheckpoint(leaderDbCheckpoint);
+    } catch (IOException ioe) {
+      // throw IOException as expected
+    }
 
     String errorMsg = "Reloading old state of SCM";
     Assert.assertTrue(logCapture.getOutput().contains(errorMsg));
@@ -201,18 +207,17 @@ public class TestSCMInstallSnapshotWithHA {
   @Test
   public void testInstallCorruptedCheckpointFailure() throws Exception {
     StorageContainerManager leaderSCM = getLeader(cluster);
-    String leaderNodeId = leaderSCM.getScmId();
     // Find the inactive SCM
     String followerId = getInactiveSCM(cluster).getScmId();
-    StorageContainerManager follower = cluster.getSCM(followerId);
+    StorageContainerManager followerSCM = cluster.getSCM(followerId);
     // Do some transactions so that the log index increases
     writeToIncreaseLogIndex(leaderSCM, 100);
     File oldDBLocation =
-        follower.getScmMetadataStore().getStore().getDbLocation();
+        followerSCM.getScmMetadataStore().getStore().getDbLocation();
 
-    SCMStateMachine sm =
-        follower.getScmHAManager().getRatisServer().getSCMStateMachine();
-    TermIndex termIndex = sm.getLastAppliedTermIndex();
+    SCMStateMachine followerSM =
+        followerSCM.getScmHAManager().getRatisServer().getSCMStateMachine();
+    TermIndex termIndex = followerSM.getLastAppliedTermIndex();
     DBCheckpoint leaderDbCheckpoint = leaderSCM.getScmMetadataStore().getStore()
         .getCheckpoint(false);
     Path leaderCheckpointLocation = leaderDbCheckpoint.getCheckpointLocation();
@@ -229,8 +234,8 @@ public class TestSCMInstallSnapshotWithHA {
     File checkpointBackup = new File(dbDir, dbBackupName);
 
     // Take a backup of the leader checkpoint
-    Files.copy(leaderCheckpointLocation.toAbsolutePath(),
-        checkpointBackup.toPath());
+    FileUtils.copyDirectory(leaderCheckpointLocation.toFile(),
+        checkpointBackup, false);
     // Corrupt the leader checkpoint and install that on the follower. The
     // operation should fail and  should shutdown.
     boolean delete = true;
@@ -247,29 +252,26 @@ public class TestSCMInstallSnapshotWithHA {
     }
 
     SCMHAManagerImpl scmhaManager =
-        (SCMHAManagerImpl) (follower.getScmHAManager());
+        (SCMHAManagerImpl) (followerSCM.getScmHAManager());
     GenericTestUtils.setLogLevel(SCMHAManagerImpl.getLogger(), Level.ERROR);
     GenericTestUtils.LogCapturer logCapture =
         GenericTestUtils.LogCapturer.captureLogs(SCMHAManagerImpl.getLogger());
     scmhaManager.setExitManagerForTesting(new DummyExitManager());
 
-    scmhaManager.installCheckpoint(leaderNodeId, leaderCheckpointLocation,
+    followerSM.pause();
+    scmhaManager.installCheckpoint(leaderCheckpointLocation,
         leaderCheckpointTrxnInfo);
 
     Assert.assertTrue(logCapture.getOutput()
         .contains("Failed to reload SCM state and instantiate services."));
-    Assert.assertTrue(sm.getLifeCycleState().isPausingOrPaused());
+    Assert.assertTrue(followerSM.getLifeCycleState().isPausingOrPaused());
 
     // Verify correct reloading
-    HAUtils
-        .replaceDBWithCheckpoint(leaderCheckpointTrxnInfo.getTransactionIndex(),
-            oldDBLocation, checkpointBackup.toPath(),
-            OzoneConsts.SCM_DB_BACKUP_PREFIX);
-    scmhaManager.startServices();
-    sm.unpause(leaderCheckpointTrxnInfo.getTerm(),
-        leaderCheckpointTrxnInfo.getTransactionIndex());
-    Assert.assertTrue(sm.getLastAppliedTermIndex()
-        .equals(leaderCheckpointTrxnInfo.getTermIndex()));
+    followerSM.setInstallingDBCheckpoint(
+        new RocksDBCheckpoint(checkpointBackup.toPath()));
+    followerSM.reinitialize();
+    Assert.assertEquals(followerSM.getLastAppliedTermIndex(),
+        leaderCheckpointTrxnInfo.getTermIndex());
   }
 
   private List<ContainerInfo> writeToIncreaseLogIndex(

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -153,7 +153,6 @@ public class TestSCMInstallSnapshotWithHA {
   public void testInstallOldCheckpointFailure() throws Exception {
     // Get the leader SCM
     StorageContainerManager leaderSCM = getLeader(cluster);
-    String leaderNodeId = leaderSCM.getScmNodeDetails().getNodeId();
     String followerId = getInactiveSCM(cluster).getScmId();
     // Find the inactive SCM
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As mentioned in https://issues.apache.org/jira/browse/RATIS-1370
During `notifyInstallSnapshotFromLeader`, `StateMachineUpdater` may call `applyTransactions` when StateMachine is in PAUSED state.
Just divide snapshot related work into `notifyInstallSnapshotFromLeader` and `reinitialize` for `SCMStateMachine`.

During `notifyInstallSnapshotFromLeader`, SCM just downloads snapshot but not modify StateMachine, since StateMachineUpdater is in RUNNING state, may call applyTransactions during this period.
During `reinitialize`, SCM can safely reload the StateMachine, such as rocksdb and in-memory state. During this period, StateMachineUpdater is in RELOAD state, thus there will be no contention between SCM and StateMachineUpdater.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5173

## How was this patch tested?

CI
