### PR TITLE
HDDS-5434. Fix potential InterruptedException in Ozone

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.hdds.freon;
 
+import org.apache.commons.logging.Log;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;
@@ -26,12 +27,16 @@ import org.apache.ratis.proto.RaftProtos.RequestVoteReplyProto;
 import org.apache.ratis.proto.RaftProtos.RequestVoteRequestProto;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.thirdparty.io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helper class to use it to replace original Ratis GRPC outgoing calls.
  */
 public final class FakeRatisFollower {
 
+  private static final Logger LOG =
+          LoggerFactory.getLogger(FakeRatisFollower.class);
   private static int simulatedLatency = 0;
 
   static {
@@ -118,7 +123,7 @@ public final class FakeRatisFollower {
       try {
         Thread.sleep(simulatedLatency);
       } catch (InterruptedException e) {
-        e.printStackTrace();
+        LOG.error("Interrupted exception while sleeping.", e);
         Thread.currentThread().interrupt();
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
@@ -119,6 +119,7 @@ public final class FakeRatisFollower {
         Thread.sleep(simulatedLatency);
       } catch (InterruptedException e) {
         e.printStackTrace();
+        Thread.currentThread().interrupt();
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/hdds/freon/FakeRatisFollower.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.hdds.freon;
 
-import org.apache.commons.logging.Log;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesReplyProto.AppendResult;
 import org.apache.ratis.proto.RaftProtos.AppendEntriesRequestProto;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ReportManager.java
@@ -79,8 +79,9 @@ public final class ReportManager {
     executorService.shutdown();
     try {
       executorService.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       LOG.error("Failed to shutdown Report Manager", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -284,6 +284,7 @@ public class DatanodeStateMachine implements Closeable {
             Thread.sleep(nextHB.get() - now);
           } catch (InterruptedException e) {
             //triggerHeartbeat is called during the sleep
+            Thread.currentThread().interrupt();
           }
         }
       }
@@ -558,6 +559,7 @@ public class DatanodeStateMachine implements Closeable {
             }
           } catch (InterruptedException e) {
             // Ignore this exception.
+            Thread.currentThread().interrupt();
           }
         }
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -152,8 +152,9 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
       server.shutdown();
       try {
         server.awaitTermination(5, TimeUnit.SECONDS);
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         LOG.error("failed to shutdown XceiverServerGrpc", e);
+        Thread.currentThread().interrupt();
       }
       isStarted = false;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -116,8 +116,9 @@ public class GrpcReplicationClient implements AutoCloseable{
     channel.shutdown();
     try {
       channel.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       LOG.error("failed to shutdown replication channel", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -116,6 +116,7 @@ public class ReplicationServer {
       server.shutdown().awaitTermination(10L, TimeUnit.SECONDS);
     } catch (InterruptedException ex) {
       LOG.warn("{} couldn't be stopped gracefully", getClass().getSimpleName());
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/update/client/CRLClientUpdateHandler.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/update/client/CRLClientUpdateHandler.java
@@ -151,9 +151,10 @@ public class CRLClientUpdateHandler implements ClientUpdateHandler {
     executorService.shutdown();
     try {
       executorService.awaitTermination(10, TimeUnit.SECONDS);
-    } catch (Exception e) {
-      LOG.error("Unexpected exception while waiting for executor service" +
+    } catch (InterruptedException e) {
+      LOG.error("InterruptedException while waiting for executor service" +
           " to shutdown", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/update/client/SCMUpdateServiceGrpcClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/update/client/SCMUpdateServiceGrpcClient.java
@@ -183,8 +183,9 @@ public class SCMUpdateServiceGrpcClient {
     channel.shutdown();
     try {
       channel.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       LOG.error("Failed to shutdown {} channel", CLIENT_NAME, e);
+      Thread.currentThread().interrupt();
     } finally {
       channel.shutdownNow();
       channel = null;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -255,7 +255,9 @@ public class ContainerBalancer {
       //if fully completed
       try {
         Thread.sleep(50);
-      } catch (InterruptedException e) {}
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
       /////////////////////////////
 
       if (unBalancedNodes.isEmpty()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcClient.java
@@ -105,8 +105,9 @@ public class InterSCMGrpcClient implements SCMSnapshotDownloader {
     channel.shutdown();
     try {
       channel.awaitTermination(5, TimeUnit.SECONDS);
-    } catch (Exception e) {
+    } catch (InterruptedException e) {
       LOG.error("failed to shutdown replication channel", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/InterSCMGrpcProtocolService.java
@@ -101,8 +101,9 @@ public class InterSCMGrpcProtocolService {
       server.shutdown();
       try {
         server.awaitTermination(5, TimeUnit.SECONDS);
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         LOG.error("failed to shutdown XceiverServerGrpc", e);
+        Thread.currentThread().interrupt();
       }
       isStarted.set(false);
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/update/server/SCMUpdateServiceGrpcServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/update/server/SCMUpdateServiceGrpcServer.java
@@ -76,8 +76,9 @@ public class SCMUpdateServiceGrpcServer {
       server.shutdown();
       try {
         server.awaitTermination(5, TimeUnit.SECONDS);
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         LOG.error("failed to shutdown SCMClientGrpcServer", e);
+        Thread.currentThread().interrupt();
       } finally {
         server.shutdownNow();
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashPolicyOzone.java
@@ -238,6 +238,7 @@ public class TrashPolicyOzone extends TrashPolicyDefault {
           executor.awaitTermination(60, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
           LOG.error("Error attempting to shutdown", e);
+          Thread.currentThread().interrupt();
         }
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -136,6 +136,7 @@ public class ChunkKeyHandler extends KeyHandler implements
             xceiverClient, datanodeBlockID, keyLocation.getToken());
       } catch (InterruptedException e) {
         LOG.error("Execution interrupted due to " + e);
+        Thread.currentThread().interrupt();
       }
       JsonArray responseFromAllNodes = new JsonArray();
       for (Map.Entry<DatanodeDetails, ContainerProtos.GetBlockResponseProto>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -215,8 +215,9 @@ public class BaseFreonGenerator {
     executor.shutdown();
     try {
       executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
-    } catch (Exception ex) {
+    } catch (InterruptedException ex) {
       ex.printStackTrace();
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -216,7 +216,7 @@ public class BaseFreonGenerator {
     try {
       executor.awaitTermination(Integer.MAX_VALUE, TimeUnit.MILLISECONDS);
     } catch (InterruptedException ex) {
-      ex.printStackTrace();
+      LOG.error("Error attempting to shutdown", ex);
       Thread.currentThread().interrupt();
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -220,10 +220,11 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
         long callId = callIdRandom.nextLong();
         inFlightMessages.put(callId);
         sender.onNext(createAppendLogEntry(sequence, callId));
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         LOG.error(
             "Error while sending new append entry request (HB) to the "
                 + "follower", e);
+        Thread.currentThread().interrupt();
       }
     });
   }
@@ -241,6 +242,7 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
         rateLimiter.acquire();
       } catch (InterruptedException e) {
         LOG.error("Rate limiter acquire has been interrupted", e);
+        Thread.currentThread().interrupt();
       }
     }
     long previousLog = nextIndex - 1;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -414,6 +414,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
       }
     } catch (InterruptedException e) {
       e.printStackTrace();
+      Thread.currentThread().interrupt();
     }
 
     executor.shutdown();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/RandomKeyGenerator.java
@@ -413,7 +413,7 @@ public final class RandomKeyGenerator implements Callable<Void> {
         }
       }
     } catch (InterruptedException e) {
-      e.printStackTrace();
+      LOG.error("Failed to wait until all Buckets are cleaned", e);
       Thread.currentThread().interrupt();
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`InterruptedExceptions` should never be ignored in the code. The throwing of the `InterruptedException` clears the interrupted state of the Thread, so if the exception is not handled properly the information that the thread was interrupted will be lost. 

Instead, `InterruptedExceptions` should either be rethrown - immediately or after cleaning up the method’s state - or the thread should be re-interrupted by calling `Thread.interrupt()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5434

## How was this patch tested?

No test.
