### PR TITLE
HDDS-5422. Avoid eager string formatting in preconditions

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -179,11 +179,10 @@ public class ContainerReader implements Runnable {
 
     if (!isInUpgradeMode) {
       Preconditions.checkArgument(clusterDir.exists(),
-          "Storage Dir:" + clusterDir + " doesn't exists");
+          "Storage Dir: %s doesn't exist", clusterDir);
       Preconditions.checkArgument(storageLoc.equals(clusterDir),
-          "configured storage location path" + storageLoc +
-              " does not container the clusterId:" +
-              hddsVolume.getClusterID());
+          "configured storage location %s does not contain the clusterId: %s",
+              storageLoc, hddsVolume.getClusterID());
       return storageLoc;
     }
 
@@ -192,7 +191,7 @@ public class ContainerReader implements Runnable {
     }
 
     try {
-      LOG.info("Storage dir based on clusterId doesn't exists." +
+      LOG.info("Storage dir based on clusterId doesn't exist." +
           "Renaming storage location:{} to {}", storageLoc, clusterDir);
       NativeIO.renameTo(storageLoc, clusterDir);
       return clusterDir;
@@ -297,7 +296,7 @@ public class ContainerReader implements Runnable {
 
     if (!isInUpgradeMode) {
       Preconditions.checkArgument(newPath.toFile().exists(),
-          "modified path:" + newPath + " doesn't exists");
+          "modified path:%s doesn't exist", newPath);
     }
 
     LOG.debug("new Normalized Path is:{}", newPath);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/MetadataKeyFilters.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/MetadataKeyFilters.java
@@ -104,7 +104,7 @@ public final class MetadataKeyFilters {
 
     public KeyPrefixFilter addFilter(String keyPrefix, boolean negative) {
       Preconditions.checkArgument(!Strings.isNullOrEmpty(keyPrefix),
-          "KeyPrefix is null or empty: " + keyPrefix);
+          "KeyPrefix is null or empty: %s", keyPrefix);
       // keyPrefix which needs to be added should not be prefix of any opposing
       // filter already present. If keyPrefix is a negative filter it should not
       // be a prefix of any positive filter. Nor should any opposing filter be

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/SCMBlockDeletingService.java
@@ -97,7 +97,7 @@ public class SCMBlockDeletingService extends BackgroundService
     blockDeleteLimitSize =
         conf.getObject(ScmConfig.class).getBlockDeletionLimit();
     Preconditions.checkArgument(blockDeleteLimitSize > 0,
-        "Block deletion limit should be " + "positive.");
+        "Block deletion limit should be positive.");
 
     // register SCMBlockDeletingService to SCMServiceManager
     serviceManager.register(this);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateMap.java
@@ -65,9 +65,9 @@ class PipelineStateMap {
     Preconditions.checkArgument(
         pipeline.getNodes().size() == pipeline.getReplicationConfig()
             .getRequiredNodes(),
-        String.format("Nodes size=%d, replication factor=%d do not match ",
+        "Nodes size=%s, replication factor=%s do not match ",
             pipeline.getNodes().size(), pipeline.getReplicationConfig()
-                .getRequiredNodes()));
+                .getRequiredNodes());
 
     if (pipelineMap.putIfAbsent(pipeline.getId(), pipeline) != null) {
       LOG.warn("Duplicate pipeline ID detected. {}", pipeline.getId());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/WithObjectID.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import com.google.common.base.Preconditions;
-
 /**
  * Mixin class to handle ObjectID and UpdateID.
  */
@@ -103,8 +101,8 @@ public class WithObjectID extends WithMetadata {
     // Main reason, in non-HA transaction Index after restart starts from 0.
     // And also because of this same reason we don't do replay checks in non-HA.
 
-    if (isRatisEnabled) {
-      Preconditions.checkArgument(updateId >= this.updateID, String.format(
+    if (isRatisEnabled && updateId < this.updateID) {
+      throw new IllegalArgumentException(String.format(
           "Trying to set updateID to %d which is not greater than the " +
               "current value of %d for %s", updateId, this.updateID,
           getObjectInfo()));

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -115,9 +115,10 @@ public class BasicOzoneFileSystem extends FileSystem {
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
     setConf(conf);
-    Objects.requireNonNull(name.getScheme(), "No scheme provided in " + name);
+    Preconditions.checkNotNull(name.getScheme(),
+        "No scheme provided in %s", name);
     Preconditions.checkArgument(getScheme().equals(name.getScheme()),
-        "Invalid scheme provided in " + name);
+        "Invalid scheme provided in %s", name);
 
     String authority = name.getAuthority();
     if (authority == null) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -111,9 +111,10 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   public void initialize(URI name, Configuration conf) throws IOException {
     super.initialize(name, conf);
     setConf(conf);
-    Objects.requireNonNull(name.getScheme(), "No scheme provided in " + name);
+    Preconditions.checkNotNull(name.getScheme(),
+        "No scheme provided in %s", name);
     Preconditions.checkArgument(getScheme().equals(name.getScheme()),
-        "Invalid scheme provided in " + name);
+        "Invalid scheme provided in %s", name);
 
     String authority = name.getAuthority();
     if (authority == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some calls to `Preconditions.check...` eagerly format the error message, resulting in unnecessary allocations.

https://issues.apache.org/jira/browse/HDDS-5422

## How was this patch tested?

:eyes:

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1011814193