### PR TITLE
HDDS-5457. services.s3g.environment.OZONE-SITE.XML_ozone.om.enable.filesystem.paths must be a string, number or null

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -28,7 +28,7 @@ x-common-config:
 x-layout_version:
   &metadata_layout
   OZONE-SITE.XML_ozone.om.metadata.layout: ${OZONE_OM_METADATA_LAYOUT:-SIMPLE}
-  OZONE-SITE.XML_ozone.om.enable.filesystem.paths: ${OZONE_OM_ENABLE_FILESYSTEM_PATHS:-'false'}
+  OZONE-SITE.XML_ozone.om.enable.filesystem.paths: "${OZONE_OM_ENABLE_FILESYSTEM_PATHS:-false}"
 
 x-replication:
   &replication

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -28,7 +28,7 @@ x-common-config:
 x-layout_version:
   &metadata_layout
   OZONE-SITE.XML_ozone.om.metadata.layout: ${OZONE_OM_METADATA_LAYOUT:-SIMPLE}
-  OZONE-SITE.XML_ozone.om.enable.filesystem.paths: ${OZONE_OM_ENABLE_FILESYSTEM_PATHS:-false}
+  OZONE-SITE.XML_ozone.om.enable.filesystem.paths: ${OZONE_OM_ENABLE_FILESYSTEM_PATHS:-'false'}
 
 x-replication:
   &replication


### PR DESCRIPTION
Need to escape `false` in yaml for the latest Docker for Mac to work properly.

https://issues.apache.org/jira/browse/HDDS-5457