### PR TITLE
HDDS-5164. Improve client and server logging.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -673,10 +673,10 @@ public class BlockOutputStream extends OutputStream {
         }
         return e;
       }, responseExecutor).exceptionally(e -> {
-        LOG.error("writing chunk failed " + chunkInfo.getChunkName() +
-                " blockID " + blockID + " with exception "
-                + e.getLocalizedMessage());
-        CompletionException ce = new CompletionException(e);
+        String msg = "Failed to write chunk " + chunkInfo.getChunkName() + " " +
+            "into block " + blockID;
+        LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
+        CompletionException ce = new CompletionException(msg, e);
         setIoException(ce);
         throw ce;
       });

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -238,7 +238,7 @@ public class BlockOutputStreamEntryPool {
    */
   private void allocateNewBlock() throws IOException {
     if (!excludeList.isEmpty()) {
-      LOG.info("Allocating block with {}", excludeList);
+      LOG.debug("Allocating block with {}", excludeList);
     }
     OmKeyLocationInfo subKeyInfo =
         omClient.allocateBlock(keyArgs, openID, excludeList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -106,6 +106,8 @@ import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMHANodeDetails;
 import org.apache.hadoop.ozone.om.ha.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
@@ -883,6 +885,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         false)) {
       rpcServer.refreshServiceAcl(conf, OMPolicyProvider.getInstance());
     }
+
+    rpcServer.addSuppressedLoggingExceptions(OMNotLeaderException.class,
+        OMLeaderNotReadyException.class);
+
     return rpcServer;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -193,22 +193,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
   }
 
-  private ServiceException createNotLeaderException() {
-    RaftPeerId raftPeerId = omRatisServer.getRaftPeerId();
-
-    // TODO: Set suggest leaderID. Right now, client is not using suggest
-    // leaderID. Need to fix this.
-
-    OMNotLeaderException notLeaderException =
-        new OMNotLeaderException(raftPeerId);
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug(notLeaderException.getMessage());
-    }
-
-    return new ServiceException(notLeaderException);
-  }
-
   private ServiceException createLeaderErrorException(
       RaftServerStatus raftServerStatus) {
     if (raftServerStatus == NOT_LEADER) {
@@ -218,13 +202,28 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
   }
 
+  private ServiceException createNotLeaderException() {
+    RaftPeerId raftPeerId = omRatisServer.getRaftPeerId();
+
+    // TODO: Set suggest leaderID. Right now, client is not using suggest
+    // leaderID. Need to fix this.
+
+    OMNotLeaderException notLeaderException =
+        new OMNotLeaderException(raftPeerId);
+
+    LOG.debug(notLeaderException.getMessage());
+
+    return new ServiceException(notLeaderException);
+  }
 
   private ServiceException createLeaderNotReadyException() {
     RaftPeerId raftPeerId = omRatisServer.getRaftPeerId();
 
     OMLeaderNotReadyException leaderNotReadyException =
         new OMLeaderNotReadyException(raftPeerId.toString() + " is Leader " +
-            "but not ready to process request");
+            "but not ready to process request yet.");
+
+    LOG.debug(leaderNotReadyException.getMessage());
 
     return new ServiceException(leaderNotReadyException);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On the OM server side, NotLeaderException and LeaderNotReadyExceptions can be suppressed. Otherwise, OM1 log is flooded with NotLeaderExceptions as clients always try OM1 before moving to the next OM. Instead we can change these exception logs to DEBUG.

Some BlockOutputStream and BlockOutputStreamEntryPool logs should be DEBUG level instead of INFO. For example, block allocation with an exclude list need not be logged at INFO level.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5164

## How was this patch tested?

No new tests. Changing only LOG levels.
