### PR TITLE
HDDS-5562 EC: ContainerPlacementPolicyFactory#getPolicyInternal() should not be public

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/ContainerPlacementPolicyFactory.java
@@ -70,7 +70,7 @@ public final class ContainerPlacementPolicyFactory {
         fallback, metrics);
   }
 
-  public static PlacementPolicy getPolicyInternal(
+  private static PlacementPolicy getPolicyInternal(
       Class<? extends PlacementPolicy> placementClass,
       ConfigurationSource conf, final NodeManager nodeManager,
       NetworkTopology clusterMap, final boolean fallback,


### PR DESCRIPTION
## What changes were proposed in this pull request?

The method name itself contradicts the public modifier, also the method is only used inside the class, so it worth to change it to private. (This change is added on just the EC branch so far.)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5562

## How was this patch tested?
No extra tests were done, as the method is used just within the class, and the only change is the visibility.
