### PR TITLE
HDDS-5347. Wrong cache key for integration tests

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -247,10 +247,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.check }}
+          key: maven-repo-${{ hashFiles('mnt/ozone/**/pom.xml') }}-8-${{ matrix.profile }}
           restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-${{ hashFiles('mnt/ozone/**/pom.xml') }}-8
+            maven-repo-${{ hashFiles('mnt/ozone/**/pom.xml') }}
             maven-repo-
       - name: Execute tests
         run: mnt/ozone/hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
@@ -285,7 +285,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.check }}
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ github.job }}
           restore-keys: |
             maven-repo-${{ hashFiles('**/pom.xml') }}-8
             maven-repo-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Cache key for integration tests is incomplete, hash of pom.xml files is missing:
   ```
   Run actions/cache@v2
     with:
       path: ~/.m2/repository
       key: maven-repo--8-
       restore-keys: maven-repo--8
     maven-repo-
     maven-repo-
   ...
   Cache restored from key: maven-repo--8-
   ```
   Path for `hashFiles` needs to include the custom checkout dir for _integration_ check.

2. Fix reference to undefined `matrix.check` in _integration_ and _coverage_ checks.

https://issues.apache.org/jira/browse/HDDS-5347

## How was this patch tested?

Verified cache restore key in CI:

```
Run actions/cache@v2
  with:
    path: ~/.m2/repository
    key: maven-repo-56cc6f8280fca1fe3170b0f76702498cdbcf129fe0d6acde06a612c2a210b2c8-8-filesystem-hdds
    restore-keys: maven-repo-56cc6f8280fca1fe3170b0f76702498cdbcf129fe0d6acde06a612c2a210b2c8-8
  maven-repo-56cc6f8280fca1fe3170b0f76702498cdbcf129fe0d6acde06a612c2a210b2c8
  maven-repo-
...
Cache restored from key: maven-repo-6ff0cbbe45787840d0cb6dc629936b8771df1fdb184182b74c0fa60e4702c860-8
```

https://github.com/adoroszlai/hadoop-ozone/runs/2826201686#step:4:1