### PR TITLE
HDDS-5424. Pipeline list command's output should be in local timezone.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -386,7 +387,8 @@ public final class Pipeline {
     b.append(", ReplicationConfig: ").append(replicationConfig);
     b.append(", State:").append(getPipelineState());
     b.append(", leaderId:").append(leaderId != null ? leaderId.toString() : "");
-    b.append(", CreationTimestamp").append(getCreationTimestamp());
+    b.append(", CreationTimestamp").append(getCreationTimestamp()
+        .atZone(ZoneId.systemDefault()));
     b.append("]");
     return b.toString();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Pipeline list command prints the creation time in UTC format, this should be in the system's local timezone.

Options

## What is the link to the Apache JIRA
HDDS-5424.


## How was this patch tested?
Manual testing done
