### PR TITLE
HDDS-5539. Fix actual value in assertion in TestRDBStore

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -165,7 +165,7 @@ public class TestRDBStore {
         Assert.assertNotNull(newvalue);
         //and it is not same as what we wrote to the FirstTable, and equals
         // the new value.
-        Assert.assertArrayEquals(nextValue, nextValue);
+        Assert.assertArrayEquals(nextValue, newvalue);
       }
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The assertion that the expected value is the same as the actual value is meaningless.
`Assert.assertArrayEquals(nextValue, nextValue);`

This change is to fix the previously wrong `Assert.assertArrayEquals()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5539

## How was this patch tested?

Local TestRDBStroe pass.
