### PR TITLE
HDDS-5414. Data buffers incorrectly filtered for Ozone Insight

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -286,6 +286,7 @@ public final class ContainerUtils {
         }
         if (msg.getReadChunk().hasDataBuffers()) {
           builder.getReadChunkBuilder().getDataBuffersBuilder()
+              .clearBuffers()
               .addBuffers(REDACTED);
         }
       }
@@ -295,7 +296,9 @@ public final class ContainerUtils {
         }
         if (msg.getGetSmallFile().getData().hasDataBuffers()) {
           builder.getGetSmallFileBuilder().getDataBuilder()
-              .getDataBuffersBuilder().addBuffers(REDACTED);
+              .getDataBuffersBuilder()
+                  .clearBuffers()
+                  .addBuffers(REDACTED);
         }
       }
       return builder.build();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.helpers;
+
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
+import org.apache.hadoop.hdds.scm.ByteStringConversion;
+import org.apache.hadoop.ozone.common.ChunkBuffer;
+import org.junit.Test;
+
+import java.nio.ByteBuffer;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.ReadChunk;
+import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getReadChunkResponse;
+import static org.apache.hadoop.ozone.container.common.helpers.ContainerUtils.processForDebug;
+import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link ContainerUtils}.
+ */
+public class TestContainerUtils {
+
+  @Test
+  public void redactsDataBuffers() {
+    // GIVEN
+    ContainerCommandRequestProto req = getDummyCommandRequestProto(ReadChunk);
+    ChunkBuffer data = ChunkBuffer.wrap(ByteBuffer.wrap(
+        "junk".getBytes(UTF_8)));
+    ContainerCommandResponseProto resp = getReadChunkResponse(req, data,
+        ByteStringConversion::safeWrap);
+
+    // WHEN
+    ContainerCommandResponseProto processed = processForDebug(resp);
+
+    // THEN
+    ContainerProtos.DataBuffers dataBuffers =
+        processed.getReadChunk().getDataBuffers();
+    assertEquals(1, dataBuffers.getBuffersCount());
+    assertEquals("<redacted>", dataBuffers.getBuffers(0).toString(UTF_8));
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the issue that Ozone Insight prints binary data for `dataBuffers`:

```
[TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=ReadChunk] request is processed. Response:
cmdType: ReadChunk
traceID: ""
result: SUCCESS
readChunk {
  ...
  dataBuffers {
    buffers: "4w7u1Zp8@{"
    buffers: "<redacted>"
  }
}
```

This is caused by appending to the list of buffers in `processForDebug` instead of replacing the list with a single item.

https://issues.apache.org/jira/browse/HDDS-5414

## How was this patch tested?

Added unit test.  Also tested on compose-based cluster:

```
# console 1
ozone insight logs -v datanode.dispatcher -f datanode=ozone_datanode_1

# console 2
ozone freon ockg -n10 -t1 -p test -s 10
ozone freon ockv -n10 -t1 -p test
```

Output:

```
[TRACE|org.apache.hadoop.ozone.container.common.impl.HddsDispatcher|OzoneProtocolMessageDispatcher] [service=DatanodeClient] [type=ReadChunk] request is processed. Response:
cmdType: ReadChunk
traceID: ""
result: SUCCESS
readChunk {
  ...
  dataBuffers {
    buffers: "<redacted>"
  }
}
```