### PR TITLE
HDDS-5273. Handle unsecure cluster convert to secure cluster for SCM.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -988,6 +988,18 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     } else {
       clusterId = scmStorageConfig.getClusterID();
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();
+
+      // Initialize security if security is enabled later.
+      if (OzoneSecurityUtil.isSecurityEnabled(conf)
+          && scmStorageConfig.getScmCertSerialId() == null) {
+        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
+            getScmAddress(haDetails, conf), true);
+        scmStorageConfig.forceInitialize();
+        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
+                "Persisted SCM Certificate SerialID {}",
+            scmStorageConfig.getScmCertSerialId());
+      }
+
       if (SCMHAUtils.isSCMHAEnabled(conf) && !isSCMHAEnabled) {
         SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),
             scmStorageConfig.getScmId(), haDetails.getLocalNodeDetails(),
@@ -997,6 +1009,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         scmStorageConfig.forceInitialize();
         LOG.debug("Enabled SCM HA");
       }
+
       LOG.info("SCM already initialized. Reusing existing cluster id for sd={}"
               + ";cid={}; layoutVersion={}; HAEnabled={}",
           scmStorageConfig.getStorageDir(), clusterId,


### PR DESCRIPTION
## What changes were proposed in this pull request?

In SCM sub-ca certs are set up during init, if a cluster is converted to secure later, in else part of the scmInit, we need to initialize security.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5273

## How was this patch tested?

I Will test out the fix on the cluster and update here. Posting fix for CI run.

Tested this on a cluster and later it is converted to secure.

```
2021-05-26 01:15:23,478 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Init response: GETCERT
2021-05-26 01:15:23,815 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Successfully stored SCM signed certificate.
2021-05-26 01:15:23,822 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManager: SCM already initialized. Reusing existing cluster id for sd=/var/lib/hadoop-ozone/scm/data/scm;cid=CID-9efddf03-b533-4134-816a-a35b87eec46b; layoutVersion=0; HAEnabled=false
```