### PR TITLE
HDDS-5398. Avoid object creation in ReplicationManger debug log statements

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -606,7 +606,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
     });
     containerManager.updateContainerState(container.containerID(),
         HddsProtos.LifeCycleEvent.DELETE);
-    LOG.debug("Deleting empty container {} replicas,", container.containerID());
+    LOG.debug("Deleting empty container replicas for {},", container);
   }
 
   /**
@@ -621,8 +621,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
     if (replicas.size() == 0) {
       containerManager.updateContainerState(container.containerID(),
           HddsProtos.LifeCycleEvent.CLEANUP);
-      LOG.debug("Container {} state changes to DELETED",
-          container.containerID());
+      LOG.debug("Container {} state changes to DELETED", container);
     } else {
       // Check whether to resend the delete replica command
       final List<DatanodeDetails> deletionInFlight = inflightDeletion
@@ -638,8 +637,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
         filteredReplicas.stream().forEach(rp -> {
           sendDeleteCommand(container, rp.getDatanodeDetails(), false);
         });
-        LOG.debug("Resend delete Container {} command",
-            container.containerID());
+        LOG.debug("Resend delete Container command for {}", container);
       }
     }
   }
@@ -692,8 +690,7 @@ public class ReplicationManager implements MetricsSource, SCMService {
   private void handleUnderReplicatedContainer(final ContainerInfo container,
       final ContainerReplicaCount replicaSet,
       final ContainerPlacementStatus placementStatus) {
-    LOG.debug("Handling under-replicated container: {}",
-        container.getContainerID());
+    LOG.debug("Handling under-replicated container: {}", container);
     Set<ContainerReplica> replicas = replicaSet.getReplica();
     try {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are a few debug log entries in replication manager like this:

```
    LOG.debug("Handling under-replicated container: {}",
        container.getContainerID());

      LOG.debug("Deleting empty container {} replicas,", container.containerID());
```

Especially the latter one, will always allocates a new ContainerID object on each call, even if debug is not enabled.

If we just pass "container" then it will use the container.toString() method inside the logger, only if debug is enabled. The `ContainerInfo.toString()` looks like:

```
  @Override
  public String toString() {
    return "ContainerInfo{"
        + "id=" + containerID
        + ", state=" + state
        + ", pipelineID=" + pipelineID
        + ", stateEnterTime=" + stateEnterTime
        + ", owner=" + owner
        + '}';
  }
```

It contains some extra information, but some of that may be useful if debugging a problem.

I propose just passing container to the debug logged and allowing the toString() value to be output in the log.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5398

## How was this patch tested?

No tests changed or added.
