### PR TITLE
HDDS-5415. Fix TestSCMNodeManager after merge of master at 1d8f972 into upgrade branch

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestUtils.java
@@ -293,11 +293,21 @@ public final class TestUtils {
   }
 
   public static MetadataStorageReportProto createMetadataStorageReport(
+      String path, long capacity) {
+    return createMetadataStorageReport(path,
+        capacity,
+        0,
+        capacity,
+        StorageTypeProto.DISK, false);
+  }
+
+  public static MetadataStorageReportProto createMetadataStorageReport(
       String path, long capacity, long used, long remaining,
       StorageTypeProto type) {
     return createMetadataStorageReport(path, capacity, used, remaining,
         type, false);
   }
+
   /**
    * Creates metadata storage report with the given information.
    *

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.StorageReportProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.TestUtils;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
@@ -285,13 +286,18 @@ public class TestSCMNodeManager {
   private DatanodeDetails registerWithCapacity(SCMNodeManager nodeManager,
       LayoutVersionProto layout, ErrorCode expectedResult) {
     DatanodeDetails details = MockDatanodeDetails.randomDatanodeDetails();
+
     StorageReportProto storageReport =
         TestUtils.createStorageReport(details.getUuid(),
             details.getNetworkFullPath(), Long.MAX_VALUE);
+    MetadataStorageReportProto metadataStorageReport =
+        TestUtils.createMetadataStorageReport(details.getNetworkFullPath(),
+            Long.MAX_VALUE);
+
     RegisteredCommand cmd = nodeManager.register(
         MockDatanodeDetails.randomDatanodeDetails(),
         TestUtils.createNodeReport(Arrays.asList(storageReport),
-            Collections.emptyList()),
+            Arrays.asList(metadataStorageReport)),
         getRandomPipelineReports(), layout);
 
     Assert.assertEquals(expectedResult, cmd.getError());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix `TestSCMNodeManager#testScmLayoutOnRegister` and `testScmLayoutOnHeartbeat` to register nodes with metadata capacity after HDDS-5269.

## What is the link to the Apache JIRA

HDDS-5415

## How was this patch tested?

Failed tests pass after the change is applied.
