### PR TITLE
HDDS-5272. Make ozonefs.robot execution repeatable

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
-import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.security.token.TokenVerifier;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
@@ -174,13 +173,15 @@ public class OzoneContainer {
         new BlockDeletingService(this, svcInterval.toMillis(), serviceTimeout,
             TimeUnit.MILLISECONDS, config);
 
-    List< X509Certificate > x509Certificates = null;
-    if (certClient != null) {
-      x509Certificates = HAUtils.buildCAX509List(certClient, conf);
+    if (certClient != null && secConf.isGrpcTlsEnabled()) {
+      List<X509Certificate> x509Certificates =
+          HAUtils.buildCAX509List(certClient, conf);
+      tlsClientConfig = new GrpcTlsConfig(
+          certClient.getPrivateKey(), certClient.getCertificate(),
+          x509Certificates, true);
+    } else {
+      tlsClientConfig = null;
     }
-
-    tlsClientConfig = RatisHelper.createTlsClientConfig(secConf,
-        x509Certificates);
 
     initializingStatus =
         new AtomicReference<>(InitializingStatus.UNINITIALIZED);

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
@@ -30,6 +30,10 @@ ${DEEP_DIR}          test/${SCHEME}/dir
 
 *** Keywords ***
 Setup for FS test
+    ${random} =         Generate Random String  5  [NUMBERS]
+    Set Suite Variable  ${BUCKET}  ${random}-${BUCKET_TYPE}1-${SCHEME}
+    Set Suite Variable  ${BUCKET2}  ${random}-${BUCKET_TYPE}2-${SCHEME}
+    Set Suite Variable  ${BUCKET_IN_VOL2}  ${random}-${BUCKET_TYPE}3-${SCHEME}
     Create volumes for FS test
     Run Keyword    Create ${BUCKET_TYPE}s for FS test
     Sanity check for FS test

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
@@ -30,14 +30,10 @@ ${DEEP_DIR}          test/${SCHEME}/dir
 
 *** Keywords ***
 Setup for FS test
-    ${random} =         Generate Random String  5  [NUMBERS]
-    Set Suite Variable  ${BUCKET}  ${random}-${BUCKET_TYPE}1-${SCHEME}
-    Set Suite Variable  ${BUCKET2}  ${random}-${BUCKET_TYPE}2-${SCHEME}
-    Set Suite Variable  ${BUCKET_IN_VOL2}  ${random}-${BUCKET_TYPE}3-${SCHEME}
+    Assign suite vars for FS test
     Create volumes for FS test
     Run Keyword    Create ${BUCKET_TYPE}s for FS test
     Sanity check for FS test
-    Assign suite vars for FS test
     Log    Completed setup for ${SCHEME} tests with ${BUCKET_TYPE}s in ${VOLUME}/${BUCKET} using FS base URL: ${BASE_URL}
 
 Create volumes for FS test
@@ -69,6 +65,10 @@ Sanity check for FS test
                         Should contain        ${result}               ${BUCKET2}
 
 Assign suite vars for FS test
-    ${BASE_URL} =       Format FS URL         ${SCHEME}     ${VOLUME}    ${BUCKET}    /
+    ${random} =         Generate Random String  5  [NUMBERS]
+    Set Suite Variable  ${BUCKET}               ${random}-${BUCKET_TYPE}1-${SCHEME}
+    Set Suite Variable  ${BUCKET2}              ${random}-${BUCKET_TYPE}2-${SCHEME}
+    Set Suite Variable  ${BUCKET_IN_VOL2}       ${random}-${BUCKET_TYPE}3-${SCHEME}
+    ${BASE_URL} =       Format FS URL           ${SCHEME}     ${VOLUME}    ${BUCKET}    /
     Set Suite Variable  ${BASE_URL}
-    Set Suite Variable  ${DEEP_URL}           ${BASE_URL}${DEEP_DIR}
+    Set Suite Variable  ${DEEP_URL}             ${BASE_URL}${DEEP_DIR}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most of our smoketests can be executed multiple times, which helps us to debug the tests locally.

Unfortunately, it's not the case `ozonefs/ozonefs.robot`. This test uses hard-coded bucket/volume names instead of using randomized bucket names.

For example:

docker-compose up -d --scale datanode=3
docker-compose exec scm bash
robot smoketest/ozonefs/ozonefs.robot

robot smoketest/ozonefs/ozonefs.robot

The second execution fails which makes harder to debug test problems.

It seems to be better to follow existing pattern and adding a random prefix to the user bucket names.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5272

## How was this patch tested?

```
cd compose/ozone
docker-compose up -d --scale datanode=3
docker-compose exec scm bash
robot smoketest/ozonefs/ozonefs.robot

robot smoketest/ozonefs/ozonefs.robot
```