### PR TITLE
HDDS-5658. Handle InterruptedException in DeleteBlocksCommandHandler and ContainerBalancer

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -60,6 +60,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -278,8 +279,9 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
       futures.forEach(f -> {
         try {
           f.get();
-        } catch (Exception e) {
+        } catch (InterruptedException | ExecutionException e) {
           LOG.error("task failed.", e);
+          Thread.currentThread().interrupt();
         }
       });
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -434,6 +434,7 @@ public class ContainerBalancer {
       } catch (InterruptedException e) {
         LOG.warn("Container move for container {} was interrupted.",
             moveSelection.getContainerID(), e);
+        Thread.currentThread().interrupt();
       } catch (ExecutionException e) {
         LOG.warn("Container move for container {} completed exceptionally.",
             moveSelection.getContainerID(), e);
@@ -728,6 +729,7 @@ public class ContainerBalancer {
       currentBalancingThread = null;
     } catch (InterruptedException e) {
       LOG.warn("Interrupted while waiting for balancing thread to join.");
+      Thread.currentThread().interrupt();
     } finally {
       lock.unlock();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle InterruptedException in [DeleteBlocksCommandHandler](https://sonarcloud.io/project/issues?id=hadoop-ozone&open=AXsvaqG__dIWFQzeEnbC&resolved=false&sinceLeakPeriod=true&types=BUG).

Handle InterruptedException in [ContainerBalancer](https://sonarcloud.io/project/issues?id=hadoop-ozone&open=AXs66eHhmEe61HHPN0_O&resolved=false&sinceLeakPeriod=true&types=BUG).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5658

## How was this patch tested?

Minor fix, no testing done.
