### PR TITLE
HDDS-5207. Intermittent failure in TestRatisPipelineProvider#testCreatePipelineWithFactorThree

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
-import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -53,13 +52,14 @@ public class TestRatisPipelineProvider {
   private static final HddsProtos.ReplicationType REPLICATION_TYPE =
       HddsProtos.ReplicationType.RATIS;
 
-  private NodeManager nodeManager;
+  private MockNodeManager nodeManager;
   private RatisPipelineProvider provider;
   private PipelineStateManager stateManager;
   private OzoneConfiguration conf;
 
   public void init(int maxPipelinePerNode) throws Exception {
     nodeManager = new MockNodeManager(true, 10);
+    nodeManager.setNumPipelinePerDatanode(maxPipelinePerNode);
     conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT,
         maxPipelinePerNode);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`testCreatePipelineWithFactorThree` fails intermittently with two 3-nodes pipeline being assigned to the same set of nodes, while only a single pipeline per datanode is allowed.  The problem is that `MockNodeManager` ignores this config and has a separate variable, which tests need to set.  Similar setting in other test:

https://github.com/apache/ozone/blob/8e8a01dfd20899cd9dc95ab3de744b636a807ab2/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java#L91-L92

https://issues.apache.org/jira/browse/HDDS-5207

## How was this patch tested?

100x repeated `TestRatisPipelineProvider`:
https://github.com/adoroszlai/hadoop-ozone/runs/2549825702

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/829491474