### PR TITLE
HDDS-5427. Either re-interrupt this method or rethrow the "InterruptedException" that can be caught here

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -261,6 +261,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
         futureHashMap.put(dn, sendCommandAsync(request, dn).getResponse());
       } catch (InterruptedException e) {
         LOG.error("Command execution was interrupted.");
+        // Re-interrupt the thread while catching InterruptedException
+        Thread.currentThread().interrupt();
       }
     }
     try{
@@ -271,6 +273,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       }
     } catch (InterruptedException e) {
       LOG.error("Command execution was interrupted.");
+      // Re-interrupt the thread while catching InterruptedException
+      Thread.currentThread().interrupt();
     } catch (ExecutionException e) {
       LOG.error("Failed to execute command " + request, e);
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -219,7 +219,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       try {
         channel.awaitTermination(60, TimeUnit.MINUTES);
       } catch (InterruptedException e) {
-        LOG.error("Unexpected exception while waiting for channel termination",
+        LOG.error("InterruptedException while waiting for channel termination",
             e);
         // Re-interrupt the thread while catching InterruptedException
         Thread.currentThread().interrupt();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -218,9 +218,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       channel.shutdownNow();
       try {
         channel.awaitTermination(60, TimeUnit.MINUTES);
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         LOG.error("Unexpected exception while waiting for channel termination",
             e);
+        // Re-interrupt the thread while catching InterruptedException
+        Thread.currentThread().interrupt();
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Re-interrupt the thread while catching InterruptedException.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5427


## How was this patch tested?

No need.
