### PR TITLE
HDDS-5275. Datanode Report Publisher publishes one extra report after DN shutdown

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -67,9 +67,9 @@ public abstract class ReportPublisher<T extends GeneratedMessage>
 
   @Override
   public void run() {
-    publishReport();
     if (!executor.isShutdown() &&
         (context.getState() != DatanodeStates.SHUTDOWN)) {
+      publishReport();
       executor.schedule(this,
           getReportFrequency(), TimeUnit.MILLISECONDS);
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -107,6 +107,9 @@ public class TestReportPublisher {
     Thread.sleep(100);
     Assert.assertEquals(2, ((DummyReportPublisher) publisher).getReportCount);
     executorService.shutdown();
+    // After executor shutdown, no new reports should be published
+    Thread.sleep(100);
+    Assert.assertEquals(2, ((DummyReportPublisher) publisher).getReportCount);
   }
 
   @Test
@@ -122,7 +125,9 @@ public class TestReportPublisher {
     executorService.shutdown();
     Assert.assertEquals(1, ((DummyReportPublisher) publisher).getReportCount);
     verify(dummyContext, times(1)).addReport(null);
-
+    // After executor shutdown, no new reports should be published
+    Thread.sleep(100);
+    Assert.assertEquals(1, ((DummyReportPublisher) publisher).getReportCount);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Fix ReportPublisher to publish report only when Datanode is not shutdown

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5275

## How was this patch tested?

- Added unit tests
