### PR TITLE
HDDS-5622. Some improvements in SCMCommonPlacementPolicy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -328,4 +328,31 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
       healthyList.removeAll(nodeManager.getPeerList(dn));
     }
   }
+
+  /**
+   * Check If a datanode is an available node.
+   * @param datanodeDetails - the datanode to check.
+   * @param metadataSizeRequired - the required size for metadata.
+   * @param dataSizeRequired - the required size for data.
+   * @return true if the datanode is available.
+   */
+  public boolean isValidNode(DatanodeDetails datanodeDetails,
+      long metadataSizeRequired, long dataSizeRequired) {
+    DatanodeInfo datanodeInfo = (DatanodeInfo)getNodeManager()
+        .getNodeByUuid(datanodeDetails.getUuidString());
+    if (datanodeInfo == null) {
+      LOG.error("Failed to find the DatanodeInfo for datanode {}",
+          datanodeDetails);
+    } else {
+      if (datanodeInfo.getNodeStatus().isNodeWritable() &&
+          (hasEnoughSpace(datanodeInfo, metadataSizeRequired,
+              dataSizeRequired))) {
+        LOG.debug("Datanode {} is chosen. Required metadata size is {} and " +
+                "required data size is {}",
+            datanodeDetails.toString(), metadataSizeRequired, dataSizeRequired);
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -269,9 +269,11 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    * to meet the placement policy. For simple policies that are not rack aware
    * we return 1, from this default implementation.
    * should have
+   *
+   * @param numReplicas - The desired replica counts
    * @return The number of racks containers should span to meet the policy
    */
-  protected int getRequiredRackCount() {
+  protected int getRequiredRackCount(int numReplicas) {
     return 1;
   }
 
@@ -292,7 +294,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   public ContainerPlacementStatus validateContainerPlacement(
       List<DatanodeDetails> dns, int replicas) {
     NetworkTopology topology = nodeManager.getClusterNetworkTopologyMap();
-    int requiredRacks = getRequiredRackCount();
+    int requiredRacks = getRequiredRackCount(replicas);
     if (topology == null || replicas == 1 || requiredRacks == 1) {
       if (dns.size() > 0) {
         // placement is always satisfied if there is at least one DN.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -359,7 +359,7 @@ public final class SCMContainerPlacementRackAware
   }
 
   @Override
-  protected int getRequiredRackCount() {
+  protected int getRequiredRackCount(int numReplicas) {
     return REQUIRED_RACKS;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.Node;
-import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -285,24 +284,13 @@ public final class SCMContainerPlacementRackAware
       }
 
       DatanodeDetails datanodeDetails = (DatanodeDetails)node;
-      DatanodeInfo datanodeInfo = (DatanodeInfo)getNodeManager()
-          .getNodeByUuid(datanodeDetails.getUuidString());
-      if (datanodeInfo == null) {
-        LOG.error("Failed to find the DatanodeInfo for datanode {}",
-            datanodeDetails);
-      } else {
-        if (datanodeInfo.getNodeStatus().isNodeWritable() &&
-            (hasEnoughSpace(datanodeInfo, metadataSizeRequired,
-                dataSizeRequired))) {
-          LOG.debug("Datanode {} is chosen. Required metadata size is {} and " +
-                  "required data size is {}",
-              node.toString(), metadataSizeRequired, dataSizeRequired);
-          metrics.incrDatanodeChooseSuccessCount();
-          if (isFallbacked) {
-            metrics.incrDatanodeChooseFallbackCount();
-          }
-          return node;
+      if (isValidNode(datanodeDetails, metadataSizeRequired,
+          dataSizeRequired)) {
+        metrics.incrDatanodeChooseSuccessCount();
+        if (isFallbacked) {
+          metrics.incrDatanodeChooseFallbackCount();
         }
+        return node;
       }
 
       maxRetry--;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -447,7 +447,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   }
 
   @Override
-  protected int getRequiredRackCount() {
+  protected int getRequiredRackCount(int numReplicas) {
     return REQUIRED_RACKS;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -156,4 +156,72 @@ public class TestSCMContainerPlacementRandom {
     // Only expect 1 more replica to give us one rack on this policy.
     assertEquals(0, status.misReplicationCount(), 3);
   }
+
+  @Test
+  public void testIsValidNode() throws SCMException {
+    //given
+    OzoneConfiguration conf = new OzoneConfiguration();
+    // We are using small units here
+    conf.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
+        1, StorageUnit.BYTES);
+
+    List<DatanodeInfo> datanodes = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+          MockDatanodeDetails.randomDatanodeDetails(),
+          NodeStatus.inServiceHealthy(),
+          UpgradeUtils.defaultLayoutVersionProto());
+
+      StorageReportProto storage1 = TestUtils.createStorageReport(
+          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          100L, 0, 100L, null);
+      MetadataStorageReportProto metaStorage1 =
+          TestUtils.createMetadataStorageReport(
+              "/metadata1-" + datanodeInfo.getUuidString(),
+              100L, 0, 100L, null);
+      datanodeInfo.updateStorageReports(
+          new ArrayList<>(Arrays.asList(storage1)));
+      datanodeInfo.updateMetaDataStorageReports(
+          new ArrayList<>(Arrays.asList(metaStorage1)));
+
+      datanodes.add(datanodeInfo);
+    }
+
+    StorageReportProto storage1 = TestUtils.createStorageReport(
+        datanodes.get(1).getUuid(),
+        "/data1-" + datanodes.get(1).getUuidString(),
+        100L, 90L, 10L, null);
+    datanodes.get(1).updateStorageReports(
+        new ArrayList<>(Arrays.asList(storage1)));
+
+    MetadataStorageReportProto metaStorage2 =
+        TestUtils.createMetadataStorageReport(
+            "/metadata1-" + datanodes.get(2).getUuidString(),
+            100L, 90, 10L, null);
+    datanodes.get(2).updateMetaDataStorageReports(
+        new ArrayList<>(Arrays.asList(metaStorage2)));
+
+    NodeManager mockNodeManager = Mockito.mock(NodeManager.class);
+    when(mockNodeManager.getNodes(NodeStatus.inServiceHealthy()))
+        .thenReturn(new ArrayList<>(datanodes));
+    when(mockNodeManager.getNodeByUuid(datanodes.get(0).getUuidString()))
+        .thenReturn(datanodes.get(0));
+    when(mockNodeManager.getNodeByUuid(datanodes.get(1).getUuidString()))
+        .thenReturn(datanodes.get(1));
+    when(mockNodeManager.getNodeByUuid(datanodes.get(2).getUuidString()))
+        .thenReturn(datanodes.get(2));
+
+    SCMContainerPlacementRandom scmContainerPlacementRandom =
+        new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
+            null);
+
+    Assert.assertTrue(
+        scmContainerPlacementRandom.isValidNode(datanodes.get(0), 15L, 15L));
+    Assert.assertFalse(
+        scmContainerPlacementRandom.isValidNode(datanodes.get(1), 15L, 15L));
+    Assert.assertFalse(
+        scmContainerPlacementRandom.isValidNode(datanodes.get(2), 15L, 15L));
+
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This ticket consists of the following changes in SCMCommonPlacementPolicy.

refactor getRequiredRackCount() to getRequiredRackCount(int numReplicas)
Add a method to check if a datanode is available.
Currently getRequiredRackCount() ingests no input arguments and the default value is ususally 1 or 2, but for EC placement policy, the required racks will be based on the numReplicas.

The availability check method is added to SCMCommonPlacementPolicy so that it can be reused by other PlacementPolicy subclasses.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5622

## How was this patch tested?

unit test
