### PR TITLE
HDDS-5633. Can't allocateBlock if tracing is enable.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocol.java
@@ -25,8 +25,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.container.common.helpers.AllocatedBlock;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 
@@ -47,26 +45,6 @@ public interface ScmBlockLocationProtocol extends Closeable {
    * Version 1: Initial version.
    */
   long versionID = 1L;
-
-  /**
-   * Asks SCM where a block should be allocated. SCM responds with the
-   * set of datanodes that should be used creating this block.
-   * @param size - size of the block.
-   * @param numBlocks - number of blocks.
-   * @param type - replication type of the blocks.
-   * @param factor - replication factor of the blocks.
-   * @param excludeList List of datanodes/containers to exclude during block
-   *                    allocation.
-   * @return allocated block accessing info (key, pipeline).
-   * @throws IOException
-   */
-  @Deprecated
-  default List<AllocatedBlock> allocateBlock(long size, int numBlocks,
-      ReplicationType type, ReplicationFactor factor, String owner,
-      ExcludeList excludeList) throws IOException {
-    return allocateBlock(size, numBlocks, ReplicationConfig
-        .fromTypeAndFactor(type, factor), owner, excludeList);
-  }
 
   /**
    * Asks SCM where a block should be allocated. SCM responds with the

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -128,8 +128,9 @@ public abstract class OMKeyRequest extends OMClientRequest {
     List<AllocatedBlock> allocatedBlocks;
     try {
       allocatedBlocks = scmClient.getBlockClient()
-          .allocateBlock(scmBlockSize, numBlocks, replicationType,
-              replicationFactor, omID, excludeList);
+          .allocateBlock(scmBlockSize, numBlocks, ReplicationConfig
+                  .fromTypeAndFactor(replicationType, replicationFactor), omID,
+              excludeList);
     } catch (SCMException ex) {
       if (ex.getResult()
           .equals(SCMException.ResultCodes.SAFE_MODE_EXCEPTION)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 import java.util.UUID;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManagerPrepareState;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
@@ -172,8 +173,9 @@ public class TestOMKeyRequest {
     allocatedBlocks.add(allocatedBlock);
 
     when(scmBlockLocationProtocol.allocateBlock(anyLong(), anyInt(),
-        any(HddsProtos.ReplicationType.class),
-        any(HddsProtos.ReplicationFactor.class),
+        ReplicationConfig
+            .fromTypeAndFactor(any(HddsProtos.ReplicationType.class),
+                any(HddsProtos.ReplicationFactor.class)),
         anyString(), any(ExcludeList.class))).thenReturn(allocatedBlocks);
 
 


### PR DESCRIPTION
If tracing is enable, when I execute 'ozone fs -put a ofs://test1/volume1/bucket1/c', will throw exception. And OM's error log like below:

```
2021-08-13 12:15:47,456 [IPC Server handler 61 on default port 9862] INFO org.apache.hadoop.ipc.Server: IPC Server handler 61 on default port 9862, call Call#8 Retry#0 org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol.submitRequest from 10.201.1.11:36224
java.lang.NoSuchMethodException: Method not found: allocateBlock
        at org.apache.hadoop.hdds.tracing.TraceAllMethod.invoke(TraceAllMethod.java:65)
        at com.sun.proxy.$Proxy35.allocateBlock(Unknown Source)
        at org.apache.hadoop.ozone.om.request.key.OMKeyRequest.allocateBlock(OMKeyRequest.java:130)
        at org.apache.hadoop.ozone.om.request.file.OMFileCreateRequest.preExecute(OMFileCreateRequest.java:132)
        at org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB.processRequest(OzoneManagerProtocolServerSideTranslatorPB.java:138)
        at org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher.processRequest(OzoneProtocolMessageDispatcher.java:87)
        at org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB.submitRequest(OzoneManagerProtocolServerSideTranslatorPB.java:123)
        at org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos$OzoneManagerService$2.callBlockingMethod(OzoneManagerProtocolProtos.java)
        at org.apache.hadoop.ipc.ProtobufRpcEngine$Server.processCall(ProtobufRpcEngine.java:466)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:574)
        at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server$ProtoBufRpcInvoker.call(ProtobufRpcEngine2.java:552)
        at org.apache.hadoop.ipc.RPC$Server.call(RPC.java:1093)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:1035)
        at org.apache.hadoop.ipc.Server$RpcCall.run(Server.java:963)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1878)
        at org.apache.hadoop.ipc.Server$Handler.run(Server.java:2966)
```

The reason is that the method "allocateBlock(long size, int numBlocks, ReplicationType type, ReplicationFactor factor, String owner, ExcludeList excludeList)" is not implement in ScmBlockLocationProtocolClientSideTranslatorPB. So findDelegatedMethod can't find this method. 

As this method is deprecated, we should remove this method.

