### PR TITLE
HDDS-5660. Separate container caches for Open and Closed containers.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -56,9 +56,10 @@ public final class ContainerCache {
   /**
    * Constructs a cache that holds DBHandle references.
    */
-  private ContainerCache(int maxSize, int stripes, float loadFactor, boolean
-      scanUntilRemovable) {
-    this.closeContainerCache = new CloseContainerCache(maxSize, loadFactor, scanUntilRemovable);
+  private ContainerCache(int maxSize, int stripes, float loadFactor,
+                         boolean scanUntilRemovable) {
+    this.closeContainerCache =
+        new CloseContainerCache(maxSize, loadFactor, scanUntilRemovable);
     this.rocksDBLock = Striped.lazyWeakLock(stripes);
     this.openContainerCache = new ConcurrentHashMap<>();
   }
@@ -285,7 +286,10 @@ public final class ContainerCache {
     return closeContainerCache;
   }
 
-  public class CloseContainerCache extends LRUMap {
+  /**
+   * Cache of closed containers.
+   */
+  public final class CloseContainerCache extends LRUMap {
     private CloseContainerCache(int maxSize, float loadFactor,
                                 boolean scanUntilRemovable) {
       super(maxSize, loadFactor, scanUntilRemovable);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -274,10 +274,10 @@ public final class ContainerCache {
     switch (state) {
     case CLOSED:
     case QUASI_CLOSED:
+    case UNHEALTHY:
       return false;
     case CLOSING:
     case OPEN:
-    case UNHEALTHY:
       return true;
     case INVALID:
     case DELETED:

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCache.java
@@ -266,7 +266,7 @@ public final class ContainerCache {
     }
   }
 
-  private boolean isContainerOpen(State state) {
+  public boolean isContainerOpen(State state) {
     switch (state) {
     case CLOSED:
     case QUASI_CLOSED:

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ContainerCacheMetrics.java
@@ -52,6 +52,18 @@ public final class ContainerCacheMetrics {
   @Metric("Number of Container Cache Evictions")
   private MutableCounterLong numCacheEvictions;
 
+  @Metric("Number of Open Container fetched successfully")
+  private MutableCounterLong numOpenContainerGetsSuccess;
+
+  @Metric("Number of Open Container fetches which failed")
+  private MutableCounterLong numOpenContainerGetsFailures;
+
+  @Metric("Number of Open Container added to Cache")
+  private MutableCounterLong numOpenContainerInserts;
+
+  @Metric("Number of Open Container removed from")
+  private MutableCounterLong numOpenContainerRemoves;
+
   private ContainerCacheMetrics(String name, MetricsSystem ms) {
     this.name = name;
     this.ms = ms;
@@ -110,5 +122,41 @@ public final class ContainerCacheMetrics {
 
   public long getNumCacheEvictions() {
     return numCacheEvictions.value();
+  }
+
+  public void incNumOpenContainerGetsSuccess() {
+    numOpenContainerGetsSuccess.incr();
+  }
+
+  public void incNumOpenContainerGetsFailures() {
+    numOpenContainerGetsFailures.incr();
+  }
+
+  public long getNumOpenContainerGetsSuccess() {
+    return numOpenContainerGetsSuccess.value();
+  }
+
+  public long getNumOpenContainerGetsFailures() {
+    return numOpenContainerGetsFailures.value();
+  }
+
+  public void incNumOpenContainerInserts() {
+    numOpenContainerInserts.incr();
+  }
+
+  public void incNumOpenContainerRemoves() {
+    numOpenContainerRemoves.incr();
+  }
+
+  public long getNumOpenContainerInserts() {
+    return numOpenContainerInserts.value();
+  }
+
+  public long getNumOpenContainerRemoves() {
+    return numOpenContainerRemoves.value();
+  }
+
+  public long getNumOpenCacheEntries() {
+    return numOpenContainerInserts.value() - numOpenContainerRemoves.value();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ReferenceCountedDB.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/ReferenceCountedDB.java
@@ -91,6 +91,10 @@ public class ReferenceCountedDB implements Closeable {
     return store;
   }
 
+  public String getContainerDBPath() {
+    return containerDBPath;
+  }
+
   @Override
   public void close() {
     decrementReference();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerPacker;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -341,6 +342,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       flushAndSyncDB();
       updateContainerData(containerData::quasiCloseContainer);
       clearPendingPutBlockCache();
+      // move the db to the closed container cache
+      ContainerCache cache = ContainerCache.getInstance(config);
+      cache.markContainerClosed(containerData.getDbFile().getAbsolutePath());
     } finally {
       writeUnlock();
     }
@@ -358,6 +362,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
       flushAndSyncDB();
       updateContainerData(containerData::closeContainer);
       clearPendingPutBlockCache();
+      // move the db to the closed container cache
+      ContainerCache cache = ContainerCache.getInstance(config);
+      cache.markContainerClosed(containerData.getDbFile().getAbsolutePath());
     } finally {
       writeUnlock();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -119,7 +119,7 @@ public final class BlockUtils {
     Preconditions.checkNotNull(containerData.getDbFile());
     try {
       return cache.getDB(containerData.getContainerID(), containerData
-          .getContainerDBType(), containerData.getDbFile().getAbsolutePath(),
+          .getState(), containerData.getDbFile().getAbsolutePath(),
               containerData.getSchemaVersion(), conf);
     } catch (IOException ex) {
       onFailure(containerData.getVolume());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/BlockUtils.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
@@ -160,10 +161,10 @@ public final class BlockUtils {
    * @param conf configuration.
    */
   public static void addDB(ReferenceCountedDB db, String containerDBPath,
-      ConfigurationSource conf) {
+      ConfigurationSource conf, State state) {
     ContainerCache cache = ContainerCache.getInstance(conf);
     Preconditions.checkNotNull(cache);
-    cache.addDB(containerDBPath, db);
+    cache.addDB(containerDBPath, db, state);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -24,7 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -117,7 +117,7 @@ public final class KeyValueContainerUtil {
     ReferenceCountedDB db =
         new ReferenceCountedDB(store, dbFile.getAbsolutePath());
     //add db handler into cache
-    BlockUtils.addDB(db, dbFile.getAbsolutePath(), conf);
+    BlockUtils.addDB(db, dbFile.getAbsolutePath(), conf, State.OPEN);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -213,13 +213,11 @@ public class ContainerReader implements Runnable {
             config);
         containerSet.addContainer(kvContainer);
         ContainerCache cache = ContainerCache.getInstance(config);
-        if (cache.isContainerOpen(kvContainerData.getState())) {
-          DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
-              kvContainerData, config, false);
-          String dbPath = kvContainerData.getDbFile().getAbsolutePath();
-          ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
-          cache.addDB(dbPath, db);
-        }
+        DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
+            kvContainerData, config, false);
+        String dbPath = kvContainerData.getDbFile().getAbsolutePath();
+        ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
+        cache.addDB(dbPath, db, kvContainerData.getState());
       } else {
         throw new StorageContainerException("Container File is corrupted. " +
             "ContainerType is KeyValueContainer but cast to " +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -212,7 +212,7 @@ public class ContainerReader implements Runnable {
             config);
         containerSet.addContainer(kvContainer);
         DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
-            kvContainerData, config, true);
+            kvContainerData, config, false);
         String dbPath = kvContainerData.getDbFile().getAbsolutePath();
         ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
         BlockUtils.addDB(db, dbPath, config);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerReader.java
@@ -30,12 +30,15 @@ import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 
+import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.KeyValueContainerUtil;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -208,6 +211,11 @@ public class ContainerReader implements Runnable {
         KeyValueContainer kvContainer = new KeyValueContainer(kvContainerData,
             config);
         containerSet.addContainer(kvContainer);
+        DatanodeStore store = BlockUtils.getUncachedDatanodeStore(
+            kvContainerData, config, true);
+        String dbPath = kvContainerData.getDbFile().getAbsolutePath();
+        ReferenceCountedDB db = new ReferenceCountedDB(store, dbPath);
+        BlockUtils.addDB(db, dbPath, config);
       } else {
         throw new StorageContainerException("Container File is corrupted. " +
             "ContainerType is KeyValueContainer but cast to " +

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.ozone.container.common.impl.TopNOrderedContainerDeletio
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.ContainerDispatcher;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.ReferenceCountedDB;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
@@ -215,6 +216,8 @@ public class TestBlockDeletingService {
       data = (KeyValueContainerData) containerSet.getContainer(
           containerID).getContainerData();
       data.setSchemaVersion(schemaVersion);
+      ContainerCache cCache = ContainerCache.getInstance(conf);
+      cCache.markContainerClosed(data.getDbFile().getAbsolutePath());
       if (schemaVersion.equals(SCHEMA_V1)) {
         createPendingDeleteBlocksSchema1(numOfBlocksPerContainer, data,
             containerID, numOfChunksPerBlock, buffer, chunkManager, container);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -76,8 +76,8 @@ public class TestContainerCache {
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
 
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir1 = new File(root, "cont1");
     File containerDir2 = new File(root, "cont2");
     File containerDir3 = new File(root, "cont3");
@@ -125,9 +125,11 @@ public class TestContainerCache {
         VersionedDatanodeFeatures.SchemaV2.chooseSchemaVersion(), conf);
     Assert.assertEquals(1, db4.getReferenceCount());
 
-    Assert.assertEquals(2, cache.size());
-    Assert.assertNotNull(cache.get(containerDir1.getPath()));
-    Assert.assertNull(cache.get(containerDir2.getPath()));
+    Assert.assertEquals(2, cache.getCloseContainerCache().size());
+    Assert.assertNotNull(cache.getCloseContainerCache()
+        .get(containerDir1.getPath()));
+    Assert.assertNull(cache.getCloseContainerCache()
+        .get(containerDir2.getPath()));
 
     // Now close both the references for container1
     db1.close();
@@ -160,8 +162,8 @@ public class TestContainerCache {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir = new File(root, "cont1");
     createContainerDB(conf, containerDir);
     ExecutorService executorService = Executors.newFixedThreadPool(2);
@@ -192,7 +194,7 @@ public class TestContainerCache {
     db.close();
     db.close();
     db.close();
-    Assert.assertEquals(1, cache.size());
+    Assert.assertEquals(1, cache.getCloseContainerCache().size());
     db.cleanup();
   }
 
@@ -205,8 +207,8 @@ public class TestContainerCache {
     conf.setInt(OzoneConfigKeys.OZONE_CONTAINER_CACHE_SIZE, 2);
 
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
-    Assert.assertEquals(0, cache.size());
+    cache.getCloseContainerCache().clear();
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
     File containerDir1 = new File(root, "cont1");
     File containerDir2 = new File(root, "cont2");
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestContainerCache.java
@@ -234,8 +234,8 @@ public class TestContainerCache {
     Assert.assertEquals(numOpenGetsFails + 1,
         metrics.getNumOpenContainerGetsFailures());
 
-    cache.addDB(containerDir1.getPath(), db1);
-    cache.addDB(containerDir2.getPath(), db2);
+    cache.addDB(containerDir1.getPath(), db1, State.OPEN);
+    cache.addDB(containerDir2.getPath(), db2, State.OPEN);
 
     Assert.assertEquals(2, metrics.getNumOpenCacheEntries());
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
+import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.utils.db.DatanodeDBProfile;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -345,6 +346,11 @@ public class TestKeyValueContainer {
    * Set container state to CLOSED.
    */
   private void closeContainer() {
+    if (keyValueContainerData.getDbFile() != null) {
+      ContainerCache.getInstance(CONF)
+          .markContainerClosed(keyValueContainerData
+              .getDbFile().getAbsolutePath());
+    }
     keyValueContainerData.setState(
         ContainerProtos.ContainerDataProto.State.CLOSED);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainer.java
@@ -516,6 +516,7 @@ public class TestKeyValueContainer {
     keyValueContainer = new KeyValueContainer(
         keyValueContainerData, CONF);
     keyValueContainer.create(volumeSet, volumeChoosingPolicy, scmId);
+    closeContainer();
 
     try (ReferenceCountedDB db =
         BlockUtils.getDB(keyValueContainerData, CONF)) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerReader.java
@@ -276,7 +276,7 @@ public class TestContainerReader {
         new MutableVolumeSet(datanodeId.toString(), clusterId, conf, null,
             StorageVolume.VolumeType.DATA_VOLUME, null);
     ContainerCache cache = ContainerCache.getInstance(conf);
-    cache.clear();
+    cache.getCloseContainerCache().clear();
 
     RoundRobinVolumeChoosingPolicy policy =
         new RoundRobinVolumeChoosingPolicy();
@@ -329,6 +329,6 @@ public class TestContainerReader {
         containerSet.getContainerMap().entrySet().size());
     // There should be no open containers cached by the ContainerReader as it
     // opens and closed them avoiding the cache.
-    Assert.assertEquals(0, cache.size());
+    Assert.assertEquals(0, cache.getCloseContainerCache().size());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureDetection.java
@@ -263,6 +263,8 @@ public class TestDatanodeHddsVolumeFailureDetection {
         .ONE, OzoneConsts.OZONE);
     Assert.assertTrue(c2.getContainerInfo().getState()
         .equals(HddsProtos.LifeCycleState.OPEN));
+    Container c2Container = oc.getContainerSet().getContainer(2);
+    c2Container.close();
 
     // corrupt db by rename dir->file
     File metadataDir = new File(c1.getContainerFile().getParent());


### PR DESCRIPTION
## What changes were proposed in this pull request?

It has been seen in deployments that with large number of containers on datanodes. we have seen cache misses on the rocksDB cache.

This patch proposes
a) to have separate caches for open and closed container
b) rocksDB containers in open container cache are never evicted.
c) Open containers are moved from open to close container cache it they are closed/quasi closed.
d) Closed container are cached in LRU fashion as they are cached right now


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5660

## How was this patch tested?
Added a new unit test
