### PR TITLE
HDDS-5242. Skip `failing` acceptance suite by default

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -40,13 +40,19 @@ create_results_dir() {
 }
 
 ## @description find all the test.sh scripts in the immediate child dirs
+all_tests_in_immediate_child_dirs() {
+  find . -mindepth 2 -maxdepth 2 -name test.sh | cut -c3- | sort
+}
+
+## @description Find all test.sh scripts in immediate child dirs,
+## @description applying OZONE_ACCEPTANCE_SUITE or OZONE_TEST_SELECTOR filter.
 find_tests(){
   if [[ -n "${OZONE_ACCEPTANCE_SUITE}" ]]; then
-     tests=$(find . -mindepth 2 -maxdepth 2 -name test.sh | cut -c3- | xargs grep -l "^#suite:${OZONE_ACCEPTANCE_SUITE}$" | sort)
+     tests=$(all_tests_in_immediate_child_dirs | xargs grep -l "^#suite:${OZONE_ACCEPTANCE_SUITE}$")
 
      # 'misc' is default suite, add untagged tests, too
     if [[ "misc" == "${OZONE_ACCEPTANCE_SUITE}" ]]; then
-       untagged="$(find . -mindepth 2 -maxdepth 2 -name test.sh | cut -c3- | xargs grep -L "^#suite:")"
+       untagged="$(all_tests_in_immediate_child_dirs | xargs grep -L "^#suite:")"
        if [[ -n "${untagged}" ]]; then
          tests=$(echo ${tests} ${untagged} | xargs -n1 | sort)
        fi
@@ -55,9 +61,11 @@ find_tests(){
     if [[ -z "${tests}" ]]; then
        echo "No tests found for suite ${OZONE_ACCEPTANCE_SUITE}"
        exit 1
-  fi
+    fi
+  elif [[ -n "${OZONE_TEST_SELECTOR}" ]]; then
+    tests=$(all_tests_in_immediate_child_dirs | grep "${OZONE_TEST_SELECTOR}")
   else
-    tests=$(find . -mindepth 2 -maxdepth 2 -name test.sh | cut -c3- | grep "${OZONE_TEST_SELECTOR:-""}" | sort)
+    tests=$(all_tests_in_immediate_child_dirs | xargs grep -L '^#suite:failing')
   fi
   echo $tests
 }

--- a/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
+++ b/hadoop-ozone/dist/src/test/shell/compose_testlib.bats
@@ -18,6 +18,12 @@
 load ../../main/compose/testlib.sh
 @test "Find test recursive, only on one level" {
   cd $BATS_TEST_DIRNAME
+  result=$(all_tests_in_immediate_child_dirs | xargs)
+  [[ "$result" == "failing1/test.sh test1/test.sh test2/test.sh test4/test.sh" ]]
+}
+
+@test "Find tests without explicit filter" {
+  cd $BATS_TEST_DIRNAME
   run find_tests
   [[ "$output" == "test1/test.sh test2/test.sh test4/test.sh" ]]
 }
@@ -27,6 +33,13 @@ load ../../main/compose/testlib.sh
   cd $BATS_TEST_DIRNAME
   run find_tests
   [[ "$output" == "test4/test.sh" ]]
+}
+
+@test "Find failing test suite explicitly" {
+  OZONE_ACCEPTANCE_SUITE=failing
+  cd $BATS_TEST_DIRNAME
+  run find_tests
+  [[ "$output" == "failing1/test.sh" ]]
 }
 
 @test "Find test default suite" {

--- a/hadoop-ozone/dist/src/test/shell/failing1/test.sh
+++ b/hadoop-ozone/dist/src/test/shell/failing1/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#suite:failing


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance tests are split into a few suites, which can be activated by setting `OZONE_ACCEPTANCE_SUITE`.  CI checks execute 3 splits for faster feedback:

 * `secure`
 * `unsecure`
 * `misc` + anything without `suite`

There are some other tests, tagged `suite:failing`, which exist only to test the behavior of the acceptance test runner when failures happen.

The goal of this change is to skip the `failing` suite by default, i.e. when acceptance tests are run without suite filter.  This would allow running all tests in sequence (e.g. in nightly job) while retaining the ability to run these special tests by setting `OZONE_ACCEPTANCE_SUITE=failing`.

https://issues.apache.org/jira/browse/HDDS-5242

## How was this patch tested?

1. Added _bats_ test case.
2. Ran `test-all.sh` with a small tweak to exit after finding tests.  The output does not include `failing1` or `failing2`:
   ```
   compatibility/test.sh ozone-csi/test.sh ozone-ha/test.sh ozone-mr/test.sh ozone-topology/test.sh ozone/test.sh ozones3-haproxy/test.sh ozonescripts/test.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test.sh restart/test.sh upgrade/test.sh xcompat/test.sh
   ```
   while on `master` it does:
   ```
   compatibility/test.sh failing1/test.sh failing2/test.sh ozone-csi/test.sh ozone-ha/test.sh ozone-mr/test.sh ozone-topology/test.sh ozone/test.sh ozones3-haproxy/test.sh ozonescripts/test.sh ozonesecure-ha/test.sh ozonesecure-mr/test.sh ozonesecure/test.sh restart/test.sh upgrade/test.sh xcompat/test.sh
   ```

https://github.com/adoroszlai/hadoop-ozone/runs/2613248841?check_suite_focus=true#step:4:27
https://github.com/adoroszlai/hadoop-ozone/actions/runs/853780974