### PR TITLE
HDDS-5509. EC: Add missing break in switch statement when requesting EC blocks

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -174,6 +174,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
     case EC:
       requestBuilder.setEcReplicationConfig(
           ((ECReplicationConfig)replicationConfig).toProto());
+      break;
     default:
       throw new IllegalArgumentException(
           "Unsupported replication type " + replicationConfig


### PR DESCRIPTION
## What changes were proposed in this pull request?

We missed a break statement in the EC branch of the switch statement, so calls for EC blocks are falling through to the exception case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5509

## How was this patch tested?
