### PR TITLE
HDDS-3983 Ozone RocksDB Iterator wrapper should not expose key() and value() API.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
@@ -36,7 +36,7 @@ public class RDBStoreIterator
   private static final Logger LOG =
       LoggerFactory.getLogger(RDBStoreIterator.class);
 
-  private RocksIterator rocksDBIterator;
+  private final RocksIterator rocksDBIterator;
   private RDBTable rocksDBTable;
   private ByteArrayKeyValue currentEntry;
 
@@ -99,23 +99,6 @@ public class RDBStoreIterator
     rocksDBIterator.seek(key);
     setCurrentEntry();
     return currentEntry;
-  }
-
-  @Override
-  public byte[] key() {
-    if (rocksDBIterator.isValid()) {
-      return rocksDBIterator.key();
-    }
-    return null;
-  }
-
-  @Override
-  public ByteArrayKeyValue value() {
-    if (rocksDBIterator.isValid()) {
-      return ByteArrayKeyValue.create(rocksDBIterator.key(),
-          rocksDBIterator.value());
-    }
-    return null;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TableIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TableIterator.java
@@ -49,18 +49,6 @@ public interface TableIterator<KEY, T> extends Iterator<T>, Closeable {
   T seek(KEY key) throws IOException;
 
   /**
-   * Returns the key value at the current position.
-   * @return KEY
-   */
-  KEY key() throws IOException;
-
-  /**
-   * Returns the VALUE at the current position.
-   * @return VALUE
-   */
-  T value();
-
-  /**
    * Remove the actual value of the iterator from the database table on
    * which the iterator is working on.
    *

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -450,24 +450,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
     }
 
     @Override
-    public KEY key() throws IOException {
-      byte[] result = rawIterator.key();
-      if (result == null) {
-        return null;
-      }
-      return codecRegistry.asObject(result, keyClass);
-    }
-
-    @Override
-    public TypedKeyValue value() {
-      KeyValue keyValue = rawIterator.value();
-      if(keyValue != null) {
-        return new TypedKeyValue(keyValue, keyClass, valueClass);
-      }
-      return null;
-    }
-
-    @Override
     public void close() throws IOException {
       rawIterator.close();
     }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -168,7 +168,8 @@ public class TestRDBStoreIterator {
     when(rocksDBIteratorMock.key()).thenReturn(new byte[]{0x00});
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    byte[] key = iter.key();
+    ByteArrayKeyValue entry = iter.next();
+    byte[] key = entry.getKey();
 
     InOrder verifier = inOrder(rocksDBIteratorMock);
 
@@ -184,14 +185,14 @@ public class TestRDBStoreIterator {
     when(rocksDBIteratorMock.value()).thenReturn(new byte[]{0x7f});
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    ByteArrayKeyValue val = iter.value();
+    ByteArrayKeyValue entry = iter.next();
 
     InOrder verifier = inOrder(rocksDBIteratorMock);
 
     verifier.verify(rocksDBIteratorMock, times(1)).isValid();
     verifier.verify(rocksDBIteratorMock, times(1)).key();
-    assertArrayEquals(new byte[]{0x00}, val.getKey());
-    assertArrayEquals(new byte[]{0x7f}, val.getValue());
+    assertArrayEquals(new byte[]{0x00}, entry.getKey());
+    assertArrayEquals(new byte[]{0x7f}, entry.getValue());
   }
 
   @Test

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -168,8 +168,11 @@ public class TestRDBStoreIterator {
     when(rocksDBIteratorMock.key()).thenReturn(new byte[]{0x00});
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    ByteArrayKeyValue entry = iter.next();
-    byte[] key = entry.getKey();
+    byte[] key = null;
+    if(iter.hasNext()) {
+      ByteArrayKeyValue entry = iter.next();
+      key = entry.getKey();
+    }
 
     InOrder verifier = inOrder(rocksDBIteratorMock);
 
@@ -185,7 +188,10 @@ public class TestRDBStoreIterator {
     when(rocksDBIteratorMock.value()).thenReturn(new byte[]{0x7f});
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    ByteArrayKeyValue entry = iter.next();
+    ByteArrayKeyValue entry = null;
+    if(iter.hasNext()) {
+      entry = iter.next();
+    }
 
     InOrder verifier = inOrder(rocksDBIteratorMock);
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -188,17 +188,21 @@ public class TestRDBStoreIterator {
     when(rocksDBIteratorMock.value()).thenReturn(new byte[]{0x7f});
 
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    ByteArrayKeyValue entry = null;
+    ByteArrayKeyValue entry;
+    byte[] key = null;
+    byte[] value = null;
     if(iter.hasNext()) {
       entry = iter.next();
+      key = entry.getKey();
+      value = entry.getValue();
     }
 
     InOrder verifier = inOrder(rocksDBIteratorMock);
 
     verifier.verify(rocksDBIteratorMock, times(1)).isValid();
     verifier.verify(rocksDBIteratorMock, times(1)).key();
-    assertArrayEquals(new byte[]{0x00}, entry.getKey());
-    assertArrayEquals(new byte[]{0x7f}, entry.getValue());
+    assertArrayEquals(new byte[]{0x00}, key);
+    assertArrayEquals(new byte[]{0x7f}, value);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -153,16 +153,6 @@ public class DeletedBlockLogStateManagerImpl
       }
 
       @Override
-      public Long key() throws IOException {
-        throw new UnsupportedOperationException("key");
-      }
-
-      @Override
-      public TypedTable.KeyValue<Long, DeletedBlocksTransaction> value() {
-        throw new UnsupportedOperationException("value");
-      }
-
-      @Override
       public void removeFromDB() throws IOException {
         throw new UnsupportedOperationException("read-only");
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2472,7 +2472,9 @@ public class KeyManagerImpl implements KeyManager {
                   OmKeyInfo fakeDirEntry = createDirectoryKey(
                       omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
                       immediateChild, omKeyInfo.getAcls());
-                  cacheKeyMap.put(entryInDb, new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
+                  cacheKeyMap.put(entryInDb,
+                      new OzoneFileStatus(fakeDirEntry,
+                          scmBlockSize, true));
                 } else {
                   // If entryKeyName matches dir name, we have the info
                   cacheKeyMap.put(entryInDb,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2429,8 +2429,7 @@ public class KeyManagerImpl implements KeyManager {
     // Then, find key in DB
     String seekKeyInDb =
         metadataManager.getOzoneKey(volumeName, bucketName, startKey);
-    Table.KeyValue<String, OmKeyInfo> entry;
-    entry = iterator.seek(seekKeyInDb);
+    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDb);
     int countEntries = 0;
     if (iterator.hasNext()) {
       if (entry.getKey().equals(keyArgs)) {
@@ -2828,7 +2827,7 @@ public class KeyManagerImpl implements KeyManager {
     while (iterator.hasNext() && numEntries - countEntries > 0) {
       Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
-      if (deletedKeySet.contains(dirInfo.getPath()) && iterator.hasNext()) {
+      if (deletedKeySet.contains(dirInfo.getPath())) {
         iterator.next(); // move to next entry in the table
         // entry is actually deleted in cache and can exists in DB
         continue;
@@ -2865,7 +2864,7 @@ public class KeyManagerImpl implements KeyManager {
     while (iterator.hasNext() && numEntries - countEntries > 0) {
       Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo keyInfo = entry.getValue();
-      if (iterator.hasNext() && deletedKeySet.contains(keyInfo.getPath())) {
+      if (deletedKeySet.contains(keyInfo.getPath())) {
         iterator.next(); // move to next entry in the table
         // entry is actually deleted in cache and can exists in DB
         continue;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2823,9 +2823,10 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
             iterator = dirTable.iterator();
 
-    Table.KeyValue<String, OmDirectoryInfo> entry = iterator.seek(seekDirInDB);
+    iterator.seek(seekDirInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
+      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
       if (deletedKeySet.contains(dirInfo.getPath()) && iterator.hasNext()) {
         iterator.next(); // move to next entry in the table
@@ -2847,8 +2848,6 @@ public class KeyManagerImpl implements KeyManager {
                 true));
         countEntries++;
       }
-      // move to next entry in the DirTable
-      entry = iterator.next();
     }
 
     return countEntries;
@@ -2862,8 +2861,9 @@ public class KeyManagerImpl implements KeyManager {
       TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
           iterator)
       throws IOException {
-    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekKeyInDB);
+    iterator.seek(seekKeyInDB);
     while (iterator.hasNext() && numEntries - countEntries > 0) {
+      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo keyInfo = entry.getValue();
       if (iterator.hasNext() && deletedKeySet.contains(keyInfo.getPath())) {
         iterator.next(); // move to next entry in the table
@@ -2882,7 +2882,6 @@ public class KeyManagerImpl implements KeyManager {
       cacheKeyMap.put(fullKeyPath,
               new OzoneFileStatus(keyInfo, scmBlockSize, false));
       countEntries++;
-      entry = iterator.next(); // move to next entry in the table
     }
     return countEntries;
   }
@@ -3200,9 +3199,10 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
         iterator = dirTable.iterator();
 
-    Table.KeyValue<String, OmDirectoryInfo> entry = iterator.seek(seekDirInDB);
+    iterator.seek(seekDirInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
+      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
       if (!OMFileRequest.isImmediateChild(dirInfo.getParentObjectID(),
           parentInfo.getObjectID())) {
@@ -3215,9 +3215,6 @@ public class KeyManagerImpl implements KeyManager {
           dirName);
       directories.add(omKeyInfo);
       countEntries++;
-
-      // move to next entry in the DirTable
-      entry = iterator.next();
     }
 
     return directories;
@@ -3237,9 +3234,10 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
         iterator = fileTable.iterator();
 
-    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekFileInDB);
+    iterator.seek(seekFileInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
+      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo fileInfo = entry.getValue();
       if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
           parentInfo.getObjectID())) {
@@ -3252,8 +3250,6 @@ public class KeyManagerImpl implements KeyManager {
 
       files.add(fileInfo);
       countEntries++;
-      // move to next entry in the KeyTable
-      entry = iterator.next();
     }
 
     return files;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2472,8 +2472,7 @@ public class KeyManagerImpl implements KeyManager {
                   OmKeyInfo fakeDirEntry = createDirectoryKey(
                       omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
                       immediateChild, omKeyInfo.getAcls());
-                  cacheKeyMap.put(entryInDb,
-                      new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
+                  cacheKeyMap.put(entryInDb, new OzoneFileStatus(fakeDirEntry, scmBlockSize, true));
                 } else {
                   // If entryKeyName matches dir name, we have the info
                   cacheKeyMap.put(entryInDb,
@@ -2822,13 +2821,12 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
             iterator = dirTable.iterator();
 
-    iterator.seek(seekDirInDB);
+    Table.KeyValue<String, OmDirectoryInfo> entry = iterator.seek(seekDirInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
-      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
-      if (deletedKeySet.contains(dirInfo.getPath()) && iterator.hasNext()) {
-        iterator.next(); // move to next entry in the table
+      if (deletedKeySet.contains(dirInfo.getPath())) {
+        entry = iterator.next(); // move to next entry in the table
         // entry is actually deleted in cache and can exists in DB
         continue;
       }
@@ -2848,7 +2846,7 @@ public class KeyManagerImpl implements KeyManager {
         countEntries++;
       }
       // move to next entry in the DirTable
-      iterator.next();
+      entry = iterator.next();
     }
 
     return countEntries;
@@ -2866,8 +2864,8 @@ public class KeyManagerImpl implements KeyManager {
     while (iterator.hasNext() && numEntries - countEntries > 0) {
       Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo keyInfo = entry.getValue();
-      if (deletedKeySet.contains(keyInfo.getPath()) && iterator.hasNext()) {
-        iterator.next(); // move to next entry in the table
+      if (iterator.hasNext() && deletedKeySet.contains(keyInfo.getPath())) {
+        entry = iterator.next(); // move to next entry in the table
         // entry is actually deleted in cache and can exists in DB
         continue;
       }
@@ -2883,7 +2881,7 @@ public class KeyManagerImpl implements KeyManager {
       cacheKeyMap.put(fullKeyPath,
               new OzoneFileStatus(keyInfo, scmBlockSize, false));
       countEntries++;
-      iterator.next(); // move to next entry in the table
+      entry = iterator.next(); // move to next entry in the table
     }
     return countEntries;
   }
@@ -3201,10 +3199,9 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
         iterator = dirTable.iterator();
 
-    iterator.seek(seekDirInDB);
+    Table.KeyValue<String, OmDirectoryInfo> entry = iterator.seek(seekDirInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
-      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
       if (!OMFileRequest.isImmediateChild(dirInfo.getParentObjectID(),
           parentInfo.getObjectID())) {
@@ -3220,7 +3217,7 @@ public class KeyManagerImpl implements KeyManager {
 
       // move to next entry in the DirTable
       if(iterator.hasNext()) {
-        iterator.next();
+        entry = iterator.next();
       }
     }
 
@@ -3241,10 +3238,9 @@ public class KeyManagerImpl implements KeyManager {
     TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
         iterator = fileTable.iterator();
 
-    iterator.seek(seekFileInDB);
+    Table.KeyValue<String, OmKeyInfo> entry = iterator.seek(seekFileInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {
-      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo fileInfo = entry.getValue();
       if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
           parentInfo.getObjectID())) {
@@ -3259,7 +3255,7 @@ public class KeyManagerImpl implements KeyManager {
       countEntries++;
       // move to next entry in the KeyTable
       if(iterator.hasNext()) {
-        iterator.next();
+        entry = iterator.next();
       }
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -888,7 +888,8 @@ public final class OMFileRequest {
     iterator.seek(seekDirInDB);
 
     if (iterator.hasNext()) {
-      OmDirectoryInfo dirInfo = iterator.value().getValue();
+      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
+      OmDirectoryInfo dirInfo = entry.getValue();
       return isImmediateChild(dirInfo.getParentObjectID(),
               omKeyInfo.getObjectID());
     }
@@ -926,7 +927,8 @@ public final class OMFileRequest {
     iterator.seek(seekFileInDB);
 
     if (iterator.hasNext()) {
-      OmKeyInfo fileInfo = iterator.value().getValue();
+      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
+      OmKeyInfo fileInfo = entry.getValue();
       return isImmediateChild(fileInfo.getParentObjectID(),
               omKeyInfo.getObjectID()); // found a sub path file
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

It was found that there is discrepancy in the implementation of the next(), key() and value() methods in the RDBStoreIterator wrapper class.

next() returns the current rocksdb entry and moves ahead to the next entry.
key() returns current rocksdb entry's key.
value() returns current rocksdb entry's value.

This means that during iteration next() returns the current value, and subsequent calls to key() / value() after next() will return the next value. To solve this, we can remove those 2 APIs from the iterator class, and have the usages follow this pattern.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3983

## How was this patch tested?

Unit tests locally.
