### PR TITLE
HDDS-5197. Pass option variables to OZONE_OPTS before adding default GC opts

### DIFF
--- a/hadoop-ozone/dist/src/shell/ozone/ozone
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone
@@ -290,14 +290,14 @@ ozone_assemble_classpath
 
 ozone_add_client_opts
 
-ozone_add_default_gc_opts
-
 if [[ ${OZONE_WORKER_MODE} = true ]]; then
   ozone_worker_mode_execute "${OZONE_HOME}/bin/ozone" "${OZONE_USER_PARAMS[@]}"
   exit $?
 fi
 
 ozone_subcommand_opts "${OZONE_SHELL_EXECNAME}" "${OZONE_SUBCMD}"
+
+ozone_add_default_gc_opts
 
 # everything is in globals at this point, so call the generic handler
 ozone_generic_java_subcmd_handler


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix an issue where `OZONE_*_OPTS` are not actually passed to daemon invocations.

## What is the link to the Apache JIRA

[HDDS-5197](https://issues.apache.org/jira/browse/HDDS-5197)

## How was this patch tested?

Partially tested in one of datanodes in our production environment.
