### PR TITLE
HDDS-5041. Use getShortUserName in getTrashRoot(s)

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
@@ -298,7 +298,8 @@ public class OFSPath {
       throw new RuntimeException("Volume or bucket doesn't have trash root.");
     }
     try {
-      String username = UserGroupInformation.getCurrentUser().getUserName();
+      final String username =
+              UserGroupInformation.getCurrentUser().getShortUserName();
       final Path pathRoot = new Path(
           OZONE_OFS_URI_SCHEME, authority, OZONE_URI_DELIMITER);
       final Path pathToVolume = new Path(pathRoot, volumeName);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -578,7 +578,8 @@ public class BasicRootedOzoneClientAdapterImpl
     List<FileStatus> ret = new ArrayList<>();
     try {
       Iterator<? extends OzoneVolume> iterVol;
-      String username = UserGroupInformation.getCurrentUser().getUserName();
+      final String username =
+              UserGroupInformation.getCurrentUser().getShortUserName();
       if (allUsers) {
         iterVol = objectStore.listVolumes("");
       } else {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-5041

Note: this commit changes the username set inside OFS `.Trash` directory when Kerberos is enabled from principal name to mapped shorted user name.