### PR TITLE
HDDS-5318. Intermittent failure in TestOzoneManagerDoubleBufferWithOMResponse

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -194,8 +194,9 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
     checkDeletedBuckets(deleteBucketQueue);
 
     // Check lastAppliedIndex is updated correctly or not.
-    Assert.assertEquals(bucketCount + deleteCount + 1, lastAppliedIndex);
-
+    GenericTestUtils.waitFor(() ->
+        bucketCount + deleteCount + 1 == lastAppliedIndex,
+        100, 30000);
 
     TransactionInfo transactionInfo =
         omMetadataManager.getTransactionInfoTable().get(TRANSACTION_INFO_KEY);


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestOzoneManagerDoubleBufferWithOMResponse` is flaky because double buffer involves another thread.  `flushTransactions` updates `flushedTransactionCount`, then somewhat later also updates `lastAppliedIndex`.  The test waits for the former, but simply checks the latter with assertion.  We need to wait for this update, too.

https://issues.apache.org/jira/browse/HDDS-5318

## How was this patch tested?

Repeated `TestOzoneManagerDoubleBufferWithOMResponse` 50x:
https://github.com/adoroszlai/hadoop-ozone/runs/2771888499

Regular CI (pending):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/918284218