### PR TITLE
HDDS-5220 when datanode delete the data,first delete metadata,then delete chunk files

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -419,7 +419,7 @@ public class BlockDeletingService extends BackgroundService {
             .getHandler(container.getContainerType()));
 
 
-        // fist remove the blockID from blockDataTable,and then delete the blocks
+        // remove the blockID from blockDataTable,and then delete the blocks
         // and also remove the transactions from txnTable.
         try(BatchOperation batch = meta.getStore().getBatchHandler()
             .initBatchOperation()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -418,6 +418,7 @@ public class BlockDeletingService extends BackgroundService {
         Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
             .getHandler(container.getContainerType()));
 
+
         // remove the blockID from blockDataTable,and then delete the blocks
         // and also remove the transactions from txnTable.
         try(BatchOperation batch = meta.getStore().getBatchHandler()
@@ -429,9 +430,9 @@ public class BlockDeletingService extends BackgroundService {
               meta.getStore().getBlockDataTable().deleteWithBatch(batch, bID);
             }
           }
+          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           totalBlocks =
               deleteTransactions(delBlocks, handler, blockDataTable, container);
-          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           containerData.updateAndCommitDBCounters(meta, batch,
               totalBlocks);
           // update count of pending deletion blocks and block count in

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -418,7 +418,6 @@ public class BlockDeletingService extends BackgroundService {
         Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
             .getHandler(container.getContainerType()));
 
-
         // remove the blockID from blockDataTable,and then delete the blocks
         // and also remove the transactions from txnTable.
         try(BatchOperation batch = meta.getStore().getBatchHandler()
@@ -430,9 +429,9 @@ public class BlockDeletingService extends BackgroundService {
               meta.getStore().getBlockDataTable().deleteWithBatch(batch, bID);
             }
           }
-          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           totalBlocks =
               deleteTransactions(delBlocks, handler, blockDataTable, container);
+          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           containerData.updateAndCommitDBCounters(meta, batch,
               totalBlocks);
           // update count of pending deletion blocks and block count in

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -418,10 +418,8 @@ public class BlockDeletingService extends BackgroundService {
         Handler handler = Objects.requireNonNull(ozoneContainer.getDispatcher()
             .getHandler(container.getContainerType()));
 
-        totalBlocks =
-            deleteTransactions(delBlocks, handler, blockDataTable, container);
 
-        // Once blocks are deleted... remove the blockID from blockDataTable
+        // fist remove the blockID from blockDataTable,and then delete the blocks
         // and also remove the transactions from txnTable.
         try(BatchOperation batch = meta.getStore().getBatchHandler()
             .initBatchOperation()) {
@@ -433,6 +431,8 @@ public class BlockDeletingService extends BackgroundService {
             }
           }
           meta.getStore().getBatchHandler().commitBatchOperation(batch);
+          totalBlocks =
+              deleteTransactions(delBlocks, handler, blockDataTable, container);
           containerData.updateAndCommitDBCounters(meta, batch,
               totalBlocks);
           // update count of pending deletion blocks and block count in

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -430,9 +430,9 @@ public class BlockDeletingService extends BackgroundService {
               meta.getStore().getBlockDataTable().deleteWithBatch(batch, bID);
             }
           }
-          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           totalBlocks =
               deleteTransactions(delBlocks, handler, blockDataTable, container);
+          meta.getStore().getBatchHandler().commitBatchOperation(batch);
           containerData.updateAndCommitDBCounters(meta, batch,
               totalBlocks);
           // update count of pending deletion blocks and block count in

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.1.0-ff8aa66-SNAPSHOT</ratis.version>
+    <ratis.version>2.0.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.7.0-a398b19-SNAPSHOT</ratis.thirdparty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.0.0</ratis.version>
+    <ratis.version>2.1.0-ff8aa66-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.7.0-a398b19-SNAPSHOT</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
when use datanode scanner scan the container，the checksum bases on Rocksdb metadata to find the chunk file on disk,but when datanode delete data，datanode should delete metadata first，the delete chunk file，in order to avoid when chunk file was deleted，but the metadata can not be modified，the datanode scanner scan the datanode will mark this container unhealthy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5220

## How was this patch tested?
