### PR TITLE
HDDS-5193. change to use getShortUserName instead of getUsername

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -541,7 +541,7 @@ public class RpcClient implements ClientProtocol {
    * @return listOfAcls
    * */
   private List<OzoneAcl> getAclList() {
-    return OzoneAclUtil.getAclList(ugi.getShortUserName(), ugi.getGroupNames(),
+    return OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
         userRights, groupRights);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -541,7 +541,7 @@ public class RpcClient implements ClientProtocol {
    * @return listOfAcls
    * */
   private List<OzoneAcl> getAclList() {
-    return OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
+    return OzoneAclUtil.getAclList(ugi.getShortUserName(), ugi.getGroupNames(),
         userRights, groupRights);
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -126,7 +126,7 @@ public final class OzoneAclUtil {
   public static boolean checkAclRights(List<OzoneAcl> acls,
       RequestContext context) throws OMException {
     String[] userGroups = context.getClientUgi().getGroupNames();
-    String userName = context.getClientUgi().getUserName();
+    String userName = context.getClientUgi().getShortUserName();
     ACLType aclToCheck = context.getAclRights();
     for (OzoneAcl acl : acls) {
       if (checkAccessInAcl(acl, userGroups, userName, aclToCheck)) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
-import static org.apache.hadoop.ozone.OzoneAcl.AclScope.DEFAULT;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.GROUP;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType.USER;
 import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.ALL;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneAclUtil.java
@@ -168,7 +168,6 @@ public final class OzoneAclUtil {
     List<OzoneAcl> inheritedAcls = null;
     if (parentAcls != null && !parentAcls.isEmpty()) {
       inheritedAcls = parentAcls.stream()
-          .filter(a -> a.getAclScope() == DEFAULT)
           .map(acl -> new OzoneAcl(acl.getType(), acl.getName(),
               acl.getAclBitSet(), ACCESS))
           .collect(Collectors.toList());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -264,9 +264,14 @@ public abstract class OMKeyRequest extends OMClientRequest {
       }
     }
 
-    // Inherit all acls from bucket
     if (bucketInfo != null) {
+      // Inherit DEFAULT acls from bucket only if DEFAULT acls for
+      // prefix are not set.
       if (OzoneAclUtil.inheritDefaultAcls(acls, bucketInfo.getAcls())) {
+        return acls;
+      }
+      // Inherit ACCESS acls from bucket for File/Key creation
+      if (OzoneAclUtil.inheritAccessAcls(acls, bucketInfo.getAcls())) {
         return acls;
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -245,10 +245,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
       OmBucketInfo bucketInfo, PrefixManager prefixManager) {
     List<OzoneAcl> acls = new ArrayList<>();
 
-    if(keyArgs.getAclsList() != null) {
-      acls.addAll(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()));
-    }
-
     // Inherit DEFAULT acls from prefix.
     if(prefixManager != null) {
       List< OmPrefixInfo > prefixList = prefixManager.getLongestPrefixPath(
@@ -268,8 +264,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
       }
     }
 
-    // Inherit DEFAULT acls from bucket only if DEFAULT acls for
-    // prefix are not set.
+    // Inherit all acls from bucket
     if (bucketInfo != null) {
       if (OzoneAclUtil.inheritDefaultAcls(acls, bucketInfo.getAcls())) {
         return acls;


### PR DESCRIPTION
HDDS-5193. change to use getShortUserName instead of getUsername

## What changes were proposed in this pull request?

IMHO, in kerberized cluster identity `pakapoj_tul@DEV.TAP` and `pakapoj_tul` are equal so I propose to use `getShortUsername()` instead of `getShortUsername()` from UGI interface when assign and/or compare any ACLs. To leverage **auth_to_local** property to translate any identity from `auth:KERBEROS` to plain username which should be consistent with identity from `auth:TOKEN`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5193

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

I manually tested on my ozone cluster, bare metal deployment. there are following tests
```
ozone sh vol create /vol1
ozone sh bucket create /vol1/bucket1
ozone fs -put sample_seq_data.snappy.orc /vol1/bucket1
ozone sh vol addacl --acl=user:pakapoj_tul:a /vol1
ozone sh bucket addacl --acl=user:pakapoj_tul:a /vol1/bucket1
ozone sh key addacl --acl=user:pakapoj_tul:a /vol1/bucket1/sample_seq_data.snappy.orc
ozone sh token get -t ozone.token
ozone s3 getsecret --om-service-id=dev-ozone
aws configure
aws s3 ls --endpoint http://mtg8-devozonem-01.dev.tap:9878 s3://common-bucket
aws s3api --endpoint http://mtg8-devozonem-01.dev.tap:9878 create-bucket --bucket buckettest
aws s3api --endpoint http://mtg8-devozonem-01.dev.tap:9878 delete-bucket --bucket buckettest
aws s3 cp --endpoint http://mtg8-devozonem-01.dev.tap:9878 README.md s3://common-bucket
aws s3 rm --endpoint http://mtg8-devozonem-01.dev.tap:9878 s3://common-bucket/README.md
```
also test by running spark application in cluster mode
```
val data = spark.read.format("orc").load(src)
data.write.format("orc").save(des)
```
given
```
src = "ofs://dev-ozone/vol1/bucket1/sample_seq_data.snappy.orc"
des = "ofs://dev-ozone/vol1/bucket1/mykey"
```