### PR TITLE
HDDS-5462. Multi-raft style placement with permutations for offline data generator

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -25,11 +25,14 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.concurrent.Callable;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -87,7 +90,8 @@ public class GeneratorDatanode extends BaseGenerator {
 
   @Option(names = {"--index"},
       description = "Index of the datanode. For example datanode #3 should "
-          + "have only every 3rd container in a 10 node cluster.).",
+          + "have only every 3rd container in a 10 node cluster. " +
+          "First datanode is 1 not 0.).",
       defaultValue = "1")
   private int datanodeIndex;
 
@@ -95,6 +99,14 @@ public class GeneratorDatanode extends BaseGenerator {
       description = "Use zero bytes instead of random data.",
       defaultValue = "false")
   private boolean zero;
+
+  @Option(names = {"--overlap"},
+      description = "Number of overlapping pipelines between 1 and 3." +
+          " This number provides a lightweight simulation of multi-raft" +
+          " placement. Set to 3 to have more sources ((overlap + 1) % 3 = 4)" +
+          " for replication in case of node failures.",
+      defaultValue = "1")
+  private int overlap;
 
   private ChunkManager chunkManager;
 
@@ -112,19 +124,10 @@ public class GeneratorDatanode extends BaseGenerator {
   private int logCounter;
   private String datanodeId;
   private String scmId;
-  private int numberOfPipelines;
-  private int currentPipeline;
 
   @Override
   public Void call() throws Exception {
     init();
-
-    numberOfPipelines = datanodes / 3;
-
-    //generate only containers for one datanodes
-    setTestNo(getTestNo() / numberOfPipelines);
-
-    currentPipeline = (datanodeIndex - 1) % numberOfPipelines;
 
     config = createOzoneConfiguration();
 
@@ -193,12 +196,43 @@ public class GeneratorDatanode extends BaseGenerator {
     return scmDirName.toString();
   }
 
-  private void generateData(long index) throws Exception {
+
+  /**
+   * Return the placement of the container with ONE based indexes.
+   * (first datanode is 1).
+   */
+  @VisibleForTesting
+  public static Set<Integer> getPlacement(
+      long containerId,
+      int maxDatanodes,
+      int overlap) {
+    int parallelPipelines = maxDatanodes / 3;
+    int startOffset = (int) ((containerId % parallelPipelines) * 3);
+
+    int pipelineLevel = (int) (containerId / parallelPipelines);
+
+    startOffset += pipelineLevel % overlap;
+
+    Set<Integer> result = new HashSet<>();
+    for (int i = startOffset; i < startOffset + 3; i++) {
+      result.add(i % maxDatanodes + 1);
+    }
+    return result;
+  }
+
+  public void generateData(long index) throws Exception {
 
     timer.time((Callable<Void>) () -> {
 
-      long containerId =
-          getContainerIdOffset() + index * numberOfPipelines + currentPipeline;
+      long containerId = index;
+
+      Set<Integer> selectedDatanodes = GeneratorDatanode
+          .getPlacement(containerId, datanodes, overlap);
+
+      //this container shouldn't be saved to this datanode.
+      if (!selectedDatanodes.contains(datanodeIndex)) {
+        return null;
+      }
 
       SplittableRandom random = new SplittableRandom(containerId);
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/containergenerator/TestGeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/containergenerator/TestGeneratorDatanode.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon.containergenerator;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Test datanode container generation placement.
+ */
+public class TestGeneratorDatanode {
+
+  @Test
+  public void testPlacementSinglePipeline() {
+    //one datanode
+    compare(0, 3, 1, 1, 2, 3);
+    compare(1, 3, 1, 1, 2, 3);
+  }
+
+  @Test
+  public void testPlacement10Nodes() {
+    //10 datanodes
+    compare(0, 10, 1, 1, 2, 3);
+    compare(1, 10, 1, 4, 5, 6);
+    compare(2, 10, 1, 7, 8, 9);
+    compare(3, 10, 1, 1, 2, 3);
+  }
+
+  @Test
+  public void testPlacement10NodesOverlap() {
+    //one datanode
+    compare(0, 10, 2, 1, 2, 3);
+    compare(1, 10, 2, 4, 5, 6);
+    compare(2, 10, 2, 7, 8, 9);
+
+    compare(3, 10, 2, 2, 3, 4);
+    compare(4, 10, 2, 5, 6, 7);
+    compare(5, 10, 2, 8, 9, 10);
+
+    compare(6, 10, 2, 1, 2, 3);
+    compare(7, 10, 2, 4, 5, 6);
+    compare(8, 10, 2, 7, 8, 9);
+  }
+
+  public void compare(
+      int containerId,
+      int maxDatanodes,
+      int overlap,
+      Integer... expectations) {
+    Assert.assertEquals(
+        new HashSet<Integer>(Arrays.asList(expectations)),
+        GeneratorDatanode.getPlacement(containerId, maxDatanodes, overlap));
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5462

## What changes were proposed in this pull request?

Freon does have an offline generator test suite to generate quickly local data (rocksdb + container) for load testing.

But today, the datanode generator doesn't support different replication sets for the same node. Containers are generated in a way where the replication sets ("pipelines") are always include the same nodes:

![image](https://user-images.githubusercontent.com/170549/126157023-0a2e6ec8-4705-4754-a706-19a28c84bf7e.png)

In this case, if `node1` is down, only `node2` and `node3` can be used as the source of the nodes.

With multi-raft option enabled, it's possible to have a placement were more than two nodes are used as source.

This patch uses a very simple permutation based approach to have similar layout but still keep the generation to be predictable.

With the new `--overlap` argument, different containers can have slightly different replication set / pipelines:

![image](https://user-images.githubusercontent.com/170549/126157328-2f2e068c-5d39-49dd-9021-83358d54e60c.png)
Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Unit test is added for the new placement calculation.