### PR TITLE
HDDS-5249. Race Condition between Full and Incremental Container Reports

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/IncrementalContainerReportHandler.java
@@ -71,31 +71,37 @@ public class IncrementalContainerReportHandler extends
     }
 
     boolean success = true;
-    for (ContainerReplicaProto replicaProto :
-        report.getReport().getReportList()) {
-      try {
-        final ContainerID id = ContainerID.valueOf(
-            replicaProto.getContainerID());
-        if (!replicaProto.getState().equals(
-            ContainerReplicaProto.State.DELETED)) {
-          nodeManager.addContainer(dd, id);
+    // HDDS-5249 - we must ensure that an ICR and FCR for the same datanode
+    // do not run at the same time or it can result in a data consistency
+    // issue between the container list in NodeManager and the replicas in
+    // ContainerManager.
+    synchronized (dd) {
+      for (ContainerReplicaProto replicaProto :
+          report.getReport().getReportList()) {
+        try {
+          final ContainerID id = ContainerID.valueOf(
+              replicaProto.getContainerID());
+          if (!replicaProto.getState().equals(
+              ContainerReplicaProto.State.DELETED)) {
+            nodeManager.addContainer(dd, id);
+          }
+          processContainerReplica(dd, replicaProto, publisher);
+        } catch (ContainerNotFoundException e) {
+          success = false;
+          LOG.warn("Container {} not found!", replicaProto.getContainerID());
+        } catch (NodeNotFoundException ex) {
+          success = false;
+          LOG.error("Received ICR from unknown datanode {}",
+              report.getDatanodeDetails(), ex);
+        } catch (ContainerReplicaNotFoundException e) {
+          success = false;
+          LOG.warn("Container {} replica not found!",
+              replicaProto.getContainerID());
+        } catch (IOException | InvalidStateTransitionException e) {
+          success = false;
+          LOG.error("Exception while processing ICR for container {}",
+              replicaProto.getContainerID(), e);
         }
-        processContainerReplica(dd, replicaProto, publisher);
-      } catch (ContainerNotFoundException e) {
-        success = false;
-        LOG.warn("Container {} not found!", replicaProto.getContainerID());
-      } catch (NodeNotFoundException ex) {
-        success = false;
-        LOG.error("Received ICR from unknown datanode {}",
-            report.getDatanodeDetails(), ex);
-      } catch (ContainerReplicaNotFoundException e){
-        success = false;
-        LOG.warn("Container {} replica not found!",
-            replicaProto.getContainerID());
-      } catch (IOException | InvalidStateTransitionException e) {
-        success = false;
-        LOG.error("Exception while processing ICR for container {}",
-            replicaProto.getContainerID(), e);
       }
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -663,14 +663,14 @@ public class TestContainerReportHandler {
     return new ContainerReportFromDatanode(dn, containerReport);
   }
 
-  private static ContainerReportsProto getContainerReportsProto(
+  protected static ContainerReportsProto getContainerReportsProto(
       final ContainerID containerId, final ContainerReplicaProto.State state,
       final String originNodeId) {
     return getContainerReportsProto(containerId, state, originNodeId,
         2000000000L, 100000000L);
   }
 
-  private static ContainerReportsProto getContainerReportsProto(
+  protected static ContainerReportsProto getContainerReportsProto(
       final ContainerID containerId, final ContainerReplicaProto.State state,
       final String originNodeId, final long usedBytes, final long keyCount) {
     final ContainerReportsProto.Builder crBuilder =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -31,6 +32,8 @@ import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.SCMNodeManager;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
     .IncrementalContainerReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
@@ -49,8 +52,13 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
+import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.scm.TestUtils.getContainer;
 import static org.apache.hadoop.hdds.scm.TestUtils.getReplicas;
 
@@ -108,6 +116,15 @@ public class TestIncrementalContainerReportHandler {
     }).when(containerManager).updateContainerState(
         Mockito.any(ContainerID.class),
         Mockito.any(HddsProtos.LifeCycleEvent.class));
+
+    Mockito.doAnswer(invocation -> {
+      containerStateManager
+          .updateContainerReplica((ContainerID)invocation.getArguments()[0],
+              (ContainerReplica) invocation.getArguments()[1]);
+      return null;
+    }).when(containerManager).updateContainerReplica(
+        Mockito.any(ContainerID.class),
+        Mockito.any(ContainerReplica.class));
 
   }
 
@@ -227,7 +244,7 @@ public class TestIncrementalContainerReportHandler {
 
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
-            ContainerReplicaProto.State.CLOSED,
+            CLOSED,
             datanodeThree.getUuidString());
     final IncrementalContainerReportFromDatanode icr =
         new IncrementalContainerReportFromDatanode(
@@ -250,7 +267,7 @@ public class TestIncrementalContainerReportHandler {
     nodeManager.register(datanodeThree, null, null);
     final Set<ContainerReplica> containerReplicas = getReplicas(
         container.containerID(),
-        ContainerReplicaProto.State.CLOSED,
+        CLOSED,
         datanodeOne, datanodeTwo, datanodeThree);
 
     containerStateManager.loadContainer(container);
@@ -274,6 +291,81 @@ public class TestIncrementalContainerReportHandler {
     reportHandler.onMessage(icr, publisher);
     Assert.assertEquals(2, containerStateManager
         .getContainerReplicas(container.containerID()).size());
+  }
+
+  @Test
+  // HDDS-5249 - This test reproduces the race condition mentioned in the Jira
+  // until the code was changed to fix the race condition.
+  public void testICRFCRRace() throws IOException, NodeNotFoundException,
+      ExecutionException, InterruptedException {
+    final IncrementalContainerReportHandler reportHandler =
+        new IncrementalContainerReportHandler(
+            nodeManager, containerManager, scmContext);
+    final ContainerReportHandler fullReportHandler =
+        new ContainerReportHandler(nodeManager, containerManager);
+
+    final ContainerInfo container = getContainer(LifeCycleState.CLOSED);
+    final ContainerInfo containerTwo = getContainer(LifeCycleState.CLOSED);
+    final DatanodeDetails datanode = randomDatanodeDetails();
+    nodeManager.register(datanode, null, null);
+
+    containerStateManager.loadContainer(container);
+    containerStateManager.loadContainer(containerTwo);
+
+    Assert.assertEquals(0, nodeManager.getContainers(datanode).size());
+
+    final IncrementalContainerReportProto containerReport =
+        getIncrementalContainerReportProto(container.containerID(),
+            CLOSED,
+            datanode.getUuidString());
+    final IncrementalContainerReportFromDatanode icr =
+        new IncrementalContainerReportFromDatanode(
+            datanode, containerReport);
+
+    final ContainerReportsProto fullReport = TestContainerReportHandler
+        .getContainerReportsProto(containerTwo.containerID(), CLOSED,
+            datanode.getUuidString());
+    final ContainerReportFromDatanode fcr =new ContainerReportFromDatanode(
+        datanode, fullReport);
+
+    // We need to run the FCR and ICR at the same time via the executor so we
+    // can try to simulate the race condition.
+    ThreadPoolExecutor executor =
+        (ThreadPoolExecutor)Executors.newFixedThreadPool(2);
+    try {
+      // Running this test 10 times to ensure the race condition we are testing
+      // for does not occur. In local tests, before the code was fixed, this
+      // test failed consistently every time (reproducing the issue).
+      for (int i=0; i<10; i++) {
+        Future<?> t1 =
+            executor.submit(() -> fullReportHandler.onMessage(fcr, publisher));
+        Future<?> t2 =
+            executor.submit(() -> reportHandler.onMessage(icr, publisher));
+        t1.get();
+        t2.get();
+
+        Set<ContainerID> nmContainers = nodeManager.getContainers(datanode);
+        if (nmContainers.contains(container.containerID())) {
+          // If we find "container" in the NM, then we must also have it in
+          // Container Manager.
+          Assert.assertEquals(1, containerStateManager
+              .getContainerReplicas(container.containerID()).size());
+          Assert.assertEquals(2, nmContainers.size());
+        } else {
+          // If the race condition occurs as mentioned in HDDS-5249, then this
+          // assert should fail. We will have found nothing for "container" in
+          // NM, but have found something for it in ContainerManager, and that
+          // should not happen. It should be in both, or neither.
+          Assert.assertEquals(0, containerStateManager
+              .getContainerReplicas(container.containerID()).size());
+          Assert.assertEquals(1, nmContainers.size());
+        }
+        Assert.assertEquals(1, containerStateManager
+            .getContainerReplicas(containerTwo.containerID()).size());
+      }
+    } finally {
+      executor.shutdown();
+    }
   }
 
   private static IncrementalContainerReportProto


### PR DESCRIPTION
## What changes were proposed in this pull request?



During testing we came across an issue with ICR and FCR handing.

The following log shows the issue:

```
2021-05-18 13:14:15,394 DEBUG org.apache.hadoop.hdds.scm.container.ContainerReportHandler: Processing replica of container #1 from datanode 945aa180-5cff-4298-a8ad-8197542e4562{ip: 172.27.108.136, host: quasar-nqdywv-7.quasar-nqdywv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}


2021-05-18 13:14:15,394 DEBUG org.apache.hadoop.hdds.scm.container.IncrementalContainerReportHandler: Processing replica of container #1001 from datanode 945aa180-5cff-4298-a8ad-8197542e4562{ip: 172.27.108.136, host: quasar-nqdywv-7.quasar-nqdywv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}


2021-05-18 13:14:15,394 DEBUG org.apache.hadoop.hdds.scm.container.ContainerReportHandler: Processing replica of container #2 from datanode 945aa180-5cff-4298-a8ad-8197542e4562{ip: 172.27.108.136, host: quasar-nqdywv-7.quasar-nqdywv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}
2021-05-18 13:14:15,394 DEBUG org.apache.hadoop.hdds.scm.container.ContainerReportHandler: Processing replica of container #3 from datanode 945aa180-5cff-4298-a8ad-8197542e4562{ip: 172.27.108.136, host: quasar-nqdywv-7.quasar-nqdywv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}
2021-05-18 13:14:15,394 DEBUG org.apache.hadoop.hdds.scm.container.ContainerReportHandler: Processing replica of container #4 from datanode 945aa180-5cff-4298-a8ad-8197542e4562{ip: 172.27.108.136, host: quasar-nqdywv-7.quasar-nqdywv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}
...
```

In the above log, SCM is processing both an ICR and FCR for the same Datanode at the same time. The FCR does not container container #1001.

The FCR starts first, and it takes a snapshot of the containers on the node via NodeManager.

Then it starts processing the containers one by one.

The ICR then starts, and it added #1001 to the ContainerManager and to the NodeManager.

When the FCR completes, it replaces the list of containers in NodeManager with those in the FCR.

At this point, container #1001 is in the ContainerManager, but it is not listed against the node in NodeManager.

This would get fixed by the next FCR, but then the node goes dead. The dead node handler runs and uses the list of containers in NodeManager to remove all containers for the node. As #1001 is not listed, it is not removed by the DeadNodeManager. This means the container will never been seen as under replicated, as 3 copies will exist forever in the ContainerManager.

This issue is quite tricky to fully fix. There are two issues:

1. Parallel processing of ICR and FCR can lead to data inconsistency between the ComtainerManager and NodeManager. This is what caused the bug above.

2. A FCR wiping out a reference to a container recently sent in an ICR, but which is not included in the FCR.

The second issue is less serious, as the next FCR will fix the problem, as the FCRs are produced approximately every 60 seconds by default.

We can fix problem 1 quite easily by synchronising on the datanode when processing FCRs and ICRs, that will ensure the data inconsistency will not happen.

This PR is for issue 1, and we should probably create a followup issue for 2.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5249

## How was this patch tested?

Added a new test to reproduce the race condition and verified it passes after the code change.
