### PR TITLE
HDDS-5216. Fix race condition causing SCM failOverProxy which is causing failover wrongly.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -148,6 +148,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
     if (currentProxyInfo == null) {
       currentProxyInfo = createSCMProxy(currentProxyNodeId);
     }
+    LOG.info("Bharat getProxy {}", currentProxyNodeId);
     return currentProxyInfo;
   }
 
@@ -156,11 +157,14 @@ public class SCMBlockLocationFailoverProxyProvider implements
       ScmBlockLocationProtocolPB newLeader) {
     //If leader node id is set, use that or else move to next proxy index.
     if (updatedLeaderNodeID != null) {
+      LOG.info("Bharat updatedLeaderNodeID not null {}", updatedLeaderNodeID);
       currentProxySCMNodeId = updatedLeaderNodeID;
     } else {
       nextProxyIndex();
+      LOG.info("Bharat Failing over to next proxy. {}",
+          getCurrentProxySCMNodeId());
     }
-    LOG.debug("Failing over to next proxy. {}", getCurrentProxySCMNodeId());
+
   }
 
   public synchronized void performFailoverToAssignedLeader(String newLeader,
@@ -207,18 +211,23 @@ public class SCMBlockLocationFailoverProxyProvider implements
 
   private synchronized void nextProxyIndex() {
     // round robin the next proxy
+
     currentProxyIndex = (getCurrentProxyIndex() + 1) % scmProxyInfoMap.size();
     currentProxySCMNodeId =  scmNodeIds.get(currentProxyIndex);
+    LOG.info("Bharat getCurrentProxyIndex{}, currentProxyIndex{}, " +
+            "currentProxyNodeId{}, map size {}",
+        getCurrentProxyIndex(), currentProxyIndex, currentProxySCMNodeId,
+        scmProxyInfoMap.size());
   }
 
   private synchronized void assignLeaderToNode(String newLeaderNodeId) {
     if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
-      if (scmProxies.containsKey(newLeaderNodeId)) {
+      if (scmProxyInfoMap.containsKey(newLeaderNodeId)) {
         updatedLeaderNodeID = newLeaderNodeId;
-        LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
+        LOG.info("Bharat Updated LeaderNodeID {}", updatedLeaderNodeID);
+      } else {
+        updatedLeaderNodeID = null;
       }
-    } else {
-      updatedLeaderNodeID = null;
     }
   }
 
@@ -265,6 +274,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
       @Override
       public RetryAction shouldRetry(Exception e, int retry,
                                      int failover, boolean b) {
+        LOG.info("Bharat retry called");
         if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
           setUpdatedLeaderNodeID();
         } else {
@@ -282,6 +292,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
   }
 
   public synchronized void setUpdatedLeaderNodeID() {
+    LOG.info("Bharat setUpdatedLeaderNodeID {}", updatedLeaderNodeID);
     this.updatedLeaderNodeID = getCurrentProxySCMNodeId();
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -61,6 +61,13 @@ public class SCMBlockLocationFailoverProxyProvider implements
   private Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
+  // As when SCM Client is shared across threads, performFailOver method
+  // updates the currentProxySCMNodeId based on the updateLeaderNodeId which is
+  // updated in shouldRetry. So, when 2 threads run parallel for
+  // one of the thread performFailOver is not called which is taken care by
+  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
+  // shall not call performFailOver it will call getProxy() where we use
+  // currentProxySCMNodeId and return proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
 
@@ -74,7 +81,7 @@ public class SCMBlockLocationFailoverProxyProvider implements
 
   private final UserGroupInformation ugi;
 
-  private volatile String updatedLeaderNodeID = null;
+  private String updatedLeaderNodeID = null;
 
 
   public SCMBlockLocationFailoverProxyProvider(ConfigurationSource conf) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -148,7 +148,6 @@ public class SCMBlockLocationFailoverProxyProvider implements
     if (currentProxyInfo == null) {
       currentProxyInfo = createSCMProxy(currentProxyNodeId);
     }
-    LOG.info("Bharat getProxy {}", currentProxyNodeId);
     return currentProxyInfo;
   }
 
@@ -157,12 +156,9 @@ public class SCMBlockLocationFailoverProxyProvider implements
       ScmBlockLocationProtocolPB newLeader) {
     //If leader node id is set, use that or else move to next proxy index.
     if (updatedLeaderNodeID != null) {
-      LOG.info("Bharat updatedLeaderNodeID not null {}", updatedLeaderNodeID);
       currentProxySCMNodeId = updatedLeaderNodeID;
     } else {
       nextProxyIndex();
-      LOG.info("Bharat Failing over to next proxy. {}",
-          getCurrentProxySCMNodeId());
     }
 
   }
