### PR TITLE
HDDS-4692. Handle CRLStatusReport got from DN heartbeats and persist them

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLStatus.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.hadoop.hdds.security.x509.crl;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.List;
+
+/**
+ * Class that contains the CRL status.
+ */
+public class CRLStatus {
+  private final long receivedCRLId;
+  private final List<Long> pendingCRLIds;
+
+  /**
+   * Constructs a CRL Status.
+   * @param receivedCRLId The last received CRL id.
+   * @param pendingCRLIds A list of CRL Ids that are pending processing.
+   */
+  public CRLStatus(long receivedCRLId, List<Long> pendingCRLIds) {
+    this.receivedCRLId = receivedCRLId;
+    this.pendingCRLIds = pendingCRLIds;
+  }
+
+
+  public long getReceivedCRLId() {
+    return receivedCRLId;
+  }
+
+  public List<Long> getPendingCRLIds() {
+    return pendingCRLIds;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof CRLStatus)) {
+      return false;
+    }
+
+    CRLStatus that = (CRLStatus) obj;
+
+    if (this.receivedCRLId != that.getReceivedCRLId()) {
+      return false;
+    }
+    if (this.pendingCRLIds.size() != that.getPendingCRLIds().size()) {
+      return false;
+    }
+
+    return CollectionUtils.isEqualCollection(this.pendingCRLIds,
+        that.getPendingCRLIds());
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(81, 145)
+        .append(receivedCRLId)
+        .append(pendingCRLIds)
+        .toHashCode();
+  }
+
+  @Override
+  public String toString() {
+    return "CRLStatus{" +
+        ", receivedCRLId=" + receivedCRLId +
+        ", pendingCRLIds=" + pendingCRLIds +
+        '}';
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLStatus.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/crl/CRLStatus.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.security.x509.crl;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.List;
@@ -80,7 +81,7 @@ public class CRLStatus {
   public String toString() {
     return "CRLStatus{" +
         ", receivedCRLId=" + receivedCRLId +
-        ", pendingCRLIds=" + pendingCRLIds +
+        ", pendingCRLIds=" + StringUtils.join(pendingCRLIds, ",") +
         '}';
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/authority/CertificateStore.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.scm.metadata.Replicate;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -33,6 +34,7 @@ import java.security.cert.X509Certificate;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  * This interface allows the DefaultCA to be portable and use different DB
@@ -156,6 +158,10 @@ public interface CertificateStore {
    * @return latest CRL id.
    */
   long getLatestCrlId();
+
+  CRLStatus getCRLStatusForDN(UUID uuid);
+
+  void setCRLStatusForDN(UUID uuid, CRLStatus crlStatus);
 
   /**
    * Different kind of Certificate stores.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/MockCAStore.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.security.x509.certificate.authority;
 
 import org.apache.hadoop.hdds.security.x509.certificate.CertInfo;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
+import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 
 /**
  *
@@ -100,5 +102,15 @@ public class MockCAStore implements CertificateStore {
   @Override
   public long getLatestCrlId() {
     return 0;
+  }
+
+  @Override
+  public CRLStatus getCRLStatusForDN(UUID uuid) {
+    return null;
+  }
+
+  @Override
+  public void setCRLStatusForDN(UUID uuid, CRLStatus crlStatus) {
+
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/CRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/CRLStatusReportHandler.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hdds.scm.crl;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CRLStatusReportFromDatanode;
@@ -26,6 +27,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateSto
 import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,40 +41,47 @@ public class CRLStatusReportHandler implements
 
   private static final Logger LOGGER = LoggerFactory
       .getLogger(CRLStatusReportHandler.class);
-  private final CertificateStore certStore;
+  private CertificateStore certStore = null;
+  private final boolean isSecurityEnabled;
 
-  public CRLStatusReportHandler(CertificateStore certificateStore) {
-    Preconditions.checkNotNull(certificateStore);
-    this.certStore = certificateStore;
+  public CRLStatusReportHandler(CertificateStore certificateStore,
+                                OzoneConfiguration conf) {
+    isSecurityEnabled = OzoneSecurityUtil.isSecurityEnabled(conf);
+    if (isSecurityEnabled) {
+      Preconditions.checkNotNull(certificateStore);
+      this.certStore = certificateStore;
+    }
   }
 
   @Override
   public void onMessage(CRLStatusReportFromDatanode reportFromDatanode,
       EventPublisher publisher) {
-    Preconditions.checkNotNull(reportFromDatanode);
-    DatanodeDetails dn = reportFromDatanode.getDatanodeDetails();
-    Preconditions.checkNotNull(dn, "CRLStatusReport is "
-        + "missing DatanodeDetails.");
+    if (isSecurityEnabled) {
+      Preconditions.checkNotNull(reportFromDatanode);
+      DatanodeDetails dn = reportFromDatanode.getDatanodeDetails();
+      Preconditions.checkNotNull(dn, "CRLStatusReport is "
+          + "missing DatanodeDetails.");
 
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Processing CRL status report for dn: {}", dn);
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Processing CRL status report for dn: {}", dn);
+      }
+      CRLStatusReport crlStatusReport = reportFromDatanode.getReport();
+      long receivedCRLId = crlStatusReport.getReceivedCrlId();
+      List<Long> pendingCRLIds = crlStatusReport.getPendingCrlIdsList();
+
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Updating Processed CRL Id: {} and Pending CRL Ids: {} ",
+            receivedCRLId,
+            pendingCRLIds);
+      }
+
+      CRLStatus crlStatus = new CRLStatus(receivedCRLId, pendingCRLIds);
+      certStore.setCRLStatusForDN(dn.getUuid(), crlStatus);
+
+      // Todo: send command for new CRL
+      // if crl > dn received crl id, then send a command to DN to process the
+      // new CRL via heartbeat response.
+
     }
-    CRLStatusReport crlStatusReport = reportFromDatanode.getReport();
-    long receivedCRLId = crlStatusReport.getReceivedCrlId();
-    List<Long> pendingCRLIds = crlStatusReport.getPendingCrlIdsList();
-
-    if (LOGGER.isTraceEnabled()) {
-      LOGGER.trace("Updating Processed CRL Id: {} and Pending CRL Ids: {} ",
-          receivedCRLId,
-          pendingCRLIds);
-    }
-
-    CRLStatus crlStatus = new CRLStatus(receivedCRLId, pendingCRLIds);
-    certStore.setCRLStatusForDN(dn.getUuid(), crlStatus);
-
-    // Todo: send command for new CRL
-    // if crl > dn received crl id, then send a command to DN to process the
-    // new CRL via heartbeat response.
-    
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/CRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/CRLStatusReportHandler.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.crl;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CRLStatusReportFromDatanode;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
+import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Handles CRL Status Reports from datanode.
+ */
+public class CRLStatusReportHandler implements
+    EventHandler<CRLStatusReportFromDatanode> {
+
+  private static final Logger LOGGER = LoggerFactory
+      .getLogger(CRLStatusReportHandler.class);
+  private final CertificateStore certStore;
+
+  public CRLStatusReportHandler(CertificateStore certificateStore) {
+    Preconditions.checkNotNull(certificateStore);
+    this.certStore = certificateStore;
+  }
+
+  @Override
+  public void onMessage(CRLStatusReportFromDatanode reportFromDatanode,
+      EventPublisher publisher) {
+    Preconditions.checkNotNull(reportFromDatanode);
+    DatanodeDetails dn = reportFromDatanode.getDatanodeDetails();
+    Preconditions.checkNotNull(dn, "CRLStatusReport is "
+        + "missing DatanodeDetails.");
+
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("Processing CRL status report for dn: {}", dn);
+    }
+    CRLStatusReport crlStatusReport = reportFromDatanode.getReport();
+    long receivedCRLId = crlStatusReport.getReceivedCrlId();
+    List<Long> pendingCRLIds = crlStatusReport.getPendingCrlIdsList();
+
+    if (LOGGER.isTraceEnabled()) {
+      LOGGER.trace("Updating Processed CRL Id: {} and Pending CRL Ids: {} ",
+          receivedCRLId,
+          pendingCRLIds);
+    }
+
+    CRLStatus crlStatus = new CRLStatus(receivedCRLId, pendingCRLIds);
+    certStore.setCRLStatusForDN(dn.getUuid(), crlStatus);
+
+    // Todo: send command for new CRL
+    // if crl > dn received crl id, then send a command to DN to process the
+    // new CRL via heartbeat response.
+    
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/package-info.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/crl/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ * <p>
+ */
+
+/**
+ * This package contains CRL related classes.
+ */
+package org.apache.hadoop.hdds.scm.crl;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.scm.command.CommandStatusReportHandler;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CRLStatusReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CommandStatusReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerActionsFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
@@ -193,6 +194,15 @@ public final class SCMEvents {
 
   public static final TypedEvent<SafeModeStatus> SAFE_MODE_STATUS =
       new TypedEvent<>(SafeModeStatus.class, "Safe mode status");
+
+  /**
+   * A CRL status report will be sent by datanodes. This report is received
+   * and processed by SCMDatanodeHeartbeatDispatcher.
+   */
+  public static final TypedEvent<CRLStatusReportFromDatanode>
+      CRL_STATUS_REPORT =
+      new TypedEvent<>(CRLStatusReportFromDatanode.class,
+          "Crl_Status_Report");
 
   /**
    * Private Ctor. Never Constructed.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -27,11 +27,12 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -69,14 +70,14 @@ public final class SCMCertStore implements CertificateStore {
       LoggerFactory.getLogger(SCMCertStore.class);
   private SCMMetadataStore scmMetadataStore;
   private final Lock lock;
-  private AtomicLong crlSequenceId;
-  private HashMap<UUID, CRLStatus> crlStatusMap;
+  private final AtomicLong crlSequenceId;
+  private final Map<UUID, CRLStatus> crlStatusMap;
 
   private SCMCertStore(SCMMetadataStore dbStore, long sequenceId) {
     this.scmMetadataStore = dbStore;
     lock = new ReentrantLock();
     crlSequenceId = new AtomicLong(sequenceId);
-    crlStatusMap = new HashMap<>();
+    crlStatusMap = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -299,7 +300,7 @@ public final class SCMCertStore implements CertificateStore {
   /**
    * Reinitialise the underlying store with SCMMetaStore
    * during SCM StateMachine reload.
-   * @param metadataStore
+   * @param metadataStore SCMMetadataStore
    */
   @Override
   public void reinitialize(SCMMetadataStore metadataStore) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -27,9 +27,11 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Date;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -37,6 +39,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
 import org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol;
+import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
@@ -67,11 +70,13 @@ public final class SCMCertStore implements CertificateStore {
   private SCMMetadataStore scmMetadataStore;
   private final Lock lock;
   private AtomicLong crlSequenceId;
+  private HashMap<UUID, CRLStatus> crlStatusMap;
 
   private SCMCertStore(SCMMetadataStore dbStore, long sequenceId) {
     this.scmMetadataStore = dbStore;
     lock = new ReentrantLock();
     crlSequenceId = new AtomicLong(sequenceId);
+    crlStatusMap = new HashMap<>();
   }
 
   @Override
@@ -362,5 +367,15 @@ public final class SCMCertStore implements CertificateStore {
   @Override
   public long getLatestCrlId() {
     return crlSequenceId.get();
+  }
+
+  @Override
+  public CRLStatus getCRLStatusForDN(UUID uuid) {
+    return crlStatusMap.get(uuid);
+  }
+
+  @Override
+  public void setCRLStatusForDN(UUID uuid, CRLStatus crlStatus) {
+    crlStatusMap.put(uuid, crlStatus);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -19,6 +19,8 @@ package org.apache.hadoop.hdds.scm.server;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.IncrementalContainerReportProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -287,4 +289,15 @@ public final class SCMDatanodeHeartbeatDispatcher {
     }
   }
 
+  /**
+   * CRL Status report event payload with origin.
+   */
+  public static class CRLStatusReportFromDatanode
+      extends ReportFromDatanode<CRLStatusReport> {
+
+    public CRLStatusReportFromDatanode(DatanodeDetails datanodeDetails,
+                                           CRLStatusReport report) {
+      super(datanodeDetails, report);
+    }
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -376,7 +376,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     PipelineActionHandler pipelineActionHandler =
         new PipelineActionHandler(pipelineManager, scmContext, conf);
     CRLStatusReportHandler crlStatusReportHandler =
-        new CRLStatusReportHandler(certificateStore);
+        new CRLStatusReportHandler(certificateStore, conf);
 
     scmAdminUsernames = conf.getTrimmedStringCollection(OzoneConfigKeys
         .OZONE_ADMINISTRATORS);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
+import org.apache.hadoop.hdds.scm.crl.CRLStatusReportHandler;
 import org.apache.hadoop.hdds.scm.ha.HASecurityUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
@@ -281,7 +282,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     Objects.requireNonNull(conf, "configuration cannot not be null");
 
     scmHANodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
-
     configuration = conf;
     initMetrics();
     containerReportCache = buildContainerReportCache();
@@ -370,13 +370,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     ContainerReportHandler containerReportHandler =
         new ContainerReportHandler(
             scmNodeManager, containerManager, scmContext, conf);
-
     IncrementalContainerReportHandler incrementalContainerReportHandler =
         new IncrementalContainerReportHandler(
             scmNodeManager, containerManager, scmContext);
-
     PipelineActionHandler pipelineActionHandler =
         new PipelineActionHandler(pipelineManager, scmContext, conf);
+    CRLStatusReportHandler crlStatusReportHandler =
+        new CRLStatusReportHandler(certificateStore);
 
     scmAdminUsernames = conf.getTrimmedStringCollection(OzoneConfigKeys
         .OZONE_ADMINISTRATORS);
@@ -413,6 +413,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
         (DeletedBlockLogImplV2) scmBlockManager.getDeletedBlockLog());
     eventQueue.addHandler(SCMEvents.PIPELINE_ACTIONS, pipelineActionHandler);
     eventQueue.addHandler(SCMEvents.PIPELINE_REPORT, pipelineReportHandler);
+    eventQueue.addHandler(SCMEvents.CRL_STATUS_REPORT, crlStatusReportHandler);
 
     containerBalancer = new ContainerBalancer(scmNodeManager,
         containerManager, replicationManager, configuration, scmContext);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -22,6 +22,8 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto
+    .StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.PipelineAction;
 import org.apache.hadoop.hdds.protocol.proto
@@ -431,6 +433,18 @@ public final class TestUtils {
     CommandStatusReportsProto.Builder report = CommandStatusReportsProto
         .newBuilder();
     report.addAllCmdStatus(reports);
+    return report.build();
+  }
+
+  /**
+   * Create CRL Status report object.
+   * @return {@link CRLStatusReport}
+   */
+  public static CRLStatusReport createCRLStatusReport(
+      List<Long> pendingCRLIds, long receivedCRLId) {
+    CRLStatusReport.Builder report = CRLStatusReport.newBuilder();
+    report.addAllPendingCrlIds(pendingCRLIds);
+    report.setReceivedCrlId(receivedCRLId);
     return report.build();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -438,6 +438,8 @@ public final class TestUtils {
 
   /**
    * Create CRL Status report object.
+   * @param pendingCRLIds List of Pending CRL Ids in the report.
+   * @param receivedCRLId Latest received CRL Id in the report.
    * @return {@link CRLStatusReport}
    */
   public static CRLStatusReport createCRLStatusReport(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateSto
 import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
 import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -55,6 +56,7 @@ public class TestCRLStatusReportHandler implements EventPublisher {
       .getLogger(TestCRLStatusReportHandler.class);
   private CRLStatusReportHandler crlStatusReportHandler;
   private CertificateStore certificateStore;
+  private SCMMetadataStore scmMetadataStore;
 
   @Rule
   public final TemporaryFolder tempDir = new TemporaryFolder();
@@ -69,13 +71,21 @@ public class TestCRLStatusReportHandler implements EventPublisher {
 
     SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
     Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
-    SCMMetadataStore scmMetadataStore = new SCMMetadataStoreImpl(config);
+    scmMetadataStore = new SCMMetadataStoreImpl(config);
     certificateStore = new SCMCertStore.Builder()
         .setRatisServer(null)
         .setMetadaStore(scmMetadataStore)
         .build();
     crlStatusReportHandler =
         new CRLStatusReportHandler(certificateStore, config);
+  }
+
+  @After
+  public void destroyDbStore() throws Exception {
+    if (scmMetadataStore.getStore() != null) {
+      scmMetadataStore.getStore().close();
+      scmMetadataStore = null;
+    }
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.crl;
+
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
+import org.apache.hadoop.hdds.scm.TestUtils;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
+import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
+import org.apache.hadoop.hdds.scm.server.SCMCertStore;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CRLStatusReportFromDatanode;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateStore;
+import org.apache.hadoop.hdds.security.x509.crl.CRLStatus;
+import org.apache.hadoop.hdds.server.events.Event;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test for the CRL Status Report Handler.
+ */
+public class TestCRLStatusReportHandler implements EventPublisher {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(TestCRLStatusReportHandler.class);
+  private CRLStatusReportHandler crlStatusReportHandler;
+  private CertificateStore certificateStore;
+
+  @Rule
+  public final TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Before
+  public void init() throws IOException {
+    OzoneConfiguration config = new OzoneConfiguration();
+
+    config.set(HddsConfigKeys.OZONE_METADATA_DIRS,
+        tempDir.newFolder().getAbsolutePath());
+
+    SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
+    Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
+    SCMMetadataStore scmMetadataStore = new SCMMetadataStoreImpl(config);
+    certificateStore = new SCMCertStore.Builder()
+        .setRatisServer(null)
+        .setMetadaStore(scmMetadataStore)
+        .build();
+    crlStatusReportHandler = new CRLStatusReportHandler(certificateStore);
+  }
+
+  @Test
+  public void testCRLStatusReport() {
+    DatanodeDetails dn1 = MockDatanodeDetails.randomDatanodeDetails();
+    DatanodeDetails dn2 = MockDatanodeDetails.randomDatanodeDetails();
+    List<Long> pendingCRLIds1 = new ArrayList<>();
+    List<Long> pendingCRLIds2 = new ArrayList<>();
+    pendingCRLIds1.add(3L);
+    pendingCRLIds1.add(4L);
+    pendingCRLIds2.add(1L);
+    CRLStatusReportFromDatanode reportFromDatanode1 =
+        getCRLStatusReport(dn1, pendingCRLIds1, 5L);
+    CRLStatusReportFromDatanode reportFromDatanode2 =
+        getCRLStatusReport(dn2, pendingCRLIds2, 2L);
+    crlStatusReportHandler.onMessage(reportFromDatanode1, this);
+    CRLStatus crlStatus = certificateStore.getCRLStatusForDN(dn1.getUuid());
+    Assert.assertTrue(crlStatus.getPendingCRLIds().containsAll(pendingCRLIds1));
+    Assert.assertEquals(5L, crlStatus.getReceivedCRLId());
+
+    pendingCRLIds1.remove(0);
+    reportFromDatanode1 = getCRLStatusReport(dn1, pendingCRLIds1, 6L);
+    crlStatusReportHandler.onMessage(reportFromDatanode1, this);
+    crlStatus = certificateStore.getCRLStatusForDN(dn1.getUuid());
+    Assert.assertEquals(1, crlStatus.getPendingCRLIds().size());
+    Assert.assertEquals(4L, crlStatus.getPendingCRLIds().get(0).longValue());
+    Assert.assertEquals(6L, crlStatus.getReceivedCRLId());
+
+    crlStatusReportHandler.onMessage(reportFromDatanode2, this);
+    crlStatus = certificateStore.getCRLStatusForDN(dn2.getUuid());
+    Assert.assertTrue(crlStatus.getPendingCRLIds().containsAll(pendingCRLIds2));
+    Assert.assertEquals(2L, crlStatus.getReceivedCRLId());
+  }
+
+  private CRLStatusReportFromDatanode getCRLStatusReport(
+      DatanodeDetails dn,
+      List<Long> pendingCRLIds,
+      long receivedCRLId) {
+    CRLStatusReport crlStatusReportProto =
+        TestUtils.createCRLStatusReport(pendingCRLIds, receivedCRLId);
+    return new CRLStatusReportFromDatanode(dn, crlStatusReportProto);
+  }
+
+  @Override
+  public <PAYLOAD, EVENT_TYPE extends Event<PAYLOAD>> void fireEvent(
+      EVENT_TYPE event, PAYLOAD payload) {
+    LOG.info("Event is published: {}", payload);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/crl/TestCRLStatusReportHandler.java
@@ -44,6 +44,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
+
 /**
  * Test for the CRL Status Report Handler.
  */
@@ -63,6 +65,7 @@ public class TestCRLStatusReportHandler implements EventPublisher {
 
     config.set(HddsConfigKeys.OZONE_METADATA_DIRS,
         tempDir.newFolder().getAbsolutePath());
+    config.setBoolean(OZONE_SECURITY_ENABLED_KEY, true);
 
     SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
     Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
@@ -71,7 +74,8 @@ public class TestCRLStatusReportHandler implements EventPublisher {
         .setRatisServer(null)
         .setMetadaStore(scmMetadataStore)
         .build();
-    crlStatusReportHandler = new CRLStatusReportHandler(certificateStore);
+    crlStatusReportHandler =
+        new CRLStatusReportHandler(certificateStore, config);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

 - Add a heartbeat handler for CRLStatusReport received from DNs
 - Store CRL Status of each DN in SCM (in memory)
 - Add unit tests
 
 Todo:
 Send command to DNs to process new CRL. This will be covered in https://issues.apache.org/jira/browse/HDDS-5346

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4692

## How was this patch tested?

Added unit tests to test the report processing part.
