### PR TITLE
HDDS-5005. Multipart Upload fails due to partName mismatch.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -297,8 +297,15 @@ public class TestOzoneClientMultipartUploadWithFSO {
     Assert.assertNotNull(commitUploadPartInfo);
     Assert.assertNotNull(commitUploadPartInfo.getPartName());
 
-    // PartName should be different from old part Name.
-    Assert.assertNotEquals("Part names should be different", partName,
+    // PartName should be same from old part Name.
+    // AWS S3 for same content generates same partName during upload part.
+    // In AWS S3 ETag is generated from md5sum. In Ozone right now we
+    // don't do this. For now to make things work for large file upload
+    // through aws s3 cp, the partName are generated in a predictable fashion.
+    // So, when a part is override partNames will still be same irrespective
+    // of content in ozone s3. This will make S3 Mpu completeMPU pass when
+    // comparing part names and large file uploads work using aws cp.
+    Assert.assertEquals("Part names should be same", partName,
             commitUploadPartInfo.getPartName());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -306,7 +306,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
     // of content in ozone s3. This will make S3 Mpu completeMPU pass when
     // comparing part names and large file uploads work using aws cp.
     Assert.assertEquals("Part names should be same", partName,
-            commitUploadPartInfo.getPartName());
+        commitUploadPartInfo.getPartName());
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2262,7 +2262,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String partName = commitUploadPartInfo.getPartName();
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    //Overwrite the part by creating part key with same part number.
+    //Overwrite the part by creating part key with same part number and different content.
     sampleData = "sample Data Changed";
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         sampleData.length(), partNumber, uploadID);
@@ -2275,12 +2275,13 @@ public abstract class TestOzoneRpcClientAbstract {
     assertNotNull(commitUploadPartInfo);
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    // AWS S3 for same content generates same partName. In AWS S3 ETag is
-    // generated from md5sum. In Ozone right now we don't do this. For now to
-    // make things work, the partName are generated in a predictable fashion.
-    // So, when a part is override partNames will still be same and when parts
-    // are override the partNames will be same. This will make S3 Mpu complete
-    // pass when comparing part names.
+    // AWS S3 for same content generates same partName during upload part.
+    // In AWS S3 ETag is generated from md5sum. In Ozone right now we
+    // don't do this. For now to make things work for large file upload
+    // through aws s3 cp, the partName are generated in a predictable fashion.
+    // So, when a part is override partNames will still be same irrespective
+    // of content in ozone s3. This will make S3 Mpu completeMPU pass when
+    // comparing part names and large file uploads work using aws cp.
     assertEquals("Part names should be same", partName,
         commitUploadPartInfo.getPartName());
   }
@@ -2321,8 +2322,7 @@ public abstract class TestOzoneRpcClientAbstract {
     String partName = commitUploadPartInfo.getPartName();
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    //Overwrite the part by creating part key with same part number.
-    sampleData = "sample Data Changed";
+    //Overwrite the part by creating part key with same part number and same content.
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         sampleData.length(), partNumber, uploadID);
     ozoneOutputStream.write(string2Bytes(sampleData), 0, "name".length());
