### PR TITLE
HDDS-5701. Add auditLog when DN register fail

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -239,6 +239,8 @@ public class SCMDatanodeProtocolServer implements
       eventPublisher.fireEvent(PIPELINE_REPORT,
               new PipelineReportFromDatanode(datanodeDetails,
                       pipelineReportsProto));
+    } else {
+      auditSuccess = false;
     }
     try {
       return getRegisteredResponse(registeredCommand);
@@ -251,6 +253,9 @@ public class SCMDatanodeProtocolServer implements
       if(auditSuccess) {
         AUDIT.logWriteSuccess(
             buildAuditMessageForSuccess(SCMAction.REGISTER, auditMap));
+      } else {
+        AUDIT.logWriteFailure(
+            buildAuditMessageForFailure(SCMAction.REGISTER, auditMap, null));
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

I recently upgraded the scm, after upgrade I found the dn can not register to scm.
So, I checked the audit log and want to know why it failed，the audit log like this
`2021-08-31 14:47:07,920 | INFO  | SCMAudit | user=ozone | ip=localhost | op=REGISTER {datanodeDetails=161de39c-0ffe-4d39-8f81-f66fbd8148a7{ip: localhost, host: , ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: null, persistedOpStateExpiryEpochSec: 0}} | ret=SUCCESS |`
the audit log is still register success, but the real thing is that the dn registration failed.
The register dn layout version lower than scm version, it may be that we need to log the failure in the audit.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5701