### PR TITLE
HDDS-5263. SCM may stay in safe mode forever after a unclean shutdown of SCM.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -437,7 +437,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private void setPendingRequestsLimits(RaftProperties properties) {
 
-    final long pendingRequestsByteLimit = (int)conf.getStorageSize(
+    final int pendingRequestsByteLimit = (int)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.BYTES);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -437,7 +437,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private void setPendingRequestsLimits(RaftProperties properties) {
 
-    final long pendingRequestsByteLimit = (long)conf.getStorageSize(
+    final long pendingRequestsByteLimit = (int)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.BYTES);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -437,7 +437,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private void setPendingRequestsLimits(RaftProperties properties) {
 
-    final int pendingRequestsByteLimit = (int)conf.getStorageSize(
+    final long pendingRequestsByteLimit = (long)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.BYTES);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -224,7 +224,7 @@ public class SCMBlockDeletingService extends BackgroundService
   public void notifyStatusChanged() {
     serviceLock.lock();
     try {
-      if (scmContext.isLeader()) {
+      if (scmContext.isLeaderReady()) {
         serviceStatus = ServiceStatus.RUNNING;
       } else {
         serviceStatus = ServiceStatus.PAUSING;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -1283,9 +1283,9 @@ public class ReplicationManager implements MetricsSource, SCMService {
   public void notifyStatusChanged() {
     serviceLock.lock();
     try {
-      // 1) SCMContext#isLeader returns true.
+      // 1) SCMContext#isLeaderReady returns true.
       // 2) not in safe mode.
-      if (scmContext.isLeader() && !scmContext.isInSafeMode()) {
+      if (scmContext.isLeaderReady() && !scmContext.isInSafeMode()) {
         // transition from PAUSING to RUNNING
         if (serviceStatus != ServiceStatus.RUNNING) {
           LOG.info("Service {} transitions to RUNNING.", getServiceName());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -96,6 +96,10 @@ public final class SCMContext {
     }
   }
 
+  /**
+   * Update isLeader flag.
+   * @param leader
+   */
   public void updateLeader(boolean leader) {
     lock.writeLock().lock();
     try {
@@ -108,6 +112,10 @@ public final class SCMContext {
     }
   }
 
+  /**
+   * Update term with new term.
+   * @param newTerm
+   */
   public void updateTerm(long newTerm) {
     lock.writeLock().lock();
     try {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -96,6 +96,30 @@ public final class SCMContext {
     }
   }
 
+  public void updateLeader(boolean leader) {
+    lock.writeLock().lock();
+    try {
+      LOG.info("update <isLeader> from <{}> to <{}>",
+          isLeader, leader);
+
+      isLeader = leader;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  public void updateTerm(long newTerm) {
+    lock.writeLock().lock();
+    try {
+      LOG.info("update <term> from <{}> to <{}>",
+          term, newTerm);
+
+      term = newTerm;
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
   /**
    * Check whether current SCM is leader or not.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -108,8 +108,7 @@ public final class SCMContext {
         return true;
       }
 
-      return isLeader && scm.getScmHAManager().getRatisServer()
-          .getDivision().getInfo().isLeaderReady();
+      return isLeader;
     } finally {
       lock.readLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -108,7 +108,8 @@ public final class SCMContext {
         return true;
       }
 
-      return isLeader;
+      return isLeader && scm.getScmHAManager().getRatisServer()
+          .getDivision().getInfo().isLeaderReady();
     } finally {
       lock.readLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -95,6 +95,8 @@ public final class SCMContext {
       // If it is not leader, set isLeaderReady to false.
       if (!isLeader) {
         isLeaderReady = false;
+        LOG.info("update <isLeaderReady> from <{}> to <{}>", isLeaderReady,
+            false);
       }
       term = newTerm;
     } finally {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMContext.java
@@ -61,6 +61,7 @@ public final class SCMContext {
    * Raft related info.
    */
   private boolean isLeader;
+  private boolean isLeaderReady;
   private long term;
 
   /**
@@ -77,6 +78,7 @@ public final class SCMContext {
     this.term = term;
     this.safeModeStatus = safeModeStatus;
     this.scm = scm;
+    this.isLeaderReady = false;
   }
 
   /**
@@ -90,6 +92,10 @@ public final class SCMContext {
           isLeader, term, leader, newTerm);
 
       isLeader = leader;
+      // If it is not leader, set isLeaderReady to false.
+      if (!isLeader) {
+        isLeaderReady = false;
+      }
       term = newTerm;
     } finally {
       lock.writeLock().unlock();
@@ -97,32 +103,20 @@ public final class SCMContext {
   }
 
   /**
-   * Update isLeader flag.
-   * @param leader
+   * Set isLeaderReady flag to true, this indicate leader is ready to accept
+   * transactions.
+   *
+   * On the leader SCM once all the previous leader term transaction are
+   * applied, this will be called to set the isLeaderReady to true.
+   *
    */
-  public void updateLeader(boolean leader) {
+  public void setLeaderReady() {
     lock.writeLock().lock();
     try {
-      LOG.info("update <isLeader> from <{}> to <{}>",
-          isLeader, leader);
+      LOG.info("update <isLeaderReady> from <{}> to <{}>",
+          isLeaderReady, true);
 
-      isLeader = leader;
-    } finally {
-      lock.writeLock().unlock();
-    }
-  }
-
-  /**
-   * Update term with new term.
-   * @param newTerm
-   */
-  public void updateTerm(long newTerm) {
-    lock.writeLock().lock();
-    try {
-      LOG.info("update <term> from <{}> to <{}>",
-          term, newTerm);
-
-      term = newTerm;
+      isLeaderReady = true;
     } finally {
       lock.writeLock().unlock();
     }
@@ -130,6 +124,10 @@ public final class SCMContext {
 
   /**
    * Check whether current SCM is leader or not.
+   *
+   * Use this API to know if SCM can send a command to DN once after it is
+   * elected as leader.
+   * True - it is leader, else false.
    *
    * @return isLeader
    */
@@ -141,6 +139,34 @@ public final class SCMContext {
       }
 
       return isLeader;
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+
+  /**
+   * Check whether current SCM is leader ready.
+   *
+   * Use this API to know when all the previous leader term transactions are
+   * applied and the SCM DB/in-memory state is latest state and then only
+   * particular command/action need to be taken by SCM.
+   *
+   * In general all background services should use this API to start their
+   * service.
+   *
+   * True - it is leader and ready, else false.
+   *
+   * @return isLeaderReady
+   */
+  public boolean isLeaderReady() {
+    lock.readLock().lock();
+    try {
+      if (term == INVALID_TERM) {
+        return true;
+      }
+
+      return isLeaderReady;
     } finally {
       lock.readLock().unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImplV2;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
-import org.apache.hadoop.util.Daemon;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.hadoop.util.Time;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -138,12 +138,9 @@ public class SCMStateMachine extends BaseStateMachine {
           Message.valueOf(trx.getStateMachineLogEntry().getLogData()));
       applyTransactionFuture.complete(process(request));
 
-      // If not leader we still need to refresh and validate.
-      // The follower can still stuck in safemode in the case when leader is
-      // out of safemode, and it has closed few pipelines. Then safemode
-      // rules need to be refresh and validated to get current state of SCM.
-      if (scm.isInSafeMode() && refreshedAfterLeaderReady.get()
-          && !scm.getScmContext().isLeader()) {
+      // After previous term transactions are applied, still in safe mode,
+      // perform refreshAndValidate to update the safemode rule state.
+      if (scm.isInSafeMode() && refreshedAfterLeaderReady.get()) {
         scm.getScmSafeModeManager().refreshAndValidate();
       }
       transactionBuffer.updateLatestTrxInfo(TransactionInfo.builder()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -184,7 +184,6 @@ public class SCMStateMachine extends BaseStateMachine {
 
     scm.getScmContext().updateLeaderAndTerm(false, 0);
     scm.getSCMServiceManager().notifyStatusChanged();
-
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -252,7 +252,8 @@ public class SCMStateMachine extends BaseStateMachine {
 
     LOG.info("current SCM becomes leader of term {}.", currentLeaderTerm);
 
-    scm.getScmContext().updateTerm(currentLeaderTerm.get());
+    scm.getScmContext().updateLeaderAndTerm(true,
+        currentLeaderTerm.get());
     scm.getSequenceIdGen().invalidateBatch();
 
     DeletedBlockLog deletedBlockLog = scm.getScmBlockManager()
@@ -306,10 +307,12 @@ public class SCMStateMachine extends BaseStateMachine {
     // updateLastApplied updates lastAppliedTermIndex.
     updateLastAppliedTermIndex(term, index);
 
+    // Once all previous leader term transactions are applied, refresh safe-mode
+    // rule state to udpate with latest state of SCM.
     if (currentLeaderTerm.get() == term &&
         scm.getScmHAManager().getRatisServer().getDivision().getInfo()
             .isLeaderReady()) {
-      scm.getScmContext().updateLeader(true);
+      scm.getScmContext().setLeaderReady();
       scm.getSCMServiceManager().notifyStatusChanged();
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -294,6 +294,11 @@ public class SCMStateMachine extends BaseStateMachine {
 
   @Override
   public void notifyTermIndexUpdated(long term, long index) {
+
+    if (!isInitialized) {
+      return;
+    }
+
     if (transactionBuffer != null) {
       transactionBuffer.updateLatestTrxInfo(
           TransactionInfo.builder().setCurrentTerm(term)
@@ -326,12 +331,8 @@ public class SCMStateMachine extends BaseStateMachine {
 
         refreshedAfterLeaderReady.set(true);
       }
-
       currentLeaderTerm.set(-1L);
-
     }
-
-
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreatorV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreatorV2.java
@@ -254,7 +254,7 @@ public class BackgroundPipelineCreatorV2 implements SCMService {
     try {
       // 1) SCMContext#isLeader returns true.
       // 2) not in safe mode or createPipelineInSafeMode is true
-      if (scmContext.isLeader() &&
+      if (scmContext.isLeaderReady() &&
           (!scmContext.isInSafeMode() || createPipelineInSafeMode)) {
         // transition from PAUSING to RUNNING
         if (serviceStatus != ServiceStatus.RUNNING) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -55,7 +55,7 @@ public class ContainerSafeModeRule extends
       ConfigurationSource conf,
       List<ContainerInfo> containers,
       ContainerManagerV2 containerManager, SCMSafeModeManager manager) {
-    super(manager, ruleName, eventQueue, conf);
+    super(manager, ruleName, eventQueue);
     this.containerManager = containerManager;
     safeModeCutoff = conf.getDouble(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.hdds.server.events.TypedEvent;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Class defining Safe mode exit criteria for Containers.
@@ -42,6 +44,8 @@ import com.google.common.base.Preconditions;
 public class ContainerSafeModeRule extends
     SafeModeExitRule<NodeRegistrationContainerReport>{
 
+  public static final Logger LOG =
+      LoggerFactory.getLogger(ContainerSafeModeRule.class);
   // Required cutoff % for containers with at least 1 reported replica.
   private double safeModeCutoff;
   // Containers read from scm db (excluding containers in ALLOCATED state).
@@ -81,6 +85,8 @@ public class ContainerSafeModeRule extends
     maxContainer = containerMap.size();
     long cutOff = (long) Math.ceil(maxContainer * safeModeCutoff);
     getSafeModeMetrics().setNumContainerWithOneReplicaReportedThreshold(cutOff);
+
+    LOG.info("containers with one replica threshold count {}", cutOff);
   }
 
 
@@ -158,6 +164,9 @@ public class ContainerSafeModeRule extends
 
       maxContainer = containerMap.size();
       long cutOff = (long) Math.ceil(maxContainer * safeModeCutoff);
+
+      LOG.info("Refreshed one replica container threshold {}, " +
+              "currentThreshold {}", cutOff, containerWithMinReplicas.get());
       getSafeModeMetrics()
           .setNumContainerWithOneReplicaReportedThreshold(cutOff);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -142,22 +142,24 @@ public class ContainerSafeModeRule extends
 
   @Override
   public synchronized void refresh() {
-    containerMap.clear();
-    containerManager.getContainers().forEach(container -> {
-      // There can be containers in OPEN/CLOSING state which were never
-      // created by the client. We are not considering these containers for
-      // now. These containers can be handled by tracking pipelines.
+    if (!validate()) {
+      containerMap.clear();
+      containerManager.getContainers().forEach(container -> {
+        // There can be containers in OPEN/CLOSING state which were never
+        // created by the client. We are not considering these containers for
+        // now. These containers can be handled by tracking pipelines.
 
-      Optional.ofNullable(container.getState())
-          .filter(state -> (state == HddsProtos.LifeCycleState.QUASI_CLOSED ||
-              state == HddsProtos.LifeCycleState.CLOSED))
-          .ifPresent(s -> containerMap.put(container.getContainerID(),
-              container));
-    });
+        Optional.ofNullable(container.getState())
+            .filter(state -> (state == HddsProtos.LifeCycleState.QUASI_CLOSED ||
+                state == HddsProtos.LifeCycleState.CLOSED))
+            .ifPresent(s -> containerMap.put(container.getContainerID(),
+                container));
+      });
 
-    maxContainer = containerMap.size();
-    long cutOff = (long) Math.ceil(maxContainer * safeModeCutoff);
-    getSafeModeMetrics().setNumContainerWithOneReplicaReportedThreshold(cutOff);
+      maxContainer = containerMap.size();
+      long cutOff = (long) Math.ceil(maxContainer * safeModeCutoff);
+      getSafeModeMetrics().setNumContainerWithOneReplicaReportedThreshold(cutOff);
+    }
   }
 
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -158,7 +158,8 @@ public class ContainerSafeModeRule extends
 
       maxContainer = containerMap.size();
       long cutOff = (long) Math.ceil(maxContainer * safeModeCutoff);
-      getSafeModeMetrics().setNumContainerWithOneReplicaReportedThreshold(cutOff);
+      getSafeModeMetrics()
+          .setNumContainerWithOneReplicaReportedThreshold(cutOff);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -150,9 +150,10 @@ public class ContainerSafeModeRule extends
   public synchronized void refresh(boolean forceRefresh) {
     if (forceRefresh) {
       reInitializeRule();
-    }
-    if (!validate()) {
-      reInitializeRule();
+    } else {
+      if (!validate()) {
+        reInitializeRule();
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/ContainerSafeModeRule.java
@@ -149,7 +149,7 @@ public class ContainerSafeModeRule extends
   @Override
   public synchronized void refresh(boolean forceRefresh) {
     if (forceRefresh) {
-     reInitializeRule();
+      reInitializeRule();
     }
     if (!validate()) {
       reInitializeRule();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
@@ -44,7 +44,7 @@ public class DataNodeSafeModeRule extends
   public DataNodeSafeModeRule(String ruleName, EventQueue eventQueue,
       ConfigurationSource conf,
       SCMSafeModeManager manager) {
-    super(manager, ruleName, eventQueue, conf);
+    super(manager, ruleName, eventQueue);
     requiredDns = conf.getInt(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE,
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE_DEFAULT);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
@@ -44,7 +44,7 @@ public class DataNodeSafeModeRule extends
   public DataNodeSafeModeRule(String ruleName, EventQueue eventQueue,
       ConfigurationSource conf,
       SCMSafeModeManager manager) {
-    super(manager, ruleName, eventQueue);
+    super(manager, ruleName, eventQueue, conf);
     requiredDns = conf.getInt(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE,
         HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE_DEFAULT);
@@ -85,5 +85,13 @@ public class DataNodeSafeModeRule extends
     return String
         .format("registered datanodes (=%d) >= required datanodes (=%d)",
             this.registeredDns, this.requiredDns);
+  }
+
+
+  @Override
+  public void refresh() {
+    // Do nothing.
+    // As for this rule, there is nothing we read from SCM DB state and
+    // validate it.
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/DataNodeSafeModeRule.java
@@ -89,7 +89,7 @@ public class DataNodeSafeModeRule extends
 
 
   @Override
-  public void refresh() {
+  public void refresh(boolean forceRefresh) {
     // Do nothing.
     // As for this rule, there is nothing we read from SCM DB state and
     // validate it.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -88,7 +88,8 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
   @VisibleForTesting
-  public synchronized void setHealthyPipelineThresholdCount(int actualPipelineCount) {
+  public synchronized void setHealthyPipelineThresholdCount(
+      int actualPipelineCount) {
     healthyPipelineThresholdCount =
         (int) Math.ceil(healthyPipelinesPercent * actualPipelineCount);
   }
@@ -123,7 +124,8 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
       SCMSafeModeManager.getLogger().info(
           "SCM in safe mode. Healthy pipelines reported count is {}, " +
               "required healthy pipeline reported count is {}",
-          currentHealthyPipelineCount, healthyPipelineThresholdCount);
+          currentHealthyPipelineCount, getHealthyPipelineThresholdCount());
+
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -74,7 +74,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
             HDDS_SCM_SAFEMODE_HEALTHY_PIPELINE_THRESHOLD_PCT
             + " value should be >= 0.0 and <= 1.0");
 
-    initializeRule();
+    initializeRule(false);
   }
 
   private int getMinHealthyPipelines(ConfigurationSource config) {
@@ -132,11 +132,11 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
   public synchronized void refresh() {
     if (!validate()) {
-      initializeRule();
+      initializeRule(true);
     }
   }
 
-  private synchronized void initializeRule() {
+  private synchronized void initializeRule(boolean refresh) {
     int pipelineCount = pipelineManager.getPipelines(
         new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE),
         Pipeline.PipelineState.OPEN).size();
@@ -144,8 +144,15 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
     healthyPipelineThresholdCount = Math.max(minHealthyPipelines,
         (int) Math.ceil(healthyPipelinesPercent * pipelineCount));
 
-    LOG.info("Total pipeline count is {}, healthy pipeline " +
-        "threshold count is {}", pipelineCount, healthyPipelineThresholdCount);
+    if (refresh) {
+      LOG.info("Refreshed total pipeline count is {}, healthy pipeline " +
+          "threshold count is {}", pipelineCount,
+          healthyPipelineThresholdCount);
+    } else {
+      LOG.info("Total pipeline count is {}, healthy pipeline " +
+          "threshold count is {}", pipelineCount,
+          healthyPipelineThresholdCount);
+    }
 
     getSafeModeMetrics().setNumHealthyPipelinesThreshold(
         healthyPipelineThresholdCount);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -88,7 +88,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
   @VisibleForTesting
-  public void setHealthyPipelineThresholdCount(int actualPipelineCount) {
+  public synchronized void setHealthyPipelineThresholdCount(int actualPipelineCount) {
     healthyPipelineThresholdCount =
         (int) Math.ceil(healthyPipelinesPercent * actualPipelineCount);
   }
@@ -167,7 +167,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   public String getStatusText() {
     return String.format("healthy Ratis/THREE pipelines (=%d) >= "
             + "healthyPipelineThresholdCount (=%d)",
-        this.currentHealthyPipelineCount,
-        this.healthyPipelineThresholdCount);
+        getCurrentHealthyPipelineCount(),
+        getHealthyPipelineThresholdCount());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -52,11 +52,12 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   private final double healthyPipelinesPercent;
   private final Set<PipelineID> processedPipelineIDs = new HashSet<>();
   private final PipelineManager pipelineManager;
+  private final int minHealthyPipelines;
 
   HealthyPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
       PipelineManager pipelineManager,
       SCMSafeModeManager manager, ConfigurationSource configuration) {
-    super(manager, ruleName, eventQueue, configuration);
+    super(manager, ruleName, eventQueue);
     this.pipelineManager = pipelineManager;
     healthyPipelinesPercent =
         configuration.getDouble(HddsConfigKeys.
@@ -65,7 +66,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
                 HDDS_SCM_SAFEMODE_HEALTHY_PIPELINE_THRESHOLD_PCT_DEFAULT);
 
     // We only care about THREE replica pipeline
-    int minHealthyPipelines = getMinHealthyPipelines(configuration);
+    minHealthyPipelines = getMinHealthyPipelines(configuration);
 
     Preconditions.checkArgument(
         (healthyPipelinesPercent >= 0.0 && healthyPipelinesPercent <= 1.0),
@@ -132,7 +133,6 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
   private synchronized void initializeRule() {
-    int minHealthyPipelines = getMinHealthyPipelines(conf);
     int pipelineCount = pipelineManager.getPipelines(
         new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE),
         Pipeline.PipelineState.OPEN).size();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -105,7 +105,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
   @Override
-  protected void process(Pipeline pipeline) {
+  protected synchronized void process(Pipeline pipeline) {
 
     // When SCM is in safe mode for long time, already registered
     // datanode can send pipeline report again, or SCMPipelineManager will
@@ -131,7 +131,9 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
 
   public synchronized void refresh() {
-    initializeRule();
+    if (!validate()) {
+      initializeRule();
+    }
   }
 
   private synchronized void initializeRule() {
@@ -156,7 +158,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
   @VisibleForTesting
-  public int getCurrentHealthyPipelineCount() {
+  public synchronized int getCurrentHealthyPipelineCount() {
     return currentHealthyPipelineCount;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -130,9 +130,13 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
   }
 
 
-  public synchronized void refresh() {
-    if (!validate()) {
+  public synchronized void refresh(boolean forceRefresh) {
+    if (forceRefresh) {
       initializeRule(true);
+    } else {
+      if (!validate()) {
+        initializeRule(true);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -77,7 +77,7 @@ public class OneReplicaPipelineSafeModeRule extends
             " value should be >= 0.0 and <= 1.0");
 
     this.pipelineManager = pipelineManager;
-    initializeRule();
+    initializeRule(false);
 
   }
 
@@ -153,11 +153,11 @@ public class OneReplicaPipelineSafeModeRule extends
   @Override
   public synchronized void refresh() {
     if (!validate()) {
-      initializeRule();
+      initializeRule(true);
     }
   }
 
-  private synchronized void initializeRule() {
+  private synchronized void initializeRule(boolean refresh) {
 
     oldPipelineIDSet = pipelineManager.getPipelines(
         new RatisReplicationConfig(ReplicationFactor.THREE),
@@ -168,9 +168,15 @@ public class OneReplicaPipelineSafeModeRule extends
 
     thresholdCount = (int) Math.ceil(pipelinePercent * totalPipelineCount);
 
-    LOG.info("Total pipeline count is {}, pipeline's with at least one " +
-            "datanode reported threshold count is {}", totalPipelineCount,
-        thresholdCount);
+    if (refresh) {
+      LOG.info("Total pipeline count is {}, pipeline's with at least one " +
+              "datanode reported threshold count is {}", totalPipelineCount,
+          thresholdCount);
+    } else {
+      LOG.info("Refreshed total pipeline count is {}, pipeline's with at " +
+              "least one datanode reported threshold count is {}",
+          totalPipelineCount, thresholdCount);
+    }
 
     getSafeModeMetrics().setNumPipelinesWithAtleastOneReplicaReportedThreshold(
         thresholdCount);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -136,7 +136,7 @@ public class OneReplicaPipelineSafeModeRule extends
   }
 
   @VisibleForTesting
-  public int getCurrentReportedPipelineCount() {
+  public synchronized int getCurrentReportedPipelineCount() {
     return currentReportedPipelineCount;
   }
 
@@ -146,8 +146,8 @@ public class OneReplicaPipelineSafeModeRule extends
         .format(
             "reported Ratis/THREE pipelines with at least one datanode (=%d) "
                 + ">= threshold (=%d)",
-            this.currentReportedPipelineCount,
-            this.thresholdCount);
+            getCurrentReportedPipelineCount(),
+            getThresholdCount());
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -62,7 +62,7 @@ public class OneReplicaPipelineSafeModeRule extends
   public OneReplicaPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
       PipelineManager pipelineManager,
       SCMSafeModeManager safeModeManager, ConfigurationSource configuration) {
-    super(safeModeManager, ruleName, eventQueue, configuration);
+    super(safeModeManager, ruleName, eventQueue);
 
     pipelinePercent =
         configuration.getDouble(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -56,39 +56,29 @@ public class OneReplicaPipelineSafeModeRule extends
   private Set<PipelineID> oldPipelineIDSet;
   private int currentReportedPipelineCount = 0;
   private PipelineManager pipelineManager;
+  private final double pipelinePercent;
 
 
   public OneReplicaPipelineSafeModeRule(String ruleName, EventQueue eventQueue,
       PipelineManager pipelineManager,
       SCMSafeModeManager safeModeManager, ConfigurationSource configuration) {
-    super(safeModeManager, ruleName, eventQueue);
+    super(safeModeManager, ruleName, eventQueue, configuration);
 
-    double percent =
+    pipelinePercent =
         configuration.getDouble(
             HddsConfigKeys.HDDS_SCM_SAFEMODE_ONE_NODE_REPORTED_PIPELINE_PCT,
             HddsConfigKeys.
                 HDDS_SCM_SAFEMODE_ONE_NODE_REPORTED_PIPELINE_PCT_DEFAULT);
 
-    Preconditions.checkArgument((percent >= 0.0 && percent <= 1.0),
+    Preconditions.checkArgument((pipelinePercent >= 0.0
+            && pipelinePercent <= 1.0),
         HddsConfigKeys.
             HDDS_SCM_SAFEMODE_ONE_NODE_REPORTED_PIPELINE_PCT  +
             " value should be >= 0.0 and <= 1.0");
 
     this.pipelineManager = pipelineManager;
-    oldPipelineIDSet = pipelineManager.getPipelines(
-        new RatisReplicationConfig(ReplicationFactor.THREE),
-        Pipeline.PipelineState.OPEN)
-        .stream().map(p -> p.getId()).collect(Collectors.toSet());
-    int totalPipelineCount = oldPipelineIDSet.size();
+    initializeRule();
 
-    thresholdCount = (int) Math.ceil(percent * totalPipelineCount);
-
-    LOG.info("Total pipeline count is {}, pipeline's with at least one " +
-        "datanode reported threshold count is {}", totalPipelineCount,
-        thresholdCount);
-
-    getSafeModeMetrics().setNumPipelinesWithAtleastOneReplicaReportedThreshold(
-        thresholdCount);
   }
 
   @Override
@@ -97,12 +87,12 @@ public class OneReplicaPipelineSafeModeRule extends
   }
 
   @Override
-  protected boolean validate() {
+  protected synchronized boolean validate() {
     return currentReportedPipelineCount >= thresholdCount;
   }
 
   @Override
-  protected void process(PipelineReportFromDatanode report) {
+  protected synchronized void process(PipelineReportFromDatanode report) {
     Preconditions.checkNotNull(report);
     for (PipelineReport report1 : report.getReport().getPipelineReportList()) {
       Pipeline pipeline;
@@ -136,12 +126,12 @@ public class OneReplicaPipelineSafeModeRule extends
   }
 
   @Override
-  protected void cleanup() {
+  protected synchronized void cleanup() {
     reportedPipelineIDSet.clear();
   }
 
   @VisibleForTesting
-  public int getThresholdCount() {
+  public synchronized int getThresholdCount() {
     return thresholdCount;
   }
 
@@ -158,5 +148,29 @@ public class OneReplicaPipelineSafeModeRule extends
                 + ">= threshold (=%d)",
             this.currentReportedPipelineCount,
             this.thresholdCount);
+  }
+
+  @Override
+  public synchronized void refresh() {
+    initializeRule();
+  }
+
+  private synchronized void initializeRule() {
+
+    oldPipelineIDSet = pipelineManager.getPipelines(
+        new RatisReplicationConfig(ReplicationFactor.THREE),
+        Pipeline.PipelineState.OPEN)
+        .stream().map(p -> p.getId()).collect(Collectors.toSet());
+
+    int totalPipelineCount = oldPipelineIDSet.size();
+
+    thresholdCount = (int) Math.ceil(pipelinePercent * totalPipelineCount);
+
+    LOG.info("Total pipeline count is {}, pipeline's with at least one " +
+            "datanode reported threshold count is {}", totalPipelineCount,
+        thresholdCount);
+
+    getSafeModeMetrics().setNumPipelinesWithAtleastOneReplicaReportedThreshold(
+        thresholdCount);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -157,7 +157,7 @@ public class OneReplicaPipelineSafeModeRule extends
     }
   }
 
-  private synchronized void initializeRule(boolean refresh) {
+  private void initializeRule(boolean refresh) {
 
     oldPipelineIDSet = pipelineManager.getPipelines(
         new RatisReplicationConfig(ReplicationFactor.THREE),
@@ -169,11 +169,11 @@ public class OneReplicaPipelineSafeModeRule extends
     thresholdCount = (int) Math.ceil(pipelinePercent * totalPipelineCount);
 
     if (refresh) {
-      LOG.info("Total pipeline count is {}, pipeline's with at least one " +
-              "datanode reported threshold count is {}", totalPipelineCount,
-          thresholdCount);
+      LOG.info("Refreshed Total pipeline count is {}, pipeline's with at " +
+              "least one datanode reported threshold count is {}",
+          totalPipelineCount, thresholdCount);
     } else {
-      LOG.info("Refreshed total pipeline count is {}, pipeline's with at " +
+      LOG.info("Total pipeline count is {}, pipeline's with at " +
               "least one datanode reported threshold count is {}",
           totalPipelineCount, thresholdCount);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -152,7 +152,9 @@ public class OneReplicaPipelineSafeModeRule extends
 
   @Override
   public synchronized void refresh() {
-    initializeRule();
+    if (!validate()) {
+      initializeRule();
+    }
   }
 
   private synchronized void initializeRule() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -151,9 +151,13 @@ public class OneReplicaPipelineSafeModeRule extends
   }
 
   @Override
-  public synchronized void refresh() {
-    if (!validate()) {
+  public synchronized void refresh(boolean forceRefresh) {
+    if (forceRefresh) {
       initializeRule(true);
+    } else {
+      if (!validate()) {
+        initializeRule(true);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -196,11 +196,13 @@ public class SCMSafeModeManager implements SafeModeManager {
       EventPublisher eventQueue) {
 
     if (exitRules.get(ruleName) != null) {
-      validatedRules.add(ruleName);
+      boolean added = validatedRules.add(ruleName);
       if (preCheckRules.contains(ruleName)) {
         validatedPreCheckRules.add(ruleName);
       }
-      LOG.info("{} rule is successfully validated", ruleName);
+      if (added) {
+        LOG.info("{} rule is successfully validated", ruleName);
+      }
     } else {
       // This should never happen
       LOG.error("No Such Exit rule {}", ruleName);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -259,13 +259,15 @@ public class SCMSafeModeManager implements SafeModeManager {
    * Refresh Rule state and validate safe mode rule.
    */
   public void refreshAndValidate() {
-    exitRules.values().forEach(rule -> {
-      rule.refresh();
-      if (rule.validate()) {
-        validateSafeModeExitRules(rule.getRuleName(), eventPublisher);
-        rule.cleanup();
-      }
-    });
+    if (inSafeMode.get()) {
+      exitRules.values().forEach(rule -> {
+        rule.refresh();
+        if (rule.validate() && inSafeMode.get()) {
+          validateSafeModeExitRules(rule.getRuleName(), eventPublisher);
+          rule.cleanup();
+        }
+      });
+    }
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -258,7 +258,18 @@ public class SCMSafeModeManager implements SafeModeManager {
   }
 
   /**
-   * Refresh Rule state and validate safe mode rule.
+   * Refresh Rule state.
+   */
+  public void refresh() {
+    if (inSafeMode.get()) {
+      exitRules.values().forEach(rule -> {
+        rule.refresh();
+      });
+    }
+  }
+
+  /**
+   * Refresh Rule state and validate rules.
    */
   public void refreshAndValidate() {
     if (inSafeMode.get()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SCMSafeModeManager.java
@@ -263,7 +263,10 @@ public class SCMSafeModeManager implements SafeModeManager {
   public void refresh() {
     if (inSafeMode.get()) {
       exitRules.values().forEach(rule -> {
-        rule.refresh();
+        // Refresh rule irrespective of validate(), as at this point validate
+        // does not represent current state validation, as validate is being
+        // done with stale state.
+        rule.refresh(true);
       });
     }
   }
@@ -274,7 +277,7 @@ public class SCMSafeModeManager implements SafeModeManager {
   public void refreshAndValidate() {
     if (inSafeMode.get()) {
       exitRules.values().forEach(rule -> {
-        rule.refresh();
+        rule.refresh(false);
         if (rule.validate() && inSafeMode.get()) {
           validateSafeModeExitRules(rule.getRuleName(), eventPublisher);
           rule.cleanup();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.safemode;
 
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -38,12 +39,14 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
 
   private final SCMSafeModeManager safeModeManager;
   private final String ruleName;
+  protected final ConfigurationSource conf;
 
   public SafeModeExitRule(SCMSafeModeManager safeModeManager,
-      String ruleName, EventQueue eventQueue) {
+      String ruleName, EventQueue eventQueue, ConfigurationSource config) {
     this.safeModeManager = safeModeManager;
     this.ruleName = ruleName;
     eventQueue.addHandler(getEventType(), this);
+    this.conf = config;
   }
 
   /**
@@ -116,4 +119,9 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
    * @return status text.
    */
   abstract String getStatusText();
+
+  /**
+   * Refresh the rule state from current state of SCM.
+   */
+  protected abstract void refresh();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.safemode;
 
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
@@ -39,14 +38,12 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
 
   private final SCMSafeModeManager safeModeManager;
   private final String ruleName;
-  protected final ConfigurationSource conf;
 
   public SafeModeExitRule(SCMSafeModeManager safeModeManager,
-      String ruleName, EventQueue eventQueue, ConfigurationSource config) {
+      String ruleName, EventQueue eventQueue) {
     this.safeModeManager = safeModeManager;
     this.ruleName = ruleName;
     eventQueue.addHandler(getEventType(), this);
-    this.conf = config;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/SafeModeExitRule.java
@@ -119,6 +119,10 @@ public abstract class SafeModeExitRule<T> implements EventHandler<T> {
 
   /**
    * Refresh the rule state from current state of SCM.
+   *
+   * @param forceRefresh - refresh rule irrespective of validate() is
+   * true/false.
+   *
    */
-  protected abstract void refresh();
+  protected abstract void refresh(boolean forceRefresh);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -579,7 +579,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       scmSafeModeManager = configurator.getScmSafeModeManager();
     } else {
       scmSafeModeManager = new SCMSafeModeManager(conf,
-          containerManager.getContainers(),
+          containerManager.getContainers(), containerManager,
           pipelineManager, eventQueue, serviceManager, scmContext);
     }
     scmDecommissionManager = new NodeDecommissionManager(conf, scmNodeManager,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1520,7 +1520,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   public boolean checkLeader() {
     // For NON-HA setup, the node will always be the leader
     if (!SCMHAUtils.isSCMHAEnabled(configuration)) {
-      Preconditions.checkArgument(scmContext.isLeader());
       return true;
     } else {
       // FOR HA setup, the node has to be the leader and ready to serve

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1229,7 +1229,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       LOG.info(buildRpcServerStartMessage("ScmDatanodeProtocl RPC " +
           "server", getDatanodeProtocolServer().getDatanodeRpcAddress()));
     }
-    getDatanodeProtocolServer().start();
+
+    // If HA is enabled, start datanode protocol server once leader is ready.
+    if (!scmStorageConfig.isSCMHAEnabled()) {
+      getDatanodeProtocolServer().start();
+    }
     if (getSecurityProtocolServer() != null) {
       getSecurityProtocolServer().start();
       persistSCMCertificates();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -157,7 +157,7 @@ public class TestBlockManager {
             pipelineManager,
             scmMetadataStore.getContainerTable());
     SCMSafeModeManager safeModeManager = new SCMSafeModeManager(conf,
-        containerManager.getContainers(),
+        containerManager.getContainers(), containerManager,
         pipelineManager, eventQueue, serviceManager, scmContext) {
       @Override
       public void emitSafeModeStatus() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -41,7 +41,9 @@ public class TestSCMContext {
 
     // become leader
     scmContext.updateLeaderAndTerm(true, 10);
+    scmContext.setLeaderReady();
     assertTrue(scmContext.isLeader());
+    assertTrue(scmContext.isLeaderReady());
     try {
       assertEquals(scmContext.getTermOfLeader(), 10);
     } catch (NotLeaderException e) {
@@ -51,6 +53,7 @@ public class TestSCMContext {
     // step down
     scmContext.updateLeaderAndTerm(false, 0);
     assertFalse(scmContext.isLeader());
+    assertFalse(scmContext.isLeaderReady());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -348,7 +348,7 @@ public class TestPipelineManagerImpl {
   public void testPipelineReport() throws Exception {
     PipelineManagerV2Impl pipelineManager = createPipelineManager(true);
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(conf, new ArrayList<>(), pipelineManager,
+        new SCMSafeModeManager(conf, new ArrayList<>(), null, pipelineManager,
             new EventQueue(), serviceManager, scmContext);
     Pipeline pipeline = pipelineManager
         .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
@@ -464,7 +464,7 @@ public class TestPipelineManagerImpl {
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(),
+        new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(), null,
             pipelineManager, new EventQueue(), serviceManager, scmContext);
     PipelineReportHandler pipelineReportHandler =
         new PipelineReportHandler(scmSafeModeManager, pipelineManager,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -464,8 +464,9 @@ public class TestPipelineManagerImpl {
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(), null,
-            pipelineManager, new EventQueue(), serviceManager, scmContext);
+        new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(),
+            null, pipelineManager, new EventQueue(),
+            serviceManager, scmContext);
     PipelineReportHandler pipelineReportHandler =
         new PipelineReportHandler(scmSafeModeManager, pipelineManager,
             SCMContext.emptyContext(), conf);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMPipelineManager.java
@@ -222,8 +222,8 @@ public class TestSCMPipelineManager {
         mockRatisProvider);
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(conf, new ArrayList<>(), pipelineManager,
-            eventQueue, new SCMServiceManager(),
+        new SCMSafeModeManager(conf, new ArrayList<>(), null,
+            pipelineManager, eventQueue, new SCMServiceManager(),
             SCMContext.emptyContext());
 
     // create a pipeline in allocated state with no dns yet reported
@@ -494,7 +494,7 @@ public class TestSCMPipelineManager {
 
     SCMSafeModeManager scmSafeModeManager =
         new SCMSafeModeManager(new OzoneConfiguration(), new ArrayList<>(),
-            pipelineManager, eventQueue,
+            null, pipelineManager, eventQueue,
             new SCMServiceManager(),
             SCMContext.emptyContext());
     PipelineReportHandler pipelineReportHandler =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -92,7 +92,7 @@ public class TestHealthyPipelineSafeModeRule {
       pipelineManager.setPipelineProvider(HddsProtos.ReplicationType.RATIS,
           mockRatisProvider);
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, pipelineManager, eventQueue,
+          config, containers, null, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =
@@ -172,7 +172,7 @@ public class TestHealthyPipelineSafeModeRule {
       MockRatisPipelineProvider.markPipelineHealthy(pipeline3);
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, pipelineManager, eventQueue,
+          config, containers, null, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =
@@ -270,7 +270,7 @@ public class TestHealthyPipelineSafeModeRule {
       MockRatisPipelineProvider.markPipelineHealthy(pipeline3);
 
       SCMSafeModeManager scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, pipelineManager, eventQueue,
+          config, containers, null, pipelineManager, eventQueue,
           serviceManager, scmContext);
 
       HealthyPipelineSafeModeRule healthyPipelineSafeModeRule =

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -111,7 +111,7 @@ public class TestOneReplicaPipelineSafeModeRule {
         HddsProtos.ReplicationFactor.ONE);
 
     SCMSafeModeManager scmSafeModeManager =
-        new SCMSafeModeManager(ozoneConfiguration, containers,
+        new SCMSafeModeManager(ozoneConfiguration, containers, null,
             pipelineManager, eventQueue, serviceManager, scmContext);
 
     rule = scmSafeModeManager.getOneReplicaPipelineSafeModeRule();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -135,7 +135,8 @@ public class TestSCMSafeModeManager {
       container.setState(HddsProtos.LifeCycleState.CLOSED);
     }
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, null,null, queue, serviceManager, scmContext);
+        config, containers, null, null, queue,
+        serviceManager, scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
     queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
@@ -168,7 +169,8 @@ public class TestSCMSafeModeManager {
       container.setState(HddsProtos.LifeCycleState.CLOSED);
     }
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, null,null, queue, serviceManager, scmContext);
+        config, containers, null, null, queue,
+        serviceManager, scmContext);
 
     long cutOff = (long) Math.ceil(numContainers * config.getDouble(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -123,7 +123,7 @@ public class TestSCMSafeModeManager {
   @Test
   public void testSafeModeStateWithNullContainers() {
     new SCMSafeModeManager(config, Collections.emptyList(),
-        null, queue, serviceManager, scmContext);
+        null, null,  queue, serviceManager, scmContext);
   }
 
   private void testSafeMode(int numContainers) throws Exception {
@@ -135,7 +135,7 @@ public class TestSCMSafeModeManager {
       container.setState(HddsProtos.LifeCycleState.CLOSED);
     }
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, null, queue, serviceManager, scmContext);
+        config, containers, null,null, queue, serviceManager, scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
     queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
@@ -168,7 +168,7 @@ public class TestSCMSafeModeManager {
       container.setState(HddsProtos.LifeCycleState.CLOSED);
     }
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, null, queue, serviceManager, scmContext);
+        config, containers, null,null, queue, serviceManager, scmContext);
 
     long cutOff = (long) Math.ceil(numContainers * config.getDouble(
         HddsConfigKeys.HDDS_SCM_SAFEMODE_THRESHOLD_PCT,
@@ -264,7 +264,8 @@ public class TestSCMSafeModeManager {
               scmContext,
               serviceManager);
       scmSafeModeManager = new SCMSafeModeManager(
-          conf, containers, pipelineManager, queue, serviceManager, scmContext);
+          conf, containers, null, pipelineManager, queue, serviceManager,
+          scmContext);
       fail("testFailWithIncorrectValueForHealthyPipelinePercent");
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("value should be >= 0.0 and <=" +
@@ -289,7 +290,8 @@ public class TestSCMSafeModeManager {
               scmContext,
               serviceManager);
       scmSafeModeManager = new SCMSafeModeManager(
-          conf, containers, pipelineManager, queue, serviceManager, scmContext);
+          conf, containers, null, pipelineManager, queue, serviceManager,
+          scmContext);
       fail("testFailWithIncorrectValueForOneReplicaPipelinePercent");
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("value should be >= 0.0 and <=" +
@@ -313,7 +315,8 @@ public class TestSCMSafeModeManager {
               scmContext,
               serviceManager);
       scmSafeModeManager = new SCMSafeModeManager(
-          conf, containers, pipelineManager, queue, serviceManager, scmContext);
+          conf, containers, null, pipelineManager, queue, serviceManager,
+          scmContext);
       fail("testFailWithIncorrectValueForSafeModePercent");
     } catch (IllegalArgumentException ex) {
       GenericTestUtils.assertExceptionContains("value should be >= 0.0 and <=" +
@@ -367,7 +370,8 @@ public class TestSCMSafeModeManager {
     }
 
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, pipelineManager, queue, serviceManager, scmContext);
+        conf, containers, null, pipelineManager, queue, serviceManager,
+        scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
     testContainerThreshold(containers, 1.0);
@@ -478,7 +482,8 @@ public class TestSCMSafeModeManager {
     conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
     PipelineManager pipelineManager = Mockito.mock(PipelineManager.class);
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, pipelineManager, queue, serviceManager, scmContext);
+        conf, containers, null, pipelineManager, queue, serviceManager,
+        scmContext);
     assertFalse(scmSafeModeManager.getInSafeMode());
   }
 
@@ -510,7 +515,7 @@ public class TestSCMSafeModeManager {
     }
 
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, null, queue, serviceManager, scmContext);
+        config, containers, null, null, queue, serviceManager, scmContext);
 
     assertTrue(scmSafeModeManager.getInSafeMode());
 
@@ -534,7 +539,8 @@ public class TestSCMSafeModeManager {
     OzoneConfiguration conf = new OzoneConfiguration(config);
     conf.setInt(HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE, numOfDns);
     scmSafeModeManager = new SCMSafeModeManager(
-        conf, containers, null, queue, serviceManager, scmContext);
+        conf, containers, null, null, queue,
+        serviceManager, scmContext);
 
     // Assert SCM is in Safe mode.
     assertTrue(scmSafeModeManager.getInSafeMode());
@@ -609,7 +615,7 @@ public class TestSCMSafeModeManager {
       MockRatisPipelineProvider.markPipelineHealthy(pipeline);
 
       scmSafeModeManager = new SCMSafeModeManager(
-          config, containers, pipelineManager, queue, serviceManager,
+          config, containers, null, pipelineManager, queue, serviceManager,
           scmContext);
 
       queue.fireEvent(SCMEvents.NODE_REGISTRATION_CONT_REPORT,
@@ -669,7 +675,8 @@ public class TestSCMSafeModeManager {
     SafeModeEventHandler smHandler = new SafeModeEventHandler();
     queue.addHandler(SCMEvents.SAFE_MODE_STATUS, smHandler);
     scmSafeModeManager = new SCMSafeModeManager(
-        config, containers, pipelineManager, queue, serviceManager, scmContext);
+        config, containers, null, pipelineManager, queue, serviceManager,
+        scmContext);
 
     // Assert SCM is in Safe mode.
     assertTrue(scmSafeModeManager.getInSafeMode());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -682,6 +682,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       // default max retry timeout set to 30s
       scmClientConfig.setMaxRetryTimeout(30 * 1000);
       conf.setFromObject(scmClientConfig);
+      // In this way safemode exit will happen only when atleast we have one
+      // pipeline.
+      conf.setInt(HddsConfigKeys.HDDS_SCM_SAFEMODE_MIN_DATANODE,
+          numOfDatanodes >=3 ? 3 : 1);
       configureTrace();
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -727,6 +727,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       scmStore.setScmId(scmId.get());
       scmStore.initialize();
       if (SCMHAUtils.isSCMHAEnabled(conf)) {
+        scmStore.setSCMHAFlag(true);
+        scmStore.persistCurrentState();
         SCMRatisServerImpl.initialize(clusterId, scmId.get(),
             SCMHANodeDetails.loadSCMHAConfig(conf).getLocalNodeDetails(), conf);
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -93,6 +93,7 @@ public class TestSCMInstallSnapshotWithHA {
     scmhaConfiguration.setRatisSnapshotThreshold(SNAPSHOT_THRESHOLD);
     conf.setFromObject(scmhaConfiguration);
 
+
     cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newHABuilder(conf)
         .setClusterId(clusterId)
         .setScmId(scmId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

After unclean SCM shutdown, SCM may not come out of safemode.

Attached a document to Jira with the problem statement and the proposal.

Proposal:
1. Use leader ready to start Background services.
2. In apply transaction after apply is complete if SCM is in safemode, refresh and validate safemode rules with current state.
3. For leader ready have a back ground daemon thread and check is leader ready using Ratis API. And also call notifyStatusChanged in SCMServices and also update isLeader in SCMContext.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5263

## How was this patch tested?
Tested the fix on a cluster.
Testing is described here [link](https://github.com/apache/ozone/pull/2294#issuecomment-854422133)
Performed failover testing also to check leader status is properly propogated.
Added tests for SCMContext new API.