### PR TITLE
HDDS-5472. Old versions of location in OmKeyLocationInfoGroup causes OOM of OM

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -286,7 +286,6 @@ public final class OmKeyInfo extends WithParentObjectId {
       // it is important that the new version are always at the tail of the list
       OmKeyLocationInfoGroup currentLatestVersion =
           keyLocationVersions.get(keyLocationVersions.size() - 1);
-      // the new version is created based on the current latest version
       OmKeyLocationInfoGroup newVersion =
           currentLatestVersion.generateNextVersion(newLocationList);
       keyLocationVersions.add(newVersion);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -109,6 +109,7 @@ public class OmKeyLocationInfoGroup {
     return locationVersionMap.values().stream().mapToLong(List::size).sum();
   }
 
+  @Deprecated
   public List<OmKeyLocationInfo> getLocationList(Long versionToFetch) {
     return new ArrayList<>(locationVersionMap.get(versionToFetch));
   }
@@ -149,7 +150,7 @@ public class OmKeyLocationInfoGroup {
   OmKeyLocationInfoGroup generateNextVersion(
       List<OmKeyLocationInfo> newLocationList) {
     Map<Long, List<OmKeyLocationInfo>> newMap =
-        new HashMap<>(locationVersionMap);
+        new HashMap<>();
     newMap.put(version + 1, new ArrayList<>(newLocationList));
     return new OmKeyLocationInfoGroup(version + 1, newMap);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -32,6 +32,8 @@ import java.util.stream.Collectors;
  */
 public class OmKeyLocationInfoGroup {
   private final long version;
+  // TODO: HDDS-5472 Store one version of locationInfo for each
+  //   OmKeyLocationInfoGroup
   private final Map<Long, List<OmKeyLocationInfo>> locationVersionMap;
   private  boolean isMultipartKey;
 

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyLocationInfoGroup.java
@@ -44,6 +44,25 @@ public class TestOmKeyLocationInfoGroup {
     Assert.assertEquals(2, list.size());
   }
 
+  @Test
+  public void testGenerateNextVersion() {
+    OmKeyLocationInfoGroup testInstance = createTestInstance();
+    List<OmKeyLocationInfo> locationInfoList = createLocationList();
+    OmKeyLocationInfoGroup newInstance =
+        testInstance.generateNextVersion(locationInfoList);
+    Assert.assertEquals(1, newInstance.getLocationList().size());
+    // createTestInstance is of version 2, nextVersion should be 3
+    Assert.assertEquals(3, newInstance.getVersion());
+
+  }
+
+  private List<OmKeyLocationInfo> createLocationList() {
+    OmKeyLocationInfo info = new OmKeyLocationInfo.Builder().build();
+    List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
+    locationInfoList.add(info);
+    return locationInfoList;
+  }
+
   private OmKeyLocationInfoGroup createTestInstance() {
     OmKeyLocationInfo info1 = new OmKeyLocationInfo.Builder().build();
     info1.setCreateVersion(1);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -38,7 +38,6 @@ import org.junit.Assert;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -130,7 +130,7 @@ public class TestOmBlockVersioning {
     keyInfo = ozoneManager.lookupKey(keyArgs);
     highestVersion = checkVersions(keyInfo.getKeyLocationVersions());
     assertEquals(1, highestVersion.getVersion());
-    assertEquals(2, highestVersion.getLocationList().size());
+    assertEquals(1, highestVersion.getLocationList().size());
 
     // 3rd update, version 2
     openKey = ozoneManager.openKey(keyArgs);
@@ -150,7 +150,7 @@ public class TestOmBlockVersioning {
     keyInfo = ozoneManager.lookupKey(keyArgs);
     highestVersion = checkVersions(keyInfo.getKeyLocationVersions());
     assertEquals(2, highestVersion.getVersion());
-    assertEquals(4, highestVersion.getLocationList().size());
+    assertEquals(2, highestVersion.getLocationList().size());
   }
 
   private OmKeyLocationInfoGroup checkVersions(
@@ -159,18 +159,6 @@ public class TestOmBlockVersioning {
     for (OmKeyLocationInfoGroup version : versions) {
       if (currentVersion != null) {
         assertEquals(currentVersion.getVersion() + 1, version.getVersion());
-        for (OmKeyLocationInfo info : currentVersion.getLocationList()) {
-          boolean found = false;
-          // all the blocks from the previous version must present in the next
-          // version
-          for (OmKeyLocationInfo info2 : version.getLocationList()) {
-            if (info.getLocalID() == info2.getLocalID()) {
-              found = true;
-              break;
-            }
-          }
-          assertTrue(found);
-        }
       }
       currentVersion = version;
     }
@@ -212,7 +200,7 @@ public class TestOmBlockVersioning {
     keyInfo = ozoneManager.lookupKey(omKeyArgs);
     assertEquals(dataString, TestDataUtil.getKey(bucket, keyName));
     assertEquals(1, keyInfo.getLatestVersionLocations().getVersion());
-    assertEquals(2,
+    assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
 
     dataString = RandomStringUtils.randomAlphabetic(200);
@@ -221,7 +209,7 @@ public class TestOmBlockVersioning {
     keyInfo = ozoneManager.lookupKey(omKeyArgs);
     assertEquals(dataString, TestDataUtil.getKey(bucket, keyName));
     assertEquals(2, keyInfo.getLatestVersionLocations().getVersion());
-    assertEquals(3,
+    assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the keyLocation of different versions is stored redundantly in OmKeyInfo. 

OmKeyInfo:
keyLocationVersions: List<OmKeyLocationInfoGroup>  stores different versions of information in a list.
OmKeyLocationInfoGroup:
 locationVersionMap: Map<Long, List<OmKeyLocationInfo>> stores different versions of location in a map.
If the versions are large, the redundent location is causing the large GC overhead for OM, in our cluster, the OM even crashes because of OOM.

This ticket is to remove the redundant location information to keep OM healthy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5472

## How was this patch tested?

unit test
