### PR TITLE
HDDS-5561. EC: ECReplicationConfig should be immutable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -82,16 +82,8 @@ public class ECReplicationConfig implements ReplicationConfig {
     return data;
   }
 
-  public void setData(int data) {
-    this.data = data;
-  }
-
   public int getParity() {
     return parity;
-  }
-
-  public void setParity(int parity) {
-    this.parity = parity;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Just as other ReplicationConfig implementations, the ECReplicationConfig class should not expose setters, and should be immutable.
There aren't any setter usages yet, and it does not seem to be any reason to leave this class mutable, in case we need it we can add it back later on, when there is a reason for it to become mutable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5561

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

No particular tests were run, IDEA did not found any use of these methods, and the patch just removes them.
