### PR TITLE
HDDS-4483. Datanodes should send last processed CRL sequence ID in heartbeats

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -34,10 +34,14 @@ public final class HddsConfigKeys {
       "hdds.container.report.interval";
   public static final String HDDS_CONTAINER_REPORT_INTERVAL_DEFAULT =
       "60s";
+  public static final String HDDS_CRL_STATUS_REPORT_INTERVAL =
+      "hdds.crl.status.report.interval";
+  public static final String HDDS_CRL_STATUS_REPORT_INTERVAL_DEFAULT =
+      "60s";
   public static final String HDDS_PIPELINE_REPORT_INTERVAL =
-          "hdds.pipeline.report.interval";
+      "hdds.pipeline.report.interval";
   public static final String HDDS_PIPELINE_REPORT_INTERVAL_DEFAULT =
-          "60s";
+      "60s";
   public static final String HDDS_COMMAND_STATUS_REPORT_INTERVAL =
       "hdds.command.status.report.interval";
   public static final String HDDS_COMMAND_STATUS_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -316,6 +316,14 @@
       defined with postfix (ns,ms,s,m,h,d)</description>
   </property>
   <property>
+    <name>hdds.crl.status.report.interval</name>
+    <value>60000ms</value>
+    <tag>OZONE, SECURITY, MANAGEMENT</tag>
+    <description>Time interval of the datanode to send CRL status report. Each
+      datanode periodically sends CRL status report to SCM. Unit could be
+      defined with postfix (ns,ms,s,m,h,d)</description>
+  </property>
+  <property>
     <name>hdds.pipeline.report.interval</name>
     <value>60000ms</value>
     <tag>OZONE, PIPELINE, MANAGEMENT</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -253,7 +253,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
         initializeCertificateClient(conf);
       }
       datanodeStateMachine = new DatanodeStateMachine(datanodeDetails, conf,
-          dnCertClient, this::terminateDatanode);
+          dnCertClient, this::terminateDatanode, dnCRLStore);
       try {
         httpServer = new HddsDatanodeHttpServer(conf);
         httpServer.start();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/CRLStatusReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/CRLStatusReportPublisher.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.report;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStore;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
+import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CRL_STATUS_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CRL_STATUS_REPORT_INTERVAL_DEFAULT;
+
+/**
+ * Publishes CRLStatusReport which will be sent to SCM as part of heartbeat.
+ * CRLStatusReport consist of the following information:
+ *   - receivedCRLId : The latest processed CRL Sequence ID.
+ *   - pendingCRLIds : The list of CRL IDs that are still pending in the
+ *   queue to be processed in the future.
+ */
+public class CRLStatusReportPublisher extends
+    ReportPublisher<CRLStatusReport> {
+
+  private Long crlStatusReportInterval = null;
+
+  @Override
+  protected long getReportFrequency() {
+    if (crlStatusReportInterval == null) {
+      crlStatusReportInterval = getConf().getTimeDuration(
+          HDDS_CRL_STATUS_REPORT_INTERVAL,
+          HDDS_CRL_STATUS_REPORT_INTERVAL_DEFAULT,
+          TimeUnit.MILLISECONDS);
+
+      long heartbeatFrequency = HddsServerUtil.getScmHeartbeatInterval(
+          getConf());
+
+      Preconditions.checkState(
+          heartbeatFrequency <= crlStatusReportInterval,
+          HDDS_CRL_STATUS_REPORT_INTERVAL +
+              " cannot be configured lower than heartbeat frequency.");
+    }
+    return crlStatusReportInterval;
+  }
+
+  @Override
+  protected CRLStatusReport getReport() throws IOException {
+
+    CRLStatusReport.Builder builder = CRLStatusReport.newBuilder();
+
+    DatanodeCRLStore dnCRLStore = this.getContext().getParent().getDnCRLStore();
+
+    builder.setReceivedCrlId(dnCRLStore.getLatestCRLSequenceID());
+    if (dnCRLStore.getPendingCRLs().size() > 0) {
+      List<Long> pendingCRLIds =
+          dnCRLStore.getPendingCRLs().stream().map(CRLInfo::getCrlSequenceID)
+              .collect(Collectors.toList());
+      builder.addAllPendingCrlIds(pendingCRLIds);
+    }
+
+    return builder.build();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportPublisherFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportPublisherFactory.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
@@ -53,6 +54,7 @@ public class ReportPublisherFactory {
         CommandStatusReportPublisher.class);
     report2publisher.put(PipelineReportsProto.class,
             PipelineReportPublisher.class);
+    report2publisher.put(CRLStatusReport.class, CRLStatusReportPublisher.class);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStateMachine.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -153,7 +153,8 @@ public class TestDatanodeStateMachine {
   public void testStartStopDatanodeStateMachine() throws IOException,
       InterruptedException, TimeoutException {
     try (DatanodeStateMachine stateMachine =
-        new DatanodeStateMachine(getNewDatanodeDetails(), conf, null, null)) {
+        new DatanodeStateMachine(getNewDatanodeDetails(), conf, null, null,
+            null)) {
       stateMachine.startDaemon();
       SCMConnectionManager connectionManager =
           stateMachine.getConnectionManager();
@@ -216,7 +217,8 @@ public class TestDatanodeStateMachine {
     ContainerUtils.writeDatanodeDetailsTo(datanodeDetails, idPath);
 
     try (DatanodeStateMachine stateMachine =
-             new DatanodeStateMachine(datanodeDetails, conf, null, null)) {
+             new DatanodeStateMachine(datanodeDetails, conf, null, null,
+                 null)) {
       DatanodeStateMachine.DatanodeStates currentState =
           stateMachine.getContext().getState();
       Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
@@ -338,7 +340,8 @@ public class TestDatanodeStateMachine {
     datanodeDetails.setPort(port);
 
     try (DatanodeStateMachine stateMachine =
-             new DatanodeStateMachine(datanodeDetails, conf, null, null)) {
+             new DatanodeStateMachine(datanodeDetails, conf, null, null,
+                 null)) {
       DatanodeStateMachine.DatanodeStates currentState =
           stateMachine.getContext().getState();
       Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,
@@ -401,7 +404,7 @@ public class TestDatanodeStateMachine {
       perTestConf.setStrings(entry.getKey(), entry.getValue());
       LOG.info("Test with {} = {}", entry.getKey(), entry.getValue());
       try (DatanodeStateMachine stateMachine = new DatanodeStateMachine(
-          getNewDatanodeDetails(), perTestConf, null, null)) {
+          getNewDatanodeDetails(), perTestConf, null, null, null)) {
         DatanodeStateMachine.DatanodeStates currentState =
             stateMachine.getContext().getState();
         Assert.assertEquals(DatanodeStateMachine.DatanodeStates.INIT,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisherFactory.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisherFactory.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -52,6 +53,16 @@ public class TestReportPublisherFactory {
     ReportPublisher publisher = factory
         .getPublisherFor(NodeReportProto.class);
     Assert.assertEquals(NodeReportPublisher.class, publisher.getClass());
+    Assert.assertEquals(conf, publisher.getConf());
+  }
+
+  @Test
+  public void testGetCRLStatusReportPublisher() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ReportPublisherFactory factory = new ReportPublisherFactory(conf);
+    ReportPublisher publisher = factory
+        .getPublisherFor(CRLStatusReport.class);
+    Assert.assertEquals(CRLStatusReportPublisher.class, publisher.getClass());
     Assert.assertEquals(conf, publisher.getConf());
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestStateContext.java
@@ -126,6 +126,12 @@ public class TestStateContext {
       fail("Should throw exception when putting back unaccepted reports!");
     } catch (IllegalArgumentException ignored) {
     }
+    try {
+      ctx.putBackReports(Collections.singletonList(
+          newMockReport(StateContext.CRL_STATUS_REPORT_PROTO_NAME)), scm1);
+      fail("Should throw exception when putting back unaccepted reports!");
+    } catch (IllegalArgumentException ignored) {
+    }
 
     // Case 3: Put back mixed types of incremental reports
 
@@ -153,7 +159,8 @@ public class TestStateContext {
       ctx.putBackReports(Arrays.asList(
           newMockReport(StateContext.CONTAINER_REPORTS_PROTO_NAME),
           newMockReport(StateContext.NODE_REPORT_PROTO_NAME),
-          newMockReport(StateContext.PIPELINE_REPORTS_PROTO_NAME)
+          newMockReport(StateContext.PIPELINE_REPORTS_PROTO_NAME),
+          newMockReport(StateContext.CRL_STATUS_REPORT_PROTO_NAME)
       ), scm1);
       fail("Should throw exception when putting back unaccepted reports!");
     } catch (IllegalArgumentException ignored) {
@@ -189,46 +196,6 @@ public class TestStateContext {
     assertEquals(0, ctx.getAllAvailableReports(scm2).size());
 
     Map<String, Integer> expectedReportCount = new HashMap<>();
-
-    // Add a bunch of ContainerReports
-    batchAddReports(ctx, StateContext.CONTAINER_REPORTS_PROTO_NAME, 128);
-    // Should only keep the latest one
-    expectedReportCount.put(StateContext.CONTAINER_REPORTS_PROTO_NAME, 1);
-    checkReportCount(ctx.getAllAvailableReports(scm1), expectedReportCount);
-    checkReportCount(ctx.getAllAvailableReports(scm2), expectedReportCount);
-
-    // Add a bunch of NodeReport
-    batchAddReports(ctx, StateContext.NODE_REPORT_PROTO_NAME, 128);
-    // Should only keep the latest one
-    expectedReportCount.put(StateContext.NODE_REPORT_PROTO_NAME, 1);
-    checkReportCount(ctx.getAllAvailableReports(scm1), expectedReportCount);
-    checkReportCount(ctx.getAllAvailableReports(scm2), expectedReportCount);
-
-    // Add a bunch of PipelineReports
-    batchAddReports(ctx, StateContext.PIPELINE_REPORTS_PROTO_NAME, 128);
-    // Should only keep the latest one
-    expectedReportCount.put(StateContext.PIPELINE_REPORTS_PROTO_NAME, 1);
-    checkReportCount(ctx.getAllAvailableReports(scm1), expectedReportCount);
-    checkReportCount(ctx.getAllAvailableReports(scm2), expectedReportCount);
-
-    // Add a bunch of PipelineReports
-    batchAddReports(ctx, StateContext.PIPELINE_REPORTS_PROTO_NAME, 128);
-    // Should only keep the latest one
-    expectedReportCount.put(StateContext.PIPELINE_REPORTS_PROTO_NAME, 1);
-    checkReportCount(ctx.getAllAvailableReports(scm1), expectedReportCount);
-    checkReportCount(ctx.getAllAvailableReports(scm2), expectedReportCount);
-
-    // Add a bunch of CommandStatusReports
-    batchAddReports(ctx,
-        StateContext.COMMAND_STATUS_REPORTS_PROTO_NAME, 128);
-    expectedReportCount.put(
-        StateContext.COMMAND_STATUS_REPORTS_PROTO_NAME, 128);
-    // Should keep all of them
-    checkReportCount(ctx.getAllAvailableReports(scm1), expectedReportCount);
-    checkReportCount(ctx.getAllAvailableReports(scm2), expectedReportCount);
-    // getReports dequeues incremental reports
-    expectedReportCount.remove(
-        StateContext.COMMAND_STATUS_REPORTS_PROTO_NAME);
 
     // Add a bunch of IncrementalContainerReport
     batchAddReports(ctx,
@@ -321,12 +288,12 @@ public class TestStateContext {
   }
 
   private GeneratedMessage newMockReport(String messageType) {
-    GeneratedMessage pipelineReports = mock(GeneratedMessage.class);
-    when(pipelineReports.getDescriptorForType()).thenReturn(
+    GeneratedMessage report = mock(GeneratedMessage.class);
+    when(report.getDescriptorForType()).thenReturn(
         mock(Descriptor.class));
-    when(pipelineReports.getDescriptorForType().getFullName()).thenReturn(
+    when(report.getDescriptorForType().getFullName()).thenReturn(
         messageType);
-    return pipelineReports;
+    return report;
   }
 
   @Test
@@ -340,11 +307,8 @@ public class TestStateContext {
     InetSocketAddress scm1 = new InetSocketAddress("scm1", 9001);
     InetSocketAddress scm2 = new InetSocketAddress("scm2", 9001);
 
-    GeneratedMessage generatedMessage = mock(GeneratedMessage.class);
-    when(generatedMessage.getDescriptorForType()).thenReturn(
-        mock(Descriptor.class));
-    when(generatedMessage.getDescriptorForType().getFullName()).thenReturn(
-        "hadoop.hdds.CommandStatusReportsProto");
+    GeneratedMessage generatedMessage =
+        newMockReport(StateContext.COMMAND_STATUS_REPORTS_PROTO_NAME);
 
     // Try to add report with zero endpoint. Should not be stored.
     stateContext.addReport(generatedMessage);
@@ -588,6 +552,7 @@ public class TestStateContext {
     batchAddReports(ctx, StateContext.CONTAINER_REPORTS_PROTO_NAME, 128);
     batchAddReports(ctx, StateContext.NODE_REPORT_PROTO_NAME, 128);
     batchAddReports(ctx, StateContext.PIPELINE_REPORTS_PROTO_NAME, 128);
+    batchAddReports(ctx, StateContext.CRL_STATUS_REPORT_PROTO_NAME, 128);
     batchAddReports(ctx,
         StateContext.INCREMENTAL_CONTAINER_REPORT_PROTO_NAME, 128);
 
@@ -595,9 +560,12 @@ public class TestStateContext {
     expectedReportCount.put(StateContext.CONTAINER_REPORTS_PROTO_NAME, 1);
     expectedReportCount.put(StateContext.NODE_REPORT_PROTO_NAME, 1);
     expectedReportCount.put(StateContext.PIPELINE_REPORTS_PROTO_NAME, 1);
+    expectedReportCount.put(StateContext.CRL_STATUS_REPORT_PROTO_NAME, 1);
     // Should keep less or equal than maxLimit depending on other reports' size.
+    // Here, the incremental container reports count must be 96
+    // (100 - 4 non-incremental reports)
     expectedReportCount.put(
-        StateContext.INCREMENTAL_CONTAINER_REPORT_PROTO_NAME, 97);
+        StateContext.INCREMENTAL_CONTAINER_REPORT_PROTO_NAME, 96);
     checkReportCount(ctx.getReports(scm1, 100), expectedReportCount);
     checkReportCount(ctx.getReports(scm2, 100), expectedReportCount);
   }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -403,6 +403,18 @@ message SetNodeOperationalStateCommandProto {
   required  int64 stateExpiryEpochSeconds = 3;
 }
 
+message CRLStatusReport {
+  required int64 receivedCrlId=1;
+  repeated int64 pendingCrlIds=2;
+}
+
+/**
+ * This command asks the datanode to process a new CRL.
+ */
+message ProcessCRLCommandProto {
+  required CRLInfoProto crlInfo = 1;
+}
+
 /**
  * Protocol used from a datanode to StorageContainerManager.
  *

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -465,7 +465,7 @@ public class TestEndPoint {
 
     // Create a datanode state machine for stateConext used by endpoint task
     try (DatanodeStateMachine stateMachine = new DatanodeStateMachine(
-        randomDatanodeDetails(), conf, null, null);
+        randomDatanodeDetails(), conf, null, null, null);
         EndpointStateMachine rpcEndPoint =
             createEndpoint(conf, scmAddress, rpcTimeout)) {
       HddsProtos.DatanodeDetailsProto datanodeDetailsProto =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -221,7 +221,7 @@ public class TestMiniOzoneCluster {
 
       for (int i = 0; i < 3; i++) {
         stateMachines.add(new DatanodeStateMachine(
-            randomDatanodeDetails(), ozoneConf, null, null));
+            randomDatanodeDetails(), ozoneConf, null, null, null));
       }
 
       //we need to start all the servers to get the fix ports
@@ -266,11 +266,11 @@ public class TestMiniOzoneCluster {
     ozoneConf.setBoolean(OzoneConfigKeys.DFS_CONTAINER_IPC_RANDOM_PORT, false);
     try (
         DatanodeStateMachine sm1 = new DatanodeStateMachine(
-            randomDatanodeDetails(), ozoneConf,  null, null);
+            randomDatanodeDetails(), ozoneConf,  null, null, null);
         DatanodeStateMachine sm2 = new DatanodeStateMachine(
-            randomDatanodeDetails(), ozoneConf,  null, null);
+            randomDatanodeDetails(), ozoneConf,  null, null, null);
         DatanodeStateMachine sm3 = new DatanodeStateMachine(
-            randomDatanodeDetails(), ozoneConf,  null, null);
+            randomDatanodeDetails(), ozoneConf,  null, null, null);
     ) {
       HashSet<Integer> ports = new HashSet<Integer>();
       assertTrue(ports.add(sm1.getContainer().getReadChannel().getIPCPort()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Datanodes should generate and publish CRL Status reports via heartbeats
  - The CRL Status report will contain last received CRL id and pending CRL ids 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4483

## How was this patch tested?

- Unit tests and integration tests