### PR TITLE
HDDS-5692. Combine some tests in TestOzoneManagerHAWithData to reuse mini-Clusters

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -60,20 +60,15 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
   /**
    * Test a client request when all OM nodes are running. The request should
-   * succeed.
+   * succeed. Repeat with one OM node down.
    * @throws Exception
    */
   @Test
-  public void testAllOMNodesRunning() throws Exception {
+  public void testAllOMNodesRunningAndOneDown() throws Exception {
     createVolumeTest(true);
     createKeyTest(true);
-  }
 
-  /**
-   * Test client request succeeds even if one OM is down.
-   */
-  @Test
-  public void testOneOMNodeDown() throws Exception {
+    // Repeat the test with one OM down
     getCluster().stopOzoneManager(1);
     Thread.sleep(NODE_FAILURE_TIMEOUT * 4);
 
@@ -109,11 +104,17 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
     createMultipartKeyAndReadKey(ozoneBucket, keyName, uploadID);
 
+    testMultipartUploadWithOneOmNodeDown();
   }
 
-
   @Test
-  public void testFileOperationsWithRecursive() throws Exception {
+  public void testFileOperationsAndDelete() throws Exception {
+    testFileOperationsWithRecursive();
+    testFileOperationsWithNonRecursive();
+    testKeysDelete();
+  }
+
+  private void testFileOperationsWithRecursive() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
 
     String data = "random data";
@@ -152,8 +153,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
   }
 
-  @Test
-  public void testKeysDelete() throws Exception {
+  private void testKeysDelete() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
     String data = "random data";
     String keyName1 = "dir/file1";
@@ -193,8 +193,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
   }
 
 
-  @Test
-  public void testFileOperationsWithNonRecursive() throws Exception {
+  private void testFileOperationsWithNonRecursive() throws Exception {
     OzoneBucket ozoneBucket = setupBucket();
 
     String data = "random data";
@@ -250,8 +249,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
   }
 
-  @Test
-  public void testMultipartUploadWithOneOmNodeDown() throws Exception {
+  private void testMultipartUploadWithOneOmNodeDown() throws Exception {
 
     OzoneBucket ozoneBucket = setupBucket();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -277,7 +277,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     String newLeaderOMNodeId =
         omFailoverProxyProvider.getCurrentProxyOMNodeId();
 
-    Assert.assertTrue(leaderOMNodeId != newLeaderOMNodeId);
+    Assert.assertTrue(!leaderOMNodeId.equals(newLeaderOMNodeId));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some tests in TestOzoneManagerHAWithData can naturally be combined. For example some run the same test with all OMs up and then one OM down.

Some other tests can be run on the same cluster in isolated buckets, as they do not restart any nodes.

This test suit typically runs for about 490 seconds , so it would be good to reduce its runtime.

```
[INFO] Running org.apache.hadoop.ozone.om.TestOzoneManagerHAWithData
Warning:  Tests run: 12, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 490.975 s - in org.apache.hadoop.ozone.om.TestOzoneManagerHAWithData
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5692

## How was this patch tested?

Existing tests
