### PR TITLE
HDDS-5295. testCRLStatusReportPublisher fails to create CRLInfo

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/report/TestReportPublisher.java
@@ -183,12 +183,8 @@ public class TestReportPublisher {
     DatanodeCRLStore dnCrlStore = Mockito.mock(DatanodeCRLStore.class);
     when(dnCrlStore.getLatestCRLSequenceID()).thenReturn(3L);
     List<CRLInfo> pendingCRLs = new ArrayList<>();
-    pendingCRLs.add(new CRLInfo.Builder()
-        .setCrlSequenceID(100L)
-        .build());
-    pendingCRLs.add(new CRLInfo.Builder()
-        .setCrlSequenceID(101L)
-        .build());
+    pendingCRLs.add(Mockito.mock(CRLInfo.class));
+    pendingCRLs.add(Mockito.mock(CRLInfo.class));
     when(dnCrlStore.getPendingCRLs()).thenReturn(pendingCRLs);
     when(dummyStateMachine.getDnCRLStore()).thenReturn(dnCrlStore);
     when(dummyContext.getParent()).thenReturn(dummyStateMachine);


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-5154 made `x509CRL` mandatory in `CRLInfo`.  HDDS-4483 added a unit test where `x509CRL` is not set.  These two changes were tested without each other, hence passed.  Together they fail on `master`: https://github.com/apache/ozone/runs/2732634889#step:4:853

https://issues.apache.org/jira/browse/HDDS-5295

## How was this patch tested?

```
[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.196 s - in org.apache.hadoop.ozone.container.common.report.TestReportPublisher
```

https://github.com/adoroszlai/hadoop-ozone/runs/2734503211#step:4:918