### PR TITLE
HDDS-5243. Return latest key location for clients

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -449,9 +449,9 @@ public final class OzoneConfigKeys {
   public static final long OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT =
       TimeUnit.DAYS.toMillis(10); // 10 days
 
-  public static final String OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION =
-      "ozone.client.key.latest.location.version";
-  public static final boolean OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION_DEFAULT =
+  public static final String OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION =
+      "ozone.client.key.latest.version.location";
+  public static final boolean OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION_DEFAULT =
       true;
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -449,10 +449,10 @@ public final class OzoneConfigKeys {
   public static final long OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT =
       TimeUnit.DAYS.toMillis(10); // 10 days
 
-  public static final String OZONE_CLIENT_KEY_FULL_LOCATION_VERSION =
-      "ozone.client.key.full.location.version";
-  public static final boolean OZONE_CLIENT_KEY_FULL_LOCATION_VERSION_DEFAULT =
-      false;
+  public static final String OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION =
+      "ozone.client.key.latest.location.version";
+  public static final boolean OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION_DEFAULT =
+      true;
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -449,6 +449,11 @@ public final class OzoneConfigKeys {
   public static final long OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT =
       TimeUnit.DAYS.toMillis(10); // 10 days
 
+  public static final String OZONE_CLIENT_KEY_FULL_LOCATION_VERSION =
+      "ozone.client.key.full.location.version";
+  public static final boolean OZONE_CLIENT_KEY_FULL_LOCATION_VERSION_DEFAULT =
+      false;
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2855,10 +2855,10 @@
   </property>
 
   <property>
-    <name>ozone.client.key.latest.location.version</name>
+    <name>ozone.client.key.latest.version.location</name>
     <tag>OZONE, CLIENT</tag>
     <value>true</value>
-    <description>Ozone client get the latest location version.
+    <description>Ozone client gets the latest version location.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2857,8 +2857,8 @@
   <property>
     <name>ozone.client.key.full.location.version</name>
     <tag>OZONE, CLIENT</tag>
-    <value>false</value>
-    <description>Ozone client get full location version.
+    <value>true</value>
+    <description>Ozone client get the latest location version.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2855,7 +2855,7 @@
   </property>
 
   <property>
-    <name>ozone.client.key.full.location.version</name>
+    <name>ozone.client.key.latest.location.version</name>
     <tag>OZONE, CLIENT</tag>
     <value>true</value>
     <description>Ozone client get the latest location version.

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2841,7 +2841,6 @@
     </description>
   </property>
 
-
   <property>
     <name>ozone.scm.ca.list.retry.interval</name>
     <tag>OZONE, SCM, OM, DATANODE</tag>
@@ -2855,4 +2854,11 @@
     </description>
   </property>
 
+  <property>
+    <name>ozone.client.key.full.location.version</name>
+    <tag>OZONE, CLIENT</tag>
+    <value>false</value>
+    <description>Ozone client get full location version.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -160,7 +160,7 @@ public class RpcClient implements ClientProtocol {
   private final boolean checkKeyNameEnabled;
   private final OzoneClientConfig clientConfig;
   private final Cache<URI, KeyProvider> keyProviderCache;
-  private final boolean getFullLocationVersion;
+  private final boolean getLatestLocationVersion;
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -231,9 +231,9 @@ public class RpcClient implements ClientProtocol {
     checkKeyNameEnabled = conf.getBoolean(
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_KEY,
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT);
-    getFullLocationVersion = conf.getBoolean(
-        OzoneConfigKeys.OZONE_CLIENT_KEY_FULL_LOCATION_VERSION,
-        OzoneConfigKeys.OZONE_CLIENT_KEY_FULL_LOCATION_VERSION_DEFAULT);
+    getLatestLocationVersion = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION,
+        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION_DEFAULT);
 
     long keyProviderCacheExpiryMs = conf.getTimeDuration(
         OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY,
@@ -823,7 +823,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setFullLocationVersion(getFullLocationVersion)
+        .setLatestLocationVersion(getLatestLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -936,7 +936,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setFullLocationVersion(getFullLocationVersion)
+        .setLatestLocationVersion(getLatestLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
 
@@ -1161,7 +1161,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setFullLocationVersion(getFullLocationVersion)
+        .setLatestLocationVersion(getLatestLocationVersion)
         .build();
     return ozoneManagerClient.getFileStatus(keyArgs);
   }
@@ -1185,7 +1185,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setFullLocationVersion(getFullLocationVersion)
+        .setLatestLocationVersion(getLatestLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupFile(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -1218,7 +1218,7 @@ public class RpcClient implements ClientProtocol {
             .setKeyName(omKeyInfo.getKeyName())
             .setRefreshPipeline(true)
             .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-            .setFullLocationVersion(getFullLocationVersion)
+            .setLatestLocationVersion(getLatestLocationVersion)
             .build();
         return ozoneManagerClient.lookupKey(omKeyArgs);
       } catch (IOException e) {
@@ -1257,7 +1257,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setFullLocationVersion(getFullLocationVersion)
+        .setLatestLocationVersion(getLatestLocationVersion)
         .build();
     return ozoneManagerClient
         .listStatus(keyArgs, recursive, startKey, numEntries);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -160,6 +160,7 @@ public class RpcClient implements ClientProtocol {
   private final boolean checkKeyNameEnabled;
   private final OzoneClientConfig clientConfig;
   private final Cache<URI, KeyProvider> keyProviderCache;
+  private final boolean getFullLocationVersion;
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -230,6 +231,9 @@ public class RpcClient implements ClientProtocol {
     checkKeyNameEnabled = conf.getBoolean(
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_KEY,
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT);
+    getFullLocationVersion = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_KEY_FULL_LOCATION_VERSION,
+        OzoneConfigKeys.OZONE_CLIENT_KEY_FULL_LOCATION_VERSION_DEFAULT);
 
     long keyProviderCacheExpiryMs = conf.getTimeDuration(
         OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY,
@@ -819,6 +823,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+        .setFullLocationVersion(getFullLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -931,6 +936,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+        .setFullLocationVersion(getFullLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
 
@@ -1155,6 +1161,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+        .setFullLocationVersion(getFullLocationVersion)
         .build();
     return ozoneManagerClient.getFileStatus(keyArgs);
   }
@@ -1178,6 +1185,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+        .setFullLocationVersion(getFullLocationVersion)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupFile(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -1210,6 +1218,7 @@ public class RpcClient implements ClientProtocol {
             .setKeyName(omKeyInfo.getKeyName())
             .setRefreshPipeline(true)
             .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+            .setFullLocationVersion(getFullLocationVersion)
             .build();
         return ozoneManagerClient.lookupKey(omKeyArgs);
       } catch (IOException e) {
@@ -1248,6 +1257,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
+        .setFullLocationVersion(getFullLocationVersion)
         .build();
     return ozoneManagerClient
         .listStatus(keyArgs, recursive, startKey, numEntries);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -160,7 +160,7 @@ public class RpcClient implements ClientProtocol {
   private final boolean checkKeyNameEnabled;
   private final OzoneClientConfig clientConfig;
   private final Cache<URI, KeyProvider> keyProviderCache;
-  private final boolean getLatestLocationVersion;
+  private final boolean getLatestVersionLocation;
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -231,9 +231,9 @@ public class RpcClient implements ClientProtocol {
     checkKeyNameEnabled = conf.getBoolean(
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_KEY,
         OMConfigKeys.OZONE_OM_KEYNAME_CHARACTER_CHECK_ENABLED_DEFAULT);
-    getLatestLocationVersion = conf.getBoolean(
-        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION,
-        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_LOCATION_VERSION_DEFAULT);
+    getLatestVersionLocation = conf.getBoolean(
+        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION,
+        OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION_DEFAULT);
 
     long keyProviderCacheExpiryMs = conf.getTimeDuration(
         OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY,
@@ -823,7 +823,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setLatestLocationVersion(getLatestLocationVersion)
+        .setLatestVersionLocation(getLatestVersionLocation)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -936,7 +936,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setLatestLocationVersion(getLatestLocationVersion)
+        .setLatestVersionLocation(getLatestVersionLocation)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
 
@@ -1161,7 +1161,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setLatestLocationVersion(getLatestLocationVersion)
+        .setLatestVersionLocation(getLatestVersionLocation)
         .build();
     return ozoneManagerClient.getFileStatus(keyArgs);
   }
@@ -1185,7 +1185,7 @@ public class RpcClient implements ClientProtocol {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setLatestLocationVersion(getLatestLocationVersion)
+        .setLatestVersionLocation(getLatestVersionLocation)
         .build();
     OmKeyInfo keyInfo = ozoneManagerClient.lookupFile(keyArgs);
     return getInputStreamWithRetryFunction(keyInfo);
@@ -1218,7 +1218,7 @@ public class RpcClient implements ClientProtocol {
             .setKeyName(omKeyInfo.getKeyName())
             .setRefreshPipeline(true)
             .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-            .setLatestLocationVersion(getLatestLocationVersion)
+            .setLatestVersionLocation(getLatestVersionLocation)
             .build();
         return ozoneManagerClient.lookupKey(omKeyArgs);
       } catch (IOException e) {
@@ -1257,7 +1257,7 @@ public class RpcClient implements ClientProtocol {
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(topologyAwareReadEnabled)
-        .setLatestLocationVersion(getLatestLocationVersion)
+        .setLatestVersionLocation(getLatestVersionLocation)
         .build();
     return ozoneManagerClient
         .listStatus(keyArgs, recursive, startKey, numEntries);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -48,6 +48,7 @@ public final class OmKeyArgs implements Auditable {
   private boolean refreshPipeline;
   private boolean sortDatanodesInPipeline;
   private List<OzoneAcl> acls;
+  private boolean fullLocationVersion;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -55,7 +56,8 @@ public final class OmKeyArgs implements Auditable {
       List<OmKeyLocationInfo> locationInfoList, boolean isMultipart,
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
-      List<OzoneAcl> acls, boolean sortDatanode) {
+      List<OzoneAcl> acls, boolean sortDatanode,
+      boolean fullLocationVersion) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -70,6 +72,7 @@ public final class OmKeyArgs implements Auditable {
     this.refreshPipeline = refreshPipeline;
     this.acls = acls;
     this.sortDatanodesInPipeline = sortDatanode;
+    this.fullLocationVersion = fullLocationVersion;
   }
 
   public boolean getIsMultipartKey() {
@@ -140,6 +143,10 @@ public final class OmKeyArgs implements Auditable {
     return sortDatanodesInPipeline;
   }
 
+  public boolean getFullLocationVersion() {
+    return fullLocationVersion;
+  }
+
   @Override
   public Map<String, String> toAuditMap() {
     Map<String, String> auditMap = new LinkedHashMap<>();
@@ -177,6 +184,7 @@ public final class OmKeyArgs implements Auditable {
         .addAllMetadata(metadata)
         .setRefreshPipeline(refreshPipeline)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
+        .setFullLocationVersion(fullLocationVersion)
         .setAcls(acls);
   }
 
@@ -197,6 +205,7 @@ public final class OmKeyArgs implements Auditable {
     private Map<String, String> metadata = new HashMap<>();
     private boolean refreshPipeline;
     private boolean sortDatanodesInPipeline;
+    private boolean fullLocationVersion;
     private List<OzoneAcl> acls;
 
     public Builder setVolumeName(String volume) {
@@ -274,11 +283,16 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
+    public Builder setFullLocationVersion(boolean full) {
+      this.fullLocationVersion = full;
+      return this;
+    }
+
     public OmKeyArgs build() {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize, type,
           factor, locationInfoList, isMultipartKey, multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline);
+          sortDatanodesInPipeline, fullLocationVersion);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -48,7 +48,7 @@ public final class OmKeyArgs implements Auditable {
   private boolean refreshPipeline;
   private boolean sortDatanodesInPipeline;
   private List<OzoneAcl> acls;
-  private boolean latestLocationVersion;
+  private boolean latestVersionLocation;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -57,7 +57,7 @@ public final class OmKeyArgs implements Auditable {
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
       List<OzoneAcl> acls, boolean sortDatanode,
-      boolean latestLocationVersion) {
+      boolean latestVersionLocation) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -72,7 +72,7 @@ public final class OmKeyArgs implements Auditable {
     this.refreshPipeline = refreshPipeline;
     this.acls = acls;
     this.sortDatanodesInPipeline = sortDatanode;
-    this.latestLocationVersion = latestLocationVersion;
+    this.latestVersionLocation = latestVersionLocation;
   }
 
   public boolean getIsMultipartKey() {
@@ -143,8 +143,8 @@ public final class OmKeyArgs implements Auditable {
     return sortDatanodesInPipeline;
   }
 
-  public boolean getLatestLocationVersion() {
-    return latestLocationVersion;
+  public boolean getLatestVersionLocation() {
+    return latestVersionLocation;
   }
 
   @Override
@@ -184,7 +184,7 @@ public final class OmKeyArgs implements Auditable {
         .addAllMetadata(metadata)
         .setRefreshPipeline(refreshPipeline)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
-        .setLatestLocationVersion(latestLocationVersion)
+        .setLatestVersionLocation(latestVersionLocation)
         .setAcls(acls);
   }
 
@@ -205,7 +205,7 @@ public final class OmKeyArgs implements Auditable {
     private Map<String, String> metadata = new HashMap<>();
     private boolean refreshPipeline;
     private boolean sortDatanodesInPipeline;
-    private boolean latestLocationVersion;
+    private boolean latestVersionLocation;
     private List<OzoneAcl> acls;
 
     public Builder setVolumeName(String volume) {
@@ -283,8 +283,8 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
-    public Builder setLatestLocationVersion(boolean latest) {
-      this.latestLocationVersion = latest;
+    public Builder setLatestVersionLocation(boolean latest) {
+      this.latestVersionLocation = latest;
       return this;
     }
 
@@ -292,7 +292,7 @@ public final class OmKeyArgs implements Auditable {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize, type,
           factor, locationInfoList, isMultipartKey, multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline, latestLocationVersion);
+          sortDatanodesInPipeline, latestVersionLocation);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -48,7 +48,7 @@ public final class OmKeyArgs implements Auditable {
   private boolean refreshPipeline;
   private boolean sortDatanodesInPipeline;
   private List<OzoneAcl> acls;
-  private boolean fullLocationVersion;
+  private boolean latestLocationVersion;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -57,7 +57,7 @@ public final class OmKeyArgs implements Auditable {
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
       List<OzoneAcl> acls, boolean sortDatanode,
-      boolean fullLocationVersion) {
+      boolean latestLocationVersion) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -72,7 +72,7 @@ public final class OmKeyArgs implements Auditable {
     this.refreshPipeline = refreshPipeline;
     this.acls = acls;
     this.sortDatanodesInPipeline = sortDatanode;
-    this.fullLocationVersion = fullLocationVersion;
+    this.latestLocationVersion = latestLocationVersion;
   }
 
   public boolean getIsMultipartKey() {
@@ -143,8 +143,8 @@ public final class OmKeyArgs implements Auditable {
     return sortDatanodesInPipeline;
   }
 
-  public boolean getFullLocationVersion() {
-    return fullLocationVersion;
+  public boolean getLatestLocationVersion() {
+    return latestLocationVersion;
   }
 
   @Override
@@ -184,7 +184,7 @@ public final class OmKeyArgs implements Auditable {
         .addAllMetadata(metadata)
         .setRefreshPipeline(refreshPipeline)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
-        .setFullLocationVersion(fullLocationVersion)
+        .setLatestLocationVersion(latestLocationVersion)
         .setAcls(acls);
   }
 
@@ -205,7 +205,7 @@ public final class OmKeyArgs implements Auditable {
     private Map<String, String> metadata = new HashMap<>();
     private boolean refreshPipeline;
     private boolean sortDatanodesInPipeline;
-    private boolean fullLocationVersion;
+    private boolean latestLocationVersion;
     private List<OzoneAcl> acls;
 
     public Builder setVolumeName(String volume) {
@@ -283,8 +283,8 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
-    public Builder setFullLocationVersion(boolean full) {
-      this.fullLocationVersion = full;
+    public Builder setLatestLocationVersion(boolean latest) {
+      this.latestLocationVersion = latest;
       return this;
     }
 
@@ -292,7 +292,7 @@ public final class OmKeyArgs implements Auditable {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize, type,
           factor, locationInfoList, isMultipartKey, multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline, fullLocationVersion);
+          sortDatanodesInPipeline, latestLocationVersion);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLoca
 import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 import org.apache.hadoop.util.Time;
 
-import com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,17 +75,6 @@ public final class OmKeyInfo extends WithObjectID {
     this.bucketName = bucketName;
     this.keyName = keyName;
     this.dataSize = dataSize;
-    // it is important that the versions are ordered from old to new.
-    // Do this sanity check when versions got loaded on creating OmKeyInfo.
-    // TODO : this is not necessary, here only because versioning is still a
-    // work in-progress, remove this following check when versioning is
-    // complete and prove correctly functioning
-    long currentVersion = -1;
-    for (OmKeyLocationInfoGroup version : versions) {
-      Preconditions.checkArgument(
-            currentVersion + 1 == version.getVersion());
-      currentVersion = version.getVersion();
-    }
     this.keyLocationVersions = versions;
     this.creationTime = creationTime;
     this.modificationTime = modificationTime;
@@ -138,6 +126,11 @@ public final class OmKeyInfo extends WithObjectID {
 
   public List<OmKeyLocationInfoGroup> getKeyLocationVersions() {
     return keyLocationVersions;
+  }
+
+  public void setKeyLocationVersions(
+      List<OmKeyLocationInfoGroup> keyLocationVersions) {
+    this.keyLocationVersions = keyLocationVersions;
   }
 
   public void updateModifcationTime() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -677,7 +677,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
         .setSortDatanodes(args.getSortDatanodes())
-        .setFullLocationVersion(args.getFullLocationVersion())
+        .setLatestLocationVersion(args.getLatestLocationVersion())
         .build();
     req.setKeyArgs(keyArgs);
 
@@ -1203,7 +1203,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setFullLocationVersion(args.getFullLocationVersion())
+        .setLatestLocationVersion(args.getLatestLocationVersion())
         .build();
     GetFileStatusRequest req =
         GetFileStatusRequest.newBuilder()
@@ -1257,7 +1257,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setFullLocationVersion(args.getFullLocationVersion())
+        .setLatestLocationVersion(args.getLatestLocationVersion())
         .build();
     LookupFileRequest lookupFileRequest = LookupFileRequest.newBuilder()
             .setKeyArgs(keyArgs)
@@ -1419,7 +1419,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setFullLocationVersion(args.getFullLocationVersion())
+        .setLatestLocationVersion(args.getLatestLocationVersion())
         .build();
     ListStatusRequest listStatusRequest =
         ListStatusRequest.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -677,7 +677,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
         .setSortDatanodes(args.getSortDatanodes())
-        .setLatestLocationVersion(args.getLatestLocationVersion())
+        .setLatestVersionLocation(args.getLatestVersionLocation())
         .build();
     req.setKeyArgs(keyArgs);
 
@@ -1203,7 +1203,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setLatestLocationVersion(args.getLatestLocationVersion())
+        .setLatestVersionLocation(args.getLatestVersionLocation())
         .build();
     GetFileStatusRequest req =
         GetFileStatusRequest.newBuilder()
@@ -1257,7 +1257,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setLatestLocationVersion(args.getLatestLocationVersion())
+        .setLatestVersionLocation(args.getLatestVersionLocation())
         .build();
     LookupFileRequest lookupFileRequest = LookupFileRequest.newBuilder()
             .setKeyArgs(keyArgs)
@@ -1419,7 +1419,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
-        .setLatestLocationVersion(args.getLatestLocationVersion())
+        .setLatestVersionLocation(args.getLatestVersionLocation())
         .build();
     ListStatusRequest listStatusRequest =
         ListStatusRequest.newBuilder()

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -677,6 +677,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setKeyName(args.getKeyName())
         .setDataSize(args.getDataSize())
         .setSortDatanodes(args.getSortDatanodes())
+        .setFullLocationVersion(args.getFullLocationVersion())
         .build();
     req.setKeyArgs(keyArgs);
 
@@ -1202,6 +1203,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
+        .setFullLocationVersion(args.getFullLocationVersion())
         .build();
     GetFileStatusRequest req =
         GetFileStatusRequest.newBuilder()
@@ -1255,6 +1257,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
+        .setFullLocationVersion(args.getFullLocationVersion())
         .build();
     LookupFileRequest lookupFileRequest = LookupFileRequest.newBuilder()
             .setKeyArgs(keyArgs)
@@ -1416,6 +1419,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setBucketName(args.getBucketName())
         .setKeyName(args.getKeyName())
         .setSortDatanodes(args.getSortDatanodes())
+        .setFullLocationVersion(args.getFullLocationVersion())
         .build();
     ListStatusRequest listStatusRequest =
         ListStatusRequest.newBuilder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -818,7 +818,7 @@ public class TestKeyManagerImpl {
     String keyName = RandomStringUtils.randomAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
-        .setLatestLocationVersion(true)
+        .setLatestVersionLocation(true)
         .build();
 
     // lookup for a non-existent key
@@ -885,7 +885,7 @@ public class TestKeyManagerImpl {
 
     keyArgs = createBuilder()
         .setKeyName(keyName)
-        .setLatestLocationVersion(false)
+        .setLatestVersionLocation(false)
         .build();
 
     // Test lookupKey (latestLocationVersion == false)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -814,6 +814,106 @@ public class TestKeyManagerImpl {
   }
 
   @Test
+  public void testFullLocationVersion() throws IOException {
+    String keyName = RandomStringUtils.randomAlphabetic(5);
+    OmKeyArgs keyArgs = createBuilder()
+        .setKeyName(keyName)
+        .build();
+
+    // lookup for a non-existent key
+    try {
+      keyManager.lookupKey(keyArgs, null);
+      Assert.fail("Lookup key should fail for non existent key");
+    } catch (OMException ex) {
+      if (ex.getResult() != OMException.ResultCodes.KEY_NOT_FOUND) {
+        throw ex;
+      }
+    }
+
+    // create a key
+    OpenKeySession keySession = keyManager.createFile(keyArgs, false, false);
+    // randomly select 3 datanodes
+    List<DatanodeDetails> nodeList = new ArrayList<>();
+    nodeList.add((DatanodeDetails)scm.getClusterMap().getNode(
+        0, null, null, null, null, 0));
+    nodeList.add((DatanodeDetails)scm.getClusterMap().getNode(
+        1, null, null, null, null, 0));
+    nodeList.add((DatanodeDetails)scm.getClusterMap().getNode(
+        2, null, null, null, null, 0));
+    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(1)));
+    Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
+    // create a pipeline using 3 datanodes
+    Pipeline pipeline = scm.getPipelineManager().createPipeline(
+        new RatisReplicationConfig(ReplicationFactor.THREE), nodeList);
+    List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
+    List<OmKeyLocationInfo> locationList =
+        keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
+    Assert.assertEquals(1, locationList.size());
+    locationInfoList.add(
+        new OmKeyLocationInfo.Builder().setPipeline(pipeline)
+            .setBlockID(new BlockID(locationList.get(0).getContainerID(),
+                locationList.get(0).getLocalID())).build());
+    keyArgs.setLocationInfoList(locationInfoList);
+
+    keyManager.commitKey(keyArgs, keySession.getId());
+    OmKeyInfo key = keyManager.lookupKey(keyArgs, null);
+    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+
+    keySession = keyManager.createFile(keyArgs, true, true);
+    keyManager.commitKey(keyArgs, keySession.getId());
+
+    // Test lookupKey (fullLocationVersion == false)
+    key = keyManager.lookupKey(keyArgs, null);
+    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+
+    // Test ListStatus (fullLocationVersion == false)
+    List<OzoneFileStatus> fileStatuses =
+        keyManager.listStatus(keyArgs, false, "", 1);
+    Assert.assertEquals(fileStatuses.size(), 1);
+    Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
+        .getKeyLocationVersions().size(), 1);
+
+    // Test GetFileStatus (fullLocationVersion == false)
+    OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
+    Assert.assertEquals(ozoneFileStatus.getKeyInfo()
+        .getKeyLocationVersions().size(), 1);
+
+    // Test LookupFile (fullLocationVersion == false)
+    key = keyManager.lookupFile(keyArgs, null);
+    Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
+
+    keyArgs = createBuilder()
+        .setKeyName(keyName)
+        .setFullLocationVersion(true)
+        .build();
+
+    // Test lookupKey (fullLocationVersion == true)
+    key = keyManager.lookupKey(keyArgs, null);
+    Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
+
+    // Test ListStatus (fullLocationVersion == true)
+    fileStatuses = keyManager.listStatus(keyArgs, false, "", 100);
+    Assert.assertEquals(fileStatuses.size(), 1);
+    Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
+        .getKeyLocationVersions().size(), 2);
+
+    // Test GetFileStatus (fullLocationVersion == true)
+    ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
+    Assert.assertEquals(ozoneFileStatus.getKeyInfo()
+        .getKeyLocationVersions().size(), 2);
+
+    // Test LookupFile (fullLocationVersion == true)
+    key = keyManager.lookupFile(keyArgs, null);
+    Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
+
+    // Test ListKeys (fullLocationVersion is always false for ListKeys)
+    List<OmKeyInfo> keyInfos = keyManager.listKeys(keyArgs.getVolumeName(),
+        keyArgs.getBucketName(), "", keyArgs.getKeyName(), 100);
+    Assert.assertEquals(keyInfos.size(), 1);
+    Assert.assertEquals(keyInfos.get(0).getKeyLocationVersions().size(), 1);
+  }
+
+  @Test
   public void testListStatusWithTableCache() throws Exception {
     // Inspired by TestOmMetadataManager#testListKeys
     String prefixKeyInDB = "key-d";

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -814,10 +814,11 @@ public class TestKeyManagerImpl {
   }
 
   @Test
-  public void testFullLocationVersion() throws IOException {
+  public void testLatestLocationVersion() throws IOException {
     String keyName = RandomStringUtils.randomAlphabetic(5);
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(keyName)
+        .setLatestLocationVersion(true)
         .build();
 
     // lookup for a non-existent key
@@ -862,51 +863,51 @@ public class TestKeyManagerImpl {
     keySession = keyManager.createFile(keyArgs, true, true);
     keyManager.commitKey(keyArgs, keySession.getId());
 
-    // Test lookupKey (fullLocationVersion == false)
+    // Test lookupKey (latestLocationVersion == true)
     key = keyManager.lookupKey(keyArgs, null);
     Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
 
-    // Test ListStatus (fullLocationVersion == false)
+    // Test ListStatus (latestLocationVersion == true)
     List<OzoneFileStatus> fileStatuses =
         keyManager.listStatus(keyArgs, false, "", 1);
     Assert.assertEquals(fileStatuses.size(), 1);
     Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
         .getKeyLocationVersions().size(), 1);
 
-    // Test GetFileStatus (fullLocationVersion == false)
+    // Test GetFileStatus (latestLocationVersion == true)
     OzoneFileStatus ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
     Assert.assertEquals(ozoneFileStatus.getKeyInfo()
         .getKeyLocationVersions().size(), 1);
 
-    // Test LookupFile (fullLocationVersion == false)
+    // Test LookupFile (latestLocationVersion == true)
     key = keyManager.lookupFile(keyArgs, null);
     Assert.assertEquals(key.getKeyLocationVersions().size(), 1);
 
     keyArgs = createBuilder()
         .setKeyName(keyName)
-        .setFullLocationVersion(true)
+        .setLatestLocationVersion(false)
         .build();
 
-    // Test lookupKey (fullLocationVersion == true)
+    // Test lookupKey (latestLocationVersion == false)
     key = keyManager.lookupKey(keyArgs, null);
     Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
 
-    // Test ListStatus (fullLocationVersion == true)
+    // Test ListStatus (latestLocationVersion == false)
     fileStatuses = keyManager.listStatus(keyArgs, false, "", 100);
     Assert.assertEquals(fileStatuses.size(), 1);
     Assert.assertEquals(fileStatuses.get(0).getKeyInfo()
         .getKeyLocationVersions().size(), 2);
 
-    // Test GetFileStatus (fullLocationVersion == true)
+    // Test GetFileStatus (latestLocationVersion == false)
     ozoneFileStatus = keyManager.getFileStatus(keyArgs, null);
     Assert.assertEquals(ozoneFileStatus.getKeyInfo()
         .getKeyLocationVersions().size(), 2);
 
-    // Test LookupFile (fullLocationVersion == true)
+    // Test LookupFile (latestLocationVersion == false)
     key = keyManager.lookupFile(keyArgs, null);
     Assert.assertEquals(key.getKeyLocationVersions().size(), 2);
 
-    // Test ListKeys (fullLocationVersion is always false for ListKeys)
+    // Test ListKeys (latestLocationVersion is always true for ListKeys)
     List<OmKeyInfo> keyInfos = keyManager.listKeys(keyArgs.getVolumeName(),
         keyArgs.getBucketName(), "", keyArgs.getKeyName(), 100);
     Assert.assertEquals(keyInfos.size(), 1);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -735,6 +735,7 @@ message KeyArgs {
 
     // This will be set by leader OM in HA and update the original request.
     optional FileEncryptionInfoProto fileEncryptionInfo = 15;
+    optional bool fullLocationVersion = 16;
 }
 
 message KeyLocation {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -735,7 +735,7 @@ message KeyArgs {
 
     // This will be set by leader OM in HA and update the original request.
     optional FileEncryptionInfoProto fileEncryptionInfo = 15;
-    optional bool latestLocationVersion = 16;
+    optional bool latestVersionLocation = 16;
 }
 
 message KeyLocation {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -735,7 +735,7 @@ message KeyArgs {
 
     // This will be set by leader OM in HA and update the original request.
     optional FileEncryptionInfoProto fileEncryptionInfo = 15;
-    optional bool fullLocationVersion = 16;
+    optional bool latestLocationVersion = 16;
 }
 
 message KeyLocation {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -679,7 +679,7 @@ public class KeyManagerImpl implements KeyManager {
       throw new OMException("Key not found", KEY_NOT_FOUND);
     }
 
-    if (!args.getFullLocationVersion()) {
+    if (args.getLatestLocationVersion()) {
       slimLocationVersion(value);
     }
 
@@ -1785,7 +1785,7 @@ public class KeyManagerImpl implements KeyManager {
 
     return getOzoneFileStatus(volumeName, bucketName, keyName,
         args.getRefreshPipeline(), args.getSortDatanodes(),
-        args.getFullLocationVersion(), clientAddress);
+        args.getLatestLocationVersion(), clientAddress);
   }
 
   private OzoneFileStatus getOzoneFileStatus(String volumeName,
@@ -1793,7 +1793,7 @@ public class KeyManagerImpl implements KeyManager {
                                              String keyName,
                                              boolean refreshPipeline,
                                              boolean sortDatanodes,
-                                             boolean fullLocationVersion,
+                                             boolean latestLocationVersion,
                                              String clientAddress)
       throws IOException {
     OmKeyInfo fileKeyInfo = null;
@@ -1827,7 +1827,7 @@ public class KeyManagerImpl implements KeyManager {
 
       // if the key is a file then do refresh pipeline info in OM by asking SCM
       if (fileKeyInfo != null) {
-        if (!fullLocationVersion) {
+        if (latestLocationVersion) {
           slimLocationVersion(fileKeyInfo);
         }
         // refreshPipeline flag check has been removed as part of
@@ -1996,7 +1996,7 @@ public class KeyManagerImpl implements KeyManager {
     String keyName = args.getKeyName();
     OzoneFileStatus fileStatus = getOzoneFileStatus(volumeName, bucketName,
         keyName, args.getRefreshPipeline(), args.getSortDatanodes(),
-        args.getFullLocationVersion(), clientAddress);
+        args.getLatestLocationVersion(), clientAddress);
       //if key is not of type file or if key is not found we throw an exception
     if (fileStatus.isFile()) {
       // add block token for read.
@@ -2223,7 +2223,7 @@ public class KeyManagerImpl implements KeyManager {
     for (OzoneFileStatus fileStatus : fileStatusList) {
       keyInfoList.add(fileStatus.getKeyInfo());
     }
-    if (!args.getFullLocationVersion()) {
+    if (args.getLatestLocationVersion()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
     refreshPipeline(keyInfoList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -679,7 +679,7 @@ public class KeyManagerImpl implements KeyManager {
       throw new OMException("Key not found", KEY_NOT_FOUND);
     }
 
-    if (args.getLatestLocationVersion()) {
+    if (args.getLatestVersionLocation()) {
       slimLocationVersion(value);
     }
 
@@ -1785,7 +1785,7 @@ public class KeyManagerImpl implements KeyManager {
 
     return getOzoneFileStatus(volumeName, bucketName, keyName,
         args.getRefreshPipeline(), args.getSortDatanodes(),
-        args.getLatestLocationVersion(), clientAddress);
+        args.getLatestVersionLocation(), clientAddress);
   }
 
   private OzoneFileStatus getOzoneFileStatus(String volumeName,
@@ -1996,7 +1996,7 @@ public class KeyManagerImpl implements KeyManager {
     String keyName = args.getKeyName();
     OzoneFileStatus fileStatus = getOzoneFileStatus(volumeName, bucketName,
         keyName, args.getRefreshPipeline(), args.getSortDatanodes(),
-        args.getLatestLocationVersion(), clientAddress);
+        args.getLatestVersionLocation(), clientAddress);
       //if key is not of type file or if key is not found we throw an exception
     if (fileStatus.isFile()) {
       // add block token for read.
@@ -2223,7 +2223,7 @@ public class KeyManagerImpl implements KeyManager {
     for (OzoneFileStatus fileStatus : fileStatusList) {
       keyInfoList.add(fileStatus.getKeyInfo());
     }
-    if (args.getLatestLocationVersion()) {
+    if (args.getLatestVersionLocation()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
     refreshPipeline(keyInfoList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -361,6 +361,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
+        .setFullLocationVersion(keyArgs.getFullLocationVersion())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
     resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
@@ -558,6 +559,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
+        .setFullLocationVersion(keyArgs.getFullLocationVersion())
         .build();
     return LookupFileResponse.newBuilder()
         .setKeyInfo(impl.lookupFile(omKeyArgs).getProtobuf(clientVersion))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -361,7 +361,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
-        .setLatestLocationVersion(keyArgs.getLatestLocationVersion())
+        .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
     resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
@@ -559,7 +559,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
-        .setLatestLocationVersion(keyArgs.getLatestLocationVersion())
+        .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .build();
     return LookupFileResponse.newBuilder()
         .setKeyInfo(impl.lookupFile(omKeyArgs).getProtobuf(clientVersion))

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -361,7 +361,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
-        .setFullLocationVersion(keyArgs.getFullLocationVersion())
+        .setLatestLocationVersion(keyArgs.getLatestLocationVersion())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
     resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
@@ -559,7 +559,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
-        .setFullLocationVersion(keyArgs.getFullLocationVersion())
+        .setLatestLocationVersion(keyArgs.getLatestLocationVersion())
         .build();
     return LookupFileResponse.newBuilder()
         .setKeyInfo(impl.lookupFile(omKeyArgs).getProtobuf(clientVersion))


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, OM queries all history versions of locations for a key and replied to clients, which may exceed the IPC response size and cost OM many resources to process history key locations.
This patch added a config that can be specified to let OM return only the latest key location to clients.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5243

## How was this patch tested?

Unit test
