### PR TITLE
HDDS-5604. Intermittent failure in TestPipelineClose.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -238,7 +238,7 @@ public class TestPipelineClose {
     xceiverRatis.handleNodeLogFailure(groupId, null);
 
     // verify SCM receives a pipeline action report "immediately"
-    Mockito.verify(pipelineActionTest, Mockito.timeout(500))
+    Mockito.verify(pipelineActionTest, Mockito.timeout(1000))
         .onMessage(
             actionCaptor.capture(),
             Mockito.any(EventPublisher.class));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -222,11 +222,7 @@ public class TestPipelineClose {
     Pipeline openPipeline = containerWithPipeline.getPipeline();
     RaftGroupId groupId = RaftGroupId.valueOf(openPipeline.getId().getId());
 
-    try {
-      pipelineManager.getPipeline(openPipeline.getId());
-    } catch (PipelineNotFoundException e) {
-      Assert.assertTrue("pipeline should exist", false);
-    }
+    pipelineManager.getPipeline(openPipeline.getId());
 
     DatanodeDetails datanodeDetails = openPipeline.getNodes().get(0);
     int index = cluster.getHddsDatanodeIndex(datanodeDetails);
@@ -242,7 +238,7 @@ public class TestPipelineClose {
     xceiverRatis.handleNodeLogFailure(groupId, null);
 
     // verify SCM receives a pipeline action report "immediately"
-    Mockito.verify(pipelineActionTest, Mockito.timeout(100))
+    Mockito.verify(pipelineActionTest, Mockito.timeout(500))
         .onMessage(
             actionCaptor.capture(),
             Mockito.any(EventPublisher.class));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -88,12 +88,12 @@ public class TestPipelineClose {
   @Before
   public void init() throws Exception {
     conf = new OzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     conf.setTimeDuration(HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL, 1000,
         TimeUnit.MILLISECONDS);
     pipelineDestroyTimeoutInMillis = 1000;
     conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT,
         pipelineDestroyTimeoutInMillis, TimeUnit.MILLISECONDS);
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();
     scm = cluster.getStorageContainerManager();
     containerManager = scm.getContainerManager();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent test failure in TestPipelineClose#testPipelineCloseWithLogFailure. The mechanics of the test look good to me. Based on my testing the issue was an overly aggressive timeout waiting for a mockito invocation.

## What is the link to the Apache JIRA

HDDS-5604

## How was this patch tested?

Before patch, test failed after 30 runs locally. After patch, The test passed with 100 runs on CI: https://github.com/errose28/hadoop-ozone/runs/3354906907
    - The test was run on a different commit by accident, but the changes are identical. Check the small diff for that commit if unsure.

