### PR TITLE
HDDS-5206. Addendum: Support revoking S3 secret

### DIFF
--- a/hadoop-hdds/docs/content/interface/S3.md
+++ b/hadoop-hdds/docs/content/interface/S3.md
@@ -113,6 +113,27 @@ export AWS_SECRET_ACCESS_KEY=c261b6ecabf7d37d5f9ded654b1c724adac9bd9f13e247a235e
 aws s3api --endpoint http://localhost:9878 create-bucket --bucket bucket1
 ```
 
+To invalidate/revoke the secret, use `ozone s3 revokesecret` command. Parameter '-y' can be appended to skip the interactive confirmation.
+
+```bash
+ozone s3 revokesecret
+Enter 'y' to confirm S3 secret revocation for 'testuser/scm@EXAMPLE.COM': y
+S3 secret revoked.
+```
+
+Ozone Manager administrators can run `ozone s3 getsecret` and `ozone s3 revokesecret` command with `-u` parameter to specify another users.
+
+```bash
+# Obtained Kerberos TGT for testuser/scm@EXAMPLE.COM with kinit,
+# testuser/scm@EXAMPLE.COM is an OM admin.
+ozone s3 getsecret -u om/om@EXAMPLE.COM
+awsAccessKey=om/om@EXAMPLE.COM
+awsSecret=1e9379d0424cce6669b1a501ff14834e46dee004ee868b41a313b49eabcfb68f
+
+ozone s3 revokesecret -u om/om@EXAMPLE.COM -y
+S3 secret revoked.
+```
+
 ## Expose any volume
 
 Ozone has one more element in the name-space hierarchy compared to S3: the volumes. By default, all the buckets of the `/s3v` volume can be accessed with S3 interface but only the (Ozone) buckets of the `/s3v` volumes are exposed.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -162,7 +162,6 @@ import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
 import org.apache.hadoop.ozone.security.acl.RequestContext;
 import org.apache.hadoop.hdds.ExitManager;
 import org.apache.hadoop.ozone.util.OzoneVersionInfo;
-import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.UserGroupInformation.AuthenticationMethod;
@@ -3571,15 +3570,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   /**
-   * Return true if remoteUser is OM admin, false otherwise.
-   * @param remoteUser User name
-   * @throws AccessControlException
+   * Return true if a UserGroupInformation is OM admin, false otherwise.
+   * @param callerUgi Caller UserGroupInformation
    */
-  public boolean isAdmin(String remoteUser) throws AccessControlException {
-    if (remoteUser == null || remoteUser.isEmpty()) {
+  public boolean isAdmin(UserGroupInformation callerUgi) {
+    if (callerUgi == null || omAdminUsernames == null) {
       return false;
     }
-    return omAdminUsernames.contains(remoteUser)
+
+    return omAdminUsernames.contains(callerUgi.getShortUserName())
+        || omAdminUsernames.contains(callerUgi.getUserName())
         || omAdminUsernames.contains(OZONE_ADMINISTRATORS_WILDCARD);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -72,12 +72,13 @@ public class S3GetSecretRequest extends OMClientRequest {
     // Generate S3 Secret to be used by OM quorum.
     String kerberosID = s3GetSecretRequest.getKerberosID();
 
-    UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
+    final UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
+    final String username = user.getUserName();
     // Permission check. Users need to be themselves or have admin privilege
-    if (!user.getUserName().equals(kerberosID) &&
-        !ozoneManager.isAdmin(kerberosID)) {
+    if (!username.equals(kerberosID) &&
+        !ozoneManager.isAdmin(username)) {
       throw new OMException("Requested user name '" + kerberosID +
-          "' doesn't match current user '" + user.getUserName() +
+          "' doesn't match current user '" + username +
           "', nor does current user has administrator privilege.",
           OMException.ResultCodes.USER_MISMATCH);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -72,11 +72,11 @@ public class S3GetSecretRequest extends OMClientRequest {
     // Generate S3 Secret to be used by OM quorum.
     String kerberosID = s3GetSecretRequest.getKerberosID();
 
-    final UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
-    final String username = user.getUserName();
+    final UserGroupInformation ugi = ProtobufRpcEngine.Server.getRemoteUser();
+    final String username = ugi.getUserName();
     // Permission check. Users need to be themselves or have admin privilege
     if (!username.equals(kerberosID) &&
-        !ozoneManager.isAdmin(username)) {
+        !ozoneManager.isAdmin(ugi)) {
       throw new OMException("Requested user name '" + kerberosID +
           "' doesn't match current user '" + username +
           "', nor does current user has administrator privilege.",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
@@ -63,11 +63,11 @@ public class S3RevokeSecretRequest extends OMClientRequest {
     final RevokeS3SecretRequest s3RevokeSecretRequest =
         getOmRequest().getRevokeS3SecretRequest();
     final String kerberosID = s3RevokeSecretRequest.getKerberosID();
-    final UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
-    final String username = user.getUserName();
+    final UserGroupInformation ugi = ProtobufRpcEngine.Server.getRemoteUser();
+    final String username = ugi.getUserName();
     // Permission check. Users need to be themselves or have admin privilege
     if (!username.equals(kerberosID) &&
-        !ozoneManager.isAdmin(username)) {
+        !ozoneManager.isAdmin(ugi)) {
       throw new OMException("Requested user name '" + kerberosID +
           "' doesn't match current user '" + username +
           "', nor does current user has administrator privilege.",

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3RevokeSecretRequest.java
@@ -64,12 +64,12 @@ public class S3RevokeSecretRequest extends OMClientRequest {
         getOmRequest().getRevokeS3SecretRequest();
     final String kerberosID = s3RevokeSecretRequest.getKerberosID();
     final UserGroupInformation user = ProtobufRpcEngine.Server.getRemoteUser();
-
+    final String username = user.getUserName();
     // Permission check. Users need to be themselves or have admin privilege
-    if (!user.getUserName().equals(kerberosID) &&
-        !ozoneManager.isAdmin(kerberosID)) {
+    if (!username.equals(kerberosID) &&
+        !ozoneManager.isAdmin(username)) {
       throw new OMException("Requested user name '" + kerberosID +
-          "' doesn't match current user '" + user.getUserName() +
+          "' doesn't match current user '" + username +
           "', nor does current user has administrator privilege.",
           OMException.ResultCodes.USER_MISMATCH);
     }


### PR DESCRIPTION
This is an addendum to #2239 .

Fixes the typo which wasn't caught in the previous review for s3 getsecret / revokesecret admin permission check.