### PR TITLE
HDDS-5202. Use scm#checkLeader before processing client requests .

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -104,7 +104,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   @Override
   public SCMBlockLocationResponse send(RpcController controller,
       SCMBlockLocationRequest request) throws ServiceException {
-    if (!scm.getScmContext().isLeader()) {
+    if (!scm.checkLeader()) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),
           scm.getBlockProtocolRpcPort(), scm.getScmId());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -145,7 +145,7 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   public ScmContainerLocationResponse submitRequest(RpcController controller,
       ScmContainerLocationRequest request) throws ServiceException {
     // not leader or not belong to admin command.
-    if (!scm.getScmContext().isLeader()
+    if (!scm.checkLeader()
         && !ADMIN_COMMAND_TYPE.contains(request.getCmdType())) {
       RatisUtil.checkRatisException(
           scm.getScmHAManager().getRatisServer().triggerNotLeaderException(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1471,8 +1471,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     } else {
       // FOR HA setup, the node has to be the leader and ready to serve
       // requests.
-      return scmContext.isLeader() && getScmHAManager().getRatisServer()
-          .getDivision().getInfo().isLeaderReady();
+      return getScmHAManager().getRatisServer().getDivision().getInfo()
+          .isLeaderReady();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCM server should start accepting requests when it is leader and isLeaderReady.

We need isLeaderReady also because Statemachine should apply all the log committed transactions to start accepting requests.

So, instead of scmContext#isLeader, use scm#checkLeader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5202

## How was this patch tested?

Existing CI
