### PR TITLE
HDDS-5531. For Link Buckets avoid showing metadata.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/JsonUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hdds.server;
 import java.io.IOException;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -39,6 +40,7 @@ public final class JsonUtils {
   private static final ObjectWriter WRITTER;
   static {
     MAPPER = new ObjectMapper()
+        .setSerializationInclusion(JsonInclude.Include.NON_NULL)
         .registerModule(new JavaTimeModule())
         .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
     WRITTER = MAPPER.writerWithDefaultPrettyPrinter();

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -76,7 +76,7 @@ Link Bucket info
     ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
                         Should Contain              ${result}            ${source}
                         Should Contain              ${result}            readable-bucket
-                        Should Contain              ${result}            ${target}t
+                        Should Contain              ${result}            ${target}
                         Should Contain              ${result}            readable-link
                         Should Contain              ${result}            modificationTime
                         Should Contain              ${result}            creationTime

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -48,6 +48,17 @@ Setup ACL tests
     Execute             ozone sh bucket addacl --acl user:testuser2/scm@EXAMPLE.COM:r ${target}/readable-link
     Execute             ozone sh bucket addacl --acl user:testuser2/scm@EXAMPLE.COM:r ${target}/link-to-unreadable-bucket
 
+Link Bucket info
+    Execute             kdestroy
+    Run Keyword         Kinit test user             testuser2            testuser2.keytab
+    ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
+                        Should Contain              ${result}            ${source}
+                        Should Contain              ${result}            readable-bucket
+                        Should Contain              ${result}            ${target}t
+                        Should Contain              ${result}            readable-link
+                        Should Contain              ${result}            modificationTime
+                        Should Contain              ${result}            creationTime
+                        Should Not contain          ${result}            metadata
 Can follow link with read access
     Execute             kdestroy
     Run Keyword         Kinit test user             testuser2         testuser2.keytab

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -70,16 +70,6 @@ ACL verified on source bucket
                         Should Contain              ${result}         PERMISSION_DENIED
 
 *** Test Cases ***
-Link Bucket info
-    ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
-                        Should Contain              ${result}            ${source}
-                        Should Contain              ${result}            readable-bucket
-                        Should Contain              ${result}            ${target}
-                        Should Contain              ${result}            readable-link
-                        Should Contain              ${result}            modificationTime
-                        Should Contain              ${result}            creationTime
-                        Should Not contain          ${result}            metadata
-
 Link to non-existent bucket
                         Execute                     ozone sh bucket link ${source}/no-such-bucket ${target}/dangling-link
     ${result} =         Execute And Ignore Error    ozone sh key list ${target}/dangling-link
@@ -113,8 +103,14 @@ Bucket list contains links
                         Should Contain              ${result}         dangling-link
 
 Bucket info shows source
-    ${result} =         Execute                     ozone sh bucket info ${target}/link1 | jq -r '.sourceVolume, .sourceBucket' | xargs
-                        Should Be Equal             ${result}    ${source} bucket1
+    ${result} =         Execute                     ozone sh bucket info ${target}/link1
+                        Should Contain              ${result}            ${source}
+                        Should Contain              ${result}            bucket1
+                        Should Contain              ${result}            ${target}
+                        Should Contain              ${result}            link1
+                        Should Contain              ${result}            modificationTime
+                        Should Contain              ${result}            creationTime
+                        Should Not contain          ${result}            metadata
 
 Source and target have separate ACLs
     Execute       ozone sh bucket addacl --acl user:user1:rwxy ${target}/link1

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -48,17 +48,6 @@ Setup ACL tests
     Execute             ozone sh bucket addacl --acl user:testuser2/scm@EXAMPLE.COM:r ${target}/readable-link
     Execute             ozone sh bucket addacl --acl user:testuser2/scm@EXAMPLE.COM:r ${target}/link-to-unreadable-bucket
 
-Link Bucket info
-    Execute             kdestroy
-    Run Keyword         Kinit test user             testuser2            testuser2.keytab
-    ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
-                        Should Contain              ${result}            ${source}
-                        Should Contain              ${result}            readable-bucket
-                        Should Contain              ${result}            ${target}t
-                        Should Contain              ${result}            readable-link
-                        Should Contain              ${result}            modificationTime
-                        Should Contain              ${result}            creationTime
-                        Should Not contain          ${result}            metadata
 Can follow link with read access
     Execute             kdestroy
     Run Keyword         Kinit test user             testuser2         testuser2.keytab
@@ -81,6 +70,18 @@ ACL verified on source bucket
                         Should Contain              ${result}         PERMISSION_DENIED
 
 *** Test Cases ***
+Link Bucket info
+    Execute             kdestroy
+    Run Keyword         Kinit test user             testuser2            testuser2.keytab
+    ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
+                        Should Contain              ${result}            ${source}
+                        Should Contain              ${result}            readable-bucket
+                        Should Contain              ${result}            ${target}t
+                        Should Contain              ${result}            readable-link
+                        Should Contain              ${result}            modificationTime
+                        Should Contain              ${result}            creationTime
+                        Should Not contain          ${result}            metadata
+
 Link to non-existent bucket
                         Execute                     ozone sh bucket link ${source}/no-such-bucket ${target}/dangling-link
     ${result} =         Execute And Ignore Error    ozone sh key list ${target}/dangling-link

--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -71,8 +71,6 @@ ACL verified on source bucket
 
 *** Test Cases ***
 Link Bucket info
-    Execute             kdestroy
-    Run Keyword         Kinit test user             testuser2            testuser2.keytab
     ${result} =         Execute And Ignore Error    ozone sh bucket info ${target}/readable-link
                         Should Contain              ${result}            ${source}
                         Should Contain              ${result}            readable-bucket

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
@@ -54,16 +54,16 @@ public class InfoBucketHandler extends BucketHandler {
   private static class LinkBucket {
     private String volumeName;
     private String bucketName;
-    private String sourceVolumeName;
-    private String sourceBucketName;
+    private String sourceVolume;
+    private String sourceBucket;
     private Instant creationTime;
     private Instant modificationTime;
 
     LinkBucket(OzoneBucket ozoneBucket) {
       this.volumeName = ozoneBucket.getVolumeName();
       this.bucketName = ozoneBucket.getName();
-      this.sourceVolumeName = ozoneBucket.getSourceVolume();
-      this.sourceBucketName = ozoneBucket.getSourceBucket();
+      this.sourceVolume = ozoneBucket.getSourceVolume();
+      this.sourceBucket = ozoneBucket.getSourceBucket();
       this.creationTime = ozoneBucket.getCreationTime();
       this.modificationTime = ozoneBucket.getModificationTime();
     }
@@ -76,12 +76,12 @@ public class InfoBucketHandler extends BucketHandler {
       return bucketName;
     }
 
-    public String getSourceVolumeName() {
-      return sourceVolumeName;
+    public String getSourceVolume() {
+      return sourceVolume;
     }
 
-    public String getSourceBucketName() {
-      return sourceBucketName;
+    public String getSourceBucket() {
+      return sourceBucket;
     }
 
     public Instant getCreationTime() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine.Command;
 
 import java.io.IOException;
+import java.time.Instant;
 
 /**
  * Executes Info bucket.
@@ -40,7 +41,56 @@ public class InfoBucketHandler extends BucketHandler {
         .getVolume(address.getVolumeName())
         .getBucket(address.getBucketName());
 
-    printObjectAsJson(bucket);
+    if (bucket.getSourceBucket() != null && bucket.getSourceVolume() != null) {
+      printObjectAsJson(new LinkBucket(bucket));
+    } else {
+      printObjectAsJson(bucket);
+    }
+  }
+
+  /**
+   * Class used for link buckets.
+   */
+  private static class LinkBucket {
+    private String volumeName;
+    private String bucketName;
+    private String sourceVolumeName;
+    private String sourceBucketName;
+    private Instant creationTime;
+    private Instant modificationTime;
+
+    LinkBucket(OzoneBucket ozoneBucket) {
+      this.volumeName = ozoneBucket.getVolumeName();
+      this.bucketName = ozoneBucket.getName();
+      this.sourceVolumeName = ozoneBucket.getSourceVolume();
+      this.sourceBucketName = ozoneBucket.getSourceBucket();
+      this.creationTime = ozoneBucket.getCreationTime();
+      this.modificationTime = ozoneBucket.getModificationTime();
+    }
+
+    public String getVolumeName() {
+      return volumeName;
+    }
+
+    public String getBucketName() {
+      return bucketName;
+    }
+
+    public String getSourceVolumeName() {
+      return sourceVolumeName;
+    }
+
+    public String getSourceBucketName() {
+      return sourceBucketName;
+    }
+
+    public Instant getCreationTime() {
+      return creationTime;
+    }
+
+    public Instant getModificationTime() {
+      return modificationTime;
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid showing unnecessary metadata for link buckets. This is to avoid confusion like when link is to encrypted bucket showing encryption key null would confuse shell users


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5531

## How was this patch tested?

Manual test and also updated robot test

bash-4.2$ ozone sh bucket info /linkvol/linkbuck
```
{
  "volumeName" : "linkvol",
  "bucketName" : "linkbuck",
  "sourceVolume" : "vol1",
  "sourceBucket" : "buck1",
  "creationTime" : "2021-08-05T06:51:24.815Z",
  "modificationTime" : "2021-08-05T06:51:24.815Z"
}
bash-4.2$ ozone sh bucket info /vol1/buck1
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "buck1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2021-08-05T06:50:46.936Z",
  "modificationTime" : "2021-08-05T06:50:46.936Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY"
}
```
