### PR TITLE
HDDS-5433. Rename hadooprpc proto compilation in pom to refer to proto2.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/hdds-version-info.properties
+++ b/hadoop-hdds/common/src/main/resources/hdds-version-info.properties
@@ -23,5 +23,5 @@ user=${user.name}
 date=${version-info.build.time}
 url=${version-info.scm.uri}
 srcChecksum=${version-info.source.md5}
-hadoopProtocVersion=${hadooprpc.protobuf.version}
+hadoopProtocVersion=${proto2.hadooprpc.protobuf.version}
 grpcProtocVersion=${grpc.protobuf-compile.version}

--- a/hadoop-hdds/interface-admin/pom.xml
+++ b/hadoop-hdds/interface-admin/pom.xml
@@ -60,7 +60,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <outputDirectory>target/generated-sources/java</outputDirectory>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -89,7 +89,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <includes>

--- a/hadoop-hdds/interface-server/pom.xml
+++ b/hadoop-hdds/interface-server/pom.xml
@@ -86,7 +86,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             </goals>
             <configuration>
               <protocArtifact>
-                com.google.protobuf:protoc:${hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <excludes>

--- a/hadoop-ozone/common/src/main/resources/ozone-version-info.properties
+++ b/hadoop-ozone/common/src/main/resources/ozone-version-info.properties
@@ -24,5 +24,5 @@ user=${user.name}
 date=${version-info.build.time}
 url=${version-info.scm.uri}
 srcChecksum=${version-info.source.md5}
-hadoopProtocVersion=${hadooprpc.protobuf.version}
+hadoopProtocVersion=${proto2.hadooprpc.protobuf.version}
 grpcProtocVersion=${grpc.protobuf-compile.version}

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -59,7 +59,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
             <configuration>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <protocArtifact>
-                com.google.protobuf:protoc:${hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
             </configuration>
           </execution>

--- a/hadoop-ozone/interface-storage/pom.xml
+++ b/hadoop-ozone/interface-storage/pom.xml
@@ -91,7 +91,7 @@
             <configuration>
               <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
               <protocArtifact>
-                com.google.protobuf:protoc:${hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+                com.google.protobuf:protoc:${proto2.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
               </protocArtifact>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- ProtocolBuffer version, used to verify the protoc version and -->
     <!-- define the protobuf JAR version                               -->
-    <hadooprpc.protobuf.version>2.5.0</hadooprpc.protobuf.version>
+    <proto2.hadooprpc.protobuf.version>2.5.0</proto2.hadooprpc.protobuf.version>
 
     <findbugs.version>3.0.0</findbugs.version>
     <spotbugs.version>3.1.12</spotbugs.version>
@@ -1301,7 +1301,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
-        <version>${hadooprpc.protobuf.version}</version>
+        <version>${proto2.hadooprpc.protobuf.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-daemon</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Simple change to rename hadooprpc.protobuf.version to proto2.hadooprpc.protobuf.version

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5433

## How was this patch tested?
Compilation works
