### PR TITLE
HDDS-5342. HTML report missing from acceptance results

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
@@ -23,7 +23,9 @@ source "$SCRIPT_DIR/../testlib.sh"
 tests=$(find_tests)
 cd "$SCRIPT_DIR"
 
-run_test_scripts ${tests}
-RESULT=$?
+RESULT=0
+run_test_scripts ${tests} || RESULT=$?
+
+generate_report "ozone-mr" "${ALL_RESULT_DIR}"
 
 exit ${RESULT}

--- a/hadoop-ozone/dist/src/main/compose/test-all.sh
+++ b/hadoop-ozone/dist/src/main/compose/test-all.sh
@@ -36,14 +36,14 @@ fi
 tests=$(find_tests)
 cd "$SCRIPT_DIR"
 
-run_test_scripts ${tests}
-RESULT=$?
-
-rebot --nostatusrc -N acceptance -d "$ALL_RESULT_DIR" "$ALL_RESULT_DIR"/*.xml
+RESULT=0
+run_test_scripts ${tests} || RESULT=$?
 
 if [ "$OZONE_WITH_COVERAGE" ]; then
   pkill -f JacocoServer
   cp /tmp/jacoco-combined.exec "$SCRIPT_DIR"/result
 fi
+
+generate_report "acceptance" "${ALL_RESULT_DIR}"
 
 exit $RESULT

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -24,8 +24,8 @@ source "$SCRIPT_DIR/../testlib.sh"
 tests=$(find_tests)
 cd "$SCRIPT_DIR"
 
-run_test_scripts ${tests}
-RESULT=$?
+RESULT=0
+run_test_scripts ${tests} || RESULT=$?
 
 generate_report "upgrade" "${ALL_RESULT_DIR}"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Make sure HTML report is generated even after failing tests.  Previously it was missing due to early exit from `test-all.sh` script.

https://issues.apache.org/jira/browse/HDDS-5342

## How was this patch tested?

Ran failing tests, verified `log.html` is generated:

```
$ OZONE_ACCEPTANCE_SUITE=failing ./hadoop-ozone/dev-support/checks/acceptance.sh
...
Output:  hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/result/failing1.xml
...
Output:  hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/result/failing2.xml
...
Log:     hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/result/log.html
Report:  hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/result/report.html

$ open target/acceptance/log.html
```

Also verified HTML reports are present in both successful and failed acceptance test artifacts:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/935969500