### PR TITLE
HDDS-5313. ContainerInfo should use ReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 
@@ -30,6 +31,7 @@ public class RatisReplicationConfig
     implements ReplicationConfig {
 
   private final ReplicationFactor replicationFactor;
+  private static final ReplicationType REPLICATION_TYPE = ReplicationType.RATIS;
 
   public RatisReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;
@@ -60,8 +62,9 @@ public class RatisReplicationConfig
   }
 
   @Override
+  @JsonProperty("replicationType")
   public ReplicationType getReplicationType() {
-    return ReplicationType.RATIS;
+    return REPLICATION_TYPE;
   }
 
   @Override
@@ -87,7 +90,7 @@ public class RatisReplicationConfig
 
   @Override
   public String toString() {
-    return "RATIS/" + replicationFactor;
+    return REPLICATION_TYPE.name() + "/" + replicationFactor;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 
@@ -29,6 +30,7 @@ import java.util.Objects;
 public class StandaloneReplicationConfig implements ReplicationConfig {
 
   private final ReplicationFactor replicationFactor;
+  private static final String REPLICATION_TYPE = "STANDALONE";
 
   public StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;
@@ -57,6 +59,17 @@ public class StandaloneReplicationConfig implements ReplicationConfig {
     return ReplicationType.STAND_ALONE;
   }
 
+  @JsonProperty("replicationType")
+  /**
+   * This method is here only to allow the string value for replicationType to
+   * be output in JSON. The enum defining the replication type STAND_ALONE has a
+   * string value of "STAND_ALONE", however various tests expect to see
+   * "STANDALONE" as the string.
+   */
+  public String replicationType() {
+    return REPLICATION_TYPE;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -71,7 +84,7 @@ public class StandaloneReplicationConfig implements ReplicationConfig {
 
   @Override
   public String toString() {
-    return "STANDALONE/" + replicationFactor;
+    return REPLICATION_TYPE + "/" + replicationFactor;
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -25,9 +25,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.util.Time;
 
@@ -50,8 +49,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
   private HddsProtos.LifeCycleState state;
   @JsonIgnore
   private PipelineID pipelineID;
-  private ReplicationFactor replicationFactor;
-  private ReplicationType replicationType;
+  private ReplicationConfig replicationConfig;
   private long usedBytes;
   private long numberOfKeys;
   private Instant lastUsed;
@@ -82,8 +80,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
       String owner,
       long deleteTransactionId,
       long sequenceId,
-      ReplicationFactor replicationFactor,
-      ReplicationType repType) {
+      ReplicationConfig repConfig) {
     this.containerID = containerID;
     this.pipelineID = pipelineID;
     this.usedBytes = usedBytes;
@@ -94,8 +91,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     this.owner = owner;
     this.deleteTransactionId = deleteTransactionId;
     this.sequenceId = sequenceId;
-    this.replicationFactor = replicationFactor;
-    this.replicationType = repType;
+    this.replicationConfig = repConfig;
   }
 
   /**
@@ -106,6 +102,8 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
 
   public static ContainerInfo fromProtobuf(HddsProtos.ContainerInfoProto info) {
     ContainerInfo.Builder builder = new ContainerInfo.Builder();
+    final ReplicationConfig config = ReplicationConfig
+        .fromProto(info.getReplicationType(), info.getReplicationFactor());
     builder.setUsedBytes(info.getUsedBytes())
         .setNumberOfKeys(info.getNumberOfKeys())
         .setState(info.getState())
@@ -113,8 +111,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
         .setOwner(info.getOwner())
         .setContainerID(info.getContainerID())
         .setDeleteTransactionId(info.getDeleteTransactionId())
-        .setReplicationFactor(info.getReplicationFactor())
-        .setReplicationType(info.getReplicationType())
+        .setReplicationConfig(config)
         .setSequenceId(info.getSequenceId())
         .build();
 
@@ -146,8 +143,12 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     return stateEnterTime;
   }
 
-  public ReplicationFactor getReplicationFactor() {
-    return replicationFactor;
+  public ReplicationConfig getReplicationConfig() {
+    return replicationConfig;
+  }
+
+  public HddsProtos.ReplicationType getReplicationType() {
+    return replicationConfig.getReplicationType();
   }
 
   public PipelineID getPipelineID() {
@@ -200,10 +201,6 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     return lastUsed;
   }
 
-  public ReplicationType getReplicationType() {
-    return replicationType;
-  }
-
   public void updateLastUsedTime() {
     lastUsed = Instant.ofEpochMilli(Time.now());
   }
@@ -219,10 +216,12 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
         .setStateEnterTime(getStateEnterTime().toEpochMilli())
         .setContainerID(getContainerID())
         .setDeleteTransactionId(getDeleteTransactionId())
-        .setReplicationFactor(getReplicationFactor())
-        .setReplicationType(getReplicationType())
         .setOwner(getOwner())
         .setSequenceId(getSequenceId());
+
+    builder.setReplicationFactor(
+        ReplicationConfig.getLegacyFactor(replicationConfig));
+    builder.setReplicationType(replicationConfig.getReplicationType());
 
     if (getPipelineID() != null) {
       builder.setPipelineID(getPipelineID().getProtobuf());
@@ -390,22 +389,15 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     private long deleteTransactionId;
     private long sequenceId;
     private PipelineID pipelineID;
-    private ReplicationFactor replicationFactor;
-    private ReplicationType replicationType;
-
-    public Builder setReplicationType(
-        ReplicationType repType) {
-      this.replicationType = repType;
-      return this;
-    }
+    private ReplicationConfig replicationConfig;
 
     public Builder setPipelineID(PipelineID pipelineId) {
       this.pipelineID = pipelineId;
       return this;
     }
 
-    public Builder setReplicationFactor(ReplicationFactor repFactor) {
-      this.replicationFactor = repFactor;
+    public Builder setReplicationConfig(ReplicationConfig repConfig) {
+      this.replicationConfig = repConfig;
       return this;
     }
 
@@ -453,7 +445,7 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     public ContainerInfo build() {
       return new ContainerInfo(containerID, state, pipelineID,
           used, keys, stateEnterTime, owner, deleteTransactionId,
-          sequenceId, replicationFactor, replicationType);
+          sequenceId, replicationConfig);
     }
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+
+/**
+ * Tests for the ContainerInfo class.
+ */
+
+public class TestContainerInfo {
+
+  @Test
+  public void getProtobufMessageEC() throws IOException {
+    ContainerInfo container =
+        createContainerInfo(new RatisReplicationConfig(THREE));
+    HddsProtos.ContainerInfoProto proto = container.getProtobuf();
+
+    // No EC Config
+    Assert.assertFalse(proto.hasEcReplicationConfig());
+    Assert.assertEquals(THREE, proto.getReplicationFactor());
+    Assert.assertEquals(RATIS, proto.getReplicationType());
+
+    // Reconstruct object from Proto
+    ContainerInfo recovered = ContainerInfo.fromProtobuf(proto);
+    Assert.assertEquals(RATIS, recovered.getReplicationType());
+    Assert.assertTrue(
+        recovered.getReplicationConfig() instanceof RatisReplicationConfig);
+
+    // EC Config
+    container = createContainerInfo(new ECReplicationConfig(3, 2));
+    proto = container.getProtobuf();
+
+    Assert.assertEquals(3, proto.getEcReplicationConfig().getData());
+    Assert.assertEquals(2, proto.getEcReplicationConfig().getParity());
+    Assert.assertFalse(proto.hasReplicationFactor());
+    Assert.assertEquals(EC, proto.getReplicationType());
+
+    // Reconstruct object from Proto
+    recovered = ContainerInfo.fromProtobuf(proto);
+    Assert.assertEquals(EC, recovered.getReplicationType());
+    Assert.assertTrue(
+        recovered.getReplicationConfig() instanceof ECReplicationConfig);
+    ECReplicationConfig config =
+        (ECReplicationConfig)recovered.getReplicationConfig();
+    Assert.assertEquals(3, config.getData());
+    Assert.assertEquals(2, config.getParity());
+  }
+
+  private ContainerInfo createContainerInfo(ReplicationConfig repConfig) {
+    ContainerInfo.Builder builder = new ContainerInfo.Builder();
+    builder.setContainerID(1234)
+        .setReplicationConfig(repConfig)
+        .setPipelineID(PipelineID.randomId())
+        .setState(HddsProtos.LifeCycleState.OPEN)
+        .setOwner("scm");
+    return builder.build();
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/package-info.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/package-info.java
@@ -1,0 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+/**
+ Test cases for SCM Container classes.
+ */

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -219,8 +219,9 @@ message ContainerInfoProto {
     required string owner = 7;
     optional int64 deleteTransactionId = 8;
     optional int64 sequenceId = 9;
-    required ReplicationFactor replicationFactor  = 10;
+    optional ReplicationFactor replicationFactor  = 10;
     required ReplicationType replicationType  = 11;
+    optional ECReplicationConfig ecReplicationConfig = 12;
 }
 
 message ContainerWithPipeline {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -279,7 +279,7 @@ public class DeletedBlockLogImpl
           // corresponding nodes commit the txn. It is required to check that
           // the nodes returned in the pipeline match the replication factor.
           if (min(replicas.size(), dnsWithCommittedTxn.size())
-              >= container.getReplicationFactor().getNumber()) {
+              >= container.getReplicationConfig().getRequiredNodes()) {
             List<UUID> containerDns = replicas.stream()
                 .map(ContainerReplica::getDatanodeDetails)
                 .map(DatanodeDetails::getUuid)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImplV2.java
@@ -230,7 +230,7 @@ public class DeletedBlockLogImplV2
           // corresponding nodes commit the txn. It is required to check that
           // the nodes returned in the pipeline match the replication factor.
           if (min(replicas.size(), dnsWithCommittedTxn.size())
-              >= container.getReplicationFactor().getNumber()) {
+              >= container.getReplicationConfig().getRequiredNodes()) {
             List<UUID> containerDns = replicas.stream()
                 .map(ContainerReplica::getDatanodeDetails)
                 .map(DatanodeDetails::getUuid)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -305,9 +305,7 @@ public class ContainerStateManager {
         .setOwner(owner)
         .setContainerID(containerID)
         .setDeleteTransactionId(0)
-        .setReplicationFactor(
-            ReplicationConfig.getLegacyFactor(pipeline.getReplicationConfig()))
-        .setReplicationType(pipeline.getType())
+        .setReplicationConfig(pipeline.getReplicationConfig())
         .build();
     addContainerInfo(containerID, containerInfo, pipelineManager, pipeline);
     if (LOG.isTraceEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -387,7 +387,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
       ContainerReplicaCount replicaSet =
           getContainerReplicaCount(container, replicas);
       ContainerPlacementStatus placementStatus = getPlacementStatus(
-          replicas, container.getReplicationFactor().getNumber());
+          replicas, container.getReplicationConfig().getRequiredNodes());
 
       /*
        * We don't have to take any action if the container is healthy.
@@ -567,7 +567,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
         replica,
         getInflightAdd(container.containerID()),
         getInflightDel(container.containerID()),
-        container.getReplicationFactor().getNumber(),
+        container.getReplicationConfig().getRequiredNodes(),
         minHealthyForMaintenance);
   }
 
@@ -583,7 +583,8 @@ public class ReplicationManager implements MetricsSource, SCMService {
       final Set<ContainerReplica> replicas) {
     Preconditions.assertTrue(container.getState() ==
         LifeCycleState.QUASI_CLOSED);
-    final int replicationFactor = container.getReplicationFactor().getNumber();
+    final int replicationFactor =
+        container.getReplicationConfig().getRequiredNodes();
     final long uniqueQuasiClosedReplicaCount = replicas.stream()
         .filter(r -> r.getState() == State.QUASI_CLOSED)
         .map(ContainerReplica::getOriginDatanodeId)
@@ -739,7 +740,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
           .collect(Collectors.toList());
       if (source.size() > 0) {
         final int replicationFactor = container
-            .getReplicationFactor().getNumber();
+            .getReplicationConfig().getRequiredNodes();
         // Want to check if the container is mis-replicated after considering
         // inflight add and delete.
         // Create a new list from source (healthy replicas minus pending delete)
@@ -818,7 +819,8 @@ public class ReplicationManager implements MetricsSource, SCMService {
 
     final Set<ContainerReplica> replicas = replicaSet.getReplica();
     final ContainerID id = container.containerID();
-    final int replicationFactor = container.getReplicationFactor().getNumber();
+    final int replicationFactor =
+        container.getReplicationConfig().getRequiredNodes();
     int excess = replicaSet.additionalReplicaNeeded() * -1;
     if (excess > 0) {
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -117,7 +118,8 @@ public class ContainerStateMap {
       containerMap.put(id, info);
       lifeCycleStateMap.insert(info.getState(), id);
       ownerMap.insert(info.getOwner(), id);
-      factorMap.insert(info.getReplicationFactor(), id);
+      factorMap.insert(
+          ReplicationConfig.getLegacyFactor(info.getReplicationConfig()), id);
       typeMap.insert(info.getReplicationType(), id);
       replicaMap.put(id, ConcurrentHashMap.newKeySet());
 
@@ -145,7 +147,8 @@ public class ContainerStateMap {
       final ContainerInfo info = containerMap.remove(id);
       lifeCycleStateMap.remove(info.getState(), id);
       ownerMap.remove(info.getOwner(), id);
-      factorMap.remove(info.getReplicationFactor(), id);
+      factorMap.remove(
+          ReplicationConfig.getLegacyFactor(info.getReplicationConfig()), id);
       typeMap.remove(info.getReplicationType(), id);
       // Flush the cache of this container type.
       flushCache(info);
@@ -455,7 +458,8 @@ public class ContainerStateMap {
       final ContainerQueryKey key = new ContainerQueryKey(
           containerInfo.getState(),
           containerInfo.getOwner(),
-          containerInfo.getReplicationFactor(),
+          ReplicationConfig.getLegacyFactor(
+              containerInfo.getReplicationConfig()),
           containerInfo.getReplicationType());
       resultCache.remove(key);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -250,7 +250,8 @@ public class SCMClientProtocolServer implements
 
     if (pipeline == null) {
       pipeline = scm.getPipelineManager().createPipeline(
-          new StandaloneReplicationConfig(container.getReplicationFactor()),
+          new StandaloneReplicationConfig(ReplicationConfig
+              .getLegacyFactor(container.getReplicationConfig())),
           scm.getContainerManager()
               .getContainerReplicas(cid).stream()
               .map(ContainerReplica::getDatanodeDetails)
@@ -335,7 +336,7 @@ public class SCMClientProtocolServer implements
     try{
       return getScm().getContainerManager()
           .getContainerReplicas(contInfo.containerID())
-          .size() >= contInfo.getReplicationFactor().getNumber();
+          .size() >= contInfo.getReplicationConfig().getRequiredNodes();
     } catch (ContainerNotFoundException ex) {
       // getContainerReplicas throws exception if no replica's exist for given
       // container.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -537,8 +537,8 @@ public final class TestUtils {
       final HddsProtos.LifeCycleState state) {
     return new ContainerInfo.Builder()
         .setContainerID(RandomUtils.nextLong())
-        .setReplicationType(HddsProtos.ReplicationType.RATIS)
-        .setReplicationFactor(HddsProtos.ReplicationFactor.THREE)
+        .setReplicationConfig(
+            new RatisReplicationConfig(ReplicationFactor.THREE))
         .setState(state)
         .setSequenceId(10000L)
         .setOwner("TEST")

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.scm.block;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.HddsConfigKeys;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto
@@ -68,6 +68,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
 import static org.mockito.Matchers.anyObject;
@@ -123,7 +124,7 @@ public class TestDeletedBlockLog {
 
     final ContainerInfo container =
         new ContainerInfo.Builder().setContainerID(1)
-            .setReplicationFactor(ReplicationFactor.THREE)
+            .setReplicationConfig(new RatisReplicationConfig(THREE))
             .setState(HddsProtos.LifeCycleState.CLOSED)
             .build();
     final Set<ContainerReplica> replicaSet = dnList.stream()
@@ -419,9 +420,7 @@ public class TestDeletedBlockLog {
     ContainerInfo.Builder builder = new ContainerInfo.Builder();
     builder.setContainerID(containerID)
         .setPipelineID(pipeline.getId())
-        .setReplicationType(pipeline.getType())
-        .setReplicationFactor(
-            ReplicationConfig.getLegacyFactor(pipeline.getReplicationConfig()));
+        .setReplicationConfig(pipeline.getReplicationConfig());
 
     ContainerInfo containerInfo = builder.build();
     Mockito.doReturn(containerInfo).when(containerManager)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -91,7 +91,7 @@ public class TestContainerStateManager {
         .getContainerReplicas(c1.containerID());
 
     Assert.assertEquals(2, replicas.size());
-    Assert.assertEquals(3, c1.getReplicationFactor().getNumber());
+    Assert.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
   }
 
   private void addReplica(ContainerInfo cont, DatanodeDetails node)

--- a/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/container.robot
@@ -64,7 +64,7 @@ Verbose container info
                         Should contain   ${output}   Pipeline Info
 
 Close container
-    ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationFactor == "THREE") | .containerID' | head -1
+    ${container} =      Execute          ozone admin container list --state OPEN | jq -r 'select(.replicationConfig.replicationFactor == "THREE") | .containerID' | head -1
                         Execute          ozone admin container close "${container}"
     ${output} =         Execute          ozone admin container info "${container}"
                         Should contain   ${output}   CLOS

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -25,6 +25,7 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto
@@ -108,7 +109,7 @@ public class TestContainerStateManagerIntegration {
     Assert.assertEquals(SCMTestUtils.getReplicationType(conf),
         info.getReplicationType());
     Assert.assertEquals(SCMTestUtils.getReplicationFactor(conf),
-        info.getReplicationFactor());
+        ReplicationConfig.getLegacyFactor(info.getReplicationConfig()));
     Assert.assertEquals(HddsProtos.LifeCycleState.OPEN, info.getState());
 
     // Check there are two containers in ALLOCATED state after allocation
@@ -182,7 +183,7 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getReplicationType() == SCMTestUtils.getReplicationType(conf))
         .filter(info ->
-            info.getReplicationFactor() ==
+            ReplicationConfig.getLegacyFactor(info.getReplicationConfig()) ==
                 SCMTestUtils.getReplicationFactor(conf))
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.OPEN)
@@ -194,7 +195,7 @@ public class TestContainerStateManagerIntegration {
         .filter(info ->
             info.getReplicationType() == SCMTestUtils.getReplicationType(conf))
         .filter(info ->
-            info.getReplicationFactor() ==
+            ReplicationConfig.getLegacyFactor(info.getReplicationConfig()) ==
                 SCMTestUtils.getReplicationFactor(conf))
         .filter(info ->
             info.getState() == HddsProtos.LifeCycleState.CLOSING)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.crypto.key.kms.KMSClientProvider;
 import org.apache.hadoop.crypto.key.kms.server.MiniKMS;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -327,7 +328,8 @@ public class TestOzoneAtRestEncryption {
         keyInfo.getLatestVersionLocations().getLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
-      if (!container.getReplicationFactor().equals(replicationFactor) || (
+      if (!ReplicationConfig.getLegacyFactor(container.getReplicationConfig())
+          .equals(replicationFactor) || (
           container.getReplicationType() != replicationType)) {
         return false;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -38,6 +38,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.OzoneQuota;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -807,7 +808,8 @@ public abstract class TestOzoneRpcClientAbstract {
         keyInfo.getLatestVersionLocations().getLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
-      if (!container.getReplicationFactor().equals(replicationFactor) || (
+      if (!ReplicationConfig.getLegacyFactor(container.getReplicationConfig())
+          .equals(replicationFactor) || (
           container.getReplicationType() != replicationType)) {
         return false;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -224,7 +225,8 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
         keyInfo.getLatestVersionLocations().getLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
-      if (!container.getReplicationFactor().equals(replicationFactor) || (
+      if (!ReplicationConfig.getLegacyFactor(container.getReplicationConfig())
+          .equals(replicationFactor) || (
           container.getReplicationType() != replicationType)) {
         return false;
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/scrubber/TestDataScrubber.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.ozone.dn.scrubber;
 
 import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -220,7 +221,8 @@ public class TestDataScrubber {
         keyInfo.getLatestVersionLocations().getLocationList()) {
       ContainerInfo container =
           storageContainerLocationClient.getContainer(info.getContainerID());
-      if (!container.getReplicationFactor().equals(replicationFactor) || (
+      if (!ReplicationConfig.getLegacyFactor(container.getReplicationConfig())
+          .equals(replicationFactor) || (
           container.getReplicationType() != replicationType)) {
         return false;
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -252,7 +252,7 @@ public class ContainerEndpoint {
 
             List<ContainerHistory> datanodes =
                 containerManager.getLatestContainerHistory(containerID,
-                    containerInfo.getReplicationFactor().getNumber());
+                    containerInfo.getReplicationConfig().getRequiredNodes());
             missingContainers.add(new MissingContainerMetadata(containerID,
                 container.getInStateSince(), keyCount, pipelineID, datanodes));
           } catch (IOException ioEx) {
@@ -312,7 +312,7 @@ public class ContainerEndpoint {
         UUID pipelineID = containerInfo.getPipelineID().getId();
         List<ContainerHistory> datanodes =
             containerManager.getLatestContainerHistory(containerID,
-                containerInfo.getReplicationFactor().getNumber());
+                containerInfo.getReplicationConfig().getRequiredNodes());
         unhealthyMeta.add(new UnhealthyContainerMetadata(
             c, datanodes, pipelineID, keyCount));
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthStatus.java
@@ -42,7 +42,7 @@ public class ContainerHealthStatus {
   ContainerHealthStatus(ContainerInfo container,
       Set<ContainerReplica> replicas, PlacementPolicy placementPolicy) {
     this.container = container;
-    int repFactor = container.getReplicationFactor().getNumber();
+    int repFactor = container.getReplicationConfig().getRequiredNodes();
     this.replicas = replicas
         .stream()
         .filter(r -> !r.getState()
@@ -61,7 +61,7 @@ public class ContainerHealthStatus {
   }
 
   public int getReplicationFactor() {
-    return container.getReplicationFactor().getNumber();
+    return container.getReplicationConfig().getRequiredNodes();
   }
 
   public boolean isHealthy() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -465,11 +466,11 @@ public class TestContainerEndpoint {
   ContainerInfo newContainerInfo(long containerId) {
     return new ContainerInfo.Builder()
         .setContainerID(containerId)
-        .setReplicationType(HddsProtos.ReplicationType.RATIS)
+        .setReplicationConfig(
+            new RatisReplicationConfig(ReplicationFactor.THREE))
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setOwner("owner1")
         .setNumberOfKeys(keyCount)
-        .setReplicationFactor(ReplicationFactor.THREE)
         .setPipelineID(pipelineID)
         .build();
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -20,13 +20,13 @@ package org.apache.hadoop.ozone.recon.api;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos
     .ExtendedDatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.PipelineID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -160,11 +160,10 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
     ContainerInfo containerInfo = new ContainerInfo.Builder()
         .setContainerID(containerId)
-        .setReplicationFactor(ReplicationFactor.ONE)
+        .setReplicationConfig(new RatisReplicationConfig(ReplicationFactor.ONE))
         .setState(LifeCycleState.OPEN)
         .setOwner("test")
         .setPipelineID(pipeline.getId())
-        .setReplicationType(ReplicationType.RATIS)
         .build();
     ContainerWithPipeline containerWithPipeline =
         new ContainerWithPipeline(containerInfo, pipeline);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.recon.fsck;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
@@ -50,8 +51,9 @@ public class TestContainerHealthStatus {
   public void setup() {
     placementPolicy = mock(PlacementPolicy.class);
     container = mock(ContainerInfo.class);
-    when(container.getReplicationFactor())
-        .thenReturn(HddsProtos.ReplicationFactor.THREE);
+    when(container.getReplicationConfig())
+        .thenReturn(
+            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
     when(container.containerID()).thenReturn(ContainerID.valueOf(123456));
     when(container.getContainerID()).thenReturn((long)123456);
     when(placementPolicy.validateContainerPlacement(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -225,8 +226,9 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     for (int i = 1; i <= num; i++) {
       ContainerInfo c = mock(ContainerInfo.class);
       when(c.getContainerID()).thenReturn((long)i);
-      when(c.getReplicationFactor())
-          .thenReturn(HddsProtos.ReplicationFactor.THREE);
+      when(c.getReplicationConfig())
+          .thenReturn(new RatisReplicationConfig(
+              HddsProtos.ReplicationFactor.THREE));
       when(c.containerID()).thenReturn(ContainerID.valueOf(i));
       containers.add(c);
     }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.recon.fsck;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
@@ -57,8 +58,9 @@ public class TestContainerHealthTaskRecordGenerator {
   public void setup() {
     placementPolicy = mock(PlacementPolicy.class);
     container = mock(ContainerInfo.class);
-    when(container.getReplicationFactor())
-        .thenReturn(HddsProtos.ReplicationFactor.THREE);
+    when(container.getReplicationConfig())
+        .thenReturn(
+            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
     when(container.containerID()).thenReturn(ContainerID.valueOf(123456));
     when(container.getContainerID()).thenReturn((long)123456);
     when(placementPolicy.validateContainerPlacement(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -48,7 +49,6 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState.OPEN;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.STAND_ALONE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition.CONTAINERS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_METADATA_DIRS;
@@ -144,10 +144,9 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationFactor(ONE)
+            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
             .setOwner("test")
             .setState(OPEN)
-            .setReplicationType(STAND_ALONE)
             .build();
     ContainerWithPipeline containerWithPipeline =
         new ContainerWithPipeline(containerInfo, pipeline);
@@ -165,11 +164,10 @@ public class AbstractReconContainerManagerTest {
               .setContainerID(cID.getId())
               .setNumberOfKeys(10)
               .setPipelineID(pipeline.getId())
-              .setReplicationFactor(ONE)
+              .setReplicationConfig(new StandaloneReplicationConfig(ONE))
               .setOwner("test")
               //add containers in all kinds of state
               .setState(stateTypes[i % stateTypeCount])
-              .setReplicationType(STAND_ALONE)
               .build();
       verifiedContainerPipeline.add(
           new ContainerWithPipeline(cInfo, pipeline));
@@ -200,10 +198,9 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationFactor(ONE)
+            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
             .setOwner("test")
             .setState(state)
-            .setReplicationType(STAND_ALONE)
             .build();
     return new ContainerWithPipeline(containerInfo, pipeline);
   }
@@ -219,10 +216,9 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationFactor(ONE)
+            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
             .setOwner("test")
             .setState(state)
-            .setReplicationType(STAND_ALONE)
             .build();
     return new ContainerWithPipeline(containerInfo, pipeline);
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.NavigableSet;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
@@ -184,11 +185,11 @@ public class TestReconContainerManager
   ContainerInfo newContainerInfo(long containerId, Pipeline pipeline) {
     return new ContainerInfo.Builder()
         .setContainerID(containerId)
-        .setReplicationType(HddsProtos.ReplicationType.RATIS)
+        .setReplicationConfig(new RatisReplicationConfig(
+            HddsProtos.ReplicationFactor.THREE))
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setOwner("owner2")
         .setNumberOfKeys(99L)
-        .setReplicationFactor(HddsProtos.ReplicationFactor.THREE)
         .setPipelineID(pipeline.getId())
         .build();
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorScm.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorScm.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.ozone.freon.containergenerator;
 import java.util.concurrent.Callable;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
@@ -78,8 +78,8 @@ public class GeneratorScm extends BaseGenerator {
           new ContainerInfo.Builder()
               .setContainerID(containerId)
               .setState(LifeCycleState.CLOSED)
-              .setReplicationFactor(ReplicationFactor.THREE)
-              .setReplicationType(ReplicationType.STAND_ALONE)
+              .setReplicationConfig(
+                  new StandaloneReplicationConfig(ReplicationFactor.THREE))
               .setOwner(getUserId())
               .build();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/genesis/BenchMarkContainerStateMap.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.genesis;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
@@ -107,9 +106,7 @@ public class BenchMarkContainerStateMap {
         ContainerInfo containerInfo = new ContainerInfo.Builder()
             .setState(CLOSED)
             .setPipelineID(pipeline.getId())
-            .setReplicationType(pipeline.getType())
-            .setReplicationFactor(ReplicationConfig
-                .getLegacyFactor(pipeline.getReplicationConfig()))
+            .setReplicationConfig(pipeline.getReplicationConfig())
             .setUsedBytes(0)
             .setNumberOfKeys(0)
             .setStateEnterTime(Time.now())
@@ -128,9 +125,7 @@ public class BenchMarkContainerStateMap {
         ContainerInfo containerInfo = new ContainerInfo.Builder()
             .setState(OPEN)
             .setPipelineID(pipeline.getId())
-            .setReplicationType(pipeline.getType())
-            .setReplicationFactor(ReplicationConfig
-                .getLegacyFactor(pipeline.getReplicationConfig()))
+            .setReplicationConfig(pipeline.getReplicationConfig())
             .setUsedBytes(0)
             .setNumberOfKeys(0)
             .setStateEnterTime(Time.now())
@@ -148,9 +143,7 @@ public class BenchMarkContainerStateMap {
       ContainerInfo containerInfo = new ContainerInfo.Builder()
           .setState(OPEN)
           .setPipelineID(pipeline.getId())
-          .setReplicationType(pipeline.getType())
-          .setReplicationFactor(ReplicationConfig
-              .getLegacyFactor(pipeline.getReplicationConfig()))
+          .setReplicationConfig(pipeline.getReplicationConfig())
           .setUsedBytes(0)
           .setNumberOfKeys(0)
           .setStateEnterTime(Time.now())
@@ -181,10 +174,7 @@ public class BenchMarkContainerStateMap {
     return new ContainerInfo.Builder()
         .setState(CLOSED)
         .setPipelineID(pipeline.getId())
-        .setReplicationType(
-            pipeline.getReplicationConfig().getReplicationType())
-        .setReplicationFactor(
-            ReplicationConfig.getLegacyFactor(pipeline.getReplicationConfig()))
+        .setReplicationConfig(pipeline.getReplicationConfig())
         .setUsedBytes(0)
         .setNumberOfKeys(0)
         .setStateEnterTime(Time.now())


### PR DESCRIPTION
## What changes were proposed in this pull request?

We introduced ReplicationConfig to most classes already, but we missed ContainerInfo.

This change will ensure that ContainerInfo uses ReplicationConfig rather than the legacy Type and Factor fields.

This is a backport of the same change committed to master, but with some additional needed for the EC branch to allow it to compile and work correctly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5313

## How was this patch tested?

New and existing unit tests
