### PR TITLE
HDDS-5494. Reduce retry in Kubernetes test

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -37,10 +37,13 @@ grep_log() {
 
 wait_for_startup(){
    print_phase "Waiting until the k8s cluster is running"
-   retry all_pods_are_running
-   retry grep_log scm-0 "SCM exiting safe mode."
-   retry grep_log om-0 "HTTP server of ozoneManager listening"
-   print_phase "Cluster is up and running"
+   if retry all_pods_are_running \
+       && retry grep_log scm-0 "SCM exiting safe mode." \
+       && retry grep_log om-0 "HTTP server of ozoneManager listening"; then
+     print_phase "Cluster is up and running"
+   else
+     return 1
+   fi
 }
 
 all_pods_are_running() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

_kubernetes_ tests wait for cluster startup, checking some conditions with retry.  In worst case all conditions are checked 100 times with 3 seconds delay, so the test may take 15 minutes to fail.

Skip waiting for SCM and OM readiness if retries for previous conditions are exhausted.

https://issues.apache.org/jira/browse/HDDS-5494

## How was this patch tested?

Currently the test in `ozone` env. fails to start the cluster, so the change is verified by the failing CI check:

```
...
99 'all_pods_are_running' is failed...
4 pods are running out from the 5
100 'all_pods_are_running' is failed...

**** Executing robot tests scm-0 ****

...
```

https://github.com/adoroszlai/hadoop-ozone/runs/3159798487#step:6:797

The happy path is verified by successful startup in `getting-started` env.:

```
...
-1 pods are running. Waiting for more.
12 'all_pods_are_running' is failed...
5 pods are running out from the 6
13 'all_pods_are_running' is failed...
1 'grep_log scm-0 SCM exiting safe mode.' is failed...
2 'grep_log scm-0 SCM exiting safe mode.' is failed...
3 'grep_log scm-0 SCM exiting safe mode.' is failed...
4 'grep_log scm-0 SCM exiting safe mode.' is failed...
5 'grep_log scm-0 SCM exiting safe mode.' is failed...
6 'grep_log scm-0 SCM exiting safe mode.' is failed...
7 'grep_log scm-0 SCM exiting safe mode.' is failed...
8 'grep_log scm-0 SCM exiting safe mode.' is failed...
2021-07-26 09:01:01 INFO  SCMSafeModeManager:248 - SCM exiting safe mode.
2021-07-26 09:01:02 INFO  BaseHttpServer:329 - HTTP server of ozoneManager listening at http://0.0.0.0:9874

**** Cluster is up and running ****

...
```

https://github.com/adoroszlai/hadoop-ozone/runs/3159798487#step:6:172