### PR TITLE
HDDS-5600. Allow nested blocks in switch case statements in checkstyle checks.

### DIFF
--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -163,7 +163,9 @@
 
         <!-- Checks for blocks. You know, those {}'s         -->
         <!-- See http://checkstyle.sf.net/config_blocks.html -->
-        <module name="AvoidNestedBlocks"/>
+        <module name="AvoidNestedBlocks">
+            <property name="allowInSwitchCase" value="true"/>
+        </module>
         <module name="EmptyBlock"/>
         <module name="LeftCurly"/>
         <module name="NeedBraces"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In the checkstyle rules, we enable the module AvoidNestedBlocks.

This is a problem, if for example a variable scope needs to be created inside a switch case statement, where this rule gives a warning if a case defines a code block ("{}").

This PR is to loosen this rule, and allow nested blocks in switch statements.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5600

## How was this patch tested?
Added a random test code with a switch case with blocks, and ran checkstyle, then removed the random code block.