### PR TITLE
HDDS-5392. Avoid catching Error while creating Ozone client

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -137,11 +137,11 @@ public class OzoneClientProducer {
         LOG.debug("Error during Client Creation: ", ex);
       }
       throw wrapOS3Exception(ex);
-    } catch (Throwable t) {
+    } catch (Exception e) {
       // For any other critical errors during object creation throw Internal
       // error.
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Error during Client Creation: ", t);
+        LOG.debug("Error during Client Creation: ", e);
       }
       throw wrapOS3Exception(INTERNAL_ERROR);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OzoneClientProducer` catches any `Throwable` while creating the Ozone client and logs it at debug level.  Errors such as `OutOfMemoryError` should not be suppressed like this.

https://issues.apache.org/jira/browse/HDDS-5392

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1025056374