### PR TITLE
HDDS-5621. Support returning nodes of a level in NetworkTopology

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNode.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNode.java
@@ -61,6 +61,13 @@ public interface InnerNode extends Node {
   int getNumOfNodes(int level);
 
   /**
+   * @return all nodes at level <i>level</i>. Here level is a relative level.
+   * If level is 1, means node itself. If level is 2, means its direct
+   * children, and so on.
+   **/
+  List<Node> getNodes(int level);
+
+  /**
    * Get <i>leafIndex</i> leaf of this subtree.
    *
    * @param leafIndex an indexed leaf of the node

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.net;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -100,6 +101,32 @@ public class InnerNodeImpl extends NodeImpl implements InnerNode {
       }
     }
     return count;
+  }
+
+  /**
+   * @return all nodes at level <i>level</i>. Here level is a relative level.
+   * If level is 1, means node itself. If level is 2, means its direct
+   * children, and so on.
+   **/
+  @Override
+  public List<Node> getNodes(int level) {
+    Preconditions.checkArgument(level > 0);
+    List<Node> result = new ArrayList<>();
+    if (level == 1) {
+      result.add(this);
+    } else if (level == 2) {
+      result.addAll(childrenMap.values());
+    } else {
+      for (Node node: childrenMap.values()) {
+        if (node instanceof InnerNode) {
+          result.addAll(((InnerNode)node).getNodes(level -1));
+        } else {
+          throw new RuntimeException("Cannot support Level:" + level +
+              " on this node " + this.toString());
+        }
+      }
+    }
+    return result;
   }
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopology.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopology.java
@@ -104,6 +104,13 @@ public interface NetworkTopology {
   int getNumOfNodes(int level);
 
   /**
+   * Return the nodes at level <i>level</i>.
+   * @param level topology level, start from 1, which means ROOT
+   * @return the nodes on the level
+   */
+  List<Node> getNodes(int level);
+
+  /**
    * Randomly choose a node in the scope.
    * @param scope range of nodes from which a node will be chosen. If scope
    *              starts with ~, choose one from the all nodes except for the

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -287,6 +287,23 @@ public class NetworkTopologyImpl implements NetworkTopology{
   }
 
   /**
+   * Return the node at level <i>level</i>.
+   * @param level topology level, start from 1, which means ROOT
+   * @return the nodes on the level
+   */
+  @Override
+  public List<Node> getNodes(int level) {
+    Preconditions.checkArgument(level > 0 && level <= maxLevel,
+        "Invalid level");
+    netlock.readLock().lock();
+    try {
+      return clusterTree.getNodes(level);
+    } finally {
+      netlock.readLock().unlock();
+    }
+  }
+
+  /**
    * Randomly choose a node in the scope.
    * @param scope range of nodes from which a node will be chosen. If scope
    *              starts with ~, choose one from the all nodes except for the

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -296,7 +296,7 @@ public class TestNetworkTopologyImpl {
   }
 
   @Test
-  public void testGetNodesWithLevel() {
+  public void testGetNumOfNodesWithLevel() {
     int maxLevel = cluster.getMaxLevel();
     try {
       assertEquals(1, cluster.getNumOfNodes(0));
@@ -331,6 +331,30 @@ public class TestNetworkTopologyImpl {
     // leaf nodes
     assertEquals(dataNodes.length, cluster.getNumOfNodes(maxLevel));
     assertEquals(dataNodes.length, cluster.getNumOfNodes(maxLevel));
+  }
+
+  @Test
+  public void testGetNodesWithLevel() {
+    int maxLevel = cluster.getMaxLevel();
+    try {
+      assertNotNull(cluster.getNodes(0));
+      fail("level 0 is not supported");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().startsWith("Invalid level"));
+    }
+
+    try {
+      assertNotNull(cluster.getNodes(maxLevel + 1));
+      fail("level out of scope");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().startsWith("Invalid level"));
+    }
+
+    // root node
+    assertEquals(1, cluster.getNodes(1).size());
+    // leaf nodes
+    assertEquals(dataNodes.length, cluster.getNodes(maxLevel).size());
+    assertEquals(dataNodes.length, cluster.getNodes(maxLevel).size());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, NetworkTopology has a function of "getNumOfNodes", which can be used to get the number of nodes in one level.

This ticket is to add a function which can be used be get all the nodes in one level. Which will be quite useful to spread datanodes across all racks.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5621

## How was this patch tested?

unit test
