### PR TITLE
HDDS-5208. bump rocksdb version to 6.20.3

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
@@ -91,7 +91,7 @@ public class TestOzoneManagerRocksDBLogging {
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()
             .contains("db_impl.cc"),
-        1000, 10000);
+        1000, 30000);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1602,7 +1602,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>6.8.1</version>
+        <version>6.20.3</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

now , the rocksdb version used in ozone is 6.8.1, which is build on Apr 16 , 2020.
this PR bumps rockdsb to 6.20.3, which is build on May 5, 2021, and includes many new bug-fix

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5208

## How was this patch tested?

no need to add additional tests