### PR TITLE
HDDS-5240. Fix out of bound exception when loading auditparser

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -336,7 +336,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       }
     }
 
-    auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString());
+    auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString().replaceAll("\\n", " "));
 
     // audit log
     auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -336,7 +336,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       }
     }
 
-    auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString().replaceAll("\\n", " "));
+    auditMap.put(OzoneConsts.MULTIPART_LIST, partsList.toString()
+        .replaceAll("\\n", " "));
 
     // audit log
     auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
@@ -181,7 +181,7 @@ public class TestAuditParser {
   }
 
   /**
-   * Test to execute load audit log
+   * Test to execute load audit log.
    */
   @Test
   public void testLoadCommand() {
@@ -190,7 +190,8 @@ public class TestAuditParser {
       execute(args1, "");
       fail("No exception thrown.");
     } catch (Exception e) {
-      assertTrue(e.getMessage().contains("java.lang.ArrayIndexOutOfBoundsException: 5"));
+      assertTrue(e.getMessage()
+          .contains("java.lang.ArrayIndexOutOfBoundsException: 5"));
     }
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/audit/parser/TestAuditParser.java
@@ -43,6 +43,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests AuditParser.
@@ -60,6 +62,8 @@ public class TestAuditParser {
   private static String dbName;
   private static final String LOGS = TestAuditParser.class
       .getClassLoader().getResource("testaudit.log").getPath();
+  private static final String LOGS1 = TestAuditParser.class
+      .getClassLoader().getResource("testloadaudit.log").getPath();
   /**
    * Creates output directory which will be used by the test-cases.
    * If a test-case needs a separate directory, it has to create a random
@@ -138,8 +142,8 @@ public class TestAuditParser {
         "DELETE_KEY\t3\t\n" +
             "ALLOCATE_KEY\t2\t\n" +
             "COMMIT_KEY\t2\t\n" +
-            "CREATE_BUCKET\t1\t\n" +
-            "CREATE_VOLUME\t1\t\n\n");
+            "CREATE_BUCKET\t2\t\n" +
+            "CREATE_VOLUME\t2\t\n\n");
   }
 
   /**
@@ -148,7 +152,7 @@ public class TestAuditParser {
   @Test
   public void testTemplateTop5Users() {
     String[] args = new String[]{dbName, "template", "top5users"};
-    execute(args, "hadoop\t9\t\n");
+    execute(args, "hadoop\t12\t\n");
   }
 
   /**
@@ -160,9 +164,9 @@ public class TestAuditParser {
     execute(args,
         "2018-09-06 01:57:22\t3\t\n" +
             "2018-09-06 01:58:08\t1\t\n" +
+            "2018-09-06 01:58:09\t1\t\n" +
             "2018-09-06 01:58:18\t1\t\n" +
-            "2018-09-06 01:59:36\t1\t\n" +
-            "2018-09-06 01:59:41\t1\t\n");
+            "2018-09-06 01:59:18\t1\t\n");
   }
 
   /**
@@ -173,7 +177,21 @@ public class TestAuditParser {
     String[] args = new String[]{dbName, "query",
         "select count(*) from audit"};
     execute(args,
-        "9");
+        "12");
+  }
+
+  /**
+   * Test to execute load audit log
+   */
+  @Test
+  public void testLoadCommand() {
+    String[] args1 = new String[]{dbName, "load", LOGS1};
+    try{
+      execute(args1, "");
+      fail("No exception thrown.");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("java.lang.ArrayIndexOutOfBoundsException: 5"));
+    }
   }
 
   /**

--- a/hadoop-ozone/tools/src/test/resources/testaudit.log
+++ b/hadoop-ozone/tools/src/test/resources/testaudit.log
@@ -4,12 +4,15 @@
 2018-09-06 01:58:08,035 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_VOLUME {admin=hadoop, owner=tom, volume=dcv, creationTime=0, quotaInBytes=1152921504606846976} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException
 at org.apache.hadoop.ozone.om.VolumeManagerImpl.createVolume(VolumeManagerImpl.java:137)
 at org.apache.hadoop.ozone.om.OzoneManager.createVolume(OzoneManager.java:469)
+2018-09-06 01:58:09,035 | INFO | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_VOLUME {admin=hadoop, owner=tom, volume=ddv, creationTime=0, quotaInBytes=1152921504606846976} | ret=SUCCESS |
 2018-09-06 01:58:18,447 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_BUCKET {volume=dcv, bucket=dcb, acls=[USER:hadoop:rw, GROUP:users:rw], isVersionEnabled=false, storageType=DISK, creationTime=0} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException: Bucket already exist
 at org.apache.hadoop.ozone.om.BucketManagerImpl.createBucket(BucketManagerImpl.java:98)
 at org.apache.hadoop.ozone.om.OzoneManager.createBucket(OzoneManager.java:694)
+2018-09-06 01:59:18,447 | INFO | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_BUCKET {volume=dcv, bucket=dbb, acls=[USER:hadoop:rw, GROUP:users:rw], isVersionEnabled=false, storageType=DISK, creationTime=0} | ret=SUCCESS |
 2018-09-06 01:59:36,686 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck1, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=SUCCESS |
 2018-09-06 01:59:41,027 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck2, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=SUCCESS |
 2018-09-06 01:59:47,169 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck2, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException: Key not found
 at org.apache.hadoop.ozone.om.KeyManagerImpl.deleteKey(KeyManagerImpl.java:448)
 at org.apache.hadoop.ozone.om.OzoneManager.deleteKey(OzoneManager.java:892)
 2018-09-06 01:60:22,900 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=ALLOCATE_KEY {volume=vol-8-67105, bucket=bucket-0-68911, key=key-246-29031, dataSize=10240, replicationType=STAND_ALONE, replicationFactor=ONE, keyLocationInfo=null} | ret=SUCCESS |
+2021-05-18 11:03:21,306 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 |op=COMPLETE_MULTIPART_UPLOAD {volume=vol-8-67105, bucket=bucket-0-68911,key=key-246-29032/chunks/000005, dataSize=0, replicationType=RATIS, replicationFactor=ONE,multipartList=[partNumber: 1 partName:"/vol-8-67105/bucket-0-68911/key-246-29032/chunks/000005106253975577886743" , partNumber: 2 partName: "/vol-8-67105/bucket-0-68911/key-246-29032/chunks/000005106253975577886745" , partNumber: 3 partName: "/vol-8-67105/bucket-0-68911/key-246-29032/chunks/000005106253975577886744" , partNumber: 4 partName: "/vol-8-67105/bucket-0-68911/key-246-29032/chunks/000005106253975577886742" ]} | ret=SUCCESS |

--- a/hadoop-ozone/tools/src/test/resources/testloadaudit.log
+++ b/hadoop-ozone/tools/src/test/resources/testloadaudit.log
@@ -1,0 +1,21 @@
+2021-05-18 01:57:22,996 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=ALLOCATE_KEY {volume=vol-7-67105, bucket=bucket-0-68911, key=key-246-29031, dataSize=10240, replicationType=STAND_ALONE, replicationFactor=ONE, keyLocationInfo=null} | ret=SUCCESS |
+2021-05-18 01:57:22,997 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=COMMIT_KEY {volume=vol-4-88912, bucket=bucket-0-27678, key=key-241-42688, dataSize=10240, replicationType=null, replicationFactor=null, keyLocationInfo=[org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo@25bd7387], clientID=61987500296} | ret=SUCCESS |
+2021-05-18 01:57:22,997 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=COMMIT_KEY {volume=vol-1-59303, bucket=bucket-0-47510, key=key-248-17213, dataSize=10240, replicationType=null, replicationFactor=null, keyLocationInfo=[org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo@788f5bea], clientID=61990833797} | ret=SUCCESS |
+2021-05-18 01:58:08,035 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_VOLUME {admin=hadoop, owner=tom, volume=dcv, creationTime=0, quotaInBytes=1152921504606846976} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException
+at org.apache.hadoop.ozone.om.VolumeManagerImpl.createVolume(VolumeManagerImpl.java:137)
+at org.apache.hadoop.ozone.om.OzoneManager.createVolume(OzoneManager.java:469)
+2021-05-18 01:58:18,447 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=CREATE_BUCKET {volume=dcv, bucket=dcb, acls=[USER:hadoop:rw, GROUP:users:rw], isVersionEnabled=false, storageType=DISK, creationTime=0} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException: Bucket already exist
+at org.apache.hadoop.ozone.om.BucketManagerImpl.createBucket(BucketManagerImpl.java:98)
+at org.apache.hadoop.ozone.om.OzoneManager.createBucket(OzoneManager.java:694)
+2021-05-18 01:59:36,686 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck1, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=SUCCESS |
+2021-05-18 01:59:41,027 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck2, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=SUCCESS |
+2021-05-18 01:59:47,169 | ERROR | OMAudit | user=hadoop | ip=172.18.0.4 | op=DELETE_KEY {volume=dcv, bucket=dcb, key=dck2, dataSize=0, replicationType=null, replicationFactor=null, keyLocationInfo=null} | ret=FAILURE | org.apache.hadoop.ozone.om.exceptions.OMException: Key not found
+at org.apache.hadoop.ozone.om.KeyManagerImpl.deleteKey(KeyManagerImpl.java:448)
+at org.apache.hadoop.ozone.om.OzoneManager.deleteKey(OzoneManager.java:892)
+2021-05-18 01:60:22,900 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 | op=ALLOCATE_KEY {volume=vol-8-67105, bucket=bucket-0-68911, key=key-246-29031, dataSize=10240, replicationType=STAND_ALONE, replicationFactor=ONE, keyLocationInfo=null} | ret=SUCCESS |
+2021-05-18 01:60:22,900 | INFO  | OMAudit | user=hadoop | ip=172.18.0.4 |
+op=COMPLETE_MULTIPART_UPLOAD {volume=vol-8-67105, bucket=bucket-0-68911, key=key-246-29031/key-test.jar, dataSize=0, replicationType=RATIS, replicationFactor=ONE, multipartList=[partNumber: 1
+partName: "/vol-8-67105/bucket-0-68911/key-246-29033/key-test.jar106233237949176650"
+, partNumber: 2
+partName: "/vol-8-67105/bucket-0-68911/key-246-29033/key-test.jar106233237955992395"
+]} | ret=SUCCESS |


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone auditparser ~/audit.db load /logs/om-audit.log`
The command throw out of bound exception:

Index 6 out of bounds for length 6.

The audit log like this

![image](https://user-images.githubusercontent.com/32935220/118604330-a0eac180-b7e7-11eb-994b-0d61759eda38.png)

There is "\n" after "partNumber: 1" and "partName***"

so, `bReader.readLine()` only read before the first "\n"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5240?filter=-2

## How was this patch tested?

UT
