### PR TITLE
HDDS-5264. SCM should send token for CloseContainer command

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -98,7 +98,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
             .isExist(closeCommand.getPipelineID())) {
           ContainerCommandRequestProto request =
               getContainerCommandRequestProto(datanodeDetails,
-                  closeCommand.getContainerID());
+                  closeCommand.getContainerID(),
+                  command.getEncodedToken());
           ozoneContainer.getWriteChannel()
               .submitRequest(request, closeCommand.getPipelineID());
         } else {
@@ -134,7 +135,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
   }
 
   private ContainerCommandRequestProto getContainerCommandRequestProto(
-      final DatanodeDetails datanodeDetails, final long containerId) {
+      final DatanodeDetails datanodeDetails, final long containerId,
+      final String encodedToken) {
     final ContainerCommandRequestProto.Builder command =
         ContainerCommandRequestProto.newBuilder();
     command.setCmdType(ContainerProtos.Type.CloseContainer);
@@ -143,6 +145,9 @@ public class CloseContainerCommandHandler implements CommandHandler {
     command.setCloseContainer(
         ContainerProtos.CloseContainerRequestProto.getDefaultInstance());
     command.setDatanodeUuid(datanodeDetails.getUuidString());
+    if (encodedToken != null) {
+      command.setEncodedToken(encodedToken);
+    }
     return command.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -290,6 +290,10 @@ public class HeartbeatEndpointTask
         if (commandResponseProto.hasTerm()) {
           closeContainer.setTerm(commandResponseProto.getTerm());
         }
+        if (commandResponseProto.hasEncodedToken()) {
+          closeContainer.setEncodedToken(
+              commandResponseProto.getEncodedToken());
+        }
         if (LOG.isDebugEnabled()) {
           LOG.debug("Received SCM container close request for container {}",
               closeContainer.getContainerID());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/SCMCommand.java
@@ -36,6 +36,8 @@ public abstract class SCMCommand<T extends GeneratedMessage> implements
   // SCM is a leader. If running without Ratis, holds SCMContext.INVALID_TERM.
   private long term;
 
+  private String encodedToken = "";
+
   SCMCommand() {
     this.id = HddsIdFactory.getLongId();
   }
@@ -77,5 +79,13 @@ public abstract class SCMCommand<T extends GeneratedMessage> implements
    */
   public void setTerm(long term) {
     this.term = term;
+  }
+
+  public String getEncodedToken() {
+    return encodedToken;
+  }
+
+  public void setEncodedToken(String encodedToken) {
+    this.encodedToken = encodedToken;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenGenerator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenGenerator.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.security.token;
+
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.security.token.Token;
+
+import java.io.UncheckedIOException;
+
+/**
+ * Generates container tokens.
+ */
+public interface ContainerTokenGenerator {
+
+  /**
+   * Shortcut for generating encoded token.
+   * @throws UncheckedIOException if URL-encoding fails
+   */
+  String generateEncodedToken(String user, ContainerID containerID);
+
+  /**
+   * Generate token for the container.
+   */
+  Token<ContainerTokenIdentifier> generateToken(String user,
+      ContainerID containerID);
+
+  /**
+   * No-op implementation for when container tokens are disabled.
+   */
+  ContainerTokenGenerator DISABLED = new ContainerTokenGenerator() {
+    @Override
+    public String generateEncodedToken(String user, ContainerID containerID) {
+      return "";
+    }
+
+    @Override
+    public Token<ContainerTokenIdentifier> generateToken(String user,
+        ContainerID containerID) {
+      return new Token<>();
+    }
+  };
+
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenGenerator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenGenerator.java
@@ -28,10 +28,10 @@ import java.io.UncheckedIOException;
 public interface ContainerTokenGenerator {
 
   /**
-   * Shortcut for generating encoded token.
-   * @throws UncheckedIOException if URL-encoding fails
+   * Shortcut for generating encoded token for current user.
+   * @throws UncheckedIOException if user lookup or URL-encoding fails
    */
-  String generateEncodedToken(String user, ContainerID containerID);
+  String generateEncodedToken(ContainerID containerID);
 
   /**
    * Generate token for the container.
@@ -44,7 +44,7 @@ public interface ContainerTokenGenerator {
    */
   ContainerTokenGenerator DISABLED = new ContainerTokenGenerator() {
     @Override
-    public String generateEncodedToken(String user, ContainerID containerID) {
+    public String generateEncodedToken(ContainerID containerID) {
       return "";
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenSecretManager.java
@@ -21,8 +21,12 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
 
 /**
  * Secret manager for container tokens.
@@ -30,7 +34,8 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 public class ContainerTokenSecretManager
-    extends ShortLivedTokenSecretManager<ContainerTokenIdentifier> {
+    extends ShortLivedTokenSecretManager<ContainerTokenIdentifier>
+    implements ContainerTokenGenerator {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerTokenSecretManager.class);
@@ -44,5 +49,20 @@ public class ContainerTokenSecretManager
       ContainerID containerID) {
     return new ContainerTokenIdentifier(user, containerID,
         getCertSerialId(), getTokenExpiryTime());
+  }
+
+  @Override
+  public String generateEncodedToken(String user, ContainerID containerID) {
+    try {
+      return generateToken(user, containerID).encodeToUrlString();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to encode token", e);
+    }
+  }
+
+  @Override
+  public Token<ContainerTokenIdentifier> generateToken(String user,
+      ContainerID containerID) {
+    return generateToken(createIdentifier(user, containerID));
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenSecretManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/token/ContainerTokenSecretManager.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,14 @@ public class ContainerTokenSecretManager
   }
 
   @Override
-  public String generateEncodedToken(String user, ContainerID containerID) {
+  public String generateEncodedToken(ContainerID containerID) {
+    String user;
+    try {
+      user = UserGroupInformation.getCurrentUser().getUserName();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to get current user", e);
+    }
+
     try {
       return generateToken(user, containerID).encodeToUrlString();
     } catch (IOException e) {

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -309,6 +309,7 @@ message SCMCommandProto {
   // If running upon Ratis, holds term of underlying RaftServer iff current
   // SCM is a leader. If running without Ratis, holds SCMContext.INVALID_TERM.
   optional int64 term = 15;
+  optional string encodedToken = 16;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -104,8 +104,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
   private String getContainerToken(ContainerID containerID) {
     StorageContainerManager scm = scmContext.getScm();
     return scm != null
-        ? scm.getContainerTokenGenerator()
-            .generateEncodedToken(getClass().getSimpleName(), containerID)
+        ? scm.getContainerTokenGenerator().generateEncodedToken(containerID)
         : ""; // unit test
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/CloseContainerEventHandler.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
@@ -82,6 +83,7 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
         SCMCommand<?> command = new CloseContainerCommand(
             containerID.getId(), container.getPipelineID());
         command.setTerm(scmContext.getTermOfLeader());
+        command.setEncodedToken(getContainerToken(containerID));
 
         getNodes(container).forEach(node ->
             publisher.fireEvent(DATANODE_COMMAND,
@@ -97,6 +99,14 @@ public class CloseContainerEventHandler implements EventHandler<ContainerID> {
     } catch (IOException | InvalidStateTransitionException ex) {
       LOG.error("Failed to close the container {}.", containerID, ex);
     }
+  }
+
+  private String getContainerToken(ContainerID containerID) {
+    StorageContainerManager scm = scmContext.getScm();
+    return scm != null
+        ? scm.getContainerTokenGenerator()
+            .generateEncodedToken(getClass().getSimpleName(), containerID)
+        : ""; // unit test
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -997,8 +998,9 @@ public class ReplicationManager implements MetricsSource, SCMService {
                                 final DatanodeDetails datanode,
                                 final boolean force) {
 
+    ContainerID containerID = container.containerID();
     LOG.info("Sending close container command for container {}" +
-            " to datanode {}.", container.containerID(), datanode);
+            " to datanode {}.", containerID, datanode);
     CloseContainerCommand closeContainerCommand =
         new CloseContainerCommand(container.getContainerID(),
             container.getPipelineID(), force);
@@ -1009,8 +1011,17 @@ public class ReplicationManager implements MetricsSource, SCMService {
           + " since current SCM is not leader.", nle);
       return;
     }
+    closeContainerCommand.setEncodedToken(getContainerToken(containerID));
     eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND,
         new CommandForDatanode<>(datanode.getUuid(), closeContainerCommand));
+  }
+
+  private String getContainerToken(ContainerID containerID) {
+    StorageContainerManager scm = scmContext.getScm();
+    return scm != null
+        ? scm.getContainerTokenGenerator()
+            .generateEncodedToken(getClass().getSimpleName(), containerID)
+        : "";
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -1019,9 +1019,8 @@ public class ReplicationManager implements MetricsSource, SCMService {
   private String getContainerToken(ContainerID containerID) {
     StorageContainerManager scm = scmContext.getScm();
     return scm != null
-        ? scm.getContainerTokenGenerator()
-            .generateEncodedToken(getClass().getSimpleName(), containerID)
-        : "";
+        ? scm.getContainerTokenGenerator().generateEncodedToken(containerID)
+        : ""; // unit test
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -17,6 +17,7 @@
 
 package org.apache.hadoop.hdds.scm.ha;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -47,7 +48,7 @@ public final class SCMContext {
   public static final long INVALID_TERM = -1;
 
   private static final SCMContext EMPTY_CONTEXT
-      = new SCMContext.Builder().build();
+      = new SCMContext.Builder().buildMaybeInvalid();
 
   /**
    * Used by non-HA mode SCM, Recon and Unit Tests.
@@ -173,7 +174,6 @@ public final class SCMContext {
    * @return StorageContainerManager
    */
   public StorageContainerManager getScm() {
-    Preconditions.checkNotNull(scm, "scm == null");
     return scm;
   }
 
@@ -214,6 +214,15 @@ public final class SCMContext {
     }
 
     public SCMContext build() {
+      Preconditions.checkNotNull(scm, "scm == null");
+      return buildMaybeInvalid();
+    }
+
+    /**
+     * Allows {@code null} SCM.  Only for tests.
+     */
+    @VisibleForTesting
+    SCMContext buildMaybeInvalid() {
       return new SCMContext(
           isLeader,
           term,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -54,7 +54,6 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocolServerSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolPB;
-import org.apache.hadoop.hdds.security.token.ContainerTokenSecretManager;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
@@ -84,8 +83,6 @@ import java.util.TreeSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
-import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StorageContainerLocationProtocolService.newReflectiveBlockingService;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HANDLER_COUNT_KEY;
@@ -106,13 +103,10 @@ public class SCMClientProtocolServer implements
   private final InetSocketAddress clientRpcAddress;
   private final StorageContainerManager scm;
   private final ProtocolMessageMetrics<ProtocolMessageEnum> protocolMetrics;
-  private final boolean containerTokenEnabled;
 
   public SCMClientProtocolServer(OzoneConfiguration conf,
       StorageContainerManager scm) throws IOException {
     this.scm = scm;
-    containerTokenEnabled = conf.getBoolean(HDDS_CONTAINER_TOKEN_ENABLED,
-        HDDS_CONTAINER_TOKEN_ENABLED_DEFAULT);
     final int handlerCount =
         conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,
             OZONE_SCM_HANDLER_COUNT_DEFAULT);
@@ -789,15 +783,8 @@ public class SCMClientProtocolServer implements
     UserGroupInformation remoteUser = getRemoteUser();
     getScm().checkAdminAccess(remoteUser);
 
-    if (!containerTokenEnabled) {
-      return new Token<>();
-    }
-
-    ContainerTokenSecretManager secretManager =
-        scm.getContainerTokenSecretManager();
-
-    return secretManager.generateToken(
-        secretManager.createIdentifier(remoteUser.getUserName(), containerID));
+    return scm.getContainerTokenGenerator()
+        .generateToken(remoteUser.getUserName(), containerID);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -292,8 +292,8 @@ public class SCMDatanodeProtocolServer implements
   @VisibleForTesting
   public SCMCommandProto getCommandResponse(SCMCommand cmd)
       throws IOException {
-    SCMCommandProto.Builder builder =
-        SCMCommandProto.newBuilder();
+    SCMCommandProto.Builder builder = SCMCommandProto.newBuilder()
+        .setEncodedToken(cmd.getEncodedToken());
 
     // In HA mode, it is the term of current leader SCM.
     // In non-HA mode, it is the default value 0.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
 import org.apache.hadoop.hdds.scm.ScmInfo;
+import org.apache.hadoop.hdds.security.token.ContainerTokenGenerator;
 import org.apache.hadoop.hdds.security.token.ContainerTokenSecretManager;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.DefaultCAProfile;
@@ -1726,8 +1727,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
   }
 
-  ContainerTokenSecretManager getContainerTokenSecretManager() {
-    return containerTokenMgr;
+  public ContainerTokenGenerator getContainerTokenGenerator() {
+    return containerTokenMgr != null
+        ? containerTokenMgr
+        : ContainerTokenGenerator.DISABLED;
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -34,8 +34,8 @@ public class TestSCMContext {
   @Test
   public void testRaftOperations() {
     // start as follower
-    SCMContext scmContext =
-        new SCMContext.Builder().setLeader(false).setTerm(0).build();
+    SCMContext scmContext = new SCMContext.Builder()
+        .setLeader(false).setTerm(0).buildMaybeInvalid();
 
     assertFalse(scmContext.isLeader());
 
@@ -59,7 +59,7 @@ public class TestSCMContext {
     SCMContext scmContext = new SCMContext.Builder()
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
-        .build();
+        .buildMaybeInvalid();
 
     assertTrue(scmContext.isInSafeMode());
     assertFalse(scmContext.isPreCheckComplete());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
@@ -32,7 +32,7 @@ public class TestSCMServiceManager {
         .setTerm(1)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
-        .build();
+        .buildMaybeInvalid();
 
     // A service runs when it is leader.
     SCMService serviceRunWhenLeader = new SCMService() {
@@ -102,7 +102,7 @@ public class TestSCMServiceManager {
         .setTerm(1)
         .setIsInSafeMode(true)
         .setIsPreCheckComplete(false)
-        .build();
+        .buildMaybeInvalid();
 
     // A service runs when it is leader and out of safe mode.
     SCMService serviceRunWhenLeaderAndOutOfSafeMode = new SCMService() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -90,7 +90,7 @@ public class TestSCMSafeModeManager {
   @Before
   public void setUp() {
     queue = new EventQueue();
-    scmContext = new SCMContext.Builder().build();
+    scmContext = SCMContext.emptyContext();
     serviceManager = new SCMServiceManager();
     config = new OzoneConfiguration();
     config.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION,

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -29,6 +29,11 @@ Create test data
     Run Keyword if      '${SECURITY_ENABLED}' == 'true'     Kinit test user     testuser     testuser.keytab
                         Execute          ozone freon ockg -n1 -t1 -p container
 
+Container is closed
+    [arguments]     ${container}
+    ${output} =         Execute          ozone admin container info "${container}"
+                        Should contain   ${output}   CLOSED
+
 *** Test Cases ***
 Create container
     ${output} =         Execute          ozone admin container create
@@ -59,9 +64,11 @@ Verbose container info
                         Should contain   ${output}   Pipeline Info
 
 Close container
-                        Execute          ozone admin container close "${CONTAINER}"
-    ${output} =         Execute          ozone admin container info "${CONTAINER}"
+    ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationFactor == "THREE") | .containerID' | head -1
+                        Execute          ozone admin container close "${container}"
+    ${output} =         Execute          ozone admin container info "${container}"
                         Should contain   ${output}   CLOS
+    Wait until keyword succeeds    1min    10sec    Container is closed    ${container}
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin container


### PR DESCRIPTION
## What changes were proposed in this pull request?

Close container command from SCM fails due to lack of token.  This change adds the token to `SCMCommand`.

https://issues.apache.org/jira/browse/HDDS-5264

## How was this patch tested?

Updated acceptance test to verify that the container actually gets `CLOSED` (previously it was stuck in `CLOSING`).