### PR TITLE
HDDS-5214. Bump logical release name of Ozone 1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- version for hdds/ozone components -->
     <hdds.version>${ozone.version}</hdds.version>
     <ozone.version>1.2.0-SNAPSHOT</ozone.version>
-    <ozone.release>Denali</ozone.release>
+    <ozone.release>Glacier</ozone.release>
     <declared.hdds.version>${hdds.version}</declared.hdds.version>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5214

## What changes were proposed in this pull request?

Use logical release name 'glacier' for Ozone 1.2 as discussed during the community sync. (Next letter was G and Glacier was the obvious choice)

## How was this patch tested?

```
./ozone version                             
                  //////////////                 
               ////////////////////              
            ////////     ////////////////        
           //////      ////////////////          
          /////      ////////////////  /         
         /////            ////////   ///         
         ////           ////////    /////        
        /////         ////////////////           
        /////       ////////////////   //        
         ////     ///////////////   /////        
         /////  ///////////////     ////         
          /////       //////      /////          
           //////   //////       /////           
             ///////////     ////////            
               //////  ////////////              
               ///   //////////                  
              /    1.2.0-SNAPSHOT(Glacier)
...
```