### PR TITLE
HDDS-5644. Speed up decommission tests using a background Mini Cluster provider

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -295,7 +295,7 @@ public interface MiniOzoneCluster {
     protected static final int DEFAULT_PIPELIME_LIMIT = 3;
     protected static final int DEFAULT_RATIS_RPC_TIMEOUT_SEC = 1;
 
-    protected final OzoneConfiguration conf;
+    protected OzoneConfiguration conf;
     protected String path;
 
     protected String clusterId;
@@ -339,6 +339,11 @@ public interface MiniOzoneCluster {
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
       setClusterId(UUID.randomUUID().toString());
+    }
+
+    public Builder setConf(OzoneConfiguration config) {
+      this.conf = config;
+      return this;
     }
 
     /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -1,0 +1,143 @@
+package org.apache.hadoop.ozone;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * Class to create mini-clusters in the background.
+ */
+public class MiniOzoneClusterProvider {
+
+  private int preCreatedLimit = 1;
+  private boolean shutdown = false;
+
+  private final OzoneConfiguration conf;
+  private final MiniOzoneCluster.Builder builder;
+  private Thread createThread;
+  private Thread reapThread;
+
+  private final BlockingQueue<MiniOzoneCluster> clusters
+      = new ArrayBlockingQueue<>(preCreatedLimit);
+  private final BlockingQueue<MiniOzoneCluster> expiredClusters
+      = new ArrayBlockingQueue<>(4);
+
+  public MiniOzoneClusterProvider(OzoneConfiguration conf,
+      MiniOzoneCluster.Builder builder) {
+    this.conf = conf;
+    this.builder = builder;
+    createThread = createClusters();
+    reapThread = reapClusters();
+  }
+
+  public synchronized MiniOzoneCluster provide()
+      throws InterruptedException, IOException {
+    ensureNotShutdown();
+    return clusters.poll(100, SECONDS);
+  }
+
+  public synchronized void destroy(MiniOzoneCluster c)
+      throws InterruptedException, IOException {
+    ensureNotShutdown();
+    expiredClusters.put(c);
+  }
+
+  public synchronized void shutdown() throws InterruptedException {
+    createThread.interrupt();
+    createThread.join();
+    destroyRemainingClusters();
+    reapThread.interrupt();
+    reapThread.join();
+    shutdown = true;
+  }
+
+  private void ensureNotShutdown() throws IOException {
+    if (shutdown) {
+      throw new IOException("The mini-cluster provider is shutdown");
+    }
+  }
+
+  private Thread reapClusters() {
+    Thread t = new Thread(() -> {
+      boolean shouldRun = true;
+      while(shouldRun || !expiredClusters.isEmpty()) {
+        try {
+          if (Thread.interrupted()) {
+            throw new InterruptedException();
+          }
+          MiniOzoneCluster c = expiredClusters.take();
+          c.shutdown();
+        } catch (InterruptedException e) {
+          shouldRun = false;
+        }
+      }
+    });
+    t.setName("Mini-Cluster-Provider-Reap");
+    t.start();
+    return t;
+  }
+
+  private Thread createClusters() {
+    Thread t = new Thread(() -> {
+      while (!Thread.interrupted()) {
+        MiniOzoneCluster cluster = null;
+        try {
+          builder.setClusterId(UUID.randomUUID().toString());
+
+          OzoneConfiguration newConf = new OzoneConfiguration(conf);
+          List<Integer> portList = getFreePortList(4);
+          newConf.set(OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+              "127.0.0.1:" + portList.get(0));
+          newConf.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY,
+              "127.0.0.1:" + portList.get(1));
+          newConf.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY,
+              "127.0.0.1:" + portList.get(2));
+          newConf.setInt(OMConfigKeys.OZONE_OM_RATIS_PORT_KEY,
+              portList.get(3));
+          builder.setConf(newConf);
+
+          cluster = builder.build();
+          cluster.waitForClusterToBeReady();
+          clusters.put(cluster);
+        } catch (InterruptedException e) {
+          if (cluster != null) {
+            cluster.shutdown();
+          }
+          break;
+        } catch (IOException | TimeoutException e) {
+          throw new RuntimeException("Unable to build cluster", e);
+        }
+      }
+    });
+    t.setName("Mini-Cluster-Provider-Create");
+    t.start();
+    return t;
+  }
+
+  private void destroyRemainingClusters() throws InterruptedException {
+    while(!clusters.isEmpty()) {
+      try {
+        expiredClusters.add(clusters.poll(100, TimeUnit.MILLISECONDS));
+      } catch (InterruptedException e) {
+        // Do nothing
+      }
+    }
+  }
+
+  private List<Integer> getFreePortList(int size) {
+    return org.apache.ratis.util.NetUtils.createLocalServerAddress(size)
+        .stream()
+        .map(inetSocketAddress -> inetSocketAddress.getPort())
+        .collect(Collectors.toList());
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -129,7 +129,7 @@ public class TestDecommissionAndMaintenance {
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(numOfDatanodes);
 
-    clusterProvider = new MiniOzoneClusterProvider(conf, builder);
+    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 11);
   }
 
   @AfterClass


### PR DESCRIPTION
## What changes were proposed in this pull request?

The integration (ozone) test suit is the slowest part of the github actions build, taking over 2 hours usually. In a random PR I checked, 2hr16.

Often in integration tests, a large part of the test time is spent creating a new mini-Ozone cluster for each test, which can take 10 - 20 seconds to startup.

I also timed stopping a mini-cluster and found that can take up to 10 seconds.

Changing the tests to reuse the same cluster can be difficult and make the tests less standalone and more brittle, which is not a good thing. Changing the tests is also time consuming work.

Assuming a test runs for longer than the time taken to setup a mini-cluster and stop it, it would make the tests faster if we pre-created a mini-cluster in the background. Then when one test completes, the next cluster is already there, saving the startup time. Obviously this costs more concurrent cpu to reduce the wall clock time.

We could also queue the shutdown of the clusters in another background thread.

The slowest part of the Integration (Ozone) test suit are the decommission tests, taking 843 seconds on the last run I checked.

This PR adds a Mini-Cluster provider to the Decommission tests as an experiment to see if it makes the runtime significantly faster in practice. If it does, this may be something we can roll out across other integration tests.

As a baseline, I ran the decommission tests on my laptop, and it took 8min 37s.

After the changes in this PR, the test suit ran in 3min 53s.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5644

## How was this patch tested?

Existing tests