### PR TITLE
HDDS-5234. Change default grpc and ratis ports for scm ha

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -431,11 +431,11 @@ public final class ScmConfigKeys {
   public static final String OZONE_SCM_RATIS_PORT_KEY
       = "ozone.scm.ratis.port";
   public static final int OZONE_SCM_RATIS_PORT_DEFAULT
-      = 9865;
+      = 9894;
   public static final String OZONE_SCM_GRPC_PORT_KEY
       = "ozone.scm.grpc.port";
   public static final int OZONE_SCM_GRPC_PORT_DEFAULT
-      = 9866;
+      = 9895;
   public static final String OZONE_SCM_RATIS_RPC_TYPE_KEY
       = "ozone.scm.ratis.rpc.type";
   public static final String OZONE_SCM_RATIS_RPC_TYPE_DEFAULT

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAConfiguration.java
@@ -54,11 +54,11 @@ public class SCMHAConfiguration {
 
   @Config(key = "ratis.bind.port",
       type = ConfigType.INT,
-      defaultValue = "9865",
+      defaultValue = "9894",
       tags = {OZONE, SCM, HA, RATIS},
       description = "Port used by SCM for Ratis Server."
   )
-  private int ratisBindPort = 9865;
+  private int ratisBindPort = 9894;
 
 
   @Config(key = "ratis.rpc.type",

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2029,7 +2029,7 @@
 
   <property>
     <name>ozone.scm.ratis.port</name>
-    <value>9865</value>
+    <value>9894</value>
     <tag>OZONE, SCM, HA, RATIS</tag>
     <description>
       The port number of the SCM's Ratis server.
@@ -2038,7 +2038,7 @@
 
   <property>
     <name>ozone.scm.grpc.port</name>
-    <value>9866</value>
+    <value>9895</value>
     <tag>OZONE, SCM, HA, RATIS</tag>
     <description>
       The port number of the SCM's grpc server.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/MockSCMHAManager.java
@@ -224,7 +224,7 @@ public final class MockSCMHAManager implements SCMHAManager {
     @Override
     public List<String> getRatisRoles() {
       return Arrays
-          .asList("180.3.14.5:9865", "180.3.14.21:9865", "180.3.14.145:9865");
+          .asList("180.3.14.5:9894", "180.3.14.21:9894", "180.3.14.145:9894");
     }
 
     @Override

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
   om1:
     <<: *common-config
     environment:
-      WAITFOR: scm3:9865
+      WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       <<: *replication
     ports:
@@ -52,7 +52,7 @@ services:
   om2:
     <<: *common-config
     environment:
-      WAITFOR: scm3:9865
+      WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       <<: *replication
     ports:
@@ -63,7 +63,7 @@ services:
   om3:
     <<: *common-config
     environment:
-      WAITFOR: scm3:9865
+      WAITFOR: scm3:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       <<: *replication
     ports:
@@ -85,7 +85,7 @@ services:
     ports:
       - 9876
     environment:
-      WAITFOR: scm1:9865
+      WAITFOR: scm1:9894
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication
@@ -95,7 +95,7 @@ services:
     ports:
       - 9876
     environment:
-      WAITFOR: scm2:9865
+      WAITFOR: scm2:9894
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: ${OZONE_SAFEMODE_MIN_DATANODES:-1}
       <<: *replication

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -56,7 +56,7 @@ services:
     env_file:
       - docker-config
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       KERBEROS_KEYTABS: dn HTTP
       OZONE_OPTS:
     networks:
@@ -77,7 +77,7 @@ services:
     env_file:
       - docker-config
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       KERBEROS_KEYTABS: dn HTTP
       OZONE_OPTS:
     networks:
@@ -98,7 +98,7 @@ services:
     env_file:
       - docker-config
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       KERBEROS_KEYTABS: dn HTTP
       OZONE_OPTS:
     networks:
@@ -114,7 +114,7 @@ services:
       - 9890:9872
       #- 18001:18001
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       KERBEROS_KEYTABS: om HTTP
       OZONE_OPTS:
@@ -138,7 +138,7 @@ services:
       - 9892:9872
       #- 18002:18002
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       KERBEROS_KEYTABS: om HTTP
       OZONE_OPTS:
@@ -162,7 +162,7 @@ services:
       - 9894:9872
       #- 18003:18003
     environment:
-      WAITFOR: scm3.org:9865
+      WAITFOR: scm3.org:9894
       ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
       KERBEROS_KEYTABS: om HTTP
       OZONE_OPTS:
@@ -229,7 +229,7 @@ services:
     env_file:
       - docker-config
     environment:
-      WAITFOR: scm1.org:9865
+      WAITFOR: scm1.org:9894
       KERBEROS_KEYTABS: scm HTTP testuser testuser2
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-3}"
@@ -256,7 +256,7 @@ services:
     env_file:
       - docker-config
     environment:
-      WAITFOR: scm2.org:9865
+      WAITFOR: scm2.org:9894
       KERBEROS_KEYTABS: scm HTTP testuser testuser2
       ENSURE_SCM_BOOTSTRAPPED: /data/metadata/scm/current/VERSION
       OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-3}"

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/scmha.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/scmha.robot
@@ -25,4 +25,4 @@ Test Timeout        5 minutes
 *** Test Cases ***
 Run scm roles
     ${output} =         Execute          ozone admin scm roles
-                        Should Match Regexp   ${output}  [scm:9865(:LEADER|)]
+                        Should Match Regexp   ${output}  [scm:9894(:LEADER|)]


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, by default scm ratis and scm grpc ports are defined to be 9865 and 9866 by default. These ports are also used for datanode https and datanode ports for hdfs by default hence may lead to port conflict issue in ozone deployment alongside hdfs . These ports are replaced with port numbers 9894 and 9895 respectively.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5234

## How was this patch tested?
Tested manually on a docker scm ha cluster
