### PR TITLE
HDDS-5189. fix markdown files to make them hugo83 compatible (and valid)

### DIFF
--- a/hadoop-hdds/docs/content/interface/ReconApi.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.md
@@ -6,7 +6,6 @@ menu:
       parent: "Client Interfaces"
 summary: Recon server supports HTTP endpoints to help troubleshoot and monitor Ozone cluster.
 ---
-
 <!---
   Licensed to the Apache Software Foundation (ASF) under one or more
   contributor license agreements.  See the NOTICE file distributed with
@@ -27,32 +26,25 @@ summary: Recon server supports HTTP endpoints to help troubleshoot and monitor O
 The Recon API v1 is a set of HTTP endpoints that help you understand the current 
 state of an Ozone cluster and to troubleshoot if needed. 
 
-### HTTP Endpoints
+## Containers 
 
-#### Containers
+### GET /api/v1/containers
 
-* **/containers**
+**Parameters**
 
-    **URL Structure** 
-    ```
-    GET /api/v1/containers
-    ```
+* prevKey (optional)
 
-    **Parameters**
+    Only returns the containers with ID greater than the given prevKey.
+    Example: prevKey=1
     
-    * prevKey (optional)
-    
-        Only returns the containers with ID greater than the given prevKey.
-        Example: prevKey=1
-        
-    * limit (optional)
-    
-        Only returns the limited number of results. The default limit is 1000.
-    
-    **Returns**
-    
-    Returns all the ContainerMetadata objects.
-    
+* limit (optional)
+
+    Only returns the limited number of results. The default limit is 1000.
+
+**Returns**
+
+Returns all the ContainerMetadata objects.
+
 ```json
     {
       "data": {
@@ -73,29 +65,24 @@ state of an Ozone cluster and to troubleshoot if needed.
         ]
       }
     }
-    ```
+```
 
-* **/containers/:id/keys**
+### GET /api/v1/containers/:id/keys
 
-    **URL Structure** 
-    ```
-    GET /api/v1/containers/:id/keys
-    ```
+**Parameters**
 
-    **Parameters**
+* prevKey (optional)
+
+    Only returns the keys that are present after the given prevKey key prefix.
+    Example: prevKey=/vol1/bucket1/key1
     
-    * prevKey (optional)
-    
-        Only returns the keys that are present after the given prevKey key prefix.
-        Example: prevKey=/vol1/bucket1/key1
-        
-    * limit (optional)
-    
-        Only returns the limited number of results. The default limit is 1000.  
-    
-    **Returns**
-    
-    Returns all the KeyMetadata objects for the given ContainerID.
+* limit (optional)
+
+    Only returns the limited number of results. The default limit is 1000.  
+
+**Returns**
+
+Returns all the KeyMetadata objects for the given ContainerID.
     
 ```json
     {
@@ -121,22 +108,17 @@ state of an Ozone cluster and to troubleshoot if needed.
         ...
       ]
     }
-    ```
+```
 
-* **/containers/missing**
+### GET /api/v1/containers/missing
 
-    **URL Structure** 
-    ```
-    GET /api/v1/containers/missing
-    ```
+**Parameters**
 
-    **Parameters**
-    
-    No parameters.  
-    
-    **Returns**
-    
-    Returns the MissingContainerMetadata objects for all the missing containers.
+No parameters.  
+
+**Returns**
+
+Returns the MissingContainerMetadata objects for all the missing containers.
     
 ```json
     {
@@ -158,22 +140,17 @@ state of an Ozone cluster and to troubleshoot if needed.
         ...
         ]
     }
-    ``` 
+``` 
   
-* **/containers/:id/replicaHistory**
+### GET /api/v1/containers/:id/replicaHistory
 
-    **URL Structure** 
-    ```
-    GET /api/v1/containers/:id/replicaHistory
-    ```
+**Parameters**
 
-    **Parameters**
-    
-    No parameters.  
-    
-    **Returns**
-    
-    Returns all the ContainerHistory objects for the given ContainerID.
+No parameters.  
+
+**Returns**
+
+Returns all the ContainerHistory objects for the given ContainerID.
     
 ```json
     [
@@ -185,30 +162,26 @@ state of an Ozone cluster and to troubleshoot if needed.
       },
       ...
     ]
