### PR TITLE
HDDS-5425: Client side pipeline cache key should use host and port combination

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientManager.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
@@ -249,9 +250,16 @@ public class XceiverClientManager implements Closeable, XceiverClientFactory {
 
   private String getPipelineCacheKey(Pipeline pipeline, boolean forRead) {
     String key = pipeline.getId().getId().toString() + pipeline.getType();
-    if (topologyAwareRead && forRead) {
+    boolean isEC = pipeline.getReplicationConfig()
+        .getReplicationType() == HddsProtos.ReplicationType.EC;
+    if (topologyAwareRead && forRead || isEC) {
       try {
         key += pipeline.getClosestNode().getHostName();
+        if (isEC) {
+          // Currently EC uses standalone client.
+          key += pipeline.getClosestNode()
+              .getPort(DatanodeDetails.Port.Name.STANDALONE);
+        }
       } catch (IOException e) {
         LOG.error("Failed to get closest node to create pipeline cache key:" +
             e.getMessage());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Client side cache uses pipeline ids as keys. In EC case we wanted to use IP:Host in keys so that we can get different keys for each node in block group.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5425

## How was this patch tested?

Added tests to verify the behavior.