@@ -214,17 +210,13 @@ public class SCMBlockLocationFailoverProxyProvider implements
 
     currentProxyIndex = (getCurrentProxyIndex() + 1) % scmProxyInfoMap.size();
     currentProxySCMNodeId =  scmNodeIds.get(currentProxyIndex);
-    LOG.info("Bharat getCurrentProxyIndex{}, currentProxyIndex{}, " +
-            "currentProxyNodeId{}, map size {}",
-        getCurrentProxyIndex(), currentProxyIndex, currentProxySCMNodeId,
-        scmProxyInfoMap.size());
   }
 
   private synchronized void assignLeaderToNode(String newLeaderNodeId) {
     if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
       if (scmProxyInfoMap.containsKey(newLeaderNodeId)) {
         updatedLeaderNodeID = newLeaderNodeId;
-        LOG.info("Bharat Updated LeaderNodeID {}", updatedLeaderNodeID);
+        LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
       } else {
         updatedLeaderNodeID = null;
       }
@@ -274,7 +266,6 @@ public class SCMBlockLocationFailoverProxyProvider implements
       @Override
       public RetryAction shouldRetry(Exception e, int retry,
                                      int failover, boolean b) {
-        LOG.info("Bharat retry called");
         if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
           setUpdatedLeaderNodeID();
         } else {
@@ -292,7 +283,6 @@ public class SCMBlockLocationFailoverProxyProvider implements
   }
 
   public synchronized void setUpdatedLeaderNodeID() {
-    LOG.info("Bharat setUpdatedLeaderNodeID {}", updatedLeaderNodeID);
     this.updatedLeaderNodeID = getCurrentProxySCMNodeId();
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -61,13 +61,13 @@ public class SCMBlockLocationFailoverProxyProvider implements
   private Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
-  // As when SCM Client is shared across threads, performFailOver method
+  // As SCM Client is shared across threads, performFailOver()
   // updates the currentProxySCMNodeId based on the updateLeaderNodeId which is
-  // updated in shouldRetry. So, when 2 threads run parallel for
-  // one of the thread performFailOver is not called which is taken care by
-  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
-  // shall not call performFailOver it will call getProxy() where we use
-  // currentProxySCMNodeId and return proxy.
+  // updated in shouldRetry(). When 2 or more threads run in parallel, the
+  // RetryInvocationHandler will check the expectedFailOverCount
+  // and not execute performFailOver() for one of them. So the other thread(s)
+  // shall not call performFailOver(), it will call getProxy() which uses
+  // currentProxySCMNodeId and returns the proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -234,12 +234,12 @@ public class SCMContainerLocationFailoverProxyProvider implements
 
   private synchronized void assignLeaderToNode(String newLeaderNodeId) {
     if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
-      if (scmProxies.containsKey(newLeaderNodeId)) {
+      if (scmProxyInfoMap.containsKey(newLeaderNodeId)) {
         updatedLeaderNodeID = newLeaderNodeId;
         LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
+      } else {
+        updatedLeaderNodeID = null;
       }
-    } else {
-      updatedLeaderNodeID = null;
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -63,8 +63,8 @@ public class SCMContainerLocationFailoverProxyProvider implements
   private final Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
-  private String currentProxySCMNodeId;
-  private int currentProxyIndex;
+  private volatile String currentProxySCMNodeId;
+  private volatile int currentProxyIndex;
 
   private final ConfigurationSource conf;
   private final SCMClientConfig scmClientConfig;
@@ -76,6 +76,8 @@ public class SCMContainerLocationFailoverProxyProvider implements
   private final long retryInterval;
 
   private final UserGroupInformation ugi;
+
+  private volatile String updatedLeaderNodeID = null;
 
   /**
    * Construct SCMContainerLocationFailoverProxyProvider.
@@ -132,9 +134,6 @@ public class SCMContainerLocationFailoverProxyProvider implements
         scmNodeIds.add(scmNodeId);
         SCMProxyInfo scmProxyInfo = new SCMProxyInfo(scmServiceId, scmNodeId,
             scmClientAddress);
-        ProxyInfo< StorageContainerLocationProtocolPB > proxy
-            = new ProxyInfo<>(null, scmProxyInfo.toString());
-        scmProxies.put(scmNodeId, proxy);
         scmProxyInfoMap.put(scmNodeId, scmProxyInfo);
       }
     }
@@ -154,16 +153,20 @@ public class SCMContainerLocationFailoverProxyProvider implements
 
   @Override
   public synchronized ProxyInfo<StorageContainerLocationProtocolPB> getProxy() {
-    ProxyInfo<StorageContainerLocationProtocolPB> currentProxyInfo
-        = scmProxies.get(currentProxySCMNodeId);
-    createSCMProxyIfNeeded(currentProxyInfo, currentProxySCMNodeId);
+    ProxyInfo currentProxyInfo = scmProxies.get(getCurrentProxySCMNodeId());
+    if (currentProxyInfo == null) {
+      currentProxyInfo = createSCMProxy(getCurrentProxySCMNodeId());
+    }
     return currentProxyInfo;
   }
 
   public synchronized List<StorageContainerLocationProtocolPB> getProxies() {
-    scmProxies.forEach(
-        (nodeId, proxyInfo) -> createSCMProxyIfNeeded(proxyInfo, nodeId));
-
+    for (SCMProxyInfo scmProxyInfo : scmProxyInfoMap.values()) {
+      if (scmProxies.get(scmProxyInfo.getNodeId()) == null) {
+        scmProxies.put(scmProxyInfo.getNodeId(),
+            createSCMProxy(scmProxyInfo.getNodeId()));
+      }
+    }
     return scmProxies.values().stream()
         .map(proxyInfo -> proxyInfo.proxy).collect(Collectors.toList());
   }
@@ -171,7 +174,11 @@ public class SCMContainerLocationFailoverProxyProvider implements
   @Override
   public void performFailover(
       StorageContainerLocationProtocolPB newLeader) {
-    // Should do nothing here.
+    if (updatedLeaderNodeID != null) {
+      currentProxySCMNodeId = updatedLeaderNodeID;
+    } else {
+      nextProxyIndex();
+    }
     LOG.debug("Failing over to next proxy. {}", getCurrentProxySCMNodeId());
   }
 
@@ -194,17 +201,7 @@ public class SCMContainerLocationFailoverProxyProvider implements
             Arrays.toString(scmProxyInfoMap.values().toArray()));
       }
     }
-    if (newLeader == null) {
-      // If newLeader is not assigned, it will fail over to next proxy.
-      nextProxyIndex();
-      LOG.debug("Performing failover to next proxy node {}",
-          currentProxySCMNodeId);
-    } else {
-      if (!assignLeaderToNode(newLeader)) {
-        LOG.debug("Failing over SCM proxy to nodeId: {}", newLeader);
-        nextProxyIndex();
-      }
-    }
+    assignLeaderToNode(newLeader);
   }
 
   @Override
@@ -229,48 +226,43 @@ public class SCMContainerLocationFailoverProxyProvider implements
     return retryInterval;
   }
 
-  private synchronized int nextProxyIndex() {
+  private synchronized void nextProxyIndex() {
     // round robin the next proxy
-    currentProxyIndex = (currentProxyIndex + 1) % scmProxies.size();
+    currentProxyIndex = (currentProxyIndex + 1) % scmProxyInfoMap.size();
     currentProxySCMNodeId =  scmNodeIds.get(currentProxyIndex);
-    return currentProxyIndex;
   }
 
-  private synchronized boolean assignLeaderToNode(String newLeaderNodeId) {
-    if (!currentProxySCMNodeId.equals(newLeaderNodeId)
-        && scmProxies.containsKey(newLeaderNodeId)) {
-      currentProxySCMNodeId = newLeaderNodeId;
-      currentProxyIndex = scmNodeIds.indexOf(currentProxySCMNodeId);
-
-      LOG.debug("Failing over SCM proxy to nodeId: {}", newLeaderNodeId);
-      return true;
+  private synchronized void assignLeaderToNode(String newLeaderNodeId) {
+    if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
+      if (scmProxies.containsKey(newLeaderNodeId)) {
+        updatedLeaderNodeID = newLeaderNodeId;
+        LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
+      }
+    } else {
+      updatedLeaderNodeID = null;
     }
-    return false;
   }
 
   /**
-   * Creates proxy object if it does not already exist.
+   * Creates proxy object.
    */
-  private void createSCMProxyIfNeeded(ProxyInfo proxyInfo,
-                                      String nodeId) {
-    if (proxyInfo.proxy == null) {
-      InetSocketAddress address = scmProxyInfoMap.get(nodeId).getAddress();
-      try {
-        StorageContainerLocationProtocolPB proxy =
-            createSCMProxy(address);
-        try {
-          proxyInfo.proxy = proxy;
-        } catch (IllegalAccessError iae) {
-          scmProxies.put(nodeId,
-              new ProxyInfo<>(proxy, proxyInfo.proxyInfo));
-        }
-      } catch (IOException ioe) {
-        LOG.error("{} Failed to create RPC proxy to SCM at {}",
-            this.getClass().getSimpleName(), address, ioe);
-        throw new RuntimeException(ioe);
-      }
+  private ProxyInfo createSCMProxy(String nodeId) {
+    ProxyInfo proxyInfo;
+    SCMProxyInfo scmProxyInfo = scmProxyInfoMap.get(nodeId);
+    InetSocketAddress address = scmProxyInfo.getAddress();
+    try {
+      StorageContainerLocationProtocolPB scmProxy = createSCMProxy(address);
+      // Create proxyInfo here, to make it work with all Hadoop versions.
+      proxyInfo = new ProxyInfo<>(scmProxy, scmProxyInfo.toString());
+      scmProxies.put(nodeId, proxyInfo);
+      return proxyInfo;
+    } catch (IOException ioe) {
+      LOG.error("{} Failed to create RPC proxy to SCM at {}",
+          this.getClass().getSimpleName(), address, ioe);
+      throw new RuntimeException(ioe);
     }
   }
+
 
   private StorageContainerLocationProtocolPB createSCMProxy(
       InetSocketAddress scmAddress) throws IOException {
@@ -295,12 +287,18 @@ public class SCMContainerLocationFailoverProxyProvider implements
       @Override
       public RetryAction shouldRetry(Exception e, int retry,
                                      int failover, boolean b) {
-        if (!SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
+        if (SCMHAUtils.checkRetriableWithNoFailoverException(e)) {
+          setUpdatedLeaderNodeID();
+        } else {
           performFailoverToAssignedLeader(null, e);
         }
         return SCMHAUtils.getRetryAction(failover, retry, e, maxRetryCount,
             getRetryInterval());
       }
     };
+  }
+
+  public synchronized void setUpdatedLeaderNodeID() {
+    this.updatedLeaderNodeID = getCurrentProxySCMNodeId();
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -84,7 +84,7 @@ public class SCMContainerLocationFailoverProxyProvider implements
 
   private final UserGroupInformation ugi;
 
-  private volatile String updatedLeaderNodeID = null;
+  private String updatedLeaderNodeID = null;
 
   /**
    * Construct SCMContainerLocationFailoverProxyProvider.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -172,7 +172,7 @@ public class SCMContainerLocationFailoverProxyProvider implements
   }
 
   @Override
-  public void performFailover(
+  public synchronized void performFailover(
       StorageContainerLocationProtocolPB newLeader) {
     if (updatedLeaderNodeID != null) {
       currentProxySCMNodeId = updatedLeaderNodeID;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -63,6 +63,13 @@ public class SCMContainerLocationFailoverProxyProvider implements
   private final Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
+  // As when SCM Client is shared across threads, performFailOver method
+  // updates the currentProxySCMNodeId based on updateLeaderNodeId which is
+  // updated in shouldRetry. So, when 2 threads run parallel for
+  // one of the thread performFailOver is not called which is taken care by
+  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
+  // shall not call performFailOver it will call getProxy() where we use
+  // currentProxySCMNodeId and return proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMContainerLocationFailoverProxyProvider.java
@@ -63,13 +63,13 @@ public class SCMContainerLocationFailoverProxyProvider implements
   private final Map<String, SCMProxyInfo> scmProxyInfoMap;
   private List<String> scmNodeIds;
 
-  // As when SCM Client is shared across threads, performFailOver method
-  // updates the currentProxySCMNodeId based on updateLeaderNodeId which is
-  // updated in shouldRetry. So, when 2 threads run parallel for
-  // one of the thread performFailOver is not called which is taken care by
-  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
-  // shall not call performFailOver it will call getProxy() where we use
-  // currentProxySCMNodeId and return proxy.
+  // As SCM Client is shared across threads, performFailOver()
+  // updates the currentProxySCMNodeId based on the updateLeaderNodeId which is
+  // updated in shouldRetry(). When 2 or more threads run in parallel, the
+  // RetryInvocationHandler will check the expectedFailOverCount
+  // and not execute performFailOver() for one of them. So the other thread(s)
+  // shall not call performFailOver(), it will call getProxy() which uses
+  // currentProxySCMNodeId and returns the proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -64,8 +64,8 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   private List<String> scmNodeIds;
 
-  private String currentProxySCMNodeId;
-  private int currentProxyIndex;
+  private volatile String currentProxySCMNodeId;
+  private volatile int currentProxyIndex;
 
   private final ConfigurationSource conf;
   private final SCMClientConfig scmClientConfig;
@@ -77,6 +77,8 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
   private final long retryInterval;
 
   private final UserGroupInformation ugi;
+
+  private volatile String updatedLeaderNodeID = null;
 
   /**
    * Construct fail-over proxy provider for SCMSecurityProtocol Server.
@@ -176,11 +178,12 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   @Override
   public synchronized void performFailover(SCMSecurityProtocolPB currentProxy) {
-    if (LOG.isDebugEnabled()) {
-      int currentIndex = getCurrentProxyIndex();
-      LOG.debug("Failing over SCM Security proxy to index: {}, nodeId: {}",
-          currentIndex, scmNodeIds.get(currentIndex));
+    if (updatedLeaderNodeID != null) {
+      currentProxySCMNodeId = updatedLeaderNodeID;
+    } else {
+      nextProxyIndex();
     }
+    LOG.debug("Failing over to next proxy. {}", getCurrentProxySCMNodeId());
   }
 
   public synchronized void performFailoverToAssignedLeader(String newLeader,
@@ -202,39 +205,18 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
             Arrays.toString(scmProxyInfoMap.values().toArray()));
       }
     }
-    if (newLeader == null) {
-      // If newLeader is not assigned, it will fail over to next proxy.
-      performFailoverToNextProxy();
-      LOG.debug("Performing failover to next proxy node {}",
-          currentProxySCMNodeId);
-    } else {
-      if (!assignLeaderToNode(newLeader)) {
-        LOG.debug("Failing over SCM proxy to nodeId: {}", newLeader);
-        performFailoverToNextProxy();
+    assignLeaderToNode(newLeader);
+  }
+
+
+  private synchronized void assignLeaderToNode(String newLeaderNodeId) {
+    if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
+      if (scmProxies.containsKey(newLeaderNodeId)) {
+        updatedLeaderNodeID = newLeaderNodeId;
+        LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
       }
-    }
-  }
-
-  private synchronized boolean assignLeaderToNode(String newLeaderNodeId) {
-    if (!currentProxySCMNodeId.equals(newLeaderNodeId)
-        && scmProxies.containsKey(newLeaderNodeId)) {
-      currentProxySCMNodeId = newLeaderNodeId;
-      currentProxyIndex = scmNodeIds.indexOf(currentProxySCMNodeId);
-
-      LOG.debug("Failing over SCM proxy to nodeId: {}", newLeaderNodeId);
-      return true;
-    }
-
-    return false;
-  }
-  /**
-   * Performs fail-over to the next proxy.
-   */
-  public synchronized void performFailoverToNextProxy() {
-    int newProxyIndex = incrementProxyIndex();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Incrementing SCM Security proxy index to {}, nodeId: {}",
-          newProxyIndex, scmNodeIds.get(newProxyIndex));
+    } else {
+      updatedLeaderNodeID = null;
     }
   }
 
@@ -242,10 +224,10 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
    * Update the proxy index to the next proxy in the list.
    * @return the new proxy index
    */
-  private synchronized int incrementProxyIndex() {
-    currentProxyIndex = (currentProxyIndex + 1) % scmProxyInfoMap.size();
-    currentProxySCMNodeId = scmNodeIds.get(currentProxyIndex);
-    return currentProxyIndex;
+  private synchronized void nextProxyIndex() {
+    // round robin the next proxy
+    currentProxyIndex = (getCurrentProxyIndex() + 1) % scmProxyInfoMap.size();
+    currentProxySCMNodeId =  scmNodeIds.get(currentProxyIndex);
   }
 
   public RetryPolicy getRetryPolicy() {
@@ -269,7 +251,9 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
           }
         }
 
-        if (!SCMHAUtils.checkRetriableWithNoFailoverException(exception)) {
+        if (SCMHAUtils.checkRetriableWithNoFailoverException(exception)) {
+          setUpdatedLeaderNodeID();
+        } else {
           performFailoverToAssignedLeader(null, exception);
         }
         return SCMHAUtils
@@ -281,6 +265,9 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
     return retryPolicy;
   }
 
+  public synchronized void setUpdatedLeaderNodeID() {
+    this.updatedLeaderNodeID = getCurrentProxySCMNodeId();
+  }
 
   @Override
   public Class< SCMSecurityProtocolPB > getInterface() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -211,12 +211,12 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   private synchronized void assignLeaderToNode(String newLeaderNodeId) {
     if (!currentProxySCMNodeId.equals(newLeaderNodeId)) {
-      if (scmProxies.containsKey(newLeaderNodeId)) {
+      if (scmProxyInfoMap.containsKey(newLeaderNodeId)) {
         updatedLeaderNodeID = newLeaderNodeId;
         LOG.debug("Updated LeaderNodeID {}", updatedLeaderNodeID);
+      } else {
+        updatedLeaderNodeID = null;
       }
-    } else {
-      updatedLeaderNodeID = null;
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -64,8 +64,16 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   private List<String> scmNodeIds;
 
+  // As when SCM Client is shared across threads, performFailOver method
+  // updates the currentProxySCMNodeId based on updateLeaderNodeId which is
+  // updated in shouldRetry. So, when 2 threads run parallel for
+  // one of the thread performFailOver is not called which is taken care by
+  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
+  // shall not call performFailOver it will call getProxy() where we use
+  // currentProxySCMNodeId and return proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
+
 
   private final ConfigurationSource conf;
   private final SCMClientConfig scmClientConfig;
@@ -78,7 +86,7 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   private final UserGroupInformation ugi;
 
-  private volatile String updatedLeaderNodeID = null;
+  private String updatedLeaderNodeID = null;
 
   /**
    * Construct fail-over proxy provider for SCMSecurityProtocol Server.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMSecurityProtocolFailoverProxyProvider.java
@@ -64,13 +64,13 @@ public class SCMSecurityProtocolFailoverProxyProvider implements
 
   private List<String> scmNodeIds;
 
-  // As when SCM Client is shared across threads, performFailOver method
-  // updates the currentProxySCMNodeId based on updateLeaderNodeId which is
-  // updated in shouldRetry. So, when 2 threads run parallel for
-  // one of the thread performFailOver is not called which is taken care by
-  // RetryInvocationHandler by checking expectedFailOverCount. So other thread
-  // shall not call performFailOver it will call getProxy() where we use
-  // currentProxySCMNodeId and return proxy.
+  // As SCM Client is shared across threads, performFailOver()
+  // updates the currentProxySCMNodeId based on the updateLeaderNodeId which is
+  // updated in shouldRetry(). When 2 or more threads run in parallel, the
+  // RetryInvocationHandler will check the expectedFailOverCount
+  // and not execute performFailOver() for one of them. So the other thread(s)
+  // shall not call performFailOver(), it will call getProxy() which uses
+  // currentProxySCMNodeId and returns the proxy.
   private volatile String currentProxySCMNodeId;
   private volatile int currentProxyIndex;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In OzoneManager, SCM client is shared across RpcHandler threads.
Where we have observed that failOver across multiple threads causing failover to happen incorrectly on same SCM and is exhausting retry count.

And also one thing I have observed is

If we observe the error is no route to scm3, but retry happened on scm1/172.31.0.9:9863
```
2021-05-11 05:59:53,202 [IPC Server handler 10 on default port 9862] INFO retry.RetryInvocationHandler: com.google.protobuf.ServiceException: java.net.NoRouteToHostException: No Route to Host from  om1/172.31.0.11 to scm3:9863 failed on socket timeout exception: java.net.NoRouteToHostException: No route to host; For more details see:  http://wiki.apache.org/hadoop/NoRouteToHost, while invoking $Proxy32.send over nodeId=scm1,nodeAddress=scm1/172.31.0.9:9863 after 9 failover attempts. Trying to failover after sleeping for 2000ms.
If we observe the error is no route to scm3, but retry happened on scm1/172.31.0.9:9863
```
If we observe the error is no route to scm3, but retry happened on scm1/172.31.0.9:9863
```
2021-05-11 05:59:59,345 [IPC Server handler 10 on default port 9862] WARN ipc.Client: Address change detected. Old: scm3/172.31.0.5:9863 New: scm3:9863
2021-05-11 05:59:59,347 [IPC Server handler 10 on default port 9862] INFO retry.RetryInvocationHandler: com.google.protobuf.ServiceException: java.net.NoRouteToHostException: No Route to Host from  om1/172.31.0.11 to scm3:9863 failed on socket timeout exception: java.net.NoRouteToHostException: No route to host; For more details see:  http://wiki.apache.org/hadoop/NoRouteToHost, while invoking $Proxy32.send over nodeId=scm2,nodeAddress=scm2/172.31.0.6:9863 after 10 failover attempts. Trying to failover after sleeping for 2000ms.
```
This is because our performFailOver is a no-op and if failOver is needed we update currentSCMProxyNodeID in shouldRetry in RetryPolicy. 

**For example**
2 Threads contacted SCM3, and got NoRouteToHostException, so shouldRetry from first thread will move the currentSCMProxyNodeID to scm1 and other thread, after this move currentSCMProxyNodeID to scm2. 

Hadoop Proxy RetryInvocationHandler already takes care of if there is another thread trying to perform failOver it will not call performFailOver again. We shall see below WARN message, and get the currentProxy and contact that node.

**om3_1       | 2021-05-14 05:04:28,699 [IPC Server handler 34 on default port 9862] WARN retry.RetryInvocationHandler: A failover has occurred since the start of call #24329 $Proxy32.send over nodeId=scm3,nodeAddress=scm3/192.168.0.6:9863**

Solution here is to use performFailOver to update scmNodeID instead of using shouldRetry to update currentSCMProxyNodeID.

And also made a few more changes to make the logic common across classes for proxy creation.

Opened a Jira to avoid duplication [HDDS-5227](https://issues.apache.org/jira/browse/HDDS-5227)
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5216

## How was this patch tested?
Tested locally, and now observed that it will not perform failOver again and exhausting retry counts.