### PR TITLE
HDDS-5443 Create and then recreate a bucket with a randomized name

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -32,7 +32,10 @@ Create new bucket
     Create bucket
 
 Create bucket which already exists
-    Create bucket with name     ${BUCKET}
+    Create bucket with name     ${PREFIX}-bucket
+    ${result} =                 Execute AWSS3APICli     list-buckets | jq -r '.Buckets[].Name'
+                                Should contain          ${result}    ${PREFIX}-bucket
+    Create bucket with name     ${PREFIX}-bucket
 
 Create bucket with invalid bucket name
     ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket bucket_1   255

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -32,10 +32,8 @@ Create new bucket
     Create bucket
 
 Create bucket which already exists
-    Create bucket with name     ${PREFIX}-bucket
-    ${result} =                 Execute AWSS3APICli     list-buckets | jq -r '.Buckets[].Name'
-                                Should contain          ${result}    ${PREFIX}-bucket
-    Create bucket with name     ${PREFIX}-bucket
+    ${bucket} =                 Create bucket
+    Create bucket with name     ${bucket}
 
 Create bucket with invalid bucket name
     ${result} =         Execute AWSS3APICli and checkrc         create-bucket --bucket bucket_1   255


### PR DESCRIPTION
## What changes were proposed in this pull request?

Stop using the well known ${BUCKET} value due to side effects of having created a bucket other tests will test for. Uses a randomized bucket name instead that is then confirmed to exist before the second bucket creation command is executed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5443

## How was this patch tested?

The issue is really only seen when running tests manually and substituting in a custom bucket name, per test instructions and that bucket didn't happen to exist and you were expecting it to still not exist after the test is run. 

The changes were tested manually and as part of the s3 acceptance tests since this test is run as part of the s3 acceptance tests. 