### PR TITLE
HDDS-5317. BootStrapped SCM fails to bootstrap if it connects to another bootstrapped SCM first.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/RetriableWithFailOverException.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/RetriableWithFailOverException.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.ha;
+
+import java.io.IOException;
+
+/**
+ * This exception indicates that the request can be retried, and client need
+ * to retry on the next server.
+ */
+public class RetriableWithFailOverException extends IOException {
+  public RetriableWithFailOverException(IOException exception) {
+    super(exception);
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -320,6 +320,8 @@ public final class SCMHAUtils {
     } else if (SCMHAUtils.checkNonRetriableException(e)) {
       return RetryPolicy.RetryAction.FAIL;
     } else {
+      // For any other exception like RetriableWithFailOverException or any
+      // other we perform fail-over and retry.
       if (failovers < maxRetryCount) {
         return new RetryPolicy.RetryAction(
             RetryPolicy.RetryAction.RetryDecision.FAILOVER_AND_RETRY,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -357,7 +357,7 @@ public final class HASecurityUtils {
         .setLeaderId(null)
         .setProperties(properties)
         .setRetryPolicy(
-            RetryPolicies.retryUpToMaximumCountWithFixedSleep(15,
+            RetryPolicies.retryUpToMaximumCountWithFixedSleep(120,
                 TimeDuration.valueOf(500, TimeUnit.MILLISECONDS)));
 
     if (tlsConfig != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_DN_CERTIFICATE_FAILED;
 import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_OM_CERTIFICATE_FAILED;
 import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_SCM_CERTIFICATE_FAILED;
 import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.NOT_A_PRIMARY_SCM;
@@ -200,14 +201,15 @@ public final class RatisUtil {
       // primary SCM. When the bootstrapped SCM connects to other
       // bootstrapped SCM we get the NOT_A_PRIMARY_SCM. In this scenario
       // client needs to retry next SCM.
+
+      // And also on primary/leader SCM if it failed due to any other reason
+      // retry again.
       SCMSecurityException ex = (SCMSecurityException) e;
       if (ex.getErrorCode().equals(NOT_A_PRIMARY_SCM)) {
         throw new ServiceException(new RetriableWithFailOverException(e));
       } else if (ex.getErrorCode().equals(GET_SCM_CERTIFICATE_FAILED) ||
           ex.getErrorCode().equals(GET_OM_CERTIFICATE_FAILED) ||
-          ex.getErrorCode().equals(GET_OM_CERTIFICATE_FAILED)) {
-        // And also on primary SCM if it failed due to any other reason give
-        // another retry again.
+          ex.getErrorCode().equals(GET_DN_CERTIFICATE_FAILED)) {
         throw new ServiceException(new RetriableWithNoFailoverException(e));
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -22,6 +22,7 @@ import com.google.protobuf.ServiceException;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.ratis.ServerNotLeaderException;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.server.ServerUtils;
 import org.apache.ratis.RaftConfigKeys;
 import org.apache.ratis.conf.RaftProperties;
@@ -37,6 +38,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_OM_CERTIFICATE_FAILED;
+import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.GET_SCM_CERTIFICATE_FAILED;
+import static org.apache.hadoop.hdds.security.exception.SCMSecurityException.ErrorCode.NOT_A_PRIMARY_SCM;
 import static org.apache.ratis.server.RaftServerConfigKeys.Log;
 import static org.apache.ratis.server.RaftServerConfigKeys.RetryCache;
 import static org.apache.ratis.server.RaftServerConfigKeys.Rpc;
@@ -190,6 +194,22 @@ public final class RatisUtil {
       throw new ServiceException(ServerNotLeaderException
           .convertToNotLeaderException(nle,
               SCMRatisServerImpl.getSelfPeerId(scmId), port));
+    } else if (e instanceof SCMSecurityException) {
+      // For this error client needs to retry on next SCM.
+      // GetSCMCertificate call can happen on non-leader SCM and only an
+      // primary SCM. When the bootstrapped SCM connects to other
+      // bootstrapped SCM we get the NOT_A_PRIMARY_SCM. In this scenario
+      // client needs to retry next SCM.
+      SCMSecurityException ex = (SCMSecurityException) e;
+      if (ex.getErrorCode().equals(NOT_A_PRIMARY_SCM)) {
+        throw new ServiceException(new RetriableWithFailOverException(e));
+      } else if (ex.getErrorCode().equals(GET_SCM_CERTIFICATE_FAILED) ||
+          ex.getErrorCode().equals(GET_OM_CERTIFICATE_FAILED) ||
+          ex.getErrorCode().equals(GET_OM_CERTIFICATE_FAILED)) {
+        // And also on primary SCM if it failed due to any other reason give
+        // another retry again.
+        throw new ServiceException(new RetriableWithNoFailoverException(e));
+      }
     }
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -196,7 +196,7 @@ public final class RatisUtil {
           .convertToNotLeaderException(nle,
               SCMRatisServerImpl.getSelfPeerId(scmId), port));
     } else if (e instanceof SCMSecurityException) {
-      // For this error client needs to retry on next SCM.
+      // For NOT_A_PRIMARY_SCM error client needs to retry on next SCM.
       // GetSCMCertificate call can happen on non-leader SCM and only an
       // primary SCM. When the bootstrapped SCM connects to other
       // bootstrapped SCM we get the NOT_A_PRIMARY_SCM. In this scenario


### PR DESCRIPTION
## What changes were proposed in this pull request?

On SCM check if it is SCMSecurityException with errorCode NOT_A_PRIMARY_SCM return a RetriableWithFailOverException. In this way, FailOverProxyProvider performs failOver and Retry to the next SCM. And also increased Ratiis client retry count to a longer value.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5317

## How was this patch tested?

Tested manually on docker-compose where I have changed the order of node ids to scm2,scm3,scm1
And started  SCM1, SCM2, and SCM3 in this order. SCM during bootstrap it will connect to scm2, and see whether it is able to bootstrap or not.

SCM3 connected to SCM2 and it is throwing RetriableWithFailOverException.
```
scm2.org_1   | org.apache.hadoop.hdds.scm.ha.RetriableWithFailOverException: org.apache.hadoop.hdds.security.exception.SCMSecurityException: Get SCM Certificate can be run only primary SCM
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.ha.RatisUtil.checkRatisException(RatisUtil.java:206)
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB.processRequest(SCMSecurityProtocolServerSideTranslatorPB.java:157)
scm2.org_1   | 	at org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher.processRequest(OzoneProtocolMessageDispatcher.java:87)
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB.submitRequest(SCMSecurityProtocolServerSideTranslatorPB.java:97)
scm2.org_1   | 	at org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos$SCMSecurityProtocolService$2.callBlockingMethod(SCMSecurityProtocolProtos.java:15124)
scm2.org_1   | 	at org.apache.hadoop.ipc.ProtobufRpcEngine$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine.java:528)
scm2.org_1   | 	at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1086)
scm2.org_1   | 	at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1029)
scm2.org_1   | 	at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:957)
scm2.org_1   | 	at java.base/java.security.AccessController.doPrivileged(Native Method)
scm2.org_1   | 	at java.base/javax.security.auth.Subject.doAs(Subject.java:423)
scm2.org_1   | 	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1762)
scm2.org_1   | 	at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2957)
scm2.org_1   | Caused by: org.apache.hadoop.hdds.security.exception.SCMSecurityException: Get SCM Certificate can be run only primary SCM
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.server.SCMSecurityProtocolServer.getSCMCertificate(SCMSecurityProtocolServer.java:200)
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB.getSCMCertificate(SCMSecurityProtocolServerSideTranslatorPB.java:228)
scm2.org_1   | 	at org.apache.hadoop.hdds.scm.protocol.SCMSecurityProtocolServerSideTranslatorPB.processRequest(SCMSecurityProtocolServerSideTranslatorPB.java:127)
scm2.org_1   | 	... 11 more
```

SCM3 bootstrap is successful.
```
scm3.org_1   | 2021-06-08 08:11:53,076 [main] INFO server.StorageContainerManager: SCM BootStrap  is successful for ClusterID CID-74d4b242-a5d7-4b07-8677-f75f0207c0e8, SCMID d7a4c94b-423a-45ae-b04a-9474584206d1
scm3.org_1   | 2021-06-08 08:11:53,076 [main] INFO server.StorageContainerManager: Primary SCM Node ID 4f54d4de-8942-47b0-a88e-99e5d1bbcad7
scm3.org_1   | 2021-06-08 08:11:53,086 [shutdown-hook-0] INFO server.StorageContainerManagerStarter: SHUTDOWN_MSG:
```
