### PR TITLE
HDDS-5632. Intermittent failure in TestOzoneManagerBootstrap#testBootstrapTwoNewOMs

### DIFF
--- a/hadoop-ozone/integration-test/pom.xml
+++ b/hadoop-ozone/integration-test/pom.xml
@@ -188,6 +188,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
       <type>test-jar</type>
     </dependency>
+    <dependency>
+      <groupId>org.apache.ratis</groupId>
+      <artifactId>ratis-common</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -44,7 +44,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.ServerSocket;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -984,7 +983,7 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
           ss.close();
         } catch (IOException e) {
           LOG.error("Got exception while closing ServerSocket: " +
-              e.getMessage() );
+              e.getMessage());
         }
       }
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -43,6 +43,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.BindException;
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -700,6 +701,9 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     while (true) {
       try {
         basePort = 10000 + RANDOM.nextInt(1000) * 4;
+        if (!isPortAvailable(basePort)) {
+          throw new BindException();
+        }
         OzoneConfiguration newConf = addNewOMToConfig(getOMServiceId(),
             omNodeId, basePort);
 
@@ -966,4 +970,11 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
     return getStorageContainerManagers().get(0);
   }
 
+  private boolean isPortAvailable(int port) {
+    try (Socket ignored = new Socket("localhost", port)) {
+      return false;
+    } catch (IOException ignored) {
+      return true;
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Root cause is when MiniOzoneHAClusterImpl#bootstrapOzoneManager is creating a new OM, it may encounter a port conflict, this function will retry with a new port, but before that, the metadataManager of the first OM didn't close the lock on the rocksdb, which causes the test to fail for the retry.

Options to solve:

I tried to add a "metadataManager.stop()" in the constructor of OM when it fails to start RPC server, but it will prompt another error about the lock on ratis directory.
I tried to stop the ratisServer too, but in https://github.com/apache/ratis/blob/dc0b68b4c0b8c187a08f669422a2cd099d7be0b7/ratis-common/src/main/java/org/apache/ratis/util/LifeCycle.java#L308, the close function will not be called, so the lock won't be released. Tried to call the closeMethod for State.NEW, but something wrong else happened.
So I think it's much easier to just check if the port is available in MiniOzoneHAClusterImpl. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5632

## How was this patch tested?

Test passed with following change.
```
@@ -697,9 +698,11 @@ public void bootstrapOzoneManager(String omNodeId) throws Exception {
 
     long leaderSnapshotIndex = getOMLeader().getRatisSnapshotIndex();
 
+    int start = 0;
     while (true) {
       try {
-        basePort = 10000 + RANDOM.nextInt(1000) * 4;
+//        basePort = 10000 + RANDOM.nextInt(1000) * 4;
+        basePort = 10000 + start * 4;
         OzoneConfiguration newConf = addNewOMToConfig(getOMServiceId(),
             omNodeId, basePort);
 
@@ -721,6 +724,7 @@ public void bootstrapOzoneManager(String omNodeId) throws Exception {
         if (e instanceof BindException ||
             e.getCause() instanceof BindException) {
           ++retryCount;
+          start++;
           LOG.info("MiniOzoneHACluster port conflicts, retried {} times",
               retryCount);
         } else {
```
