### PR TITLE
HDDS-5389. Include ozoneserviceid in fs.defaultFS when configuring o3fs

### DIFF
--- a/hadoop-hdds/docs/content/interface/O3fs.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.md
@@ -59,10 +59,15 @@ Please add the following entry to the core-site.xml.
 </property>
 <property>
   <name>fs.defaultFS</name>
-  <value>o3fs://bucket.volume.OzoneServiceId</value>
+  <value>o3fs://bucket.volume</value>
 </property>
 ```
+<div class="alert alert-warning" role="alert">
 
+Tip: For the OM HA cluster, you need to specify the ozone service id.
+For non-HA, it can be `o3fs://bucket.volume`.
+
+</div>
 This will make this bucket to be the default Hadoop compatible file system and register the o3fs file system type.
 
 You also need to add the ozone-filesystem-hadoop3.jar file to the classpath:

--- a/hadoop-hdds/docs/content/interface/O3fs.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.md
@@ -62,12 +62,15 @@ Please add the following entry to the core-site.xml.
   <value>o3fs://bucket.volume</value>
 </property>
 ```
+
 <div class="alert alert-warning" role="alert">
 
-Tip: For the OM HA cluster, you need to specify the ozone service id.
+Tip: For the [OM HA]({{< ref "feature/OM-HA.md">}}) cluster, you need to specify the ozone service id. For example, 
+if `ozone.om.service.ids = ozone1`, then the URL is `o3fs://bucket.volume.ozone1`.
 For non-HA, it can be `o3fs://bucket.volume`.
 
 </div>
+
 This will make this bucket to be the default Hadoop compatible file system and register the o3fs file system type.
 
 You also need to add the ozone-filesystem-hadoop3.jar file to the classpath:

--- a/hadoop-hdds/docs/content/interface/O3fs.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.md
@@ -59,7 +59,7 @@ Please add the following entry to the core-site.xml.
 </property>
 <property>
   <name>fs.defaultFS</name>
-  <value>o3fs://bucket.volume</value>
+  <value>o3fs://bucket.volume.OzoneServiceId</value>
 </property>
 ```
 

--- a/hadoop-hdds/docs/content/interface/O3fs.zh.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.zh.md
@@ -61,7 +61,8 @@ ozone sh bucket create /volume/bucket
 
 <div class="alert alert-warning" role="alert">
 
-提示：对于 OM HA 集群，需要指定 ozone service id。
+提示: 对于 [OM HA]({{< ref "feature/OM-HA.zh.md">}}) 集群，需要指定 ozone service id。例如，
+如果 `ozone.om.service.ids = ozone1`，则 URL 是 `o3fs://bucket.volume.ozone1`。
 对于非 HA，它可以是 `o3fs://bucket.volume`。
 
 </div>

--- a/hadoop-hdds/docs/content/interface/O3fs.zh.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.zh.md
@@ -55,7 +55,7 @@ ozone sh bucket create /volume/bucket
 </property>
 <property>
   <name>fs.defaultFS</name>
-  <value>o3fs://bucket.volume</value>
+  <value>o3fs://bucket.volume.OzoneServiceId</value>
 </property>
 {{< /highlight >}}
 

--- a/hadoop-hdds/docs/content/interface/O3fs.zh.md
+++ b/hadoop-hdds/docs/content/interface/O3fs.zh.md
@@ -55,9 +55,16 @@ ozone sh bucket create /volume/bucket
 </property>
 <property>
   <name>fs.defaultFS</name>
-  <value>o3fs://bucket.volume.OzoneServiceId</value>
+  <value>o3fs://bucket.volume</value>
 </property>
 {{< /highlight >}}
+
+<div class="alert alert-warning" role="alert">
+
+提示：对于 OM HA 集群，需要指定 ozone service id。
+对于非 HA，它可以是 `o3fs://bucket.volume`。
+
+</div>
 
 这样会使指定的桶成为 HDFS 的 dfs 命令的默认文件系统，并且将其注册为了 o3fs 文件系统类型。
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The new version of o3fs must require Service ID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5389

## How was this patch tested?

Local Hugo pass.
