### PR TITLE
HDDS-5680. Fix bug for incomplete SCM ratis metrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -526,7 +526,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     } else {
       clusterMap = new NetworkTopologyImpl(conf);
     }
-
+    // This needs to be done before initializing Ratis.
+    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap);
     if (configurator.getSCMHAManager() != null) {
       scmHAManager = configurator.getSCMHAManager();
     } else {
@@ -1262,8 +1263,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     ms = HddsServerUtil
         .initializeMetrics(configuration, "StorageContainerManager");
-
-    RatisDropwizardExports.registerRatisMetricReporters(ratisMetricsMap);
 
     commandWatcherLeaseManager.start();
     getClientProtocolServer().start();


### PR DESCRIPTION
## What changes were proposed in this pull request?

change the place where the RatisMetricReporters registers

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5680

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

CI

right now the metrics all appears
![WX20210826-204106](https://user-images.githubusercontent.com/10106574/130964321-3e9daf30-8ed7-4d05-a2e7-92e8b8cba6da.png)

