### PR TITLE
HDDS-5386. Add a NSSummaryTask to write NSSummary info into RDB

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconControllerModule.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.recon.spi.impl.ReconNamespaceSummaryManagerImpl;
 import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.ContainerKeyMapperTask;
 import org.apache.hadoop.ozone.recon.tasks.FileSizeCountTask;
+import org.apache.hadoop.ozone.recon.tasks.NSSummaryTask;
 import org.apache.hadoop.ozone.recon.tasks.TableCountTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconOmTask;
 import org.apache.hadoop.ozone.recon.tasks.ReconTaskController;
@@ -123,6 +124,7 @@ public class ReconControllerModule extends AbstractModule {
       taskBinder.addBinding().to(ContainerKeyMapperTask.class);
       taskBinder.addBinding().to(FileSizeCountTask.class);
       taskBinder.addBinding().to(TableCountTask.class);
+      taskBinder.addBinding().to(NSSummaryTask.class);
     }
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -311,7 +311,14 @@ public class ReconUtils {
   }
 
   public static int getBinIndex(long fileSize) {
+    // if the file size is larger than our track scope,
+    // we map it to the last bin
+    if (fileSize >= ReconConstants.MAX_FILE_SIZE_UPPER_BOUND) {
+      return ReconConstants.NUM_OF_BINS - 1;
+    }
     int index = nextClosestPowerIndexOfTwo(fileSize);
+    // if the file size is smaller than our track scope,
+    // we map it to the first bin
     return index < 10 ? 0 : index - 10;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -299,4 +299,28 @@ public class ReconUtils {
       globalStatsDao.update(newRecord);
     }
   }
