### PR TITLE
HDDS-5655. SCM terminates when allocatecontainer happens on closed pipeline.

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds;
 
-import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Paths;
 import java.util.ArrayList;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -178,12 +178,13 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       throws IOException {
     // Acquire pipeline manager lock, to avoid any updates to pipeline
     // while allocate container happens. This is to avoid scenario like
-    // mentioned in HDDS-5655..
+    // mentioned in HDDS-5655.
     pipelineManager.acquireLock();
     try {
       lock.lock();
     } catch (Exception ex) {
-      // Release pipeline manager lock and throw exception.
+      // If any exception during container manager acquire lock, release
+      // pipeline manager lock and throw exception
       pipelineManager.releaseLock();
       throw ex;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -177,11 +177,15 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       final ReplicationConfig replicationConfig, final String owner)
       throws IOException {
     lock.lock();
+    // Acquire pipeline manager lock, to avoid any updates to pipeline
+    // while allocate container happens. This is to avoid scenario like
+    // mentioned in HDDS-5655.
     try {
-      // Acquire pipeline manager lock, to avoid any updates to pipeline
-      // while allocate container happens. This is to avoid scenario like
-      // mentioned in HDDS-5655.
       pipelineManager.acquireLock();
+    } catch (Exception ex) {
+      lock.unlock();
+    }
+    try {
       final List<Pipeline> pipelines = pipelineManager
           .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -184,7 +184,9 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       pipelineManager.acquireLock();
     } catch (Exception ex) {
       lock.unlock();
+      throw ex;
     }
+
     try {
       final List<Pipeline> pipelines = pipelineManager
           .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -180,42 +180,60 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
     // while allocate container happens. This is to avoid scenario like
     // mentioned in HDDS-5655.
     pipelineManager.acquireLock();
+    lock.lock();
+    List<Pipeline> pipelines;
+    Pipeline pipeline;
+    ContainerInfo containerInfo = null;
     try {
-      lock.lock();
-    } catch (Exception ex) {
-      // If any exception during container manager acquire lock, release
-      // pipeline manager lock and throw exception
-      pipelineManager.releaseLock();
-      throw ex;
-    }
-
-    try {
-      final List<Pipeline> pipelines = pipelineManager
+      pipelines = pipelineManager
           .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
-
-      final Pipeline pipeline;
-      if (pipelines.isEmpty()) {
-        try {
-          pipeline = pipelineManager.createPipeline(replicationConfig);
-          pipelineManager.waitPipelineReady(pipeline.getId(), 0);
-        } catch (IOException e) {
-          scmContainerManagerMetrics.incNumFailureCreateContainers();
-          throw new IOException("Could not allocate container. Cannot get any" +
-              " matching pipeline for replicationConfig: " + replicationConfig
-              + ", State:PipelineState.OPEN", e);
-        }
-      } else {
+      if (!pipelines.isEmpty()) {
         pipeline = pipelines.get(random.nextInt(pipelines.size()));
+        containerInfo = createContainer(pipeline, owner);
       }
-      final ContainerInfo containerInfo = allocateContainer(pipeline, owner);
-      if (LOG.isTraceEnabled()) {
-        LOG.trace("New container allocated: {}", containerInfo);
-      }
-      return containerInfo;
     } finally {
       lock.unlock();
       pipelineManager.releaseLock();
     }
+
+    if (pipelines.isEmpty()) {
+      try {
+        pipeline = pipelineManager.createPipeline(replicationConfig);
+        pipelineManager.waitPipelineReady(pipeline.getId(), 0);
+      } catch (IOException e) {
+        scmContainerManagerMetrics.incNumFailureCreateContainers();
+        throw new IOException("Could not allocate container. Cannot get any" +
+            " matching pipeline for replicationConfig: " + replicationConfig
+            + ", State:PipelineState.OPEN", e);
+      }
+      pipelineManager.acquireLock();
+      lock.lock();
+      try {
+        pipelines = pipelineManager
+            .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
+        if (!pipelines.isEmpty()) {
+          pipeline = pipelines.get(random.nextInt(pipelines.size()));
+          containerInfo = createContainer(pipeline, owner);
+        } else {
+          throw new IOException("Could not allocate container. Cannot get any" +
+              " matching pipeline for replicationConfig: " + replicationConfig
+              + ", State:PipelineState.OPEN");
+        }
+      } finally {
+        lock.unlock();
+        pipelineManager.releaseLock();
+      }
+    }
+    return containerInfo;
+  }
+
+  private ContainerInfo createContainer(Pipeline pipeline, String owner)
+      throws IOException {
+    final ContainerInfo containerInfo = allocateContainer(pipeline, owner);
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("New container allocated: {}", containerInfo);
+    }
+    return containerInfo;
   }
 
   private ContainerInfo allocateContainer(final Pipeline pipeline,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -179,7 +179,7 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
     // Acquire pipeline manager lock, to avoid any updates to pipeline
     // while allocate container happens. This is to avoid scenario like
     // mentioned in HDDS-5655.
-    pipelineManager.acquireLock();
+    pipelineManager.acquireReadLock();
     lock.lock();
     List<Pipeline> pipelines;
     Pipeline pipeline;
@@ -193,7 +193,7 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       }
     } finally {
       lock.unlock();
-      pipelineManager.releaseLock();
+      pipelineManager.releaseReadLock();
     }
 
     if (pipelines.isEmpty()) {
@@ -206,7 +206,7 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
             " matching pipeline for replicationConfig: " + replicationConfig
             + ", State:PipelineState.OPEN", e);
       }
