### PR TITLE
HDDS-5660. Separate container caches for Open and Closed containers.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -56,9 +56,10 @@ public final class ContainerCache {
   /**
    * Constructs a cache that holds DBHandle references.
    */
-  private ContainerCache(int maxSize, int stripes, float loadFactor, boolean
-      scanUntilRemovable) {
-    this.closeContainerCache = new CloseContainerCache(maxSize, loadFactor, scanUntilRemovable);
+  private ContainerCache(int maxSize, int stripes, float loadFactor,
+                         boolean scanUntilRemovable) {
+    this.closeContainerCache =
+        new CloseContainerCache(maxSize, loadFactor, scanUntilRemovable);
     this.rocksDBLock = Striped.lazyWeakLock(stripes);
     this.openContainerCache = new ConcurrentHashMap<>();
   }
@@ -285,7 +286,10 @@ public final class ContainerCache {
     return closeContainerCache;
   }
 
-  public class CloseContainerCache extends LRUMap {
+  /**
+   * Cache of closed containers.
+   */
+  public final class CloseContainerCache extends LRUMap {
     private CloseContainerCache(int maxSize, float loadFactor,
                                 boolean scanUntilRemovable) {
       super(maxSize, loadFactor, scanUntilRemovable);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -52,6 +52,18 @@ public final class ContainerCacheMetrics {
   @Metric("Number of Container Cache Evictions")
   private MutableCounterLong numCacheEvictions;
 
+  @Metric("Number of Open Container fetched successfully")
+  private MutableCounterLong numOpenContainerGetsSuccess;
+
+  @Metric("Number of Open Container fetches which failed")
+  private MutableCounterLong numOpenContainerGetsFailures;
+
+  @Metric("Number of Open Container added to Cache")
+  private MutableCounterLong numOpenContainerInserts;
+
+  @Metric("Number of Open Container removed from")
+  private MutableCounterLong numOpenContainerRemoves;
+
   private ContainerCacheMetrics(String name, MetricsSystem ms) {
     this.name = name;
     this.ms = ms;
@@ -110,5 +122,41 @@ public final class ContainerCacheMetrics {
 
   public long getNumCacheEvictions() {
     return numCacheEvictions.value();
+  }
+
+  public void incNumOpenContainerGetsSuccess() {
+    numOpenContainerGetsSuccess.incr();
+  }
+
+  public void incNumOpenContainerGetsFailures() {
+    numOpenContainerGetsFailures.incr();
+  }
+
+  public long getNumOpenContainerGetsSuccess() {
+    return numOpenContainerGetsSuccess.value();
+  }
+
+  public long getNumOpenContainerGetsFailures() {
+    return numOpenContainerGetsFailures.value();
+  }
+
+  public void incNumOpenContainerInserts() {
+    numOpenContainerInserts.incr();
+  }
+
+  public void incNumOpenContainerRemoves() {
+    numOpenContainerRemoves.incr();
+  }
+
+  public long getNumOpenContainerInserts() {
+    return numOpenContainerInserts.value();
+  }
+
+  public long getNumOpenContainerRemoves() {
+    return numOpenContainerRemoves.value();
+  }
+
+  public long getNumOpenCacheEntries() {
+    return numOpenContainerInserts.value() - numOpenContainerRemoves.value();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ReferenceCountedDB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ReferenceCountedDB.java
@@ -91,6 +91,10 @@ public class ReferenceCountedDB implements Closeable {
     return store;
   }
 
+  public String getContainerDBPath() {
+    return containerDBPath;
+  }
+
   @Override
   public void close() {
     decrementReference();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -312,6 +313,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       // been done outside the lock.
       flushAndSyncDB();
       updateContainerData(containerData::quasiCloseContainer);
+      // move the db to the closed container cache
+      ContainerCache cache = ContainerCache.getInstance(config);
+      cache.markContainerClosed(containerData.getDbFile().getAbsolutePath());
     } finally {
       writeUnlock();
     }
@@ -328,6 +332,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       // been done outside the lock.
       flushAndSyncDB();
       updateContainerData(containerData::closeContainer);
+      // move the db to the closed container cache
+      ContainerCache cache = ContainerCache.getInstance(config);
+      cache.markContainerClosed(containerData.getDbFile().getAbsolutePath());
     } finally {
       writeUnlock();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -119,7 +119,7 @@ public final class BlockUtils {
     Preconditions.checkNotNull(containerData.getDbFile());
     try {
       return cache.getDB(containerData.getContainerID(), containerData
-          .getContainerDBType(), containerData.getDbFile().getAbsolutePath(),
+          .getState(), containerData.getDbFile().getAbsolutePath(),
               containerData.getSchemaVersion(), conf);
     } catch (IOException ex) {
       onFailure(containerData.getVolume());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -279,7 +279,7 @@ public class ContainerReader implements Runnable {
         }
         containerSet.addContainer(kvContainer);
         DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
-            kvContainerData, config, true);
+            kvContainerData, config, false);
         String dbPath = kvContainerData.getDbFile().getAbsolutePath();
         ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
         BlockUtils.addDB(db, dbPath, config);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -36,12 +36,15 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
+import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -275,6 +278,11 @@ public class ContainerReader implements Runnable {
               kvContainerData, config);
         }
         containerSet.addContainer(kvContainer);
+        DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
+            kvContainerData, config, true);
+        String dbPath = kvContainerData.getDbFile().getAbsolutePath();
+        ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
+        BlockUtils.addDB(db, dbPath, config);
       } else {
         throw new StorageContainerException("Container File is corrupted. " +
             "ContainerType is KeyValueContainer but cast to " +

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.container.common.impl.TopNOrderedContainerDeletio
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
@@ -214,6 +215,8 @@ public class TestBlockDeletingService {
       data = (KeyValueContainerData) containerSet.getContainer(
           containerID).getContainerData();
       data.setSchemaVersion(schemaVersion);
+      ContainerCache cCache = ContainerCache.getInstance(conf);
+      cCache.markContainerClosed(data.getDbFile().getAbsolutePath());
       if (schemaVersion.equals(SCHEMA_V1)) {
         createPendingDeleteBlocksSchema1(numOfBlocksPerContainer, data,
             containerID, numOfChunksPerBlock, buffer, chunkManager, container);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -76,8 +76,8 @@ public class TestContainerCache {
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
 
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir1 = new File(root, "cont1");
     File containerDir2 = new File(root, "cont2");
     File containerDir3 = new File(root, "cont3");
@@ -121,9 +121,11 @@ public class TestContainerCache {
             containerDir3.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(1, db4.getReferenceCount());
 
-    Assert.assertEquals(2, cache.size());
-    Assert.assertNotNull(cache.get(containerDir1.getPath()));
-    Assert.assertNull(cache.get(containerDir2.getPath()));
+    Assert.assertEquals(2, cache.getCloseContainerCache().size());
+    Assert.assertNotNull(cache.getCloseContainerCache()
+        .get(containerDir1.getPath()));
+    Assert.assertNull(cache.getCloseContainerCache()
+        .get(containerDir2.getPath()));
 
     // Now close both the references for container1
     db1.close();
@@ -155,8 +157,8 @@ public class TestContainerCache {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir = new File(root, "cont1");
     createContainerDB(conf, containerDir);
     ExecutorService executorService = Executors.newFixedThreadPool(2);
@@ -185,7 +187,7 @@ public class TestContainerCache {
     db.close();
     db.close();
     db.close();
-    Assert.assertEquals(1, cache.size());
+    Assert.assertEquals(1, cache.getCloseContainerCache().size());
     db.cleanup();
   }
 
@@ -198,8 +200,8 @@ public class TestContainerCache {
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
 
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir1 = new File(root, "cont1");
     File containerDir2 = new File(root, "cont2");
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.common;
 
 import org.apache.hadoop.fs.FileSystemTestHelper;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
@@ -51,8 +52,8 @@ public class TestContainerCache {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
 
-  private void createContainerDB(OzoneConfiguration conf, File dbFile)
-      throws Exception {
+  private ReferenceCountedDB createContainerDB(OzoneConfiguration conf,
+      File dbFile) throws Exception {
     DatanodeStore store = new DatanodeStoreSchemaTwoImpl(
             conf, 1, dbFile.getAbsolutePath(), false);
 
@@ -61,6 +62,9 @@ public class TestContainerCache {
     // in a container.
 
     store.stop();
+    ReferenceCountedDB db =
+        new ReferenceCountedDB(store, dbFile.getAbsolutePath());
+    return db;
   }
 
   @Test
@@ -89,11 +93,11 @@ public class TestContainerCache {
     long numDbGetCount = metrics.getNumDbGetOps();
     long numCacheMisses = metrics.getNumCacheMisses();
     // Get 2 references out of the same db and verify the objects are same.
-    ReferenceCountedDB db1 = cache.getDB(1, "RocksDB",
+    ReferenceCountedDB db1 = cache.getDB(1, State.CLOSED,
             containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(1, db1.getReferenceCount());
     Assert.assertEquals(numDbGetCount + 1, metrics.getNumDbGetOps());
-    ReferenceCountedDB db2 = cache.getDB(1, "RocksDB",
+    ReferenceCountedDB db2 = cache.getDB(1, State.CLOSED,
             containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(2, db2.getReferenceCount());
     Assert.assertEquals(numCacheMisses + 1, metrics.getNumCacheMisses());
@@ -103,7 +107,7 @@ public class TestContainerCache {
     Assert.assertEquals(numCacheMisses + 1, metrics.getNumCacheMisses());
 
     // add one more references to ContainerCache.
-    ReferenceCountedDB db3 = cache.getDB(2, "RocksDB",
+    ReferenceCountedDB db3 = cache.getDB(2, State.CLOSED,
             containerDir2.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(1, db3.getReferenceCount());
 
@@ -113,7 +117,7 @@ public class TestContainerCache {
 
     // add one more reference to ContainerCache and verify that it will not
     // evict the least recent entry as it has reference.
-    ReferenceCountedDB db4 = cache.getDB(3, "RocksDB",
+    ReferenceCountedDB db4 = cache.getDB(3, State.CLOSED,
             containerDir3.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(1, db4.getReferenceCount());
 
@@ -129,7 +133,7 @@ public class TestContainerCache {
 
 
     // The reference count for container1 is 0 but it is not evicted.
-    ReferenceCountedDB db5 = cache.getDB(1, "RocksDB",
+    ReferenceCountedDB db5 = cache.getDB(1, State.CLOSED,
             containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     Assert.assertEquals(1, db5.getReferenceCount());
     Assert.assertEquals(db1, db5);
@@ -158,7 +162,7 @@ public class TestContainerCache {
     ExecutorService executorService = Executors.newFixedThreadPool(2);
     Runnable task = () -> {
       try {
-        ReferenceCountedDB db1 = cache.getDB(1, "RocksDB",
+        ReferenceCountedDB db1 = cache.getDB(1, State.CLOSED,
             containerDir.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
         Assert.assertNotNull(db1);
       } catch (IOException e) {
@@ -176,12 +180,88 @@ public class TestContainerCache {
       }
     }
 
-    ReferenceCountedDB db = cache.getDB(1, "RocksDB",
+    ReferenceCountedDB db = cache.getDB(1, State.CLOSED,
         containerDir.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
     db.close();
     db.close();
     db.close();
     Assert.assertEquals(1, cache.size());
     db.cleanup();
+  }
+
+  @Test
+  public void testOpenContainerCache() throws Exception {
+    File root = new File(testRoot);
+    root.mkdirs();
+
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
+
+    ContainerCache cache = ContainerCache.getInstance(conf);
+    cache.clear();
+    Assert.assertEquals(0, cache.size());
+    File containerDir1 = new File(root, "cont1");
+    File containerDir2 = new File(root, "cont2");
+
+    ReferenceCountedDB db1 = createContainerDB(conf, containerDir1);
+    ReferenceCountedDB db2 = createContainerDB(conf, containerDir2);
+
+    ContainerCacheMetrics metrics = cache.getMetrics();
+
+    long numOpenGetsFails = metrics.getNumOpenContainerGetsFailures();
+    long numCacheHits = metrics.getNumCacheHits();
+
+    long numOpenGetsSuccess = metrics.getNumOpenContainerGetsSuccess();
+
+    try {
+      cache.getDB(1, State.OPEN,
+          containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
+      Assert.fail("This should fail as container is not added to Cache");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof IOException);
+    }
+
+    Assert.assertEquals(numOpenGetsFails + 1,
+        metrics.getNumOpenContainerGetsFailures());
+
+    cache.addDB(containerDir1.getPath(), db1);
+    cache.addDB(containerDir2.getPath(), db2);
+
+    Assert.assertEquals(2, metrics.getNumOpenCacheEntries());
+
+    ReferenceCountedDB db3 = cache.getDB(1, State.OPEN,
+        containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
+
+    Assert.assertEquals(db1, db3);
+    Assert.assertEquals(numOpenGetsSuccess + 1,
+        metrics.getNumOpenContainerGetsSuccess());
+    Assert.assertEquals(1, db1.getReferenceCount());
+    Assert.assertEquals(0, db2.getReferenceCount());
+
+    // Now mark container as closed
+    cache.markContainerClosed(containerDir1.getPath());
+    Assert.assertEquals(1, metrics.getNumOpenCacheEntries());
+
+    ReferenceCountedDB db4 = cache.getDB(1, State.CLOSED,
+        containerDir1.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
+    // Assert this is not read as open container
+    Assert.assertEquals(numOpenGetsSuccess + 1,
+        metrics.getNumOpenContainerGetsSuccess());
+    // Assert this is read from close container cache
+    Assert.assertEquals(numCacheHits + 1, metrics.getNumCacheHits());
+    Assert.assertEquals(2, db4.getReferenceCount());
+    Assert.assertEquals(0, db2.getReferenceCount());
+    db3.close();
+    db3.close();
+    Assert.assertEquals(0, db2.getReferenceCount());
+
+    // Now again open
+    ReferenceCountedDB db5 = cache.getDB(2, State.OPEN,
+        containerDir2.getPath(), OzoneConsts.SCHEMA_LATEST, conf);
+    db5.close();
+    Assert.assertEquals(numOpenGetsSuccess + 2,
+        metrics.getNumOpenContainerGetsSuccess());
+
+    cache.shutdownCache();
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ChunkLayOutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume
@@ -275,6 +276,11 @@ public class TestKeyValueContainer {
    * Set container state to CLOSED.
    */
   private void closeContainer() {
+    if (keyValueContainerData.getDbFile() != null) {
+      ContainerCache.getInstance(CONF)
+          .markContainerClosed(keyValueContainerData
+              .getDbFile().getAbsolutePath());
+    }
     keyValueContainerData.setState(
         ContainerProtos.ContainerDataProto.State.CLOSED);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -276,7 +276,7 @@ public class TestContainerReader {
         new MutableVolumeSet(datanodeId.toString(), clusterId, conf, null,
             StorageVolume.VolumeType.DATA_VOLUME, null);
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
+    cache.getCloseContainerCache().clear();
 
     RoundRobinVolumeChoosingPolicy policy =
         new RoundRobinVolumeChoosingPolicy();
@@ -329,6 +329,6 @@ public class TestContainerReader {
         containerSet.getContainerMap().entrySet().size());
     // There should be no open containers cached by the ContainerReader as it
     // opens and closed them avoiding the cache.
-    Assert.assertEquals(0, cache.size());
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -262,6 +262,8 @@ public class TestDatanodeHddsVolumeFailureDetection {
         .ONE, OzoneConsts.OZONE);
     Assert.assertTrue(c2.getContainerInfo().getState()
         .equals(HddsProtos.LifeCycleState.OPEN));
+    Container c2Container = oc.getContainerSet().getContainer(2);
+    c2Container.close();
 
     // corrupt db by rename dir->file
     File metadataDir = new File(c1.getContainerFile().getParent());


### PR DESCRIPTION
## What changes were proposed in this pull request?
It has been seen in deployments that with large number of containers on datanodes. we have seen cache misses on the rocksDB cache.

This patch proposes
a) to have separate caches for open and closed container
b) rocksDB containers in open container cache are never evicted.
c) Open containers are moved from open to close container cache it they are closed/quasi closed.
d) Closed container are cached in LRU fashion as they are cached right now

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5660

## How was this patch tested?
Added new unit test
