### PR TITLE
HDDS-5246. Wait for ever to obtain CA list which is needed during OM/DN startup

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -524,9 +524,9 @@ public final class ScmConfigKeys {
   public static final long OZONE_SCM_INFO_WAIT_DURATION_DEFAULT =
       10 * 60;
 
-  public static final String OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION =
-      "ozone.scm.ca.list.retry.wait.duration";
-  public static final long OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT = 10;
+  public static final String OZONE_SCM_CA_LIST_RETRY_INTERVAL =
+      "ozone.scm.ca.list.retry.interval";
+  public static final long OZONE_SCM_CA_LIST_RETRY_INTERVAL_DEFAULT = 10;
 
   /**
    * Never constructed.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -524,6 +524,10 @@ public final class ScmConfigKeys {
   public static final long OZONE_SCM_INFO_WAIT_DURATION_DEFAULT =
       10 * 60;
 
+  public static final String OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION =
+      "ozone.scm.ca.list.retry.wait.duration";
+  public static final long OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT = 10;
+
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2849,7 +2849,7 @@
     <description>SCM client wait duration between each retry to get Scm CA
       list. OM/Datanode obtain CA list during startup, and wait
       for the CA List size to be matched with SCM node count size plus
-      1.(Additional one certificate is root CA certificate). If the received
+      1. (Additional one certificate is root CA certificate). If the received
       CA list size is not matching with expected count, this is the duration
       used to wait before making next attempt to get CA list.
     </description>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2841,4 +2841,18 @@
     </description>
   </property>
 
+
+  <property>
+    <name>ozone.scm.ca.list.retry.wait.duration</name>
+    <tag>OZONE, SCM, OM, DATANODE</tag>
+    <value>10s</value>
+    <description>SCM client wait duration between each retry to get Scm CA
+      list. OM/Datanode obtain CA list during startup, and wait
+      for the CA List size to be matched with SCM node count size plus
+      1.(Additional one certificate is root CA certificate). If the received
+      CA list size is not matching with expected count, this is the duration
+      used to wait before making next attempt to get CA list.
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2843,7 +2843,7 @@
 
 
   <property>
-    <name>ozone.scm.ca.list.retry.wait.duration</name>
+    <name>ozone.scm.ca.list.retry.interval</name>
     <tag>OZONE, SCM, OM, DATANODE</tag>
     <value>10s</value>
     <description>SCM client wait duration between each retry to get Scm CA

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -429,7 +429,7 @@ public final class HAUtils {
     RetryPolicy retryPolicy = RetryPolicies.retryForeverWithFixedSleep(
         waitDuration, TimeUnit.SECONDS);
     RetriableTask<List<String>> retriableTask =
-        new RetriableTask(retryPolicy, "getCAList", task);
+        new RetriableTask<>(retryPolicy, "getCAList", task);
     try {
       return retriableTask.call();
     } catch (Exception ex) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -422,7 +422,6 @@ public final class HAUtils {
    * Retry for ever until CA list matches expected count.
    * @param task - task to get CA list.
    * @return CA list.
-   * @throws IOException
    */
   private static List<String> getCAListWithRetry(Callable<List<String>> task,
       long waitDuration) throws IOException {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -424,7 +424,7 @@ public final class HAUtils {
    * @return CA list.
    * @throws IOException
    */
-  private static List<String> getCAListWithRetry(Callable task,
+  private static List<String> getCAListWithRetry(Callable<List<String>> task,
       long waitDuration) throws IOException {
     RetryPolicy retryPolicy = RetryPolicies.retryForeverWithFixedSleep(
         waitDuration, TimeUnit.SECONDS);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -448,7 +448,7 @@ public final class HAUtils {
     boolean caListUpToDate;
     List<String> caCertPemList;
     caCertPemList = applyFunction.get();
-    caListUpToDate = caCertPemList.size() == expectedCount ? true : false;
+    caListUpToDate = caCertPemList.size() == expectedCount;
     if (!caListUpToDate) {
       LOG.info("Expected CA list size {}, where as received CA List size " +
           "{}.", expectedCount, caCertPemList.size());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -444,10 +444,8 @@ public final class HAUtils {
     //  refetched if listCA size is less than scm ha config node list size.
     // For now when Client of SCM's are started we compare their node list
     // size and ca list size if it is as expected, we return the ca list.
-    boolean caListUpToDate;
-    List<String> caCertPemList;
-    caCertPemList = applyFunction.get();
-    caListUpToDate = caCertPemList.size() == expectedCount;
+    List<String> caCertPemList = applyFunction.get();
+    boolean caListUpToDate = caCertPemList.size() == expectedCount;
     if (!caListUpToDate) {
       LOG.info("Expected CA list size {}, where as received CA List size " +
           "{}.", expectedCount, caCertPemList.size());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -43,9 +43,10 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.io.retry.RetryPolicies;
+import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.util.Time;
 import org.apache.ratis.util.ExitUtils;
 import org.apache.ratis.util.FileUtils;
 import org.slf4j.Logger;
@@ -61,8 +62,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
@@ -355,8 +359,10 @@ public final class HAUtils {
    */
   public static List<String> buildCAList(CertificateClient certClient,
       ConfigurationSource configuration) throws IOException {
-    //TODO: make it configurable.
     List<String> caCertPemList;
+    long waitDuration =
+        configuration.getTimeDuration(OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION,
+            OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT, TimeUnit.SECONDS);
     if (certClient != null) {
       caCertPemList = new ArrayList<>();
       if (!SCMHAUtils.isSCMHAEnabled(configuration)) {
@@ -377,9 +383,9 @@ public final class HAUtils {
           if (caCertPemList != null && caCertPemList.size() == expectedCount) {
             return caCertPemList;
           }
-          caCertPemList = waitForCACerts(() -> certClient.updateCAList(),
-              expectedCount);
-          checkCertCount(caCertPemList.size(), expectedCount);
+          caCertPemList = getCAListWithRetry(() ->
+              waitForCACerts(() -> certClient.updateCAList(), expectedCount),
+              waitDuration);
         } else {
           caCertPemList = certClient.listCA();
         }
@@ -401,10 +407,9 @@ public final class HAUtils {
         Collection<String> scmNodes = SCMHAUtils.getSCMNodeIds(configuration);
         int expectedCount = scmNodes.size() + 1;
         if (scmNodes.size() > 1) {
-          caCertPemList = waitForCACerts(
+          caCertPemList = getCAListWithRetry(() -> waitForCACerts(
               () -> scmSecurityProtocolClient.listCACertificate(),
-              expectedCount);
-          checkCertCount(caCertPemList.size(), expectedCount);
+              expectedCount), waitDuration);
         } else{
           caCertPemList = scmSecurityProtocolClient.listCACertificate();
         }
@@ -413,47 +418,44 @@ public final class HAUtils {
     return caCertPemList;
   }
 
+  /**
+   * Retry for ever until CA list matches expected count.
+   * @param task - task to get CA list.
+   * @return CA list.
+   * @throws IOException
+   */
+  private static List<String> getCAListWithRetry(Callable task,
+      long waitDuration) throws IOException {
+    RetryPolicy retryPolicy = RetryPolicies.retryForeverWithFixedSleep(
+        waitDuration, TimeUnit.SECONDS);
+    RetriableTask<List<String>> retriableTask =
+        new RetriableTask(retryPolicy, "getCAList", task);
+    try {
+      return retriableTask.call();
+    } catch (Exception ex) {
+      throw new SCMSecurityException("Unable to obtain complete CA " +
+          "list", ex);
+    }
+  }
+
   private static List<String> waitForCACerts(
       final SupplierWithIOException<List<String>> applyFunction,
       int expectedCount) throws IOException {
-    //TODO: make wait time and sleep time configurable if needed.
     // TODO: If SCMs are bootstrapped later, then listCA need to be
     //  refetched if listCA size is less than scm ha config node list size.
     // For now when Client of SCM's are started we compare their node list
     // size and ca list size if it is as expected, we return the ca list.
     boolean caListUpToDate;
-    long waitTime = 5 * 60 * 1000L;
-    long retryTime = 10 * 1000L;
-    long currentTime = Time.monotonicNow();
     List<String> caCertPemList;
-    do {
-      caCertPemList = applyFunction.get();
-      caListUpToDate =
-          caCertPemList.size() == expectedCount ? true : false;
-      if (!caListUpToDate) {
-        LOG.info("Expected CA list size {}, where as received CA List size " +
-            "{}. Retry to fetch CA List after {} seconds", expectedCount,
-            caCertPemList.size(), retryTime);
-        try {
-          Thread.sleep(retryTime);
-        } catch (InterruptedException ex) {
-          Thread.currentThread().interrupt();
-        }
-      }
-    } while (!caListUpToDate &&
-        Time.monotonicNow() - currentTime < waitTime);
-    return caCertPemList;
-  }
-
-
-  private static void checkCertCount(int certCount, int expectedCount)
-      throws SCMSecurityException{
-    if (certCount != expectedCount) {
-      LOG.error("Unable to obtain CA list for SCM cluster, obtained CA list " +
-              "size is {}, where as expected list size is {}",
-          certCount, expectedCount);
-      throw new SCMSecurityException("Unable to obtain complete CA list");
+    caCertPemList = applyFunction.get();
+    caListUpToDate = caCertPemList.size() == expectedCount ? true : false;
+    if (!caListUpToDate) {
+      LOG.info("Expected CA list size {}, where as received CA List size " +
+          "{}.", expectedCount, caCertPemList.size());
+      throw new SCMSecurityException("Expected CA list size " + expectedCount
+          + " is not matching actual count " + caCertPemList.size());
     }
+    return caCertPemList;
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -408,7 +408,7 @@ public final class HAUtils {
         int expectedCount = scmNodes.size() + 1;
         if (scmNodes.size() > 1) {
           caCertPemList = getCAListWithRetry(() -> waitForCACerts(
-              () -> scmSecurityProtocolClient.listCACertificate(),
+              scmSecurityProtocolClient::listCACertificate,
               expectedCount), waitDuration);
         } else{
           caCertPemList = scmSecurityProtocolClient.listCACertificate();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -384,7 +384,7 @@ public final class HAUtils {
             return caCertPemList;
           }
           caCertPemList = getCAListWithRetry(() ->
-              waitForCACerts(() -> certClient.updateCAList(), expectedCount),
+              waitForCACerts(certClient::updateCAList, expectedCount),
               waitDuration);
         } else {
           caCertPemList = certClient.listCA();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -65,8 +65,8 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_RETRY_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CA_LIST_RETRY_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.getOzoneMetaDirPath;
@@ -361,8 +361,8 @@ public final class HAUtils {
       ConfigurationSource configuration) throws IOException {
     List<String> caCertPemList;
     long waitDuration =
-        configuration.getTimeDuration(OZONE_SCM_CA_LIST_RETRY_WAIT_DURATION,
-            OZONE_SCM_CA_LIST_WAIT_RETRY_DURATION_DEFAULT, TimeUnit.SECONDS);
+        configuration.getTimeDuration(OZONE_SCM_CA_LIST_RETRY_INTERVAL,
+            OZONE_SCM_CA_LIST_RETRY_INTERVAL_DEFAULT, TimeUnit.SECONDS);
     if (certClient != null) {
       caCertPemList = new ArrayList<>();
       if (!SCMHAUtils.isSCMHAEnabled(configuration)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wait forever to obtain the CA list.
And also made retry wait configurable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5246

## How was this patch tested?

Tested with docker-compose ozonesecure-ha (with few changes to remove WAITFOR scm3.org)


```
docker-compose up scm1.org
docker-compose om1
docker-compose datanode1
```


```
om1_1        | 2021-05-19 09:02:16,082 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:02:26,102 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:02:26,103 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:02:36,147 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:02:36,147 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:02:46,198 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:02:46,198 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:02:56,222 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:02:56,222 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:03:06,245 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:03:06,245 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:03:16,263 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:03:16,263 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:03:26,296 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
om1_1        | 2021-05-19 09:03:26,296 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:03:36,333 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 3.
om1_1        | 2021-05-19 09:03:36,333 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
om1_1        | 2021-05-19 09:03:46,376 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 3.
om1_1        | 2021-05-19 09:03:46,376 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
```

```
datanode1_1  | 2021-05-19 09:02:50,155 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:00,179 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
datanode1_1  | 2021-05-19 09:03:00,179 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:10,204 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
datanode1_1  | 2021-05-19 09:03:10,204 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:20,225 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
datanode1_1  | 2021-05-19 09:03:20,225 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:30,266 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 2.
datanode1_1  | 2021-05-19 09:03:30,266 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:40,293 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 3.
datanode1_1  | 2021-05-19 09:03:40,293 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
datanode1_1  | 2021-05-19 09:03:50,323 [main] INFO utils.HAUtils: Expected CA list size 4, where as received CA List size 3.
datanode1_1  | 2021-05-19 09:03:50,323 [main] INFO utils.RetriableTask: Execution of task getCAList failed, will be retried in 10000 ms
```