@@ -2334,12 +2334,13 @@ public abstract class TestOzoneRpcClientAbstract {
     assertNotNull(commitUploadPartInfo);
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    // AWS S3 for same content generates same partName. In AWS S3 ETag is
-    // generated from md5sum. In Ozone right now we don't do this. For now to
-    // make things work for large file upload through aws s3 cp,
-    // the partName are generated in a predictable fashion.
-    // So, when a part is override partNames will still be same.
-    // This will make S3 Mpu completeMPU pass when comparing part names and large file uploads work using aws cp.
+    // AWS S3 for same content generates same partName during upload part.
+    // In AWS S3 ETag is generated from md5sum. In Ozone right now we
+    // don't do this. For now to make things work for large file upload
+    // through aws s3 cp, the partName are generated in a predictable fashion.
+    // So, when a part is override partNames will still be same irrespective
+    // of content in ozone s3. This will make S3 Mpu completeMPU pass when
+    // comparing part names and large file uploads work using aws cp.
     assertEquals("Part names should be same", partName,
         commitUploadPartInfo.getPartName());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2262,7 +2262,8 @@ public abstract class TestOzoneRpcClientAbstract {
     String partName = commitUploadPartInfo.getPartName();
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    //Overwrite the part by creating part key with same part number and different content.
+    // Overwrite the part by creating part key with same part number
+    // and different content.
     sampleData = "sample Data Changed";
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         sampleData.length(), partNumber, uploadID);
@@ -2322,7 +2323,8 @@ public abstract class TestOzoneRpcClientAbstract {
     String partName = commitUploadPartInfo.getPartName();
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    //Overwrite the part by creating part key with same part number and same content.
+    // Overwrite the part by creating part key with same part number
+    // and same content.
     ozoneOutputStream = bucket.createMultipartKey(keyName,
         sampleData.length(), partNumber, uploadID);
     ozoneOutputStream.write(string2Bytes(sampleData), 0, "name".length());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -2275,8 +2275,13 @@ public abstract class TestOzoneRpcClientAbstract {
     assertNotNull(commitUploadPartInfo);
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    // PartName should be different from old part Name.
-    assertNotEquals("Part names should be different", partName,
+    // AWS S3 for same content generates same partName. In AWS S3 ETag is
+    // generated from md5sum. In Ozone right now we don't do this. For now to
+    // make things work, the partName are generated in a predictable fashion.
+    // So, when a part is override partNames will still be same and when parts
+    // are override the partNames will be same. This will make S3 Mpu complete
+    // pass when comparing part names.
+    assertEquals("Part names should be same", partName,
         commitUploadPartInfo.getPartName());
   }
 
@@ -2329,8 +2334,13 @@ public abstract class TestOzoneRpcClientAbstract {
     assertNotNull(commitUploadPartInfo);
     assertNotNull(commitUploadPartInfo.getPartName());
 
-    // PartName should be different from old part Name.
-    assertNotEquals("Part names should be different", partName,
+    // AWS S3 for same content generates same partName. In AWS S3 ETag is
+    // generated from md5sum. In Ozone right now we don't do this. For now to
+    // make things work for large file upload through aws s3 cp,
+    // the partName are generated in a predictable fashion.
+    // So, when a part is override partNames will still be same.
+    // This will make S3 Mpu completeMPU pass when comparing part names and large file uploads work using aws cp.
+    assertEquals("Part names should be same", partName,
         commitUploadPartInfo.getPartName());
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -262,7 +262,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
 
   @VisibleForTesting
   public static String getPartName(String ozoneKey, String uploadID,
-                                   long partNumber) {
+      long partNumber) {
     return ozoneKey + "-" + uploadID + "-" + partNumber;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -166,7 +166,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
-      partName = ozoneKey + clientID;
+      int partNumber = keyArgs.getMultipartNumber();
+      partName = ozoneKey + uploadID + "-" + partNumber;
 
       if (multipartKeyInfo == null) {
         // This can occur when user started uploading part by the time commit
@@ -180,7 +181,6 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
             OMException.ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR);
       }
 
-      int partNumber = keyArgs.getMultipartNumber();
       oldPartKeyInfo = multipartKeyInfo.getPartKeyInfo(partNumber);
 
       // Build this multipart upload part info.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import jdk.nashorn.internal.runtime.regexp.joni.ast.StringNode;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -167,7 +169,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
       int partNumber = keyArgs.getMultipartNumber();
-      partName = ozoneKey + uploadID + "-" + partNumber;
+      partName = getPartName(ozoneKey, uploadID, partNumber);
 
       if (multipartKeyInfo == null) {
         // This can occur when user started uploading part by the time commit
@@ -257,6 +259,11 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
             result);
 
     return omClientResponse;
+  }
+
+  @VisibleForTesting
+  public static String getPartName(String ozoneKey, String uploadID, long partNumber) {
+    return ozoneKey + "-" + uploadID + "-" + partNumber;
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
-import jdk.nashorn.internal.runtime.regexp.joni.ast.StringNode;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -262,7 +261,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   }
 
   @VisibleForTesting
-  public static String getPartName(String ozoneKey, String uploadID, long partNumber) {
+  public static String getPartName(String ozoneKey, String uploadID,
+                                   long partNumber) {
     return ozoneKey + "-" + uploadID + "-" + partNumber;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -90,9 +90,9 @@ public class TestS3MultipartUploadCompleteRequest
     List<Part> partList = new ArrayList<>();
 
     String partName = getPartName(volumeName, bucketName, keyName,
-            multipartUploadID, 1);
+        multipartUploadID, 1);
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(1)
-            .build());
+        .build());
 
     OMRequest completeMultipartRequest = doPreExecuteCompleteMPU(volumeName,
         bucketName, keyName, multipartUploadID, partList);
@@ -155,7 +155,7 @@ public class TestS3MultipartUploadCompleteRequest
     List<Part> partList = new ArrayList<>();
 
     String partName= getPartName(volumeName, bucketName, keyName,
-            multipartUploadID, 23);
+        multipartUploadID, 23);
 
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(23)
             .build());
@@ -271,9 +271,9 @@ public class TestS3MultipartUploadCompleteRequest
       String keyName, String uploadID, int partNumber) {
 
     String dbOzoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
-            keyName);
+        keyName);
     return S3MultipartUploadCommitPartRequest.getPartName(dbOzoneKey, uploadID,
-            partNumber);
+        partNumber);
   }
 
   protected String getOzoneDBKey(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -89,7 +89,7 @@ public class TestS3MultipartUploadCompleteRequest
 
     List<Part> partList = new ArrayList<>();
 
-    String partName = getPartName(volumeName, bucketName, keyName, clientID);
+    String partName = getPartName(volumeName, bucketName, keyName, multipartUploadID, 1);
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(1)
             .build());
 
