### PR TITLE
HDDS-5456. Inject a Clock into Replication Manager to allow timeouts to be tested

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/MonotonicClock.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/MonotonicClock.java
@@ -29,7 +29,7 @@ import java.time.ZoneId;
  * System.currentTimeMills.
  */
 
-public class MonotonicClock extends Clock {
+public final class MonotonicClock extends Clock {
 
   private final ZoneId zoneId;
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/MonotonicClock.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/MonotonicClock.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.common;
+
+import org.apache.hadoop.util.Time;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
+/**
+ * This is a class which implements the Clock interface. It is a copy of the
+ * Java Clock.SystemClock only it uses MonotonicNow (nanotime) rather than
+ * System.currentTimeMills.
+ */
+
+public class MonotonicClock extends Clock {
+
+  private final ZoneId zoneId;
+
+  public MonotonicClock(ZoneId zone) {
+    this.zoneId = zone;
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return zoneId;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    if (zone.equals(this.zoneId)) {  // intentional NPE
+      return this;
+    }
+    return new MonotonicClock(zone);
+  }
+
+  @Override
+  public long millis() {
+    return Time.monotonicNow();
+  }
+
+  @Override
+  public Instant instant() {
+    return Instant.ofEpochMilli(millis());
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof MonotonicClock) {
+      return zoneId.equals(((MonotonicClock) obj).zoneId);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return zoneId.hashCode() + 1;
+  }
+
+  @Override
+  public String toString() {
+    return "MonotonicClock[" + zoneId + "]";
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -126,6 +126,7 @@ import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.lease.LeaseManager;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
@@ -147,6 +148,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -600,7 +602,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           eventQueue,
           scmContext,
           serviceManager,
-          scmNodeManager);
+          scmNodeManager,
+          new MonotonicClock(ZoneId.of("UTC")));
     }
     if(configurator.getScmSafeModeManager() != null) {
       scmSafeModeManager = configurator.getScmSafeModeManager();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -148,7 +148,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -603,7 +603,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           scmContext,
           serviceManager,
           scmNodeManager,
-          new MonotonicClock(ZoneId.of("UTC")));
+          new MonotonicClock(ZoneOffset.UTC));
     }
     if(configurator.getScmSafeModeManager() != null) {
       scmSafeModeManager = configurator.getScmSafeModeManager();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ozone.test.TestClock;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,6 +51,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -89,6 +92,7 @@ public class TestReplicationManager {
   private ContainerManagerV2 containerManager;
   private OzoneConfiguration conf;
   private SCMNodeManager scmNodeManager;
+  private TestClock clock;
 
   @Before
   public void setup()
@@ -152,17 +156,8 @@ public class TestReplicationManager {
 
     SCMServiceManager serviceManager = new SCMServiceManager();
 
-    replicationManager = new ReplicationManager(
-        conf,
-        containerManager,
-        containerPlacementPolicy,
-        eventQueue,
-        SCMContext.emptyContext(),
-        serviceManager,
-        nodeManager);
-
-    serviceManager.notifyStatusChanged();
-    Thread.sleep(100L);
+    clock = new TestClock(Instant.now(), ZoneId.of("UTC"));
+    createReplicationManager(new ReplicationManagerConfiguration());
   }
 
   private void createReplicationManager(ReplicationManagerConfiguration rmConf)
@@ -174,7 +169,6 @@ public class TestReplicationManager {
     config.setFromObject(rmConf);
 
     SCMServiceManager serviceManager = new SCMServiceManager();
-
     replicationManager = new ReplicationManager(
         config,
         containerManager,
@@ -182,7 +176,8 @@ public class TestReplicationManager {
         eventQueue,
         SCMContext.emptyContext(),
         serviceManager,
-        nodeManager);
+        nodeManager,
+        clock);
 
     serviceManager.notifyStatusChanged();
     Thread.sleep(100L);
@@ -1091,6 +1086,25 @@ public class TestReplicationManager {
     // There should be replica scheduled, but as all nodes are stale, nothing
     // gets scheduled.
     assertReplicaScheduled(0);
+  }
+
+  @Test
+  public void testReplicateCommandTimeout() throws
+      SCMException, InterruptedException {
+    long timeout = new ReplicationManagerConfiguration().getEventTimeout();
+
+    final ContainerInfo container = createContainer(LifeCycleState.CLOSED);
+    addReplica(container, new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
+    addReplica(container, new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
+    assertReplicaScheduled(1);
+
+    // Already a pending replica, so nothing scheduled
+    assertReplicaScheduled(0);
+
+    // Advance the clock past the timeout, and there should be a replica
+    // scheduled
+    clock.fastForward(timeout + 1000);
+    assertReplicaScheduled(1);
   }
 
   private ContainerInfo createContainer(LifeCycleState containerState)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -154,8 +154,6 @@ public class TestReplicationManager {
         Mockito.any(DatanodeDetails.class)))
         .thenReturn(NodeStatus.inServiceHealthy());
 
-    SCMServiceManager serviceManager = new SCMServiceManager();
-
     clock = new TestClock(Instant.now(), ZoneId.of("UTC"));
     createReplicationManager(new ReplicationManagerConfiguration());
   }

--- a/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/TestClock.java
+++ b/hadoop-hdds/test-utils/src/main/java/org/apache/ozone/test/TestClock.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.ozone.test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAmount;
+
+/**
+ * An implementation of Clock which allows the time to be set to an instant and
+ * moved forward and back. Intended for use only in tests.
+ */
+
+public class TestClock extends Clock {
+
+  private Instant instant;
+  private final ZoneId zoneId;
+
+  public TestClock(Instant instant, ZoneId zone) {
+    this.instant = instant;
+    this.zoneId = zone;
+  }
+
+  @Override
+  public ZoneId getZone() {
+    return zoneId;
+  }
+
+  @Override
+  public Clock withZone(ZoneId zone) {
+    return new TestClock(Instant.now(), zone);
+  }
+
+  @Override
+  public Instant instant() {
+    return instant;
+  }
+
+  public void fastForward(long millis) {
+    set(instant().plusMillis(millis));
+  }
+
+  public void fastForward(TemporalAmount temporalAmount) {
+    set(instant().plus(temporalAmount));
+  }
+
+  public void rewind(long millis) {
+    set(instant().minusMillis(millis));
+  }
+
+  public void rewind(TemporalAmount temporalAmount) {
+    set(instant().minus(temporalAmount));
+  }
+
+  public void set(Instant newInstant) {
+    this.instant = newInstant;
+  }
+
+}


### PR DESCRIPTION
Replication Manager currently uses Time.monotonicNow() in a few places to check if a pending command should be timed out. 

This is difficult to test without adding sleeps in the tests. 

We should inject a Clock object to use rather than making calls to SystemTime directly to allow tests more flexibility.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5456

## How was this patch tested?

New Unit test
