### PR TITLE
HDDS-5260. Bump node to v16.2.0 for Recon

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -103,7 +103,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v12.14.1</nodeVersion>
+              <nodeVersion>v16.2.0</nodeVersion>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-5260

Let's bump nodejs version used by Recon UI.