### PR TITLE
HDDS-5516. Duplicate metrics registered while running checkScmHA upon scm startup.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1028,7 +1028,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       // If SCM HA was not being used before pre-finalize, and is being used
       // when the cluster is pre-finalized for the SCM HA feature, init
       // should fail.
-      ScmHAUnfinalizedStateValidationAction.checkScmHA(conf, scmStorageConfig);
+      ScmHAUnfinalizedStateValidationAction.checkScmHA(conf, scmStorageConfig,
+          new HDDSLayoutVersionManager(scmStorageConfig.getLayoutVersion()));
 
       clusterId = scmStorageConfig.getClusterID();
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
@@ -27,8 +27,8 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.upgrade.HDDSUpgradeAction;
+import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.ozone.upgrade.UpgradeActionHdds;
 import org.apache.hadoop.ozone.upgrade.UpgradeException;
 
@@ -45,7 +45,8 @@ public class ScmHAUnfinalizedStateValidationAction
 
   @Override
   public void execute(StorageContainerManager scm) throws IOException {
-    checkScmHA(scm.getConfiguration(), scm.getScmStorageConfig());
+    checkScmHA(scm.getConfiguration(), scm.getScmStorageConfig(),
+        scm.getLayoutVersionManager());
   }
 
   /**
@@ -53,13 +54,11 @@ public class ScmHAUnfinalizedStateValidationAction
    * scm init and the upgrade action run on start.
    */
   public static void checkScmHA(OzoneConfiguration conf,
-      SCMStorageConfig storageConf) throws IOException {
+      SCMStorageConfig storageConf, LayoutVersionManager versionManager)
+      throws IOException {
 
     // Since this action may need to be called outside the upgrade framework
     // during init, it needs to check for pre-finalized state.
-    HDDSLayoutVersionManager versionManager =
-        new HDDSLayoutVersionManager(storageConf.getLayoutVersion());
-
     if (versionManager.needsFinalization() &&
         SCMHAUtils.isSCMHAEnabled(conf) &&
         !storageConf.isSCMHAEnabled()) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/ScmHAUnfinalizedStateValidationAction.java
@@ -59,7 +59,7 @@ public class ScmHAUnfinalizedStateValidationAction
 
     // Since this action may need to be called outside the upgrade framework
     // during init, it needs to check for pre-finalized state.
-    if (versionManager.needsFinalization() &&
+    if (!versionManager.isAllowed(SCM_HA) &&
         SCMHAUtils.isSCMHAEnabled(conf) &&
         !storageConf.isSCMHAEnabled()) {
       throw new UpgradeException(String.format("Configuration %s cannot be " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

Duplicate metrics registered while running checkScmHA upon scm startup.
More details in the jira below.
Here we reuse the LayoutManager instance from scm when scm is running,
and create a LayoutManager instance in scmInit() which should be in a single cmd line run, so no duplicate happens.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5516

## How was this patch tested?

manual test.