### PR TITLE
HDDS-5670. ContainerBalancer should get OzoneConfiguration from ContainerBalancerConfiguration.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -147,8 +147,8 @@ public class ContainerBalancer {
       }
 
       balancerRunning = true;
-      ozoneConfiguration = new OzoneConfiguration();
       this.config = balancerConfiguration;
+      this.ozoneConfiguration = config.getOzoneConfiguration();
       LOG.info("Starting Container Balancer...{}", this);
 
       //we should start a new balancer thread async

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -111,11 +112,9 @@ public final class ContainerBalancerConfiguration {
    */
   public ContainerBalancerConfiguration(
       OzoneConfiguration ozoneConfiguration) {
-    if (ozoneConfiguration == null) {
-      this.ozoneConfiguration = new OzoneConfiguration();
-    } else {
-      this.ozoneConfiguration = ozoneConfiguration;
-    }
+    Preconditions.checkNotNull(ozoneConfiguration,
+        "OzoneConfiguration should not be null.");
+    this.ozoneConfiguration = ozoneConfiguration;
 
     // balancing interval should be greater than DUFactory refresh period
     duConf = this.ozoneConfiguration.getObject(DUFactory.Conf.class);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -111,10 +111,14 @@ public final class ContainerBalancerConfiguration {
    */
   public ContainerBalancerConfiguration(
       OzoneConfiguration ozoneConfiguration) {
-    this.ozoneConfiguration = ozoneConfiguration;
+    if (ozoneConfiguration == null) {
+      this.ozoneConfiguration = new OzoneConfiguration();
+    } else {
+      this.ozoneConfiguration = ozoneConfiguration;
+    }
 
     // balancing interval should be greater than DUFactory refresh period
-    duConf = ozoneConfiguration.getObject(DUFactory.Conf.class);
+    duConf = this.ozoneConfiguration.getObject(DUFactory.Conf.class);
     balancingInterval = duConf.getRefreshPeriod().toMillis() +
         Duration.ofMinutes(10).toMillis();
   }
@@ -273,6 +277,15 @@ public final class ContainerBalancerConfiguration {
       LOG.warn("Balancing interval duration must be greater than du refresh " +
           "period, {} milliseconds", duConf.getRefreshPeriod().toMillis());
     }
+  }
+
+  /**
+   * Gets the {@link OzoneConfiguration} using which this configuration was
+   * constructed.
+   * @return the {@link OzoneConfiguration} being used by this configuration
+   */
+  public OzoneConfiguration getOzoneConfiguration() {
+    return this.ozoneConfiguration;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, ContainerBalancer creates a new OzoneConfiguration in ContainerBalancer#start and uses that. Instead, it should get the OzoneConfiguration object from ContainerBalancerConfiguration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5670

## How was this patch tested?

TestContainerBalancer UT
