### PR TITLE
HDDS-5460: ReplicationConfig#getDefault is hardcoded with RatisReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 
 /**
  * Replication configuration for any ReplicationType with all the required
@@ -63,7 +64,9 @@ public interface ReplicationConfig {
   }
 
   static ReplicationConfig getDefault(ConfigurationSource config) {
-    return new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE);
+    return ReplicationConfig.fromTypeAndString(ReplicationType
+            .valueOf(config.get(OzoneConfigKeys.OZONE_REPLICATION_TYPE)),
+        config.get(OzoneConfigKeys.OZONE_REPLICATION));
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -64,9 +64,14 @@ public interface ReplicationConfig {
   }
 
   static ReplicationConfig getDefault(ConfigurationSource config) {
-    return ReplicationConfig.fromTypeAndString(ReplicationType
-            .valueOf(config.get(OzoneConfigKeys.OZONE_REPLICATION_TYPE)),
-        config.get(OzoneConfigKeys.OZONE_REPLICATION));
+    String replication = config.get(OzoneConfigKeys.OZONE_REPLICATION);
+    String replType = config.get(OzoneConfigKeys.OZONE_REPLICATION_TYPE);
+    ReplicationConfig replicationConfig = null;
+    if (replication != null && replType != null) {
+      replicationConfig = ReplicationConfig
+          .fromTypeAndString(ReplicationType.valueOf(replType), replication);
+    }
+    return replicationConfig;
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hdds.client;
 
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +28,23 @@ import org.junit.Test;
  * Test replicationConfig.
  */
 public class TestReplicationConfig {
+
+  @Test
+  public void testGetDefaultShouldCreateReplicationConfigFromConf() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ReplicationConfig replicationConfig = ReplicationConfig.getDefault(conf);
+    Assert.assertEquals(
+        org.apache.hadoop.hdds.client.ReplicationType.RATIS.name(),
+        replicationConfig.getReplicationType().name());
+    Assert.assertEquals(3, replicationConfig.getRequiredNodes());
+    conf.set(OzoneConfigKeys.OZONE_REPLICATION_TYPE, "STAND_ALONE");
+    conf.set(OzoneConfigKeys.OZONE_REPLICATION, "1");
+    replicationConfig = ReplicationConfig.getDefault(conf);
+    Assert.assertEquals(
+        org.apache.hadoop.hdds.client.ReplicationType.STAND_ALONE.name(),
+        replicationConfig.getReplicationType().name());
+    Assert.assertEquals(1, replicationConfig.getRequiredNodes());
+  }
 
   @Test
   public void deserializeRatis() {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfig.java
@@ -30,16 +30,21 @@ import org.junit.Test;
 public class TestReplicationConfig {
 
   @Test
-  public void testGetDefaultShouldCreateReplicationConfigFromConf() {
+  public void testGetDefaultShouldCreateReplicationConfigFromDefaultConf() {
     OzoneConfiguration conf = new OzoneConfiguration();
     ReplicationConfig replicationConfig = ReplicationConfig.getDefault(conf);
     Assert.assertEquals(
         org.apache.hadoop.hdds.client.ReplicationType.RATIS.name(),
         replicationConfig.getReplicationType().name());
     Assert.assertEquals(3, replicationConfig.getRequiredNodes());
+  }
+
+  @Test
+  public void testGetDefaultShouldCreateReplicationConfFromCustomConfValues() {
+    OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OzoneConfigKeys.OZONE_REPLICATION_TYPE, "STAND_ALONE");
     conf.set(OzoneConfigKeys.OZONE_REPLICATION, "1");
-    replicationConfig = ReplicationConfig.getDefault(conf);
+    ReplicationConfig replicationConfig = ReplicationConfig.getDefault(conf);
     Assert.assertEquals(
         org.apache.hadoop.hdds.client.ReplicationType.STAND_ALONE.name(),
         replicationConfig.getReplicationType().name());


### PR DESCRIPTION
…
## What changes were proposed in this pull request?

ReplicationConfig#getDefault uses the passed config defaults instead of hardcoding to RATIS.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5460

## How was this patch tested?

Added a unit test.
