### PR TITLE
HDDS-5668. Fix TestOzoneConfigurationFields.

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2853,6 +2853,13 @@
     <description>Byte limit for Raft's Log Worker queue.</description>
   </property>
   <property>
+    <name>ozone.scm.ha.ratis.log.appender.queue.num-elements</name>
+    <value>1024</value>
+    <tag>SCM, OZONE, HA, RATIS</tag>
+    <description>Number of operation pending with Raft's Log Worker.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.ha.ratis.log.purge.enabled</name>
     <value>false</value>
     <tag>SCM, OZONE, HA, RATIS</tag>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix TestOzoneConfigurationFields which is failing after HDDS-5391 Fix issues in SCMHAConfiguration (#2567).
The test is failing due to as new config key is not added to ozone-default.xml

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5668

## How was this patch tested?

Updated test
