### PR TITLE
HDDS-5428. Fix potential BigDecimal precision in StorageUnit.java

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageUnit.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/StorageUnit.java
@@ -478,8 +478,8 @@ public enum StorageUnit {
    * @return -- returns a double that represents this value
    */
   private static double divide(double value, double divisor) {
-    BigDecimal val = new BigDecimal(value);
-    BigDecimal bDivisor = new BigDecimal(divisor);
+    BigDecimal val = BigDecimal.valueOf(value);
+    BigDecimal bDivisor = BigDecimal.valueOf(divisor);
     return val.divide(bDivisor).setScale(PRECISION, RoundingMode.HALF_UP)
         .doubleValue();
   }
@@ -492,8 +492,8 @@ public enum StorageUnit {
    * @return Returns a double
    */
   private static double multiply(double first, double second) {
-    BigDecimal firstVal = new BigDecimal(first);
-    BigDecimal secondVal = new BigDecimal(second);
+    BigDecimal firstVal = BigDecimal.valueOf(first);
+    BigDecimal secondVal = BigDecimal.valueOf(second);
     return firstVal.multiply(secondVal)
         .setScale(PRECISION, RoundingMode.HALF_UP).doubleValue();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Because of floating point imprecision, you’re unlikely to get the value you expect from the `BigDecimal(double)` constructor.

Instead, you should use `BigDecimal.valueOf`, which uses a string under the covers to eliminate floating point rounding errors.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5428

## How was this patch tested?

No need.
