### PR TITLE
HDDS-5449 Recon namespace summary 'du' information should return replicated size of a key

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -118,8 +119,10 @@ public class TestReconWithOzoneManagerFSO {
             (ReconOMMetadataManager)
                     cluster.getReconServer().getOzoneManagerServiceProvider()
                             .getOMMetadataManagerInstance();
+    OzoneStorageContainerManager reconSCM =
+            cluster.getReconServer().getReconStorageContainerManager();
     NSSummaryEndpoint endpoint = new NSSummaryEndpoint(namespaceSummaryManager,
-            omMetadataManagerInstance);
+            omMetadataManagerInstance, reconSCM);
     Response basicInfo = endpoint.getBasicInfo("/vol1/bucket1/dir1");
     NamespaceSummaryResponse entity =
             (NamespaceSummaryResponse) basicInfo.getEntity();

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NSSummaryEndpoint.java
@@ -980,7 +980,7 @@ public class NSSummaryEndpoint {
     OmKeyLocationInfoGroup locationGroup = keyInfo.getLatestVersionLocations();
     List<OmKeyLocationInfo> keyLocations =
             locationGroup.getBlocksLatestVersionOnly();
-    long du = keyInfo.getDataSize();
+    long du = 0L;
     // a key could be too large to fit in one single container
     for (OmKeyLocationInfo location: keyLocations) {
       BlockID block = location.getBlockID();
@@ -988,8 +988,8 @@ public class NSSummaryEndpoint {
       try {
         int replicationFactor =
                 containerManager.getContainerReplicas(containerId).size();
-        du *= replicationFactor;
-        break;
+        long blockSize = location.getLength() * replicationFactor;
+        du += blockSize;
       } catch (ContainerNotFoundException cnfe) {
         LOG.warn("Cannot find container");
       }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DUResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DUResponse.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon.api.types;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -55,6 +56,7 @@ public class DUResponse {
 
   public DUResponse() {
     this.status = ResponseStatus.OK;
+    this.duData = new ArrayList<>();
     // by default, the replication feature is disabled
     this.sizeWithReplica = -1L;
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DUResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DUResponse.java
@@ -30,6 +30,18 @@ public class DUResponse {
   @JsonProperty("status")
   private ResponseStatus status;
 
+  /** The current path request. */
+  @JsonProperty("path")
+  private String path;
+
+  /** Total size under current path.*/
+  @JsonProperty("size")
+  private long size;
+
+  /** Total size with replicas counted.*/
+  @JsonProperty("sizeWithReplica")
+  private long sizeWithReplica;
+
   /** The number of subpaths under the request path. */
   @JsonProperty("subPathCount")
   private int count;
@@ -43,6 +55,8 @@ public class DUResponse {
 
   public DUResponse() {
     this.status = ResponseStatus.OK;
+    // by default, the replication feature is disabled
+    this.sizeWithReplica = -1L;
   }
 
   public ResponseStatus getStatus() {
@@ -51,6 +65,30 @@ public class DUResponse {
 
   public void setStatus(ResponseStatus status) {
     this.status = status;
+  }
+
+  public long getSize() {
+    return size;
+  }
+
+  public void setSize(long size) {
+    this.size = size;
+  }
+
+  public long getSizeWithReplica() {
+    return sizeWithReplica;
+  }
+
+  public void setSizeWithReplica(long sizeWithReplica) {
+    this.sizeWithReplica = sizeWithReplica;
+  }
+
+  public String getPath() {
+    return path;
+  }
+
+  public void setPath(String path) {
+    this.path = path;
   }
 
   public int getCount() {
@@ -89,6 +127,14 @@ public class DUResponse {
     @JsonProperty("size")
     private long size;
 
+    /** Disk usage with replication under the subpath. */
+    @JsonProperty("sizeWithReplica")
+    private long sizeWithReplica;
+
+    public DiskUsage() {
+      this.sizeWithReplica = -1L;
+    }
+
     public long getSize() {
       return size;
     }
@@ -97,12 +143,20 @@ public class DUResponse {
       return subpath;
     }
 
+    public long getSizeWithReplica() {
+      return sizeWithReplica;
+    }
+
     public void setSize(long size) {
       this.size = size;
     }
 
     public void setSubpath(String subpath) {
       this.subpath = subpath;
+    }
+
+    public void setSizeWithReplica(long sizeWithReplica) {
+      this.sizeWithReplica = sizeWithReplica;
     }
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NamespaceSummaryResponse.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/NamespaceSummaryResponse.java
@@ -27,20 +27,21 @@ public class NamespaceSummaryResponse {
   @JsonProperty("type")
   private EntityType entityType;
 
+  /** Total number of volumes under root, -1 for other types. */
   @JsonProperty("numVolume")
   private int numVolume;
 
-  /** Total number of buckets for volume, 0 for other types. */
+  /** Total number of buckets for root/volume, -1 for other types. */
   @JsonProperty("numBucket")
   private int numBucket;
 
-  /** Total number of directories for a bucket or directory, 0 for others. */
+  /** Total number of directories for all types except key, -1 for key. */
   @JsonProperty("numDir")
   private int numTotalDir;
 
-  /** Total number of keys for a bucket or directory, 0 for others. */
+  /** Total number of keys. */
   @JsonProperty("numKey")
-  private int numTotalKey;
+  private long numTotalKey;
 
   /** Path Status. */
   @JsonProperty("status")
@@ -48,9 +49,9 @@ public class NamespaceSummaryResponse {
 
   public NamespaceSummaryResponse(EntityType entityType) {
     this.entityType = entityType;
-    this.numVolume = 0;
-    this.numBucket = 0;
-    this.numTotalDir = 0;
+    this.numVolume = -1;
+    this.numBucket = -1;
+    this.numTotalDir = -1;
     this.numTotalKey = 0;
     this.status = ResponseStatus.OK;
   }
@@ -71,7 +72,7 @@ public class NamespaceSummaryResponse {
     return this.numTotalDir;
   }
 
-  public int getNumTotalKey() {
+  public long getNumTotalKey() {
     return this.numTotalKey;
   }
 
@@ -95,7 +96,7 @@ public class NamespaceSummaryResponse {
     this.numTotalDir = numTotalDir;
   }
 
-  public void setNumTotalKey(int numTotalKey) {
+  public void setNumTotalKey(long numTotalKey) {
     this.numTotalKey = numTotalKey;
   }
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -210,6 +210,29 @@ public final class OMMetadataManagerTestUtils {
                     .build());
   }
 
+  @SuppressWarnings("checkstyle:parameternumber")
+  public static void writeKeyToOm(OMMetadataManager omMetadataManager,
+                                  long parentObjectId,
+                                  long objectId,
+                                  String volName,
+                                  String bucketName,
+                                  String keyName,
+                                  String fileName,
+                                  List<OmKeyLocationInfoGroup> locationVersions)
+          throws IOException {
+    String omKey = omMetadataManager.getOzonePathKey(parentObjectId, fileName);
+    omMetadataManager.getKeyTable().put(omKey,
+            new OmKeyInfo.Builder()
+                    .setBucketName(bucketName)
+                    .setVolumeName(volName)
+                    .setKeyName(keyName)
+                    .setOmKeyLocationInfos(locationVersions)
+                    .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+                    .setObjectID(objectId)
+                    .setParentObjectID(parentObjectId)
+                    .build());
+  }
+
   public static void writeDirToOm(OMMetadataManager omMetadataManager,
                                   long objectId,
                                   long parentObjectId,

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.api;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
@@ -34,8 +35,11 @@ import org.apache.hadoop.ozone.recon.api.types.FileSizeDistributionResponse;
 import org.apache.hadoop.ozone.recon.api.types.ResponseStatus;
 import org.apache.hadoop.ozone.recon.api.types.QuotaUsageResponse;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
+import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
+import org.apache.hadoop.ozone.recon.spi.impl.StorageContainerServiceProviderImpl;
 import org.apache.hadoop.ozone.recon.tasks.NSSummaryTask;
 import org.junit.Assert;
 import org.junit.Before;
@@ -56,6 +60,7 @@ import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOz
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
+import static org.mockito.Mockito.mock;
 
 /**
  * Test for NSSummary REST APIs.
@@ -178,6 +183,10 @@ public class TestNSSummaryEndpoint {
                     .withOmServiceProvider(ozoneManagerServiceProvider)
                     .withReconSqlDb()
                     .withContainerDB()
+                    .addBinding(OzoneStorageContainerManager.class,
+                            ReconStorageContainerManagerFacade.class)
+                    .addBinding(StorageContainerServiceProvider.class,
+                            mock(StorageContainerServiceProviderImpl.class))
                     .addBinding(NSSummaryEndpoint.class)
                     .build();
     reconNamespaceSummaryManager =

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
@@ -257,7 +257,8 @@ public class TestNSSummaryEndpoint {
   @Test
   public void testDiskUsage() throws Exception {
     // volume level DU
-    Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH);
+    Response volResponse = nsSummaryEndpoint.getDiskUsage(VOL_PATH,
+            false, false);
     DUResponse duVolRes = (DUResponse) volResponse.getEntity();
     Assert.assertEquals(2, duVolRes.getCount());
     List<DUResponse.DiskUsage> duData = duVolRes.getDuData();
@@ -272,7 +273,8 @@ public class TestNSSummaryEndpoint {
     Assert.assertEquals(BUCKET_TWO_DATA_SIZE, duBucket2.getSize());
 
     // bucket level DU
-    Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH);
+    Response bucketResponse = nsSummaryEndpoint.getDiskUsage(BUCKET_ONE_PATH,
+            false, false);
     DUResponse duBucketResponse = (DUResponse) bucketResponse.getEntity();
     Assert.assertEquals(1, duBucketResponse.getCount());
     DUResponse.DiskUsage duDir1 = duBucketResponse.getDuData().get(0);
@@ -280,7 +282,8 @@ public class TestNSSummaryEndpoint {
     Assert.assertEquals(DIR_ONE_DATA_SIZE, duDir1.getSize());
 
     // dir level DU
-    Response dirResponse = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH);
+    Response dirResponse = nsSummaryEndpoint.getDiskUsage(DIR_ONE_PATH,
+            false, false);
     DUResponse duDirReponse = (DUResponse) dirResponse.getEntity();
     Assert.assertEquals(3, duDirReponse.getCount());
     List<DUResponse.DiskUsage> duSubDir = duDirReponse.getDuData();
@@ -299,13 +302,15 @@ public class TestNSSummaryEndpoint {
     Assert.assertEquals(KEY_SIX_SIZE, duDir4.getSize());
 
     // key level DU
-    Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH);
+    Response keyResponse = nsSummaryEndpoint.getDiskUsage(KEY_PATH,
+            false, false);
     DUResponse keyObj = (DUResponse) keyResponse.getEntity();
-    Assert.assertEquals(1, keyObj.getCount());
-    Assert.assertEquals(KEY_FOUR_SIZE, keyObj.getDuData().get(0).getSize());
+    Assert.assertEquals(0, keyObj.getCount());
+    Assert.assertEquals(KEY_FOUR_SIZE, keyObj.getSize());
 
     // invalid path check
-    Response invalidResponse = nsSummaryEndpoint.getDiskUsage(INVALID_PATH);
+    Response invalidResponse = nsSummaryEndpoint.getDiskUsage(INVALID_PATH,
+            false, false);
     DUResponse invalidObj = (DUResponse) invalidResponse.getEntity();
     Assert.assertEquals(ResponseStatus.PATH_NOT_FOUND,
             invalidObj.getStatus());

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
@@ -87,7 +87,6 @@ public class TestNSSummaryEndpoint {
   private ReconNamespaceSummaryManager reconNamespaceSummaryManager;
   private OMMetadataManager omMetadataManager;
   private ReconOMMetadataManager reconOMMetadataManager;
-  private OzoneStorageContainerManager ozoneStorageContainerManager;
   private OzoneManagerServiceProviderImpl ozoneManagerServiceProvider;
   private NSSummaryEndpoint nsSummaryEndpoint;
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestNSSummaryEndpoint.java
@@ -30,7 +30,10 @@ import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
-import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.recon.ReconConstants;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
@@ -57,11 +60,19 @@ import javax.ws.rs.core.Response;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
-import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.*;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeDirToOm;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.writeKeyToOm;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
+import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getMockOzoneManagerServiceProviderWithFSO;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In addition to actual key size, Recon 'du' should also return the replicated size of a key.
For example, for a 3 way replicated key of size = 1MB, Recon 'du' should return '1MB' as the size of the key, and '3MB' as the replicated size if the key is fully replicated.

[Refactoring]
1. DU response now shows a "structure"
2. DU key response shouldn't have subpaths

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5449

## How was this patch tested?

Since this is an improvement/refactoring feature on top of HDDS-5378, no additional unit test is implemented. I tested remotely on the cluster endpoint with the following configs:
![Screen Shot 2021-08-03 at 1 46 36 PM](https://user-images.githubusercontent.com/53324985/128062467-ff763bc6-07a0-4a5a-9eab-857b8643523a.png)
All keys are three-way replicated except `key3`

[Root DU]
http://localhost:9888/api/v1/namespace/du?path=/&replica=true
![root du -rep](https://user-images.githubusercontent.com/53324985/128065104-1e4fdbdd-9b84-4c75-9b14-cf70fb7ea5c7.png)

[Volume DU]
http://localhost:9888/api/v1/namespace/du?path=/vol&replica=true
![vol du -rep](https://user-images.githubusercontent.com/53324985/128065167-758ffd63-e89f-4120-a03b-3f7acea11715.png)

[Bucket DU] `&files=true` enabled
http://localhost:9888/api/v1/namespace/du?path=/vol/bucket&files=true&replica=true
![bucket du -rep](https://user-images.githubusercontent.com/53324985/128065213-9049b519-27a6-443c-b387-450b9b9f2993.png)

[Directory DU] `&files=true` enabled
http://localhost:9888/api/v1/namespace/du?path=/vol/bucket/dir1&files=true&replica=true
![dir1 du -rep](https://user-images.githubusercontent.com/53324985/128065242-e6b9efbd-532d-42e7-b2ac-9d913b8e8cff.png)
(Key3 is one-way replicated.)

[Nested Directory DU]
http://localhost:9888/api/v1/namespace/du?path=/vol/bucket/dir1/dir2&files=true&replica=true
![dir2 du -rep](https://user-images.githubusercontent.com/53324985/128065272-15b0af28-b79e-4f98-9666-f4c22ec9bf53.png)

[Key DU]
http://localhost:9888/api/v1/namespace/du?path=/vol/bucket/dir1/dir2/dir3/key6&files=true&replica=true
![key du -rep](https://user-images.githubusercontent.com/53324985/128065331-8f0f3023-f50a-47a7-84f1-65774524708d.png)