### PR TITLE
HDDS-5278. replication manager will delete over-replicated container with storage utilization priority

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -112,6 +112,13 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   SCMNodeStat getStats();
 
   /**
+   * Returns the a certain node stats.
+   * @param datanodeDetails DatanodeDetails.
+   * @return the a certain node stats.
+   */
+  SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails);
+
+  /**
    * Return a map of node stats.
    * @return a map of individual node stats (live/stale but not dead).
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -607,7 +607,13 @@ public class SCMNodeManager implements NodeManager {
     return nodeStat != null ? new SCMNodeMetric(nodeStat) : null;
   }
 
-  private SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails) {
+  /**
+   * Returns the a certain node stats.
+   * @param datanodeDetails DatanodeDetails.
+   * @return the a certain node stats.
+   */
+  @Override
+  public SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails) {
     try {
       long capacity = 0L;
       long used = 0L;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -97,6 +97,7 @@ public class MockNodeManager implements NodeManager {
   private final List<DatanodeDetails> deadNodes;
   private final Map<DatanodeDetails, SCMNodeStat> nodeMetricMap;
   private final SCMNodeStat aggregateStat;
+  private SCMNodeStat newStat;
   private boolean safemode;
   private final Map<UUID, List<SCMCommand>> commandMap;
   private Node2PipelineMap node2PipelineMap;
@@ -178,7 +179,7 @@ public class MockNodeManager implements NodeManager {
    * @param datanodeDetails - Datanode details
    */
   private void populateNodeMetric(DatanodeDetails datanodeDetails, int x) {
-    SCMNodeStat newStat = new SCMNodeStat();
+    newStat = new SCMNodeStat();
     long remaining =
         NODES[x % NODES.length].capacity - NODES[x % NODES.length].used;
     newStat.set(
@@ -305,6 +306,16 @@ public class MockNodeManager implements NodeManager {
   @Override
   public SCMNodeStat getStats() {
     return aggregateStat;
+  }
+
+  /**
+   * Returns the a certain node stats.
+   * @param datanodeDetails DatanodeDetails.
+   * @return the a certain node stats.
+   */
+  @Override
+  public SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails){
+    return newStat;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -208,6 +208,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails){
+    return null;
+  }
+
+  @Override
   public Map<DatanodeDetails, SCMNodeStat> getNodeStats() {
     return null;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -152,6 +152,16 @@ public class ReplicationNodeManagerMock implements NodeManager {
   }
 
   /**
+   * Returns the a certain node stats.
+   * @param datanodeDetails DatanodeDetails.
+   * @return the a certain node stats.
+   */
+  @Override
+  public SCMNodeStat getNodeStatInternal(DatanodeDetails datanodeDetails){
+    return  null;
+  }
+
+  /**
    * Return a map of node stats.
    *
    * @return a map of individual node stats (live/stale but not dead).


### PR DESCRIPTION
## What changes were proposed in this pull request?

when a container is over-replicated, replication manager will choose some of the replica to delete.  this PR aims that the deletion candidate replicas will be deleted by storage utilization priority

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5278

## How was this patch tested?

unit test
