### PR TITLE
HDDS-5468. Avoid long sleep in TestPeriodicVolumeChecker

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ImmutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/ImmutableVolumeSet.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.container.common.volume;
 
 import com.google.common.collect.ImmutableList;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -32,9 +34,23 @@ public final class ImmutableVolumeSet implements VolumeSet {
     this.volumes = ImmutableList.copyOf(volumes);
   }
 
+  public ImmutableVolumeSet(Collection<? extends StorageVolume> volumes) {
+    this.volumes = ImmutableList.copyOf(volumes);
+  }
+
   @Override
   public List<StorageVolume> getVolumesList() {
     return volumes;
+  }
+
+  @Override
+  public void checkAllVolumes(StorageVolumeChecker checker) throws IOException {
+    try {
+      checker.checkAllVolumes(volumes);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted while running disk check", e);
+    }
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -217,7 +217,13 @@ public class MutableVolumeSet implements VolumeSet {
    * failed volumes.
    */
   public void checkAllVolumes() throws IOException {
-    if (volumeChecker == null) {
+    checkAllVolumes(volumeChecker);
+  }
+
+  @Override
+  public void checkAllVolumes(StorageVolumeChecker checker)
+      throws IOException {
+    if (checker == null) {
       LOG.debug("No volumeChecker, skip checkAllVolumes");
       return;
     }
@@ -225,7 +231,7 @@ public class MutableVolumeSet implements VolumeSet {
     List<StorageVolume> allVolumes = getVolumesList();
     Set<? extends StorageVolume> failedVolumes;
     try {
-      failedVolumes = volumeChecker.checkAllVolumes(allVolumes);
+      failedVolumes = checker.checkAllVolumes(allVolumes);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
       throw new IOException("Interrupted while running disk check", e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeChecker.java
@@ -96,8 +96,7 @@ public class StorageVolumeChecker {
    */
   private final ScheduledExecutorService diskCheckerservice;
   private final ScheduledFuture<?> periodicDiskChecker;
-
-  private List<MutableVolumeSet> registeredVolumeSets;
+  private final List<VolumeSet> registeredVolumeSets;
 
   /**
    * @param conf  Configuration object.
@@ -146,7 +145,7 @@ public class StorageVolumeChecker {
             TimeUnit.MINUTES);
   }
 
-  public synchronized void registerVolumeSet(MutableVolumeSet volumeSet) {
+  public synchronized void registerVolumeSet(VolumeSet volumeSet) {
     registeredVolumeSets.add(volumeSet);
   }
 
@@ -164,8 +163,8 @@ public class StorageVolumeChecker {
     }
 
     try {
-      for (MutableVolumeSet volSet : registeredVolumeSets) {
-        volSet.checkAllVolumes();
+      for (VolumeSet volSet : registeredVolumeSets) {
+        volSet.checkAllVolumes(this);
       }
 
       lastAllVolumeSetsCheckComplete = timer.monotonicNow();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeSet.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.volume;
 
 import org.apache.hadoop.ozone.lock.ReadWriteLockable;
 
+import java.io.IOException;
 import java.util.List;
 
 /**
@@ -26,4 +27,6 @@ import java.util.List;
  */
 public interface VolumeSet extends ReadWriteLockable {
   List<StorageVolume> getVolumesList();
+
+  void checkAllVolumes(StorageVolumeChecker checker) throws IOException;
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
@@ -97,8 +97,6 @@ public class TestPeriodicVolumeChecker {
       volumeChecker.setDelegateChecker(
           new TestStorageVolumeChecker.DummyChecker());
 
-      // 1 for volumeSet and 1 for metadataVolumeSet
-      // in MutableVolumeSet constructor
       Assert.assertEquals(0, volumeChecker.getNumAllVolumeChecks());
       Assert.assertEquals(0, volumeChecker.getNumAllVolumeSetsChecks());
 
@@ -106,7 +104,6 @@ public class TestPeriodicVolumeChecker {
       timer.advance(gap.toMillis() / 3);
       volumeChecker.checkAllVolumeSets();
 
-      // 2 for volumeSet and 2 for metadataVolumeSet
       Assert.assertEquals(2, volumeChecker.getNumAllVolumeChecks());
       Assert.assertEquals(1, volumeChecker.getNumAllVolumeSetsChecks());
       Assert.assertEquals(0, volumeChecker.getNumSkippedChecks());

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestPeriodicVolumeChecker.java
@@ -20,12 +20,10 @@ package org.apache.hadoop.ozone.container.common.volume;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
-import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
+import org.apache.hadoop.util.FakeTimer;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,6 +37,10 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import static org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult.HEALTHY;
+import static org.apache.hadoop.ozone.container.common.volume.TestStorageVolumeChecker.makeVolumes;
 
 /**
  * Test periodic volume checker in StorageVolumeChecker.
@@ -79,40 +81,54 @@ public class TestPeriodicVolumeChecker {
 
     DatanodeConfiguration dnConf =
         conf.getObject(DatanodeConfiguration.class);
-    dnConf.setDiskCheckMinGap(Duration.ofMinutes(2));
-    dnConf.setPeriodicDiskCheckIntervalMinutes(1);
-    conf.setFromObject(dnConf);
+    Duration gap = dnConf.getDiskCheckMinGap();
+    Duration interval = Duration.ofMinutes(
+        dnConf.getPeriodicDiskCheckIntervalMinutes());
 
-    DatanodeDetails datanodeDetails =
-        ContainerTestUtils.createDatanodeDetails();
-    OzoneContainer ozoneContainer =
-        ContainerTestUtils.getOzoneContainer(datanodeDetails, conf);
-    MutableVolumeSet dataVolumeSet = ozoneContainer.getVolumeSet();
+    FakeTimer timer = new FakeTimer();
 
-    StorageVolumeChecker volumeChecker = dataVolumeSet.getVolumeChecker();
-    volumeChecker.setDelegateChecker(
-        new TestStorageVolumeChecker.DummyChecker());
+    StorageVolumeChecker volumeChecker = new StorageVolumeChecker(conf, timer);
 
-    // 1 for volumeSet and 1 for metadataVolumeSet
-    // in MutableVolumeSet constructor
-    Assert.assertEquals(2, volumeChecker.getNumAllVolumeChecks());
-    Assert.assertEquals(0, volumeChecker.getNumAllVolumeSetsChecks());
+    try {
+      volumeChecker.registerVolumeSet(new ImmutableVolumeSet(makeVolumes(
+          2, HEALTHY)));
+      volumeChecker.registerVolumeSet(new ImmutableVolumeSet(makeVolumes(
+          1, HEALTHY)));
+      volumeChecker.setDelegateChecker(
+          new TestStorageVolumeChecker.DummyChecker());
 
-    // wait for periodic disk checker start
-    Thread.sleep((60 + 5) * 1000);
+      // 1 for volumeSet and 1 for metadataVolumeSet
+      // in MutableVolumeSet constructor
+      Assert.assertEquals(0, volumeChecker.getNumAllVolumeChecks());
+      Assert.assertEquals(0, volumeChecker.getNumAllVolumeSetsChecks());
 
-    // first round
-    // 2 for volumeSet and 2 for metadataVolumeSet
-    Assert.assertEquals(4, volumeChecker.getNumAllVolumeChecks());
-    Assert.assertEquals(1, volumeChecker.getNumAllVolumeSetsChecks());
-    Assert.assertEquals(0, volumeChecker.getNumSkippedChecks());
+      // first round
+      timer.advance(gap.toMillis() / 3);
+      volumeChecker.checkAllVolumeSets();
 
-    // wait for periodic disk checker next round
-    Thread.sleep((60 + 5) * 1000);
+      // 2 for volumeSet and 2 for metadataVolumeSet
+      Assert.assertEquals(2, volumeChecker.getNumAllVolumeChecks());
+      Assert.assertEquals(1, volumeChecker.getNumAllVolumeSetsChecks());
+      Assert.assertEquals(0, volumeChecker.getNumSkippedChecks());
 
-    // skipped next round
-    Assert.assertEquals(4, volumeChecker.getNumAllVolumeChecks());
-    Assert.assertEquals(1, volumeChecker.getNumAllVolumeSetsChecks());
-    Assert.assertEquals(1, volumeChecker.getNumSkippedChecks());
+      // periodic disk checker next round within gap
+      timer.advance(gap.toMillis() / 3);
+      volumeChecker.checkAllVolumeSets();
+
+      // skipped next round
+      Assert.assertEquals(2, volumeChecker.getNumAllVolumeChecks());
+      Assert.assertEquals(1, volumeChecker.getNumAllVolumeSetsChecks());
+      Assert.assertEquals(1, volumeChecker.getNumSkippedChecks());
+
+      // periodic disk checker next round
+      timer.advance(interval.toMillis());
+      volumeChecker.checkAllVolumeSets();
+
+      Assert.assertEquals(4, volumeChecker.getNumAllVolumeChecks());
+      Assert.assertEquals(2, volumeChecker.getNumAllVolumeSetsChecks());
+      Assert.assertEquals(1, volumeChecker.getNumSkippedChecks());
+    } finally {
+      volumeChecker.shutdownAndWait(1, TimeUnit.SECONDS);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Eliminate the need for costly sleep in `TestPeriodicVolumeChecker`:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 132.95 s - in org.apache.hadoop.ozone.container.common.volume.TestPeriodicVolumeChecker
```

https://github.com/apache/ozone/runs/3112345557#step:4:923

by:
 * manually calling `checkAllVolumeSets` instead of waiting for the real executor to schedule it,
 * and using `FakeTimer` to "advance" time between the calls.

https://issues.apache.org/jira/browse/HDDS-5468

## How was this patch tested?

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.276 s - in org.apache.hadoop.ozone.container.common.volume.TestPeriodicVolumeChecker
```

https://github.com/adoroszlai/hadoop-ozone/runs/3115013489#step:4:1100