### PR TITLE
HDDS-5352. java.lang.ClassNotFoundException: org/eclipse/jetty/alpn/ALPN

### DIFF
--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -152,6 +152,9 @@
                   <shadedPattern>
                     ${shaded.prefix}.io
                   </shadedPattern>
+                  <excludes>
+                    <exclude>io!netty!*</exclude>
+                  </excludes>
                 </relocation>
 
                 <!-- handling some special packages with special names -->


### PR DESCRIPTION
## What changes were proposed in this pull request?
On a secure cluster with GRPC TLS enabled, Hive/Spark/HDFS commands that read data blocks from Ozone do not work.

This happens due to the shading of the ozone filesystem client JAR that changes the value of a String constant representing the io.netty package in code to org.apache.hadoop.ozone.shaded.io.netty in the class io.netty.util.internal.NativeLibraryLoader. The code in that class seems to be written in such a way that it can elude "shading", but in vain.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5352

## How was this patch tested?
Manually tested. 
Integration/Acceptance test pending.
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
