### PR TITLE
HDDS-5283. getStorageSize cast to int can cause issue

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -65,6 +65,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_D
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 
+import org.apache.ratis.util.SizeInBytes;
 import org.apache.hadoop.ozone.conf.OzoneServiceConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -89,6 +90,8 @@ public final class HddsUtils {
   private static final String MULTIPLE_SCM_NOT_YET_SUPPORTED =
       ScmConfigKeys.OZONE_SCM_NAMES + " must contain a single hostname."
           + " Multiple SCM hosts are currently unsupported";
+
+  private static final int ONE_MB = SizeInBytes.valueOf("1m").getSizeInt();
 
   private static final int NO_PORT = -1;
 
@@ -611,5 +614,12 @@ public final class HddsUtils {
    */
   public static long getShutDownTimeOut(ConfigurationSource conf) {
     return conf.getObject(OzoneServiceConfig.class).getServiceShutdownTimeout();
+  }
+
+  /**
+   * Utility method to round up bytes into the nearest MB.
+   */
+  public static int roundupMb(long bytes) {
+    return Math.toIntExact((bytes - 1) / ONE_MB + 1);
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -620,6 +620,6 @@ public final class HddsUtils {
    * Utility method to round up bytes into the nearest MB.
    */
   public static int roundupMb(long bytes) {
-    return Math.toIntExact((bytes - 1) / ONE_MB + 1);
+    return (int)Math.ceil((double) bytes/(double) ONE_MB);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -169,13 +169,13 @@ public class ContainerStateMachine extends BaseStateMachine {
     int numPendingRequests = conf
         .getObject(DatanodeRatisServerConfig.class)
         .getLeaderNumPendingRequests();
-    int pendingRequestsByteLimit = (int) conf.getStorageSize(
+    int pendingRequestsMegaBytesLimit = (int) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
-        StorageUnit.BYTES);
+        StorageUnit.MB);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
         (index, data) -> new int[] {1, data.size()}, numPendingRequests,
-        pendingRequestsByteLimit);
+        pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -174,8 +174,8 @@ public class ContainerStateMachine extends BaseStateMachine {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] {1, data.size()}, numPendingRequests,
-        pendingRequestsMegaBytesLimit);
+        (index, data) -> new int[] {1, (int) StorageUnit.MB.fromBytes(data.size())},
+        numPendingRequests, pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -176,7 +176,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     int pendingRequestsMegaBytesLimit =
         HddsUtils.roundupMb(pendingRequestsBytesLimit);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] {1, data.size()}, numPendingRequests,
+        (index, data) -> new int[] {1, HddsUtils.roundupMb(data.size())}, numPendingRequests,
         pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -169,18 +169,15 @@ public class ContainerStateMachine extends BaseStateMachine {
     int numPendingRequests = conf
         .getObject(DatanodeRatisServerConfig.class)
         .getLeaderNumPendingRequests();
-    int pendingRequestsMegaBytesLimit = (int) conf.getStorageSize(
+    long pendingRequestsBytesLimit = (long)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
+    int pendingRequestsMegaBytesLimit =
+        HddsUtils.roundupMb(pendingRequestsBytesLimit);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] { 1,
-            // if data.size() is non zero but when conversion to MB becomes 0,
-            // pass 1 MB as the request size.
-            ((int) StorageUnit.MB.fromBytes(data.size()) == 0
-                && data.size() != 0) ? 1 :
-                (int) StorageUnit.MB.fromBytes(data.size()) },
-        numPendingRequests, pendingRequestsMegaBytesLimit);
+        (index, data) -> new int[] {1, data.size()}, numPendingRequests,
+        pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -174,8 +174,9 @@ public class ContainerStateMachine extends BaseStateMachine {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] {1, (int) StorageUnit.MB.fromBytes(data.size())},
-        numPendingRequests, pendingRequestsMegaBytesLimit);
+        (index, data) -> new int[] { 1,
+            (int) StorageUnit.MB.fromBytes(data.size()) }, numPendingRequests,
+        pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -176,7 +176,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     int pendingRequestsMegaBytesLimit =
         HddsUtils.roundupMb(pendingRequestsBytesLimit);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] { 1, HddsUtils.roundupMb(data.size()) },
+        (index, data) -> new int[] {1, HddsUtils.roundupMb(data.size())},
         numPendingRequests, pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -172,7 +172,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     long pendingRequestsBytesLimit = (long)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
