### PR TITLE
HDDS-5678. Handle unsecure SCM HA converted to secure SCM HA.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -915,15 +915,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           scmStorageConfig.getScmId());
 
       // Initialize security if security is enabled later.
-      if (OzoneSecurityUtil.isSecurityEnabled(conf)
-          && scmStorageConfig.getScmCertSerialId() == null) {
-        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
-            getScmAddress(scmhaNodeDetails, conf), true);
-        scmStorageConfig.forceInitialize();
-        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
-                "Persisted SCM Certificate SerialID {}",
-            scmStorageConfig.getScmCertSerialId());
-      }
+      initializeSecurityIfNeeded(conf, scmhaNodeDetails, scmStorageConfig);
 
       return true;
     }
@@ -948,15 +940,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
 
       // Initialize security if security is enabled later.
-      if (OzoneSecurityUtil.isSecurityEnabled(conf)
-          && scmStorageConfig.getScmCertSerialId() == null) {
-        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
-            getScmAddress(scmhaNodeDetails, conf), true);
-        scmStorageConfig.forceInitialize();
-        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
-                "Persisted SCM Certificate SerialID {}",
-            scmStorageConfig.getScmCertSerialId());
-      }
+      initializeSecurityIfNeeded(conf, scmhaNodeDetails, scmStorageConfig);
 
     } else {
       try {
@@ -985,6 +969,29 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       }
     }
     return true;
