### PR TITLE
HDDS-5391 Fix issues in SCMHAConfiguration

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -489,6 +489,11 @@ public final class ScmConfigKeys {
   public static final String
           OZONE_SCM_HA_RAFT_SEGMENT_PRE_ALLOCATED_SIZE_DEFAULT = "16KB";
 
+  public static final String OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM =
+      "ozone.scm.ha.ratis.log.appender.queue.num-elements";
+  public static final int
+      OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM_DEFAULT = 1024;
+
   public static final String OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT =
           "ozone.scm.ha.ratis.log.appender.queue.byte-limit";
   public static final String

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/RatisUtil.java
@@ -170,11 +170,10 @@ public final class RatisUtil {
                 ScmConfigKeys.OZONE_SCM_HA_RAFT_SEGMENT_SIZE_DEFAULT,
                 StorageUnit.BYTES)));
     Log.Appender.setBufferElementLimit(properties,
-        (int) ozoneConf.getStorageSize(
-                ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT,
+        ozoneConf.getInt(
+                ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM,
                 ScmConfigKeys.
-                        OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT_DEFAULT,
-                StorageUnit.BYTES));
+                        OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM_DEFAULT));
     Log.Appender.setBufferByteLimit(properties, SizeInBytes.valueOf(
         (long) ozoneConf.getStorageSize(
               ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT,


### PR DESCRIPTION
## What changes were proposed in this pull request?

This bug missed the merge boat and got stale. In the current context, what this bug really means now is to make sure in RatisUtil, the call to Log.Appender.setBufferElementLimit is set to queue num-elements: 1024 and not queue byte-limit: 32 * 1024 * 1024 using the current HA config pattern.

SCMHAConfiguration used to provide this:
  @Config(key = "ratis.log.appender.queue.num-elements",
      type = ConfigType.INT,
      defaultValue = "1024",
      tags = {SCM, OZONE, HA, RATIS},
      description = "Number of operation pending with Raft's Log Worker."
  )
  private int raftLogAppenderQueueNum = 1024;

  @Config(key = "ratis.log.appender.queue.byte-limit",
      type = ConfigType.SIZE,
      defaultValue = "32MB",
      tags = {SCM, OZONE, HA, RATIS},
      description = "Byte limit for Raft's Log Worker queue."
  )
  private int raftLogAppenderQueueByteLimit = 32 * 1024 * 1024;
...
  public int getRaftLogAppenderQueueNum() {
    return raftLogAppenderQueueNum;
  }

The call to getRaftLogAppenderQueueNum() was used to populate Log.Appender.setBufferElementLimit( ... )

This is how the property name for byte-limit was brought over:
  public static final String OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_BYTE_LIMIT =
          "ozone.scm.ha.ratis.log.appender.queue.byte-limit";

I'm copying what I can see was done for 'ratis.log.appender.queue.byte-limit', namely prepend 'ozone.scm.ha' and make a couple static entries in SCMConfigKeys following the established name pattern:

Added  to SCMConfigKeys:
  public static final String OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM =
          "ozone.scm.ha.ratis.log.appender.queue.num-elements";
  public static final int
          OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM_DEFAULT = 1024;


Then finally in RatisUtil:
    Log.Appender.setBufferElementLimit(properties,
        ozoneConf.getInt(
                ScmConfigKeys.OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM,
                ScmConfigKeys.
                        OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM_DEFAULT));

The rest of the associated cleanup requested and done for HDDS-5391 is no longer needed since SCMHAConfiguration was removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5391

## How was this patch tested?

Manually and CI tests