### PR TITLE
HDDS-5280. Make XceiverClientManager creation when necessary in ContainerOperationClient

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -69,16 +69,20 @@ public class ContainerOperationClient implements ScmClient {
   private final StorageContainerLocationProtocol
       storageContainerLocationClient;
   private final boolean containerTokenEnabled;
+  private final OzoneConfiguration configuration;
+  private XceiverClientManager xceiverClientManager;
 
-  public XceiverClientManager getXceiverClientManager() {
+  public synchronized XceiverClientManager getXceiverClientManager()
+      throws IOException {
+    if (this.xceiverClientManager == null) {
+      this.xceiverClientManager = newXCeiverClientManager(configuration);
+    }
     return xceiverClientManager;
   }
 
-  private final XceiverClientManager xceiverClientManager;
-
   public ContainerOperationClient(OzoneConfiguration conf) throws IOException {
+    this.configuration = conf;
     storageContainerLocationClient = newContainerRpcClient(conf);
-    this.xceiverClientManager = newXCeiverClientManager(conf);
     containerSizeB = (int) conf.getStorageSize(OZONE_SCM_CONTAINER_SIZE,
         OZONE_SCM_CONTAINER_SIZE_DEFAULT, StorageUnit.BYTES);
     boolean useRatis = conf.getBoolean(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ScmOption.java
@@ -53,16 +53,12 @@ public class ScmOption {
   private String scmServiceId;
 
   public ScmClient createScmClient() {
-    try {
-      GenericParentCommand parent = (GenericParentCommand)
-          spec.root().userObject();
-      OzoneConfiguration conf = parent.createOzoneConfiguration();
-      checkAndSetSCMAddressArg(conf);
+    GenericParentCommand parent = (GenericParentCommand)
+        spec.root().userObject();
+    OzoneConfiguration conf = parent.createOzoneConfiguration();
+    checkAndSetSCMAddressArg(conf);
 
-      return new ContainerOperationClient(conf);
-    } catch (IOException ex) {
-      throw new IllegalArgumentException("Can't create SCM client", ex);
-    }
+    return new ContainerOperationClient(conf);
   }
 
   private void checkAndSetSCMAddressArg(MutableConfigurationSource conf) {

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/BaseInsightPoint.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.insight;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -69,8 +68,7 @@ public abstract class BaseInsightPoint implements InsightPoint {
   /**
    * Create scm client.
    */
-  public ScmClient createScmClient(OzoneConfiguration ozoneConf)
-      throws IOException {
+  public ScmClient createScmClient(OzoneConfiguration ozoneConf) {
     if (!HddsUtils.getHostNameFromConfigKeys(ozoneConf,
         ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY).isPresent()) {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We can avoid listCA which is not required for most admin commands. It is required only for ChunkKeyHandler.

This will help when ACLS are configured for SCM security protocol where only admin/service principals can make calls to the SCMSecurityProtocol server, then we don't need to add all the users to them to make these commands work.

As for few of the commands like pipeline list, safe mode status we don't require admin privilege.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5280

## How was this patch tested?

Existing admin test suite should cover this.
