### PR TITLE
HDDS-5503. On finalize upgrade actions not running.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
@@ -38,7 +38,6 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Function;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
 
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeAction;
@@ -197,16 +196,14 @@ public abstract class BasicUpgradeFinalizer
 
   protected void finalizeUpgrade(Function<LayoutFeature,
       Function<UpgradeActionType, Optional<? extends UpgradeAction>>>
-      aFunction, Supplier<Storage> storageSuppplier)
-      throws UpgradeException {
+      aFunction, Storage storage) throws UpgradeException {
     for (Object obj : versionManager.unfinalizedFeatures()) {
       LayoutFeature lf = (LayoutFeature) obj;
-      Storage layoutStorage = storageSuppplier.get();
       Function<UpgradeActionType, Optional<? extends UpgradeAction>> function =
           aFunction.apply(lf);
       Optional<? extends UpgradeAction> action = function.apply(ON_FINALIZE);
       runFinalizationAction(lf, action);
-      updateLayoutVersionInVersionFile(lf, layoutStorage);
+      updateLayoutVersionInVersionFile(lf, storage);
       versionManager.finalized(lf);
     }
     versionManager.completeFinalization();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/upgrade/BasicUpgradeFinalizer.java
@@ -195,12 +195,16 @@ public abstract class BasicUpgradeFinalizer
         || status.equals(FINALIZATION_DONE);
   }
 
-  protected void finalizeUpgrade(Supplier<Storage> storageSuppplier)
+  protected void finalizeUpgrade(Function<LayoutFeature,
+      Function<UpgradeActionType, Optional<? extends UpgradeAction>>>
+      aFunction, Supplier<Storage> storageSuppplier)
       throws UpgradeException {
     for (Object obj : versionManager.unfinalizedFeatures()) {
       LayoutFeature lf = (LayoutFeature) obj;
       Storage layoutStorage = storageSuppplier.get();
-      Optional<? extends UpgradeAction> action = lf.action(ON_FINALIZE);
+      Function<UpgradeActionType, Optional<? extends UpgradeAction>> function =
+          aFunction.apply(lf);
+      Optional<? extends UpgradeAction> action = function.apply(ON_FINALIZE);
       runFinalizationAction(lf, action);
       updateLayoutVersionInVersionFile(lf, layoutStorage);
       versionManager.finalized(lf);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
@@ -82,7 +82,7 @@ public class DataNodeUpgradeFinalizer extends
   public void finalizeUpgrade(DatanodeStateMachine dsm)
       throws UpgradeException {
     super.finalizeUpgrade(lf -> ((HDDSLayoutFeature) lf)::datanodeAction,
-        dsm::getLayoutStorage);
+        dsm.getLayoutStorage());
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/DataNodeUpgradeFinalizer.java
@@ -81,7 +81,8 @@ public class DataNodeUpgradeFinalizer extends
   @Override
   public void finalizeUpgrade(DatanodeStateMachine dsm)
       throws UpgradeException {
-    super.finalizeUpgrade(dsm::getLayoutStorage);
+    super.finalizeUpgrade(lf -> ((HDDSLayoutFeature) lf)::datanodeAction,
+        dsm::getLayoutStorage);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -82,7 +82,8 @@ public class SCMUpgradeFinalizer extends
   @Override
   public void finalizeUpgrade(StorageContainerManager scm)
       throws UpgradeException {
-    super.finalizeUpgrade(scm::getScmStorageConfig);
+    super.finalizeUpgrade(lf -> ((HDDSLayoutFeature) lf)::scmAction,
+        scm::getScmStorageConfig);
   }
 
   public void postFinalizeUpgrade(StorageContainerManager scm)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -83,7 +83,7 @@ public class SCMUpgradeFinalizer extends
   public void finalizeUpgrade(StorageContainerManager scm)
       throws UpgradeException {
     super.finalizeUpgrade(lf -> ((HDDSLayoutFeature) lf)::scmAction,
-        scm::getScmStorageConfig);
+        scm.getScmStorageConfig());
   }
 
   public void postFinalizeUpgrade(StorageContainerManager scm)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizer.java
@@ -39,7 +39,8 @@ public class OMUpgradeFinalizer extends BasicUpgradeFinalizer<OzoneManager,
   @Override
   public void finalizeUpgrade(OzoneManager om)
       throws UpgradeException {
-    super.finalizeUpgrade(om::getOmStorage);
+    super.finalizeUpgrade(lf -> ((OMLayoutFeature) lf)::action,
+        om::getOmStorage);
   }
 
   public void runPrefinalizeStateActions(Storage storage, OzoneManager om)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/upgrade/OMUpgradeFinalizer.java
@@ -40,7 +40,7 @@ public class OMUpgradeFinalizer extends BasicUpgradeFinalizer<OzoneManager,
   public void finalizeUpgrade(OzoneManager om)
       throws UpgradeException {
     super.finalizeUpgrade(lf -> ((OMLayoutFeature) lf)::action,
-        om::getOmStorage);
+        om.getOmStorage());
   }
 
   public void runPrefinalizeStateActions(Storage storage, OzoneManager om)


### PR DESCRIPTION
## What changes were proposed in this pull request?

On finalize upgrade actions not running.
Actually it is just a default function `action()` that does not got overrided for HDDSLayoutFeature,
and we could pass it in as done in runPrefinalizeStateActions.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5503

## How was this patch tested?

manual test.
