### PR TITLE
HDDS-5459. Replication Manager should process containers synchronously for tests

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -74,9 +74,7 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.ExitUtil;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.GeneratedMessage;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
 import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -206,9 +206,9 @@ public class TestReplicationManager {
   public void testOpenContainer() throws SCMException, InterruptedException {
     final ContainerInfo container = getContainer(LifeCycleState.OPEN);
     containerStateManager.loadContainer(container);
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
 
   }
@@ -241,9 +241,9 @@ public class TestReplicationManager {
     final int currentCloseCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
 
@@ -252,9 +252,9 @@ public class TestReplicationManager {
       containerStateManager.updateContainerReplica(id, replica);
     }
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentCloseCommandCount + 6, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
   }
@@ -287,9 +287,9 @@ public class TestReplicationManager {
     final int currentCloseCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
     // Two of the replicas are in OPEN state
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentCloseCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
     Assert.assertTrue(datanodeCommandHandler.received(
@@ -325,9 +325,9 @@ public class TestReplicationManager {
 
     // All the QUASI_CLOSED replicas have same originNodeId, so the
     // container will not be closed. ReplicationManager should take no action.
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
   }
 
@@ -366,9 +366,9 @@ public class TestReplicationManager {
 
     // All the QUASI_CLOSED replicas have same originNodeId, so the
     // container will not be closed. ReplicationManager should take no action.
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
 
     // Make the first replica unhealthy
@@ -377,9 +377,9 @@ public class TestReplicationManager {
         replicaOne.getDatanodeDetails());
     containerStateManager.updateContainerReplica(id, unhealthyReplica);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assert.assertTrue(datanodeCommandHandler.received(
@@ -390,9 +390,9 @@ public class TestReplicationManager {
     containerStateManager.removeContainerReplica(id, replicaOne);
 
     // The container is under replicated as unhealthy replica is removed
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
 
     // We should get replicate command
     Assert.assertEquals(currentReplicateCommandCount + 1,
@@ -428,9 +428,9 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
   }
@@ -465,9 +465,9 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assert.assertTrue(datanodeCommandHandler.received(
@@ -497,9 +497,9 @@ public class TestReplicationManager {
     final int currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentReplicateCommandCount + 1,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
@@ -545,7 +545,7 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
     GenericTestUtils.waitFor(
         () -> (currentReplicateCommandCount + 1) == datanodeCommandHandler
@@ -571,9 +571,9 @@ public class TestReplicationManager {
      * iteration it should delete the unhealthy replica.
      */
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     // ReplicaTwo should be deleted, that is the unhealthy one
@@ -589,9 +589,9 @@ public class TestReplicationManager {
      * is under replicated now
      */
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentReplicateCommandCount + 2,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
@@ -621,9 +621,9 @@ public class TestReplicationManager {
     final int currentCloseCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
 
     // All the replicas have same BCSID, so all of them will be closed.
     Assert.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
@@ -651,9 +651,9 @@ public class TestReplicationManager {
       containerStateManager.updateContainerReplica(id, replica);
     }
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
   }
 
@@ -679,10 +679,9 @@ public class TestReplicationManager {
         Mockito.mock(CloseContainerEventHandler.class);
     eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);
 
-    replicationManager.processContainersNow();
-
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Mockito.verify(closeContainerHandler, Mockito.times(1))
         .onMessage(id, eventQueue);
   }
@@ -730,9 +729,9 @@ public class TestReplicationManager {
     int currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     // At this stage, due to the mocked calls to validteContainerPlacement
     // the mis-replicated racks will not have improved, so expect to see nothing
     // scheduled.
@@ -752,9 +751,9 @@ public class TestReplicationManager {
     currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     // At this stage, due to the mocked calls to validteContainerPlacement
     // the mis-replicated racks will not have improved, so expect to see nothing
     // scheduled.
@@ -798,9 +797,9 @@ public class TestReplicationManager {
     int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     // The unhealthy replica should be removed, but not the other replica
     // as each time we test with 3 replicas, Mockitor ensures it returns
     // mis-replicated
@@ -842,9 +841,9 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
   }
@@ -882,9 +881,9 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
   }
@@ -1049,9 +1048,9 @@ public class TestReplicationManager {
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     // Get the DECOM and Maint replica and ensure none of them are scheduled
@@ -1136,9 +1135,9 @@ public class TestReplicationManager {
     final int currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
 
-    replicationManager.processContainersNow();
+    replicationManager.processAll();
     // Wait for EventQueue to call the event handler
-    Thread.sleep(100L);
+    eventQueue.processAll(1000);
     Assert.assertEquals(currentReplicateCommandCount + delta,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManager.java
@@ -807,7 +807,7 @@ public class TestStorageContainerManager {
       Thread.sleep(5000);
       // Give ReplicationManager some time to process the containers.
       cluster.getStorageContainerManager()
-          .getReplicationManager().processContainersNow();
+          .getReplicationManager().processAll();
       Thread.sleep(5000);
 
       verify(publisher).fireEvent(eq(SCMEvents.DATANODE_COMMAND), argThat(new

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -325,7 +325,7 @@ public class TestBlockDeletion {
     });
 
     cluster.shutdownHddsDatanode(0);
-    scm.getReplicationManager().processContainersNow();
+    scm.getReplicationManager().processAll();
     // Wait for container state change to DELETING
     Thread.sleep(100);
     containerInfos = scm.getContainerManager().getContainers();
@@ -336,7 +336,7 @@ public class TestBlockDeletion {
         LogCapturer.captureLogs(ReplicationManager.LOG);
     logCapturer.clearOutput();
 
-    scm.getReplicationManager().processContainersNow();
+    scm.getReplicationManager().processAll();
     Thread.sleep(100);
     // Wait for delete replica command resend
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()
@@ -344,7 +344,7 @@ public class TestBlockDeletion {
     cluster.restartHddsDatanode(0, true);
     Thread.sleep(100);
 
-    scm.getReplicationManager().processContainersNow();
+    scm.getReplicationManager().processAll();
     // Wait for container state change to DELETED
     Thread.sleep(100);
     containerInfos = scm.getContainerManager().getContainers();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -326,8 +326,6 @@ public class TestBlockDeletion {
 
     cluster.shutdownHddsDatanode(0);
     scm.getReplicationManager().processAll();
-    // Wait for container state change to DELETING
-    Thread.sleep(100);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container ->
         Assert.assertEquals(HddsProtos.LifeCycleState.DELETING,
@@ -337,16 +335,12 @@ public class TestBlockDeletion {
     logCapturer.clearOutput();
 
     scm.getReplicationManager().processAll();
-    Thread.sleep(100);
-    // Wait for delete replica command resend
     GenericTestUtils.waitFor(() -> logCapturer.getOutput()
         .contains("Resend delete Container"), 500, 5000);
     cluster.restartHddsDatanode(0, true);
     Thread.sleep(100);
 
     scm.getReplicationManager().processAll();
-    // Wait for container state change to DELETED
-    Thread.sleep(100);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container -> {
       Assert.assertEquals(HddsProtos.LifeCycleState.DELETED,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMContainerPlacementPolicyMetrics.java
@@ -135,7 +135,7 @@ public class TestSCMContainerPlacementPolicyMetrics {
     } catch (InterruptedException e) {
     }
     cluster.getStorageContainerManager().getReplicationManager()
-        .processContainersNow();
+        .processAll();
     try {
       Thread.sleep(30 * 1000);
     } catch (InterruptedException e) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The method `ReplicationManager.processContainersNow()` only wakes up the thread, and returns before the containers have been processed.

This results in all RM tests having a `sleep(100)` after all calls to this method.

With a small refactor to RM, we can avoid this sleep. After this change all tests run about 100ms faster, and the code in the tests is slightly better.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5459

## How was this patch tested?

Existing tests
