### PR TITLE
HDDS-5198. Remove JBoss repo definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,13 +47,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
     </repository>
-    <repository>
-      <id>repository.jboss.org</id>
-      <url>http://repository.jboss.org/nexus/content/groups/public/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
   </repositories>
 
   <licenses>


### PR DESCRIPTION
## What changes were proposed in this pull request?

[Maven 3.8.1](https://maven.apache.org/docs/3.8.1/release-notes.html) blocks http repos by default for security.  Github Actions runner environment was [already updated](https://github.com/actions/virtual-environments/commit/08dd8f3a6aca4ced2b7315b316f2e052e40af105) to this new version.  We need to fix the JBoss repo definition in `pom.xml`, either by changing to https or removing it completely.  I have tried building without Maven cache both ways, both were OK, all dependencies were found elsewhere.  So I think it is safe to remove it.

https://issues.apache.org/jira/browse/HDDS-5198

## How was this patch tested?

CI, with [Maven cache temporarily removed](https://github.com/adoroszlai/hadoop-ozone/commit/c4f3dfe701613ee864e4e90772a482af3d594d18):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/827254915

```
Apache Maven 3.8.1 (05c21c65bdfed0f71a2f2ada8b84da59348c4c5d)
```

https://github.com/adoroszlai/hadoop-ozone/runs/2543467878?check_suite_focus=true#step:5:9