### PR TITLE
HDDS-5620. Fix and extend hadoop.http.idle_timeout.ms to 60k

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2832,4 +2832,13 @@
     <description>The S3Gateway service principal.
       Ex: s3g/_HOST@REALM.COM</description>
   </property>
+
+  <property>
+    <name>hadoop.http.idle_timeout.ms</name>
+    <value>60000</value>
+    <tag>OZONE, PERFORMANCE, S3GATEWAY</tag>
+    <description>
+      OM/SCM/DN/S3GATEWAY Server connection timeout in milliseconds.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -152,9 +152,15 @@ public final class HttpServer2 implements FilterContainer {
   // idle timeout in milliseconds
   private static final String HTTP_IDLE_TIMEOUT_MS_KEY =
       "hadoop.http.idle_timeout.ms";
-  // This value will never be used because the default value is set in
-  // core-default.xml from hadoop-common and ozone-default.xml. The value
-  // 60k here is aligned to the value in ozone-default.xml.
+
+  /**
+   *  This value will never be used because the default value is set in
+   *  core-default.xml from hadoop-common and ozone-default.xml. The value 60k
+   *  here is aligned to the value in ozone-default.xml.
+   *
+   *  TODO: default values for other properties defined here are likely to be
+   *   ignored if defaults are defined in hadoop-common as well.
+   **/
   private static final int HTTP_IDLE_TIMEOUT_MS_DEFAULT = 60000;
   private static final String HTTP_TEMP_DIR_KEY = "hadoop.http.temp.dir";
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -49,6 +49,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.ConfServlet;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
@@ -151,7 +152,10 @@ public final class HttpServer2 implements FilterContainer {
   // idle timeout in milliseconds
   private static final String HTTP_IDLE_TIMEOUT_MS_KEY =
       "hadoop.http.idle_timeout.ms";
-  private static final int HTTP_IDLE_TIMEOUT_MS_DEFAULT = 10000;
+  // This value will never be used because the default value is set in
+  // core-default.xml from hadoop-common and ozone-default.xml. The value
+  // 60k here is aligned to the value in ozone-default.xml.
+  private static final int HTTP_IDLE_TIMEOUT_MS_DEFAULT = 60000;
   private static final String HTTP_TEMP_DIR_KEY = "hadoop.http.temp.dir";
 
   private static final String FILTER_INITIALIZER_PROPERTY
@@ -1752,5 +1756,10 @@ public final class HttpServer2 implements FilterContainer {
     headers.put(HTTP_HEADER_PREFIX + splitVal[0],
         splitVal[1]);
     return headers;
+  }
+
+  @VisibleForTesting
+  protected List<ServerConnector> getListeners() {
+    return listeners;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -49,7 +49,6 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.HadoopIllegalArgumentException;
 import org.apache.hadoop.conf.ConfServlet;
 import org.apache.hadoop.conf.Configuration.IntegerRanges;
@@ -76,6 +75,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 import org.apache.hadoop.util.Shell;
 import org.apache.hadoop.util.StringUtils;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -25,8 +25,17 @@ import java.net.URI;
 
 import static org.junit.Assert.assertEquals;
 
+/**
+ * Testing HttpServer2.
+ */
 public class TestHttpServer2 {
 
+  /**
+   * Test hadoop.http.idle_timeout.ms correctly loaded, and not being default
+   * value from core-default.xml of hadoop-common.
+   *
+   * @throws Exception
+   */
   @Test
   public void testIdleTimeout() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -1,0 +1,28 @@
+package org.apache.hadoop.hdds.server.http;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestHttpServer2 {
+
+  @Test
+  public void testIdleTimeout() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    URI uri = URI.create("https://example.com/");
+
+    HttpServer2 srv = new HttpServer2.Builder()
+            .setConf(conf)
+            .setName("test")
+            .addEndpoint(uri)
+            .build();
+    for (ServerConnector server : srv.getListeners()) {
+      // Check default value in ozone-default.xml
+      assertEquals(60000, server.getIdleTimeout());
+    }
+  }
+}

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds.server.http;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.conf.TestConfigurationFieldsBase;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig;
+import org.apache.hadoop.http.HttpServer2;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
@@ -63,6 +64,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ".duration"); // Deprecated config
     configurationPropsToSkipCompare
         .add(ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION);
+    // This property is tested in TestHttpServer2 instead
+    xmlPropsToSkipCompare.add(HttpServer2.HTTP_IDLE_TIMEOUT_MS_KEY);
     addPropertiesNotInXml();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The default value of `hadoop.http.idle_timeout.ms` seems to be inteneded as 10k in `HttpServer2.java`, but it is ignored and actually falls into 1000 defined in core-site.xml from hadoop-common implemented in HADOOP-15696 . I would also propose extending the default value to 60k, which is commonly used value among other Hadoop projects.

## What is the link to the Apache JIRA

HDDS-5620

## How was this patch tested?

- manual tests in laptop
- a unit test is added as `TestHttpServer2`
