### PR TITLE
HDDS-5276. Use built-in cancel support for duplicates

### DIFF
--- a/.github/workflows/cancel-ci.yaml
+++ b/.github/workflows/cancel-ci.yaml
@@ -24,14 +24,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: potiuk/cancel-workflow-runs@a81b3c4d59c61e27484cfacdc13897dd908419c9
-        name: "Cancel duplicate PR builds"
-        with:
-          cancelMode: allDuplicates
-          cancelFutureDuplicates: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sourceRunId: ${{ github.event.workflow_run.id }}
-          skipEventTypes: '["push", "schedule"]'
-      - uses: potiuk/cancel-workflow-runs@a81b3c4d59c61e27484cfacdc13897dd908419c9
         name: "Cancel failing PR builds"
         with:
           cancelMode: failedJobs

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -22,6 +22,9 @@ on:
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   compile:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
## What changes were proposed in this pull request?

GitHub Actions now provides [support to cancel duplicate workflows](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency) (and limit workflow concurrency).  This usage of the `cancel-workflow-runs` action can be replaced.

As previously, only PR workflows are cancelled, not ones triggered by commits or schedule.  This is made possible by using commit SHA to form concurrency group for non-PR builds (and PR number for PRs).

https://issues.apache.org/jira/browse/HDDS-5276

## How was this patch tested?

Tested in my fork:
https://github.com/adoroszlai/hadoop-ozone/pull/19
https://github.com/adoroszlai/hadoop-ozone/actions