### PR TITLE
HDDS-5312. Intermittent failure in SCM Ratis integration test

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreatorV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreatorV2.java
@@ -150,7 +150,7 @@ public class BackgroundPipelineCreatorV2 implements SCMService {
    * Stop RatisPipelineUtilsThread.
    */
   public void stop() {
-    if (running.compareAndSet(true, false)) {
+    if (!running.compareAndSet(true, false)) {
       LOG.warn("{} is not running, just ignore.", THREAD_NAME);
       return;
     }
@@ -280,7 +280,13 @@ public class BackgroundPipelineCreatorV2 implements SCMService {
         || event == UNHEALTHY_TO_HEALTHY_NODE_HANDLER_TRIGGERED
         || event == PRE_CHECK_COMPLETED) {
       LOG.info("trigger a one-shot run on {}.", THREAD_NAME);
-      oneShotRun = true;
+
+      serviceLock.lock();
+      try {
+        oneShotRun = true;
+      } finally {
+        serviceLock.unlock();
+      }
 
       synchronized (monitor) {
         monitor.notifyAll();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -62,6 +62,7 @@ public class TestSCMInstallSnapshot {
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
     SCMHAConfiguration scmhaConfiguration = conf.getObject(
         SCMHAConfiguration.class);
     scmhaConfiguration.setRatisSnapshotThreshold(1L);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -48,6 +48,7 @@ public class TestSCMSnapshot {
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
     SCMHAConfiguration scmhaConfiguration = conf.getObject(
         SCMHAConfiguration.class);
     scmhaConfiguration.setRatisSnapshotThreshold(1L);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -200,7 +200,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
 
   public void waitForSCMToBeReady() throws TimeoutException,
       InterruptedException {
-    // Nothing implemented here
+    if (SCMHAUtils.isSCMHAEnabled(conf)) {
+      GenericTestUtils.waitFor(scm::checkLeader,
+          1000, waitForClusterToBeReadyTimeout);
+    }
   }
 
   public StorageContainerManager getActiveSCM() {
@@ -225,8 +228,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
           isNodeReady ? "Nodes are ready" : "Waiting for nodes to be ready",
           healthy, hddsDatanodes.size());
       LOG.info(exitSafeMode ? "Cluster exits safe mode" :
-              "Waiting for cluster to exit safe mode",
-          healthy, hddsDatanodes.size());
+              "Waiting for cluster to exit safe mode");
       LOG.info(checkScmLeader ? "SCM became leader" :
           "SCM has not become leader");
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -493,6 +493,7 @@ public class TestStorageContainerManager {
   public void testSCMInitializationWithHAEnabled() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
     final String path = GenericTestUtils.getTempPath(
         UUID.randomUUID().toString());
     Path scmPath = Paths.get(path, "scm-meta");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -88,6 +88,7 @@ public class TestStorageContainerManagerHA {
   @Before
   public void init() throws Exception {
     conf = new OzoneConfiguration();
+    conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL, "10s");
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
     omServiceId = "om-service-test1";


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Mini cluster in SCM HA tests waits for two events sequentially:
 - SCM leader election
 - datanode registration, pipeline creation
The same 2 minutes timeout applies to both of these separately.

This change makes single SCM _with Ratis enabled_ also wait for leader election, to allow for time spent to start up Ratis.  Most timeouts are observed in tests with such setup (single SCM with Ratis).

2. Increase frequency of pipeline creation attempts for some integration tests.

3. Fix `BackgroundPipelineCreatorV2#stop()`: the thread was always considered "not running" due to wrong condition for return value of `compareAndSet` (returns `true` if update is successful).

4. Guard `oneShotRun` value assignment in `notifyEventTriggered` by `serviceLock`, similar to other access in `shouldRun`.

https://issues.apache.org/jira/browse/HDDS-5312

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/914869219

20x repetitions of affected tests:
https://github.com/adoroszlai/hadoop-ozone/runs/2764193856