### PR TITLE
HDDS-5465. Delete redundant code when set、add and remove bucket acl

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.response.bucket.acl.OMBucketAclResponse;
 import org.apache.hadoop.ozone.util.BooleanBiFunction;
 import org.apache.hadoop.ozone.om.request.util.ObjectParser;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -204,8 +205,11 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
    * @param exception
    * @return OMClientResponse
    */
-  abstract OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception);
+  OMClientResponse onFailure(OMResponse.Builder omResponse,
+      IOException exception) {
+    return new OMBucketAclResponse(
+        createErrorOMResponse(omResponse, exception));
+  }
 
   /**
    * Completion hook for final processing before return without lock.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -120,12 +120,6 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
   }
 
   @Override
-  OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception) {
-    return super.onFailure(omResponse, exception);
-  }
-
-  @Override
   void onComplete(boolean operationResult, IOException exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -127,9 +127,7 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Add acl: {} to path: {} success!", getAcls(), getPath());
-      }
+      LOG.debug("Add acl: {} to path: {} success!", getAcls(), getPath());
     } else {
       omMetrics.incNumBucketUpdateFails();
       if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAddAclRequest.java
@@ -122,8 +122,7 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(
-        createErrorOMResponse(omResponse, exception));
+    return super.onFailure(omResponse, exception);
   }
 
   @Override
@@ -134,7 +133,9 @@ public class OMBucketAddAclRequest extends OMBucketAclRequest {
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {
-      LOG.debug("Add acl: {} to path: {} success!", getAcls(), getPath());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Add acl: {} to path: {} success!", getAcls(), getPath());
+      }
     } else {
       omMetrics.incNumBucketUpdateFails();
       if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -124,9 +124,7 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Remove acl: {} for path: {} success!", getAcls(), getPath());
-      }
+      LOG.debug("Remove acl: {} for path: {} success!", getAcls(), getPath());
     } else {
       omMetrics.incNumBucketUpdateFails();
       if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -117,12 +117,6 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
   }
 
   @Override
-  OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception) {
-    return super.onFailure(omResponse, exception);
-  }
-
-  @Override
   void onComplete(boolean operationResult, IOException exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketRemoveAclRequest.java
@@ -119,8 +119,7 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(
-        createErrorOMResponse(omResponse, exception));
+    return super.onFailure(omResponse, exception);
   }
 
   @Override
@@ -131,7 +130,9 @@ public class OMBucketRemoveAclRequest extends OMBucketAclRequest {
         exception, getOmRequest().getUserInfo()));
 
     if (operationResult) {
-      LOG.debug("Remove acl: {} for path: {} success!", getAcls(), getPath());
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Remove acl: {} for path: {} success!", getAcls(), getPath());
+      }
     } else {
       omMetrics.incNumBucketUpdateFails();
       if (exception == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -118,12 +118,6 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
   }
 
   @Override
-  OMClientResponse onFailure(OMResponse.Builder omResponse,
-      IOException exception) {
-    return super.onFailure(omResponse, exception);
-  }
-
-  @Override
   void onComplete(boolean operationResult, IOException exception,
       OMMetrics omMetrics, AuditLogger auditLogger,
       Map<String, String> auditMap){

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketSetAclRequest.java
@@ -120,8 +120,7 @@ public class OMBucketSetAclRequest extends OMBucketAclRequest {
   @Override
   OMClientResponse onFailure(OMResponse.Builder omResponse,
       IOException exception) {
-    return new OMBucketAclResponse(
-        createErrorOMResponse(omResponse, exception));
+    return super.onFailure(omResponse, exception);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

I found that if the ACL operation of the bucket fails, onFailure has the same operation in OMBucketAddAclRequest、OMBucketRemoveAclRequest、OMBucketSetAclRequest.
So maybe we can move the onfailure operation to the parent class.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5465


## How was this patch tested?