+
+  public static long getFileSizeUpperBound(long fileSize) {
+    if (fileSize >= ReconConstants.MAX_FILE_SIZE_UPPER_BOUND) {
+      return Long.MAX_VALUE;
+    }
+    // The smallest file size being tracked for count
+    // is 1 KB i.e. 1024 = 2 ^ 10.
+    int binIndex = getBinIndex(fileSize);
+    return (long) Math.pow(2, (10 + binIndex));
+  }
+
+  public static int getBinIndex(long fileSize) {
+    int index = nextClosestPowerIndexOfTwo(fileSize);
+    return index < 10 ? 0 : index - 10;
+  }
+
+  private static int nextClosestPowerIndexOfTwo(long dataSize) {
+    int index = 0;
+    while(dataSize != 0) {
+      dataSize >>= 1;
+      index += 1;
+    }
+    return index;
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -317,7 +317,7 @@ public class ReconUtils {
 
   private static int nextClosestPowerIndexOfTwo(long dataSize) {
     int index = 0;
-    while(dataSize != 0) {
+    while (dataSize != 0) {
       dataSize >>= 1;
       index += 1;
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -28,16 +28,16 @@ import java.util.Arrays;
 
 public class NSSummary {
   private int numOfFiles;
-  private int sizeOfFiles;
+  private long sizeOfFiles;
   private int[] fileSizeBucket;
 
   public NSSummary() {
     this.numOfFiles = 0;
-    this.sizeOfFiles = 0;
+    this.sizeOfFiles = 0L;
     this.fileSizeBucket = new int[ReconConstants.NUM_OF_BINS];
   }
 
-  public NSSummary(int numOfFiles, int sizeOfFiles, int[] bucket) {
+  public NSSummary(int numOfFiles, long sizeOfFiles, int[] bucket) {
     this.numOfFiles = numOfFiles;
     this.sizeOfFiles = sizeOfFiles;
     setFileSizeBucket(bucket);
@@ -47,7 +47,7 @@ public class NSSummary {
     return numOfFiles;
   }
 
-  public int getSizeOfFiles() {
+  public long getSizeOfFiles() {
     return sizeOfFiles;
   }
 
@@ -59,7 +59,7 @@ public class NSSummary {
     this.numOfFiles = numOfFiles;
   }
 
-  public void setSizeOfFiles(int sizeOfFiles) {
+  public void setSizeOfFiles(long sizeOfFiles) {
     this.sizeOfFiles = sizeOfFiles;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -20,7 +20,9 @@ package org.apache.hadoop.ozone.recon.api.types;
 
 import org.apache.hadoop.ozone.recon.ReconConstants;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Class to encapsulate namespace metadata summaries from OM.
@@ -30,17 +32,23 @@ public class NSSummary {
   private int numOfFiles;
   private long sizeOfFiles;
   private int[] fileSizeBucket;
+  private List<Long> childDir;
 
   public NSSummary() {
     this.numOfFiles = 0;
     this.sizeOfFiles = 0L;
     this.fileSizeBucket = new int[ReconConstants.NUM_OF_BINS];
+    this.childDir = new ArrayList<>();
   }
 
-  public NSSummary(int numOfFiles, long sizeOfFiles, int[] bucket) {
+  public NSSummary(int numOfFiles,
+                   long sizeOfFiles,
+                   int[] bucket,
+                   List<Long> childDir) {
     this.numOfFiles = numOfFiles;
     this.sizeOfFiles = sizeOfFiles;
     setFileSizeBucket(bucket);
+    setChildDir(childDir);
   }
 
   public int getNumOfFiles() {
@@ -55,6 +63,10 @@ public class NSSummary {
     return Arrays.copyOf(this.fileSizeBucket, ReconConstants.NUM_OF_BINS);
   }
 
+  public List<Long> getChildDir() {
+    return new ArrayList<>(childDir);
+  }
+
   public void setNumOfFiles(int numOfFiles) {
     this.numOfFiles = numOfFiles;
   }
@@ -66,5 +78,9 @@ public class NSSummary {
   public void setFileSizeBucket(int[] fileSizeBucket) {
     this.fileSizeBucket = Arrays.copyOf(
             fileSizeBucket, ReconConstants.NUM_OF_BINS);
+  }
+
+  public void setChildDir(List<Long> childDir) {
+    this.childDir = new ArrayList<>(childDir);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -47,7 +47,7 @@ public class NSSummary {
                    List<Long> childDir) {
     this.numOfFiles = numOfFiles;
     this.sizeOfFiles = sizeOfFiles;
-    this.fileSizeBucket = bucket;
+    setFileSizeBucket(bucket);
     this.childDir = childDir;
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.recon.api.types;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -59,11 +60,11 @@ public class NSSummary {
   }
 
   public int[] getFileSizeBucket() {
-    return fileSizeBucket;
+    return Arrays.copyOf(fileSizeBucket, ReconConstants.NUM_OF_BINS);
   }
 
   public List<Long> getChildDir() {
-    return new ArrayList<>(childDir);
+    return childDir;
   }
 
   public void setNumOfFiles(int numOfFiles) {
@@ -75,7 +76,8 @@ public class NSSummary {
   }
 
   public void setFileSizeBucket(int[] fileSizeBucket) {
-    this.fileSizeBucket = fileSizeBucket;
+    this.fileSizeBucket = Arrays.copyOf(fileSizeBucket,
+            ReconConstants.NUM_OF_BINS);
   }
 
   public void setChildDir(List<Long> childDir) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NSSummary.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.recon.api.types;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -47,8 +46,8 @@ public class NSSummary {
                    List<Long> childDir) {
     this.numOfFiles = numOfFiles;
     this.sizeOfFiles = sizeOfFiles;
-    setFileSizeBucket(bucket);
-    setChildDir(childDir);
+    this.fileSizeBucket = bucket;
+    this.childDir = childDir;
   }
 
   public int getNumOfFiles() {
@@ -60,7 +59,7 @@ public class NSSummary {
   }
 
   public int[] getFileSizeBucket() {
-    return Arrays.copyOf(this.fileSizeBucket, ReconConstants.NUM_OF_BINS);
+    return fileSizeBucket;
   }
 
   public List<Long> getChildDir() {
@@ -76,11 +75,10 @@ public class NSSummary {
   }
 
   public void setFileSizeBucket(int[] fileSizeBucket) {
-    this.fileSizeBucket = Arrays.copyOf(
-            fileSizeBucket, ReconConstants.NUM_OF_BINS);
+    this.fileSizeBucket = fileSizeBucket;
   }
 
   public void setChildDir(List<Long> childDir) {
-    this.childDir = new ArrayList<>(childDir);
+    this.childDir = childDir;
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 @InterfaceStability.Unstable
 public interface ReconNamespaceSummaryManager {
 
-  void initNSSummaryTable() throws IOException;
+  void clearNSSummaryTable() throws IOException;
 
   void storeNSSummary(long objectId, NSSummary nsSummary) throws IOException;
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
@@ -33,5 +33,7 @@ public interface ReconNamespaceSummaryManager {
 
   void storeNSSummary(long objectId, NSSummary nsSummary) throws IOException;
 
+  void deleteNSSummary(long objectId) throws IOException;
+
   NSSummary getNSSummary(long objectId) throws IOException;
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
@@ -57,6 +57,11 @@ public class ReconNamespaceSummaryManagerImpl
   }
 
   @Override
+  public void deleteNSSummary(long objectId) throws IOException {
+    nsSummaryTable.delete(objectId);
+  }
+
+  @Override
   public NSSummary getNSSummary(long objectId) throws IOException {
     return nsSummaryTable.get(objectId);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
@@ -46,7 +46,7 @@ public class ReconNamespaceSummaryManagerImpl
   }
 
   @Override
-  public void initNSSummaryTable() throws IOException {
+  public void clearNSSummaryTable() throws IOException {
     truncateTable(nsSummaryTable);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.recon.ReconConstants;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.hadoop.ozone.recon.schema.UtilizationSchemaDefinition;
 import org.hadoop.ozone.recon.schema.tables.daos.FileCountBySizeDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.FileCountBySize;
@@ -62,15 +63,6 @@ public class FileSizeCountTask implements ReconOmTask {
                                utilizationSchemaDefinition) {
     this.fileCountBySizeDao = fileCountBySizeDao;
     this.dslContext = utilizationSchemaDefinition.getDSLContext();
-  }
-
-  private static int nextClosestPowerIndexOfTwo(long dataSize) {
-    int index = 0;
-    while(dataSize != 0) {
-      dataSize >>= 1;
-      index += 1;
-    }
-    return index;
   }
 
   /**
@@ -165,17 +157,6 @@ public class FileSizeCountTask implements ReconOmTask {
     return new ImmutablePair<>(getTaskName(), true);
   }
 
-  private long getFileSizeUpperBound(long fileSize) {
-    if (fileSize >= ReconConstants.MAX_FILE_SIZE_UPPER_BOUND) {
-      return Long.MAX_VALUE;
-    }
-    int index = nextClosestPowerIndexOfTwo(fileSize);
-    // The smallest file size being tracked for count
-    // is 1 KB i.e. 1024 = 2 ^ 10.
-    int binIndex = index < 10 ? 0 : index - 10;
-    return (long) Math.pow(2, (10 + binIndex));
-  }
-
   /**
    * Populate DB with the counts of file sizes calculated
    * using the dao.
@@ -219,7 +200,7 @@ public class FileSizeCountTask implements ReconOmTask {
   private FileSizeCountKey getFileSizeCountKey(OmKeyInfo omKeyInfo) {
     return new FileSizeCountKey(omKeyInfo.getVolumeName(),
         omKeyInfo.getBucketName(),
-        getFileSizeUpperBound(omKeyInfo.getDataSize()));
+            ReconUtils.getFileSizeUpperBound(omKeyInfo.getDataSize()));
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -1,0 +1,169 @@
+package org.apache.hadoop.ozone.recon.tasks;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.recon.ReconConstants;
+import org.apache.hadoop.ozone.recon.ReconUtils;
+import org.apache.hadoop.ozone.recon.api.types.NSSummary;
+import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Iterator;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+
+public class NSSummaryTask implements ReconOmTask {
+  private static final Logger LOG =
+          LoggerFactory.getLogger(NSSummaryTask.class);
+  private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
+
+  @Inject
+  public NSSummaryTask(ReconNamespaceSummaryManager reconNamespaceSummaryManager) {
+    this.reconNamespaceSummaryManager = reconNamespaceSummaryManager;
+  }
+
+  @Override
+  public String getTaskName() {
+    return "NSSummaryTask";
+  }
+
+  public Collection<String> getTaskTables() {
+    return Collections.singletonList(KEY_TABLE);
+  }
+
+  @Override
+  public Pair<String, Boolean> process(OMUpdateEventBatch events) {
+    Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
+    final Collection<String> taskTables = getTaskTables();
+
+    while (eventIterator.hasNext()) {
+      OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent = eventIterator.next();
+      // we only process updates on OM's KeyTable.
+      if (!taskTables.contains(omdbUpdateEvent.getTable())) {
+        continue;
+      }
+      String updatedKey = omdbUpdateEvent.getKey();
+      OmKeyInfo updatedKeyValue = omdbUpdateEvent.getValue();
+
+      try {
+        switch (omdbUpdateEvent.getAction()) {
+          case PUT:
+            writeOmKeyInfoOnNamespaceDB(updatedKeyValue);
+            break;
+
+          case DELETE:
+            deleteOmKeyInfoOnNamespaceDB(updatedKeyValue);
+            break;
+
+          case UPDATE:
+            if (omdbUpdateEvent.getOldValue() != null) {
+              // delete first, then put
+              deleteOmKeyInfoOnNamespaceDB(omdbUpdateEvent.getOldValue());
+            } else {
+              LOG.warn("Update event does not have the old Key Info for {}.",
+                      updatedKey);
+            }
+            writeOmKeyInfoOnNamespaceDB(updatedKeyValue);
+            break;
+
+          default: LOG.debug("Skipping DB update event : {}",
+                  omdbUpdateEvent.getAction());
+        }
+
+      } catch (IOException ioEx) {
+        LOG.error("Unable to process Namespace Summary data in Recon DB. ",
+                ioEx);
+        return new ImmutablePair<>(getTaskName(), false);
+      }
+    }
+    LOG.info("Completed a process run of NSSummaryTask");
+    return new ImmutablePair<>(getTaskName(), true);
+  }
+
+  @Override
+  public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    Table keyTable = omMetadataManager.getKeyTable();
+    TableIterator<String, ? extends
+            Table.KeyValue<String, OmKeyInfo>> tableIter = keyTable.iterator();
+
+    try {
+      // reinit Recon RocksDB's namespace CF.
+      reconNamespaceSummaryManager.initNSSummaryTable();
+
+      while (tableIter.hasNext()) {
+        Table.KeyValue<String, OmKeyInfo> kv = tableIter.next();
+        OmKeyInfo keyInfo = kv.getValue();
+        writeOmKeyInfoOnNamespaceDB(keyInfo);
+      }
+    } catch (IOException ioEx) {
+      LOG.error("Unable to reprocess Namespace Summary data in Recon DB. ",
+              ioEx);
+      return new ImmutablePair<>(getTaskName(), false);
+    }
+
+    LOG.info("Completed a reprocess run of NSSummaryTask");
+    return new ImmutablePair<>(getTaskName(), true);
+  }
+
+  private void writeOmKeyInfoOnNamespaceDB(OmKeyInfo keyInfo)
+          throws IOException {
+    long parentObjectId = keyInfo.getParentObjectID();
+    NSSummary nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    int numOfFile = nsSummary.getNumOfFiles();
+    long sizeOfFile = nsSummary.getSizeOfFiles();
+    int[] fileBucket = nsSummary.getFileSizeBucket();
+    nsSummary.setNumOfFiles(numOfFile + 1);
+    long dataSize = keyInfo.getDataSize();
+    nsSummary.setSizeOfFiles(sizeOfFile + dataSize);
+    int binIndex = ReconUtils.getBinIndex(dataSize);
+
+    // make sure the file is within our scope of tracking.
+    if (binIndex >= 0 && binIndex < ReconConstants.NUM_OF_BINS) {
+      ++fileBucket[binIndex];
+    } else {
+      LOG.error("Bucket bin isn't correctly computed.");
+    }
+    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+  }
+
+  private void deleteOmKeyInfoOnNamespaceDB(OmKeyInfo keyInfo)
+          throws IOException {
+    long parentObjectId = keyInfo.getParentObjectID();
+    NSSummary nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    int numOfFile = nsSummary.getNumOfFiles();
+    long sizeOfFile = nsSummary.getSizeOfFiles();
+    int[] fileBucket = nsSummary.getFileSizeBucket();
+
+    long dataSize = keyInfo.getDataSize();
+    int binIndex = ReconUtils.getBinIndex(dataSize);
+
+    if (binIndex < 0 || binIndex >= ReconConstants.NUM_OF_BINS) {
+      LOG.error("Bucket bin isn't correctly computed.");
+      return;
+    }
+
+    // Just in case the OmKeyInfo isn't correctly written.
+    if (numOfFile == 0
+            || sizeOfFile < dataSize
+            || fileBucket[binIndex] == 0) {
+      LOG.error("The namespace table is not correctly populated.");
+      return;
+    }
+
+    // decrement count, data size, and bucket count
+    nsSummary.setNumOfFiles(numOfFile - 1);
+    nsSummary.setSizeOfFiles(sizeOfFile - dataSize);
+    --fileBucket[binIndex];
+    nsSummary.setFileSizeBucket(fileBucket);
+    // TODO: if key count reduces to zero, should we delete it from table?
+    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+  }
+}

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -247,7 +247,6 @@ public class NSSummaryTask implements ReconOmTask {
     } else {
       LOG.warn("Duplicate write on the same directory.");
     }
-    //nsSummary.setChildDir(childDir);
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 
@@ -298,7 +297,6 @@ public class NSSummaryTask implements ReconOmTask {
     } else {
       LOG.warn("Try to delete a non-existent child.");
     }
-    //nsSummary.setChildDir(childDir);
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -247,7 +247,7 @@ public class NSSummaryTask implements ReconOmTask {
     } else {
       LOG.warn("Duplicate write on the same directory.");
     }
-    nsSummary.setChildDir(childDir);
+    //nsSummary.setChildDir(childDir);
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 
@@ -298,7 +298,7 @@ public class NSSummaryTask implements ReconOmTask {
     } else {
       LOG.warn("Try to delete a non-existent child.");
     }
-    nsSummary.setChildDir(childDir);
+    //nsSummary.setChildDir(childDir);
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
-import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
@@ -44,6 +43,19 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 
 /**
  * Task to query data from OMDB and write into Recon RocksDB.
+ * Reprocess() will take a snapshots on OMDB, and iterate the keyTable and
+ * dirTable to write all information to RocksDB.
+ *
+ * For FSO-enabled keyTable (fileTable), we need to fetch the parent object
+ * (bucket or directory), increment its numOfKeys by 1, increase its sizeOfKeys
+ * by the file data size, and update the file size distribution bin accordingly.
+ *
+ * For dirTable, we need to fetch the parent object (bucket or directory),
+ * add the current directory's objectID to the parent object's childDir field.
+ *
+ * Process() will write all OMDB updates to RocksDB.
+ * The write logic is the same as above. For update action, we will treat it as
+ * delete old value first, and write updated value then.
  */
 public class NSSummaryTask implements ReconOmTask {
   private static final Logger LOG =
@@ -134,8 +146,6 @@ public class NSSummaryTask implements ReconOmTask {
             break;
 
           case UPDATE:
-            // TODO: we may just want to ignore update event on table,
-            //  if objectId and parentObjectId cannot be modified.
             if (oldDirectoryInfo != null) {
               // delete first, then put
               deleteOmDirectoryInfoOnNamespaceDB(oldDirectoryInfo);
@@ -163,21 +173,10 @@ public class NSSummaryTask implements ReconOmTask {
 
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
-    // actually fileTable with FSO
-    Table keyTable = omMetadataManager.getKeyTable();
-
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-            keyTableIter = keyTable.iterator();
 
     try {
       // reinit Recon RocksDB's namespace CF.
-      reconNamespaceSummaryManager.initNSSummaryTable();
-
-      while (keyTableIter.hasNext()) {
-        Table.KeyValue<String, OmKeyInfo> kv = keyTableIter.next();
-        OmKeyInfo keyInfo = kv.getValue();
-        writeOmKeyInfoOnNamespaceDB(keyInfo);
-      }
+      reconNamespaceSummaryManager.clearNSSummaryTable();
 
       Table dirTable = omMetadataManager.getDirectoryTable();
       TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
@@ -187,6 +186,18 @@ public class NSSummaryTask implements ReconOmTask {
         Table.KeyValue<String, OmDirectoryInfo> kv = dirTableIter.next();
         OmDirectoryInfo directoryInfo = kv.getValue();
         writeOmDirectoryInfoOnNamespaceDB(directoryInfo);
+      }
+
+      // actually fileTable with FSO
+      Table keyTable = omMetadataManager.getKeyTable();
+
+      TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+              keyTableIter = keyTable.iterator();
+
+      while (keyTableIter.hasNext()) {
+        Table.KeyValue<String, OmKeyInfo> kv = keyTableIter.next();
+        OmKeyInfo keyInfo = kv.getValue();
+        writeOmKeyInfoOnNamespaceDB(keyInfo);
       }
 
     } catch (IOException ioEx) {
@@ -215,13 +226,8 @@ public class NSSummaryTask implements ReconOmTask {
     nsSummary.setSizeOfFiles(sizeOfFile + dataSize);
     int binIndex = ReconUtils.getBinIndex(dataSize);
 
-    // make sure the file is within our scope of tracking.
-    if (binIndex >= 0 && binIndex < ReconConstants.NUM_OF_BINS) {
-      ++fileBucket[binIndex];
-      nsSummary.setFileSizeBucket(fileBucket);
-    } else {
-      LOG.warn("File size beyond our tracking scope.");
-    }
+    ++fileBucket[binIndex];
+    nsSummary.setFileSizeBucket(fileBucket);
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 
@@ -262,11 +268,6 @@ public class NSSummaryTask implements ReconOmTask {
 
     long dataSize = keyInfo.getDataSize();
     int binIndex = ReconUtils.getBinIndex(dataSize);
-
-    if (binIndex < 0 || binIndex >= ReconConstants.NUM_OF_BINS) {
-      LOG.error("Bucket bin isn't correctly computed.");
-      return;
-    }
 
     // decrement count, data size, and bucket count
     // even if there's no direct key, we still keep the entry because

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -143,7 +143,7 @@ public class NSSummaryTask implements ReconOmTask {
               LOG.warn("Update event does not have the old dirInfo for {}.",
                       updatedKey);
             }
-            writeOmDirectoryInfoOnNamespaceDB(oldDirectoryInfo);
+            writeOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
             break;
 
           default:

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -22,7 +22,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.WithParentObjectId;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
@@ -32,11 +34,13 @@ import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
+import java.util.List;
 
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 
 /**
  * Task to query data from OMDB and write into Recon RocksDB.
@@ -57,8 +61,9 @@ public class NSSummaryTask implements ReconOmTask {
     return "NSSummaryTask";
   }
 
+  // We only listen to updates from FSO-enabled KeyTable(FileTable) and DirTable
   public Collection<String> getTaskTables() {
-    return Collections.singletonList(KEY_TABLE);
+    return Arrays.asList(new String[]{FILE_TABLE, DIRECTORY_TABLE});
   }
 
   @Override
@@ -67,40 +72,85 @@ public class NSSummaryTask implements ReconOmTask {
     final Collection<String> taskTables = getTaskTables();
 
     while (eventIterator.hasNext()) {
-      OMDBUpdateEvent<String, OmKeyInfo> omdbUpdateEvent = eventIterator.next();
-      // we only process updates on OM's KeyTable.
-      if (!taskTables.contains(omdbUpdateEvent.getTable())) {
+      OMDBUpdateEvent<String, ? extends
+              WithParentObjectId> omdbUpdateEvent = eventIterator.next();
+      OMDBUpdateEvent.OMDBUpdateAction action = omdbUpdateEvent.getAction();
+
+      // we only process updates on OM's KeyTable and Dirtable
+      String table = omdbUpdateEvent.getTable();
+      boolean updateOnFileTable = table.equals(FILE_TABLE);
+      if (!taskTables.contains(table)) {
         continue;
       }
+
       String updatedKey = omdbUpdateEvent.getKey();
-      OmKeyInfo updatedKeyValue = omdbUpdateEvent.getValue();
 
       try {
-        switch (omdbUpdateEvent.getAction()) {
-        case PUT:
-          writeOmKeyInfoOnNamespaceDB(updatedKeyValue);
-          break;
+        if (updateOnFileTable) {
+          // key update on fileTable
+          OMDBUpdateEvent<String, OmKeyInfo> keyTableUpdateEvent =
+                  (OMDBUpdateEvent<String, OmKeyInfo>) omdbUpdateEvent;
+          OmKeyInfo updatedKeyInfo = keyTableUpdateEvent.getValue();
+          OmKeyInfo oldKeyInfo = keyTableUpdateEvent.getOldValue();
 
-        case DELETE:
-          deleteOmKeyInfoOnNamespaceDB(updatedKeyValue);
-          break;
+          switch (action) {
+          case PUT:
+            writeOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            break;
 
-        case UPDATE:
-          if (omdbUpdateEvent.getOldValue() != null) {
-            // delete first, then put
-            deleteOmKeyInfoOnNamespaceDB(omdbUpdateEvent.getOldValue());
-          } else {
-            LOG.warn("Update event does not have the old Key Info for {}.",
-                    updatedKey);
+          case DELETE:
+            deleteOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            break;
+
+          case UPDATE:
+            if (oldKeyInfo != null) {
+              // delete first, then put
+              deleteOmKeyInfoOnNamespaceDB(oldKeyInfo);
+            } else {
+              LOG.warn("Update event does not have the old keyInfo for {}.",
+                      updatedKey);
+            }
+            writeOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            break;
+
+          default:
+            LOG.debug("Skipping DB update event : {}",
+                    omdbUpdateEvent.getAction());
           }
-          writeOmKeyInfoOnNamespaceDB(updatedKeyValue);
-          break;
+        } else {
+          // directory update on DirTable
+          OMDBUpdateEvent<String, OmDirectoryInfo> dirTableUpdateEvent =
+                  (OMDBUpdateEvent<String, OmDirectoryInfo>) omdbUpdateEvent;
+          OmDirectoryInfo updatedDirectoryInfo = dirTableUpdateEvent.getValue();
+          OmDirectoryInfo oldDirectoryInfo = dirTableUpdateEvent.getOldValue();
 
-        default:
-          LOG.debug("Skipping DB update event : {}",
-                  omdbUpdateEvent.getAction());
+          switch (action) {
+          case PUT:
+            writeOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
+            break;
+
+          case DELETE:
+            deleteOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
+            break;
+
+          case UPDATE:
+            // TODO: we may just want to ignore update event on table,
+            //  if objectId and parentObjectId cannot be modified.
+            if (oldDirectoryInfo != null) {
+              // delete first, then put
+              deleteOmDirectoryInfoOnNamespaceDB(oldDirectoryInfo);
+            } else {
+              LOG.warn("Update event does not have the old dirInfo for {}.",
+                      updatedKey);
+            }
+            writeOmDirectoryInfoOnNamespaceDB(oldDirectoryInfo);
+            break;
+
+          default:
+            LOG.debug("Skipping DB update event : {}",
+                    omdbUpdateEvent.getAction());
+          }
         }
-
       } catch (IOException ioEx) {
         LOG.error("Unable to process Namespace Summary data in Recon DB. ",
                 ioEx);
@@ -113,19 +163,32 @@ public class NSSummaryTask implements ReconOmTask {
 
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    // actually fileTable with FSO
     Table keyTable = omMetadataManager.getKeyTable();
-    TableIterator<String, ? extends
-            Table.KeyValue<String, OmKeyInfo>> tableIter = keyTable.iterator();
+
+    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+            keyTableIter = keyTable.iterator();
 
     try {
       // reinit Recon RocksDB's namespace CF.
       reconNamespaceSummaryManager.initNSSummaryTable();
 
-      while (tableIter.hasNext()) {
-        Table.KeyValue<String, OmKeyInfo> kv = tableIter.next();
+      while (keyTableIter.hasNext()) {
+        Table.KeyValue<String, OmKeyInfo> kv = keyTableIter.next();
         OmKeyInfo keyInfo = kv.getValue();
         writeOmKeyInfoOnNamespaceDB(keyInfo);
       }
+
+      Table dirTable = omMetadataManager.getDirectoryTable();
+      TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
+              dirTableIter = dirTable.iterator();
+
+      while (dirTableIter.hasNext()) {
+        Table.KeyValue<String, OmDirectoryInfo> kv = dirTableIter.next();
+        OmDirectoryInfo directoryInfo = kv.getValue();
+        writeOmDirectoryInfoOnNamespaceDB(directoryInfo);
+      }
+
     } catch (IOException ioEx) {
       LOG.error("Unable to reprocess Namespace Summary data in Recon DB. ",
               ioEx);
@@ -142,7 +205,7 @@ public class NSSummaryTask implements ReconOmTask {
     NSSummary nsSummary = reconNamespaceSummaryManager
             .getNSSummary(parentObjectId);
     if (nsSummary == null) {
-      nsSummary = getEmptyNSSummary();
+      nsSummary = new NSSummary();
     }
     int numOfFile = nsSummary.getNumOfFiles();
     long sizeOfFile = nsSummary.getSizeOfFiles();
@@ -162,6 +225,26 @@ public class NSSummaryTask implements ReconOmTask {
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 
+  private void writeOmDirectoryInfoOnNamespaceDB(OmDirectoryInfo directoryInfo)
+          throws IOException {
+    long parentObjectId = directoryInfo.getParentObjectID();
+    long objectId = directoryInfo.getObjectID();
+    NSSummary nsSummary = reconNamespaceSummaryManager
+            .getNSSummary(parentObjectId);
+    if (nsSummary == null) {
+      nsSummary = new NSSummary();
+    }
+    List<Long> childDir = nsSummary.getChildDir();
+    // make sure don't write duplicates
+    if (!childDir.contains(objectId)) {
+      childDir.add(objectId);
+    } else {
+      LOG.warn("Duplicate write on the same directory.");
+    }
+    nsSummary.setChildDir(childDir);
+    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+  }
+
   private void deleteOmKeyInfoOnNamespaceDB(OmKeyInfo keyInfo)
           throws IOException {
     long parentObjectId = keyInfo.getParentObjectID();
@@ -177,12 +260,6 @@ public class NSSummaryTask implements ReconOmTask {
     long sizeOfFile = nsSummary.getSizeOfFiles();
     int[] fileBucket = nsSummary.getFileSizeBucket();
 
-    // if the key is the only key, we simply delete the entry
-    if (numOfFile == 1) {
-      reconNamespaceSummaryManager.deleteNSSummary(parentObjectId);
-      return;
-    }
-
     long dataSize = keyInfo.getDataSize();
     int binIndex = ReconUtils.getBinIndex(dataSize);
 
@@ -192,6 +269,8 @@ public class NSSummaryTask implements ReconOmTask {
     }
 
     // decrement count, data size, and bucket count
+    // even if there's no direct key, we still keep the entry because
+    // we still need children dir IDs info
     nsSummary.setNumOfFiles(numOfFile - 1);
     nsSummary.setSizeOfFiles(sizeOfFile - dataSize);
     --fileBucket[binIndex];
@@ -199,7 +278,27 @@ public class NSSummaryTask implements ReconOmTask {
     reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 
-  private NSSummary getEmptyNSSummary() {
-    return new NSSummary(0, 0L, new int[ReconConstants.NUM_OF_BINS]);
+  private void deleteOmDirectoryInfoOnNamespaceDB(OmDirectoryInfo directoryInfo)
+          throws IOException {
+    long parentObjectId = directoryInfo.getParentObjectID();
+    long objectId = directoryInfo.getObjectID();
+    NSSummary nsSummary = reconNamespaceSummaryManager
+            .getNSSummary(parentObjectId);
+
+    // Just in case the OmDirectoryInfo isn't correctly written.
+    if (nsSummary == null) {
+      LOG.error("The namespace table is not correctly populated.");
+      return;
+    }
+
+    List<Long> childDir = nsSummary.getChildDir();
+    if (childDir.contains(objectId)) {
+      childDir.remove(objectId);
+    } else {
+      LOG.warn("Try to delete a non-existent child.");
+    }
+    nsSummary.setChildDir(childDir);
+    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
   }
 }
+

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
@@ -83,7 +83,7 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
     }
     OMDBUpdateEvent that = (OMDBUpdateEvent) o;
     return this.updatedKey.equals(that.updatedKey) &&
-            this.table.equals(that.table) &&
+        this.table.equals(that.table) &&
         this.action.equals(that.action);
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
@@ -83,6 +83,7 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
     }
     OMDBUpdateEvent that = (OMDBUpdateEvent) o;
     return this.updatedKey.equals(that.updatedKey) &&
+            this.table.equals(that.table) &&
         this.action.equals(that.action);
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -59,7 +59,7 @@ public class TestReconNamespaceSummaryManagerImpl {
   @Before
   public void setUp() throws Exception {
     // Clear namespace table before running each test
-    reconNamespaceSummaryManager.initNSSummaryTable();
+    reconNamespaceSummaryManager.clearNSSummaryTable();
   }
 
   @Test
@@ -86,7 +86,7 @@ public class TestReconNamespaceSummaryManagerImpl {
     putThreeNSMetadata();
     Assert.assertFalse(
             reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
-    reconNamespaceSummaryManager.initNSSummaryTable();
+    reconNamespaceSummaryManager.clearNSSummaryTable();
     Assert.assertTrue(
             reconNamespaceSummaryManager.getNSSummaryTable().isEmpty());
   }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -24,7 +24,10 @@ import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -35,6 +38,8 @@ public class TestReconNamespaceSummaryManagerImpl {
   public static final TemporaryFolder TEMP_FOLDER = new TemporaryFolder();
   private static ReconNamespaceSummaryManagerImpl reconNamespaceSummaryManager;
   private static int[] testBucket;
+  private static final List<Long> TEST_CHILD_DIR =
+          new ArrayList<>(Arrays.asList(new Long[]{1L, 2L, 3L}));
 
   @BeforeClass
   public static void setupOnce() throws Exception {
@@ -69,6 +74,9 @@ public class TestReconNamespaceSummaryManagerImpl {
     Assert.assertEquals(4, summary2.getSizeOfFiles());
     Assert.assertEquals(5, summary3.getNumOfFiles());
     Assert.assertEquals(6, summary3.getSizeOfFiles());
+
+    // test child dir is written
+    Assert.assertEquals(3, summary.getChildDir().size());
     // non-existent key
     Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(0L));
   }
@@ -85,9 +93,9 @@ public class TestReconNamespaceSummaryManagerImpl {
 
   private void putThreeNSMetadata() throws IOException {
     HashMap<Long, NSSummary> hmap = new HashMap<>();
-    hmap.put(1L, new NSSummary(1, 2, testBucket));
-    hmap.put(2L, new NSSummary(3, 4, testBucket));
-    hmap.put(3L, new NSSummary(5, 6, testBucket));
+    hmap.put(1L, new NSSummary(1, 2, testBucket, TEST_CHILD_DIR));
+    hmap.put(2L, new NSSummary(3, 4, testBucket, TEST_CHILD_DIR));
+    hmap.put(3L, new NSSummary(5, 6, testBucket, TEST_CHILD_DIR));
     for (Map.Entry entry: hmap.entrySet()) {
       reconNamespaceSummaryManager.storeNSSummary(
               (long)entry.getKey(), (NSSummary)entry.getValue());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.tasks;
 
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProvider;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getOmKeyLocationInfo;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
@@ -25,8 +26,6 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializ
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -47,7 +46,6 @@ import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -281,18 +279,5 @@ public class TestContainerKeyMapperTask {
         .setOmKeyLocationInfos(Collections.singletonList(
             omKeyLocationInfoGroup))
         .build();
-  }
-
-  private OzoneManagerServiceProviderImpl getMockOzoneManagerServiceProvider()
-      throws IOException {
-    OzoneManagerServiceProviderImpl omServiceProviderMock =
-        mock(OzoneManagerServiceProviderImpl.class);
-    OMMetadataManager omMetadataManagerMock = mock(OMMetadataManager.class);
-    Table tableMock = mock(Table.class);
-    when(tableMock.getName()).thenReturn("keyTable");
-    when(omMetadataManagerMock.getKeyTable()).thenReturn(tableMock);
-    when(omServiceProviderMock.getOMMetadataManagerInstance())
-        .thenReturn(omMetadataManagerMock);
-    return omServiceProviderMock;
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -1,0 +1,329 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.recon.tasks;
+
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.recon.ReconConstants;
+import org.apache.hadoop.ozone.recon.ReconTestInjector;
+import org.apache.hadoop.ozone.recon.api.types.NSSummary;
+import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProvider;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.initializeNewOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDataToOm;
+
+/**
+ * Test for NSSummaryTask.
+ */
+public class TestNSSummaryTask {
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
+  private OMMetadataManager omMetadataManager;
+  private ReconOMMetadataManager reconOMMetadataManager;
+  private OzoneManagerServiceProviderImpl ozoneManagerServiceProvider;
+
+  private static final String VOL = "vol";
+  private static final String BUCKET_ONE = "bucket1";
+  private static final String BUCKET_TWO = "bucket2";
+  private static final String KEY_ONE = "file1";
+  private static final String KEY_TWO = "file2";
+  private static final String KEY_THREE = "dir1/dir2/file3";
+  private static final String KEY_FOUR = "file4";
+  private static final String KEY_FIVE = "file5";
+
+  private static final long BUCKET_ONE_OBJECT_ID = 1L;
+  private static final long BUCKET_TWO_OBJECT_ID = 2L;
+  private static final long KEY_ONE_OBJECT_ID = 3L;
+  private static final long DIR_ONE_OBJECT_ID = 4L;
+  private static final long KEY_TWO_OBJECT_ID = 5L;
+  private static final long KEY_FOUR_OBJECT_ID = 6L;
+  private static final long DIR_TWO_OBJECT_ID = 7L;
+  private static final long KEY_THREE_OBJECT_ID = 8L;
+  private static final long KEY_FIVE_OBJECT_ID = 9L;
+
+  private static final long KEY_ONE_SIZE = 500L;
+  private static final long KEY_TWO_OLD_SIZE = 1025L;
+  private static final long KEY_TWO_UPDATE_SIZE = 1023L;
+  private static final long KEY_THREE_SIZE =
+          ReconConstants.MAX_FILE_SIZE_UPPER_BOUND - 100L;
+  private static final long KEY_FOUR_SIZE = 2050L;
+  private static final long KEY_FIVE_SIZE = 100L;
+
+  @Before
+  public void setUp() throws Exception {
+    omMetadataManager = initializeNewOmMetadataManager(
+            temporaryFolder.newFolder());
+    ozoneManagerServiceProvider =
+            getMockOzoneManagerServiceProvider();
+    reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
+            temporaryFolder.newFolder());
+
+    ReconTestInjector reconTestInjector =
+            new ReconTestInjector.Builder(temporaryFolder)
+                    .withReconOm(reconOMMetadataManager)
+                    .withOmServiceProvider(ozoneManagerServiceProvider)
+                    .withReconSqlDb()
+                    .withContainerDB()
+                    .build();
+    reconNamespaceSummaryManager =
+            reconTestInjector.getInstance(ReconNamespaceSummaryManager.class);
+  }
+
+  @Test
+  public void testReprocess() throws Exception {
+    NSSummary nonExistentSummary =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
+    Assert.assertNull(nonExistentSummary);
+
+    populateOMDB();
+
+    NSSummaryTask nsSummaryTask = new NSSummaryTask(
+            reconNamespaceSummaryManager);
+    nsSummaryTask.reprocess(reconOMMetadataManager);
+    NSSummary nsSummaryForBucket1 =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
+    NSSummary nsSummaryForBucket2 =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
+    Assert.assertNotNull(nsSummaryForBucket1);
+    Assert.assertNotNull(nsSummaryForBucket2);
+
+    Assert.assertEquals(1, nsSummaryForBucket1.getNumOfFiles());
+    Assert.assertEquals(2, nsSummaryForBucket2.getNumOfFiles());
+
+    Assert.assertEquals(KEY_ONE_SIZE, nsSummaryForBucket1.getSizeOfFiles());
+    Assert.assertEquals(KEY_TWO_OLD_SIZE + KEY_FOUR_SIZE,
+            nsSummaryForBucket2.getSizeOfFiles());
+
+    int[] fileDistBucket1 = nsSummaryForBucket1.getFileSizeBucket();
+    int[] fileDistBucket2 = nsSummaryForBucket2.getFileSizeBucket();
+    Assert.assertEquals(ReconConstants.NUM_OF_BINS, fileDistBucket1.length);
+    Assert.assertEquals(ReconConstants.NUM_OF_BINS, fileDistBucket2.length);
+
+    Assert.assertEquals(1, fileDistBucket1[0]);
+    for (int i = 1; i < ReconConstants.NUM_OF_BINS; ++i) {
+      Assert.assertEquals(0, fileDistBucket1[i]);
+    }
+    Assert.assertEquals(1, fileDistBucket2[1]);
+    Assert.assertEquals(1, fileDistBucket2[2]);
+    for (int i = 0; i < ReconConstants.NUM_OF_BINS; ++i) {
+      if (i == 1 || i == 2) {
+        continue;
+      }
+      Assert.assertEquals(0, fileDistBucket2[i]);
+    }
+
+    // should be empty dir.
+    NSSummary nsSummaryInDir1 = reconNamespaceSummaryManager
+            .getNSSummary(DIR_ONE_OBJECT_ID);
+    Assert.assertNull(nsSummaryInDir1);
+
+    NSSummary nsSummaryInDir2 = reconNamespaceSummaryManager
+            .getNSSummary(DIR_TWO_OBJECT_ID);
+    Assert.assertEquals(1, nsSummaryInDir2.getNumOfFiles());
+    Assert.assertEquals(KEY_THREE_SIZE, nsSummaryInDir2.getSizeOfFiles());
+
+    int[] fileDistForDir2 = nsSummaryInDir2.getFileSizeBucket();
+    Assert.assertEquals(ReconConstants.NUM_OF_BINS, fileDistForDir2.length);
+    Assert.assertEquals(1, fileDistForDir2[fileDistForDir2.length - 1]);
+    for (int i = 0; i < ReconConstants.NUM_OF_BINS - 1; ++i) {
+      Assert.assertEquals(0, fileDistForDir2[i]);
+    }
+  }
+
+  @Test
+  public void testProcess() throws Exception {
+    NSSummary nonExistentSummary =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
+    Assert.assertNull(nonExistentSummary);
+
+    populateOMDB();
+    // Events: put file5, delete file 1, update file 2.
+    String omPutKey = omMetadataManager.getOzoneKey(VOL, BUCKET_TWO, KEY_FIVE);
+    OmKeyInfo omPutKeyInfo = buildOmKeyInfo(VOL, BUCKET_TWO, KEY_FIVE,
+            KEY_FIVE_OBJECT_ID, BUCKET_TWO_OBJECT_ID, KEY_FIVE_SIZE);
+    OMDBUpdateEvent keyEvent1 = new OMDBUpdateEvent.
+            OMUpdateEventBuilder<String, OmKeyInfo>()
+            .setKey(omPutKey)
+            .setValue(omPutKeyInfo)
+            .setTable(omMetadataManager.getKeyTable().getName())
+            .setAction(OMDBUpdateEvent.OMDBUpdateAction.PUT)
+            .build();
+
+    String omDeleteKey = omMetadataManager.getOzoneKey(
+            VOL, BUCKET_ONE, KEY_ONE);
+    OmKeyInfo omDeleteInfo = buildOmKeyInfo(
+            VOL, BUCKET_ONE, KEY_ONE, KEY_ONE_OBJECT_ID, BUCKET_ONE_OBJECT_ID);
+
+    OMDBUpdateEvent keyEvent2 = new OMDBUpdateEvent.
+            OMUpdateEventBuilder<String, OmKeyInfo>()
+            .setKey(omDeleteKey)
+            .setValue(omDeleteInfo)
+            .setTable(omMetadataManager.getKeyTable().getName())
+            .setAction(OMDBUpdateEvent.OMDBUpdateAction.DELETE)
+            .build();
+
+    String omUpdateKey = omMetadataManager.getOzoneKey(
+            VOL, BUCKET_TWO, KEY_TWO);
+    OmKeyInfo omOldInfo = buildOmKeyInfo(VOL, BUCKET_TWO, KEY_TWO,
+            KEY_TWO_OBJECT_ID, BUCKET_TWO_OBJECT_ID, KEY_TWO_OLD_SIZE);
+    OmKeyInfo omUpdateInfo = buildOmKeyInfo(VOL, BUCKET_TWO, KEY_TWO,
+            KEY_TWO_OBJECT_ID, BUCKET_TWO_OBJECT_ID, KEY_TWO_UPDATE_SIZE);
+
+    OMDBUpdateEvent keyEvent3 = new OMDBUpdateEvent.
+            OMUpdateEventBuilder<String, OmKeyInfo>()
+            .setKey(omUpdateKey)
+            .setValue(omUpdateInfo)
+            .setOldValue(omOldInfo)
+            .setTable(omMetadataManager.getKeyTable().getName())
+            .setAction(OMDBUpdateEvent.OMDBUpdateAction.UPDATE)
+            .build();
+
+    OMUpdateEventBatch omUpdateEventBatch = new OMUpdateEventBatch(
+            new ArrayList<OMDBUpdateEvent>() {{
+              add(keyEvent1);
+              add(keyEvent2);
+              add(keyEvent3);
+          }});
+
+    NSSummaryTask nsSummaryTask = new NSSummaryTask(
+            reconNamespaceSummaryManager);
+    nsSummaryTask.reprocess(reconOMMetadataManager);
+    nsSummaryTask.process(omUpdateEventBatch);
+
+    // file 5 is added under bucket 2, so bucket 2 has 3 keys now
+    // file 1 is gone, so bucket 1 is empty now
+    // file 2 is updated with new datasize,
+    // so file size dist for bucket 2 should be updated
+    NSSummary nsSummaryForBucket1 =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
+    Assert.assertNull(nsSummaryForBucket1);
+
+    NSSummary nsSummaryForBucket2 =
+            reconNamespaceSummaryManager.getNSSummary(BUCKET_TWO_OBJECT_ID);
+    Assert.assertNotNull(nsSummaryForBucket2);
+    Assert.assertEquals(3, nsSummaryForBucket2.getNumOfFiles());
+    // key 4 + key 5 + updated key 2
+    Assert.assertEquals(KEY_FOUR_SIZE + KEY_FIVE_SIZE + KEY_TWO_UPDATE_SIZE,
+            nsSummaryForBucket2.getSizeOfFiles());
+
+    int[] fileSizeDist = nsSummaryForBucket2.getFileSizeBucket();
+    Assert.assertEquals(ReconConstants.NUM_OF_BINS, fileSizeDist.length);
+    // 1023L and 100L
+    Assert.assertEquals(2, fileSizeDist[0]);
+    // 2050L
+    Assert.assertEquals(1, fileSizeDist[2]);
+    for (int i = 0; i < ReconConstants.NUM_OF_BINS; ++i) {
+      if (i == 0 || i == 2) {
+        continue;
+      }
+      Assert.assertEquals(0, fileSizeDist[i]);
+    }
+  }
+
+  private OmKeyInfo buildOmKeyInfo(String volume,
+                                   String bucket,
+                                   String key,
+                                   long objectID,
+                                   long parentObjectId,
+                                   long dataSize) {
+    return new OmKeyInfo.Builder()
+            .setBucketName(bucket)
+            .setVolumeName(volume)
+            .setKeyName(key)
+            .setReplicationConfig(
+                    new StandaloneReplicationConfig(
+                            HddsProtos.ReplicationFactor.ONE))
+            .setObjectID(objectID)
+            .setParentObjectID(parentObjectId)
+            .setDataSize(dataSize)
+            .build();
+  }
+
+  private OmKeyInfo buildOmKeyInfo(String volume,
+                                   String bucket,
+                                   String key,
+                                   long objectID,
+                                   long parentObjectId) {
+    return new OmKeyInfo.Builder()
+            .setBucketName(bucket)
+            .setVolumeName(volume)
+            .setKeyName(key)
+            .setReplicationConfig(
+                    new StandaloneReplicationConfig(
+                            HddsProtos.ReplicationFactor.ONE))
+            .setObjectID(objectID)
+            .setParentObjectID(parentObjectId)
+            .build();
+  }
+
+  /**
+   * Populate OMDB with the following configs:
+   * One vol, Two buckets,
+   * Bucket 1 has one key(1) directly, and another key(3) indirectly,
+   * Bucket 2 has two key(2, 4) directly.
+   *
+   * @throws IOException
+   */
+  private void populateOMDB() throws IOException {
+    writeDataToOm(reconOMMetadataManager,
+            KEY_ONE,
+            BUCKET_ONE,
+            VOL,
+            KEY_ONE_OBJECT_ID,
+            BUCKET_ONE_OBJECT_ID,
+            KEY_ONE_SIZE);
+    writeDataToOm(reconOMMetadataManager,
+            KEY_TWO,
+            BUCKET_TWO,
+            VOL,
+            KEY_TWO_OBJECT_ID,
+            BUCKET_TWO_OBJECT_ID,
+            KEY_TWO_OLD_SIZE);
+    writeDataToOm(reconOMMetadataManager,
+            KEY_THREE,
+            BUCKET_ONE,
+            VOL,
+            KEY_THREE_OBJECT_ID,
+            DIR_TWO_OBJECT_ID,
+            KEY_THREE_SIZE);
+    writeDataToOm(reconOMMetadataManager,
+            KEY_FOUR,
+            BUCKET_TWO,
+            VOL,
+            KEY_FOUR_OBJECT_ID,
+            BUCKET_TWO_OBJECT_ID,
+            KEY_FOUR_SIZE);
+  }
+}

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -130,9 +130,14 @@ public class TestNSSummaryTask {
 
     populateOMDB();
 
+    // write a NSSummary prior to reprocess and verify it got cleaned up after.
+    NSSummary staleNSSummary = new NSSummary();
+    reconNamespaceSummaryManager.storeNSSummary(-1L, staleNSSummary);
     NSSummaryTask nsSummaryTask = new NSSummaryTask(
             reconNamespaceSummaryManager);
     nsSummaryTask.reprocess(reconOMMetadataManager);
+
+    Assert.assertNull(reconNamespaceSummaryManager.getNSSummary(-1L));
     NSSummary nsSummaryForBucket1 =
             reconNamespaceSummaryManager.getNSSummary(BUCKET_ONE_OBJECT_ID);
     NSSummary nsSummaryForBucket2 =


### PR DESCRIPTION
## What changes were proposed in this pull request?

FileSizeCountTask counts the number of bins inside each buckets.
Try to build on FileSizeCountTask to count what we need for NSSummary as well.
[6.28] Added an independent Recon task to process namespace summary info per objectID in the attempt to decouple with other task modules.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5386

## How was this patch tested?
Unit test: org.apache.hadoop.ozone.recon.tasks.TestNSSummaryTask
