### PR TITLE
[FSO] Allow existing/old buckets with any layout during OM startup

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMStartupWithBucketLayout.java
@@ -1,0 +1,161 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.util.UUID;
+
+/**
+ * Verifies OM startup with different layout.
+ */
+public class TestOMStartupWithBucketLayout {
+
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  private static MiniOzoneCluster cluster;
+
+  public static void startCluster(OzoneConfiguration conf)
+      throws Exception {
+    String clusterId = UUID.randomUUID().toString();
+    String scmId = UUID.randomUUID().toString();
+    String omId = UUID.randomUUID().toString();
+    cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
+        .setScmId(scmId).setOmId(omId).withoutDatanodes().build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  public static void restartCluster()
+      throws Exception {
+    // restart om
+    cluster.stop();
+    cluster.getOzoneManager().restart();
+  }
+
+  public static void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Test
+  public void testRestartWithFSOLayout() throws Exception {
+    try {
+      // 1. build cluster with default bucket layout FSO
+      OzoneConfiguration conf = new OzoneConfiguration();
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+      startCluster(conf);
+
+      // 2. create bucket with FSO bucket layout and verify
+      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+      // 3. verify OM default behavior with LEGACY
+      restartCluster();
+      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.LEGACY);
+      verifyBucketLayout(bucket2, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+      // 4. create bucket with OBS bucket layout and verify
+      restartCluster();
+      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.OBJECT_STORE);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+
+      // 5. verify all bucket
+      restartCluster();
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket2, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+
+      // 6. verify after update default bucket layout
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          BucketLayout.OBJECT_STORE.name());
+      restartCluster();
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket2, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+    } finally {
+      teardown();
+    }
+  }
+
+  @Test
+  public void testRestartWithOBSLayout() throws Exception {
+    try {
+      // 1. build cluster with default bucket layout OBS
+      OzoneConfiguration conf = new OzoneConfiguration();
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          BucketLayout.OBJECT_STORE.name());
+      startCluster(conf);
+
+      // 2. create bucket with FSO bucket layout and verify
+      OzoneBucket bucket1 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+      // 3. verify OM default behavior with LEGACY
+      restartCluster();
+      OzoneBucket bucket2 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.LEGACY);
+      verifyBucketLayout(bucket2, BucketLayout.OBJECT_STORE);
+
+      // 4. create bucket with OBS bucket layout and verify
+      restartCluster();
+      OzoneBucket bucket3 = TestDataUtil.createVolumeAndBucket(cluster,
+          BucketLayout.OBJECT_STORE);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+
+      // 5. verify all bucket
+      restartCluster();
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket2, BucketLayout.OBJECT_STORE);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+
+      // 6. verify after update default bucket layout
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+      restartCluster();
+      verifyBucketLayout(bucket1, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      verifyBucketLayout(bucket2, BucketLayout.OBJECT_STORE);
+      verifyBucketLayout(bucket3, BucketLayout.OBJECT_STORE);
+    } finally {
+      teardown();
+    }
+  }
+
+  private void verifyBucketLayout(OzoneBucket bucket,
+      BucketLayout metadataLayout) {
+    Assert.assertNotNull(bucket);
+    Assert.assertEquals(metadataLayout, bucket.getBucketLayout());
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -85,8 +85,6 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.DBUpdatesWrapper;
 import org.apache.hadoop.hdds.utils.db.SequenceNumberNotFoundException;
-import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.io.Text;
@@ -1325,8 +1323,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
     metadataManager.start(configuration);
 
-    validatesBucketLayoutMismatches();
-
     // Start Ratis services
     if (omRatisServer != null) {
       omRatisServer.start();
@@ -1416,8 +1412,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     HddsServerUtil.initializeMetrics(configuration, "OzoneManager");
 
     instantiateServices(false);
-
-    validatesBucketLayoutMismatches();
 
     startSecretManagerIfNecessary();
 
@@ -3630,72 +3624,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     boolean omMetadataLayoutPrefix = StringUtils.equalsIgnoreCase(metaLayout,
         OZONE_OM_METADATA_LAYOUT_PREFIX);
 
-    boolean omMetadataLayoutSimple = StringUtils.equalsIgnoreCase(metaLayout,
-        OZONE_OM_METADATA_LAYOUT_DEFAULT);
-
-    if (!(omMetadataLayoutPrefix || omMetadataLayoutSimple)) {
-      StringBuilder msg = new StringBuilder();
-      msg.append("Invalid Configuration. Failed to start OM in ");
-      msg.append(metaLayout);
-      msg.append(" layout format. Supported values are either ");
-      msg.append(OZONE_OM_METADATA_LAYOUT_DEFAULT);
-      msg.append(" or ");
-      msg.append(OZONE_OM_METADATA_LAYOUT_PREFIX);
-
-      LOG.error(msg.toString());
-      throw new IllegalArgumentException(msg.toString());
-    }
-
-    if (omMetadataLayoutPrefix && !getEnableFileSystemPaths()) {
-      StringBuilder msg = new StringBuilder();
-      msg.append("Invalid Configuration. Failed to start OM in ");
-      msg.append(OZONE_OM_METADATA_LAYOUT_PREFIX);
-      msg.append(" layout format as '");
-      msg.append(OZONE_OM_ENABLE_FILESYSTEM_PATHS);
-      msg.append("' is false!");
-
-      LOG.error(msg.toString());
-      throw new IllegalArgumentException(msg.toString());
-    }
-
     String status = omMetadataLayoutPrefix ? "enabled" : "disabled";
     LOG.info("Configured {}={} and {} optimized OM FS operations",
         OZONE_OM_METADATA_LAYOUT, metaLayout, status);
-  }
-
-  private void validatesBucketLayoutMismatches() throws IOException {
-    String clusterLevelMetaLayout = getOMMetadataLayout();
-
-    TableIterator<String, ? extends Table.KeyValue<String, OmBucketInfo>>
-        iterator = metadataManager.getBucketTable().iterator();
-
-    while (iterator.hasNext()) {
-      Map<String, String> bucketMeta = iterator.next().getValue().getMetadata();
-      verifyBucketMetaLayout(clusterLevelMetaLayout, bucketMeta);
-    }
-  }
-
-  private void verifyBucketMetaLayout(String clusterLevelMetaLayout,
-      Map<String, String> bucketMetadata) throws IOException {
-    String bucketMetaLayout = bucketMetadata.get(OZONE_OM_METADATA_LAYOUT);
-    if (StringUtils.isBlank(bucketMetaLayout)) {
-      // Defaulting to SIMPLE
-      bucketMetaLayout = OZONE_OM_METADATA_LAYOUT_DEFAULT;
-    }
-    boolean supportedMetadataLayout =
-        StringUtils.equalsIgnoreCase(clusterLevelMetaLayout, bucketMetaLayout);
-
-    if (!supportedMetadataLayout) {
-      StringBuilder msg = new StringBuilder();
-      msg.append("Failed to start OM in ");
-      msg.append(clusterLevelMetaLayout);
-      msg.append(" layout format as existing bucket has a different layout ");
-      msg.append(bucketMetaLayout);
-      msg.append(" metadata format");
-
-      LOG.error(msg.toString());
-      throw new IOException(msg.toString());
-    }
   }
 
   private BucketLayout getBucketLayout() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

I have a ozone cluster, prefix is enable when setup cluster. when restart om, then error below:

```
java.io.IOException: Failed to start OM in PREFIX layout format as existing bucket has a different layout SIMPLE metadata format
```

This issue is similar to HDDS-5094. Later in  HDDS-5362, bucket layout is supported, then addFSOptimizedBucketDetails is removed in this https://github.com/apache/ozone/commit/7df192530810a07d3b976c3a56c46328c0b1d591. So om crash when restart if layout is PREFIX.

I think there is no need to validate bucket type since HDDS-5362.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5664

## How was this patch tested?

unit tests and manual tests.
