### PR TITLE
HDDS-5501. Support to upload/read keys from encrypted buckets through S3G

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2807,4 +2807,21 @@
       will not be allocated a pipeline or container replica.
     </description>
   </property>
+
+  <property>
+    <name>ozone.s3g.kerberos.keytab.file</name>
+    <value>/etc/security/keytabs/s3g.keytab</value>
+    <tag>OZONE, SECURITY, KERBEROS, S3GATEWAY</tag>
+    <description> The keytab file used by S3Gateway daemon to login as its
+      service principal. The principal name is configured with
+      ozone.s3g.kerberos.principal.
+    </description>
+  </property>
+  <property>
+    <name>ozone.s3g.kerberos.principal</name>
+    <value>s3g/_HOST@REALM</value>
+    <tag>OZONE, SECURITY, KERBEROS, S3GATEWAY</tag>
+    <description>The S3Gateway service principal.
+      Ex: s3g/_HOST@REALM.COM</description>
+  </property>
 </configuration>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -25,6 +25,7 @@ import javax.crypto.CipherOutputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.security.InvalidKeyException;
+import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -802,9 +803,28 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     // check crypto protocol version
     OzoneKMSUtil.checkCryptoProtocolVersion(feInfo);
-    KeyProvider.KeyVersion decrypted;
-    decrypted = OzoneKMSUtil.decryptEncryptedDataEncryptionKey(feInfo,
-        getKeyProvider());
+    KeyProvider.KeyVersion decrypted = null;
+    try {
+      // Do proxy thing only when current UGI not matching with login UGI
+      // In this way, proxying is done only for s3g where
+      // s3g can act as proxy to end user.
+      UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
+      if (!ugi.getShortUserName().equals(loginUser.getShortUserName())) {
+        UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(
+            ugi.getShortUserName(), UserGroupInformation.getLoginUser());
+        decrypted = proxyUser.doAs(
+            (PrivilegedExceptionAction<KeyProvider.KeyVersion>) () -> {
+              return OzoneKMSUtil.decryptEncryptedDataEncryptionKey(feInfo,
+                  getKeyProvider());
+            });
+      } else {
+        decrypted = OzoneKMSUtil.decryptEncryptedDataEncryptionKey(feInfo,
+            getKeyProvider());
+      }
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted during decrypt key", ex);
+    }
     return decrypted;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -811,7 +811,7 @@ public class RpcClient implements ClientProtocol {
       UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
       if (!ugi.getShortUserName().equals(loginUser.getShortUserName())) {
         UserGroupInformation proxyUser = UserGroupInformation.createProxyUser(
-            ugi.getShortUserName(), UserGroupInformation.getLoginUser());
+            ugi.getShortUserName(), loginUser);
         decrypted = proxyUser.doAs(
             (PrivilegedExceptionAction<KeyProvider.KeyVersion>) () -> {
               return OzoneKMSUtil.decryptEncryptedDataEncryptionKey(feInfo,

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -77,6 +77,9 @@ OZONE-SITE.XML_ozone.om.kerberos.keytab.file=/etc/security/keytabs/om.keytab
 OZONE-SITE.XML_ozone.recon.kerberos.keytab.file=/etc/security/keytabs/recon.keytab
 OZONE-SITE.XML_ozone.recon.kerberos.principal=recon/recon@EXAMPLE.COM
 
+OZONE-SITE.XML_ozone.s3g.kerberos.keytab.file=/etc/security/keytabs/s3g.keytab
+OZONE-SITE.XML_ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM
+
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
 HDFS-SITE.XML_dfs.datanode.keytab.file=/etc/security/keytabs/dn.keytab
 HDFS-SITE.XML_dfs.web.authentication.kerberos.principal=HTTP/ozone@EXAMPLE.COM

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -61,6 +61,9 @@ OZONE-SITE.XML_ozone.om.kerberos.keytab.file=/etc/security/keytabs/om.keytab
 OZONE-SITE.XML_ozone.recon.kerberos.keytab.file=/etc/security/keytabs/recon.keytab
 OZONE-SITE.XML_ozone.recon.kerberos.principal=recon/recon@EXAMPLE.COM
 
+OZONE-SITE.XML_ozone.s3g.kerberos.keytab.file=/etc/security/keytabs/s3g.keytab
+OZONE-SITE.XML_ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM
+
 OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
 OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -27,12 +27,16 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.ozone.util.OzoneVersionInfo;
 
 import org.apache.hadoop.ozone.util.ShutdownHookManager;
+import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine.Command;
 
 import static org.apache.hadoop.ozone.conf.OzoneServiceConfig.DEFAULT_SHUTDOWN_HOOK_PRIORITY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY;
+import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_KERBEROS_PRINCIPAL_KEY;
 
 /**
  * This class is used to start/stop S3 compatible rest server.
@@ -57,6 +61,7 @@ public class Gateway extends GenericCli {
     TracingUtil.initTracing("S3gateway", ozoneConfiguration);
     OzoneConfigurationHolder.setConfiguration(ozoneConfiguration);
     UserGroupInformation.setConfiguration(ozoneConfiguration);
+    loginS3GUser(ozoneConfiguration);
     httpServer = new S3GatewayHttpServer(ozoneConfiguration, "s3gateway");
     start();
 
@@ -83,6 +88,28 @@ public class Gateway extends GenericCli {
   public void stop() throws Exception {
     LOG.info("Stopping Ozone S3 gateway");
     httpServer.stop();
+  }
+
+  private static void loginS3GUser(OzoneConfiguration conf)
+      throws IOException, AuthenticationException {
+
+    if (SecurityUtil.getAuthenticationMethod(conf).equals(
+        UserGroupInformation.AuthenticationMethod.KERBEROS)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Ozone security is enabled. Attempting login for S3G user. "
+                + "Principal: {}, keytab: {}",
+            conf.get(OZONE_S3G_KERBEROS_PRINCIPAL_KEY),
+            conf.get(OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY));
+      }
+
+      SecurityUtil.login(conf, OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY,
+          OZONE_S3G_KERBEROS_PRINCIPAL_KEY);
+    } else {
+      throw new AuthenticationException(SecurityUtil.getAuthenticationMethod(
+          conf) + " authentication method not supported. S3 user login "
+          + "failed.");
+    }
+    LOG.info("S3Gateway login successful.");
   }
 
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -107,7 +107,7 @@ public class Gateway extends GenericCli {
             OZONE_S3G_KERBEROS_PRINCIPAL_KEY);
       } else {
         throw new AuthenticationException(SecurityUtil.getAuthenticationMethod(
-            conf) + " authentication method not supported. S3 user login "
+            conf) + " authentication method not supported. S3G user login "
             + "failed.");
       }
       LOG.info("S3Gateway login successful.");

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayConfigKeys.java
@@ -58,6 +58,13 @@ public final class S3GatewayConfigKeys {
   public static final String OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT =
       "4KB";
 
+  // S3G kerberos, principal config
+  public static final String OZONE_S3G_KERBEROS_KEYTAB_FILE_KEY =
+      "ozone.s3g.kerberos.keytab.file";
+  public static final String OZONE_S3G_KERBEROS_PRINCIPAL_KEY =
+      "ozone.s3g.kerberos.principal";
+
+
   /**
    * Never constructed.
    */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support to put/get/mpu from encrypted bucket from S3G.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5501

## How was this patch tested?

```
Manually tested the fix on secure KMS Cluster.

**S3Gatway**
<property><name>ozone.s3g.kerberos.keytab.file</name><value>/tmp/ozone.keytab</value></property>
<property><name>ozone.s3g.kerberos.principal.key</name><value>s3g/_HOST@ROOT.HWX.SITE</value></property>
**Ranger KMS**
<property><name>hadoop.kms.proxyuser.s3g.users</name><value>*</value></property
<property><name>hadoop.kms.proxyuser.s3g.hosts</name><value>*</value></property><property><name>hadoop.kms.proxyuser.s3g.groups</name><value>*</value></property>

Configure  credentials
[root@xx ~]# kinit -kt /var/run/cloudera-scm-agent/process/71-hbase-REGIONSERVER/hbase.keytab hbase/xx@ROOT.HWX.SITE

[root@xx ~]# ozone s3 getsecret --om-service-id=ozone1
awsAccessKey=hbase/xx@ROOT.HWX.SITE
awsSecret=28805795d4118e1aa4acbd70c7f6915384a30af7ac55f942ccc260ba999bcbba

[root@xx ~]# aws  configure
AWS Access Key ID [****************SITE]: hbase/xx@ROOT.HWX.SITE
AWS Secret Access Key [****************cbba]: 28805795d4118e1aa4acbd70c7f6915384a30af7ac55f942ccc260ba999bcbba
Default region name [None]: 
Default output format [None]:
Test
Create encryption key
hadoop key create key1
**Create enc buck**
[root@nightly71x-4 ~]# ozone sh bucket create /s3v/s3encbuck --bucketkey key1
21/07/26 11:23:06 INFO rpc.RpcClient: Creating Bucket: s3v/s3encbuck, with Versioning false and Storage Type set to DISK and Encryption set to true 

**S3 Test**
[root@xx~]# alias s3api='aws s3api --endpoint https://nightly71x-4.nightly71x.root.hwx.site:9879 --no-verify-ssl'

[root@xx ~]# s3api put-object --bucket s3encbuck --key key1 --body /etc/hadoop/conf/ozone-site.xml 
/usr/lib/fence-agents/bundled/botocore/vendored/requests/packages/urllib3/connectionpool.py:768: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)

[root@xx ~]# s3api get-object --bucket s3encbuck --key key1 /tmp/key1
/usr/lib/fence-agents/bundled/botocore/vendored/requests/packages/urllib3/connectionpool.py:768: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
{
    "AcceptRanges": "bytes", 
    "ContentType": "application/octet-stream", 
    "LastModified": "Mon, 26 Jul 2021 11:24:21 GMT", 
    "ContentLength": 3785, 
    "Expires": "Mon, 26 Jul 2021 11:25:01 GMT", 
    "CacheControl": "no-cache", 
    "Metadata": {}
}

[root@xx ~]# diff /tmp/key1 /etc/hadoop/conf/ozone-site.xml 

[root@xx ~]# s3api list-objects --bucket s3encbuck
/usr/lib/fence-agents/bundled/botocore/vendored/requests/packages/urllib3/connectionpool.py:768: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html
  InsecureRequestWarning)
{
    "Contents": [
        {
            "LastModified": "2021-07-26T11:24:21.458Z", 
            "ETag": "2021-07-26T11:24:21.458Z", 
            "StorageClass": "STANDARD", 
            "Key": "key1", 
            "Size": 3785
        }
    ]
}

```
**Shell Test**

```
[root@nightly71x-4 ~]# ozone sh key put /s3v/s3encbuck/key1 /etc/hadoop/conf/ozone-site.xml 
[root@nightly71x-4 ~]# ozone sh key get /s3v/s3encbuck/key1 /tmp/dkey1
[root@nightly71x-4 ~]# diff /tmp/dkey1 /etc/hadoop/conf/ozone-site.xml  
```

Opened a jira https://issues.apache.org/jira/browse/HDDS-5507 to add secure KMS and add tests for put/get/mpu from encrypted bucket using s3g.