### PR TITLE
HDDS-5289. UpdateDeleteTransactionId need not be persisted into DB

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -416,7 +416,6 @@ public final class ContainerStateManagerImpl
         final ContainerInfo info = containers.getContainerInfo(
             transaction.getKey());
         info.updateDeleteTransactionId(transaction.getValue());
-        containerStore.put(info.containerID(), info);
       }
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerV2.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerV2.java
@@ -156,7 +156,6 @@ public interface ContainerStateManagerV2 {
   /**
    *
    */
-  // Make this as @Replicate
   void updateDeleteTransactionId(Map<ContainerID, Long> deleteTransactionMap)
       throws IOException;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

With SCM HA, UpdateDeleteTransactionId need not be persisted in DB but will be learned via DN heartbeats.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5289

## How was this patch tested?
Existing tests.