@@ -153,9 +153,12 @@ public class TestS3MultipartUploadCompleteRequest
 
     List<Part> partList = new ArrayList<>();
 
-    String partName = getPartName(volumeName, bucketName, keyName, clientID);
+    String partName= getPartName(volumeName, bucketName, keyName, multipartUploadID, 23);
+
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(23)
             .build());
+
+    partName = getPartName(volumeName, bucketName, keyName, multipartUploadID, 1);
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(1)
             .build());
 
@@ -262,11 +265,11 @@ public class TestS3MultipartUploadCompleteRequest
   }
 
   private String getPartName(String volumeName, String bucketName,
-      String keyName, long clientID) throws IOException {
+      String keyName, String uploadID, int partNumber) throws IOException {
 
     String dbOzoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
             keyName);
-    return dbOzoneKey + clientID;
+    return S3MultipartUploadCommitPartRequest.getPartName(dbOzoneKey, uploadID, partNumber);
   }
 
   protected String getOzoneDBKey(String volumeName, String bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -89,7 +89,8 @@ public class TestS3MultipartUploadCompleteRequest
 
     List<Part> partList = new ArrayList<>();
 
-    String partName = getPartName(volumeName, bucketName, keyName, multipartUploadID, 1);
+    String partName = getPartName(volumeName, bucketName, keyName,
+            multipartUploadID, 1);
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(1)
             .build());
 
@@ -153,12 +154,14 @@ public class TestS3MultipartUploadCompleteRequest
 
     List<Part> partList = new ArrayList<>();
 
-    String partName= getPartName(volumeName, bucketName, keyName, multipartUploadID, 23);
+    String partName= getPartName(volumeName, bucketName, keyName,
+            multipartUploadID, 23);
 
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(23)
             .build());
 
-    partName = getPartName(volumeName, bucketName, keyName, multipartUploadID, 1);
+    partName = getPartName(volumeName, bucketName, keyName,
+        multipartUploadID, 1);
     partList.add(Part.newBuilder().setPartName(partName).setPartNumber(1)
             .build());
 
@@ -265,11 +268,12 @@ public class TestS3MultipartUploadCompleteRequest
   }
 
   private String getPartName(String volumeName, String bucketName,
-      String keyName, String uploadID, int partNumber) throws IOException {
+      String keyName, String uploadID, int partNumber) {
 
     String dbOzoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
             keyName);
-    return S3MultipartUploadCommitPartRequest.getPartName(dbOzoneKey, uploadID, partNumber);
+    return S3MultipartUploadCommitPartRequest.getPartName(dbOzoneKey, uploadID,
+            partNumber);
   }
 
   protected String getOzoneDBKey(String volumeName, String bucketName,


### PR DESCRIPTION
## What changes were proposed in this pull request?

I have verified with aws s3 end point when uploading same content for same part, PartName is always same.

In AWS S3 case it is md5sum, as in ozone we don't generate based on md5sum, to solve this issue temporarily we can use same partNames when a part upload is override again. In Aws s3 cp case, file is divided in to parts, so in this case content will be same, so it is expecting same ETag/PartName I beleive for now I will provide a fix, to generate partNames in a predictable fashion to solve this issue. (So, if same content/different content part names will still be same for same part)


```
aws s3api upload-part --bucket b1-1993 --key mpu1 --part-number 1 --body /tmp/part1 --upload-id V7QlWzticX051N0BrQBAKAm.piipdYjHJ569P4aFAB5Ti_inSpvEyXS4cKEA7sHHendCFo5WOsmF.psmTMm7lFZMtsGw1e_iLyfXoD1KEhQ-
{
    "ETag": "\"759e3a4738c1fefbcca31b232ac3ed69\""
}
bviswanadham@MacBook-Pro target % aws s3api upload-part --bucket b1-1993 --key mpu1 --part-number 1 --body /tmp/part1 --upload-id V7QlWzticX051N0BrQBAKAm.piipdYjHJ569P4aFAB5Ti_inSpvEyXS4cKEA7sHHendCFo5WOsmF.psmTMm7lFZMtsGw1e_iLyfXoD1KEhQ-
{
    "ETag": "\"759e3a4738c1fefbcca31b232ac3ed69\""
}
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5005

## How was this patch tested?

Updated tests 