-    ```
- 
-* **/containers/unhealthy**
- 
-     **URL Structure** 
-```
-     GET /api/v1/containers/unhealthy
 ```
  
-     **Parameters**
-     
-     * batchNum (optional)
-     
-         The batch number (like "page number") of results to return.
-         Passing 1, will return records 1 to limit. 2 will return
-         limit + 1 to 2 * limit, etc.
-         
-     * limit (optional)
-     
-         Only returns the limited number of results. The default limit is 1000.  
-     
-     **Returns**
-     
-     Returns the UnhealthyContainerMetadata objects for all the unhealthy containers.
+### GET /api/v1/containers/unhealthy
+
+ 
+**Parameters**
+
+* batchNum (optional)
+
+    The batch number (like "page number") of results to return.
+    Passing 1, will return records 1 to limit. 2 will return
+    limit + 1 to 2 * limit, etc.
+    
+* limit (optional)
+
+    Only returns the limited number of results. The default limit is 1000.  
+
+**Returns**
+
+Returns the UnhealthyContainerMetadata objects for all the unhealthycontainers.
      
 ```json
      {
@@ -240,47 +213,37 @@ state of an Ozone cluster and to troubleshoot if needed.
      } 
 ```
 
-* **/containers/unhealthy/:state**
+### GET /api/v1/containers/unhealthy/:state
  
-     **URL Structure** 
-```
-     GET /api/v1/containers/unhealthy/:state
-```
- 
-     **Parameters**
-     
-     * batchNum (optional)
-          
-        The batch number (like "page number") of results to return.
-        Passing 1, will return records 1 to limit. 2 will return
-        limit + 1 to 2 * limit, etc.
-      
-     * limit (optional)
-    
-        Only returns the limited number of results. The default limit is 1000.  
-     
-     **Returns**
-     
-     Returns the UnhealthyContainerMetadata objects for the containers in the given state.
-     Possible unhealthy container states are `MISSING`, `MIS_REPLICATED`, `UNDER_REPLICATED`, `OVER_REPLICATED`.
-     The response structure is same as `/containers/unhealthy`.
-     
-#### ClusterState
+**Parameters**
 
-* **/clusterState**
+* batchNum (optional)
+     
+   The batch number (like "page number") of results to return.
+   Passing 1, will return records 1 to limit. 2 will return
+   limit + 1 to 2 * limit, etc.
  
-     **URL Structure** 
-```
-     GET /api/v1/clusterState
-```
+* limit (optional)
+
+   Only returns the limited number of results. The default limit is 1000.  
+
+**Returns**
+
+Returns the UnhealthyContainerMetadata objects for the containers in the givenstate.
+Possible unhealthy container states are `MISSING`, `MIS_REPLICATED`,`UNDER_REPLICATED`, `OVER_REPLICATED`.
+The response structure is same as `/containers/unhealthy`.
+     
+## ClusterState
+
+### GET /api/v1/clusterState
  
-     **Parameters**
-     
-     No parameters.  
-     
-     **Returns**
-     
-     Returns a summary of the current state of the Ozone cluster.
+**Parameters**
+
+No parameters.  
+
+**Returns**
+
+Returns a summary of the current state of the Ozone cluster.
 
 ```json
      {
@@ -299,22 +262,17 @@ state of an Ozone cluster and to troubleshoot if needed.
      }
 ```
 
-#### Datanodes
+## Datanodes
 
-* **/datanodes**
+### GET /api/v1/datanodes
  
-     **URL Structure** 
-```
-     GET /api/v1/datanodes
-```
- 
-     **Parameters**
-     
-     No parameters.  
-     
-     **Returns**
-     
-     Returns all the datanodes in the cluster.
+**Parameters**
+
+No parameters.  
+
+**Returns**
+
+Returns all the datanodes in the cluster.
 
 ```json
      {
@@ -348,22 +306,17 @@ state of an Ozone cluster and to troubleshoot if needed.
      }
 ```
   
-#### Pipelines
+## Pipelines
 
-* **/pipelines**
+### GET /api/v1/pipelines
  
-     **URL Structure** 
-```
-     GET /api/v1/pipelines
-```
- 
-     **Parameters**
-     
-     No parameters.  
-     
-     **Returns**
-     
-     Returns all the pipelines in the cluster.
+**Parameters**
+
+No parameters.  
+
+**Returns**
+
+Returns all the pipelines in the cluster.
 
 ```json
      {
@@ -385,22 +338,17 @@ state of an Ozone cluster and to troubleshoot if needed.
      }
 ```
   
-#### Tasks
+## Tasks
 
-* **/task/status**
+### GET /api/v1/task/status
  
-     **URL Structure** 
-```
-     GET /api/v1/task/status
-```
- 
-     **Parameters**
-     
-     No parameters.  
-     
-     **Returns**
-     
-     Returns the status of all the Recon tasks.
+**Parameters**
+
+No parameters.  
+
+**Returns**
+
+Returns the status of all the Recon tasks.
 
 ```json
      [
@@ -413,33 +361,28 @@ state of an Ozone cluster and to troubleshoot if needed.
      ]
 ```
 
-#### Utilization
+## Utilization
 
-* **/utilization/fileCount**
+### GET /api/v1/utilization/fileCount
  
-     **URL Structure** 
-```
-     GET /api/v1/utilization/fileCount
-```
+**Parameters**
+
+* volume (optional)
+     
+   Filters the results based on the given volume name.
  
-     **Parameters**
-     
-     * volume (optional)
-          
-        Filters the results based on the given volume name.
-      
-     * bucket (optional)
-    
-        Filters the results based on the given bucket name.
-        
-     * fileSize (optional)
-     
-        Filters the results based on the given fileSize.
-     
-     **Returns**
-     
-     Returns the file counts within different file ranges with `fileSize` in the
-     response object being the upper cap for file size range. 
+* bucket (optional)
+
+   Filters the results based on the given bucket name.
+   
+* fileSize (optional)
+
+   Filters the results based on the given fileSize.
+
+**Returns**
+
+Returns the file counts within different file ranges with `fileSize` in the
+response object being the upper cap for file size range. 
 
 ```json
      [{
@@ -465,25 +408,20 @@ state of an Ozone cluster and to troubleshoot if needed.
      }]
 ```
   
-#### <a name="metrics"></a> Metrics
+## Metrics
 
-* **/metrics/:api**
+### GET /api/v1/metrics/:api
  
-     **URL Structure** 
-```
-     GET /api/v1/metrics/:api
-```
- 
-     **Parameters**
-     
-     Refer to [Prometheus HTTP API Reference](https://prometheus.io/docs/prometheus/latest/querying/api/) 
-     for complete documentation on querying. 
-     
-     **Returns**
-     
-     This is a proxy endpoint for Prometheus and returns the same response as 
-     the prometheus endpoint. 
-     Example: /api/v1/metrics/query?query=ratis_leader_election_electionCount
+**Parameters**
+
+Refer to [Prometheus HTTP API Reference](https://prometheus.io/docs/prometheuslatest/querying/api/) 
+for complete documentation on querying. 
+
+**Returns**
+
+This is a proxy endpoint for Prometheus and returns the same response as 
+the prometheus endpoint. 
+Example: /api/v1/metrics/query?query=ratis_leader_election_electionCount
 
 ```json
      {

--- a/hadoop-hdds/docs/content/interface/ReconApi.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.md
@@ -53,7 +53,7 @@ state of an Ozone cluster and to troubleshoot if needed.
     
     Returns all the ContainerMetadata objects.
     
-    ```json
+```json
     {
       "data": {
         "totalCount": 3,
@@ -97,7 +97,7 @@ state of an Ozone cluster and to troubleshoot if needed.
     
     Returns all the KeyMetadata objects for the given ContainerID.
     
-    ```json
+```json
     {
       "totalCount":7,
       "keys": [
@@ -138,7 +138,7 @@ state of an Ozone cluster and to troubleshoot if needed.
     
     Returns the MissingContainerMetadata objects for all the missing containers.
     
-    ```json
+```json
     {
     	"totalCount": 26,
     	"containers": [{
@@ -175,7 +175,7 @@ state of an Ozone cluster and to troubleshoot if needed.
     
     Returns all the ContainerHistory objects for the given ContainerID.
     
-    ```json
+```json
     [
       {
         "containerId": 1,
@@ -190,9 +190,9 @@ state of an Ozone cluster and to troubleshoot if needed.
 * **/containers/unhealthy**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/containers/unhealthy
-     ```
+```
  
      **Parameters**
      
@@ -210,7 +210,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      
      Returns the UnhealthyContainerMetadata objects for all the unhealthy containers.
      
-     ```json
+```json
      {
      	"missingCount": 2,
      	"underReplicatedCount": 0,
@@ -238,14 +238,14 @@ state of an Ozone cluster and to troubleshoot if needed.
         ...
         ]
      } 
-     ```
+```
 
 * **/containers/unhealthy/:state**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/containers/unhealthy/:state
-     ```
+```
  
      **Parameters**
      
@@ -270,9 +270,9 @@ state of an Ozone cluster and to troubleshoot if needed.
 * **/clusterState**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/clusterState
-     ```
+```
  
      **Parameters**
      
@@ -282,7 +282,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      
      Returns a summary of the current state of the Ozone cluster.
 
-     ```json
+```json
      {
      	"pipelines": 5,
      	"totalDatanodes": 4,
@@ -297,16 +297,16 @@ state of an Ozone cluster and to troubleshoot if needed.
      	"buckets": 26,
      	"keys": 25
      }
-     ```
+```
 
 #### Datanodes
 
 * **/datanodes**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/datanodes
-     ```
+```
  
      **Parameters**
      
@@ -316,7 +316,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      
      Returns all the datanodes in the cluster.
 
-     ```json
+```json
      {
      	"totalCount": 4,
      	"datanodes": [{
@@ -346,16 +346,16 @@ state of an Ozone cluster and to troubleshoot if needed.
         ...
         ]
      }
-     ```
+```
   
 #### Pipelines
 
 * **/pipelines**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/pipelines
-     ```
+```
  
      **Parameters**
      
@@ -365,7 +365,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      
      Returns all the pipelines in the cluster.
 
-     ```json
+```json
      {
      	"totalCount": 5,
      	"pipelines": [{
@@ -383,16 +383,16 @@ state of an Ozone cluster and to troubleshoot if needed.
         ...
         ]
      }
-     ```
+```
   
 #### Tasks
 
 * **/task/status**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/task/status
-     ```
+```
  
      **Parameters**
      
@@ -402,7 +402,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      
      Returns the status of all the Recon tasks.
 
-     ```json
+```json
      [
        {
      	"taskName": "OmDeltaRequest",
@@ -411,16 +411,16 @@ state of an Ozone cluster and to troubleshoot if needed.
        },
        ...
      ]
-     ```
+```
 
 #### Utilization
 
 * **/utilization/fileCount**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/utilization/fileCount
-     ```
+```
  
      **Parameters**
      
@@ -441,7 +441,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      Returns the file counts within different file ranges with `fileSize` in the
      response object being the upper cap for file size range. 
 
-     ```json
+```json
      [{
      	"volume": "vol-2-04168",
      	"bucket": "bucket-0-11685",
@@ -463,16 +463,16 @@ state of an Ozone cluster and to troubleshoot if needed.
      	"fileSize": 1024,
      	"count": 2
      }]
-     ```
+```
   
 #### <a name="metrics"></a> Metrics
 
 * **/metrics/:api**
  
      **URL Structure** 
-     ```
+```
      GET /api/v1/metrics/:api
-     ```
+```
  
      **Parameters**
      
@@ -485,7 +485,7 @@ state of an Ozone cluster and to troubleshoot if needed.
      the prometheus endpoint. 
      Example: /api/v1/metrics/query?query=ratis_leader_election_electionCount
 
-     ```json
+```json
      {
        "status": "success",
        "data": {
@@ -507,5 +507,5 @@ state of an Ozone cluster and to troubleshoot if needed.
          ]
        }
      }
-     ```
+```
   

--- a/hadoop-hdds/docs/content/interface/ReconApi.zh.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.zh.md
@@ -26,32 +26,23 @@ summary: Recon 服务器支持 HTTP 端点，以帮助故障排除和监听 Ozon
 
 Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前状态，并在需要时进行故障排除。
 
-### HTTP 端点
+## 容器
 
-#### 容器
+### GET /api/v1/containers
 
-* **/containers**
+**参数**
+* prevKey (可选)
 
-    **URL 结构**
-```
-    GET /api/v1/containers
-```
+    只回传ID大于给定的 prevKey 的容器。
+    示例：prevKey=1
+* limit (可选)
 
-    **参数**
+    只回传有限数量的结果。默认限制是1000。
 
-    * prevKey (可选)
-    
-        只回传ID大于给定的 prevKey 的容器。
-        示例：prevKey=1
+**回传**
 
-    * limit (可选)
-    
-        只回传有限数量的结果。默认限制是1000。
-    
-    **回传**
-    
-    回传所有 ContainerMetadata 对象。
-    
+回传所有 ContainerMetadata 对象。
+
 ```json
     {
       "data": {
@@ -74,27 +65,22 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     }
 ```
 
-* **/containers/:id/keys**
+### GET /api/v1/containers/:id/keys
+    
+**参数**
 
-    **URL 结构**
-```
-    GET /api/v1/containers/:id/keys
-```
+* prevKey (可选)
+ 
+    只回传在给定的 prevKey 键前缀之后的键。
+    示例：prevKey=/vol1/bucket1/key1
     
-    **参数**
+* limit (可选)
+
+    只回传有限数量的结果。默认限制是1000。
     
-    * prevKey (可选)
-     
-        只回传在给定的 prevKey 键前缀之后的键。
-        示例：prevKey=/vol1/bucket1/key1
-        
-    * limit (可选)
-    
-        只回传有限数量的结果。默认限制是1000。
-        
-    **回传**
-    
-    回传给定容器 ID 的所有 KeyMetadata 对象。
+**回传**
+
+回传给定容器 ID 的所有 KeyMetadata 对象。
     
 ```json
     {
@@ -121,20 +107,15 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
       ]
     }
 ```
-* **/containers/missing**
-    
-    **URL 结构**
-```
-    GET /api/v1/containers/missing
-```
-    
-    **参数**
-    
-    没有参数。
-    
-    **回传**
-    
-    回传所有丢失容器的 MissingContainerMetadata 对象。
+### GET /api/v1/containers/missing
+
+**参数**
+
+没有参数。
+
+**回传**
+
+回传所有丢失容器的 MissingContainerMetadata 对象。
     
 ```json
     {
@@ -157,20 +138,14 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ]
     }
 ```
-* **/containers/:id/replicaHistory**
+### GET /api/v1/containers/:id/replicaHistory
+    
+**参数**
 
-    **URL 结构**
-```
-    GET /api/v1/containers/:id/replicaHistory
-```
-    
-    **参数**
-    
-    没有参数。
-    
-    **回传**
+没有参数。
 
-    回传给定容器 ID 的所有 ContainerHistory 对象。
+**回传**
+回传给定容器 ID 的所有 ContainerHistory 对象。
     
 ```json
     [
@@ -183,29 +158,23 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
       ...
     ]
 ```
-* **/containers/unhealthy**
-
-    **URL 结构**
- ```
-     GET /api/v1/containers/unhealthy
- ```
+### GET /api/v1/containers/unhealthy
      
-    **参数**
-    
-    * batchNum (可选)
+**参数**
 
-        回传结果的批号(如“页码”)。
-        传递1，将回传记录1到limit。传递2，将回传limit + 1到2 * limit，依此类推。
-        
-    * limit (可选)
+* batchNum (可选)
+    回传结果的批号(如“页码”)。
+    传递1，将回传记录1到limit。传递2，将回传limit + 1到2 * limit，依此类推。
     
-        只回传有限数量的结果。默认限制是1000。
-        
-    **回传**
+* limit (可选)
+
+    只回传有限数量的结果。默认限制是1000。
     
-    回传所有不健康容器的 UnhealthyContainerMetadata 对象。
-    
- ```json
+**回传**
+
+回传所有不健康容器的 UnhealthyContainerMetadata 对象。
+
+```json
      {
      	"missingCount": 2,
      	"underReplicatedCount": 0,
@@ -233,50 +202,40 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      } 
- ```
-     
-* **/containers/unhealthy/:state**
-
-    **URL 结构**
-```
-    GET /api/v1/containers/unhealthy/:state
 ```
      
-    **参数**
-    
-    * batchNum (可选)
-    
-        回传结果的批号(如“页码”)。
-        传递1，将回传记录1到limit。传递2，将回传limit + 1到2 * limit，依此类推。
-        
-    * limit (可选)
-    
-        只回传有限数量的结果。默认限制是1000。
-        
-    **回传**
-    
-    回传处于给定状态的容器的 UnhealthyContainerMetadata 对象。
-    不健康的容器状态可能为`MISSING`, `MIS_REPLICATED`, `UNDER_REPLICATED`, `OVER_REPLICATED`。
-    响应结构与`/containers/unhealthy`相同。
-    
-#### 集群状态
-
-* **/clusterState**
-
-    **URL 结构**
-```
-    GET /api/v1/clusterState
-```
+### GET /api/v1/containers/unhealthy/:state
      
-    **参数**
+**参数**
+
+* batchNum (可选)
+
+    回传结果的批号(如“页码”)。
+    传递1，将回传记录1到limit。传递2，将回传limit + 1到2 * limit，依此类推。
     
-    没有参数。
+* limit (可选)
+
+    只回传有限数量的结果。默认限制是1000。
     
-    **回传**
+**回传**
+
+回传处于给定状态的容器的 UnhealthyContainerMetadata 对象。
+不健康的容器状态可能为`MISSING`, `MIS_REPLICATED`, `UNDER_REPLICATED`,`OVER_REPLICATED`。
+响应结构与`/containers/unhealthy`相同。
     
-    返回 Ozone 集群当前状态的摘要。
+## 集群状态
+
+### GET /api/v1/clusterState
+     
+**参数**
+
+没有参数。
+
+**回传**
+
+返回 Ozone 集群当前状态的摘要。
     
- ```json
+```json
      {
      	"pipelines": 5,
      	"totalDatanodes": 4,
@@ -291,24 +250,19 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
      	"buckets": 26,
      	"keys": 25
      }
- ```
+```
      
-#### 数据节点
+## 数据节点
 
-* **/datanodes**
+### GET /api/v1/datanodes
+    
+**参数**
 
-    **URL 结构**
-```
-    GET /api/v1/datanodes
-```
-    
-    **参数**
-    
-    没有参数。
-    
-    **回传**
-    
-    回传集群中的所有数据节点。
+没有参数。
+
+**回传**
+
+回传集群中的所有数据节点。
     
 ```json
     {
@@ -340,23 +294,19 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      }
- ```
+```
      
-#### 管道
+## 管道
 
-* **/pipelines**
+### GET /api/v1/pipelines
 
-    **URL 结构**
-```
-    GET /api/v1/pipelines
-```
-    **参数**
-    
-    没有参数
-    
-    **回传**
-    
-    回传在集群中的所有管道。
+**参数**
+
+没有参数
+
+**回传**
+
+回传在集群中的所有管道。
     
 ```json
      {
@@ -376,24 +326,19 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      }
- ```  
+```  
 
-#### 任务
+## 任务
 
-* **/task/status**
+### GET /api/v1/task/status
+    
+**参数**
 
-    **URL 结构**
-```
-    GET /api/v1/task/status
-```
-    
-    **参数**
-    
-    没有参数
-    
-    **回传**
-    
-    回传所有 Recon 任务的状态。
+没有参数
+
+**回传**
+
+回传所有 Recon 任务的状态。
   
 ```json
      [
@@ -406,32 +351,26 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
      ]
 ```
     
-#### 使用率
+## 使用率
 
-* **/utilization/fileCount**
+### GET /api/v1/utilization/fileCount
+    
+**参数**
 
-    **URL 结构**
-```
-    GET /api/v1/utilization/fileCount
-```
-    
-    **参数**
-    
-    * volume (可选)
-    
-        根据给定的卷名过滤结果。
-        
-    * bucket (可选)
-    
-        根据给定的桶名过滤结果。
-        
-    * fileSize (可选)
+* volume (可选)
 
-        根据给定的文件大小筛选结果。
-        
-    **回传**
+    根据给定的卷名过滤结果。
     
-    回传不同文件范围内的文件计数，其中响应对象中的`fileSize`是文件大小范围的上限。
+* bucket (可选)
+
+    根据给定的桶名过滤结果。
+    
+* fileSize (可选)
+    根据给定的文件大小筛选结果。
+    
+**回传**
+
+回传不同文件范围内的文件计数，其中响应对象中的`fileSize`是文件大小范围的上限。
     
 ```json
      [{
@@ -457,25 +396,20 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
      }]
 ```
     
-#### <a name="metrics"></a> 指标
+## 指标
 
-* **/metrics/:api**
-
-    **URL 结构**
-```
-    GET /api/v1/metrics/:api
-```
+### GET /api/v1/metrics/:api
     
-    **参数**
+**参数**
 
-    请参阅 [Prometheus HTTP API 参考](https://prometheus.io/docs/prometheus/latest/querying/api/) 以获取完整的查询文档。
+请参阅 [Prometheus HTTP API 参考](https://prometheus.io/docs/prometheus/latestquerying/api/) 以获取完整的查询文档。
 
-    **回传**
+**回传**
 
-    这是 Prometheus 的代理端点，并回传与 Prometheus 端点相同的响应。
-    示例：/api/v1/metrics/query?query=ratis_leader_election_electionCount
+这是 Prometheus 的代理端点，并回传与 Prometheus 端点相同的响应。
+示例：/api/v1/metrics/query?query=ratis_leader_election_electionCount
     
- ```json
+```json
      {
        "status": "success",
        "data": {
@@ -497,6 +431,6 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
          ]
        }
      }
- ```
+```
 
 

--- a/hadoop-hdds/docs/content/interface/ReconApi.zh.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.zh.md
@@ -33,9 +33,9 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
 * **/containers**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/containers
-    ```
+```
 
     **参数**
 
@@ -52,7 +52,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传所有 ContainerMetadata 对象。
     
-    ```json
+```json
     {
       "data": {
         "totalCount": 3,
@@ -72,14 +72,14 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ]
       }
     }
-    ```
+```
 
 * **/containers/:id/keys**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/containers/:id/keys
-    ```
+```
     
     **参数**
     
@@ -96,7 +96,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传给定容器 ID 的所有 KeyMetadata 对象。
     
-    ```json
+```json
     {
       "totalCount":7,
       "keys": [
@@ -120,13 +120,13 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
       ]
     }
-    ```
+```
 * **/containers/missing**
     
     **URL 结构**
-    ```
+```
     GET /api/v1/containers/missing
-    ```
+```
     
     **参数**
     
@@ -136,7 +136,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传所有丢失容器的 MissingContainerMetadata 对象。
     
-    ```json
+```json
     {
     	"totalCount": 26,
     	"containers": [{
@@ -156,13 +156,13 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
     }
-    ```
+```
 * **/containers/:id/replicaHistory**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/containers/:id/replicaHistory
-    ```
+```
     
     **参数**
     
@@ -172,7 +172,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
 
     回传给定容器 ID 的所有 ContainerHistory 对象。
     
-    ```json
+```json
     [
       {
         "containerId": 1,
@@ -182,13 +182,13 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
       },
       ...
     ]
-    ```
+```
 * **/containers/unhealthy**
 
     **URL 结构**
-     ```
+ ```
      GET /api/v1/containers/unhealthy
-     ```
+ ```
      
     **参数**
     
@@ -205,7 +205,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传所有不健康容器的 UnhealthyContainerMetadata 对象。
     
-     ```json
+ ```json
      {
      	"missingCount": 2,
      	"underReplicatedCount": 0,
@@ -233,14 +233,14 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      } 
-     ```
+ ```
      
 * **/containers/unhealthy/:state**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/containers/unhealthy/:state
-    ```
+```
      
     **参数**
     
@@ -264,9 +264,9 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
 * **/clusterState**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/clusterState
-    ```
+```
      
     **参数**
     
@@ -276,7 +276,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     返回 Ozone 集群当前状态的摘要。
     
-     ```json
+ ```json
      {
      	"pipelines": 5,
      	"totalDatanodes": 4,
@@ -291,16 +291,16 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
      	"buckets": 26,
      	"keys": 25
      }
-     ```
+ ```
      
 #### 数据节点
 
 * **/datanodes**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/datanodes
-    ```
+```
     
     **参数**
     
@@ -310,7 +310,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传集群中的所有数据节点。
     
-    ```json
+```json
     {
      	"totalCount": 4,
      	"datanodes": [{
@@ -340,16 +340,16 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      }
-     ```
+ ```
      
 #### 管道
 
 * **/pipelines**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/pipelines
-    ```
+```
     **参数**
     
     没有参数
@@ -358,7 +358,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传在集群中的所有管道。
     
-    ```json
+```json
      {
      	"totalCount": 5,
      	"pipelines": [{
@@ -376,16 +376,16 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
         ...
         ]
      }
-     ```  
+ ```  
 
 #### 任务
 
 * **/task/status**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/task/status
-    ```
+```
     
     **参数**
     
@@ -395,7 +395,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传所有 Recon 任务的状态。
   
-    ```json
+```json
      [
        {
      	"taskName": "OmDeltaRequest",
@@ -404,16 +404,16 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
        },
        ...
      ]
-    ```
+```
     
 #### 使用率
 
 * **/utilization/fileCount**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/utilization/fileCount
-    ```
+```
     
     **参数**
     
@@ -433,7 +433,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
     回传不同文件范围内的文件计数，其中响应对象中的`fileSize`是文件大小范围的上限。
     
-    ```json
+```json
      [{
      	"volume": "vol-2-04168",
      	"bucket": "bucket-0-11685",
@@ -455,16 +455,16 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
      	"fileSize": 1024,
      	"count": 2
      }]
-    ```
+```
     
 #### <a name="metrics"></a> 指标
 
 * **/metrics/:api**
 
     **URL 结构**
-    ```
+```
     GET /api/v1/metrics/:api
-    ```
+```
     
     **参数**
 
@@ -475,7 +475,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     这是 Prometheus 的代理端点，并回传与 Prometheus 端点相同的响应。
     示例：/api/v1/metrics/query?query=ratis_leader_election_electionCount
     
-     ```json
+ ```json
      {
        "status": "success",
        "data": {
@@ -497,6 +497,6 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
          ]
        }
      }
-     ```
+ ```
 
 

--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -92,7 +92,7 @@ install_hugo() {
 }
 
 _install_hugo() {
-  : ${HUGO_VERSION:=0.81.0}
+  : ${HUGO_VERSION:=0.83.1}
 
   local os=$(uname -s)
   local arch=$(uname -m)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hugo 0.83 is reported to be failing while generating Ozone docs. See https://issues.apache.org/jira/browse/HDDS-5189 for more details.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5189

## How was this patch tested?

```
./hadoop-ozone/dev-support/checks/docs.sh
```

+ full ci test on my fork