-        StorageUnit.MB);
+        StorageUnit.BYTES);
     int pendingRequestsMegaBytesLimit =
         HddsUtils.roundupMb(pendingRequestsBytesLimit);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -174,9 +174,13 @@ public class ContainerStateMachine extends BaseStateMachine {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] {1,
-            (int) StorageUnit.MB.fromBytes(data.size()) }, numPendingRequests,
-        pendingRequestsMegaBytesLimit);
+        (index, data) -> new int[] { 1,
+            // if data.size() is non zero but when conversion to MB becomes 0,
+            // pass 1 MB as the request size.
+            ((int) StorageUnit.MB.fromBytes(data.size()) == 0
+                && data.size() != 0) ? 1 :
+                (int) StorageUnit.MB.fromBytes(data.size()) },
+        numPendingRequests, pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -174,7 +174,7 @@ public class ContainerStateMachine extends BaseStateMachine {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] { 1,
+        (index, data) -> new int[] {1,
             (int) StorageUnit.MB.fromBytes(data.size()) }, numPendingRequests,
         pendingRequestsMegaBytesLimit);
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -176,8 +176,8 @@ public class ContainerStateMachine extends BaseStateMachine {
     int pendingRequestsMegaBytesLimit =
         HddsUtils.roundupMb(pendingRequestsBytesLimit);
     stateMachineDataCache = new ResourceLimitCache<>(new ConcurrentHashMap<>(),
-        (index, data) -> new int[] {1, HddsUtils.roundupMb(data.size())}, numPendingRequests,
-        pendingRequestsMegaBytesLimit);
+        (index, data) -> new int[] { 1, HddsUtils.roundupMb(data.size()) },
+        numPendingRequests, pendingRequestsMegaBytesLimit);
 
     this.chunkExecutors = chunkExecutors;
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -102,6 +102,7 @@ import org.apache.ratis.server.RaftServerRpc;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.TimeDuration;
+import org.apache.ratis.util.TraditionalBinaryPrefix;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -219,7 +220,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     setRaftSegmentAndWriteBufferSize(properties);
 
     // set raft segment pre-allocated size
-    final int raftSegmentPreallocatedSize =
+    final long raftSegmentPreallocatedSize =
         setRaftSegmentPreallocatedSize(properties);
 
     TimeUnit timeUnit;
@@ -380,8 +381,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         .setExpiryTime(properties, retryCacheTimeout);
   }
 
-  private int setRaftSegmentPreallocatedSize(RaftProperties properties) {
-    final int raftSegmentPreallocatedSize = (int) conf.getStorageSize(
+  private long setRaftSegmentPreallocatedSize(RaftProperties properties) {
+    final long raftSegmentPreallocatedSize = (long) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT,
         StorageUnit.BYTES);
@@ -425,12 +426,13 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private void setPendingRequestsLimits(RaftProperties properties) {
 
-    final int pendingRequestsByteLimit = (int)conf.getStorageSize(
+    final int pendingRequestsMegaBytesLimit = (int)conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
-        StorageUnit.BYTES);
+        StorageUnit.MB);
     RaftServerConfigKeys.Write.setByteLimit(properties,
-        SizeInBytes.valueOf(pendingRequestsByteLimit));
+        SizeInBytes.valueOf(pendingRequestsMegaBytesLimit,
+            TraditionalBinaryPrefix.MEGA));
   }
 
   public static XceiverServerRatis newXceiverServerRatis(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -41,6 +41,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -426,13 +427,14 @@ public final class XceiverServerRatis implements XceiverServerSpi {
 
   private void setPendingRequestsLimits(RaftProperties properties) {
 
-    final int pendingRequestsMegaBytesLimit = (int)conf.getStorageSize(
+    long pendingRequestsBytesLimit = (long) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
         StorageUnit.MB);
-    RaftServerConfigKeys.Write.setByteLimit(properties,
-        SizeInBytes.valueOf(pendingRequestsMegaBytesLimit,
-            TraditionalBinaryPrefix.MEGA));
+    final int pendingRequestsMegaBytesLimit =
+        HddsUtils.roundupMb(pendingRequestsBytesLimit);
+    RaftServerConfigKeys.Write.setByteLimit(properties, SizeInBytes
+        .valueOf(pendingRequestsMegaBytesLimit, TraditionalBinaryPrefix.MEGA));
   }
 
   public static XceiverServerRatis newXceiverServerRatis(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -430,7 +430,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     long pendingRequestsBytesLimit = (long) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_LEADER_PENDING_BYTES_LIMIT_DEFAULT,
-        StorageUnit.MB);
+        StorageUnit.BYTES);
     final int pendingRequestsMegaBytesLimit =
         HddsUtils.roundupMb(pendingRequestsBytesLimit);
     RaftServerConfigKeys.Write.setByteLimit(properties, SizeInBytes

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -405,7 +405,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
   }
 
   private void setRaftSegmentAndWriteBufferSize(RaftProperties properties) {
-    final int raftSegmentSize = (int)conf.getStorageSize(
+    final long raftSegmentSize = (long) conf.getStorageSize(
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_SIZE_KEY,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_SEGMENT_SIZE_DEFAULT,
         StorageUnit.BYTES);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -553,7 +553,7 @@ public final class OzoneManagerRatisServer {
     RaftServerConfigKeys.LeaderElection.setPreVote(properties, false);
 
     // Set RAFT segment size
-    final int raftSegmentSize = (int) conf.getStorageSize(
+    final long raftSegmentSize = (long) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_SIZE_DEFAULT,
         StorageUnit.BYTES);
@@ -562,7 +562,7 @@ public final class OzoneManagerRatisServer {
     RaftServerConfigKeys.Log.setPurgeUptoSnapshotIndex(properties, true);
 
     // Set RAFT segment pre-allocated size
-    final int raftSegmentPreallocatedSize = (int) conf.getStorageSize(
+    final long raftSegmentPreallocatedSize = (long) conf.getStorageSize(
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_SEGMENT_PREALLOCATED_SIZE_DEFAULT,
         StorageUnit.BYTES);

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.1.0</ratis.version>
+    <ratis.version>2.1.0-03f3b68-SNAPSHOT</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.7.0</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
 value of `pendingRequestsByteLimit` couldn’t be set beyond 2GB because of the integer limit.  Similarly there were other places where getStorageSize was cast to int.  Converted to long where possible and changed the scale of the variable if not. 


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5283

## How was this patch tested?
CI
