### PR TITLE
HDDS-5274. Revert "HDDS-5153. Decommissioning a dead node should complete immediately (#2190)"

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeDecommissionManager.java
@@ -20,7 +20,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -269,18 +268,11 @@ public class NodeDecommissionManager {
       throws NodeNotFoundException, InvalidNodeStateException {
     NodeStatus nodeStatus = getNodeStatus(dn);
     NodeOperationalState opState = nodeStatus.getOperationalState();
-    HddsProtos.NodeState health = nodeStatus.getHealth();
     if (opState == NodeOperationalState.IN_SERVICE) {
-      if (health != HddsProtos.NodeState.DEAD) {
-        LOG.info("Starting Decommission for node {}", dn);
-        nodeManager.setNodeOperationalState(
-            dn, NodeOperationalState.DECOMMISSIONING);
-        monitor.startMonitoring(dn);
-      } else {
-        LOG.info("{} is dead. Moving to decommissioned immediately", dn);
-        nodeManager.setNodeOperationalState(
-            dn, NodeOperationalState.DECOMMISSIONED);
-      }
+      LOG.info("Starting Decommission for node {}", dn);
+      nodeManager.setNodeOperationalState(
+          dn, NodeOperationalState.DECOMMISSIONING);
+      monitor.startMonitoring(dn);
     } else if (nodeStatus.isDecommission()) {
       LOG.info("Start Decommission called on node {} in state {}. Nothing to "+
           "do.", dn, opState);
@@ -362,18 +354,11 @@ public class NodeDecommissionManager {
       maintenanceEnd =
           (System.currentTimeMillis() / 1000L) + (endInHours * 60L * 60L);
     }
-    HddsProtos.NodeState health = nodeStatus.getHealth();
     if (opState == NodeOperationalState.IN_SERVICE) {
-      if (health != HddsProtos.NodeState.DEAD) {
-        nodeManager.setNodeOperationalState(
-            dn, NodeOperationalState.ENTERING_MAINTENANCE, maintenanceEnd);
-        monitor.startMonitoring(dn);
-        LOG.info("Starting Maintenance for node {}", dn);
-      }  else {
-        LOG.info("{} is dead. Moving to maintenance immediately", dn);
-        nodeManager.setNodeOperationalState(
-            dn, NodeOperationalState.IN_MAINTENANCE);
-      }
+      nodeManager.setNodeOperationalState(
+          dn, NodeOperationalState.ENTERING_MAINTENANCE, maintenanceEnd);
+      monitor.startMonitoring(dn);
+      LOG.info("Starting Maintenance for node {}", dn);
     } else if (nodeStatus.isMaintenance()) {
       LOG.info("Starting Maintenance called on node {} with state {}. "+
           "Nothing to do.", dn, opState);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
-import org.apache.hadoop.hdds.scm.container.SimpleMockNodeManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -178,22 +177,6 @@ public class TestNodeDecommissionManager {
   }
 
   @Test
-  public void testDeadNodeDecommissionsImmediately()
-      throws NodeNotFoundException, InvalidNodeStateException {
-    List<DatanodeDetails> dns = generateDatanodes();
-    DatanodeDetails dn = dns.get(1);
-
-    SimpleMockNodeManager mockNM = new SimpleMockNodeManager();
-    mockNM.register(dn, NodeStatus.inServiceDead());
-    NodeDecommissionManager decomMgr = new NodeDecommissionManager(conf, mockNM,
-        null, SCMContext.emptyContext(), new EventQueue(), null);
-
-    decomMgr.startDecommission(dns.get(1));
-    assertEquals(HddsProtos.NodeOperationalState.DECOMMISSIONED,
-        mockNM.getNodeStatus(dns.get(1)).getOperationalState());
-  }
-
-  @Test
   public void testNodesCanBePutIntoMaintenanceAndRecommissioned()
       throws InvalidHostStringException, NodeNotFoundException {
     List<DatanodeDetails> dns = generateDatanodes();
@@ -234,22 +217,6 @@ public class TestNodeDecommissionManager {
         nodeManager.getNodeStatus(dns.get(2)).getOperationalState());
     assertEquals(HddsProtos.NodeOperationalState.IN_SERVICE,
         nodeManager.getNodeStatus(dns.get(10)).getOperationalState());
-  }
-
-  @Test
-  public void testDeadNodeGoesToMaintenanceImmediately()
-      throws NodeNotFoundException, InvalidNodeStateException {
-    List<DatanodeDetails> dns = generateDatanodes();
-    DatanodeDetails dn = dns.get(1);
-
-    SimpleMockNodeManager mockNM = new SimpleMockNodeManager();
-    mockNM.register(dn, NodeStatus.inServiceDead());
-    NodeDecommissionManager decomMgr = new NodeDecommissionManager(conf, mockNM,
-        null, SCMContext.emptyContext(), new EventQueue(), null);
-
-    decomMgr.startMaintenance(dns.get(1), 0);
-    assertEquals(HddsProtos.NodeOperationalState.IN_MAINTENANCE,
-        mockNM.getNodeStatus(dns.get(1)).getOperationalState());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

After some discussion with István Fajth and Siddharth Wagle we believe that the change in HDDS-5153 should be reverted.

If a DN starts decommissioning or maintenance, but goes dead before it completes the process, then the node is moved back to a state of IN_SERVICE and DEAD by the decommission monitor when it notices it has become dead. This is because decommission should gracefully remove the node, but it goes dead first, we may not be able to replicate its containers. In this case decommission effectively fails.

In HDDS-5153, we decided that if a node is already dead and you decommission it, it should immediately move to DECOMMISSIONED. However that is not really consistent with the above behaviour.

Also, there is no real value in decommissioning a dead node - it does not do anything except adjust its state in SCM.

To keep things consistent, I propose we revert HDDS-5153 so starting decommission on a dead node will work the same as when a node goes dead part way through decommission. In both cases the node will end up as IN_SERVICE + DEAD.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5274

## How was this patch tested?

Existing tests