+  }
+
+  /**
+   * Initialize security If Ozone security is enabled and
+   * ScmStorageConfig does not have certificate serial id.
+   * @param conf
+   * @param scmhaNodeDetails
+   * @param scmStorageConfig
+   * @throws IOException
+   */
+  private static void initializeSecurityIfNeeded(OzoneConfiguration conf,
+      SCMHANodeDetails scmhaNodeDetails, SCMStorageConfig scmStorageConfig)
+      throws IOException {
+    // Initialize security if security is enabled later.
+    if (OzoneSecurityUtil.isSecurityEnabled(conf)
+        && scmStorageConfig.getScmCertSerialId() == null) {
+      HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
+          getScmAddress(scmhaNodeDetails, conf), true);
+      scmStorageConfig.forceInitialize();
+      LOG.info("SCM unsecure cluster is converted to secure cluster. " +
+              "Persisted SCM Certificate SerialID {}",
+          scmStorageConfig.getScmCertSerialId());
+    }
   }
 
   /**
@@ -1068,15 +1075,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       final boolean isSCMHAEnabled = scmStorageConfig.isSCMHAEnabled();
 
       // Initialize security if security is enabled later.
-      if (OzoneSecurityUtil.isSecurityEnabled(conf)
-          && scmStorageConfig.getScmCertSerialId() == null) {
-        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
-            getScmAddress(haDetails, conf), true);
-        scmStorageConfig.forceInitialize();
-        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
-                "Persisted SCM Certificate SerialID {}",
-            scmStorageConfig.getScmCertSerialId());
-      }
+      initializeSecurityIfNeeded(conf, haDetails, scmStorageConfig);
 
       if (SCMHAUtils.isSCMHAEnabled(conf) && !isSCMHAEnabled) {
         SCMRatisServerImpl.initialize(scmStorageConfig.getClusterID(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -913,6 +913,18 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       LOG.info("Skipping clusterId validation during bootstrap command.  "
               + "ClusterId id {}, SCM id {}", persistedClusterId,
           scmStorageConfig.getScmId());
+
+      // Initialize security if security is enabled later.
+      if (OzoneSecurityUtil.isSecurityEnabled(conf)
+          && scmStorageConfig.getScmCertSerialId() == null) {
+        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
+            getScmAddress(scmhaNodeDetails, conf), true);
+        scmStorageConfig.forceInitialize();
+        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
+                "Persisted SCM Certificate SerialID {}",
+            scmStorageConfig.getScmCertSerialId());
+      }
+
       return true;
     }
 
@@ -934,6 +946,18 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
                 + "is {}", persistedClusterId, fetchedId);
         return false;
       }
+
+      // Initialize security if security is enabled later.
+      if (OzoneSecurityUtil.isSecurityEnabled(conf)
+          && scmStorageConfig.getScmCertSerialId() == null) {
+        HASecurityUtils.initializeSecurity(scmStorageConfig, conf,
+            getScmAddress(scmhaNodeDetails, conf), true);
+        scmStorageConfig.forceInitialize();
+        LOG.info("SCM unsecure cluster is converted to secure cluster. " +
+                "Persisted SCM Certificate SerialID {}",
+            scmStorageConfig.getScmCertSerialId());
+      }
+
     } else {
       try {
         scmStorageConfig.setClusterId(fetchedId);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Handle unsecure SCM HA converted to secure SCM HA. This PR covers for bootstrapped SCMs, unlike HDDS-5273 which has taken care only for primordial/single node SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5678

## How was this patch tested?

Tested following scenario.
1. Setup SCM HA Cluster with out security
2. Enabled Kerberos
3. Started Ozone Services

**Logs from testing** (Skipped unncessary part of logs to show actual logs to show this PR has fixed the problem.

```
STARTUP_MSG: Starting StorageContainerManager
STARTUP_MSG:   host = bv-oz-4.bv-oz.root.hwx.site/172.27.99.0
STARTUP_MSG:   args = [--bootstrap]
STARTUP_MSG:   version = 1.1.0.7.2.12.0-200
2021-08-30 07:50:55,866 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManager: Skipping clusterId validation during bootstrap command.  ClusterId id CID-6fa9d66e-d857-4bd9-86a9-f293654cec20, SCM id b9285a61-463e-4eea-8d60-62fa62fcfeb8
2021-08-30 07:50:55,869 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Initializing secure StorageContainerManager.
2021-08-30 07:50:56,193 ERROR org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient: Default certificate serial id is not set. Can't locate the default certificate for this client.
2021-08-30 07:50:56,193 INFO org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient: Certificate client init case: 0
2021-08-30 07:50:56,194 INFO org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient: Creating keypair for client as keypair and certificate not found.
2021-08-30 07:50:56,628 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Init response: GETCERT
2021-08-30 07:50:57,207 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:fe80:0:0:0:42:acff:fe1b:6300%eth0 not returned.
2021-08-30 07:50:57,207 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: Adding ip:172.27.99.0,host:bv-oz-4.bv-oz.root.hwx.site
2021-08-30 07:50:57,207 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:0:0:0:0:0:0:0:1%lo not returned.
2021-08-30 07:50:57,207 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:127.0.0.1 not returned.
2021-08-30 07:50:57,294 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:fe80:0:0:0:42:acff:fe1b:6300%eth0 not returned.
2021-08-30 07:50:57,294 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: Adding ip:172.27.99.0,host:bv-oz-4.bv-oz.root.hwx.site
2021-08-30 07:50:57,295 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:0:0:0:0:0:0:0:1%lo not returned.
2021-08-30 07:50:57,295 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:127.0.0.1 not returned.
2021-08-30 07:50:57,296 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Creating csr for SCM->hostName:bv-oz-4.bv-oz.root.hwx.site,scmId:b9285a61-463e-4eea-8d60-62fa62fcfeb8,clusterId:CID-6fa9d66e-d857-4bd9-86a9-f293654cec20,subject:scm-sub@bv-oz-4.bv-oz.root.hwx.site
2021-08-30 07:50:57,351 INFO org.apache.hadoop.hdds.scm.ha.HASecurityUtils: Successfully stored SCM signed certificate.
2021-08-30 07:50:57,356 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManager: SCM unsecure cluster is converted to secure cluster. Persisted SCM Certificate SerialID 49003249912697594
2021-08-30 07:50:57,358 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SHUTDOWN_MSG:
```

**Before this fix for reference:**
```
2021-08-30 07:40:53,822 ERROR org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SCM start failed with exception
java.lang.IllegalStateException: INTERMEDIARY_CA Should not be in Initialize State during startup.
        at org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultCAServer.lambda$processVerificationStatus$4(DefaultCAServer.java:496)
        at org.apache.hadoop.hdds.security.x509.certificate.authority.DefaultCAServer.init(DefaultCAServer.java:170)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.initializeCAnSecurityProtocol(StorageContainerManager.java:616)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:327)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:440)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:452)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter$SCMStarterHelper.start(StorageContainerManagerStarter.java:165)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.startScm(StorageContainerManagerStarter.java:139)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:68)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:44)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
        at picocli.CommandLine.access$1100(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2152)
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:2530)
        at picocli.CommandLine.parseWithHandler(CommandLine.java:2465)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:96)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:87)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.main(StorageContainerManagerStarter.java:57)
```