### PR TITLE
HDDS-5431. compile both proto2 and proto3 versions of Client to OM interaction proto files.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/HddsVersionInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/HddsVersionInfo.java
@@ -47,8 +47,9 @@ public final class HddsVersionInfo {
     System.out.println("Compiled by " + HDDS_VERSION_INFO.getUser() + " on "
         + HDDS_VERSION_INFO.getDate());
     System.out.println(
-        "Compiled with protoc " + HDDS_VERSION_INFO.getHadoopProtocVersion() +
-            " and " + HDDS_VERSION_INFO.getGrpcProtocVersion());
+        "Compiled with protoc " + HDDS_VERSION_INFO.getHadoopProtoc2Version() +
+            ", " + HDDS_VERSION_INFO.getGrpcProtocVersion() +
+            " and " + HDDS_VERSION_INFO.getHadoopProtoc3Version());
     System.out.println(
         "From source with checksum " + HDDS_VERSION_INFO.getSrcChecksum());
     if (LOG.isDebugEnabled()) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/VersionInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/VersionInfo.java
@@ -89,6 +89,10 @@ public class VersionInfo {
     return info.getProperty("hadoopProtoc2Version", "Unknown");
   }
 
+  public String getHadoopProtocVersion() {
+    return getHadoopProtoc2Version();
+  }
+
   public String getHadoopProtoc3Version() {
     return info.getProperty("hadoopProtoc3Version", "Unknown");
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/VersionInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/VersionInfo.java
@@ -85,8 +85,12 @@ public class VersionInfo {
     return info.getProperty("srcChecksum", "Unknown");
   }
 
-  public String getHadoopProtocVersion() {
-    return info.getProperty("hadoopProtocVersion", "Unknown");
+  public String getHadoopProtoc2Version() {
+    return info.getProperty("hadoopProtoc2Version", "Unknown");
+  }
+
+  public String getHadoopProtoc3Version() {
+    return info.getProperty("hadoopProtoc3Version", "Unknown");
   }
 
   public String getGrpcProtocVersion() {

--- a/hadoop-hdds/common/src/main/resources/hdds-version-info.properties
+++ b/hadoop-hdds/common/src/main/resources/hdds-version-info.properties
@@ -23,5 +23,6 @@ user=${user.name}
 date=${version-info.build.time}
 url=${version-info.scm.uri}
 srcChecksum=${version-info.source.md5}
-hadoopProtocVersion=${proto2.hadooprpc.protobuf.version}
+hadoopProtoc2Version=${proto2.hadooprpc.protobuf.version}
+hadoopProtoc3Version=${proto3.hadooprpc.protobuf.version}
 grpcProtocVersion=${grpc.protobuf-compile.version}

--- a/hadoop-hdds/interface-client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-hdds/interface-client/dev-support/findbugsExcludeFile.xml
@@ -24,4 +24,7 @@
   <Match>
     <Package name="org.apache.hadoop.hdds.protocol.scm.proto"/>
   </Match>
+  <Match>
+    <Package name="org.apache.hadoop.hdds.protocol.proto3"/>
+  </Match>
 </FindBugsFilter>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -152,6 +152,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                 </replace>
                 <move file="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto"
                       tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3"/>
+                <move file="target/generated-sources/java/proto3"
+                      tofile="target/generated-sources/java"/>
               </tasks>
             </configuration>
             <goals>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -150,6 +150,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                          value="org.apache.hadoop.thirdparty.protobuf"
                          dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto">
                 </replace>
+                <move file="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto"
+                      tofile="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto3"/>
               </tasks>
             </configuration>
             <goals>

--- a/hadoop-hdds/interface-client/pom.xml
+++ b/hadoop-hdds/interface-client/pom.xml
@@ -35,6 +35,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>protobuf-java</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop.thirdparty</groupId>
+      <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-thirdparty-misc</artifactId>
       <version>${ratis.thirdparty.version}</version>
@@ -57,7 +61,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <extensions>true</extensions>
         <executions>
           <execution>
-            <id>compile-protoc-3</id>
+            <id>compile-protoc-grpc</id>
             <goals>
               <goal>compile</goal>
               <goal>test-compile</goal>
@@ -99,6 +103,24 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <clearOutputDirectory>false</clearOutputDirectory>
             </configuration>
           </execution>
+          <execution>
+            <id>compile-protoc-3</id>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <protocArtifact>
+                com.google.protobuf:protoc:${proto3.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+              </protocArtifact>
+              <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+              <includes>
+                <include>hdds.proto</include>
+              </includes>
+              <outputDirectory>target/generated-sources/java/proto3</outputDirectory>
+              <clearOutputDirectory>false</clearOutputDirectory>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -119,6 +141,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                 <replace token="com.google.common"
                          value="org.apache.ratis.thirdparty.com.google.common"
                          dir="target/generated-sources/java/org/apache/hadoop/hdds/protocol/datanode/proto">
+                </replace>
+                <replace token="org.apache.hadoop.hdds.protocol.proto"
+                         value="org.apache.hadoop.hdds.protocol.proto3"
+                         dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto">
+                </replace>
+                <replace token="com.google.protobuf"
+                         value="org.apache.hadoop.thirdparty.protobuf"
+                         dir="target/generated-sources/java/proto3/org/apache/hadoop/hdds/protocol/proto">
                 </replace>
               </tasks>
             </configuration>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/util/OzoneVersionInfo.java
@@ -72,8 +72,9 @@ public final class OzoneVersionInfo {
     System.out.println("Compiled by " + OZONE_VERSION_INFO.getUser() + " on "
         + OZONE_VERSION_INFO.getDate());
     System.out.println(
-        "Compiled with protoc " + OZONE_VERSION_INFO.getHadoopProtocVersion()
-            + " and " + OZONE_VERSION_INFO.getGrpcProtocVersion());
+        "Compiled with protoc " + OZONE_VERSION_INFO.getHadoopProtoc2Version() +
+            ", " + OZONE_VERSION_INFO.getGrpcProtocVersion() +
+            " and " + OZONE_VERSION_INFO.getHadoopProtoc3Version());
     System.out.println(
         "From source with checksum " + OZONE_VERSION_INFO.getSrcChecksum());
     System.out.println(

--- a/hadoop-ozone/common/src/main/resources/ozone-version-info.properties
+++ b/hadoop-ozone/common/src/main/resources/ozone-version-info.properties
@@ -24,5 +24,6 @@ user=${user.name}
 date=${version-info.build.time}
 url=${version-info.scm.uri}
 srcChecksum=${version-info.source.md5}
-hadoopProtocVersion=${proto2.hadooprpc.protobuf.version}
+hadoopProtoc2Version=${proto2.hadooprpc.protobuf.version}
+hadoopProtoc3Version=${proto3.hadooprpc.protobuf.version}
 grpcProtocVersion=${grpc.protobuf-compile.version}

--- a/hadoop-ozone/interface-client/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/interface-client/dev-support/findbugsExcludeFile.xml
@@ -21,4 +21,10 @@
   <Match>
     <Package name="org.apache.hadoop.ozone.security.proto"/>
   </Match>
+  <Match>
+    <Package name="org.apache.hadoop.ozone.protocol.proto3"/>
+  </Match>
+  <Match>
+    <Package name="org.apache.hadoop.ozone.security.proto3"/>
+  </Match>
 </FindBugsFilter>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -63,6 +63,59 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               </protocArtifact>
             </configuration>
           </execution>
+          <execution>
+            <id>compile-protoc3</id>
+            <goals>
+              <goal>compile</goal>
+              <goal>test-compile</goal>
+            </goals>
+            <configuration>
+              <protoSourceRoot>${basedir}/src/main/proto/</protoSourceRoot>
+              <protocArtifact>
+                com.google.protobuf:protoc:${proto3.hadooprpc.protobuf.version}:exe:${os.detected.classifier}
+              </protocArtifact>
+              <outputDirectory>target/generated-sources/protobuf/java/proto3</outputDirectory>
+              <clearOutputDirectory>false</clearOutputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <configuration>
+              <tasks>
+                <replace token="com.google.protobuf"
+                         value="org.apache.hadoop.thirdparty.protobuf"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
+                </replace>
+                <replace token="com.google.protobuf"
+                         value="org.apache.hadoop.thirdparty.protobuf"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto">
+                </replace>
+                <replace token="org.apache.hadoop.ozone.protocol.proto"
+                         value="org.apache.hadoop.ozone.protocol.proto3"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
+                </replace>
+                <replace token="org.apache.hadoop.ozone.security.proto"
+                         value="org.apache.hadoop.ozone.security.proto3"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto">
+                </replace>
+                <replace token="org.apache.hadoop.hdds.protocol.proto"
+                         value="org.apache.hadoop.hdds.protocol.proto3"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
+                </replace>
+                <replace token="org.apache.hadoop.ozone.security.proto"
+                         value="org.apache.hadoop.ozone.security.proto3"
+                         dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
+                </replace>              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -110,7 +110,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                 <replace token="org.apache.hadoop.ozone.security.proto"
                          value="org.apache.hadoop.ozone.security.proto3"
                          dir="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto">
-                </replace>              </tasks>
+                </replace>
+                <move file="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto"
+                      tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto3"/>
+                <move file="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto"
+                      tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto3"/>
+              </tasks>
             </configuration>
             <goals>
               <goal>run</goal>

--- a/hadoop-ozone/interface-client/pom.xml
+++ b/hadoop-ozone/interface-client/pom.xml
@@ -115,6 +115,8 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
                       tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/protocol/proto3"/>
                 <move file="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto"
                       tofile="target/generated-sources/protobuf/java/proto3/org/apache/hadoop/ozone/security/proto3"/>
+                <move file="target/generated-sources/protobuf/java/proto3"
+                      tofile="target/generated-sources/protobuf/java/"/>
               </tasks>
             </configuration>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- ProtocolBuffer version, used to verify the protoc version and -->
     <!-- define the protobuf JAR version                               -->
     <proto2.hadooprpc.protobuf.version>2.5.0</proto2.hadooprpc.protobuf.version>
+    <proto3.hadooprpc.protobuf.version>3.7.1</proto3.hadooprpc.protobuf.version>
+    <hadoop-thirdparty.version>1.1.1</hadoop-thirdparty.version>
 
     <findbugs.version>3.0.0</findbugs.version>
     <spotbugs.version>3.1.12</spotbugs.version>
@@ -1302,6 +1304,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>com.google.protobuf</groupId>
         <artifactId>protobuf-java</artifactId>
         <version>${proto2.hadooprpc.protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hadoop.thirdparty</groupId>
+        <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+        <version>${hadoop-thirdparty.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-daemon</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?
For Ozone to work with both hadoop2 and pre hadoop 3.3 versions, it needs to compile both proto2 and proto3 versions of the protofiles

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5431

## How was this patch tested?
Build succeeds and current tests pass
