### PR TITLE
HDDS-5149 when source datanode download container tar from target datanode,but the target datanode container file missing,import error

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -122,7 +122,15 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
                 containerID, bytes);
         task.setTransferredBytes(bytes);
 
-        importContainer(containerID, path);
+        if (bytes <= 0) {
+          task.setStatus(Status.FAILED);
+          LOG.warn("Container {} is downloaded with size {}",
+              containerID, bytes);
+        } else {
+          importContainer(containerID, path);
+          LOG.info("Container {} is replicated successfully", containerID);
+          task.setStatus(Status.DONE);
+        }
         LOG.info("Container {} is replicated successfully", containerID);
         task.setStatus(Status.DONE);
       } catch (Exception e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

fix if the metadatafile or chunksfile missing import export container error

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5149?filter=addedrecently

## How was this patch tested?
ci
