### PR TITLE
HDDS-5681. Speed up TestOzoneManagerHAWithACL

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithACL.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithACL.java
@@ -41,6 +41,20 @@ import static org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType.WRI
 public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
   @Test
+  public void testRunAllTests() throws Exception {
+    testAddBucketAcl();
+    testRemoveBucketAcl();
+    testSetBucketAcl();
+
+    testAddKeyAcl();
+    testRemoveKeyAcl();
+    testSetKeyAcl();
+
+    testAddPrefixAcl();
+    testRemovePrefixAcl();
+    testSetPrefixAcl();
+  }
+
   public void testAddBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -55,7 +69,7 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
     testAddAcl(remoteUserName, ozoneObj, defaultUserAcl);
   }
-  @Test
+
   public void testRemoveBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -72,7 +86,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
   }
 
-  @Test
   public void testSetBucketAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -112,7 +125,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
     return false;
   }
 
-  @Test
   public void testAddKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -131,7 +143,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
     testAddAcl(remoteUserName, ozoneObj, userAcl);
   }
 
-  @Test
   public void testRemoveKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -151,7 +162,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
   }
 
-  @Test
   public void testSetKeyAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -171,7 +181,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
   }
 
-  @Test
   public void testAddPrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -188,7 +197,7 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
     testAddAcl(remoteUserName, ozoneObj, defaultUserAcl);
   }
-  @Test
+
   public void testRemovePrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";
@@ -225,7 +234,6 @@ public class TestOzoneManagerHAWithACL extends TestOzoneManagerHA {
 
   }
 
-  @Test
   public void testSetPrefixAcl() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String remoteUserName = "remoteUser";


### PR DESCRIPTION
## What changes were proposed in this pull request?

The integration test class TestOzoneManagerHAWithACL takes about 370 seconds to run 9 tests. The vast majority of this runtime is spent setting up and destroying the mini-Clusters.

These tests are self contained within a bucket, so we can use a single cluster with a new bucket for each test with a small refactor. On my laptop this change makes the tests run in 34 seconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5681

## How was this patch tested?

Existing tests
