### PR TITLE
HDDS-5307 deprecate checkAclRights in OzoneAclUtil.java 

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -88,31 +88,6 @@ public final class OzoneAclUtil {
     return retList;
   }
 
-  /**
-   * Check if acl right requested for given RequestContext exist
-   * in provided acl list.
-   * Acl validation rules:
-   * 1. If user/group has ALL bit set than all user should have all rights.
-   * 2. If user/group has NONE bit set than user/group will not have any right.
-   * 3. For all other individual rights individual bits should be set.
-   *
-   * @param acls
-   * @param context
-   * @return return true if acl list contains right requsted in context.
-   * */
-  public static boolean checkAclRight(List<OzoneAcl> acls,
-      RequestContext context) throws OMException {
-    String[] userGroups = context.getClientUgi().getGroupNames();
-    String userName = context.getClientUgi().getUserName();
-    ACLType aclToCheck = context.getAclRights();
-    for (OzoneAcl a : acls) {
-      if(checkAccessInAcl(a, userGroups, userName, aclToCheck)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   private static boolean checkAccessInAcl(OzoneAcl a, String[] groups,
       String username, ACLType aclToCheck) {
     BitSet rights = a.getAclBitSet();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1782,7 +1782,7 @@ public class KeyManagerImpl implements KeyManager {
         return true;
       }
 
-      boolean hasAccess = OzoneAclUtil.checkAclRight(
+      boolean hasAccess = OzoneAclUtil.checkAclRights(
           keyInfo.getAcls(), context);
       if (LOG.isDebugEnabled()) {
         LOG.debug("user:{} has access rights for key:{} :{} ",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Deprecate checkAclRights in OzoneAclUtil.java because checkAclRights and checkAclRight seem to implement the same thing.
checkAclRight implements only on KeyManagerImpl.java so I changed to checkAclRights

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5307

## How was this patch tested?

I manually test it using ozone client to list/create/delete volume bucket and key
