### PR TITLE
HDDS-5329. remove lockmanager and synchronize on containerinfo in replication manager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -122,7 +122,6 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.lease.LeaseManager;
-import org.apache.hadoop.ozone.lock.LockManager;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -572,7 +571,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           eventQueue,
           scmContext,
           serviceManager,
-          new LockManager<>(conf),
           scmNodeManager);
     }
     if(configurator.getScmSafeModeManager() != null) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
-import org.apache.hadoop.ozone.lock.LockManager;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
@@ -162,7 +161,6 @@ public class TestReplicationManager {
         eventQueue,
         SCMContext.emptyContext(),
         serviceManager,
-        new LockManager<>(conf),
         nodeManager);
 
     serviceManager.notifyStatusChanged();
@@ -186,7 +184,6 @@ public class TestReplicationManager {
         eventQueue,
         SCMContext.emptyContext(),
         serviceManager,
-        new LockManager<ContainerID>(config),
         nodeManager);
 
     serviceManager.notifyStatusChanged();


### PR DESCRIPTION

## What changes were proposed in this pull request?

ReplicationManager has a LockManager object that creates locks based on the ContainerInfo.getContainerID().However, this lockManager is not shared with other classes in SCM. It seems to be passed into only RM.When processing a container, RM locks using this.ICRs and FCRs can change the replicas and details stored in ContainerInfo and they lock a container using synchronized(containerInfo) while processing that Container in the report.As RM and ICR/FCR use different locks the locks do not protect against changes in each other.

this PR aims to remove LockManager from RM and just make it synchronize on the containerInfo object it is processing. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5329

## How was this patch tested?

unit test
