### PR TITLE
HDDS-5187. Avoid Maven connection errors in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -21,6 +21,7 @@ on:
     - cron: 30 0,12 * * *
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
+  MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
 jobs:
   compile:
     runs-on: ubuntu-18.04

--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -16,6 +16,6 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
-export MAVEN_OPTS="-Xmx4096m"
+export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
 mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
 exit $?

--- a/hadoop-ozone/dev-support/checks/junit.sh
+++ b/hadoop-ozone/dev-support/checks/junit.sh
@@ -27,7 +27,7 @@ if [[ ${ITERATIONS} -le 0 ]]; then
   ITERATIONS=1
 fi
 
-export MAVEN_OPTS="-Xmx4096m"
+export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
 MAVEN_OPTIONS='-B -Dskip.npx -Dskip.installnpx'
 
 if [[ "${FAIL_FAST:-}" == "true" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

Disable Maven HTTP connection pooling to avoid intermittent [download errors](https://github.com/apache/ozone/runs/2454639477#step:6:2576) like:

```
[ERROR] Plugin org.apache.maven.plugins:maven-shade-plugin:3.2.4 or one of its dependencies could not be resolved: Failed to read artifact descriptor for org.apache.maven.plugins:maven-shade-plugin:jar:3.2.4: Could not transfer artifact org.apache.maven.plugins:maven-shade-plugin:pom:3.2.4 from/to central (https://repo.maven.apache.org/maven2): Transfer failed for https://repo.maven.apache.org/maven2/org/apache/maven/plugins/maven-shade-plugin/3.2.4/maven-shade-plugin-3.2.4.pom: Connection timed out (Read failed)
```

The solution is taken from https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080 and https://github.com/actions/virtual-environments/issues/1499#issuecomment-718396233.

https://issues.apache.org/jira/browse/HDDS-5187

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/830661774

Compile/test without any cache:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/830829319