### PR TITLE
HDDS-5353. Avoid unnecessary executeBatch call in insertAudits

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/common/DatabaseHelper.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/audit/parser/common/DatabaseHelper.java
@@ -85,7 +85,7 @@ public final class DatabaseHelper {
         throw new FileNotFoundException("property file '"
             + ParserConsts.PROPS_FILE + "' not found in the classpath");
       }
-    } catch(Exception e){
+    } catch (Exception e){
       LOG.error(e.getMessage());
     }
 
@@ -124,8 +124,9 @@ public final class DatabaseHelper {
           preparedStatement.executeBatch();
         }
       }
-      if (!auditEntries.isEmpty()) {
-        preparedStatement.executeBatch(); // insert remaining records
+      if (auditEntries.size() % batchSize != 0) {
+        // insert remaining records
+        preparedStatement.executeBatch();
       }
     }
     return true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

If batchSize = 1000, and the auditEntries size also 1000.

Now the executeBatch will execute twice.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5353?filter=-2

## How was this patch tested?

