### PR TITLE
HDDS-5598. Validate block file length during  writeChunk

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -265,4 +265,7 @@ public final class HddsConfigKeys {
       "hdds.datanode.ratis.server.request.timeout";
   public static final String
       HDDS_DATANODE_RATIS_SERVER_REQUEST_TIMEOUT_DEFAULT = "2m";
+
+  public static final String HDDS_DATANODE_WRITE_CHUNK_VALIDATION_CHECK =
+      "hdds.datanode.write.chunk.validation.check";
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -214,6 +214,15 @@ public class DatanodeConfiguration {
   )
   private long diskCheckTimeout = DISK_CHECK_TIMEOUT_DEFAULT;
 
+  @Config(key = "write.chunk.validation.check",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      tags = {
+      DATANODE },
+      description = "Enable safety checks to ensure"
+          + " chunk offset equal to block file length")
+  private boolean isWriteChunkValidationCheck;
+
   @PostConstruct
   public void validate() {
     if (replicationMaxStreams < 1) {
@@ -339,5 +348,13 @@ public class DatanodeConfiguration {
 
   public void setBlockDeleteQueueLimit(int queueLimit) {
     this.blockDeleteQueueLimit = queueLimit;
+  }
+
+  public boolean isWriteChunkValidationCheck() {
+    return isWriteChunkValidationCheck;
+  }
+
+  public void setWriteChunkValidationCheck(boolean writeChunkValidationCheck) {
+    this.isWriteChunkValidationCheck = writeChunkValidationCheck;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.util.AutoCloseableLock;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_VOLUME_CHOOSING_POLICY;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_DATANODE_WRITE_CHUNK_VALIDATION_CHECK;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CLOSED_CONTAINER_IO;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_INTERNAL_ERROR;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.CONTAINER_UNHEALTHY;
@@ -128,6 +129,9 @@ public class KeyValueHandler extends Handler {
     blockManager = new BlockManagerImpl(config);
     chunkManager = ChunkManagerFactory.createChunkManager(config, blockManager,
         volSet);
+    ChunkManagerFactory.setValidateWriteChunk(
+        conf.getBoolean(HDDS_DATANODE_WRITE_CHUNK_VALIDATION_CHECK,
+            false));
     try {
       volumeChoosingPolicy = conf.getClass(
           HDDS_DATANODE_VOLUME_CHOOSING_POLICY, RoundRobinVolumeChoosingPolicy

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -37,6 +37,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.function.ToLongFunction;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -372,5 +373,18 @@ public final class ChunkUtils {
     }
 
     return CONTAINER_INTERNAL_ERROR;
+  }
+
+  /**
+   * Checks if the block file length is equal to the chunk offset.
+   *
+   * @param chunkFile - File
+   * @param chunkInfo - Buffer to write
+   */
+  public static void validateChunkSize(File chunkFile, ChunkInfo chunkInfo) {
+    long offset = chunkInfo.getOffset();
+    long length = chunkFile.length();
+    Preconditions.checkArgument(offset == length,
+        "Offset does not match blockFile length");
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/ChunkManagerFactory.java
@@ -37,6 +37,7 @@ import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfi
 public final class ChunkManagerFactory {
   private static final Logger LOG =
       LoggerFactory.getLogger(ChunkManagerFactory.class);
+  private static boolean validateWriteChunk;
 
   private ChunkManagerFactory() {
   }
@@ -77,5 +78,13 @@ public final class ChunkManagerFactory {
     }
 
     return new ChunkManagerDispatcher(sync, manager, volSet);
+  }
+
+  public static void setValidateWriteChunk(boolean validateWriteChunk) {
+    ChunkManagerFactory.validateWriteChunk = validateWriteChunk;
+  }
+
+  public static boolean isValidateWriteChunk() {
+    return validateWriteChunk;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -125,6 +125,12 @@ public class FilePerBlockStrategy implements ChunkManager {
           info, overwrite, stage, chunkFile);
     }
 
+    // Safety check : When offset=0, this is the beginning of a new block and
+    // hence the block file must be empty.
+    if (offset == 0) {
+      Preconditions.checkArgument(chunkFile.length() == 0,
+          "Block file is not empty at offset 0");
+    }
     HddsVolume volume = containerData.getVolume();
 
     FileChannel channel = null;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerBlockStrategy.java
@@ -61,6 +61,7 @@ import static org.apache.hadoop.ozone.container.common.transport.server.ratis.Di
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.limitReadSize;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.validateChunkForOverwrite;
+import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.validateChunkSize;
 import static org.apache.hadoop.ozone.container.keyvalue.helpers.ChunkUtils.verifyChunkFileExists;
 
 /**
@@ -125,11 +126,12 @@ public class FilePerBlockStrategy implements ChunkManager {
           info, overwrite, stage, chunkFile);
     }
 
-    // Safety check : When offset=0, this is the beginning of a new block and
-    // hence the block file must be empty.
-    if (offset == 0) {
-      Preconditions.checkArgument(chunkFile.length() == 0,
-          "Block file is not empty at offset 0");
+    // if this is not an overwrite ,
+    // check whether offset matches block file length
+    if (ChunkManagerFactory.isValidateWriteChunk()) {
+      if (!overwrite) {
+        validateChunkSize(chunkFile, info);
+      }
     }
     HddsVolume volume = containerData.getVolume();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add a defensive check to ensure that block file is empty during the first write chunk at 0 offset. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5598

## How was this patch tested?
CI