### PR TITLE
HDDS-5556. GrpcReplication Client might fail in SCM HA Cluster

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServi
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc.IntraDatanodeProtocolServiceStub;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
+import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 
 import com.google.common.base.Preconditions;
@@ -74,7 +75,8 @@ public class GrpcReplicationClient implements AutoCloseable{
       SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
       if (certClient != null) {
         sslContextBuilder
-            .trustManager(certClient.getCACertificate())
+            .trustManager(HAUtils.buildCAX509List(certClient,
+                secConfig.getConfiguration()))
             .clientAuth(ClientAuth.REQUIRE)
             .keyManager(certClient.getPrivateKey(),
                 certClient.getCertificate());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -52,8 +52,6 @@ public class ReplicationServer {
 
   private SecurityConfig secConf;
 
-  private ConfigurationSource config;
-
   private CertificateClient caClient;
 
   private ContainerController controller;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.tracing.GrpcServerInterceptor;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add all CA Certs to trust manager while creating GRPC Replication Server between datanodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5556

## How was this patch tested?

Tested with docker-compose by bringing up the following containers initially in ozonesecure-ha environment:

```
docker-compose up -d kdc kms scm1.org scm2.org scm3.org recon om1 om2 om3 datanode1
// To change the SCM leader node
docker-compose stop scm1.org

// Start datanode2 to get its cert signed by new SCM leader (scm2.org)
docker-compose up -d datanode2

// Change leader again
docker-compose start scm1.org
docker-compose stop scm2.org

// Start dn3
docker-compose up -d datanode3

// put a file
docker-compose exec om bash
kinit -kt /etc/security/keytabs/om.keytab om/om
ozone sh vol create vol1
ozone sh bucket create vol1/bucket1
ozone sh key put /vol1/bucket1/key1 <path_to_file>

// stop dn3 and remove
docker-compose stop datanode3
docker-compose rm datanode3

// start dn3 as a fresh container
docker-compose up -d datanode3
```

After this, verified that SCM scheduled replication of the container to datanode3 and it succeeded without any errors. 
