### PR TITLE
HDDS-5662. Fix blank traceId for FsShell command

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneFsShell.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.fs.shell.CommandFactory;
 import org.apache.hadoop.fs.shell.FsCommand;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.util.ToolRunner;
 
 /** Provide command line access to a Ozone FileSystem. */
@@ -73,7 +74,8 @@ public class OzoneFsShell extends FsShell {
    */
   public static void main(String[] argv) throws Exception {
     OzoneFsShell shell = newShellInstance();
-    Configuration conf = new Configuration();
+    OzoneConfiguration conf = new OzoneConfiguration();
+    TracingUtil.initTracing("FsShell", conf);
     conf.setQuietMode(false);
     shell.setConf(conf);
     int res;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Register the global tracer for FsShell Command for the reason of black traceID.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5662

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

CI and manual test

Before
![wecom-temp-ba7aba75f79c61ccbf7a644c620b4b9d](https://user-images.githubusercontent.com/10106574/130553957-6c2e6150-bd79-4142-8867-4148d3d921b7.png)


After
![wecom-temp-b69c8075e962ce43b9dbda5a97187dd2](https://user-images.githubusercontent.com/10106574/130553964-38573dde-a258-4dd1-9611-a541c337614d.png)
