### PR TITLE
HDDS-5450. Avoid refresh pipeline for S3 headObject

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -529,6 +529,21 @@ public class OzoneBucket extends WithMetadata {
     return proxy.getKeyDetails(volumeName, name, key);
   }
 
+  /**
+   *
+   * Return basic information about the key.
+   *
+   * If Key exists, return basic information about the key.
+   * If Key does not exist, throws an exception with error code KEY_NOT_FOUND
+   *
+   * @param key
+   * @return OzoneKey which gives basic information about the key.
+   * @throws IOException
+   */
+  public OzoneKey headObject(String key) throws IOException {
+    return proxy.headObject(volumeName, name, key);
+  }
+
   public long getUsedBytes() {
     return usedBytes;
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -531,9 +531,10 @@ public class OzoneBucket extends WithMetadata {
 
   /**
    *
-   * Return basic information about the key.
+   * Returns OzoneKey that contains the application generated/visible
+   * metadata for an Ozone Object.
    *
-   * If Key exists, return basic information about the key.
+   * If Key exists, return returns OzoneKey.
    * If Key does not exist, throws an exception with error code KEY_NOT_FOUND
    *
    * @param key

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -164,4 +164,8 @@ public class OzoneKey {
     return replicationConfig.getRequiredNodes();
   }
 
+  public ReplicationConfig getReplicationConfig() {
+    return replicationConfig;
+  }
+
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -738,10 +738,10 @@ public interface ClientProtocol {
       long quotaInNamespace, long quotaInBytes) throws IOException;
 
   /**
+   * Returns OzoneKey that contains the application generated/visible
+   * metadata for an Ozone Object.
    *
-   * Return basic information about the key.
-   *
-   * If Key exists, return basic information about the key.
+   * If Key exists, return returns OzoneKey.
    * If Key does not exist, throws an exception with error code KEY_NOT_FOUND
    *
    * @param volumeName

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -736,4 +736,20 @@ public interface ClientProtocol {
    */
   void setBucketQuota(String volumeName, String bucketName,
       long quotaInNamespace, long quotaInBytes) throws IOException;
+
+  /**
+   *
+   * Return basic information about the key.
+   *
+   * If Key exists, return basic information about the key.
+   * If Key does not exist, throws an exception with error code KEY_NOT_FOUND
+   *
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   * @return OzoneKey which gives basic information about the key.
+   * @throws IOException
+   */
+  OzoneKey headObject(String volumeName, String bucketName,
+      String keyName) throws IOException;
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1461,8 +1461,6 @@ public class RpcClient implements ClientProtocol {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setRefreshPipeline(false)
-        .setSortDatanodesInPipeline(false)
         .setLatestVersionLocation(true)
         .setHeadOp(true)
         .build();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1450,4 +1450,27 @@ public class RpcClient implements ClientProtocol {
   public Cache<URI, KeyProvider> getKeyProviderCache() {
     return keyProviderCache;
   }
+
+  @Override
+  public OzoneKey headObject(String volumeName, String bucketName,
+      String keyName) throws IOException {
+    Preconditions.checkNotNull(volumeName);
+    Preconditions.checkNotNull(bucketName);
+    Preconditions.checkNotNull(keyName);
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder()
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setRefreshPipeline(false)
+        .setSortDatanodesInPipeline(false)
+        .setLatestVersionLocation(true)
+        .setHeadOp(true)
+        .build();
+    OmKeyInfo keyInfo = ozoneManagerClient.lookupKey(keyArgs);
+
+    return new OzoneKey(keyInfo.getVolumeName(), keyInfo.getBucketName(),
+        keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
+        keyInfo.getModificationTime(), keyInfo.getReplicationConfig());
+
+  }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -48,6 +48,7 @@ public final class OmKeyArgs implements Auditable {
   private List<OzoneAcl> acls;
   private boolean latestVersionLocation;
   private boolean recursive;
+  private boolean headOp;
 
   @SuppressWarnings("parameternumber")
   private OmKeyArgs(String volumeName, String bucketName, String keyName,
@@ -56,7 +57,7 @@ public final class OmKeyArgs implements Auditable {
       String uploadID, int partNumber,
       Map<String, String> metadataMap, boolean refreshPipeline,
       List<OzoneAcl> acls, boolean sortDatanode,
-      boolean latestVersionLocation, boolean recursive) {
+      boolean latestVersionLocation, boolean recursive, boolean headOp) {
     this.volumeName = volumeName;
     this.bucketName = bucketName;
     this.keyName = keyName;
@@ -72,6 +73,7 @@ public final class OmKeyArgs implements Auditable {
     this.sortDatanodesInPipeline = sortDatanode;
     this.latestVersionLocation = latestVersionLocation;
     this.recursive = recursive;
+    this.headOp = headOp;
   }
 
   public boolean getIsMultipartKey() {
@@ -146,6 +148,10 @@ public final class OmKeyArgs implements Auditable {
     return recursive;
   }
 
+  public boolean isHeadOp() {
+    return headOp;
+  }
+
   @Override
   public Map<String, String> toAuditMap() {
     Map<String, String> auditMap = new LinkedHashMap<>();
@@ -204,6 +210,7 @@ public final class OmKeyArgs implements Auditable {
     private boolean latestVersionLocation;
     private List<OzoneAcl> acls;
     private boolean recursive;
+    private boolean headOp;
 
     public Builder setVolumeName(String volume) {
       this.volumeName = volume;
@@ -285,12 +292,17 @@ public final class OmKeyArgs implements Auditable {
       return this;
     }
 
+    public Builder setHeadOp(boolean isHeadOp) {
+      this.headOp = isHeadOp;
+      return this;
+    }
+
     public OmKeyArgs build() {
       return new OmKeyArgs(volumeName, bucketName, keyName, dataSize,
           replicationConfig, locationInfoList, isMultipartKey,
           multipartUploadID,
           multipartUploadPartNumber, metadata, refreshPipeline, acls,
-          sortDatanodesInPipeline, latestVersionLocation, recursive);
+          sortDatanodesInPipeline, latestVersionLocation, recursive, headOp);
     }
 
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -690,6 +690,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(args.getDataSize())
         .setSortDatanodes(args.getSortDatanodes())
         .setLatestVersionLocation(args.getLatestVersionLocation())
+        .setHeadOp(args.isHeadOp())
         .build();
     req.setKeyArgs(keyArgs);
 

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -769,6 +769,9 @@ message KeyArgs {
 
     // This will be set when user performs delete directory recursively.
     optional bool recursive = 17;
+
+    // When it is a head operation which is to check whether key exist
+    optional bool headOp = 18;
 }
 
 message KeyLocation {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -676,21 +676,29 @@ public class KeyManagerImpl implements KeyManager {
       throw new OMException("Key:" + keyName + " not found", KEY_NOT_FOUND);
     }
 
+
     if (args.getLatestVersionLocation()) {
       slimLocationVersion(value);
     }
 
-    // add block token for read.
-    addBlockToken4Read(value);
+    // If operation is head, do not perform any additional steps based on flags.
+    // As head operation does not need any of those details.
+    if (!args.isHeadOp()) {
 
-    // Refresh container pipeline info from SCM
-    // based on OmKeyArgs.refreshPipeline flag
-    // value won't be null as the check is done inside try/catch block.
-    refresh(value);
+      // add block token for read.
+      addBlockToken4Read(value);
 
-    if (args.getSortDatanodes()) {
-      sortDatanodes(clientAddress, value);
+      // Refresh container pipeline info from SCM
+      // based on OmKeyArgs.refreshPipeline flag
+      // value won't be null as the check is done inside try/catch block.
+      refresh(value);
+
+      if (args.getSortDatanodes()) {
+        sortDatanodes(clientAddress, value);
+      }
+
     }
+
     return value;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -387,6 +387,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
+        .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .setHeadOp(keyArgs.getHeadOp())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -393,11 +393,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
 
-    if (!omKeyArgs.isHeadOp()) {
-      resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
-    } else {
-      resp.setKeyInfo(keyInfo.getProtobuf(true, clientVersion));
-    }
+    resp.setKeyInfo(keyInfo.getProtobuf(keyArgs.getHeadOp(), clientVersion));
+
 
     return resp.build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -386,8 +386,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setVolumeName(keyArgs.getVolumeName())
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
-        .setRefreshPipeline(true)
-        .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .setHeadOp(keyArgs.getHeadOp())
         .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -389,9 +389,15 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setRefreshPipeline(true)
         .setSortDatanodesInPipeline(keyArgs.getSortDatanodes())
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
+        .setHeadOp(keyArgs.getHeadOp())
         .build();
     OmKeyInfo keyInfo = impl.lookupKey(omKeyArgs);
-    resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
+
+    if (!omKeyArgs.isHeadOp()) {
+      resp.setKeyInfo(keyInfo.getProtobuf(false, clientVersion));
+    } else {
+      resp.setKeyInfo(keyInfo.getProtobuf(true, clientVersion));
+    }
 
     return resp.build();
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneKey;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
@@ -337,7 +338,7 @@ public class ObjectEndpoint extends EndpointBase {
   }
 
   private void addLastModifiedDate(
-      ResponseBuilder responseBuilder, OzoneKeyDetails key) {
+      ResponseBuilder responseBuilder, OzoneKey key) {
 
     ZonedDateTime lastModificationTime = key.getModificationTime()
         .atZone(ZoneId.of(OzoneConsts.OZONE_TIME_ZONE));
@@ -358,10 +359,10 @@ public class ObjectEndpoint extends EndpointBase {
       @PathParam("bucket") String bucketName,
       @PathParam("path") String keyPath) throws IOException, OS3Exception {
 
-    OzoneKeyDetails key;
+    OzoneKey key;
 
     try {
-      key = getBucket(bucketName).getKey(keyPath);
+      key = getBucket(bucketName).headObject(keyPath);
       // TODO: return the specified range bytes of this object.
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -126,6 +127,25 @@ public class OzoneBucketStub extends OzoneBucket {
   public OzoneKeyDetails getKey(String key) throws IOException {
     if (keyDetails.containsKey(key)) {
       return keyDetails.get(key);
+    } else {
+      throw new OMException(ResultCodes.KEY_NOT_FOUND);
+    }
+  }
+
+  @Override
+  public OzoneKey headObject(String key) throws IOException {
+    if (keyDetails.containsKey(key)) {
+      OzoneKeyDetails ozoneKeyDetails = keyDetails.get(key);
+      return new OzoneKey(ozoneKeyDetails.getVolumeName(),
+          ozoneKeyDetails.getBucketName(),
+          ozoneKeyDetails.getName(),
+          ozoneKeyDetails.getDataSize(),
+          ozoneKeyDetails.getCreationTime().toEpochMilli(),
+          ozoneKeyDetails.getModificationTime().toEpochMilli(),
+          ReplicationConfig.fromTypeAndFactor(
+              ozoneKeyDetails.getReplicationType(),
+              ReplicationFactor.valueOf(ozoneKeyDetails.getReplicationFactor())
+          ));
     } else {
       throw new OMException(ResultCodes.KEY_NOT_FOUND);
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid refresh pipeline for headObject API


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5450

## How was this patch tested?

Added a test for new API. S3 test suite should test usage of headObject from s3 interface.
