### PR TITLE
HDDS-5222. ReplicaIndex in Pipeline should be deserialized in the protobuf message

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -283,9 +283,16 @@ public final class Pipeline {
       throws UnknownPipelineStateException {
     Preconditions.checkNotNull(pipeline, "Pipeline is null");
 
-    List<DatanodeDetails> nodes = new ArrayList<>();
+    Map<DatanodeDetails, Integer> nodes = new LinkedHashMap<>();
+    int index = 0;
+    int repIndexListLength = pipeline.getMemberReplicaIndexesCount();
     for (DatanodeDetailsProto member : pipeline.getMembersList()) {
-      nodes.add(DatanodeDetails.getFromProtoBuf(member));
+      int repIndex = 0;
+      if (index < repIndexListLength) {
+        repIndex = pipeline.getMemberReplicaIndexes(index);
+      }
+      nodes.put(DatanodeDetails.getFromProtoBuf(member), repIndex);
+      index ++;
     }
     UUID leaderId = null;
     if (pipeline.hasLeaderID128()) {
@@ -309,7 +316,8 @@ public final class Pipeline {
     return new Builder().setId(PipelineID.getFromProtobuf(pipeline.getId()))
         .setReplicationConfig(config)
         .setState(PipelineState.fromProtobuf(pipeline.getState()))
-        .setNodes(nodes)
+        .setNodes(new ArrayList<>(nodes.keySet()))
+        .setReplicaIndexes(nodes)
         .setLeaderId(leaderId)
         .setSuggestedLeaderId(suggestedLeaderId)
         .setNodesInOrder(pipeline.getMemberOrdersList())
@@ -480,7 +488,6 @@ public final class Pipeline {
       this.leaderId = leaderId1;
       return this;
     }
-
     public Builder setNodes(List<DatanodeDetails> nodes) {
       this.nodeStatus = new LinkedHashMap<>();
       nodes.forEach(node -> nodeStatus.put(node, -1L));

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -292,7 +292,7 @@ public final class Pipeline {
         repIndex = pipeline.getMemberReplicaIndexes(index);
       }
       nodes.put(DatanodeDetails.getFromProtoBuf(member), repIndex);
-      index ++;
+      index++;
     }
     UUID leaderId = null;
     if (pipeline.hasLeaderID128()) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
@@ -97,12 +99,21 @@ public final class MockPipeline {
     nodes.add(MockDatanodeDetails.randomDatanodeDetails());
     nodes.add(MockDatanodeDetails.randomDatanodeDetails());
 
+    Map<DatanodeDetails, Integer> nodeIndexes = new HashMap<>();
+
+    int index = nodes.size() - 1;
+    for (DatanodeDetails dn : nodes) {
+      nodeIndexes.put(dn, index);
+      index --;
+    }
+
     return Pipeline.newBuilder()
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
             new ECReplicationConfig(3, 2))
         .setNodes(nodes)
+        .setReplicaIndexes(nodeIndexes)
         .build();
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -104,7 +104,7 @@ public final class MockPipeline {
     int index = nodes.size() - 1;
     for (DatanodeDetails dn : nodes) {
       nodeIndexes.put(dn, index);
-      index --;
+      index--;
     }
 
     return Pipeline.newBuilder()

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.junit.Assert;
 import org.junit.Test;
@@ -67,5 +68,17 @@ public class TestPipeline {
     Assert
         .assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
 
+  }
+
+  @Test
+  public void testReplicaIndexesSerialisedCorrectly() throws IOException {
+    Pipeline pipeline = MockPipeline.createEcPipeline();
+    HddsProtos.Pipeline protobufMessage = pipeline.getProtobufMessage(1);
+    Pipeline reloadedPipeline = Pipeline.getFromProtobuf(protobufMessage);
+
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      Assert.assertEquals(pipeline.getReplicaIndex(dn),
+          reloadedPipeline.getReplicaIndex(dn));
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

ReplicaIndex and ReplicationConfig were added to the Pipeline class, but we missed loading the serialized ReplicaIndex when a Pipeline is created from the protobuf message.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5222

## How was this patch tested?

New unit test.