### PR TITLE
HDDS-5481. Fix stream() and link() method in ContainerStateMachine

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -502,8 +502,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     return CompletableFuture.supplyAsync(() -> {
       try {
         ContainerCommandRequestProto requestProto =
-            getContainerCommandRequestProto(gid,
-                request.getMessage().getContent());
+            message2ContainerCommandRequestProto(request.getMessage());
         DispatcherContext context =
             new DispatcherContext.Builder()
                 .setStage(DispatcherContext.WriteChunkStage.WRITE_DATA)
@@ -520,6 +519,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     }, executor);
   }
 
+  @Override
   public CompletableFuture<?> link(DataStream stream, LogEntryProto entry) {
     return CompletableFuture.supplyAsync(() -> {
       if (stream == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Fix an inconsistency in parsing the request in `stream()` method with the `startTransaction()` method. This inconsistency caused the stream close issue in our POC code. Refer to the JIRA for more details.
2. Add `@Override` annotation to `link()` method.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5481

## How was this patch tested?

This patch is tested in our POC code, see this [commit](https://github.com/ckj996/ozone/commit/a2da593cfdb608c0de496acdea3ce98114bbe5ca), so we dont need to do ugly workarounds like this [commit](https://github.com/ckj996/ozone/commit/e199582d1b811e6258a34133935746f0617a84ff).

Unit tests will be added later after the client is finished.
