### PR TITLE
HDDS-5233. SCM subsequent init failed when previous scm init failed.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -82,7 +82,6 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       final StorageContainerManager scm, final SCMHADBTransactionBuffer buffer)
       throws IOException {
     this.scm = scm;
-    this.stateMachine = new SCMStateMachine(scm, this, buffer);
     final RaftGroupId groupId = buildRaftGroupId(scm.getClusterId());
     LOG.info("starting Raft server for scm:{}", scm.getScmId());
     // During SCM startup, the bootstrapped node will be started just with
@@ -100,9 +99,14 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     Parameters parameters = createSCMServerTlsParameters(grpcTlsConfig);
 
     this.server = newRaftServer(scm.getScmId(), conf)
-        .setStateMachine(stateMachine)
+        .setStateMachineRegistry(
+            (gId) -> new SCMStateMachine(scm, buffer))
         .setGroup(RaftGroup.valueOf(groupId))
         .setParameters(parameters).build();
+
+    this.stateMachine =
+        (SCMStateMachine) server.getDivision(groupId).getStateMachine();
+
     this.division = server.getDivision(groupId);
   }
 
@@ -111,7 +115,9 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftGroup group = buildRaftGroup(details, scmId, clusterId);
     RaftServer server = null;
     try {
-      server = newRaftServer(scmId, conf).setGroup(group).build();
+      server = newRaftServer(scmId, conf).setGroup(group)
+              .setStateMachineRegistry((groupId -> new SCMStateMachine()))
+              .build();
       server.start();
       waitForLeaderToBeReady(server, conf, group);
     } finally {
@@ -158,8 +164,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     final RaftProperties serverProperties =
         RatisUtil.newRaftProperties(haConf, conf);
     return RaftServer.newBuilder().setServerId(RaftPeerId.getRaftPeerId(scmId))
-        .setProperties(serverProperties)
-        .setStateMachine(new SCMStateMachine());
+        .setProperties(serverProperties);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -99,8 +99,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
     Parameters parameters = createSCMServerTlsParameters(grpcTlsConfig);
 
     this.server = newRaftServer(scm.getScmId(), conf)
-        .setStateMachineRegistry(
-            (gId) -> new SCMStateMachine(scm, buffer))
+        .setStateMachineRegistry((gId) -> new SCMStateMachine(scm, buffer))
         .setGroup(RaftGroup.valueOf(groupId))
         .setParameters(parameters).build();
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -954,9 +954,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
         // Do not move these code lines. If SCM version file is created,
         // the subsequent scm init should use the groupID from version file.
-        // So, initialize() should happen before ratis server initialize. In
-        // this way,we do not leave ratis storage directory with multiple raft
-        // Groups in failure scenario.
+        // So, scmStorageConfig#initialize() should happen before ratis server
+        // initialize. In this way,we do not leave ratis storage directory
+        // with multiple raft Groups in failure scenario.
 
         // The order of init should be
         // 1. SCM storage config initialize to create version file.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -971,6 +971,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
               conf);
           scmStorageConfig.setSCMHAFlag(true);
+          // Do force initialize to persist SCM_HA flag.
+          scmStorageConfig.forceInitialize();
         }
 
         LOG.info("SCM initialization succeeded. Current cluster id for sd={}"

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -970,6 +970,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
               scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
               conf);
+          scmStorageConfig = new SCMStorageConfig(conf);
           scmStorageConfig.setSCMHAFlag(true);
           // Do force initialize to persist SCM_HA flag.
           scmStorageConfig.forceInitialize();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -952,11 +952,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               getScmAddress(haDetails, conf), true);
         }
 
-        // Do not move these code lines. If SCM version file is created,
-        // the subsequent scm init should use the groupID from version file.
+        // Ensure scmRatisServer#initialize() is called post scm storage
+        // config initialization.. If SCM version file is created,
+        // the subsequent scm init should use the clusterID from version file.
         // So, scmStorageConfig#initialize() should happen before ratis server
         // initialize. In this way,we do not leave ratis storage directory
-        // with multiple raft Groups in failure scenario.
+        // with multiple raft group directories in failure scenario.
 
         // The order of init should be
         // 1. SCM storage config initialize to create version file.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -952,7 +952,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
               getScmAddress(haDetails, conf), true);
         }
 
-        // Do not move these code lines. If SCM version file is created file
+        // Do not move these code lines. If SCM version file is created,
         // the subsequent scm init should use the groupID from version file.
         // So, initialize() should happen before ratis server initialize. In
         // this way,we do not leave ratis storage directory with multiple raft

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -529,6 +529,31 @@ public class TestStorageContainerManager {
     }
   }
 
+
+  @Test
+  public void testSCMReinitializationWithHAUpgrade() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    final String path = GenericTestUtils.getTempPath(
+        UUID.randomUUID().toString());
+    Path scmPath = Paths.get(path, "scm-meta");
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, scmPath.toString());
+    //This will set the cluster id in the version file
+    final UUID clusterId = UUID.randomUUID();
+      // This will initialize SCM
+
+    StorageContainerManager.scmInit(conf, clusterId.toString());
+    SCMStorageConfig scmStore = new SCMStorageConfig(conf);
+    Assert.assertEquals(clusterId.toString(), scmStore.getClusterID());
+    Assert.assertFalse(scmStore.isSCMHAEnabled());
+
+    conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
+    StorageContainerManager.scmInit(conf, clusterId.toString());
+    scmStore = new SCMStorageConfig(conf);
+    Assert.assertTrue(scmStore.isSCMHAEnabled());
+    validateRatisGroupExists(conf, clusterId.toString());
+
+  }
+
   @VisibleForTesting
   public static void validateRatisGroupExists(OzoneConfiguration conf,
       String clusterId) throws IOException {


### PR DESCRIPTION
…iled.

## What changes were proposed in this pull request?

Initialize version file before and then perform Ratis Server initialize. In this way, we shall use the same groupID in failure scenarios.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5233
## How was this patch tested?

Existing CI.
