### PR TITLE
HDDS-5690. Speed up TestContainerReplication by removing testSkipDemmissionAndMaintenanceNode

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Random;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -48,6 +49,8 @@ import org.mockito.Mockito;
 
 import org.apache.commons.lang3.StringUtils;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
@@ -523,5 +526,34 @@ public class TestSCMContainerPlacementRackAware {
     stat = policy.validateContainerPlacement(dns, 1);
     assertTrue(stat.isPolicySatisfied());
     assertEquals(0, stat.misReplicationCount());
+  }
+
+  @Test
+  public void testOutOfServiceNodesNotSelected() throws SCMException {
+    List<DatanodeDetails> datanodeDetails =
+        policy.chooseDatanodes(null, null, 1, 0, 0);
+    Assert.assertEquals(1, datanodeDetails.size());
+
+    // Set all the nodes to out of service
+    for (DatanodeInfo dn : dnInfos) {
+      dn.setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
+    }
+
+    for (int i=0; i<10; i++) {
+      // Set a random DN to in_service and ensure it is always picked
+      int index = new Random().nextInt(dnInfos.size());
+      dnInfos.get(index).setNodeStatus(NodeStatus.inServiceHealthy());
+      try {
+        datanodeDetails =
+            policy.chooseDatanodes(null, null, 1, 0, 0);
+        Assert.assertEquals(dnInfos.get(index), datanodeDetails.get(0));
+      } catch (SCMException e) {
+        // If we get SCMException: No satisfied datanode to meet the ... this is
+        // ok, as there is only 1 IN_SERVICE node and with the retry logic we
+        // many never find it.
+      }
+
+      dnInfos.get(index).setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
+    }
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -529,11 +529,7 @@ public class TestSCMContainerPlacementRackAware {
   }
 
   @Test
-  public void testOutOfServiceNodesNotSelected() throws SCMException {
-    List<DatanodeDetails> datanodeDetails =
-        policy.chooseDatanodes(null, null, 1, 0, 0);
-    Assert.assertEquals(1, datanodeDetails.size());
-
+  public void testOutOfServiceNodesNotSelected() {
     // Set all the nodes to out of service
     for (DatanodeInfo dn : dnInfos) {
       dn.setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
@@ -544,15 +540,14 @@ public class TestSCMContainerPlacementRackAware {
       int index = new Random().nextInt(dnInfos.size());
       dnInfos.get(index).setNodeStatus(NodeStatus.inServiceHealthy());
       try {
-        datanodeDetails =
+        List<DatanodeDetails> datanodeDetails =
             policy.chooseDatanodes(null, null, 1, 0, 0);
         Assert.assertEquals(dnInfos.get(index), datanodeDetails.get(0));
       } catch (SCMException e) {
         // If we get SCMException: No satisfied datanode to meet the ... this is
         // ok, as there is only 1 IN_SERVICE node and with the retry logic we
-        // many never find it.
+        // may never find it.
       }
-
       dnInfos.get(index).setNodeStatus(new NodeStatus(DECOMMISSIONED, HEALTHY));
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestContainerReplication#testSkipDecommissionAndMaintenanceNode() was added as part of HDDS-5296. The test runs 3 times and sleeps for 30 seconds on each run to wait to ensure replication never hits an out of service node. Aside from the 30 second sleep, each run of the test takes about 1 minute, so 3 minutes in total for this test.

This class takes about 370 seconds on every pull request:

```
[INFO] Running org.apache.hadoop.ozone.container.TestContainerReplication
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 368.92 s - in org.apache.hadoop.ozone.container.TestContainerReplication
```
I feel this integration test is not needed. The logic we are testing here, is actually part of the placement policy and we can test for the original defect in TestSCMContainerPlacementRackAware much more efficiently and reliably.

Here I have added a new test to TestSCMContainerPlacementRackAware and removed the test mentioned above.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5690

## How was this patch tested?

New and existing tests
