### PR TITLE
HDDS-5387. ProfileServlet to move the default output location to an ozone specific directory

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/ProfileServlet.java
@@ -129,7 +129,7 @@ public class ProfileServlet extends HttpServlet {
   private static final int DEFAULT_DURATION_SECONDS = 10;
   private static final AtomicInteger ID_GEN = new AtomicInteger(0);
   static final Path OUTPUT_DIR =
-      Paths.get(System.getProperty("java.io.tmpdir"), "prof-output");
+      Paths.get(System.getProperty("java.io.tmpdir"), "prof-output-ozone");
   public static final String FILE_PREFIX = "async-prof-pid-";
 
   public static final Pattern FILE_NAME_PATTERN =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sharing the output directory causes permission error, because typically they are run by separate users.
We should use an output directory specific to Ozone to avoid the permission issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5387

## How was this patch tested?

No need.
