### PR TITLE
HDDS-5611. Fixed NullPointerException in ContainerStateMachine during Pipeline Close.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -47,7 +47,8 @@ public class ContainerController {
 
   private final ContainerSet containerSet;
   private final Map<ContainerType, Handler> handlers;
-  private final Logger LOG = LoggerFactory.getLogger(ContainerController.class);
+  private static final Logger LOG =
+          LoggerFactory.getLogger(ContainerController.class);
 
   public ContainerController(final ContainerSet containerSet,
       final Map<ContainerType, Handler> handlers) {
@@ -83,15 +84,15 @@ public class ContainerController {
   public void markContainerForClose(final long containerId)
       throws IOException {
     Container container = containerSet.getContainer(containerId);
-    if(container==null){
+    if (container==null) {
       Set<Long> missingContainerSet = containerSet.getMissingContainerSet();
-      if(missingContainerSet.contains(containerId)){
+      if (missingContainerSet.contains(containerId)) {
         LOG.warn("The Container is in the MissingContainerSet " +
-                "hence we can't close it.");
-      }else{
-        LOG.warn("The Container is not found");
+                "hence we can't close it. ContainerID: {}", containerId);
+      } else {
+        LOG.warn("The Container is not found. ContainerID: {}", containerId);
       }
-    }else{
+    } else {
       if (container.getContainerState() == State.OPEN) {
         getHandler(container).markContainerForClose(container);
       }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.ozoneimpl.ContainerController;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -66,7 +67,7 @@ public class TestCloseContainerCommandHandler {
   private Handler containerHandler;
   private PipelineID pipelineID;
   private PipelineID nonExistentPipelineID = PipelineID.randomId();
-
+  private ContainerController controller;
   private CloseContainerCommandHandler subject =
       new CloseContainerCommandHandler();
 
@@ -100,7 +101,7 @@ public class TestCloseContainerCommandHandler {
     containerSet.addContainer(container);
 
     containerHandler = mock(Handler.class);
-    ContainerController controller = new ContainerController(containerSet,
+    controller = new ContainerController(containerSet,
         singletonMap(ContainerProtos.ContainerType.KeyValueContainer,
             containerHandler));
 
@@ -202,6 +203,12 @@ public class TestCloseContainerCommandHandler {
         .closeContainer(container);
     verify(writeChannel, never())
         .submitRequest(any(), any());
+  }
+
+  @Test
+  public void closeNonExistenceContainer() throws IOException {
+    controller.markContainerForClose(1L);
+
   }
 
   private CloseContainerCommand closeWithKnownPipeline() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

To fix the NullPointerException when markContainerForClose method is invoked. The exception is caused when we access the getContainerState method for a container object which is null.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5611

## How was this patch tested?

The patch was tested with Unit tests and GitHub CI test.
https://github.com/aswinshakil/ozone/runs/3345654012
The integration test TestPipelineClose.testPipelineCloseWithLogFailure is failing due to some issue with flaky tests. Attached the jira for that issue here.
https://issues.apache.org/jira/browse/HDDS-5626
