### PR TITLE
HDDS-5209. Datanode hasEnoughSpace check should apply on volume instead of global DN

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -22,12 +22,14 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 
@@ -165,9 +167,15 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    */
   public boolean hasEnoughSpace(DatanodeDetails datanodeDetails,
       long sizeRequired) {
-    SCMNodeMetric nodeMetric = nodeManager.getNodeStat(datanodeDetails);
-    return (nodeMetric != null) && (nodeMetric.get() != null)
-        && nodeMetric.get().getRemaining().hasResources(sizeRequired);
+    Preconditions.checkArgument(datanodeDetails instanceof DatanodeInfo);
+
+    DatanodeInfo datanodeInfo = (DatanodeInfo) datanodeDetails;
+    for (StorageReportProto reportProto : datanodeInfo.getStorageReports()) {
+      if (reportProto.getRemaining() > sizeRequired) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -18,20 +18,23 @@ package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
+import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.junit.Assert;
@@ -43,7 +46,6 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
 
-import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.when;
 
 /**
@@ -53,7 +55,7 @@ public class TestContainerPlacementFactory {
   // network topology cluster
   private NetworkTopology cluster;
   // datanodes array list
-  private List<DatanodeDetails> datanodes = new ArrayList<>();
+  private List<DatanodeInfo> datanodes = new ArrayList<>();
   // node storage capacity
   private static final long STORAGE_CAPACITY = 100L;
   // configuration
@@ -82,24 +84,43 @@ public class TestContainerPlacementFactory {
     String hostname = "node";
     for (int i = 0; i < 15; i++) {
       // Totally 3 racks, each has 5 datanodes
-      DatanodeDetails node = MockDatanodeDetails.createDatanodeDetails(
-          hostname + i, rack + (i / 5));
-      datanodes.add(node);
-      cluster.add(node);
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+          MockDatanodeDetails.createDatanodeDetails(
+          hostname + i, rack + (i / 5)), NodeStatus.inServiceHealthy());
+
+      StorageReportProto storage1 = TestUtils.createStorageReport(
+          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          STORAGE_CAPACITY, 0, 100L, null);
+      datanodeInfo.updateStorageReports(
+          new ArrayList<>(Arrays.asList(storage1)));
+
+      datanodes.add(datanodeInfo);
+      cluster.add(datanodeInfo);
     }
+
+    StorageReportProto storage2 = TestUtils.createStorageReport(
+        datanodes.get(2).getUuid(),
+        "/data1-" + datanodes.get(2).getUuidString(),
+        STORAGE_CAPACITY, 90L, 10L, null);
+    datanodes.get(2).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage2)));
+    StorageReportProto storage3 = TestUtils.createStorageReport(
+        datanodes.get(3).getUuid(),
+        "/data1-" + datanodes.get(3).getUuidString(),
+        STORAGE_CAPACITY, 80L, 20L, null);
+    datanodes.get(3).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage3)));
+    StorageReportProto storage4 = TestUtils.createStorageReport(
+        datanodes.get(4).getUuid(),
+        "/data1-" + datanodes.get(4).getUuidString(),
+        STORAGE_CAPACITY, 70L, 30L, null);
+    datanodes.get(4).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage4)));
 
     // create mock node manager
     nodeManager = Mockito.mock(NodeManager.class);
     when(nodeManager.getNodes(NodeStatus.inServiceHealthy()))
         .thenReturn(new ArrayList<>(datanodes));
-    when(nodeManager.getNodeStat(anyObject()))
-        .thenReturn(new SCMNodeMetric(STORAGE_CAPACITY, 0L, 100L));
-    when(nodeManager.getNodeStat(datanodes.get(2)))
-        .thenReturn(new SCMNodeMetric(STORAGE_CAPACITY, 90L, 10L));
-    when(nodeManager.getNodeStat(datanodes.get(3)))
-        .thenReturn(new SCMNodeMetric(STORAGE_CAPACITY, 80L, 20L));
-    when(nodeManager.getNodeStat(datanodes.get(4)))
-        .thenReturn(new SCMNodeMetric(STORAGE_CAPACITY, 70L, 30L));
 
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getPolicy(conf, nodeManager, cluster, true,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,8 +26,11 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
@@ -45,10 +49,39 @@ public class TestSCMContainerPlacementCapacity {
     //given
     ConfigurationSource conf = new OzoneConfiguration();
 
-    List<DatanodeDetails> datanodes = new ArrayList<>();
+    List<DatanodeInfo> datanodes = new ArrayList<>();
     for (int i = 0; i < 7; i++) {
-      datanodes.add(MockDatanodeDetails.randomDatanodeDetails());
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+          MockDatanodeDetails.randomDatanodeDetails(),
+          NodeStatus.inServiceHealthy());
+
+      StorageReportProto storage1 = TestUtils.createStorageReport(
+          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          100L, 0, 100L, null);
+      datanodeInfo.updateStorageReports(
+          new ArrayList<>(Arrays.asList(storage1)));
+
+      datanodes.add(datanodeInfo);
     }
+
+    StorageReportProto storage2 = TestUtils.createStorageReport(
+        datanodes.get(2).getUuid(),
+        "/data1-" + datanodes.get(2).getUuidString(),
+        100L, 90L, 10L, null);
+    datanodes.get(2).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage2)));
+    StorageReportProto storage3 = TestUtils.createStorageReport(
+        datanodes.get(3).getUuid(),
+        "/data1-" + datanodes.get(3).getUuidString(),
+        100L, 80L, 20L, null);
+    datanodes.get(3).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage3)));
+    StorageReportProto storage4 = TestUtils.createStorageReport(
+        datanodes.get(4).getUuid(),
+        "/data1-" + datanodes.get(4).getUuidString(),
+        100L, 70L, 30L, null);
+    datanodes.get(4).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage4)));
 
     NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
     when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))


### PR DESCRIPTION
## What changes were proposed in this pull request?

When use placement policy to choose datanodes, we should check whether a datanode has a volume that
has enough space to hold the container, not check the space from all volumes together, because a container
could only be on a single volume not spread across volumes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5209

## How was this patch tested?

extended existing ut.
