### PR TITLE
HDDS-5638. Fixed docker-compose to make Recon come up.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -288,6 +288,8 @@ services:
     hostname: recon
     volumes:
       - ../..:/opt/hadoop
+      - ../_keytabs:/etc/security/keytabs
+      - ./krb5.conf:/etc/krb5.conf
     ports:
       - 9888:9888
     env_file:


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a Secure HA docker compose recon didn't come up. Added the volumes that contains the keytabs for recon.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5638

## How was this patch tested?

This patch was manually tested by spinning up the Secure HA cluster and made sure recon showed up, and also with GitHub CI tests.

https://github.com/aswinshakil/ozone/actions/runs/1151968641

