### PR TITLE
HDDS-5423. Robot test should print the entire exception stack trace.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -192,7 +192,7 @@ execute_robot_test(){
       -v OZONE_DIR:"${OZONE_DIR}" \
       -v SECURITY_ENABLED:"${SECURITY_ENABLED}" \
       -v SCM:"${SCM}" \
-      ${ARGUMENTS[@]} --log NONE --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" \
+      ${ARGUMENTS[@]} --maxerrorlines NONE --log NONE --report NONE "${OZONE_ROBOT_OPTS[@]}" --output "$OUTPUT_PATH" \
       "$SMOKETEST_DIR_INSIDE/$TEST"
   local -i rc=$?
 

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -128,7 +128,7 @@ execute_robot_test() {
 
    kubectl exec -it "${CONTAINER}" -- bash -c 'rm -rf /tmp/report'
    kubectl exec -it "${CONTAINER}" -- bash -c 'mkdir -p  /tmp/report'
-   kubectl exec -it "${CONTAINER}" -- robot --nostatusrc -d /tmp/report ${ARGUMENTS[@]} || true
+   kubectl exec -it "${CONTAINER}" -- robot --nostatusrc --maxerrorlines NONE -d /tmp/report ${ARGUMENTS[@]} || true
    kubectl cp "${CONTAINER}":/tmp/report/output.xml "result/$CONTAINER-$RANDOM.xml" || true
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Robot test truncates the exception lines in the output, this jira ensures that the entire exception is printed.

https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#limiting-error-message-length-in-reports

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5423

## How was this patch tested?

Observed output of another excpetion trace with the option enabled.