### PR TITLE
HDDS-5324. Delete unnecessary calls to decNumKeys in OMKeysDeleteRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -220,7 +220,6 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       }
       break;
     case FAILURE:
-      omMetrics.decNumKeys(deleteKeys.size());
       omMetrics.incNumKeyDeleteFails();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Keys delete failed. Volume:{}, Bucket:{}, DeletedKeys:{}, " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

If you fail to delete keys, you can avoid unnecessary calls to decNumKeys.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5324


## How was this patch tested?


