### PR TITLE
HDDS-5268. Ensure disk checker also scans the ratis log disks periodically

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
@@ -72,18 +72,6 @@ public final class DFSConfigKeysLegacy {
   public static final String DFS_DATANODE_KEYTAB_FILE_KEY =
       "dfs.datanode.keytab.file";
 
-  public static final String DFS_DATANODE_DISK_CHECK_MIN_GAP_KEY =
-      "dfs.datanode.disk.check.min.gap";
-
-  public static final String DFS_DATANODE_DISK_CHECK_MIN_GAP_DEFAULT =
-      "15m";
-
-  public static final String DFS_DATANODE_DISK_CHECK_TIMEOUT_KEY =
-      "dfs.datanode.disk.check.timeout";
-
-  public static final String DFS_DATANODE_DISK_CHECK_TIMEOUT_DEFAULT =
-      "10m";
-
   public static final String DFS_METRICS_PERCENTILES_INTERVALS_KEY =
       "dfs.metrics.percentiles.intervals";
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
@@ -295,10 +296,10 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     MutableVolumeSet volumeSet =
         getDatanodeStateMachine().getContainer().getVolumeSet();
 
-    Map<String, HddsVolume> volumeMap = volumeSet.getVolumeMap();
+    Map<String, StorageVolume> volumeMap = volumeSet.getVolumeMap();
 
-    for (Map.Entry<String, HddsVolume> entry : volumeMap.entrySet()) {
-      HddsVolume hddsVolume = entry.getValue();
+    for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
+      HddsVolume hddsVolume = (HddsVolume) entry.getValue();
       boolean result = HddsVolumeUtil.checkVolume(hddsVolume, scmId,
           clusterId, LOG);
       if (!result) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/StorageLocationReport.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.container.common.impl;
 
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.
+    StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.
     StorageContainerDatanodeProtocolProtos.StorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.
     StorageContainerDatanodeProtocolProtos.StorageTypeProto;
@@ -149,15 +151,34 @@ public final class StorageLocationReport implements
   }
 
   /**
-   * Returns the SCMStorageReport protoBuf message for the Storage Location
+   * Returns the StorageReportProto protoBuf message for the Storage Location
    * report.
-   * @return SCMStorageReport
+   * @return StorageReportProto
    * @throws IOException In case, the storage type specified is invalid.
    */
   public StorageReportProto getProtoBufMessage() throws IOException {
     StorageReportProto.Builder srb = StorageReportProto.newBuilder();
     return srb.setStorageUuid(getId())
         .setCapacity(getCapacity())
+        .setScmUsed(getScmUsed())
+        .setRemaining(getRemaining())
+        .setStorageType(getStorageTypeProto())
+        .setStorageLocation(getStorageLocation())
+        .setFailed(isFailed())
+        .build();
+  }
+
+  /**
+   * Returns the MetadataStorageReportProto protoBuf message for the
+   * Storage Location report.
+   * @return MetadataStorageReportProto
+   * @throws IOException In case, the storage type specified is invalid.
+   */
+  public MetadataStorageReportProto getMetadataProtoBufMessage()
+      throws IOException {
+    MetadataStorageReportProto.Builder srb =
+        MetadataStorageReportProto.newBuilder();
+    return srb.setCapacity(getCapacity())
         .setScmUsed(getScmUsed())
         .setRemaining(getRemaining())
         .setStorageType(getStorageTypeProto())
@@ -178,6 +199,36 @@ public final class StorageLocationReport implements
     StorageLocationReport.Builder builder = StorageLocationReport.newBuilder();
     builder.setId(report.getStorageUuid())
         .setStorageLocation(report.getStorageLocation());
+    if (report.hasCapacity()) {
+      builder.setCapacity(report.getCapacity());
+    }
+    if (report.hasScmUsed()) {
+      builder.setScmUsed(report.getScmUsed());
+    }
+    if (report.hasStorageType()) {
+      builder.setStorageType(getStorageType(report.getStorageType()));
+    }
+    if (report.hasRemaining()) {
+      builder.setRemaining(report.getRemaining());
+    }
+
+    if (report.hasFailed()) {
+      builder.setFailed(report.getFailed());
+    }
+    return builder.build();
+  }
+
+  /**
+   * Returns the StorageLocationReport from the protoBuf message.
+   * @param report MetadataStorageReportProto
+   * @return StorageLocationReport
+   * @throws IOException in case of invalid storage type
+   */
+
+  public static StorageLocationReport getMetadataFromProtobuf(
+      MetadataStorageReportProto report) throws IOException {
+    StorageLocationReport.Builder builder = StorageLocationReport.newBuilder();
+    builder.setStorageLocation(report.getStorageLocation());
     if (report.hasCapacity()) {
       builder.setCapacity(report.getCapacity());
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -275,7 +275,9 @@ public class DatanodeStateMachine implements Closeable {
 
   public void handleFatalVolumeFailures() {
     LOG.error("DatanodeStateMachine Shutdown due to too many bad volumes, "
-        + "check " + DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_KEY);
+        + "check " + DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY
+        + " and "
+        + DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY);
     hddsDatanodeStopService.stopService();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachin
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
@@ -81,7 +82,7 @@ public class VersionEndpointTask implements
           MutableVolumeSet volumeSet = ozoneContainer.getVolumeSet();
           volumeSet.writeLock();
           try {
-            Map<String, HddsVolume> volumeMap = volumeSet.getVolumeMap();
+            Map<String, StorageVolume> volumeMap = volumeSet.getVolumeMap();
 
             Preconditions.checkNotNull(scmId,
                 "Reply from SCM: scmId cannot be null");
@@ -91,12 +92,13 @@ public class VersionEndpointTask implements
             // If version file does not exist
             // create version file and also set scmId
 
-            for (Map.Entry<String, HddsVolume> entry : volumeMap.entrySet()) {
-              HddsVolume hddsVolume = entry.getValue();
-              boolean result = HddsVolumeUtil.checkVolume(hddsVolume, scmId,
-                  clusterId, LOG);
+            for (Map.Entry<String, StorageVolume> entry
+                : volumeMap.entrySet()) {
+              StorageVolume volume = entry.getValue();
+              boolean result = HddsVolumeUtil.checkVolume((HddsVolume) volume,
+                  scmId, clusterId, LOG);
               if (!result) {
-                volumeSet.failVolume(hddsVolume.getHddsRootDir().getPath());
+                volumeSet.failVolume(volume.getStorageDir().getPath());
               }
             }
             if (volumeSet.getVolumesList().size() == 0) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
-import java.util.EnumMap;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -50,7 +49,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ClosePipelineInfo;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineAction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReport;
@@ -65,14 +63,10 @@ import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
-import org.apache.hadoop.ozone.container.common.impl.StorageLocationReport;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
-import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
-import org.apache.hadoop.fs.StorageType;
-import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -152,11 +146,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   private long requestTimeout;
   private boolean shouldDeleteRatisLogDirectory;
 
-  /**
-   * Maintains a list of active volumes per StorageType.
-   */
-  private EnumMap<StorageType, List<String>> ratisVolumeMap;
-
   private XceiverServerRatis(DatanodeDetails dd,
       ContainerDispatcher dispatcher, ContainerController containerController,
       StateContext context, ConfigurationSource conf, Parameters parameters)
@@ -188,7 +177,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         HddsConfigKeys.HDDS_DATANODE_RATIS_SERVER_REQUEST_TIMEOUT,
         HddsConfigKeys.HDDS_DATANODE_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT,
         TimeUnit.MILLISECONDS);
-    initializeRatisVolumeMap();
   }
 
   private void assignPorts() {
@@ -600,43 +588,6 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     }
   }
 
-  private void  initializeRatisVolumeMap() throws IOException {
-    ratisVolumeMap = new EnumMap<>(StorageType.class);
-    Collection<String> rawLocations = HddsServerUtil.
-            getOzoneDatanodeRatisDirectory(conf);
-
-    for (String locationString : rawLocations) {
-      try {
-        StorageLocation location = StorageLocation.parse(locationString);
-        StorageType type = location.getStorageType();
-        ratisVolumeMap.computeIfAbsent(type, k -> new ArrayList<String>(1));
-        ratisVolumeMap.get(location.getStorageType()).
-                add(location.getUri().getPath());
-
-      } catch (IOException e) {
-        LOG.error("Failed to parse the storage location: " +
-                locationString, e);
-      }
-    }
-  }
-
-  @Override
-  public List<MetadataStorageReportProto> getStorageReport()
-      throws IOException {
-    List<MetadataStorageReportProto> reportProto = new ArrayList<>();
-    for (StorageType storageType : ratisVolumeMap.keySet()) {
-      for (String path : ratisVolumeMap.get(storageType)) {
-        MetadataStorageReportProto.Builder builder = MetadataStorageReportProto.
-                newBuilder();
-        builder.setStorageLocation(path);
-        builder.setStorageType(StorageLocationReport.
-                getStorageTypeProto(storageType));
-        reportProto.add(builder.build());
-      }
-    }
-    return reportProto;
-  }
-
   private RaftClientRequest createRaftClientRequest(
       ContainerCommandRequestProto request, HddsProtos.PipelineID pipelineID,
       RaftClientRequest.Type type) {
@@ -933,7 +884,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
             .DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT);
 
     final int numberOfDisks =
-        MutableVolumeSet.getDatanodeStorageDirs(conf).size();
+        HddsServerUtil.getDatanodeStorageDirs(conf).size();
 
     ThreadPoolExecutor[] executors =
         new ThreadPoolExecutor[threadCountPerDisk * numberOfDisks];

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/HddsVolumeUtil.java
@@ -24,8 +24,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.DataNodeLayoutVersion;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
-import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
@@ -235,14 +233,5 @@ public final class HddsVolumeUtil {
       return false;
     }
 
-  }
-
-  public static void onFailure(HddsVolume volume) {
-    if (volume != null) {
-      VolumeSet volumeSet = volume.getVolumeSet();
-      if (volumeSet != null && volumeSet instanceof MutableVolumeSet) {
-        ((MutableVolumeSet) volumeSet).checkVolumeAsync(volume);
-      }
-    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.utils;
+
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * A util class for {@link StorageVolume}.
+ */
+public final class StorageVolumeUtil {
+
+  private StorageVolumeUtil() {
+  }
+
+  public static void onFailure(StorageVolume volume) {
+    if (volume != null) {
+      VolumeSet volumeSet = volume.getVolumeSet();
+      if (volumeSet != null && volumeSet instanceof MutableVolumeSet) {
+        ((MutableVolumeSet) volumeSet).checkVolumeAsync(volume);
+      }
+    }
+  }
+
+  public static List<HddsVolume> getHddsVolumesList(
+      List<StorageVolume> volumes) {
+    return volumes.stream().
+        map(v -> (HddsVolume) v).collect(Collectors.toList());
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -18,27 +18,18 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
-import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
-import org.apache.hadoop.hdfs.server.datanode.checker.Checkable;
-import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.DataNodeLayoutVersion;
 import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
-import org.apache.hadoop.util.DiskChecker;
 import org.apache.hadoop.util.Time;
 
 import com.google.common.base.Preconditions;
@@ -67,18 +58,14 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
 @SuppressWarnings("finalclass")
-public class HddsVolume
-    implements Checkable<Boolean, VolumeCheckResult> {
+public class HddsVolume extends StorageVolume {
 
   private static final Logger LOG = LoggerFactory.getLogger(HddsVolume.class);
 
   public static final String HDDS_VOLUME_DIR = "hdds";
 
-  private final File hddsRootDir;
-  private final VolumeInfo volumeInfo;
   private VolumeState state;
   private final VolumeIOStats volumeIOStats;
-  private final VolumeSet volumeSet;
 
   // VERSION file properties
   private String storageID;       // id of the file system
@@ -89,46 +76,18 @@ public class HddsVolume
   private final AtomicLong committedBytes; // till Open containers become full
 
   /**
-   * Run a check on the current volume to determine if it is healthy.
-   * @param unused context for the check, ignored.
-   * @return result of checking the volume.
-   * @throws Exception if an exception was encountered while running
-   *            the volume check.
-   */
-  @Override
-  public VolumeCheckResult check(@Nullable Boolean unused) throws Exception {
-    if (!hddsRootDir.exists()) {
-      return VolumeCheckResult.FAILED;
-    }
-    DiskChecker.checkDir(hddsRootDir);
-    return VolumeCheckResult.HEALTHY;
-  }
-
-  /**
    * Builder for HddsVolume.
    */
-  public static class Builder {
-    private final String volumeRootStr;
-    private ConfigurationSource conf;
-    private StorageType storageType;
-
+  public static class Builder extends StorageVolume.Builder<Builder> {
     private String datanodeUuid;
     private String clusterID;
-    private boolean failedVolume = false;
-    private SpaceUsageCheckFactory usageCheckFactory;
-    private VolumeSet volumeSet;
 
-    public Builder(String rootDirStr) {
-      this.volumeRootStr = rootDirStr;
+    public Builder(String volumeRootStr) {
+      super(volumeRootStr, HDDS_VOLUME_DIR);
     }
 
-    public Builder conf(ConfigurationSource config) {
-      this.conf = config;
-      return this;
-    }
-
-    public Builder storageType(StorageType st) {
-      this.storageType = st;
+    @Override
+    public Builder getThis() {
       return this;
     }
 
@@ -142,64 +101,34 @@ public class HddsVolume
       return this;
     }
 
-    // This is added just to create failed volume objects, which will be used
-    // to create failed HddsVolume objects in the case of any exceptions caused
-    // during creating HddsVolume object.
-    public Builder failedVolume(boolean failed) {
-      this.failedVolume = failed;
-      return this;
-    }
-
-    public Builder usageCheckFactory(SpaceUsageCheckFactory factory) {
-      usageCheckFactory = factory;
-      return this;
-    }
-
-    public Builder volumeSet(VolumeSet volSet) {
-      this.volumeSet = volSet;
-      return this;
-    }
-
     public HddsVolume build() throws IOException {
       return new HddsVolume(this);
     }
   }
 
   private HddsVolume(Builder b) throws IOException {
-    if (!b.failedVolume) {
-      StorageLocation location = StorageLocation.parse(b.volumeRootStr);
-      hddsRootDir = new File(location.getUri().getPath(), HDDS_VOLUME_DIR);
+    super(b);
+
+    if (!b.getFailedVolume()) {
       this.state = VolumeState.NOT_INITIALIZED;
       this.clusterID = b.clusterID;
       this.datanodeUuid = b.datanodeUuid;
-      this.volumeIOStats = new VolumeIOStats(b.volumeRootStr);
-
-      volumeInfo = new VolumeInfo.Builder(b.volumeRootStr, b.conf)
-          .storageType(b.storageType)
-          .usageCheckFactory(b.usageCheckFactory)
-          .build();
+      this.volumeIOStats = new VolumeIOStats(b.getVolumeRootStr());
       this.committedBytes = new AtomicLong(0);
-      this.volumeSet = b.volumeSet;
 
-      LOG.info("Creating Volume: {} of storage type : {} and capacity : {}",
-          hddsRootDir, b.storageType, volumeInfo.getCapacity());
+      LOG.info("Creating HddsVolume: {} of storage type : {} capacity : {}",
+          getStorageDir(), b.getStorageType(), getVolumeInfo().getCapacity());
 
       initialize();
     } else {
       // Builder is called with failedVolume set, so create a failed volume
-      // HddsVolumeObject.
-      hddsRootDir = new File(b.volumeRootStr);
+      // HddsVolume Object.
       volumeIOStats = null;
-      volumeInfo = null;
       storageID = UUID.randomUUID().toString();
       state = VolumeState.FAILED;
       committedBytes = null;
-      volumeSet = null;
     }
-  }
 
-  public VolumeInfo getVolumeInfo() {
-    return volumeInfo;
   }
 
   /**
@@ -213,8 +142,8 @@ public class HddsVolume
     switch (intialVolumeState) {
     case NON_EXISTENT:
       // Root directory does not exist. Create it.
-      if (!hddsRootDir.mkdirs()) {
-        throw new IOException("Cannot create directory " + hddsRootDir);
+      if (!getStorageDir().mkdirs()) {
+        throw new IOException("Cannot create directory " + getStorageDir());
       }
       setState(VolumeState.NOT_FORMATTED);
       createVersionFile();
@@ -231,26 +160,26 @@ public class HddsVolume
     case INCONSISTENT:
       // Volume Root is in an inconsistent state. Skip loading this volume.
       throw new IOException("Volume is in an " + VolumeState.INCONSISTENT +
-          " state. Skipped loading volume: " + hddsRootDir.getPath());
+          " state. Skipped loading volume: " + getStorageDir().getPath());
     default:
       throw new IOException("Unrecognized initial state : " +
-          intialVolumeState + "of volume : " + hddsRootDir);
+          intialVolumeState + "of volume : " + getStorageDir());
     }
   }
 
   private VolumeState analyzeVolumeState() {
-    if (!hddsRootDir.exists()) {
+    if (!getStorageDir().exists()) {
       // Volume Root does not exist.
       return VolumeState.NON_EXISTENT;
     }
-    if (!hddsRootDir.isDirectory()) {
+    if (!getStorageDir().isDirectory()) {
       // Volume Root exists but is not a directory.
       LOG.warn("Volume {} exists but is not a directory,"
           + " current volume state: {}.",
-          hddsRootDir.getPath(), VolumeState.INCONSISTENT);
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
       return VolumeState.INCONSISTENT;
     }
-    File[] files = hddsRootDir.listFiles();
+    File[] files = getStorageDir().listFiles();
     if (files == null || files.length == 0) {
       // Volume Root exists and is empty.
       return VolumeState.NOT_FORMATTED;
@@ -259,7 +188,7 @@ public class HddsVolume
       // Volume Root is non empty but VERSION file does not exist.
       LOG.warn("VERSION file does not exist in volume {},"
           + " current volume state: {}.",
-          hddsRootDir.getPath(), VolumeState.INCONSISTENT);
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
       return VolumeState.INCONSISTENT;
     }
     // Volume Root and VERSION file exist.
@@ -286,7 +215,7 @@ public class HddsVolume
       // HddsDatanodeService does not have the cluster information yet. Wait
       // for registration with SCM.
       LOG.debug("ClusterID not available. Cannot format the volume {}",
-          this.hddsRootDir.getPath());
+          getStorageDir().getPath());
       setState(VolumeState.NOT_FORMATTED);
     } else {
       // Write the version file to disk.
@@ -342,20 +271,14 @@ public class HddsVolume
   }
 
   private File getVersionFile() {
-    return HddsVolumeUtil.getVersionFile(hddsRootDir);
+    return HddsVolumeUtil.getVersionFile(super.getStorageDir());
   }
 
   public File getHddsRootDir() {
-    return hddsRootDir;
+    return super.getStorageDir();
   }
 
-  public StorageType getStorageType() {
-    if(volumeInfo != null) {
-      return volumeInfo.getStorageType();
-    }
-    return StorageType.DEFAULT;
-  }
-
+  @Override
   public String getStorageID() {
     return storageID;
   }
@@ -380,18 +303,6 @@ public class HddsVolume
     return state;
   }
 
-  public long getCapacity() {
-    return volumeInfo != null ? volumeInfo.getCapacity() : 0;
-  }
-
-  public long getAvailable() {
-    return volumeInfo != null ? volumeInfo.getAvailable() : 0;
-  }
-
-  public long getUsedSpace() {
-    return volumeInfo != null ? volumeInfo.getScmUsed() : 0;
-  }
-
   public void setState(VolumeState state) {
     this.state = state;
   }
@@ -404,25 +315,19 @@ public class HddsVolume
     return volumeIOStats;
   }
 
-  public VolumeSet getVolumeSet() {
-    return volumeSet;
-  }
-
+  @Override
   public void failVolume() {
     setState(VolumeState.FAILED);
-    if (volumeInfo != null) {
-      volumeInfo.shutdownUsageThread();
-    }
+    super.failVolume();
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
     }
   }
 
+  @Override
   public void shutdown() {
     this.state = VolumeState.NON_EXISTENT;
-    if (volumeInfo != null) {
-      volumeInfo.shutdownUsageThread();
-    }
+    super.shutdown();
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
     }
@@ -464,25 +369,5 @@ public class HddsVolume
    */
   public long getCommittedBytes() {
     return committedBytes.get();
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(hddsRootDir);
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    return this == other
-        || other instanceof HddsVolume && ((HddsVolume) other).hddsRootDir
-        .equals(this.hddsRootDir);
-  }
-
-  /**
-   * Override toSting() to show the path of HddsVolume.
-   */
-  @Override
-  public String toString() {
-    return getHddsRootDir().toString();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeFactory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
+
+import java.io.IOException;
+
+/**
+ * A factory class for HddsVolume.
+ */
+public class HddsVolumeFactory extends StorageVolumeFactory {
+
+  private String datanodeUuid;
+  private String clusterID;
+
+  public HddsVolumeFactory(ConfigurationSource conf,
+      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet,
+      String datanodeUuid, String clusterID) {
+    super(conf, usageCheckFactory, volumeSet);
+    this.datanodeUuid = datanodeUuid;
+    this.clusterID = clusterID;
+  }
+
+  @Override
+  public StorageVolume createVolume(String locationString,
+      StorageType storageType) throws IOException {
+    HddsVolume.Builder volumeBuilder = new HddsVolume.Builder(locationString)
+        .conf(getConf())
+        .datanodeUuid(datanodeUuid)
+        .clusterID(clusterID)
+        .usageCheckFactory(getUsageCheckFactory())
+        .storageType(storageType)
+        .volumeSet(getVolumeSet());
+    HddsVolume volume = volumeBuilder.build();
+
+    checkAndSetClusterID(volume.getClusterID());
+
+    return volume;
+  }
+
+  @Override
+  public StorageVolume createFailedVolume(String locationString)
+      throws IOException {
+    HddsVolume.Builder volumeBuilder = new HddsVolume.Builder(locationString)
+        .failedVolume(true);
+    return volumeBuilder.build();
+  }
+
+  /**
+   * If Version file exists and the {@link #clusterID} is not set yet,
+   * assign it the value from Version file. Otherwise, check that the given
+   * id matches with the id from version file.
+   * @param idFromVersionFile value of the property from Version file
+   * @throws InconsistentStorageStateException
+   */
+  private void checkAndSetClusterID(String idFromVersionFile)
+      throws InconsistentStorageStateException {
+    // If the clusterID is null (not set), assign it the value
+    // from version file.
+    if (this.clusterID == null) {
+      this.clusterID = idFromVersionFile;
+      return;
+    }
+
+    // If the clusterID is already set, it should match with the value from the
+    // version file.
+    if (!idFromVersionFile.equals(this.clusterID)) {
+      throw new InconsistentStorageStateException(
+          "Mismatched ClusterIDs. VolumeSet has: " + this.clusterID +
+              ", and version file has: " + idFromVersionFile);
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ImmutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ImmutableVolumeSet.java
@@ -22,18 +22,18 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 /**
- * Fixed list of HDDS volumes.
+ * Fixed list of volumes.
  */
 public final class ImmutableVolumeSet implements VolumeSet {
 
-  private final List<HddsVolume> volumes;
+  private final List<StorageVolume> volumes;
 
-  public ImmutableVolumeSet(HddsVolume... volumes) {
+  public ImmutableVolumeSet(StorageVolume... volumes) {
     this.volumes = ImmutableList.copyOf(volumes);
   }
 
   @Override
-  public List<HddsVolume> getVolumesList() {
+  public List<StorageVolume> getVolumesList() {
     return volumes;
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolume.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import java.io.IOException;
+
+/**
+ * MetadataVolume represents a volume in datanode for metadata(ratis).
+ * Datanode itself doesn't consume this volume, but only manages checks
+ * and volume info for it.
+ */
+public class MetadataVolume extends StorageVolume {
+
+  protected MetadataVolume(Builder b) throws IOException {
+    super(b);
+  }
+
+  /**
+   * Builder class for MetadataVolume.
+   */
+  public static class Builder extends StorageVolume.Builder<Builder> {
+
+    public Builder(String volumeRootStr) {
+      super(volumeRootStr, "");
+    }
+
+    @Override
+    public Builder getThis() {
+      return this;
+    }
+
+    public MetadataVolume build() throws IOException {
+      return new MetadataVolume(this);
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolumeFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+
+import java.io.IOException;
+
+/**
+ * A factory class for MetadataVolume.
+ */
+public class MetadataVolumeFactory extends StorageVolumeFactory {
+
+  public MetadataVolumeFactory(ConfigurationSource conf,
+      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet) {
+    super(conf, usageCheckFactory, volumeSet);
+  }
+
+  @Override
+  StorageVolume createVolume(String locationString, StorageType storageType)
+      throws IOException {
+    MetadataVolume.Builder volumeBuilder =
+        new MetadataVolume.Builder(locationString)
+            .conf(getConf())
+            .usageCheckFactory(getUsageCheckFactory())
+            .storageType(storageType)
+            .volumeSet(getVolumeSet());
+    return volumeBuilder.build();
+  }
+
+  @Override
+  StorageVolume createFailedVolume(String locationString) throws IOException {
+    MetadataVolume.Builder volumeBuilder =
+        new MetadataVolume.Builder(locationString)
+            .failedVolume(true);
+    return volumeBuilder.build();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
+import org.apache.hadoop.hdfs.server.datanode.checker.Checkable;
+import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
+import org.apache.hadoop.util.DiskChecker;
+
+import javax.annotation.Nullable;
+import java.io.File;
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * StorageVolume represents a generic Volume in datanode, could be
+ * 1. HddsVolume for container storage.
+ * 2. MetadataVolume for metadata(ratis) storage.
+ */
+public abstract class StorageVolume
+    implements Checkable<Boolean, VolumeCheckResult> {
+
+  /**
+   * Type for StorageVolume.
+   */
+  public enum VolumeType {
+    DATA_VOLUME,
+    META_VOLUME
+  }
+
+  private final File storageDir;
+
+  private final VolumeInfo volumeInfo;
+
+  private final VolumeSet volumeSet;
+
+  protected StorageVolume(Builder<?> b) throws IOException {
+    if (!b.failedVolume) {
+      StorageLocation location = StorageLocation.parse(b.volumeRootStr);
+      storageDir = new File(location.getUri().getPath(), b.storageDirStr);
+      this.volumeInfo = new VolumeInfo.Builder(b.volumeRootStr, b.conf)
+          .storageType(b.storageType)
+          .usageCheckFactory(b.usageCheckFactory)
+          .build();
+      this.volumeSet = b.volumeSet;
+    } else {
+      storageDir = new File(b.volumeRootStr);
+      this.volumeInfo = null;
+      this.volumeSet = null;
+    }
+  }
+
+  /**
+   * Builder class for StorageVolume.
+   * @param <T> subclass Builder
+   */
+  public abstract static class Builder<T extends Builder<T>> {
+    private final String volumeRootStr;
+    private String storageDirStr;
+    private ConfigurationSource conf;
+    private StorageType storageType;
+    private SpaceUsageCheckFactory usageCheckFactory;
+    private VolumeSet volumeSet;
+    private boolean failedVolume = false;
+
+    public Builder(String volumeRootStr, String storageDirStr) {
+      this.volumeRootStr = volumeRootStr;
+      this.storageDirStr = storageDirStr;
+    }
+
+    public abstract T getThis();
+
+    public T conf(ConfigurationSource config) {
+      this.conf = config;
+      return this.getThis();
+    }
+
+    public T storageType(StorageType st) {
+      this.storageType = st;
+      return this.getThis();
+    }
+
+    public T usageCheckFactory(SpaceUsageCheckFactory factory) {
+      this.usageCheckFactory = factory;
+      return this.getThis();
+    }
+
+    public T volumeSet(VolumeSet volSet) {
+      this.volumeSet = volSet;
+      return this.getThis();
+    }
+
+    // This is added just to create failed volume objects, which will be used
+    // to create failed StorageVolume objects in the case of any exceptions
+    // caused during creating StorageVolume object.
+    public T failedVolume(boolean failed) {
+      this.failedVolume = failed;
+      return this.getThis();
+    }
+
+    public abstract StorageVolume build() throws IOException;
+
+    public String getVolumeRootStr() {
+      return this.volumeRootStr;
+    }
+
+    public boolean getFailedVolume() {
+      return this.failedVolume;
+    }
+
+    public StorageType getStorageType() {
+      return this.storageType;
+    }
+  }
+
+  public long getCapacity() {
+    return volumeInfo != null ? volumeInfo.getCapacity() : 0;
+  }
+
+  public long getAvailable() {
+    return volumeInfo != null ? volumeInfo.getAvailable() : 0;
+  }
+
+  public long getUsedSpace() {
+    return volumeInfo != null ? volumeInfo.getScmUsed() : 0;
+  }
+
+  public File getStorageDir() {
+    return this.storageDir;
+  }
+
+  public VolumeInfo getVolumeInfo() {
+    return this.volumeInfo;
+  }
+
+  public VolumeSet getVolumeSet() {
+    return this.volumeSet;
+  }
+
+  public StorageType getStorageType() {
+    if(this.volumeInfo != null) {
+      return this.volumeInfo.getStorageType();
+    }
+    return StorageType.DEFAULT;
+  }
+
+  public String getStorageID() {
+    return "";
+  }
+
+  public void failVolume() {
+    if (volumeInfo != null) {
+      volumeInfo.shutdownUsageThread();
+    }
+  }
+
+  public void shutdown() {
+    if (volumeInfo != null) {
+      volumeInfo.shutdownUsageThread();
+    }
+  }
+
+  /**
+   * Run a check on the current volume to determine if it is healthy.
+   * @param unused context for the check, ignored.
+   * @return result of checking the volume.
+   * @throws Exception if an exception was encountered while running
+   *            the volume check.
+   */
+  @Override
+  public VolumeCheckResult check(@Nullable Boolean unused) throws Exception {
+    if (!storageDir.exists()) {
+      return VolumeCheckResult.FAILED;
+    }
+    DiskChecker.checkDir(storageDir);
+    return VolumeCheckResult.HEALTHY;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(storageDir);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    return this == other
+        || other instanceof StorageVolume
+        && ((StorageVolume) other).storageDir.equals(this.storageDir);
+  }
+
+  @Override
+  public String toString() {
+    return getStorageDir().toString();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+
+import java.io.IOException;
+
+/**
+ * A factory class for StorageVolume.
+ */
+public abstract class StorageVolumeFactory {
+
+  private ConfigurationSource conf;
+  private SpaceUsageCheckFactory usageCheckFactory;
+  private MutableVolumeSet volumeSet;
+
+  public StorageVolumeFactory(ConfigurationSource conf,
+      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet) {
+    this.conf = conf;
+    this.usageCheckFactory = usageCheckFactory;
+    this.volumeSet = volumeSet;
+  }
+
+  public ConfigurationSource getConf() {
+    return conf;
+  }
+
+  public SpaceUsageCheckFactory getUsageCheckFactory() {
+    return usageCheckFactory;
+  }
+
+  public VolumeSet getVolumeSet() {
+    return this.volumeSet;
+  }
+
+  abstract StorageVolume createVolume(String locationString,
+      StorageType storageType) throws IOException;
+
+  abstract StorageVolume createFailedVolume(String locationString)
+      throws IOException;
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.ozone.lock.ReadWriteLockable;
 import java.util.List;
 
 /**
- * Set of HDDS volumes.
+ * Set of volumes.
  */
 public interface VolumeSet extends ReadWriteLockable {
-  List<HddsVolume> getVolumesList();
+  List<StorageVolume> getVolumesList();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
@@ -64,7 +65,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.ERROR_IN_DB_SYNC;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.INVALID_CONTAINER_STATE;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
-import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
+import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +111,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     long maxSize = containerData.getMaxSize();
     volumeSet.readLock();
     try {
-      HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
-          .getVolumesList(), maxSize);
+      HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(
+          StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()),
+          maxSize);
       String hddsVolumeDir = containerVolume.getHddsRootDir().toString();
 
       long containerID = containerData.getContainerID();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -63,6 +63,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
@@ -287,8 +288,9 @@ public class KeyValueHandler extends Handler {
       throws IOException {
     volumeSet.readLock();
     try {
-      HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
-          .getVolumesList(), container.getContainerData().getMaxSize());
+      HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(
+          StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()),
+          container.getContainerData().getMaxSize());
       String hddsVolumeDir = containerVolume.getHddsRootDir().toString();
       container.populatePathFields(clusterId, containerVolume, hddsVolumeDir);
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaTwoImpl;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_BLOCK;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_READ_METADATA_DB;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNKNOWN_BCSID;
-import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
+import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
 /**
  * Utils functions to help block functions.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -55,7 +55,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.NO_SUCH_ALGORITHM;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNABLE_TO_FIND_CHUNK;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
-import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
+import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -58,7 +58,7 @@ import java.util.concurrent.ExecutionException;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion.FILE_PER_BLOCK;
 import static org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage.COMMIT_DATA;
-import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.onFailure;
+import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.limitReadSize;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.validateChunkForOverwrite;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.verifyChunkFileExists;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 
 import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
@@ -59,6 +60,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -160,8 +162,10 @@ public class TestBlockDeletingService {
     clusterID = UUID.randomUUID().toString();
     conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testRoot.getAbsolutePath());
     datanodeUuid = UUID.randomUUID().toString();
-    volumeSet = new MutableVolumeSet(datanodeUuid, conf, null);
+    volumeSet = new MutableVolumeSet(datanodeUuid, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
   }
 
   @AfterClass

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.container.common;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
@@ -34,6 +35,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -112,6 +114,11 @@ public class TestSchemaOneBackwardsCompatibility {
 
     metadataDir = tempMetadataDir;
     containerFile = new File(metadataDir, TestDB.CONTAINER_FILE_NAME);
+
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY,
+        metadataDir.getAbsolutePath());
+    conf.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+        metadataDir.getAbsolutePath());
   }
 
   /**
@@ -238,7 +245,8 @@ public class TestSchemaOneBackwardsCompatibility {
     final long numBlocksToDelete = TestDB.NUM_PENDING_DELETION_BLOCKS;
     String datanodeUuid = UUID.randomUUID().toString();
     ContainerSet containerSet = makeContainerSet();
-    VolumeSet volumeSet = new MutableVolumeSet(datanodeUuid, conf, null);
+    VolumeSet volumeSet = new MutableVolumeSet(datanodeUuid, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
@@ -305,7 +313,8 @@ public class TestSchemaOneBackwardsCompatibility {
   public void testReadDeletedBlockChunkInfo() throws Exception {
     String datanodeUuid = UUID.randomUUID().toString();
     ContainerSet containerSet = makeContainerSet();
-    VolumeSet volumeSet = new MutableVolumeSet(datanodeUuid, conf, null);
+    VolumeSet volumeSet = new MutableVolumeSet(datanodeUuid, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     ContainerMetrics metrics = ContainerMetrics.create(conf);
     KeyValueHandler keyValueHandler =
         new KeyValueHandler(conf, datanodeUuid, containerSet, volumeSet,
@@ -499,8 +508,6 @@ public class TestSchemaOneBackwardsCompatibility {
       throws Exception {
     conf.setInt(OZONE_BLOCK_DELETING_CONTAINER_LIMIT_PER_INTERVAL, 10);
     conf.setInt(OzoneConfigKeys.OZONE_BLOCK_DELETING_LIMIT_PER_CONTAINER, 2);
-    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY,
-        metadataDir.getAbsolutePath());
 
     OzoneContainer container = makeMockOzoneContainer(keyValueHandler);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestContainerPersistence.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
@@ -52,6 +53,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
@@ -130,6 +132,7 @@ public class TestContainerPersistence {
     hddsPath = GenericTestUtils
         .getTempPath(TestContainerPersistence.class.getSimpleName());
     conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, hddsPath);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, hddsPath);
     volumeChoosingPolicy = new RoundRobinVolumeChoosingPolicy();
   }
 
@@ -141,7 +144,8 @@ public class TestContainerPersistence {
   @Before
   public void setupPaths() throws IOException {
     containerSet = new ContainerSet();
-    volumeSet = new MutableVolumeSet(DATANODE_UUID, conf, null);
+    volumeSet = new MutableVolumeSet(DATANODE_UUID, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     blockManager = new BlockManagerImpl(conf);
     chunkManager = ChunkManagerFactory.createChunkManager(conf, blockManager,
         null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerAction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
@@ -46,6 +47,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.ChunkLayoutTestInfo;
@@ -100,9 +102,10 @@ public class TestHddsDispatcher {
         TestHddsDispatcher.class.getSimpleName());
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_DATANODE_DIR_KEY, testDir);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDir);
     DatanodeDetails dd = randomDatanodeDetails();
     MutableVolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf,
-        null);
+        null, StorageVolume.VolumeType.DATA_VOLUME, null);
 
     try {
       UUID scmId = UUID.randomUUID();
@@ -163,6 +166,7 @@ public class TestHddsDispatcher {
       UUID scmId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
+      conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
       HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
       ContainerCommandRequestProto writeChunkRequest =
@@ -198,6 +202,7 @@ public class TestHddsDispatcher {
       UUID scmId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
+      conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
       HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
       ContainerCommandRequestProto writeChunkRequest =
@@ -239,6 +244,7 @@ public class TestHddsDispatcher {
       UUID scmId = UUID.randomUUID();
       OzoneConfiguration conf = new OzoneConfiguration();
       conf.set(HDDS_DATANODE_DIR_KEY, testDir);
+      conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testDir);
       DatanodeDetails dd = randomDatanodeDetails();
       HddsDispatcher hddsDispatcher = createDispatcher(dd, scmId, conf);
       ContainerCommandRequestProto writeChunkRequest = getWriteChunkRequest(
@@ -278,7 +284,8 @@ public class TestHddsDispatcher {
   private HddsDispatcher createDispatcher(DatanodeDetails dd, UUID scmId,
       OzoneConfiguration conf) throws IOException {
     ContainerSet containerSet = new ContainerSet();
-    VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null);
+    VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     DatanodeStateMachine stateMachine = Mockito.mock(
         DatanodeStateMachine.class);
     StateContext context = Mockito.mock(StateContext.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -20,13 +20,20 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.Test;
 
+import java.util.concurrent.TimeUnit;
+
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_DELETE_THREADS_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.CONTAINER_DELETE_THREADS_MAX_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_MIN_GAP_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_MIN_GAP_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_TIMEOUT_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_MAX_STREAMS_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.REPLICATION_STREAMS_LIMIT_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
-import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_VOLUMES_TOLERATED_DEFAULT;
 
 import static org.junit.Assert.assertEquals;
@@ -43,12 +50,21 @@ public class TestDatanodeConfiguration {
     int validDeleteThreads = 42;
     long validDiskCheckIntervalMinutes = 60;
     int validFailedVolumesTolerated = 10;
+    long validDiskCheckMinGap = 2;
+    long validDiskCheckTimeout = 1;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, validReplicationLimit);
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, validDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
         validDiskCheckIntervalMinutes);
-    conf.setInt(FAILED_VOLUMES_TOLERATED_KEY, validFailedVolumesTolerated);
+    conf.setInt(FAILED_DATA_VOLUMES_TOLERATED_KEY,
+        validFailedVolumesTolerated);
+    conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
+        validFailedVolumesTolerated);
+    conf.setTimeDuration(DISK_CHECK_MIN_GAP_KEY,
+        validDiskCheckMinGap, TimeUnit.MINUTES);
+    conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
+        validDiskCheckTimeout, TimeUnit.MINUTES);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -59,7 +75,13 @@ public class TestDatanodeConfiguration {
     assertEquals(validDiskCheckIntervalMinutes,
         subject.getPeriodicDiskCheckIntervalMinutes());
     assertEquals(validFailedVolumesTolerated,
-        subject.getFailedVolumesTolerated());
+        subject.getFailedDataVolumesTolerated());
+    assertEquals(validFailedVolumesTolerated,
+        subject.getFailedMetadataVolumesTolerated());
+    assertEquals(validDiskCheckMinGap,
+        subject.getDiskCheckMinGap().toMinutes());
+    assertEquals(validDiskCheckTimeout,
+        subject.getDiskCheckTimeout().toMinutes());
   }
 
   @Test
@@ -69,12 +91,21 @@ public class TestDatanodeConfiguration {
     int invalidDeleteThreads = 0;
     long invalidDiskCheckIntervalMinutes = -1;
     int invalidFailedVolumesTolerated = -2;
+    long invalidDiskCheckMinGap = -1;
+    long invalidDiskCheckTimeout = -1;
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(REPLICATION_STREAMS_LIMIT_KEY, invalidReplicationLimit);
     conf.setInt(CONTAINER_DELETE_THREADS_MAX_KEY, invalidDeleteThreads);
     conf.setLong(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY,
         invalidDiskCheckIntervalMinutes);
-    conf.setInt(FAILED_VOLUMES_TOLERATED_KEY, invalidFailedVolumesTolerated);
+    conf.setInt(FAILED_DATA_VOLUMES_TOLERATED_KEY,
+        invalidFailedVolumesTolerated);
+    conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
+        invalidFailedVolumesTolerated);
+    conf.setTimeDuration(DISK_CHECK_MIN_GAP_KEY,
+        invalidDiskCheckMinGap, TimeUnit.MINUTES);
+    conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
+        invalidDiskCheckTimeout, TimeUnit.MINUTES);
 
     // WHEN
     DatanodeConfiguration subject = conf.getObject(DatanodeConfiguration.class);
@@ -87,7 +118,13 @@ public class TestDatanodeConfiguration {
     assertEquals(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT,
         subject.getPeriodicDiskCheckIntervalMinutes());
     assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
-        subject.getFailedVolumesTolerated());
+        subject.getFailedDataVolumesTolerated());
+    assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
+        subject.getFailedMetadataVolumesTolerated());
+    assertEquals(DISK_CHECK_MIN_GAP_DEFAULT,
+        subject.getDiskCheckMinGap().toMillis());
+    assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,
+        subject.getDiskCheckTimeout().toMillis());
   }
 
   @Test
@@ -106,7 +143,13 @@ public class TestDatanodeConfiguration {
     assertEquals(PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT,
         subject.getPeriodicDiskCheckIntervalMinutes());
     assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
-        subject.getFailedVolumesTolerated());
+        subject.getFailedDataVolumesTolerated());
+    assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
+        subject.getFailedMetadataVolumesTolerated());
+    assertEquals(DISK_CHECK_MIN_GAP_DEFAULT,
+        subject.getDiskCheckMinGap().toMillis());
+    assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,
+        subject.getDiskCheckTimeout().toMillis());
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSet.java
@@ -23,8 +23,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
@@ -64,7 +66,8 @@ public class TestVolumeSet {
   private static final String DUMMY_IP_ADDR = "0.0.0.0";
 
   private void initializeVolumeSet() throws Exception {
-    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf, null);
+    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf,
+        null, StorageVolume.VolumeType.DATA_VOLUME, null);
   }
 
   @Rule
@@ -77,28 +80,30 @@ public class TestVolumeSet {
     volumes.add(volume1);
     volumes.add(volume2);
     conf.set(DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY, dataDirKey);
+    conf.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
+        dataDirKey);
     initializeVolumeSet();
   }
 
   @After
   public void shutdown() throws IOException {
-    // Delete the hdds volume root dir
-    List<HddsVolume> hddsVolumes = new ArrayList<>();
-    hddsVolumes.addAll(volumeSet.getVolumesList());
-    hddsVolumes.addAll(volumeSet.getFailedVolumesList());
+    // Delete the volume root dir
+    List<StorageVolume> vols = new ArrayList<>();
+    vols.addAll(volumeSet.getVolumesList());
+    vols.addAll(volumeSet.getFailedVolumesList());
 
-    for (HddsVolume volume : hddsVolumes) {
-      FileUtils.deleteDirectory(volume.getHddsRootDir());
+    for (StorageVolume volume : vols) {
+      FileUtils.deleteDirectory(volume.getStorageDir());
     }
     volumeSet.shutdown();
 
     FileUtil.fullyDelete(new File(baseDir));
   }
 
-  private boolean checkVolumeExistsInVolumeSet(String volume) {
-    for (HddsVolume hddsVolume : volumeSet.getVolumesList()) {
-      if (hddsVolume.getHddsRootDir().getPath().equals(
-          HddsVolumeUtil.getHddsRoot(volume))) {
+  private boolean checkVolumeExistsInVolumeSet(String volumeRoot) {
+    for (StorageVolume volume : volumeSet.getVolumesList()) {
+      if (volume.getStorageDir().getPath().equals(volumeRoot)
+          || volume.getStorageDir().getParent().equals(volumeRoot)) {
         return true;
       }
     }
@@ -108,7 +113,7 @@ public class TestVolumeSet {
   @Test
   public void testVolumeSetInitialization() throws Exception {
 
-    List<HddsVolume> volumesList = volumeSet.getVolumesList();
+    List<StorageVolume> volumesList = volumeSet.getVolumesList();
 
     // VolumeSet initialization should add volume1 and volume2 to VolumeSet
     assertEquals("VolumeSet intialization is incorrect",
@@ -138,7 +143,7 @@ public class TestVolumeSet {
   public void testFailVolume() throws Exception {
 
     //Fail a volume
-    volumeSet.failVolume(volume1);
+    volumeSet.failVolume(HddsVolumeUtil.getHddsRoot(volume1));
 
     // Failed volume should not show up in the volumeList
     assertEquals(1, volumeSet.getVolumesList().size());
@@ -148,8 +153,7 @@ public class TestVolumeSet {
         1, volumeSet.getFailedVolumesList().size());
     assertEquals("Failed Volume list did not match",
         HddsVolumeUtil.getHddsRoot(volume1),
-        volumeSet.getFailedVolumesList().get(0).getHddsRootDir().getPath());
-    assertTrue(volumeSet.getFailedVolumesList().get(0).isFailed());
+        volumeSet.getFailedVolumesList().get(0).getStorageDir().getPath());
 
     // Failed volume should not exist in VolumeMap
     assertFalse(volumeSet.getVolumeMap().containsKey(volume1));
@@ -161,14 +165,14 @@ public class TestVolumeSet {
     assertEquals(2, volumeSet.getVolumesList().size());
 
     // Remove a volume from VolumeSet
-    volumeSet.removeVolume(volume1);
+    volumeSet.removeVolume(HddsVolumeUtil.getHddsRoot(volume1));
     assertEquals(1, volumeSet.getVolumesList().size());
 
     // Attempting to remove a volume which does not exist in VolumeSet should
     // log a warning.
     LogCapturer logs = LogCapturer.captureLogs(
         LogFactory.getLog(MutableVolumeSet.class));
-    volumeSet.removeVolume(volume1);
+    volumeSet.removeVolume(HddsVolumeUtil.getHddsRoot(volume1));
     assertEquals(1, volumeSet.getVolumesList().size());
     String expectedLogMessage = "Volume : " +
         HddsVolumeUtil.getHddsRoot(volume1) + " does not exist in VolumeSet";
@@ -209,12 +213,12 @@ public class TestVolumeSet {
 
   @Test
   public void testShutdown() throws Exception {
-    List<HddsVolume> volumesList = volumeSet.getVolumesList();
+    List<StorageVolume> volumesList = volumeSet.getVolumesList();
 
     volumeSet.shutdown();
 
     // Verify that volume usage can be queried during shutdown.
-    for (HddsVolume volume : volumesList) {
+    for (StorageVolume volume : volumesList) {
       Assert.assertNotNull(volume.getVolumeInfo().getUsageForTesting());
       volume.getAvailable();
     }
@@ -230,11 +234,13 @@ public class TestVolumeSet {
     OzoneConfiguration ozoneConfig = new OzoneConfiguration();
     ozoneConfig.set(HDDS_DATANODE_DIR_KEY, readOnlyVolumePath.getAbsolutePath()
         + "," + volumePath.getAbsolutePath());
+    ozoneConfig.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+        volumePath.getAbsolutePath());
     volSet = new MutableVolumeSet(UUID.randomUUID().toString(), ozoneConfig,
-        null);
+        null, StorageVolume.VolumeType.DATA_VOLUME, null);
     assertEquals(1, volSet.getFailedVolumesList().size());
     assertEquals(readOnlyVolumePath, volSet.getFailedVolumesList().get(0)
-        .getHddsRootDir());
+        .getStorageDir());
 
     //Set back to writable
     try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
@@ -42,6 +43,8 @@ import org.junit.After;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -89,7 +92,8 @@ public class TestVolumeSetDiskChecks {
 
     conf = getConfWithDataNodeDirs(numVolumes);
     final MutableVolumeSet volumeSet =
-        new MutableVolumeSet(UUID.randomUUID().toString(), conf, null);
+        new MutableVolumeSet(UUID.randomUUID().toString(), conf,
+            null, StorageVolume.VolumeType.DATA_VOLUME, null);
 
     assertThat(volumeSet.getVolumesList().size(), is(numVolumes));
     assertThat(volumeSet.getFailedVolumesList().size(), is(0));
@@ -113,19 +117,27 @@ public class TestVolumeSetDiskChecks {
     final int numBadVolumes = 2;
 
     conf = getConfWithDataNodeDirs(numVolumes);
+    StorageVolumeChecker dummyChecker =
+        new DummyChecker(conf, new Timer(), numBadVolumes);
     final MutableVolumeSet volumeSet = new MutableVolumeSet(
-        UUID.randomUUID().toString(), conf, null) {
-      @Override
-      HddsVolumeChecker getVolumeChecker(ConfigurationSource configuration)
-          throws DiskErrorException {
-        return new DummyChecker(configuration, new Timer(), numBadVolumes);
-      }
-    };
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME,
+        dummyChecker);
+    final MutableVolumeSet metaVolumeSet = new MutableVolumeSet(
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.META_VOLUME,
+        dummyChecker);
 
-    assertThat(volumeSet.getFailedVolumesList().size(), is(numBadVolumes));
-    assertThat(volumeSet.getVolumesList().size(),
-        is(numVolumes - numBadVolumes));
+    Assert.assertEquals(volumeSet.getFailedVolumesList().size(),
+        numBadVolumes);
+    Assert.assertEquals(volumeSet.getVolumesList().size(),
+        numVolumes - numBadVolumes);
+    Assert.assertEquals(metaVolumeSet.getFailedVolumesList().size(),
+        numBadVolumes);
+    Assert.assertEquals(metaVolumeSet.getVolumesList().size(),
+        numVolumes - numBadVolumes);
     volumeSet.shutdown();
+    metaVolumeSet.shutdown();
   }
 
   /**
@@ -136,19 +148,24 @@ public class TestVolumeSetDiskChecks {
     final int numVolumes = 5;
 
     conf = getConfWithDataNodeDirs(numVolumes);
+    StorageVolumeChecker dummyChecker =
+        new DummyChecker(conf, new Timer(), numVolumes);
 
     final MutableVolumeSet volumeSet = new MutableVolumeSet(
-        UUID.randomUUID().toString(), conf, null) {
-      @Override
-      HddsVolumeChecker getVolumeChecker(ConfigurationSource configuration)
-          throws DiskErrorException {
-        return new DummyChecker(configuration, new Timer(), numVolumes);
-      }
-    };
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME,
+        new DummyChecker(conf, new Timer(), numVolumes));
+    final MutableVolumeSet metaVolumeSet = new MutableVolumeSet(
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.META_VOLUME,
+        dummyChecker);
 
     assertEquals(volumeSet.getFailedVolumesList().size(), numVolumes);
     assertEquals(volumeSet.getVolumesList().size(), 0);
+    assertEquals(metaVolumeSet.getFailedVolumesList().size(), numVolumes);
+    assertEquals(metaVolumeSet.getVolumesList().size(), 0);
     volumeSet.shutdown();
+    metaVolumeSet.shutdown();
   }
 
   /**
@@ -164,9 +181,17 @@ public class TestVolumeSetDiskChecks {
     }
     ozoneConf.set(DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY,
         String.join(",", dirs));
+
+    final List<String> metaDirs = new ArrayList<>();
+    for (int i = 0; i < numDirs; ++i) {
+      metaDirs.add(GenericTestUtils.getRandomizedTestDir().getPath());
+    }
+    ozoneConf.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
+        String.join(",", metaDirs));
     DatanodeConfiguration dnConf =
         ozoneConf.getObject(DatanodeConfiguration.class);
-    dnConf.setFailedVolumesTolerated(numDirs);
+    dnConf.setFailedDataVolumesTolerated(numDirs * 2);
+    dnConf.setFailedMetadataVolumesTolerated(numDirs * 2);
     ozoneConf.setFromObject(dnConf);
     return ozoneConf;
   }
@@ -175,7 +200,7 @@ public class TestVolumeSetDiskChecks {
    * A no-op checker that fails the given number of volumes and succeeds
    * the rest.
    */
-  static class DummyChecker extends HddsVolumeChecker {
+  static class DummyChecker extends StorageVolumeChecker {
     private final int numBadVolumes;
 
     DummyChecker(ConfigurationSource conf, Timer timer, int numBadVolumes)
@@ -185,7 +210,8 @@ public class TestVolumeSetDiskChecks {
     }
 
     @Override
-    public Set<HddsVolume> checkAllVolumes(Collection<HddsVolume> volumes)
+    public Set<? extends StorageVolume> checkAllVolumes(
+        Collection<? extends StorageVolume> volumes)
         throws InterruptedException {
       // Return the first 'numBadVolumes' as failed.
       return ImmutableSet.copyOf(Iterables.limit(volumes, numBadVolumes));

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
@@ -36,6 +37,7 @@ import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -85,7 +87,9 @@ public class TestKeyValueBlockIterator {
     testRoot = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
     conf.set(HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
-    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf, null);
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testRoot.getAbsolutePath());
+    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
 
     containerData = new KeyValueContainerData(105L,
             layout,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume
     .RoundRobinVolumeChoosingPolicy;
@@ -178,8 +179,8 @@ public class TestKeyValueContainer {
             datanodeId.toString());
     KeyValueContainer container = new KeyValueContainer(containerData, CONF);
 
-    HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
-        .getVolumesList(), 1);
+    HddsVolume containerVolume = volumeChoosingPolicy.chooseVolume(
+        StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()), 1);
     String hddsVolumeDir = containerVolume.getHddsRootDir().toString();
 
     container.populatePathFields(scmId, containerVolume, hddsVolumeDir);
@@ -220,8 +221,8 @@ public class TestKeyValueContainer {
             datanodeId.toString());
     container = new KeyValueContainer(containerData, CONF);
 
-    containerVolume = volumeChoosingPolicy.chooseVolume(volumeSet
-        .getVolumesList(), 1);
+    containerVolume = volumeChoosingPolicy.chooseVolume(
+        StorageVolumeUtil.getHddsVolumesList(volumeSet.getVolumesList()), 1);
     hddsVolumeDir = containerVolume.getHddsRootDir().toString();
     container.populatePathFields(scmId, containerVolume, hddsVolumeDir);
     try {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdfs.util.DataTransferThrottler;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.ChecksumData;
@@ -32,6 +33,7 @@ import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.interfaces.BlockIterator;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerLocationUtil;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
@@ -96,8 +98,10 @@ import static org.junit.Assert.assertFalse;
     this.testRoot = GenericTestUtils.getRandomizedTestDir();
     conf = new OzoneConfiguration();
     conf.set(HDDS_DATANODE_DIR_KEY, testRoot.getAbsolutePath());
+    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, testRoot.getAbsolutePath());
     chunkManagerTestInfo.updateConfig(conf);
-    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf, null);
+    volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     chunkManager = chunkManagerTestInfo.createChunkManager(true, null);
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueHandler.java
@@ -46,10 +46,12 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.ozone.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.junit.Assert.assertEquals;
 
@@ -263,9 +265,10 @@ public class TestKeyValueHandler {
     File path = GenericTestUtils.getRandomizedTestDir();
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_DATANODE_DIR_KEY, path.getAbsolutePath());
+    conf.set(OZONE_METADATA_DIRS, path.getAbsolutePath());
     MutableVolumeSet
         volumeSet = new MutableVolumeSet(UUID.randomUUID().toString(), conf,
-        null);
+        null, StorageVolume.VolumeType.DATA_VOLUME, null);
     try {
       ContainerSet cset = new ContainerSet();
       int[] interval = new int[1];

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -65,10 +65,12 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.security.UserGroupInformation;
 
+import static org.apache.hadoop.hdds.DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL_DEFAULT;
@@ -368,6 +370,20 @@ public final class HddsServerUtil {
     if (rawLocations.isEmpty()) {
       rawLocations = new ArrayList<>(1);
       rawLocations.add(ServerUtils.getDefaultRatisDirectory(conf));
+    }
+    return rawLocations;
+  }
+
+  public static Collection<String> getDatanodeStorageDirs(
+      ConfigurationSource conf) {
+    Collection<String> rawLocations = conf.getTrimmedStringCollection(
+        HDDS_DATANODE_DIR_KEY);
+    if (rawLocations.isEmpty()) {
+      rawLocations = conf.getTrimmedStringCollection(DFS_DATANODE_DATA_DIR_KEY);
+    }
+    if (rawLocations.isEmpty()) {
+      throw new IllegalArgumentException("No location configured in either "
+          + HDDS_DATANODE_DIR_KEY + " or " + DFS_DATANODE_DATA_DIR_KEY);
     }
     return rawLocations;
   }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -162,6 +162,10 @@ message StorageReportProto {
 message MetadataStorageReportProto {
   required string storageLocation = 1;
   optional StorageTypeProto storageType = 2 [default = DISK];
+  optional uint64 capacity = 3 [default = 0];
+  optional uint64 scmUsed = 4 [default = 0];
+  optional uint64 remaining = 5 [default = 0];
+  optional bool failed = 6 [default = false];
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.states.endpoint.HeartbeatEndpointTask;
 import org.apache.hadoop.ozone.container.common.states.endpoint.RegisterEndpointTask;
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
@@ -192,8 +193,8 @@ public class TestEndPoint {
       newState = versionTask.call();
       Assert.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
           newState);
-      List<HddsVolume> volumesList = ozoneContainer.getVolumeSet()
-          .getFailedVolumesList();
+      List<HddsVolume> volumesList = StorageVolumeUtil.getHddsVolumesList(
+          ozoneContainer.getVolumeSet().getFailedVolumesList());
       Assert.assertTrue(volumesList.size() == 1);
       Assert.assertTrue(logCapturer.getOutput()
           .contains("org.apache.hadoop.ozone.common" +

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerGr
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.security.OzoneBlockTokenSecretManager;
@@ -72,6 +73,7 @@ import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.HddsUtils.isReadOnly;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.SUCCESS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
@@ -168,7 +170,9 @@ public class TestSecureContainerServer {
     conf.set(HDDS_DATANODE_DIR_KEY,
         Paths.get(TEST_DIR, "dfs", "data", "hdds",
             RandomStringUtils.randomAlphabetic(4)).toString());
-    VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null);
+    conf.set(OZONE_METADATA_DIRS, TEST_DIR);
+    VolumeSet volumeSet = new MutableVolumeSet(dd.getUuidString(), conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     DatanodeStateMachine stateMachine = Mockito.mock(
         DatanodeStateMachine.class);
     StateContext context = Mockito.mock(StateContext.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/DatanodeTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.dn;
 
 import com.google.common.base.Supplier;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -181,7 +182,7 @@ public final class DatanodeTestUtils {
   /**
    * Simulate a bad rootDir by removing write permission.
    * @see {@link org.apache.hadoop.ozone.container.common.volume
-   * .HddsVolume#check(Boolean)}
+   * .StorageVolume#check(Boolean)}
    * @param rootDir
    */
   public static void simulateBadRootDir(File rootDir) {
@@ -193,16 +194,16 @@ public final class DatanodeTestUtils {
   /**
    * Simulate a bad volume by removing write permission.
    * @see {@link org.apache.hadoop.ozone.container.common.volume
-   * .HddsVolume#check(Boolean)}
+   * .StorageVolume#check(Boolean)}
    * @param vol
    */
-  public static void simulateBadVolume(HddsVolume vol) {
-    simulateBadRootDir(vol.getHddsRootDir());
+  public static void simulateBadVolume(StorageVolume vol) {
+    simulateBadRootDir(vol.getStorageDir());
   }
 
   /**
    * Restore a simulated bad volume to normal.
-   * @see {@link #simulateBadVolume(HddsVolume)}
+   * @see {@link #simulateBadVolume(StorageVolume)}
    * @param rootDir
    */
   public static void restoreBadRootDir(File rootDir) {
@@ -213,11 +214,11 @@ public final class DatanodeTestUtils {
 
   /**
    * Restore a simulated bad rootDir to normal.
-   * @see {@link #simulateBadVolume(HddsVolume)}
+   * @see {@link #simulateBadVolume(StorageVolume)}
    * @param vol
    */
-  public static void restoreBadVolume(HddsVolume vol) {
-    restoreBadRootDir(vol.getHddsRootDir());
+  public static void restoreBadVolume(StorageVolume vol) {
+    restoreBadRootDir(vol.getStorageDir());
   }
 
   /**
@@ -254,7 +255,7 @@ public final class DatanodeTestUtils {
   }
 
   public static File getHddsVolumeClusterDir(HddsVolume vol) {
-    File hddsVolumeRootDir = vol.getHddsRootDir();
+    File hddsVolumeRootDir = vol.getStorageDir();
     return new File(hddsVolumeRootDir, vol.getClusterID());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/TestDatanodeLayoutUpgradeTool.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/TestDatanodeLayoutUpgradeTool.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone.dn;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -26,7 +27,6 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
-import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.debug.DatanodeLayout;
 import org.junit.Before;
 import org.junit.After;
@@ -107,7 +107,7 @@ public class TestDatanodeLayoutUpgradeTool {
 
     List<HddsDatanodeService> dns = cluster.getHddsDatanodes();
     OzoneConfiguration c1 = dns.get(0).getConf();
-    Collection<String> paths = MutableVolumeSet.getDatanodeStorageDirs(c1);
+    Collection<String> paths = HddsServerUtil.getDatanodeStorageDirs(c1);
 
     for (String p : paths) {
       // Verify that tool is able to verify the storage path

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
-import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.dn.DatanodeTestUtils;
 import org.junit.After;
@@ -63,7 +63,7 @@ public class TestDatanodeHddsVolumeFailureToleration {
     // set tolerated = 1
     DatanodeConfiguration dnConf =
         ozoneConfig.getObject(DatanodeConfiguration.class);
-    dnConf.setFailedVolumesTolerated(1);
+    dnConf.setFailedDataVolumesTolerated(1);
     ozoneConfig.setFromObject(dnConf);
     cluster = MiniOzoneCluster.newBuilder(ozoneConfig)
         .setNumDatanodes(1)
@@ -85,9 +85,9 @@ public class TestDatanodeHddsVolumeFailureToleration {
     HddsDatanodeService dn = datanodes.get(0);
     OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
     MutableVolumeSet volSet = oc.getVolumeSet();
-    HddsVolume vol0 = volSet.getVolumesList().get(0);
+    StorageVolume vol0 = volSet.getVolumesList().get(0);
     // keep the file for restore since we'll do restart
-    File volRootDir0 = vol0.getHddsRootDir();
+    File volRootDir0 = vol0.getStorageDir();
 
     // simulate bad volumes <= tolerated
     DatanodeTestUtils.simulateBadRootDir(volRootDir0);
@@ -106,10 +106,10 @@ public class TestDatanodeHddsVolumeFailureToleration {
     HddsDatanodeService dn = datanodes.get(0);
     OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
     MutableVolumeSet volSet = oc.getVolumeSet();
-    HddsVolume vol0 = volSet.getVolumesList().get(0);
-    HddsVolume vol1 = volSet.getVolumesList().get(1);
-    File volRootDir0 = vol0.getHddsRootDir();
-    File volRootDir1 = vol1.getHddsRootDir();
+    StorageVolume vol0 = volSet.getVolumesList().get(0);
+    StorageVolume vol1 = volSet.getVolumesList().get(1);
+    File volRootDir0 = vol0.getStorageDir();
+    File volRootDir1 = vol1.getStorageDir();
 
     // simulate bad volumes > tolerated
     DatanodeTestUtils.simulateBadRootDir(volRootDir0);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DatanodeLayout.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DatanodeLayout.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
@@ -96,11 +97,14 @@ public class DatanodeLayout extends GenericCli
     OzoneContainer.buildContainerSet(volumeSet, containerSet, conf);
     volumeSet.shutdown();
 
+    List<HddsVolume> failedVolumes = StorageVolumeUtil.getHddsVolumesList(
+        volumeSet.getFailedVolumesList());
+
     if (verify) {
-      for (HddsVolume vol : volumeSet.getFailedVolumesList()) {
+      for (HddsVolume vol : failedVolumes) {
         System.out.println("Failed Volume:" + vol.getHddsRootDir());
       }
     }
-    return volumeSet.getFailedVolumesList();
+    return failedVolumes;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ChunkManagerDiskWrite.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -102,7 +103,8 @@ public class ChunkManagerDiskWrite extends BaseFreonGenerator implements
       OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
       VolumeSet volumeSet =
-          new MutableVolumeSet("dnid", "clusterid", ozoneConfiguration, null);
+          new MutableVolumeSet("dnid", "clusterid", ozoneConfiguration, null,
+              StorageVolume.VolumeType.DATA_VOLUME, null);
 
       Random random = new Random();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ClosedContainerReplicator.java
@@ -38,11 +38,13 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.TarContainerPacker;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.replication.ContainerReplicator;
@@ -85,7 +87,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
     OzoneConfiguration conf = createOzoneConfiguration();
 
     final Collection<String> datanodeStorageDirs =
-        MutableVolumeSet.getDatanodeStorageDirs(conf);
+        HddsServerUtil.getDatanodeStorageDirs(conf);
 
     for (String dir : datanodeStorageDirs) {
       checkDestinationDirectory(dir);
@@ -172,7 +174,7 @@ public class ClosedContainerReplicator extends BaseFreonGenerator implements
     ContainerMetrics metrics = ContainerMetrics.create(conf);
 
     MutableVolumeSet volumeSet = new MutableVolumeSet(fakeDatanodeUuid, conf,
-        null);
+        null, StorageVolume.VolumeType.DATA_VOLUME, null);
 
     Map<ContainerType, Handler> handlers = new HashMap<>();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChecksumData;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.Checksum;
@@ -50,6 +51,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.ratis.Dispatche
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.impl.BlockManagerImpl;
@@ -131,7 +133,7 @@ public class GeneratorDatanode extends BaseGenerator {
         .createChunkManager(config, blockManager, null);
 
     final Collection<String> storageDirs =
-        MutableVolumeSet.getDatanodeStorageDirs(config);
+        HddsServerUtil.getDatanodeStorageDirs(config);
 
     String firstStorageDir =
         StorageLocation.parse(storageDirs.iterator().next())
@@ -159,7 +161,8 @@ public class GeneratorDatanode extends BaseGenerator {
     datanodeId = HddsVolumeUtil
         .getProperty(props, OzoneConsts.DATANODE_UUID, versionFile);
 
-    volumeSet = new MutableVolumeSet(datanodeId, clusterId, config, null);
+    volumeSet = new MutableVolumeSet(datanodeId, clusterId, config, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
 
     volumeChoosingPolicy = new RoundRobinVolumeChoosingPolicy();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkDatanodeDispatcher.java
@@ -51,6 +51,7 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
@@ -102,7 +103,8 @@ public class BenchMarkDatanodeDispatcher {
     conf.set("ozone.scm.container.size", "10MB");
 
     ContainerSet containerSet = new ContainerSet();
-    volumeSet = new MutableVolumeSet(datanodeUuid, conf, null);
+    volumeSet = new MutableVolumeSet(datanodeUuid, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
     StateContext context = new StateContext(
         conf, DatanodeStates.RUNNING, null);
     ContainerMetrics metrics = ContainerMetrics.create(conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure disk checker also scans the ratis log disks periodically.
To do so, I did some refactoring work, and then add ratis log disks to disk checker.
Here is a checklist:
**Done**:
- Introduce a base class `StorageVolume` and let `HddsVolume` extends it.
  VolumeInfo and disk check stuff are extracted into `StorageVolume`
- Introduce a sub class `MetadataVolume` extends `StorageVolume`,
  so it shares the VolumeInfo and disk check stuff.
- Migrate ratisVolumeMap from `XceiverServerRatis` to `MutableVolumeSet`,
  so we mange all kinds of volumes together.
- The config 'failed.volumes.tolerated' is separated into 2:
  'failed.hdds.volumes.tolerated' & 'failed.metadata.volumes.tolerated'.
- Add VolumeInfo related fields into `MetadataStorageReportProto`,
  so SCM could get space info from datanodes.
- Have 2 separated VolumeSets: volumeSet & metaVolumeSet and one volumeChecker
  to check them all.
- legacy configuration change:
  - dfs.datanode.disk.check.min.gap -> hdds.datanode.disk.check.min.gap
  - dis.datanode.disk.check.timeout -> hdds.datanode.disk.check.timeout


**Not Done**:
- Handle the case that `MetadataVolume` and `HddsVolume` are on the same physical disk,
   so for now failed volumes may be double counted.
- Try to check a single failed `MetadataVolume` on log failure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5268

## How was this patch tested?

Exisiting unit-tests and integration-tests.
To add more tests.
