### PR TITLE
HDDS-5349. Avoid usage of locks in listStatus.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2448,10 +2448,9 @@ public class KeyManagerImpl implements KeyManager {
     Preconditions.checkNotNull(args, "Key args can not be null");
 
     // unsorted OMKeyInfo list contains combine results from TableCache and DB.
-    List<OzoneFileStatus> fileStatusFinalList = new ArrayList<>();
 
     if (numEntries <= 0) {
-      return fileStatusFinalList;
+      return new ArrayList<>();;
     }
 
     /**
@@ -2519,26 +2518,14 @@ public class KeyManagerImpl implements KeyManager {
       // (1)Seek files in fileTable
       // (2)Seek dirs in dirTable
 
-      // First under lock obtain both entries from dir/file cache.
       Set<String> deletedKeySet = new TreeSet<>();
       TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
 
-      metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
-
-      try {
-        countEntries = listStatusFindFilesInTableCache(cacheFileMap,
-            metadataManager.getKeyTable(), prefixKeyInDB, seekFileInDB,
-            prefixPath, startKey, countEntries, numEntries, deletedKeySet);
-
-        listStatusFindDirsInTableCache(tempCacheDirMap,
-            metadataManager.getDirectoryTable(),
-            prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-            bucketName, countEntries, numEntries, deletedKeySet);
-      } finally {
-        metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-            bucketName);
-      }
+      // Get files, dirs and marked for delete entries from cache.
+      countEntries = getFilesAndDirsFromCache(volumeName, bucketName,
+          cacheFileMap, tempCacheDirMap, deletedKeySet, prefixKeyInDB,
+          seekFileInDB, seekDirInDB, prefixPath, startKey, countEntries,
+          numEntries);
 
       countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
           prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
@@ -2559,6 +2546,7 @@ public class KeyManagerImpl implements KeyManager {
             prefixKeyInDB, countEntries, numEntries, recursive,
             volumeName, bucketName, deletedKeySet);
       }
+
     } else {
       /*
        * startKey will be used in iterator seek and sets the beginning point
@@ -2605,7 +2593,6 @@ public class KeyManagerImpl implements KeyManager {
           // dirTable. So, its not required to search again in the fileTable.
 
           // Seek the given key in dirTable.
-
           metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
                 bucketName);
 
@@ -2620,7 +2607,6 @@ public class KeyManagerImpl implements KeyManager {
             metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
                 bucketName);
           }
-
 
           // Now first add all entries in the dir cache, if numEntries required
           // is less than countEntries.
@@ -2645,22 +2631,12 @@ public class KeyManagerImpl implements KeyManager {
 
           TreeSet<String> deletedKeySet = new TreeSet<>();
           TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
-          metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-              bucketName);
 
-          try {
-            countEntries = listStatusFindFilesInTableCache(cacheFileMap,
-                metadataManager.getKeyTable(), prefixKeyInDB, seekFileInDB,
-                prefixPath, startKey, countEntries, numEntries, deletedKeySet);
-
-            listStatusFindDirsInTableCache(tempCacheDirMap,
-                metadataManager.getDirectoryTable(),
-                prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-                bucketName, countEntries, numEntries, deletedKeySet);
-          } finally {
-            metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-          }
+          // Get files, dirs and marked for delete entries from cache.
+          countEntries = getFilesAndDirsFromCache(volumeName, bucketName,
+              cacheFileMap, tempCacheDirMap, deletedKeySet, prefixKeyInDB,
+              seekFileInDB, seekDirInDB, prefixPath, startKey, countEntries,
+              numEntries);
 
           // 1. Seek the given key in key table.
           countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
@@ -2694,7 +2670,26 @@ public class KeyManagerImpl implements KeyManager {
       }
     }
 
+    return buildFinalStatusList(cacheFileMap, cacheDirMap, args, clientAddress);
+
+  }
+
+  /**
+   * Build final OzoneFileStatus list to be returned to client.
+   * @param cacheFileMap
+   * @param cacheDirMap
+   * @param omKeyArgs
+   * @param clientAddress
+   * @return list of OzoneFileStatus
+   * @throws IOException
+   */
+  private List<OzoneFileStatus> buildFinalStatusList(
+      Map<String, OzoneFileStatus> cacheFileMap,
+      Map<String, OzoneFileStatus> cacheDirMap, OmKeyArgs omKeyArgs,
+      String clientAddress)
+      throws IOException {
     List<OmKeyInfo> keyInfoList = new ArrayList<>();
+    List<OzoneFileStatus> fileStatusFinalList = new ArrayList<>();
 
     for (OzoneFileStatus fileStatus : cacheFileMap.values()) {
       fileStatusFinalList.add(fileStatus);
@@ -2705,7 +2700,7 @@ public class KeyManagerImpl implements KeyManager {
       fileStatusFinalList.add(fileStatus);
     }
 
-    if (args.getLatestVersionLocation()) {
+    if (omKeyArgs.getLatestVersionLocation()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
     // refreshPipeline flag check has been removed as part of
@@ -2713,11 +2708,41 @@ public class KeyManagerImpl implements KeyManager {
     // Please refer this jira for more details.
     refreshPipeline(keyInfoList);
 
-    if (args.getSortDatanodes()) {
+    if (omKeyArgs.getSortDatanodes()) {
       sortDatanodes(clientAddress, keyInfoList.toArray(new OmKeyInfo[0]));
     }
 
     return fileStatusFinalList;
+  }
+
+  private int getFilesAndDirsFromCache(String volumeName, String bucketName,
+      Map<String, OzoneFileStatus> cacheFileMap,
+      Map<String, OzoneFileStatus> tempCacheDirMap,
+      Set<String> deletedKeySet, long prefixKeyInDB,
+      String seekFileInDB,  String seekDirInDB, String prefixPath,
+      String startKey, int countEntries, long numEntries) {
+    metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+        bucketName);
+
+    // First under lock obtain both entries from dir/file cache and generate
+    // entries marked for delete.
+    try {
+      countEntries = listStatusFindFilesInTableCache(cacheFileMap,
+          metadataManager.getKeyTable(), prefixKeyInDB, seekFileInDB,
+          prefixPath, startKey, countEntries, numEntries, deletedKeySet);
+
+      // Don't count entries from dir cache, as first we need to return all
+      // files and then directories.
+      listStatusFindDirsInTableCache(tempCacheDirMap,
+          metadataManager.getDirectoryTable(),
+          prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
+          bucketName, countEntries, numEntries, deletedKeySet);
+    } finally {
+      metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+          bucketName);
+    }
+
+    return countEntries;
   }
 
   @SuppressWarnings("parameternumber")
@@ -2803,7 +2828,7 @@ public class KeyManagerImpl implements KeyManager {
    */
   @SuppressWarnings("parameternumber")
   private int listStatusFindFilesInTableCache(
-          TreeMap<String, OzoneFileStatus> cacheKeyMap, Table<String,
+          Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
           OmKeyInfo> keyTable, long prefixKeyInDB, String seekKeyInDB,
           String prefixKeyPath, String startKey, int countEntries,
           long numEntries, Set<String> deletedKeySet) {
@@ -2845,7 +2870,7 @@ public class KeyManagerImpl implements KeyManager {
    */
   @SuppressWarnings("parameternumber")
   private int listStatusFindDirsInTableCache(
-          TreeMap<String, OzoneFileStatus> cacheKeyMap, Table<String,
+          Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
           OmDirectoryInfo> dirTable, long prefixKeyInDB, String seekKeyInDB,
           String prefixKeyPath, String startKey, String volumeName,
           String bucketName, int countEntries, long numEntries,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2676,11 +2676,6 @@ public class KeyManagerImpl implements KeyManager {
 
   /**
    * Build final OzoneFileStatus list to be returned to client.
-   * @param cacheFileMap
-   * @param cacheDirMap
-   * @param omKeyArgs
-   * @param clientAddress
-   * @return list of OzoneFileStatus
    * @throws IOException
    */
   private List<OzoneFileStatus> buildFinalStatusList(
@@ -2715,6 +2710,10 @@ public class KeyManagerImpl implements KeyManager {
     return fileStatusFinalList;
   }
 
+  /***
+   * Build files, directories and marked for deleted entries from dir/file
+   * cache.
+   */
   private int getFilesAndDirsFromCache(String volumeName, String bucketName,
       Map<String, OzoneFileStatus> cacheFileMap,
       Map<String, OzoneFileStatus> tempCacheDirMap,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2450,7 +2450,7 @@ public class KeyManagerImpl implements KeyManager {
     // unsorted OMKeyInfo list contains combine results from TableCache and DB.
 
     if (numEntries <= 0) {
-      return new ArrayList<>();;
+      return new ArrayList<>();
     }
 
     /**
@@ -2714,6 +2714,7 @@ public class KeyManagerImpl implements KeyManager {
    * Build files, directories and marked for deleted entries from dir/file
    * cache.
    */
+  @SuppressWarnings("parameternumber")
   private int getFilesAndDirsFromCache(String volumeName, String bucketName,
       Map<String, OzoneFileStatus> cacheFileMap,
       Map<String, OzoneFileStatus> tempCacheDirMap,
@@ -2905,7 +2906,7 @@ public class KeyManagerImpl implements KeyManager {
 
   @SuppressWarnings("parameternumber")
   private int addKeyInfoToFileStatusList(
-      TreeMap<String, OzoneFileStatus> cacheKeyMap,
+      Map<String, OzoneFileStatus> cacheKeyMap,
       long prefixKeyInDB, String seekKeyInDB, String startKey,
       int countEntries, String cacheKey, OmKeyInfo cacheOmKeyInfo,
       boolean isDirectory) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2286,6 +2286,7 @@ public class KeyManagerImpl implements KeyManager {
    * @return list of file status
    */
   @Override
+  @SuppressWarnings("methodlength")
   public List<OzoneFileStatus> listStatus(OmKeyArgs args, boolean recursive,
       String startKey, long numEntries, String clientAddress)
           throws IOException {
@@ -2663,7 +2664,8 @@ public class KeyManagerImpl implements KeyManager {
 
           // 1. Seek the given key in key table.
           countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-              prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
+              prefixPath, prefixKeyInDB, countEntries, numEntries,
+              deletedKeySet);
 
           // Now first add all entries in the dir cache, if numEntries required
           // is less than countEntries.
@@ -2764,7 +2766,8 @@ public class KeyManagerImpl implements KeyManager {
   private int getFilesFromDirectory(
       TreeMap<String, OzoneFileStatus> cacheKeyMap,
       String seekKeyInDB, String prefixKeyPath, long prefixKeyInDB,
-      int countEntries, long numEntries, Set<String> deletedKeySet) throws IOException {
+      int countEntries, long numEntries, Set<String> deletedKeySet)
+      throws IOException {
 
     Table<String, OmKeyInfo> keyTable = metadataManager.getKeyTable();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2485,230 +2485,224 @@ public class KeyManagerImpl implements KeyManager {
 
     // TODO: recursive flag=true will be handled in HDDS-4360 jira.
 
-    try {
-      if (Strings.isNullOrEmpty(startKey)) {
-        OzoneFileStatus fileStatus = getFileStatus(args, clientAddress);
-        if (fileStatus.isFile()) {
-          return Collections.singletonList(fileStatus);
-        }
 
-        // Not required to search in DeletedTable because all the deleted
-        // keys will be marked directly in dirTable or in keyTable by
-        // breaking the pointer to its sub-dirs and sub-files. So, there is no
-        // issue of inconsistency.
+    if (Strings.isNullOrEmpty(startKey)) {
+      OzoneFileStatus fileStatus = getFileStatus(args, clientAddress);
+      if (fileStatus.isFile()) {
+        return Collections.singletonList(fileStatus);
+      }
 
-        /*
-         * keyName is a directory.
-         * Say, "/a" is the dir name and its objectID is 1024, then seek
-         * will be doing with "1024/" to get all immediate descendants.
-         */
-        if (fileStatus.getKeyInfo() != null) {
-          prefixKeyInDB = fileStatus.getKeyInfo().getObjectID();
-        } else {
-          // list root directory.
-          String bucketKey = metadataManager.getBucketKey(volumeName,
-                  bucketName);
-          OmBucketInfo omBucketInfo =
-                  metadataManager.getBucketTable().get(bucketKey);
-          prefixKeyInDB = omBucketInfo.getObjectID();
-        }
-        seekFileInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
-        seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
+      // Not required to search in DeletedTable because all the deleted
+      // keys will be marked directly in dirTable or in keyTable by
+      // breaking the pointer to its sub-dirs and sub-files. So, there is no
+      // issue of inconsistency.
 
-        // Order of seek ->
-        // (1)Seek files in fileTable
-        // (2)Seek dirs in dirTable
-
-        // First under lock obtain both entries from dir/file cache.
-        Set<String> deletedKeySet = new TreeSet<>();
-        TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
-
-        metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-            bucketName);
-
-        try {
-          countEntries = listStatusFindFilesInTableCache(cacheFileMap,
-              metadataManager.getKeyTable(),
-              prefixKeyInDB, seekFileInDB, prefixPath, startKey,
-              countEntries, numEntries, deletedKeySet);
-
-          listStatusFindDirsInTableCache(tempCacheDirMap,
-              metadataManager.getDirectoryTable(),
-              prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-              bucketName, countEntries, numEntries, deletedKeySet);
-        } finally {
-          metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-              bucketName);
-        }
-
-        countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-                prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
-
-        // Now first add all entries in the dir cache, if numEntries required
-        // is less than countEntries.
-        for (Map.Entry<String, OzoneFileStatus> dirEntry :
-            tempCacheDirMap.entrySet()) {
-          if (countEntries < numEntries) {
-            cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
-            countEntries++;
-          }
-        }
-
-        // 2. Seek the given key in dir table.
-        if (countEntries < numEntries) {
-          getDirectories(cacheDirMap, seekDirInDB, prefixPath,
-              prefixKeyInDB, countEntries, numEntries, recursive,
-              volumeName, bucketName, deletedKeySet);
-        }
+      /*
+       * keyName is a directory.
+       * Say, "/a" is the dir name and its objectID is 1024, then seek
+       * will be doing with "1024/" to get all immediate descendants.
+       */
+      if (fileStatus.getKeyInfo() != null) {
+        prefixKeyInDB = fileStatus.getKeyInfo().getObjectID();
       } else {
-        /*
-         * startKey will be used in iterator seek and sets the beginning point
-         * for key traversal.
-         * keyName will be used as parentID where the user has requested to
-         * list the keys from.
-         *
-         * When recursive flag=false, parentID won't change between two pages.
-         * For example: OM has a namespace like,
-         *    /a/1...1M files and /a/b/1...1M files.
-         *    /a/1...1M directories and /a/b/1...1M directories.
-         * Listing "/a", will always have the parentID as "a" irrespective of
-         * the startKey value.
-         */
+        // list root directory.
+        String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
+        OmBucketInfo omBucketInfo =
+            metadataManager.getBucketTable().get(bucketKey);
+        prefixKeyInDB = omBucketInfo.getObjectID();
+      }
+      seekFileInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
+      seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
 
-        // Check startKey is an immediate child of keyName. For example,
-        // keyName=/a/ and expected startKey=/a/b. startKey can't be /xyz/b.
-        if (StringUtils.isNotBlank(keyName) &&
-                !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
-                    "Returns empty list", startKey, keyName);
-          }
-          return Collections.emptyList();
-        }
+      // Order of seek ->
+      // (1)Seek files in fileTable
+      // (2)Seek dirs in dirTable
 
-        // assign startKeyPath if prefixPath is empty string.
-        if (StringUtils.isBlank(prefixPath)) {
-          prefixPath = OzoneFSUtils.getParentDir(startKey);
-        }
+      // First under lock obtain both entries from dir/file cache.
+      Set<String> deletedKeySet = new TreeSet<>();
+      TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
 
-        OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(volumeName,
-                bucketName, startKey, false, null,
-                args.getLatestVersionLocation(), true);
+      metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+          bucketName);
 
-        if (fileStatusInfo != null) {
-          prefixKeyInDB = fileStatusInfo.getKeyInfo().getParentObjectID();
-          if(fileStatusInfo.isDirectory()){
-            seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB,
-                    fileStatusInfo.getKeyInfo().getFileName());
+      try {
+        countEntries = listStatusFindFilesInTableCache(cacheFileMap,
+            metadataManager.getKeyTable(), prefixKeyInDB, seekFileInDB,
+            prefixPath, startKey, countEntries, numEntries, deletedKeySet);
 
-            // Order of seek -> (1) Seek dirs only in dirTable. In OM, always
-            // the order of search is, first seek into fileTable and then
-            // dirTable. So, its not required to search again in the fileTable.
+        listStatusFindDirsInTableCache(tempCacheDirMap,
+            metadataManager.getDirectoryTable(),
+            prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
+            bucketName, countEntries, numEntries, deletedKeySet);
+      } finally {
+        metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+            bucketName);
+      }
 
-            // Seek the given key in dirTable.
+      countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
+          prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
 
-            metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-
-            TreeSet<String> deletedKeySet = new TreeSet<>();
-            TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
-            try {
-              listStatusFindDirsInTableCache(tempCacheDirMap,
-                  metadataManager.getDirectoryTable(),
-                  prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-                  bucketName, countEntries, numEntries, deletedKeySet);
-            } finally {
-              metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-                  bucketName);
-            }
-
-
-            // Now first add all entries in the dir cache, if numEntries required
-            // is less than countEntries.
-            for (Map.Entry<String, OzoneFileStatus> dirEntry :
-                tempCacheDirMap.entrySet()) {
-              if (countEntries < numEntries) {
-                cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
-                countEntries++;
-              }
-            }
-
-            if (countEntries < numEntries) {
-              getDirectories(cacheDirMap, seekDirInDB, prefixPath,
-                  prefixKeyInDB, countEntries, numEntries, recursive,
-                  volumeName, bucketName, deletedKeySet);
-            }
-          } else {
-            seekFileInDB = metadataManager.getOzonePathKey(prefixKeyInDB,
-                    fileStatusInfo.getKeyInfo().getFileName());
-            // begins from the first sub-dir under the parent dir
-            seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
-
-
-
-            TreeSet<String> deletedKeySet = new TreeSet<>();
-            TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
-            metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-
-            try {
-              countEntries = listStatusFindFilesInTableCache(cacheFileMap,
-                  metadataManager.getKeyTable(),
-                  prefixKeyInDB, seekFileInDB, prefixPath, startKey,
-                  countEntries, numEntries, deletedKeySet);
-
-              listStatusFindDirsInTableCache(tempCacheDirMap,
-                  metadataManager.getDirectoryTable(),
-                  prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-                  bucketName, countEntries, numEntries, deletedKeySet);
-            } finally {
-              metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-                  bucketName);
-            }
-
-            // 1. Seek the given key in key table.
-            countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-                prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
-
-            // Now first add all entries in the dir cache, if numEntries required
-            // is less than countEntries.
-            for (Map.Entry<String, OzoneFileStatus> dirEntry :
-                tempCacheDirMap.entrySet()) {
-              if (countEntries < numEntries) {
-                cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
-                countEntries++;
-              }
-            }
-
-            // 2. Seek the given key in dir table.
-            if (countEntries < numEntries) {
-              getDirectories(cacheDirMap, seekDirInDB, prefixPath,
-                  prefixKeyInDB, countEntries, numEntries, recursive,
-                  volumeName, bucketName, deletedKeySet);
-            }
-          }
-        } else {
-          // TODO: HDDS-4364: startKey can be a non-existed key
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("StartKey {} is a non-existed key and returning empty " +
-                    "list", startKey);
-          }
-          return Collections.emptyList();
+      // Now first add all entries in the dir cache, if numEntries required
+      // is less than countEntries.
+      for (Map.Entry<String, OzoneFileStatus> dirEntry :
+          tempCacheDirMap.entrySet()) {
+        if (countEntries < numEntries) {
+          cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
+          countEntries++;
         }
       }
-    } finally {
-      metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+
+      // 2. Seek the given key in dir table.
+      if (countEntries < numEntries) {
+        getDirectories(cacheDirMap, seekDirInDB, prefixPath,
+            prefixKeyInDB, countEntries, numEntries, recursive,
+            volumeName, bucketName, deletedKeySet);
+      }
+    } else {
+      /*
+       * startKey will be used in iterator seek and sets the beginning point
+       * for key traversal.
+       * keyName will be used as parentID where the user has requested to
+       * list the keys from.
+       *
+       * When recursive flag=false, parentID won't change between two pages.
+       * For example: OM has a namespace like,
+       *    /a/1...1M files and /a/b/1...1M files.
+       *    /a/1...1M directories and /a/b/1...1M directories.
+       * Listing "/a", will always have the parentID as "a" irrespective of
+       * the startKey value.
+       */
+
+      // Check startKey is an immediate child of keyName. For example,
+      // keyName=/a/ and expected startKey=/a/b. startKey can't be /xyz/b.
+      if (StringUtils.isNotBlank(keyName) &&
+          !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
+              "Returns empty list", startKey, keyName);
+        }
+        return Collections.emptyList();
+      }
+
+      // assign startKeyPath if prefixPath is empty string.
+      if (StringUtils.isBlank(prefixPath)) {
+        prefixPath = OzoneFSUtils.getParentDir(startKey);
+      }
+
+      OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(volumeName,
+          bucketName, startKey, false, null,
+          args.getLatestVersionLocation(), true);
+
+      if (fileStatusInfo != null) {
+        prefixKeyInDB = fileStatusInfo.getKeyInfo().getParentObjectID();
+        if(fileStatusInfo.isDirectory()){
+          seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB,
+              fileStatusInfo.getKeyInfo().getFileName());
+
+          // Order of seek -> (1) Seek dirs only in dirTable. In OM, always
+          // the order of search is, first seek into fileTable and then
+          // dirTable. So, its not required to search again in the fileTable.
+
+          // Seek the given key in dirTable.
+
+          metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+                bucketName);
+
+          TreeSet<String> deletedKeySet = new TreeSet<>();
+          TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
+          try {
+            listStatusFindDirsInTableCache(tempCacheDirMap,
+                metadataManager.getDirectoryTable(),
+                prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
+                bucketName, countEntries, numEntries, deletedKeySet);
+          } finally {
+            metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+                bucketName);
+          }
+
+
+          // Now first add all entries in the dir cache, if numEntries required
+          // is less than countEntries.
+          for (Map.Entry<String, OzoneFileStatus> dirEntry :
+              tempCacheDirMap.entrySet()) {
+            if (countEntries < numEntries) {
+              cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
+              countEntries++;
+            }
+          }
+
+          if (countEntries < numEntries) {
+            getDirectories(cacheDirMap, seekDirInDB, prefixPath,
+                prefixKeyInDB, countEntries, numEntries, recursive,
+                volumeName, bucketName, deletedKeySet);
+          }
+        } else {
+          seekFileInDB = metadataManager.getOzonePathKey(prefixKeyInDB,
+              fileStatusInfo.getKeyInfo().getFileName());
+          // begins from the first sub-dir under the parent dir
+          seekDirInDB = metadataManager.getOzonePathKey(prefixKeyInDB, "");
+
+          TreeSet<String> deletedKeySet = new TreeSet<>();
+          TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
+          metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
               bucketName);
+
+          try {
+            countEntries = listStatusFindFilesInTableCache(cacheFileMap,
+                metadataManager.getKeyTable(), prefixKeyInDB, seekFileInDB,
+                prefixPath, startKey, countEntries, numEntries, deletedKeySet);
+
+            listStatusFindDirsInTableCache(tempCacheDirMap,
+                metadataManager.getDirectoryTable(),
+                prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
+                bucketName, countEntries, numEntries, deletedKeySet);
+          } finally {
+            metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+                bucketName);
+          }
+
+          // 1. Seek the given key in key table.
+          countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
+              prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet);
+
+          // Now first add all entries in the dir cache, if numEntries required
+          // is less than countEntries.
+          for (Map.Entry<String, OzoneFileStatus> dirEntry :
+              tempCacheDirMap.entrySet()) {
+            if (countEntries < numEntries) {
+              cacheDirMap.put(dirEntry.getKey(), dirEntry.getValue());
+              countEntries++;
+            }
+          }
+
+          // 2. Seek the given key in dir table.
+          if (countEntries < numEntries) {
+            getDirectories(cacheDirMap, seekDirInDB, prefixPath,
+                prefixKeyInDB, countEntries, numEntries, recursive,
+                volumeName, bucketName, deletedKeySet);
+          }
+        }
+      } else {
+        // TODO: HDDS-4364: startKey can be a non-existed key
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("StartKey {} is a non-existed key and returning empty " +
+                    "list", startKey);
+        }
+        return Collections.emptyList();
+      }
     }
 
     List<OmKeyInfo> keyInfoList = new ArrayList<>();
+
     for (OzoneFileStatus fileStatus : cacheFileMap.values()) {
       fileStatusFinalList.add(fileStatus);
       keyInfoList.add(fileStatus.getKeyInfo());
     }
+
     for (OzoneFileStatus fileStatus : cacheDirMap.values()) {
       fileStatusFinalList.add(fileStatus);
     }
+
     if (args.getLatestVersionLocation()) {
       slimLocationVersion(keyInfoList.toArray(new OmKeyInfo[0]));
     }
@@ -2716,9 +2710,11 @@ public class KeyManagerImpl implements KeyManager {
     // https://issues.apache.org/jira/browse/HDDS-3658.
     // Please refer this jira for more details.
     refreshPipeline(keyInfoList);
+
     if (args.getSortDatanodes()) {
       sortDatanodes(clientAddress, keyInfoList.toArray(new OmKeyInfo[0]));
     }
+
     return fileStatusFinalList;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2338,7 +2338,7 @@ public class KeyManagerImpl implements KeyManager {
       listStatusFindKeyInTableCache(cacheIter, keyArgs, startCacheKey,
           recursive, cacheKeyMap, deletedKeySet);
     } finally {
-      metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+      metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
           bucketName);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2318,110 +2318,111 @@ public class KeyManagerImpl implements KeyManager {
       startKey = OzoneFSUtils.addTrailingSlashIfNeeded(keyName);
     }
 
+    // Note: eliminating the case where startCacheKey could end with '//'
+    String keyArgs = OzoneFSUtils.addTrailingSlashIfNeeded(
+        metadataManager.getOzoneKey(volumeName, bucketName, keyName));
+
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
+
+    Table keyTable = metadataManager.getKeyTable();
     try {
-      Table keyTable = metadataManager.getKeyTable();
-      Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
+      Iterator< Map.Entry< CacheKey< String >, CacheValue< OmKeyInfo > > >
           cacheIter = keyTable.cacheIterator();
       String startCacheKey = OZONE_URI_DELIMITER + volumeName +
           OZONE_URI_DELIMITER + bucketName + OZONE_URI_DELIMITER +
           ((startKey.equals(OZONE_URI_DELIMITER)) ? "" : startKey);
-      // Note: eliminating the case where startCacheKey could end with '//'
-      String keyArgs = OzoneFSUtils.addTrailingSlashIfNeeded(
-          metadataManager.getOzoneKey(volumeName, bucketName, keyName));
 
       // First, find key in TableCache
       listStatusFindKeyInTableCache(cacheIter, keyArgs, startCacheKey,
           recursive, cacheKeyMap, deletedKeySet);
-      // Then, find key in DB
-      String seekKeyInDb =
-          metadataManager.getOzoneKey(volumeName, bucketName, startKey);
-      TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-          iterator = keyTable.iterator();
-      iterator.seek(seekKeyInDb);
-      int countEntries = 0;
-      if (iterator.hasNext()) {
-        if (iterator.key().equals(keyArgs)) {
-          // Skip the key itself, since we are listing inside the directory
-          iterator.next();
-        }
-        // Iterate through seek results
-        while (iterator.hasNext() && numEntries - countEntries > 0) {
-          String entryInDb = iterator.key();
-          OmKeyInfo omKeyInfo = iterator.value().getValue();
-          if (entryInDb.startsWith(keyArgs)) {
-            String entryKeyName = omKeyInfo.getKeyName();
-            if (recursive) {
-              // for recursive list all the entries
+    } finally {
+      metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+          bucketName);
+    }
+
+    // Then, find key in DB
+    String seekKeyInDb =
+        metadataManager.getOzoneKey(volumeName, bucketName, startKey);
+    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+        iterator = keyTable.iterator();
+    iterator.seek(seekKeyInDb);
+    int countEntries = 0;
+    if (iterator.hasNext()) {
+      if (iterator.key().equals(keyArgs)) {
+        // Skip the key itself, since we are listing inside the directory
+        iterator.next();
+      }
+      // Iterate through seek results
+      while (iterator.hasNext() && numEntries - countEntries > 0) {
+        String entryInDb = iterator.key();
+        OmKeyInfo omKeyInfo = iterator.value().getValue();
+        if (entryInDb.startsWith(keyArgs)) {
+          String entryKeyName = omKeyInfo.getKeyName();
+          if (recursive) {
+            // for recursive list all the entries
+            if (!deletedKeySet.contains(entryInDb)) {
+              cacheKeyMap.put(entryInDb, new OzoneFileStatus(omKeyInfo,
+                  scmBlockSize, !OzoneFSUtils.isFile(entryKeyName)));
+              countEntries++;
+            }
+            iterator.next();
+          } else {
+            // get the child of the directory to list from the entry. For
+            // example if directory to list is /a and entry is /a/b/c where
+            // c is a file. The immediate child is b which is a directory. c
+            // should not be listed as child of a.
+            String immediateChild = OzoneFSUtils
+                .getImmediateChild(entryKeyName, keyName);
+            boolean isFile = OzoneFSUtils.isFile(immediateChild);
+            if (isFile) {
               if (!deletedKeySet.contains(entryInDb)) {
-                cacheKeyMap.put(entryInDb, new OzoneFileStatus(omKeyInfo,
-                    scmBlockSize, !OzoneFSUtils.isFile(entryKeyName)));
+                cacheKeyMap.put(entryInDb,
+                    new OzoneFileStatus(omKeyInfo, scmBlockSize, !isFile));
                 countEntries++;
               }
               iterator.next();
             } else {
-              // get the child of the directory to list from the entry. For
-              // example if directory to list is /a and entry is /a/b/c where
-              // c is a file. The immediate child is b which is a directory. c
-              // should not be listed as child of a.
-              String immediateChild = OzoneFSUtils
-                  .getImmediateChild(entryKeyName, keyName);
-              boolean isFile = OzoneFSUtils.isFile(immediateChild);
-              if (isFile) {
-                if (!deletedKeySet.contains(entryInDb)) {
+              // if entry is a directory
+              if (!deletedKeySet.contains(entryInDb)) {
+                if (!entryKeyName.equals(immediateChild)) {
+                  OmKeyInfo fakeDirEntry = createDirectoryKey(
+                      omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
+                      immediateChild, omKeyInfo.getAcls());
                   cacheKeyMap.put(entryInDb,
-                      new OzoneFileStatus(omKeyInfo, scmBlockSize, !isFile));
-                  countEntries++;
+                      new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
+                } else {
+                  // If entryKeyName matches dir name, we have the info
+                  cacheKeyMap.put(entryInDb,
+                      new OzoneFileStatus(omKeyInfo, 0, true));
                 }
-                iterator.next();
-              } else {
-                // if entry is a directory
-                if (!deletedKeySet.contains(entryInDb)) {
-                  if (!entryKeyName.equals(immediateChild)) {
-                    OmKeyInfo fakeDirEntry = createDirectoryKey(
-                        omKeyInfo.getVolumeName(),
-                        omKeyInfo.getBucketName(),
-                        immediateChild,
-                        omKeyInfo.getAcls());
-                    cacheKeyMap.put(entryInDb,
-                        new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
-                  } else {
-                    // If entryKeyName matches dir name, we have the info
-                    cacheKeyMap.put(entryInDb,
-                        new OzoneFileStatus(omKeyInfo, 0, true));
-                  }
-                  countEntries++;
-                }
-                // skip the other descendants of this child directory.
-                iterator.seek(getNextGreaterString(
-                    volumeName, bucketName, immediateChild));
+                countEntries++;
               }
+              // skip the other descendants of this child directory.
+              iterator.seek(getNextGreaterString(volumeName, bucketName,
+                  immediateChild));
             }
-          } else {
-            break;
           }
-        }
-      }
-
-      countEntries = 0;
-      // Convert results in cacheKeyMap to List
-      for (OzoneFileStatus fileStatus : cacheKeyMap.values()) {
-        // No need to check if a key is deleted or not here, this is handled
-        // when adding entries to cacheKeyMap from DB.
-        fileStatusList.add(fileStatus);
-        countEntries++;
-        if (countEntries >= numEntries) {
+        } else {
           break;
         }
       }
-      // Clean up temp map and set
-      cacheKeyMap.clear();
-      deletedKeySet.clear();
-    } finally {
-      metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
     }
+
+    countEntries = 0;
+    // Convert results in cacheKeyMap to List
+    for (OzoneFileStatus fileStatus : cacheKeyMap.values()) {
+      // No need to check if a key is deleted or not here, this is handled
+      // when adding entries to cacheKeyMap from DB.
+      fileStatusList.add(fileStatus);
+      countEntries++;
+      if (countEntries >= numEntries) {
+        break;
+      }
+    }
+    // Clean up temp map and set
+    cacheKeyMap.clear();
+    deletedKeySet.clear();
 
     List<OmKeyInfo> keyInfoList = new ArrayList<>(fileStatusList.size());
     for (OzoneFileStatus fileStatus : fileStatusList) {


### PR DESCRIPTION
##What changes were proposed in this pull request?
Avoid usage of locks when iterating rocksdb iterator.

##What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5349

##How was this patch tested?
Existing UT's.