### PR TITLE
HDDS-4892. EC: Implement basic EC pipeline provider

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -263,6 +263,12 @@ public final class Pipeline {
   }
 
   public boolean isHealthy() {
+    // EC pipelines are not reported by the DN and do not have a leader. If a
+    // node goes stale or dead, EC pipelines will by closed like RATIS pipelines
+    // but at the current time there are not other health metrics for EC.
+    if (replicationConfig.getReplicationType() == ReplicationType.EC) {
+      return true;
+    }
     for (Long reportedTime : nodeStatus.values()) {
       if (reportedTime < 0) {
         return false;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -91,14 +91,15 @@ public final class MockPipeline {
   }
 
   public static Pipeline createEcPipeline() {
+    return createEcPipeline(new ECReplicationConfig(3, 2));
+  }
+
+  public static Pipeline createEcPipeline(ECReplicationConfig repConfig) {
 
     List<DatanodeDetails> nodes = new ArrayList<>();
-    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
-    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
-    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
-    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
-    nodes.add(MockDatanodeDetails.randomDatanodeDetails());
-
+    for (int i=0; i<repConfig.getRequiredNodes(); i++) {
+      nodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    }
     Map<DatanodeDetails, Integer> nodeIndexes = new HashMap<>();
 
     int index = nodes.size() - 1;
@@ -110,8 +111,7 @@ public final class MockPipeline {
     return Pipeline.newBuilder()
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
-        .setReplicationConfig(
-            new ECReplicationConfig(3, 2))
+        .setReplicationConfig(repConfig)
         .setNodes(nodes)
         .setReplicaIndexes(nodeIndexes)
         .build();

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -81,4 +81,10 @@ public class TestPipeline {
           reloadedPipeline.getReplicaIndex(dn));
     }
   }
+
+  @Test
+  public void testECPipelineIsAlwaysHealthy() throws IOException {
+    Pipeline pipeline = MockPipeline.createEcPipeline();
+    Assert.assertTrue(pipeline.isHealthy());
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementMetrics.java
@@ -53,8 +53,18 @@ public class SCMContainerPlacementMetrics implements MetricsSource {
   public SCMContainerPlacementMetrics() {
   }
 
+  /**
+   * Return the existing instance of SCMContainerPlacementMetrics if it is
+   * registered in the metrics System, otherwise create a new instance, register
+   * it and return it.
+   * @return A new or existing SCMContainerPlacementMetrics object
+   */
   public static SCMContainerPlacementMetrics create() {
     MetricsSystem ms = DefaultMetricsSystem.instance();
+    MetricsSource existingSource = ms.getSource(SOURCE_NAME);
+    if (existingSource != null) {
+      return (SCMContainerPlacementMetrics)existingSource;
+    }
     registry = new MetricsRegistry(RECORD_INFO);
     return ms.register(SOURCE_NAME, "SCM Container Placement Metrics",
         new SCMContainerPlacementMetrics());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class to create pipelines for EC containers.
+ */
+public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
+
+  // TODO - EC Placement Policy. Standard Network Aware topology will not work
+  //        for EC as it stands. We may want an "as many racks as possible"
+  //        policy.
+
+  private final ConfigurationSource conf;
+  private final PlacementPolicy placementPolicy;
+
+  public ECPipelineProvider(NodeManager nodeManager,
+                            StateManager stateManager,
+                            ConfigurationSource conf,
+                            PlacementPolicy placementPolicy) {
+    super(nodeManager, stateManager);
+    this.conf = conf;
+    this.placementPolicy = placementPolicy;
+  }
+
+  @Override
+  protected Pipeline create(ECReplicationConfig replicationConfig)
+      throws IOException {
+    List<DatanodeDetails> dns = placementPolicy.chooseDatanodes(null,
+        null, replicationConfig.getRequiredNodes(), 0);
+    return create(replicationConfig, dns);
+  }
+
+  @Override
+  protected Pipeline create(ECReplicationConfig replicationConfig,
+      List<DatanodeDetails> nodes) {
+
+    Map<DatanodeDetails, Integer> dnIndexes = new HashMap<>();
+    int ecIndex = 0;
+    for (DatanodeDetails dn : nodes) {
+      dnIndexes.put(dn, ecIndex);
+      ecIndex++;
+    }
+
+    return Pipeline.newBuilder()
+        .setId(PipelineID.randomId())
+        .setState(Pipeline.PipelineState.OPEN)
+        .setReplicationConfig(replicationConfig)
+        .setNodes(nodes)
+        .setReplicaIndexes(dnIndexes)
+        .build();
+  }
+
+  @Override
+  protected void close(Pipeline pipeline) throws IOException {
+    // TODO - don't need to tell the DNs to close, but need to ensure the
+    //        containers are all closed. Check the logic for closing a pipeline,
+    //        do we wait on containers to close first?
+  }
+
+  @Override
+  protected void shutdown() {
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -35,7 +35,7 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
   // TODO - EC Placement Policy. Standard Network Aware topology will not work
   //        for EC as it stands. We may want an "as many racks as possible"
-  //        policy.
+  //        policy. HDDS-5326.
 
   private final ConfigurationSource conf;
   private final PlacementPolicy placementPolicy;
@@ -62,7 +62,7 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
       List<DatanodeDetails> nodes) {
 
     Map<DatanodeDetails, Integer> dnIndexes = new HashMap<>();
-    int ecIndex = 0;
+    int ecIndex = 1;
     for (DatanodeDetails dn : nodes) {
       dnIndexes.put(dn, ecIndex);
       ecIndex++;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/ECPipelineProvider.java
@@ -70,7 +70,7 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
     return Pipeline.newBuilder()
         .setId(PipelineID.randomId())
-        .setState(Pipeline.PipelineState.OPEN)
+        .setState(Pipeline.PipelineState.ALLOCATED)
         .setReplicationConfig(replicationConfig)
         .setNodes(nodes)
         .setReplicaIndexes(dnIndexes)
@@ -79,9 +79,6 @@ public class ECPipelineProvider extends PipelineProvider<ECReplicationConfig> {
 
   @Override
   protected void close(Pipeline pipeline) throws IOException {
-    // TODO - don't need to tell the DNs to close, but need to ensure the
-    //        containers are all closed. Check the logic for closing a pipeline,
-    //        do we wait on containers to close first?
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -65,6 +65,17 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
       Collection<PipelineID> excludePipelines
   );
 
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  int getPipelineCount(
+      ReplicationConfig replicationConfig, Pipeline.PipelineState state
+  );
+
   void addContainerToPipeline(PipelineID pipelineID, ContainerID containerID)
       throws IOException;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerV2Impl.java
@@ -234,6 +234,19 @@ public class PipelineManagerV2Impl implements PipelineManager {
   }
 
   @Override
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  public int getPipelineCount(ReplicationConfig config,
+                                     Pipeline.PipelineState state) {
+    return stateManager.getPipelineCount(config, state);
+  }
+
+  @Override
   public void addContainerToPipeline(
       PipelineID pipelineID, ContainerID containerID) throws IOException {
     // should not lock here, since no ratis operation happens.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -105,10 +105,8 @@ public class PipelineStateManager implements StateManager {
    * @param state The current state of the pipelines to count
    * @return The count of pipelines meeting the above criteria
    */
-  public int getPipelineCount(
-      ReplicationConfig replicationConfig,
-      PipelineState state
-  ) {
+  public int getPipelineCount(ReplicationConfig replicationConfig,
+      PipelineState state) {
     return pipelineStateMap.getPipelineCount(replicationConfig, state);
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManager.java
@@ -98,6 +98,21 @@ public class PipelineStateManager implements StateManager {
   }
 
   @Override
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  public int getPipelineCount(
+      ReplicationConfig replicationConfig,
+      PipelineState state
+  ) {
+    return pipelineStateMap.getPipelineCount(replicationConfig, state);
+  }
+
+  @Override
   public NavigableSet<ContainerID> getContainers(PipelineID pipelineID)
       throws IOException {
     return pipelineStateMap.getContainers(pipelineID);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerV2Impl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerV2Impl.java
@@ -176,6 +176,26 @@ public class PipelineStateManagerV2Impl implements StateManager {
     }
   }
 
+
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  @Override
+  public int getPipelineCount(
+      ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state) {
+    lock.readLock().lock();
+    try {
+      return pipelineStateMap.getPipelineCount(replicationConfig, state);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
   @Override
   public NavigableSet<ContainerID> getContainers(PipelineID pipelineID)
       throws IOException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -184,6 +184,36 @@ class PipelineStateMap {
   }
 
   /**
+   * Get a count of pipelines with the given replicationConfig and state.
+   * This method is most efficient when getting a count for OPEN pipeline
+   * as the result can be obtained directly from the cached open list.
+   *
+   * @param replicationConfig - ReplicationConfig
+   * @param state             - Required PipelineState
+   * @return Count of pipelines with the specified replication config and state
+   */
+  int getPipelineCount(ReplicationConfig replicationConfig,
+      PipelineState state) {
+    Preconditions
+        .checkNotNull(replicationConfig, "ReplicationConfig cannot be null");
+    Preconditions.checkNotNull(state, "Pipeline state cannot be null");
+
+    if (state == PipelineState.OPEN) {
+      return query2OpenPipelines.getOrDefault(
+              replicationConfig, Collections.EMPTY_LIST).size();
+    }
+
+    int count = 0;
+    for (Pipeline pipeline : pipelineMap.values()) {
+      if (pipeline.getReplicationConfig().equals(replicationConfig)
+          && pipeline.getPipelineState() == state) {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  /**
    * Get list of pipeline corresponding to specified replication type,
    * replication factor and pipeline state.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/SCMPipelineManager.java
@@ -380,6 +380,17 @@ public class SCMPipelineManager implements
   }
 
   @Override
+  public int getPipelineCount(ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state) {
+    lock.readLock().lock();
+    try {
+      return stateManager.getPipelineCount(replicationConfig, state);
+    } finally {
+      lock.readLock().unlock();
+    }
+  }
+
+  @Override
   public void addContainerToPipeline(PipelineID pipelineID,
       ContainerID containerID) throws IOException {
     lock.writeLock().lock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/StateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/StateManager.java
@@ -91,6 +91,18 @@ public interface StateManager {
       Collection<PipelineID> excludePipelines
   );
 
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  int getPipelineCount(
+      ReplicationConfig replicationConfig,
+      Pipeline.PipelineState state
+  );
+
   NavigableSet<ContainerID> getContainers(PipelineID pipelineID)
       throws IOException;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableContainerFactory.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.pipeline;
 
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
@@ -33,12 +34,16 @@ public class WritableContainerFactory {
 
   private final WritableContainerProvider<ReplicationConfig> ratisProvider;
   private final WritableContainerProvider<ReplicationConfig> standaloneProvider;
+  private final WritableContainerProvider<ECReplicationConfig> ecProvider;
 
   public WritableContainerFactory(StorageContainerManager scm) {
     this.ratisProvider = new WritableRatisContainerProvider(
         scm.getConfiguration(), scm.getPipelineManager(),
         scm.getContainerManager(), scm.getPipelineChoosePolicy());
     this.standaloneProvider = ratisProvider;
+    this.ecProvider = new WritableECContainerProvider(scm.getConfiguration(),
+        scm.getPipelineManager(), scm.getContainerManager(),
+        scm.getPipelineChoosePolicy());
   }
 
   public ContainerInfo getContainer(final long size,
@@ -50,6 +55,9 @@ public class WritableContainerFactory {
           .getContainer(size, repConfig, owner, excludeList);
     case RATIS:
       return ratisProvider.getContainer(size, repConfig, owner, excludeList);
+    case EC:
+      return ecProvider.getContainer(size, (ECReplicationConfig)repConfig,
+          owner, excludeList);
     default:
       throw new IOException(repConfig.getReplicationType()
           + " is an invalid replication type");

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.PipelineRequestInformation;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.NavigableSet;
+
+import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
+
+/**
+ * Writable Container provider to obtain a writable container for EC pipelines.
+ */
+public class WritableECContainerProvider implements WritableContainerProvider {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(WritableECContainerProvider.class);
+
+  private static int minPipelines = 5;
+
+  private final ConfigurationSource conf;
+  private final PipelineManager pipelineManager;
+  private final PipelineChoosePolicy pipelineChoosePolicy;
+  private final ContainerManagerV2 containerManager;
+  private final long containerSize;
+
+  public WritableECContainerProvider(ConfigurationSource conf,
+      PipelineManager pipelineManager, ContainerManagerV2 containerManager,
+      PipelineChoosePolicy pipelineChoosePolicy) {
+    this.conf = conf;
+    this.pipelineManager = pipelineManager;
+    this.containerManager = containerManager;
+    this.pipelineChoosePolicy = pipelineChoosePolicy;
+    this.containerSize = getConfiguredContainerSize();
+  }
+
+  @Override
+  public ContainerInfo getContainer(final long size,
+      ReplicationConfig repConfig, String owner, ExcludeList excludeList)
+      throws IOException {
+    // TODO - Locking on Pipeline ID to prevent concurrent issues?
+    // TODO - exclude vs total available.
+    List<Pipeline> existingPipelines = pipelineManager.getPipelines(
+        repConfig, Pipeline.PipelineState.OPEN,
+        excludeList.getDatanodes(), excludeList.getPipelineIds());
+
+    if (existingPipelines.size() < minPipelines) {
+      try {
+        // TODO - PipelineManager should allow for creating a pipeline with
+        //        excluded nodes.
+        return allocateContainer(repConfig, size, owner);
+      } catch (IOException e) {
+        LOG.warn("Unable to allocate a container for {} with {} existing "
+            + "containers", repConfig, existingPipelines.size(), e);
+      }
+    }
+
+    PipelineRequestInformation pri =
+        PipelineRequestInformation.Builder.getBuilder().setSize(size).build();
+    Pipeline pipeline = null;
+    while (existingPipelines.size() > 0) {
+      try {
+        pipeline = pipelineChoosePolicy.choosePipeline(existingPipelines, pri);
+        ContainerInfo containerInfo = getContainerFromPipeline(pipeline);
+        if (!containerHasSpace(containerInfo, size)) {
+          // This is O(n), which isn't great if there are a lot of pipelines
+          // and we keep finding pipelines without enough space.
+          existingPipelines.remove(pipeline);
+          // TODO - when does it make sense to close the pipeline? What if the client makes
+          // unreasonable size requests, eg 2GB rather than the block size? Maybe we should
+          // only close if there is less space than the cluster block size.
+          // TODO - Also, for EC, what is the block size? If the client says 128MB, is that
+          // 128MB / 6 (for EC-6-3?)
+          pipelineManager.closePipeline(pipeline, true);
+        } else {
+          if (containerIsExcluded(containerInfo, excludeList)) {
+            existingPipelines.remove(pipeline);
+          } else {
+            return containerInfo;
+          }
+        }
+      } catch (PipelineNotFoundException | ContainerNotFoundException e) {
+        LOG.warn("Pipeline or container not found when selecting a writable "
+            + "container", e);
+        if (pipeline != null) {
+          existingPipelines.remove(pipeline);
+          pipelineManager.closePipeline(pipeline, true);
+        }
+      }
+    }
+    // TODO - handle excluded nodes
+    // TODO - skip this if the first allocate was tried and failed or try again?
+
+    // If we get here, all the pipelines we tried were no good. So try to
+    // allocate a new one and use it.
+    try {
+      return allocateContainer(repConfig, size, owner);
+    } catch (IOException e) {
+      LOG.error("Unable to allocate a container for {} after trying all "
+          + "existing containers", repConfig, e);
+      return null;
+    }
+  }
+
+  // TODO - this could throw IOEXception (SCMException) from container policy
+  //        if not enough nodes etc.
+  private ContainerInfo allocateContainer(ReplicationConfig repConfig,
+      long size, String owner) throws IOException {
+    Pipeline newPipeline = pipelineManager.createPipeline(repConfig);
+    return containerManager.getMatchingContainer(size, owner, newPipeline);
+  }
+
+  private boolean containerIsExcluded(ContainerInfo container,
+      ExcludeList excludeList) {
+    return excludeList.getContainerIds().contains(container.containerID());
+  }
+
+  private ContainerInfo getContainerFromPipeline(Pipeline pipeline)
+      throws IOException {
+    // Assume the container is still open if the below method returns it. On
+    // container FINALIZE, ContainerManager will remove the container from the
+    // pipeline list in PipelineManager. Finalize can be triggered by a DN
+    // sending a message that the container is full, or on close pipeline or
+    // on a stale / dead node event (via close pipeline).
+    NavigableSet<ContainerID> containers =
+        pipelineManager.getContainersInPipeline(pipeline.getId());
+    // Assume 1 container per pipeline for EC
+    ContainerID containerID = containers.first();
+    if (containerID == null) {
+      return null;
+    }
+    return containerManager.getContainer(containerID);
+  }
+
+  private boolean containerHasSpace(ContainerInfo container, long size) {
+    return container.getUsedBytes() + size <= containerSize;
+  }
+
+  private long getConfiguredContainerSize() {
+    return (long) conf.getStorageSize(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, BYTES);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -95,7 +95,7 @@ public class WritableECContainerProvider
       if (openPipelineCount < providerConfig.getMinimumPipelines()) {
         try {
           // TODO - PipelineManager should allow for creating a pipeline with
-          //        excluded nodes.
+          //        excluded nodes. HDDS-5375.
           return allocateContainer(repConfig, size, owner);
         } catch (IOException e) {
           LOG.warn("Unable to allocate a container for {} with {} existing "
@@ -148,7 +148,7 @@ public class WritableECContainerProvider
     try {
       synchronized(this) {
         // TODO - PipelineManager should allow for creating a pipeline with
-        //        excluded nodes.
+        //        excluded nodes. HDDS-5375.
         return allocateContainer(repConfig, size, owner);
       }
     } catch (IOException e) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -202,6 +202,9 @@ public class WritableECContainerProvider
         ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, BYTES);
   }
 
+  /**
+   * Class to hold configuration for WriteableECContainerProvider.
+   */
   @ConfigGroup(prefix = "ozone.scm.ec")
   public static class WritableECContainerProviderConfig {
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -181,6 +182,11 @@ public class TestSCMContainerPlacementRackAware {
         nodeManager, conf, cluster, true, metrics);
     policyNoFallback = new SCMContainerPlacementRackAware(
         nodeManager, conf, cluster, false, metrics);
+  }
+
+  @After
+  public void teardown() {
+    metrics.unRegister();
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -34,7 +34,7 @@ import java.util.stream.Stream;
 /**
  * Mock PipelineManager implementation for testing.
  */
-public final class MockPipelineManager implements PipelineManager {
+public class MockPipelineManager implements PipelineManager {
 
   private PipelineStateManager stateManager;
 
@@ -42,7 +42,7 @@ public final class MockPipelineManager implements PipelineManager {
     return new MockPipelineManager();
   }
 
-  private MockPipelineManager() {
+  MockPipelineManager() {
     this.stateManager = new PipelineStateManager();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -117,6 +117,19 @@ public class MockPipelineManager implements PipelineManager {
   }
 
   @Override
+  /**
+   * Returns the count of pipelines meeting the given ReplicationConfig and
+   * state.
+   * @param replicationConfig The ReplicationConfig of the pipelines to count
+   * @param state The current state of the pipelines to count
+   * @return The count of pipelines meeting the above criteria
+   */
+  public int getPipelineCount(ReplicationConfig replicationConfig,
+      final Pipeline.PipelineState state) {
+    return stateManager.getPipelineCount(replicationConfig, state);
+  }
+
+  @Override
   public void addContainerToPipeline(final PipelineID pipelineID,
                                      final ContainerID containerID)
       throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
+
+/**
+ * Test for the ECPipelineProvider.
+ */
+public class TestECPipelineProvider {
+
+  private PipelineProvider provider;
+  private OzoneConfiguration conf;
+  private NodeManager nodeManager = Mockito.mock(NodeManager.class);
+  private StateManager stateManager = Mockito.mock(StateManager.class);
+  private PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
+
+  @Before
+  public void setup() throws IOException {
+    conf = new OzoneConfiguration();
+    provider = new ECPipelineProvider(
+        nodeManager, stateManager, conf, placementPolicy);
+
+    // Placement policy will always return EC number of random nodes.
+    Mockito.when(placementPolicy.chooseDatanodes(Mockito.anyList(),
+        Mockito.anyList(), Mockito.anyInt(), Mockito.anyLong()))
+        .thenAnswer(invocation -> {
+          List<DatanodeDetails> dns = new ArrayList<>();
+          for (int i=0; i<(int)invocation.getArguments()[2]; i++) {
+            dns.add(MockDatanodeDetails.randomDatanodeDetails());
+          }
+          return dns;
+        });
+  }
+
+
+  @Test
+  public void testSimplePipelineCanBeCreatedWithIndexes() throws IOException {
+    ECReplicationConfig ecConf = new ECReplicationConfig(3, 2);
+    Pipeline pipeline = provider.create(ecConf);
+    Assert.assertEquals(EC, pipeline.getType());
+    Assert.assertEquals(ecConf.getData() + ecConf.getParity(),
+        pipeline.getNodes().size());
+    List<DatanodeDetails> dns = pipeline.getNodes();
+    for (int i=0; i<ecConf.getRequiredNodes(); i++) {
+      Assert.assertEquals(i, pipeline.getReplicaIndex(dns.get(i)));
+    }
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -19,11 +19,16 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -19,16 +19,11 @@
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,6 +34,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
+import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
 
 /**
  * Test for the ECPipelineProvider.
@@ -77,6 +73,7 @@ public class TestECPipelineProvider {
     Assert.assertEquals(EC, pipeline.getType());
     Assert.assertEquals(ecConf.getData() + ecConf.getParity(),
         pipeline.getNodes().size());
+    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     List<DatanodeDetails> dns = pipeline.getNodes();
     for (int i=0; i<ecConf.getRequiredNodes(); i++) {
       Assert.assertEquals(i, pipeline.getReplicaIndex(dns.get(i)));

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -76,7 +76,8 @@ public class TestECPipelineProvider {
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
     List<DatanodeDetails> dns = pipeline.getNodes();
     for (int i=0; i<ecConf.getRequiredNodes(); i++) {
-      Assert.assertEquals(i, pipeline.getReplicaIndex(dns.get(i)));
+      // EC DN indexes are numbered starting from 1 to N.
+      Assert.assertEquals(i+1, pipeline.getReplicaIndex(dns.get(i)));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -209,11 +209,17 @@ public class TestPipelineManagerImpl {
     Assert.assertFalse(pipelineManager
         .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
+    Assert.assertEquals(1, pipelineManager
+        .getPipelineCount(new RatisReplicationConfig(ReplicationFactor.THREE),
+            Pipeline.PipelineState.DORMANT));
 
     pipelineManager.activatePipeline(pipeline.getId());
     Assert.assertTrue(pipelineManager
         .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
+    Assert.assertEquals(1, pipelineManager
+        .getPipelineCount(new RatisReplicationConfig(ReplicationFactor.THREE),
+            Pipeline.PipelineState.OPEN));
     buffer.flush();
     Assert.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
     pipelineManager.close();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateMap.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests for PipelineStateMap.
+ */
+
+public class TestPipelineStateMap {
+
+  private PipelineStateMap map;
+
+  @Before
+  public void setup() {
+    map = new PipelineStateMap();
+  }
+
+  @After
+  public void teardown() throws IOException {
+  }
+
+  @Test
+  public void testCountPipelines() throws IOException {
+    Pipeline p;
+
+    // Open Stanadlone Pipelines
+    map.addPipeline(MockPipeline.createPipeline(1));
+    map.addPipeline(MockPipeline.createPipeline(1));
+    p = MockPipeline.createPipeline(1);
+    map.addPipeline(p);
+    map.updatePipelineState(p.getId(), Pipeline.PipelineState.CLOSED);
+
+    // Ratis pipeline
+    map.addPipeline(MockPipeline.createRatisPipeline());
+    p = MockPipeline.createRatisPipeline();
+    map.addPipeline(p);
+    map.updatePipelineState(p.getId(), Pipeline.PipelineState.CLOSED);
+
+    // EC Pipelines
+    map.addPipeline(MockPipeline.createEcPipeline(
+        new ECReplicationConfig(3, 2)));
+    map.addPipeline(MockPipeline.createEcPipeline(
+        new ECReplicationConfig(3, 2)));
+    p = MockPipeline.createEcPipeline(new ECReplicationConfig(3, 2));
+    map.addPipeline(p);
+    map.updatePipelineState(p.getId(), Pipeline.PipelineState.CLOSED);
+
+    assertEquals(2, map.getPipelineCount(new StandaloneReplicationConfig(ONE),
+        Pipeline.PipelineState.OPEN));
+    assertEquals(1, map.getPipelineCount(new RatisReplicationConfig(THREE),
+        Pipeline.PipelineState.OPEN));
+    assertEquals(2, map.getPipelineCount(new ECReplicationConfig(3, 2),
+        Pipeline.PipelineState.OPEN));
+
+    assertEquals(0, map.getPipelineCount(new ECReplicationConfig(6, 3),
+        Pipeline.PipelineState.OPEN));
+
+    assertEquals(1, map.getPipelineCount(new StandaloneReplicationConfig(ONE),
+        Pipeline.PipelineState.CLOSED));
+    assertEquals(1, map.getPipelineCount(new RatisReplicationConfig(THREE),
+        Pipeline.PipelineState.CLOSED));
+    assertEquals(1, map.getPipelineCount(new ECReplicationConfig(3, 2),
+        Pipeline.PipelineState.CLOSED));
+  }
+
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -12,7 +12,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
-import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.NavigableSet;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
@@ -37,19 +38,25 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Tests to validate the WritableECContainerProvider works correctly.
+ */
 public class TestWritableECContainerProvider {
 
   private static final Logger LOG = LoggerFactory
       .getLogger(TestWritableECContainerProvider.class);
-  private final static String OWNER = "SCM";
+  private static final String OWNER = "SCM";
   private PipelineManager pipelineManager = MockPipelineManager.getInstance();
-  private ContainerManagerV2 containerManager = Mockito.mock(ContainerManagerV2.class);
-  private PipelineChoosePolicy pipelineChoosingPolicy = new RandomPipelineChoosePolicy();
+  private ContainerManagerV2 containerManager
+      = Mockito.mock(ContainerManagerV2.class);
+  private PipelineChoosePolicy pipelineChoosingPolicy
+      = new HealthyPipelineChoosePolicy();
+
   private ConfigurationSource conf;
   private WritableContainerProvider provider;
   private ReplicationConfig repConfig;
 
-  Map<ContainerID, ContainerInfo> containers;
+  private Map<ContainerID, ContainerInfo> containers;
 
   @Before
   public void setup() throws ContainerNotFoundException {
@@ -63,7 +70,8 @@ public class TestWritableECContainerProvider {
       Pipeline pipeline = (Pipeline)call.getArguments()[2];
       ContainerInfo container = createContainer(pipeline,
           repConfig, System.nanoTime());
-      pipelineManager.addContainerToPipeline(pipeline.getId(), container.containerID());
+      pipelineManager.addContainerToPipeline(
+          pipeline.getId(), container.containerID());
       containers.put(container.containerID(), container);
       return container;
     }).when(containerManager).getMatchingContainer(Matchers.anyLong(),
@@ -80,51 +88,119 @@ public class TestWritableECContainerProvider {
   }
 
   @Test
-  public void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned() throws IOException {
+  public void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned()
+      throws IOException {
     // The first 5 calls should return a different container
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i=0; i<5; i++) {
-      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertFalse(allocatedContainers.contains(container));;
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));
       allocatedContainers.add(container);
     }
 
     allocatedContainers.clear();
     for (int i=0; i<20; i++) {
-      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
       allocatedContainers.add(container);
     }
     // Should have 5 containers created
     assertEquals(5, pipelineManager.getPipelines(repConfig, OPEN).size());
-    // We should have more than 1 allocatedContainers in the set proving a random
-    // container is selected each time. Do not check for 5 here as there is a
-    // reasonable chance that in 20 turns we don't pick all 5 nodes.
+    // We should have more than 1 allocatedContainers in the set proving a
+    // random container is selected each time. Do not check for 5 here as there
+    // is a reasonable chance that in 20 turns we don't pick all 5 nodes.
     assertTrue(allocatedContainers.size() > 2);
+  }
+
+  @Test
+  public void testPiplineLimitIgnoresExcludedPipelines() throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(
+          1, repConfig, OWNER, new ExcludeList());
+      allocatedContainers.add(container);
+    }
+    // We have the min limit of pipelines, but then exclude one. It should use
+    // one of the existing rather than createing a new one, as the limit is
+    // checked against all pipelines, not just the filtered list
+    ExcludeList exclude = new ExcludeList();
+    PipelineID excludedID = allocatedContainers
+        .stream().findFirst().get().getPipelineID();
+    exclude.addPipeline(excludedID);
+
+    ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude);
+    assertNotEquals(excludedID, c.getPipelineID());
+    assertTrue(allocatedContainers.contains(c));
+  }
+
+  @Test
+  public void testNewPipelineCreatedIfAllPipelinesExcluded()
+      throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(
+          1, repConfig, OWNER, new ExcludeList());
+      allocatedContainers.add(container);
+    }
+    // We have the min limit of pipelines, but then exclude one. It should use
+    // one of the existing rather than createing a new one, as the limit is
+    // checked against all pipelines, not just the filtered list
+    ExcludeList exclude = new ExcludeList();
+    for (ContainerInfo c : allocatedContainers) {
+      exclude.addPipeline(c.getPipelineID());
+    }
+    ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude);
+    assertFalse(allocatedContainers.contains(c));
+  }
+
+  @Test
+  public void testNewPipelineCreatedIfAllContainersExcluded()
+      throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(
+          1, repConfig, OWNER, new ExcludeList());
+      allocatedContainers.add(container);
+    }
+    // We have the min limit of pipelines, but then exclude one. It should use
+    // one of the existing rather than createing a new one, as the limit is
+    // checked against all pipelines, not just the filtered list
+    ExcludeList exclude = new ExcludeList();
+    for (ContainerInfo c : allocatedContainers) {
+      exclude.addConatinerId(c.containerID());
+    }
+    ContainerInfo c = provider.getContainer(1, repConfig, OWNER, exclude);
+    assertFalse(allocatedContainers.contains(c));
   }
 
   @Test
   public void testUnableToCreateAnyPipelinesReturnsNull() throws IOException {
     pipelineManager = new MockPipelineManager() {
       @Override
-      public Pipeline createPipeline(ReplicationConfig repConfig) throws IOException {
+      public Pipeline createPipeline(ReplicationConfig repConf)
+          throws IOException {
         throw new IOException("Cannot create pipelines");
       }
     };
     provider = new WritableECContainerProvider(
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
-    ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    ContainerInfo container =
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     assertNull(container);
   }
 
   @Test
-  public void testExistingPipelineReturnedWhenNewCannotBeCreated() throws IOException {
+  public void testExistingPipelineReturnedWhenNewCannotBeCreated()
+      throws IOException {
     pipelineManager = new MockPipelineManager() {
 
       private boolean throwError = false;
 
       @Override
-      public Pipeline createPipeline(ReplicationConfig repConfig) throws IOException {
+      public Pipeline createPipeline(ReplicationConfig repConf)
+          throws IOException {
         if (throwError) {
           throw new IOException("Cannot create pipelines");
         }
@@ -135,9 +211,11 @@ public class TestWritableECContainerProvider {
     provider = new WritableECContainerProvider(
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
-    ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    ContainerInfo container =
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     for (int i=0; i<5; i++) {
-      ContainerInfo nextContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      ContainerInfo nextContainer =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
       assertEquals(container, nextContainer);
     }
   }
@@ -147,8 +225,9 @@ public class TestWritableECContainerProvider {
       throws IOException {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i=0; i<5; i++) {
-      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertFalse(allocatedContainers.contains(container));;
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));
       allocatedContainers.add(container);
     }
     // Update all the containers to make them full
@@ -156,7 +235,8 @@ public class TestWritableECContainerProvider {
       c.setUsedBytes(getMaxContainerSize());
     }
     // Get a new container and ensure it is not one of the original set
-    ContainerInfo newContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    ContainerInfo newContainer =
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
     assertFalse(allocatedContainers.contains(newContainer));
     // The original pipelines should all be closed
@@ -167,19 +247,44 @@ public class TestWritableECContainerProvider {
   }
 
   @Test
-  public void testNewContainerAllocatedIfExistingAreExcluded() throws IOException {
-  }
+  public void testPipelineNotFoundWhenAttemptingToUseExisting()
+      throws IOException {
+    // Ensure PM throws PNF exception when we ask for the containers in the
+    // pipeline
+    pipelineManager = new MockPipelineManager() {
 
-  @Test
-  public void testPipelineNotFoundWhenAttemptingToUseExisting() throws IOException {
-  }
+      @Override
+      public NavigableSet<ContainerID> getContainersInPipeline(
+          PipelineID pipelineID) throws IOException {
+        throw new PipelineNotFoundException("Simulated exception");
+      }
+    };
+    provider = new WritableECContainerProvider(
+        conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
-  @Test
-  public void testContainerNotFoundWhenAttemptingToUseExisting() throws IOException {
     Set<ContainerInfo> allocatedContainers = new HashSet<>();
     for (int i=0; i<5; i++) {
-      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertFalse(allocatedContainers.contains(container));;
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));
+      allocatedContainers.add(container);
+    }
+    // Now attempt to get a container - any attempt to use an existing with
+    // throw PNF and then we must allocate a new one
+    ContainerInfo newContainer =
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    assertNotNull(newContainer);
+    assertFalse(allocatedContainers.contains(newContainer));
+  }
+
+  @Test
+  public void testContainerNotFoundWhenAttemptingToUseExisting()
+      throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));
       allocatedContainers.add(container);
     }
 
@@ -189,7 +294,8 @@ public class TestWritableECContainerProvider {
       throw new ContainerNotFoundException();
     }).when(containerManager).getContainer(Matchers.any(ContainerID.class));
 
-    ContainerInfo newContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    ContainerInfo newContainer =
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
     assertFalse(allocatedContainers.contains(newContainer));
 
@@ -200,14 +306,36 @@ public class TestWritableECContainerProvider {
     }
   }
 
-  // TODO - excluded pipelines and DNs
+  @Test
+  public void testPipelineOpenButContainerRemovedFromIt() throws IOException {
+    // This can happen if the container close process is triggered from the DN.
+    // When tha happens, CM will change the container state to CLOSING and
+    // remove it from the container list in pipeline Manager.
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(
+          1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));
+      allocatedContainers.add(container);
+      // Remove the container from the pipeline to simulate closing it
+      pipelineManager.removeContainerFromPipeline(
+          container.getPipelineID(), container.containerID());
+    }
+    ContainerInfo newContainer = provider.getContainer(
+        1, repConfig, OWNER, new ExcludeList());
+    assertFalse(allocatedContainers.contains(newContainer));
+    for (ContainerInfo c : allocatedContainers) {
+      Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
+      assertEquals(CLOSED, pipeline.getPipelineState());
+    }
+  }
 
   private ContainerInfo createContainer(Pipeline pipeline,
-      ReplicationConfig repConfig, long containerID) {
+      ReplicationConfig repConf, long containerID) {
     return new ContainerInfo.Builder()
         .setContainerID(containerID)
         .setOwner(OWNER)
-        .setReplicationConfig(repConfig)
+        .setReplicationConfig(repConf)
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setPipelineID(pipeline.getId())
         .setNumberOfKeys(0)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -1,0 +1,226 @@
+package org.apache.hadoop.hdds.scm.pipeline;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.PipelineChoosePolicy;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
+import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Matchers;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
+import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
+import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class TestWritableECContainerProvider {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(TestWritableECContainerProvider.class);
+  private final static String OWNER = "SCM";
+  private PipelineManager pipelineManager = MockPipelineManager.getInstance();
+  private ContainerManagerV2 containerManager = Mockito.mock(ContainerManagerV2.class);
+  private PipelineChoosePolicy pipelineChoosingPolicy = new RandomPipelineChoosePolicy();
+  private ConfigurationSource conf;
+  private WritableContainerProvider provider;
+  private ReplicationConfig repConfig;
+
+  Map<ContainerID, ContainerInfo> containers;
+
+  @Before
+  public void setup() throws ContainerNotFoundException {
+    repConfig = new ECReplicationConfig(3, 2);
+    conf = new OzoneConfiguration();
+    containers = new HashMap<>();
+    provider = new WritableECContainerProvider(
+        conf, pipelineManager, containerManager, pipelineChoosingPolicy);
+
+    Mockito.doAnswer(call -> {
+      Pipeline pipeline = (Pipeline)call.getArguments()[2];
+      ContainerInfo container = createContainer(pipeline,
+          repConfig, System.nanoTime());
+      pipelineManager.addContainerToPipeline(pipeline.getId(), container.containerID());
+      containers.put(container.containerID(), container);
+      return container;
+    }).when(containerManager).getMatchingContainer(Matchers.anyLong(),
+        Matchers.anyString(), Matchers.any(Pipeline.class));
+
+    Mockito.doAnswer(call ->
+        containers.get((ContainerID)call.getArguments()[0]))
+        .when(containerManager).getContainer(Matchers.any(ContainerID.class));
+
+  }
+
+  @After
+  public void teardown() {
+  }
+
+  @Test
+  public void testPipelinesCreatedUpToMinLimitAndRandomPipelineReturned() throws IOException {
+    // The first 5 calls should return a different container
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));;
+      allocatedContainers.add(container);
+    }
+
+    allocatedContainers.clear();
+    for (int i=0; i<20; i++) {
+      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      allocatedContainers.add(container);
+    }
+    // Should have 5 containers created
+    assertEquals(5, pipelineManager.getPipelines(repConfig, OPEN).size());
+    // We should have more than 1 allocatedContainers in the set proving a random
+    // container is selected each time. Do not check for 5 here as there is a
+    // reasonable chance that in 20 turns we don't pick all 5 nodes.
+    assertTrue(allocatedContainers.size() > 2);
+  }
+
+  @Test
+  public void testUnableToCreateAnyPipelinesReturnsNull() throws IOException {
+    pipelineManager = new MockPipelineManager() {
+      @Override
+      public Pipeline createPipeline(ReplicationConfig repConfig) throws IOException {
+        throw new IOException("Cannot create pipelines");
+      }
+    };
+    provider = new WritableECContainerProvider(
+        conf, pipelineManager, containerManager, pipelineChoosingPolicy);
+
+    ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    assertNull(container);
+  }
+
+  @Test
+  public void testExistingPipelineReturnedWhenNewCannotBeCreated() throws IOException {
+    pipelineManager = new MockPipelineManager() {
+
+      private boolean throwError = false;
+
+      @Override
+      public Pipeline createPipeline(ReplicationConfig repConfig) throws IOException {
+        if (throwError) {
+          throw new IOException("Cannot create pipelines");
+        }
+        throwError = true;
+        return super.createPipeline(repConfig);
+      }
+    };
+    provider = new WritableECContainerProvider(
+        conf, pipelineManager, containerManager, pipelineChoosingPolicy);
+
+    ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    for (int i=0; i<5; i++) {
+      ContainerInfo nextContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertEquals(container, nextContainer);
+    }
+  }
+
+  @Test
+  public void testNewContainerAllocatedAndPipelinesClosedIfNoSpaceInExisting()
+      throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));;
+      allocatedContainers.add(container);
+    }
+    // Update all the containers to make them full
+    for (ContainerInfo c : allocatedContainers) {
+      c.setUsedBytes(getMaxContainerSize());
+    }
+    // Get a new container and ensure it is not one of the original set
+    ContainerInfo newContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    assertNotNull(newContainer);
+    assertFalse(allocatedContainers.contains(newContainer));
+    // The original pipelines should all be closed
+    for (ContainerInfo c : allocatedContainers) {
+      Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
+      assertEquals(CLOSED, pipeline.getPipelineState());
+    }
+  }
+
+  @Test
+  public void testNewContainerAllocatedIfExistingAreExcluded() throws IOException {
+  }
+
+  @Test
+  public void testPipelineNotFoundWhenAttemptingToUseExisting() throws IOException {
+  }
+
+  @Test
+  public void testContainerNotFoundWhenAttemptingToUseExisting() throws IOException {
+    Set<ContainerInfo> allocatedContainers = new HashSet<>();
+    for (int i=0; i<5; i++) {
+      ContainerInfo container = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      assertFalse(allocatedContainers.contains(container));;
+      allocatedContainers.add(container);
+    }
+
+    // Ensure ContainerManager always throws when a container is requested so
+    // existing pipelines cannot be used
+    Mockito.doAnswer(call -> {
+      throw new ContainerNotFoundException();
+    }).when(containerManager).getContainer(Matchers.any(ContainerID.class));
+
+    ContainerInfo newContainer = provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    assertNotNull(newContainer);
+    assertFalse(allocatedContainers.contains(newContainer));
+
+    // Ensure all the existing pipelines are closed
+    for (ContainerInfo c : allocatedContainers) {
+      Pipeline pipeline = pipelineManager.getPipeline(c.getPipelineID());
+      assertEquals(CLOSED, pipeline.getPipelineState());
+    }
+  }
+
+  // TODO - excluded pipelines and DNs
+
+  private ContainerInfo createContainer(Pipeline pipeline,
+      ReplicationConfig repConfig, long containerID) {
+    return new ContainerInfo.Builder()
+        .setContainerID(containerID)
+        .setOwner(OWNER)
+        .setReplicationConfig(repConfig)
+        .setState(HddsProtos.LifeCycleState.OPEN)
+        .setPipelineID(pipeline.getId())
+        .setNumberOfKeys(0)
+        .setUsedBytes(0)
+        .setSequenceId(0)
+        .setDeleteTransactionId(0)
+        .build();
+  }
+
+  private long getMaxContainerSize() {
+    return (long)conf.getStorageSize(
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE,
+        ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT, BYTES);
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerManagerV2;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoosePolicy;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Matchers;
@@ -62,7 +61,7 @@ public class TestWritableECContainerProvider {
   private static final Logger LOG = LoggerFactory
       .getLogger(TestWritableECContainerProvider.class);
   private static final String OWNER = "SCM";
-  private PipelineManager pipelineManager = MockPipelineManager.getInstance();
+  private PipelineManager pipelineManager;
   private ContainerManagerV2 containerManager
       = Mockito.mock(ContainerManagerV2.class);
   private PipelineChoosePolicy pipelineChoosingPolicy
@@ -84,6 +83,7 @@ public class TestWritableECContainerProvider {
             .WritableECContainerProviderConfig.class);
     minPipelines = providerConf.getMinimumPipelines();
     containers = new HashMap<>();
+    pipelineManager = MockPipelineManager.getInstance();
     provider = new WritableECContainerProvider(
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
@@ -102,10 +102,6 @@ public class TestWritableECContainerProvider {
         containers.get((ContainerID)call.getArguments()[0]))
         .when(containerManager).getContainer(Matchers.any(ContainerID.class));
 
-  }
-
-  @After
-  public void teardown() {
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This chance creates an ECPipelineProvider instance to allow for EC Pipelines to be created in the PipelineManager.

It also adds the the WritableEcContainerProvider, so a writable container can be selected from the open pipelines, or created if necessary.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4892

## How was this patch tested?

New unit tests
