### PR TITLE
HDDS-5489. Install OS-specific flekszible

### DIFF
--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -83,7 +83,12 @@ install_flekszible() {
 
 _install_flekszible() {
   mkdir bin
-  curl -LSs https://github.com/elek/flekszible/releases/download/v1.8.1/flekszible_1.8.1_Linux_x86_64.tar.gz | tar -xz -f - -C bin
+
+  local os=$(uname -s)
+  local arch=$(uname -m)
+
+  curl -LSs https://github.com/elek/flekszible/releases/download/v1.8.1/flekszible_1.8.1_${os}_${arch}.tar.gz | tar -xz -f - -C bin
+
   chmod +x bin/flekszible
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hard-coded `Linux` in Flekszible download URL with OS/architecture-specific value.

https://issues.apache.org/jira/browse/HDDS-5489

## How was this patch tested?

Tested on a Mac:

```
$ ./hadoop-ozone/dev-support/checks/kubernetes.sh
Installed flekszible in /Users/.../ozone/.dev-tools/flekszible
...
Skip installing k3s, not supported on Mac.  Make sure a working Kubernetes cluster is available.
...
Basic :: Smoketest ozone cluster startup
==============================================================================
Check webui static resources                                          | PASS |
------------------------------------------------------------------------------
Start freon testing                                                   | PASS |
------------------------------------------------------------------------------
Basic :: Smoketest ozone cluster startup                              | PASS |
2 critical tests, 2 passed, 0 failed
...
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/3144431091#step:6:11 (install)
https://github.com/adoroszlai/hadoop-ozone/runs/3144431091#step:6:95 (use)