### PR TITLE
HDDS-5603. Stop ContainerBalancer when SCM is stopped.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -722,6 +722,12 @@ public class ContainerBalancer {
       }
       balancerRunning = false;
       currentBalancingThread.interrupt();
+      currentBalancingThread.join(1000);
+
+      // allow garbage collector to collect balancing thread
+      currentBalancingThread = null;
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while waiting for balancing thread to join.");
     } finally {
       lock.unlock();
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1338,6 +1338,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   @Override
   public void stop() {
     try {
+      LOG.info("Stopping Container Balancer service.");
+      containerBalancer.stop();
+    } catch (Exception e) {
+      LOG.error("Failed to stop Container Balancer service.");
+    }
+
+    try {
       LOG.info("Stopping Replication Manager Service.");
       replicationManager.stop();
     } catch (Exception ex) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerBalancer should be stopped in `StorageContainerManager#stop`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5603

## How was this patch tested?

Existing tests.
