### PR TITLE
HDDS-5617. Revert version of ratis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
 
     <!-- Apache Ratis version -->
-    <ratis.version>2.1.0-03f3b68-SNAPSHOT</ratis.version>
+    <ratis.version>2.1.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
     <ratis.thirdparty.version>0.7.0</ratis.thirdparty.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-5283 updated the version of ratis-server from "2.1.0" to "2.1.0-03f3b68-SNAPSHOT", which will throw the following error.
```
Failed to execute goal on project hdds-common: Could not resolve dependencies for project org.apache.ozone:hdds-common:jar:1.2.0-SNAPSHOT: The following artifacts could not be resolved: org.apache.ratis:ratis-server:jar:2.1.0-03f3b68-SNAPSHOT, org.apache.ratis:ratis-netty:jar:2.1.0-03f3b68-SNAPSHOT, org.apache.ratis:ratis-grpc:jar:2.1.0-03f3b68-SNAPSHOT: Could not find artifact org.apache.ratis:ratis-server:jar:2.1.0-03f3b68-SNAPSHOT 
```
This ticket is to revert the version of ratis-server.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5617

## How was this patch tested?

No need to test, only change version in pom