### PR TITLE
HDDS-5624. Disable test TestPipelineClose.testPipelineCloseWithLogFailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -205,7 +205,7 @@ public class TestPipelineClose {
   }
 
   @Test
-  @Ignore
+  @Ignore("HDDS-5604")
   public void testPipelineCloseWithLogFailure() throws IOException {
 
     EventQueue eventQ = (EventQueue) scm.getEventQueue();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -47,6 +47,7 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -204,6 +205,7 @@ public class TestPipelineClose {
   }
 
   @Test
+  @Ignore
   public void testPipelineCloseWithLogFailure() throws IOException {
 
     EventQueue eventQ = (EventQueue) scm.getEventQueue();


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestPipelineClose.testPipelineCloseWithLogFailure is failing in a lot of PRs and is flaky. Disabling it to improve the build stability.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5624

## How was this patch tested?

Existing tests