### PR TITLE
HDDS-5676. When use s3g and goofys, some write operation will failed.

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -149,6 +149,11 @@ public class BucketEndpoint extends EndpointBase {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+      } else if (ex.getResult() == ResultCodes.FILE_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.FILE_NOT_FOUND, bucketName);
+      } else if (ex.getResult() == ResultCodes.DIRECTORY_NOT_FOUND) {
+        throw S3ErrorTable
+            .newError(S3ErrorTable.DIRECTORY_NOT_FOUND, bucketName);
       } else {
         throw ex;
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -120,6 +120,12 @@ public final class S3ErrorTable {
       "NotImplemented", "This part of feature is not implemented yet.",
       HTTP_NOT_IMPLEMENTED);
 
+  public static final OS3Exception FILE_NOT_FOUND = new OS3Exception(
+      "FileNotFind", "File is not found.", HTTP_NOT_FOUND);
+
+  public static final OS3Exception DIRECTORY_NOT_FOUND = new OS3Exception(
+      "DirectoryNotFind", "Directory is not found.", HTTP_NOT_FOUND);
+
   /**
    * Create a new instance of Error.
    * @param e Error Template


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3g should return FILE or Directory not found with 404.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5676

## How was this patch tested?

 manual tests. 

Reproduce case:

<img width="719" alt="截屏2021-08-30 下午5 30 36" src="https://user-images.githubusercontent.com/10381583/131320344-f20993bc-c3d9-44f2-8630-45d101b20737.png">

File 'abc' in bucket tmp is not created. 

## logs 

goofys related logs: 
```
-----------------------------------------------------
2021/08/30 17:32:34.104385 s3.DEBUG DEBUG: Response s3/ListObjects Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 500 Server Error
Connection: close
Content-Length: 380
Cache-Control: must-revalidate,no-cache,no-store
Content-Type: text/html;charset=iso-8859-1
Pragma: no-cache
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block


-----------------------------------------------------
2021/08/30 17:32:34.104455 s3.DEBUG DEBUG: Validate Response s3/ListObjects failed, not retrying, error SerializationError: failed to decode S3 XML error response
	status code: 500, request id: , host id:
caused by: expected element type <Error> but have <html>
2021/08/30 17:32:34.104499 s3.DEBUG LIST abc/ = resource temporarily unavailable
2021/08/30 17:32:34.104521 fuse.DEBUG <-- LookUpInode 1 abc resource temporarily unavailable
2021/08/30 17:32:34.104571 fuse.DEBUG Op 0x00000003        connection.go:493] -> Error: "resource temporarily unavailable"
2021/08/30 17:32:34.104593 fuse.ERROR *fuseops.LookUpInodeOp error: resource temporarily unavailable
```

s3g related logs:

```
Caused by: FILE_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: Unable to get file status: volume: s3v bucket: bucket key: abc/
	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.handleError(OzoneManagerProtocolClientSideTranslatorPB.java:613)
	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.listStatus(OzoneManagerProtocolClientSideTranslatorPB.java:1508)
	at org.apache.hadoop.ozone.client.rpc.RpcClient.listStatus(RpcClient.java:1278)
```