### PR TITLE
HDDS-5323. Avoid unncessary report processing log messages in follower.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -90,13 +90,12 @@ public class PipelineReportHandler implements
     for (PipelineReport report : pipelineReport.getPipelineReportList()) {
       try {
         processPipelineReport(report, dn, publisher);
-      } catch (IOException e) {
+      } catch(NotLeaderException ex) {
         // Avoid NotLeaderException logging which happens when processing
         // pipeline report on followers.
-        if (!(e instanceof NotLeaderException)) {
-          LOGGER.error("Could not process pipeline report={} from dn={}.",
-              report, dn, e);
-        }
+      } catch(IOException e) {
+        LOGGER.error("Could not process pipeline report={} from dn={}.",
+            report, dn, e);
       }
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineReportHandler.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ClosePipelineCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,8 +91,12 @@ public class PipelineReportHandler implements
       try {
         processPipelineReport(report, dn, publisher);
       } catch (IOException e) {
-        LOGGER.error("Could not process pipeline report={} from dn={}.",
-            report, dn, e);
+        // Avoid NotLeaderException logging which happens when processing
+        // pipeline report on followers.
+        if (!(e instanceof NotLeaderException)) {
+          LOGGER.error("Could not process pipeline report={} from dn={}.",
+              report, dn, e);
+        }
       }
     }
   }
@@ -103,10 +108,13 @@ public class PipelineReportHandler implements
     try {
       pipeline = pipelineManager.getPipeline(pipelineID);
     } catch (PipelineNotFoundException e) {
-      SCMCommand<?> command = new ClosePipelineCommand(pipelineID);
-      command.setTerm(scmContext.getTermOfLeader());
-      publisher.fireEvent(SCMEvents.DATANODE_COMMAND,
-          new CommandForDatanode<>(dn.getUuid(), command));
+      if (scmContext.isLeader()) {
+        LOGGER.info("Reported pipeline {} is not found", pipelineID);
+        SCMCommand< ? > command = new ClosePipelineCommand(pipelineID);
+        command.setTerm(scmContext.getTermOfLeader());
+        publisher.fireEvent(SCMEvents.DATANODE_COMMAND,
+            new CommandForDatanode<>(dn.getUuid(), command));
+      }
       return;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid distracting logs in SCM followers during report processing. These logs don't add much value, better avoid them.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5323

## How was this patch tested?

Patched the cluster and now I don't see error logs on the report processing on followers.
