### PR TITLE
HDDS-5498. Containers are always quasi closed during finalization.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/upgrade/SCMUpgradeFinalizer.java
@@ -147,7 +147,7 @@ public class SCMUpgradeFinalizer extends
       for (Pipeline pipeline : pipelineManager.getPipelines()) {
         if (pipeline.getPipelineState() != CLOSED) {
           pipelineFound = true;
-          pipelineManager.closePipeline(pipeline, false);
+          pipelineManager.closePipeline(pipeline, true);
         }
       }
       try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -39,12 +39,14 @@ import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.STARTING_F
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -275,7 +277,16 @@ public class TestHDDSUpgrade {
   /*
    * Helper function to test Post-Upgrade conditions on all the DataNodes.
    */
-  private void testPostUpgradeConditionsDataNodes() {
+  private void testPostUpgradeConditionsDataNodes(
+      ContainerProtos.ContainerDataProto.State... validClosedContainerStates) {
+    List<ContainerProtos.ContainerDataProto.State> closeStates =
+        Arrays.asList(validClosedContainerStates);
+    // Allow closed and quasi closed containers as valid closed containers by
+    // default.
+    if (closeStates.isEmpty()) {
+      closeStates.addAll(Arrays.asList(CLOSED, QUASI_CLOSED));
+    }
+
     try {
       GenericTestUtils.waitFor(() -> {
         for (HddsDatanodeService dataNode : cluster.getHddsDatanodes()) {
@@ -308,9 +319,11 @@ public class TestHDDSUpgrade {
       // Also verify that all the existing containers are closed.
       for (Iterator<Container<?>> it =
            dsm.getContainer().getController().getContainers(); it.hasNext();) {
-        Container container = it.next();
-        Assert.assertTrue(container.getContainerState() == CLOSED ||
-            container.getContainerState() == QUASI_CLOSED);
+        Container<?> container = it.next();
+        Assert.assertTrue("Container had unexpected state " +
+                container.getContainerState(),
+            closeStates.stream().anyMatch(
+                state -> container.getContainerState().equals(state)));
         countContainers++;
       }
     }
@@ -434,7 +447,9 @@ public class TestHDDSUpgrade {
     testDataNodesStateOnSCM(HEALTHY_READONLY, HEALTHY);
 
     // Verify the SCM has driven all the DataNodes through Layout Upgrade.
-    testPostUpgradeConditionsDataNodes();
+    // In the happy path case, no containers should have been quasi closed as
+    // a result of the upgrade.
+    testPostUpgradeConditionsDataNodes(CLOSED);
 
     // Test that we can use a pipeline after upgrade.
     // Will fail with exception if there are no pipelines.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -284,7 +283,7 @@ public class TestHDDSUpgrade {
     // Allow closed and quasi closed containers as valid closed containers by
     // default.
     if (closeStates.isEmpty()) {
-      closeStates.addAll(Arrays.asList(CLOSED, QUASI_CLOSED));
+      closeStates = Arrays.asList(CLOSED, QUASI_CLOSED);
     }
 
     try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Have containers close normally during a regular upgrade with all datanodes up by not force closing pipelines.

## What is the link to the Apache JIRA

HDDS-5498

## How was this patch tested?

Integration test modified.
