### PR TITLE
HDDS-5558. vUnit invocation unit() may produce NPE

### DIFF
--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -47,11 +47,11 @@ public final class TimeDurationUtil {
     vStr = vStr.trim();
     vStr = vStr.toLowerCase();
     ParsedTimeDuration vUnit = ParsedTimeDuration.unitFor(vStr);
-    if (vUnit == null) {
+    if (null == vUnit) {
       LOG.warn("No unit for " + name + "(" + vStr + ") assuming " + unit);
       vUnit = ParsedTimeDuration.unitFor(unit);
-      if(vUnit == null){
-        throw new NullPointerException("Specified vUnit is null");
+      if(null == vUnit){
+        throw new NullPointerException("Unexpected unit" + unit);
       }
     } else {
       vStr = vStr.substring(0, vStr.lastIndexOf(vUnit.suffix()));

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.conf;
 
-import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -48,15 +47,18 @@ public final class TimeDurationUtil {
     vStr = vStr.trim();
     vStr = vStr.toLowerCase();
     ParsedTimeDuration vUnit = ParsedTimeDuration.unitFor(vStr);
-    if (null == vUnit) {
+    if (vUnit == null) {
       LOG.warn("No unit for " + name + "(" + vStr + ") assuming " + unit);
       vUnit = ParsedTimeDuration.unitFor(unit);
+      if(vUnit == null){
+        throw new NullPointerException("Specified vUnit is null");
+      }
     } else {
       vStr = vStr.substring(0, vStr.lastIndexOf(vUnit.suffix()));
     }
 
     long raw = Long.parseLong(vStr);
-    long converted = unit.convert(raw, Objects.requireNonNull(vUnit).unit());
+    long converted = unit.convert(raw, vUnit.unit());
     if (vUnit.unit().convert(converted, unit) < raw) {
       LOG.warn("Possible loss of precision converting " + vStr
           + vUnit.suffix() + " to " + unit + " for " + name);

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.conf;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
@@ -55,7 +56,7 @@ public final class TimeDurationUtil {
     }
 
     long raw = Long.parseLong(vStr);
-    long converted = unit.convert(raw, vUnit != null ? vUnit.unit() : null);
+    long converted = unit.convert(raw, Objects.requireNonNull(vUnit).unit());
     if (vUnit.unit().convert(converted, unit) < raw) {
       LOG.warn("Possible loss of precision converting " + vStr
           + vUnit.suffix() + " to " + unit + " for " + name);

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -55,7 +55,7 @@ public final class TimeDurationUtil {
     }
 
     long raw = Long.parseLong(vStr);
-    long converted = unit.convert(raw, vUnit.unit());
+    long converted = unit.convert(raw, vUnit != null ? vUnit.unit() : null);
     if (vUnit.unit().convert(converted, unit) < raw) {
       LOG.warn("Possible loss of precision converting " + vStr
           + vUnit.suffix() + " to " + unit + " for " + name);

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/TimeDurationUtil.java
@@ -50,8 +50,8 @@ public final class TimeDurationUtil {
     if (null == vUnit) {
       LOG.warn("No unit for " + name + "(" + vStr + ") assuming " + unit);
       vUnit = ParsedTimeDuration.unitFor(unit);
-      if(null == vUnit){
-        throw new NullPointerException("Unexpected unit" + unit);
+      if (null == vUnit) {
+        throw new IllegalArgumentException("Unexpected unit: " + unit);
       }
     } else {
       vStr = vStr.substring(0, vStr.lastIndexOf(vUnit.suffix()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid methods that generate NPE when calling `unit()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5558

## How was this patch tested?

No need.
