### PR TITLE
HDDS-5203. Allow suppressing deprecation warning for HADOOP_ variables

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/cli/envvars.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/cli/envvars.robot
@@ -66,6 +66,21 @@ Picks up deprecated vars if valid
                         Should contain   ${output}   WARNING: HADOOP_HOME
                         Should contain   ${output}   WARNING: HADOOP_CONF_DIR
 
+Warning for deprecated vars can be suppressed
+    Set Environment Variable       OZONE_DEPRECATION_WARNING    false
+    Set Environment Variable       HADOOP_HOME           /opt/hadoop
+    Set Environment Variable       HADOOP_LIBEXEC_DIR    %{HADOOP_HOME}/libexec
+    Set Environment Variable       HADOOP_CONF_DIR       /etc/hadoop
+    Remove Environment Variable    OZONE_HOME
+    Remove Environment Variable    OZONE_CONF_DIR
+    ${output} =         Execute          ozone envvars
+                        Should contain   ${output}   OZONE_HOME='%{HADOOP_HOME}'
+                        Should contain   ${output}   HDDS_LIB_JARS_DIR='%{HADOOP_HOME}/share/ozone/lib'
+                        Should contain   ${output}   OZONE_CONF_DIR='/etc/hadoop'
+                        Should Contain   ${output}   OZONE_LIBEXEC_DIR='%{HADOOP_HOME}/libexec'
+                        Should Not Contain   ${output}   WARNING: HADOOP_HOME
+                        Should Not Contain   ${output}   WARNING: HADOOP_CONF_DIR
+
 Works with only OZONE_HOME defined
     Remove Environment Variable    HADOOP_HOME
     Remove Environment Variable    HADOOP_CONF_DIR

--- a/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
+++ b/hadoop-ozone/dist/src/shell/ozone/ozone-functions.sh
@@ -2722,7 +2722,8 @@ function ozone_deprecate_envvar
   local oldvar=$1
   local newvar=$2
 
-  if ozone_set_var_for_compatibility "$newvar" "$oldvar"; then
+  if ozone_set_var_for_compatibility "$newvar" "$oldvar" && \
+    [[ "${OZONE_DEPRECATION_WARNING:-true}" != "false" ]]; then
     ozone_error "WARNING: ${oldvar} has been deprecated by ${newvar}."
   fi
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-4525 deprecated `HADOOP_*` variables in Ozone in favor of corresponding `OZONE_*` variables.  This change allows suppressing the deprecation warning by setting `OZONE_DEPRECATION_WARNING=false`.

https://issues.apache.org/jira/browse/HDDS-5203

## How was this patch tested?

Added new acceptance test case for `OZONE_DEPRECATION_WARNING=false`.

https://github.com/adoroszlai/hadoop-ozone/runs/2544900937#step:6:870