### PR TITLE
HDDS-5532. Missing integration test cleanup

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/ITestOzoneContractDistCp.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/ITestOzoneContractDistCp.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.tools.contract.AbstractContractDistCpTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.cleanup;
+
 
 /**
  * Contract test suite covering S3A integration with DistCp.
@@ -47,5 +49,11 @@ public class ITestOzoneContractDistCp extends AbstractContractDistCpTest {
   @Override
   protected OzoneContract createContract(Configuration conf) {
     return new OzoneContract(conf);
+  }
+
+  @Override
+  protected void deleteTestDirInTeardown() throws IOException {
+    super.deleteTestDirInTeardown();
+    cleanup("TEARDOWN", getLocalFS(), getLocalDir());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractDistCp.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractDistCp.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.tools.contract.AbstractContractDistCpTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import static org.apache.hadoop.fs.contract.ContractTestUtils.cleanup;
+
 
 /**
  * Contract test suite covering S3A integration with DistCp.
@@ -47,5 +49,11 @@ public class ITestRootedOzoneContractDistCp extends AbstractContractDistCpTest {
   @Override
   protected RootedOzoneContract createContract(Configuration conf) {
     return new RootedOzoneContract(conf);
+  }
+
+  @Override
+  protected void deleteTestDirInTeardown() throws IOException {
+    super.deleteTestDirInTeardown();
+    cleanup("TEARDOWN", getLocalFS(), getLocalDir());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestSecureContainerServer.java
@@ -105,6 +105,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -141,6 +142,11 @@ public class TestSecureContainerServer {
     containerTokenSecretManager = new ContainerTokenSecretManager(
         secConf, tokenLifetime, certSerialId);
     containerTokenSecretManager.start(caClient);
+  }
+
+  @AfterClass
+  public static void deleteTestDir() {
+    FileUtils.deleteQuietly(new File(TEST_DIR));
   }
 
   @After

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -88,6 +89,13 @@ public class TestCloseContainer {
     cluster.waitForClusterToBeReady();
 
     bucket = TestDataUtil.createVolumeAndBucket(cluster, volName, bucketName);
+  }
+
+  @After
+  public void cleanup() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add post-test cleanup for some tests where I found large leftover files.

https://github.com/adoroszlai/hadoop-ozone/runs/3232120118#step:4:3832
https://github.com/adoroszlai/hadoop-ozone/runs/3232120118#step:4:3845
https://github.com/adoroszlai/hadoop-ozone/runs/3232120118#step:4:10313
https://github.com/adoroszlai/hadoop-ozone/runs/3232120118#step:4:14016

https://issues.apache.org/jira/browse/HDDS-5532

## How was this patch tested?

Printed space after tests, verified that `test-dir` disk usage is in acceptable range.

https://github.com/adoroszlai/hadoop-ozone/runs/3234909921#step:8:28
https://github.com/adoroszlai/hadoop-ozone/runs/3234909972#step:8:28
https://github.com/adoroszlai/hadoop-ozone/runs/3234910003#step:8:28