### PR TITLE
HDDS-5315 Skip storing unwanted block tokens on OM DB

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -182,11 +182,11 @@ public final class OmKeyLocationInfo {
         .setLength(length)
         .setOffset(offset)
         .setCreateVersion(createVersion).setPartNumber(partNumber);
-    if (this.token != null) {
-      builder.setToken(OzonePBHelper.protoFromToken(token));
-    }
     if (!ignorePipeline) {
       try {
+        if (this.token != null) {
+          builder.setToken(OzonePBHelper.protoFromToken(token));
+        }
         builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
       } catch (UnknownPipelineStateException e) {
         //TODO: fix me: we should not return KeyLocation without pipeline.


### PR DESCRIPTION
## What changes were proposed in this pull request?
Block tokens do not need to be stored in OM DB.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5315

## How was this patch tested?
- [ ] Replace jar in a testbed and check keys stored.