### PR TITLE
HDDS-5384 OM refreshPipeline should not invoke the expensive OmKeyLocationInfoGroup.getLocationList()

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocationList;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -89,17 +90,27 @@ public class OmKeyLocationInfoGroup {
     return version;
   }
 
+  /**
+   * Use this expensive method only when absolutely needed!
+   * It creates a new list so it is not an O(1) operation.
+   * Use getLocationLists() instead.
+   * @return a list of OmKeyLocationInfo
+   */
   public List<OmKeyLocationInfo> getLocationList() {
     return locationVersionMap.values().stream().flatMap(List::stream)
         .collect(Collectors.toList());
+  }
+
+  public Collection<List<OmKeyLocationInfo>> getLocationLists() {
+    return locationVersionMap.values();
   }
 
   public long getLocationListCount() {
     return locationVersionMap.values().stream().mapToLong(List::size).sum();
   }
 
-  public List<OmKeyLocationInfo> getLocationList(Long versionToFetch) {
-    return new ArrayList<>(locationVersionMap.get(versionToFetch));
+  public Collection<OmKeyLocationInfo> getLocationList(Long versionToFetch) {
+    return locationVersionMap.get(versionToFetch);
   }
 
   public KeyLocationList getProtobuf(boolean ignorePipeline,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -109,8 +109,8 @@ public class OmKeyLocationInfoGroup {
     return locationVersionMap.values().stream().mapToLong(List::size).sum();
   }
 
-  public Collection<OmKeyLocationInfo> getLocationList(Long versionToFetch) {
-    return locationVersionMap.get(versionToFetch);
+  public List<OmKeyLocationInfo> getLocationList(Long versionToFetch) {
+    return new ArrayList<>(locationVersionMap.get(versionToFetch));
   }
 
   public KeyLocationList getProtobuf(boolean ignorePipeline,

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
@@ -20,6 +20,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -39,7 +40,7 @@ public class TestOmKeyLocationInfoGroup {
   @Test
   public void testGettingPreviousVersions() {
     OmKeyLocationInfoGroup testInstance = createTestInstance();
-    List<OmKeyLocationInfo> list = testInstance.getLocationList(1L);
+    Collection<OmKeyLocationInfo> list = testInstance.getLocationList(1L);
     Assert.assertEquals(2, list.size());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -745,34 +745,40 @@ public class KeyManagerImpl implements KeyManager {
     }
 
     Set<Long> containerIDs = new HashSet<>();
-    keyList.forEach(
-        keyInfo -> keyInfo.getKeyLocationVersions().forEach(
-            key -> key.getLocationLists().forEach(
-                OmKeyLocationInfoList -> OmKeyLocationInfoList.forEach(
-                    k -> containerIDs.add(k.getContainerID())
-                )
-            )
-        )
-    );
+    for (OmKeyInfo keyInfo : keyList) {
+      List<OmKeyLocationInfoGroup> locationInfoGroups =
+          keyInfo.getKeyLocationVersions();
+
+      for (OmKeyLocationInfoGroup key : locationInfoGroups) {
+        for (List<OmKeyLocationInfo> omKeyLocationInfoList :
+            key.getLocationLists()) {
+          for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoList) {
+            containerIDs.add(omKeyLocationInfo.getContainerID());
+          }
+        }
+      }
+    }
 
     Map<Long, ContainerWithPipeline> containerWithPipelineMap =
         refreshPipeline(containerIDs);
 
-    keyList.forEach(
-        keyInfo -> keyInfo.getKeyLocationVersions().forEach(
-            key -> key.getLocationLists().forEach(
-                OmKeyLocationInfoList -> OmKeyLocationInfoList.forEach(
-                    k -> {
-                      ContainerWithPipeline cp =
-                          containerWithPipelineMap.get(k.getContainerID());
-                      if (cp != null && !cp.getPipeline().equals(k.getPipeline())) {
-                        k.setPipeline(cp.getPipeline());
-                      }
-                    }
-                )
-            )
-        )
-    );
+    for (OmKeyInfo keyInfo : keyList) {
+      List<OmKeyLocationInfoGroup> locationInfoGroups =
+          keyInfo.getKeyLocationVersions();
+      for (OmKeyLocationInfoGroup key : locationInfoGroups) {
+        for (List<OmKeyLocationInfo> omKeyLocationInfoList :
+            key.getLocationLists()) {
+          for (OmKeyLocationInfo omKeyLocationInfo : omKeyLocationInfoList) {
+            ContainerWithPipeline cp = containerWithPipelineMap.get(
+                omKeyLocationInfo.getContainerID());
+            if (cp != null &&
+                !cp.getPipeline().equals(omKeyLocationInfo.getPipeline())) {
+              omKeyLocationInfo.setPipeline(cp.getPipeline());
+            }
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -745,33 +745,34 @@ public class KeyManagerImpl implements KeyManager {
     }
 
     Set<Long> containerIDs = new HashSet<>();
-    for (OmKeyInfo keyInfo : keyList) {
-      List<OmKeyLocationInfoGroup> locationInfoGroups =
-          keyInfo.getKeyLocationVersions();
-
-      for (OmKeyLocationInfoGroup key : locationInfoGroups) {
-        for (OmKeyLocationInfo k : key.getLocationList()) {
-          containerIDs.add(k.getContainerID());
-        }
-      }
-    }
+    keyList.forEach(
+        keyInfo -> keyInfo.getKeyLocationVersions().forEach(
+            key -> key.getLocationLists().forEach(
+                OmKeyLocationInfoList -> OmKeyLocationInfoList.forEach(
+                    k -> containerIDs.add(k.getContainerID())
+                )
+            )
+        )
+    );
 
     Map<Long, ContainerWithPipeline> containerWithPipelineMap =
         refreshPipeline(containerIDs);
 
-    for (OmKeyInfo keyInfo : keyList) {
-      List<OmKeyLocationInfoGroup> locationInfoGroups =
-          keyInfo.getKeyLocationVersions();
-      for (OmKeyLocationInfoGroup key : locationInfoGroups) {
-        for (OmKeyLocationInfo k : key.getLocationList()) {
-          ContainerWithPipeline cp =
-              containerWithPipelineMap.get(k.getContainerID());
-          if (cp != null && !cp.getPipeline().equals(k.getPipeline())) {
-            k.setPipeline(cp.getPipeline());
-          }
-        }
-      }
-    }
+    keyList.forEach(
+        keyInfo -> keyInfo.getKeyLocationVersions().forEach(
+            key -> key.getLocationLists().forEach(
+                OmKeyLocationInfoList -> OmKeyLocationInfoList.forEach(
+                    k -> {
+                      ContainerWithPipeline cp =
+                          containerWithPipelineMap.get(k.getContainerID());
+                      if (cp != null && !cp.getPipeline().equals(k.getPipeline())) {
+                        k.setPipeline(cp.getPipeline());
+                      }
+                    }
+                )
+            )
+        )
+    );
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Reduce the CPU/heap allocation overhead of listStatus

## What is the link to the Apache JIRA
HDDS-5384

## How was this patch tested?
Please find the flamegraph attached in the corresponding JIRA for the cpu and heap allocation before and after the change.