-      pipelineManager.acquireLock();
+      pipelineManager.acquireReadLock();
       lock.lock();
       try {
         pipelines = pipelineManager
@@ -221,7 +221,7 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
         }
       } finally {
         lock.unlock();
-        pipelineManager.releaseLock();
+        pipelineManager.releaseReadLock();
       }
     }
     return containerInfo;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -178,6 +178,10 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       throws IOException {
     lock.lock();
     try {
+      // Acquire pipeline manager lock, to avoid any updates to pipeline
+      // while allocate container happens. This is to avoid scenario like
+      // mentioned in HDDS-5655.
+      pipelineManager.acquireLock();
       final List<Pipeline> pipelines = pipelineManager
           .getPipelines(replicationConfig, Pipeline.PipelineState.OPEN);
 
@@ -201,6 +205,7 @@ public class ContainerManagerImpl implements ContainerManagerV2 {
       }
       return containerInfo;
     } finally {
+      pipelineManager.releaseLock();
       lock.unlock();
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -144,12 +144,22 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
   void resumePipelineCreation();
 
   /**
-   * Acquire lock.
+   * Acquire read lock.
    */
-  void acquireLock();
+  void acquireReadLock();
 
   /**
-   * Release lock.
+   * Release read lock.
    */
-  void releaseLock();
+  void releaseReadLock();
+
+  /**
+   * Acquire write lock.
+   */
+  void acquireWriteLock();
+
+  /**
+   * Release write lock.
+   */
+  void releaseWriteLock();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManager.java
@@ -142,4 +142,14 @@ public interface PipelineManager extends Closeable, PipelineManagerMXBean {
    * Ask pipeline manager to resume creating new pipelines.
    */
   void resumePipelineCreation();
+
+  /**
+   * Acquire lock.
+   */
+  void acquireLock();
+
+  /**
+   * Release lock.
+   */
+  void releaseLock();
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -631,4 +631,14 @@ public class PipelineManagerImpl implements PipelineManager {
   protected Lock getLock() {
     return lock;
   }
+
+  @Override
+  public void acquireLock() {
+    lock.lock();
+  }
+
+  @Override
+  public void releaseLock() {
+    lock.unlock();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -58,6 +58,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * SCM Pipeline Manager implementation.
@@ -69,7 +70,7 @@ public class PipelineManagerImpl implements PipelineManager {
       LoggerFactory.getLogger(PipelineManagerImpl.class);
 
   // Limit the number of on-going ratis operation to be 1.
-  private final Lock lock;
+  private final ReentrantReadWriteLock lock;
   private PipelineFactory pipelineFactory;
   private StateManager stateManager;
   private BackgroundPipelineCreatorV2 backgroundPipelineCreator;
@@ -93,7 +94,7 @@ public class PipelineManagerImpl implements PipelineManager {
                                 PipelineFactory pipelineFactory,
                                 EventPublisher eventPublisher,
                                 SCMContext scmContext) {
-    this.lock = new ReentrantLock();
+    this.lock = new ReentrantReadWriteLock();
     this.pipelineFactory = pipelineFactory;
     this.stateManager = pipelineStateManager;
     this.conf = conf;
@@ -164,7 +165,7 @@ public class PipelineManagerImpl implements PipelineManager {
       throw new IOException(message);
     }
 
-    lock.lock();
+    acquireWriteLock();
     try {
       Pipeline pipeline = pipelineFactory.create(replicationConfig);
       stateManager.addPipeline(pipeline.getProtobufMessage(
@@ -177,7 +178,7 @@ public class PipelineManagerImpl implements PipelineManager {
       metrics.incNumPipelineCreationFailed();
       throw ex;
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
   }
 
@@ -273,7 +274,7 @@ public class PipelineManagerImpl implements PipelineManager {
 
   @Override
   public void openPipeline(PipelineID pipelineId) throws IOException {
-    lock.lock();
+    acquireWriteLock();
     try {
       Pipeline pipeline = stateManager.getPipeline(pipelineId);
       if (pipeline.isClosed()) {
@@ -287,7 +288,7 @@ public class PipelineManagerImpl implements PipelineManager {
       metrics.incNumPipelineCreated();
       metrics.createPerPipelineMetrics(pipeline);
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
   }
 
@@ -300,7 +301,7 @@ public class PipelineManagerImpl implements PipelineManager {
   protected void removePipeline(Pipeline pipeline) throws IOException {
     pipelineFactory.close(pipeline.getType(), pipeline);
     PipelineID pipelineID = pipeline.getId();
-    lock.lock();
+    acquireWriteLock();
     try {
       stateManager.removePipeline(pipelineID.getProtobuf());
       metrics.incNumPipelineDestroyed();
@@ -308,7 +309,7 @@ public class PipelineManagerImpl implements PipelineManager {
       metrics.incNumPipelineDestroyFailed();
       throw ex;
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
   }
 
@@ -335,7 +336,7 @@ public class PipelineManagerImpl implements PipelineManager {
   public void closePipeline(Pipeline pipeline, boolean onTimeout)
       throws IOException {
     PipelineID pipelineID = pipeline.getId();
-    lock.lock();
+    acquireWriteLock();
     try {
       if (!pipeline.isClosed()) {
         stateManager.updatePipelineState(pipelineID.getProtobuf(),
@@ -344,7 +345,7 @@ public class PipelineManagerImpl implements PipelineManager {
       }
       metrics.removePipelineMetrics(pipelineID);
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
     // close containers.
     closeContainersForPipeline(pipelineID);
@@ -430,12 +431,12 @@ public class PipelineManagerImpl implements PipelineManager {
   @Override
   public void activatePipeline(PipelineID pipelineID)
       throws IOException {
-    lock.lock();
+    acquireWriteLock();
     try {
       stateManager.updatePipelineState(pipelineID.getProtobuf(),
               HddsProtos.PipelineState.PIPELINE_OPEN);
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
   }
 
@@ -448,12 +449,12 @@ public class PipelineManagerImpl implements PipelineManager {
   @Override
   public void deactivatePipeline(PipelineID pipelineID)
       throws IOException {
-    lock.lock();
+    acquireWriteLock();
     try {
       stateManager.updatePipelineState(pipelineID.getProtobuf(),
           HddsProtos.PipelineState.PIPELINE_DORMANT);
     } finally {
-      lock.unlock();
+      releaseWriteLock();
     }
   }
 
@@ -628,17 +629,23 @@ public class PipelineManagerImpl implements PipelineManager {
     }
   }
 
-  protected Lock getLock() {
-    return lock;
+  @Override
+  public void acquireReadLock() {
+    lock.readLock().lock();
   }
 
   @Override
-  public void acquireLock() {
-    lock.lock();
+  public void releaseReadLock() {
+    lock.readLock().unlock();
   }
 
   @Override
-  public void releaseLock() {
-    lock.unlock();
+  public void acquireWriteLock() {
+    lock.writeLock().lock();
+  }
+
+  @Override
+  public void releaseWriteLock() {
+    lock.writeLock().unlock();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -56,8 +56,6 @@ import java.util.NavigableSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -99,7 +99,8 @@ public class WritableRatisContainerProvider
               .getPipelines(repConfig, Pipeline.PipelineState.OPEN);
         }
         if (availablePipelines.size() != 0) {
-         containerInfo = selectContainer(availablePipelines, size, owner, excludeList);
+         containerInfo = selectContainer(availablePipelines, size, owner,
+             excludeList);
         }
         if (containerInfo != null) {
           return containerInfo;
@@ -146,7 +147,8 @@ public class WritableRatisContainerProvider
                   + "even after retrying", repConfig);
               break;
             }
-            containerInfo = selectContainer(availablePipelines, size, owner, excludeList);
+            containerInfo = selectContainer(availablePipelines, size, owner,
+                excludeList);
             if (containerInfo != null) {
               return containerInfo;
             }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -132,7 +132,8 @@ public class WritableRatisContainerProvider
 
         pipelineManager.acquireLock();
         try {
-          // Exception occurred do one final try to fetch pipelines.
+          // If Exception occurred or successful creation of pipeline do one
+          // final try to fetch pipelines.
           availablePipelines = pipelineManager
               .getPipelines(repConfig, Pipeline.PipelineState.OPEN,
                   excludeList.getDatanodes(), excludeList.getPipelineIds());

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -90,7 +90,7 @@ public class WritableRatisContainerProvider
       // Acquire pipeline manager lock, to avoid any updates to pipeline
       // while allocate container happens. This is to avoid scenario like
       // mentioned in HDDS-5655.
-      pipelineManager.acquireLock();
+      pipelineManager.acquireReadLock();
       try {
         availablePipelines = pipelineManager.getPipelines(repConfig,
             Pipeline.PipelineState.OPEN, excludeList.getDatanodes(),
@@ -109,7 +109,7 @@ public class WritableRatisContainerProvider
           return containerInfo;
         }
       } finally {
-        pipelineManager.releaseLock();
+        pipelineManager.releaseReadLock();
       }
 
       if (availablePipelines.size() == 0) {
@@ -130,7 +130,7 @@ public class WritableRatisContainerProvider
               + "Retrying get pipelines call once.", repConfig, e);
         }
 
-        pipelineManager.acquireLock();
+        pipelineManager.acquireReadLock();
         try {
           // If Exception occurred or successful creation of pipeline do one
           // final try to fetch pipelines.
@@ -154,7 +154,7 @@ public class WritableRatisContainerProvider
             return containerInfo;
           }
         } finally {
-          pipelineManager.releaseLock();
+          pipelineManager.releaseReadLock();
         }
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableRatisContainerProvider.java
@@ -99,8 +99,8 @@ public class WritableRatisContainerProvider
         }
         if (availablePipelines.size() == 0) {
           try {
-            // TODO: #CLUTIL Remove creation logic when all replication types and
-            // factors are handled by pipeline creator
+            // TODO: #CLUTIL Remove creation logic when all replication types
+            //  and factors are handled by pipeline creator
             pipeline = pipelineManager.createPipeline(repConfig);
 
             // wait until pipeline is ready

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -227,4 +227,14 @@ public final class MockPipelineManager implements PipelineManager {
   public Map<String, Integer> getPipelineInfo() {
     return null;
   }
+
+  @Override
+  public void acquireLock() {
+
+  }
+
+  @Override
+  public void releaseLock() {
+
+  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -229,12 +229,22 @@ public final class MockPipelineManager implements PipelineManager {
   }
 
   @Override
-  public void acquireLock() {
+  public void acquireReadLock() {
 
   }
 
   @Override
-  public void releaseLock() {
+  public void releaseReadLock() {
+
+  }
+
+  @Override
+  public void acquireWriteLock() {
+
+  }
+
+  @Override
+  public void releaseWriteLock() {
 
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -94,7 +94,7 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
    */
   void initializePipelines(List<Pipeline> pipelinesFromScm) throws IOException {
 
-    getLock().lock();
+    acquireWriteLock();
     try {
       List<Pipeline> pipelinesInHouse = getPipelines();
       LOG.info("Recon has {} pipelines in house.", pipelinesInHouse.size());
@@ -116,12 +116,12 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
         removeInvalidPipelines(pipelinesFromScm);
       }
     } finally {
-      getLock().unlock();
+      releaseWriteLock();
     }
   }
 
   public void removeInvalidPipelines(List<Pipeline> pipelinesFromScm) {
-    getLock().lock();
+    acquireWriteLock();
     try {
       List<Pipeline> pipelinesInHouse = getPipelines();
       // Removing pipelines in Recon that are no longer in SCM.
@@ -151,7 +151,7 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
         }
       });
     } finally {
-      getLock().unlock();
+      releaseWriteLock();
     }
   }
   /**
@@ -161,12 +161,12 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
    */
   @VisibleForTesting
   public void addPipeline(Pipeline pipeline) throws IOException {
-    getLock().lock();
+    acquireWriteLock();
     try {
       getStateManager().addPipeline(
           pipeline.getProtobufMessage(ClientVersions.CURRENT_VERSION));
     } finally {
-      getLock().unlock();
+      releaseWriteLock();
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acquire pipelineManager during allocateContainer to avoid any updates to pipelineState.
And also updated to use ReentrantReadWriteLock in PipelineManager, to allow multiple allocateBlock requests happen. This way, pipelineManager lock will not create contention.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5655

## How was this patch tested?

Existing tests
