### PR TITLE
HDDS-5677. When use s3g and goofys , mkdir a directory but file is cr…

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -115,6 +115,8 @@ public class ObjectEndpoint extends EndpointBase {
   private static final Logger LOG =
       LoggerFactory.getLogger(ObjectEndpoint.class);
 
+  private static String delimiter = "/";
+
   @Context
   private HttpHeaders headers;
 
@@ -191,8 +193,12 @@ public class ObjectEndpoint extends EndpointBase {
       // Normal put object
       OzoneBucket bucket = getBucket(bucketName);
 
-      output = bucket.createKey(keyPath, length, replicationType,
-          replicationFactor, new HashMap<>());
+      if (keyPath.endsWith(delimiter)) {
+        bucket.createDirectory(keyPath);
+      } else {
+        output = bucket.createKey(keyPath, length, replicationType,
+            replicationFactor, new HashMap<>());
+      }
 
       if ("STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
           .equals(headers.getHeaderString("x-amz-content-sha256"))) {


### PR DESCRIPTION


## What changes were proposed in this pull request?

First mount bucket1

```
goofys --endpoint http://localhost:9878 bucket1 /mount/bucket1
````

Reproduce case:
when I mkdir /mount/bucket1/dir1, but I found /mount/bucket1/dir1 is a file in actually.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5677

## How was this patch tested?

manual tests
