### PR TITLE
HDDS-5495. Ozone version mismatch in Kubernetes test lib

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -105,7 +105,9 @@ regenerate_resources() {
 
   if [ $(basename $PARENT_OF_PARENT) == "k8s" ]; then
     #running from src dir
-    OZONE_ROOT=$(realpath ../../../../../target/ozone-0.6.0-SNAPSHOT)
+    local version
+    version=$(cd ../../../../.. && mvn help:evaluate -Dexpression=ozone.version -q -DforceStdout)
+    OZONE_ROOT=$(realpath ../../../../../target/ozone-${version})
   else
     #running from dist
     OZONE_ROOT=$(realpath ../../..)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace hard-coded version number with actual version from POM.  (This is used only when running from source dir.)

https://issues.apache.org/jira/browse/HDDS-5495

## How was this patch tested?

```
$ cd hadoop-ozone/dist/src/main/k8s/examples/getting-started
$ ./test.sh

**** Modifying Kubernetes resources file for test ****

   (mounting current Ozone directory to the containers, scheduling containers to one node, ...)

WARNING: this test can be executed only with local Kubernetes cluster
   (source dir should be available from K8s nodes)

INFO[2021-07-26T11:16:21+02:00] Input dir: hadoop-ozone/dist/src/main/k8s/examples/getting-started, output dir: hadoop-ozone/dist/src/main/k8s/examples/getting-started
INFO[2021-07-26T11:16:21+02:00] Reading resources from hadoop-ozone/dist/src/main/k8s/examples/getting-started/resources
INFO[2021-07-26T11:16:21+02:00] Reading resources from hadoop-ozone/dist/src/main/k8s/definitions/ozone
INFO[2021-07-26T11:16:21+02:00] Reading resources from hadoop-ozone/dist/src/main/k8s/definitions/ozone/freon
INFO[2021-07-26T11:16:21+02:00] Loading processor configuration from hadoop-ozone/dist/src/main/k8s/definitions/ozone/transformations/config.yaml

...

Basic :: Smoketest ozone cluster startup                              | PASS |
2 critical tests, 2 passed, 0 failed
2 tests total, 2 passed, 0 failed
...
```