### PR TITLE
HDDS-5421. SCM throws NPE during JMX call.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMHANodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
@@ -1780,7 +1781,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   @Override
   public String getScmRatisRoles() throws IOException {
-    return HddsUtils.format(getScmHAManager().getRatisServer().getRatisRoles());
+    final SCMRatisServer server = getScmHAManager().getRatisServer();
+    return server != null ?
+        HddsUtils.format(server.getRatisRoles()) : "STANDALONE";
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
After this change _StorageContainerManager#getScmRatisRoles_ will return **STANDALONE** when SCM HA is not enabled.

## What is the link to the Apache JIRA
HDDS-5421

## How was this patch tested?
Manual testing
