### PR TITLE
HDDS-5200. Fix scm roles command if one of the host is unresolvable.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -229,10 +229,10 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   public List<String> getRatisRoles() throws IOException {
     Collection<RaftPeer> peers = division.getGroup().getPeers();
     List<String> ratisRoles = new ArrayList<>();
-    InetAddress peerInetAddress = null;
     for (RaftPeer peer : peers) {
+      InetAddress peerInetAddress = null;
       try {
-       peerInetAddress = InetAddress.getByName(
+        peerInetAddress = InetAddress.getByName(
             HddsUtils.getHostName(peer.getAddress()).get());
       } catch (IOException ex) {
         LOG.error("SCM Ratis PeerInetAddress {} is unresolvable",
@@ -244,10 +244,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       }
       ratisRoles.add((peer.getAddress() == null ? "" :
               peer.getAddress().concat(isLocal ?
-                      ":".concat(RaftProtos.RaftPeerRole.LEADER
-                              .toString()) :
-                      ":".concat(RaftProtos.RaftPeerRole.FOLLOWER
-                              .toString()))));
+                  ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
+                  ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))));
     }
     return ratisRoles;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -229,10 +229,19 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   public List<String> getRatisRoles() throws IOException {
     Collection<RaftPeer> peers = division.getGroup().getPeers();
     List<String> ratisRoles = new ArrayList<>();
+    InetAddress peerInetAddress = null;
     for (RaftPeer peer : peers) {
-      InetAddress peerInetAddress = InetAddress.getByName(
-              HddsUtils.getHostName(peer.getAddress()).get());
-      boolean isLocal = NetUtils.isLocalAddress(peerInetAddress);
+      try {
+       peerInetAddress = InetAddress.getByName(
+            HddsUtils.getHostName(peer.getAddress()).get());
+      } catch (IOException ex) {
+        LOG.error("SCM Ratis PeerInetAddress {} is unresolvable",
+            peer.getAddress());
+      }
+      boolean isLocal = false;
+      if (peerInetAddress != null) {
+        isLocal = NetUtils.isLocalAddress(peerInetAddress);
+      }
       ratisRoles.add((peer.getAddress() == null ? "" :
               peer.getAddress().concat(isLocal ?
                       ":".concat(RaftProtos.RaftPeerRole.LEADER


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make roles command work when SCM host is unresolvable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5200

## How was this patch tested?

Manually verified the fix.

```
docker ps
CONTAINER ID        IMAGE                            COMMAND                  CREATED              STATUS              PORTS                                              NAMES
d3c720b431aa        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32787->9876/tcp                            ozone-ha_scm1_1
ddf8f150611b        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32789->9862/tcp, 0.0.0.0:32786->9874/tcp   ozone-ha_om1_1
f3a1418485bd        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:9888->9888/tcp                             ozone-ha_recon_1
2f4a2f393127        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32785->9864/tcp, 0.0.0.0:32784->9882/tcp   ozone-ha_datanode_1
0b5ea19f8ca3        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32783->9876/tcp                            ozone-ha_scm3_1
aedb5cfe6e37        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32788->9876/tcp                            ozone-ha_scm2_1
8d184f6a3a74        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:9878->9878/tcp                             ozone-ha_s3g_1
4e0ef145f512        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32782->9862/tcp, 0.0.0.0:32781->9874/tcp   ozone-ha_om2_1
d804683767dc        apache/ozone-runner:20210329-1   "/usr/local/bin/dumb…"   About a minute ago   Up About a minute   0.0.0.0:32780->9862/tcp, 0.0.0.0:32779->9874/tcp   ozone-ha_om3_1
#Kill scm1
$ docker stop d3c720b431aa
d3c720b431aa
$ docker exec -it ddf8f150611b bash
bash-4.2$ ozone admin scm roles --service-id=scmservice
SCM address scm1:9860 for serviceID scmservice remains unresolved for node ID scm1 Check your ozone-site.xml file to ensure scm addresses are configured properly.
[scm3:9865:FOLLOWER, scm1:9865:FOLLOWER, scm2:9865:LEADER]
```
