### PR TITLE
HDDS-5496. Missing directory name in `start_k8s_env` log

### DIFF
--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -75,7 +75,7 @@ start_k8s_env() {
    kubectl delete pvc --all
    kubectl delete pv --all
 
-   print_phase "Applying k8s resources from $1"
+   print_phase "Applying k8s resources from $(pwd)"
    kubectl apply -f .
    wait_for_startup
 }

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -75,7 +75,7 @@ start_k8s_env() {
    kubectl delete pvc --all
    kubectl delete pv --all
 
-   print_phase "Applying k8s resources from $(pwd)"
+   print_phase "Applying k8s resources from $(basename $(pwd))"
    kubectl apply -f .
    wait_for_startup
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix missing directory name in messages like:

```
**** Applying k8s resources from  ****
```

Print path in `start_k8s_env` instead of expecting it to be passed (as it is not).  Current dir can be used because test execution requires `cd` to test dir anyway.

https://issues.apache.org/jira/browse/HDDS-5496

## How was this patch tested?

Verified log in CI run:

```
**** Applying k8s resources from getting-started ****
...
**** Applying k8s resources from minikube ****
...
**** Applying k8s resources from ozone-dev ****
...
**** Applying k8s resources from ozone ****
```

https://github.com/adoroszlai/hadoop-ozone/runs/3349882860#step:5:124
https://github.com/adoroszlai/hadoop-ozone/runs/3349882860#step:5:318
https://github.com/adoroszlai/hadoop-ozone/runs/3349882860#step:5:461
https://github.com/adoroszlai/hadoop-ozone/runs/3349882860#step:5:629