### PR TITLE
HDDS-5524. Use try-with-resources to properly close resources in DirectoryServerSource.java

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
@@ -47,8 +47,8 @@ public class DirectoryServerSource implements StreamingSource {
     final Path streamingDir = root.resolve(id);
     try (Stream<Path> list = Files.walk(streamingDir)
             .filter(Files::isRegularFile)) {
-        list.forEach(path -> {
-            files.put(root.relativize(path).toString(), path);
+      list.forEach(path -> {
+          files.put(root.relativize(path).toString(), path);
         });
     } catch (IOException e) {
       throw new StreamingException("Couldn't read directory for streaming: " +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
@@ -45,13 +45,11 @@ public class DirectoryServerSource implements StreamingSource {
       throws InterruptedException {
     Map<String, Path> files = new HashMap<>();
     final Path streamingDir = root.resolve(id);
-    try {
-      try (Stream<Path> list = Files.walk(streamingDir)
-              .filter(Files::isRegularFile)) {
+    try (Stream<Path> list = Files.walk(streamingDir)
+            .filter(Files::isRegularFile)) {
         list.forEach(path -> {
-          files.put(root.relativize(path).toString(), path);
+            files.put(root.relativize(path).toString(), path);
         });
-      }
     } catch (IOException e) {
       throw new StreamingException("Couldn't read directory for streaming: " +
           streamingDir, e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * Streaming files from single directory.
@@ -41,18 +42,19 @@ public class DirectoryServerSource implements StreamingSource {
    * @param id name of the subdirectory to replitace relative to root.
    */
   public Map<String, Path> getFilesToStream(String id)
-      throws InterruptedException {
+          throws InterruptedException {
     Map<String, Path> files = new HashMap<>();
     final Path streamingDir = root.resolve(id);
     try {
-      Files.walk(streamingDir)
-          .filter(Files::isRegularFile)
-          .forEach(path -> {
-            files.put(root.relativize(path).toString(), path);
-          });
+      try (Stream<Path> list = Files.walk(streamingDir)
+              .filter(Files::isRegularFile)) {
+        list.forEach(path -> {
+          files.put(root.relativize(path).toString(), path);
+        });
+      }
     } catch (IOException e) {
       throw new StreamingException("Couldn't read directory for streaming: " +
-          streamingDir, e);
+              streamingDir, e);
     }
     return files;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
@@ -42,7 +42,7 @@ public class DirectoryServerSource implements StreamingSource {
    * @param id name of the subdirectory to replitace relative to root.
    */
   public Map<String, Path> getFilesToStream(String id)
-          throws InterruptedException {
+      throws InterruptedException {
     Map<String, Path> files = new HashMap<>();
     final Path streamingDir = root.resolve(id);
     try {
@@ -54,7 +54,7 @@ public class DirectoryServerSource implements StreamingSource {
       }
     } catch (IOException e) {
       throw new StreamingException("Couldn't read directory for streaming: " +
-              streamingDir, e);
+          streamingDir, e);
     }
     return files;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/stream/DirectoryServerSource.java
@@ -48,8 +48,8 @@ public class DirectoryServerSource implements StreamingSource {
     try (Stream<Path> list = Files.walk(streamingDir)
             .filter(Files::isRegularFile)) {
       list.forEach(path -> {
-          files.put(root.relativize(path).toString(), path);
-        });
+        files.put(root.relativize(path).toString(), path);
+      });
     } catch (IOException e) {
       throw new StreamingException("Couldn't read directory for streaming: " +
           streamingDir, e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Resources should be closed.Failure to properly close resources will result in a resource leak.
Resource should be created using `try-with-resources` pattern and will be closed automatically.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5524

## How was this patch tested?

No need.
