### PR TITLE
HDDS-5211. Start OM Grpc server as part of the OM bootstrap

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -276,4 +276,9 @@ public final class OMConfigKeys {
       "ozone.path.deleting.limit.per.task";
   public static final int OZONE_PATH_DELETING_LIMIT_PER_TASK_DEFAULT = 10000;
 
+  public static final String OZONE_OM_S3_GPRC_SERVER_ENABLED =
+      "ozone.om.s3.grpc.server_enabled";
+  public static final boolean OZONE_OM_S3_GRPC_SERVER_ENABLED_DEFAULT =
+      false;
+
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -81,6 +81,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,
         OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY,
         OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
+        OMConfigKeys.OZONE_OM_S3_GPRC_SERVER_ENABLED,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -38,7 +38,6 @@ public class GrpcOzoneManagerServer {
       LoggerFactory.getLogger(GrpcOzoneManagerServer.class);
 
   private Server server;
-  private final String host = "0.0.0.0";
   private int port = 8981;
 
   public GrpcOzoneManagerServer(GrpcOzoneManagerServerConfig omServerConfig,
@@ -66,13 +65,15 @@ public class GrpcOzoneManagerServer {
   public void stop() {
     try {
       server.shutdown().awaitTermination(10L, TimeUnit.SECONDS);
+      LOG.info("Server {} is shutdown", getClass().getSimpleName());
     } catch (InterruptedException ex) {
       LOG.warn("{} couldn't be stopped gracefully", getClass().getSimpleName());
     }
   }
 
   public int getPort() {
-    return port; }
+    return port;
+  }
 
   /**
    * GrpcOzoneManagerServer configuration in Java style configuration class.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
+import io.grpc.Server;
+import io.grpc.netty.NettyServerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Separated network server for gRPC transport OzoneManagerService s3g->OM.
+ */
+public class GrpcOzoneManagerServer {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(GrpcOzoneManagerServer.class);
+
+  private Server server;
+  private final String host = "0.0.0.0";
+  private int port = 8981;
+
+  public GrpcOzoneManagerServer(GrpcOzoneManagerServerConfig omServerConfig,
+                                OzoneManagerProtocolServerSideTranslatorPB
+                                    omTranslator) {
+    this.port = omServerConfig.getPort();
+    init(omTranslator);
+  }
+
+  public void init(OzoneManagerProtocolServerSideTranslatorPB omTranslator) {
+    NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
+        .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
+        .addService(new OzoneManagerServiceGrpc(omTranslator));
+
+    server = nettyServerBuilder.build();
+  }
+
+  public void start() throws IOException {
+    server.start();
+    LOG.info("{} is started using port {}", getClass().getSimpleName(),
+        server.getPort());
+    port = server.getPort();
+  }
+
+  public void stop() {
+    try {
+      server.shutdown().awaitTermination(10L, TimeUnit.SECONDS);
+    } catch (InterruptedException ex) {
+      LOG.warn("{} couldn't be stopped gracefully", getClass().getSimpleName());
+    }
+  }
+
+  public int getPort() {
+    return port; }
+
+  /**
+   * GrpcOzoneManagerServer configuration in Java style configuration class.
+   */
+  @ConfigGroup(prefix = "ozone.om.grpc")
+  public static final class GrpcOzoneManagerServerConfig {
+    @Config(key = "port", defaultValue = "8981",
+        description = "Port used for"
+            + " the GrpcOmTransport OzoneManagerServiceGrpc server",
+        tags = {ConfigTag.MANAGEMENT})
+    private int port;
+
+    public int getPort() {
+      return port;
+    }
+
+    public GrpcOzoneManagerServerConfig setPort(int portParam) {
+      this.port = portParam;
+      return this;
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -72,8 +72,8 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
       // and importantly random ClientId.  This is currently necessary for
       // Om Ratis Server to create createWriteRaftClientRequest.
       // Look to remove Server class requirement for issuing ratis transactions
-      // for OMRequests.  Test through successful ratis-enabled OMRequest handling
-      // without dependency on hadoop IPC based Server.
+      // for OMRequests.  Test through successful ratis-enabled OMRequest 
+      // handling without dependency on hadoop IPC based Server.
       omResponse = this.omTranslator.
           submitRequest(NULL_RPC_CONTROLLER, request);
     } catch (Throwable e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.ozone.om;
 
 import com.google.protobuf.RpcController;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -18,16 +18,20 @@
 package org.apache.hadoop.ozone.om;
 
 import com.google.protobuf.RpcController;
-import com.google.protobuf.ServiceException;
 import org.apache.hadoop.ipc.ClientId;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerServiceGrpc.OzoneManagerServiceImplBase;
 import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocol.proto
+    .OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto
+    .OzoneManagerProtocolProtos.OMResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -48,19 +52,15 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
   }
 
   @Override
-  public void submitRequest(org.apache.hadoop.ozone.protocol.proto.
-                                OzoneManagerProtocolProtos.
-                                OMRequest request,
-                            io.grpc.stub.StreamObserver<org.apache.
-                                hadoop.ozone.protocol.proto.
-                                OzoneManagerProtocolProtos.OMResponse>
+  public void submitRequest(OMRequest request,
+                            io.grpc.stub.StreamObserver<OMResponse>
                                 responseObserver) {
-    LOG.debug("GrpcOzoneManagerServer: OzoneManagerServiceImplBase " +
-        "processing s3g client submit request");
+    LOG.debug("OzoneManagerServiceGrpc: OzoneManagerServiceImplBase " +
+        "processing s3g client submit request - for command {}",
+        request.getCmdType().name());
     AtomicInteger callCount = new AtomicInteger(0);
+    OMResponse omResponse;
     try {
-      // need to look into handling the error path, trapping exception
-      // will be generating OmResponse with status fail & OmException shortly
       org.apache.hadoop.ipc.Server.getCurCall().set(new Server.Call(1,
           callCount.incrementAndGet(),
           null,
@@ -68,11 +68,34 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
           RPC.RpcKind.RPC_PROTOCOL_BUFFER,
           ClientId.getClientId()));
 
-      OMResponse omResponse = this.omTranslator.
+      omResponse = this.omTranslator.
           submitRequest(NULL_RPC_CONTROLLER, request);
-      responseObserver.onNext(omResponse);
-    } catch (ServiceException e) {}
+    } catch (Throwable e) {
+      omResponse = createErrorResponse(
+          request,
+          new IOException(e));
+    }
+    responseObserver.onNext(omResponse);
     responseObserver.onCompleted();
   }
-}
 
+  /**
+   * Create OMResponse from the specified OMRequest and exception.
+   *
+   * @param omRequest
+   * @param exception
+   * @return OMResponse
+   */
+  private OMResponse createErrorResponse(
+      OMRequest omRequest, IOException exception) {
+    OMResponse.Builder omResponse = OMResponse.newBuilder()
+        .setStatus(OzoneManagerRatisUtils.exceptionToResponseStatus(exception))
+        .setCmdType(omRequest.getCmdType())
+        .setTraceID(omRequest.getTraceID())
+        .setSuccess(false);
+    if (exception.getMessage() != null) {
+      omResponse.setMessage(exception.getMessage());
+    }
+    return omResponse.build();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -67,7 +67,13 @@ public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
           null,
           RPC.RpcKind.RPC_PROTOCOL_BUFFER,
           ClientId.getClientId()));
-
+      // TODO: currently require setting the Server class for each request
+      // with thread context (Server.Call()) that includes retries
+      // and importantly random ClientId.  This is currently necessary for
+      // Om Ratis Server to create createWriteRaftClientRequest.
+      // Look to remove Server class requirement for issuing ratis transactions
+      // for OMRequests.  Test through successful ratis-enabled OMRequest handling
+      // without dependency on hadoop IPC based Server.
       omResponse = this.omTranslator.
           submitRequest(NULL_RPC_CONTROLLER, request);
     } catch (Throwable e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerServiceGrpc.java
@@ -1,0 +1,61 @@
+package org.apache.hadoop.ozone.om;
+
+import com.google.protobuf.RpcController;
+import com.google.protobuf.ServiceException;
+import org.apache.hadoop.ipc.ClientId;
+import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerServiceGrpc.OzoneManagerServiceImplBase;
+import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Grpc Service for handling S3 gateway OzoneManagerProtocol client requests.
+ */
+public class OzoneManagerServiceGrpc extends OzoneManagerServiceImplBase {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneManagerServiceGrpc.class);
+  /**
+   * RpcController is not used and hence is set to null.
+   */
+  private static final RpcController NULL_RPC_CONTROLLER = null;
+  private OzoneManagerProtocolServerSideTranslatorPB omTranslator;
+
+  OzoneManagerServiceGrpc(
+      OzoneManagerProtocolServerSideTranslatorPB omTranslator) {
+    this.omTranslator = omTranslator;
+  }
+
+  @Override
+  public void submitRequest(org.apache.hadoop.ozone.protocol.proto.
+                                OzoneManagerProtocolProtos.
+                                OMRequest request,
+                            io.grpc.stub.StreamObserver<org.apache.
+                                hadoop.ozone.protocol.proto.
+                                OzoneManagerProtocolProtos.OMResponse>
+                                responseObserver) {
+    LOG.debug("GrpcOzoneManagerServer: OzoneManagerServiceImplBase " +
+        "processing s3g client submit request");
+    AtomicInteger callCount = new AtomicInteger(0);
+    try {
+      // need to look into handling the error path, trapping exception
+      // will be generating OmResponse with status fail & OmException shortly
+      org.apache.hadoop.ipc.Server.getCurCall().set(new Server.Call(1,
+          callCount.incrementAndGet(),
+          null,
+          null,
+          RPC.RpcKind.RPC_PROTOCOL_BUFFER,
+          ClientId.getClientId()));
+
+      OMResponse omResponse = this.omTranslator.
+          submitRequest(NULL_RPC_CONTROLLER, request);
+      responseObserver.onNext(omResponse);
+    } catch (ServiceException e) {}
+    responseObserver.onCompleted();
+  }
+}
+

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
@@ -39,7 +39,7 @@ public class TestGrpcOzoneManagerServer {
   private GrpcOzoneManagerServer server;
 
   @Rule
-  public Timeout timeout = Timeout.seconds(300);
+  public Timeout timeout = Timeout.seconds(30);
 
   @Test
   public void testStartStop() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.mockito.Mockito;
+import org.apache.hadoop.ozone.protocolPB.OzoneManagerProtocolServerSideTranslatorPB;
+
+/**
+ * Tests for GrpcOzoneManagerServer.
+ */
+public class TestGrpcOzoneManagerServer {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestGrpcOzoneManagerServer.class);
+  private OzoneManager ozoneManager;
+  private OzoneManagerProtocolServerSideTranslatorPB omServerProtocol;
+  private GrpcOzoneManagerServer server;
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  @Test
+  public void testStartStop() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    ozoneManager = Mockito.mock(OzoneManager.class);
+    omServerProtocol = ozoneManager.getOmServerProtocol();
+
+    server = new GrpcOzoneManagerServer(conf.getObject(
+            GrpcOzoneManagerServer.GrpcOzoneManagerServerConfig.class),
+        omServerProtocol);
+
+    try {
+      server.start();
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      server.stop();
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
This PR includes the Grpc server service servicing `OzoneManagerProtocol` requests over gRPC invoked by the OM.  The server consists of `GrpcOzoneManagerServer` that is started by the OM and establishes the persistent connection between the om and the s3 gateway (current port 8981 and configurable by java configuration class).  The server creates the connection with the `OzoneManagerServiceGrpc` that services `OMRequests` through the  `OzoneManagerProtocolServerSideTranslatorPB`.

The `OzoneManagerServiceGrpc` requires creating a thread context '`Server.Call`' for every ratis transaction request processed through the `OzoneManagerProtocolServerSideTranslatorPB`.


The Grpc server service is enabled / disabled through the boolean configuration key : `OZONE_OM_S3_GPRC_SERVER_ENABLED` and corresponding property `ozone.om.s3.grpc.server_enabled`.  

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5211

## How was this patch tested?
Patch was tested in 2 ways, 

1. Unit test `TestGrpcOzoneManagerServer`:
Tests invoking Om gRPC service - creating gRPC server channel invoking grpc service to service OzoneManagerProtocol requests and tearing down service.
`$ cd hadoop-ozone/ozone-manager`
`$ mvn -Dtest=TestGrpcOzoneManagerServer test`

```
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestGrpcOzoneManagerServer
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 2.067 s - in org.apache.hadoop.ozone.om.TestGrpcOzoneManagerServer
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

2. Manual testing through configuring `ozone-site.xml `to enable (true)/ disable (false) ozone-manager Grpc server service through property   
```
<property>
    <name>ozone.om.s3.grpc.server_enabled</name>
    <value>true</value>
  </property>
```
Ensuring that gRPC server is started by OM when enabled and not started when disabled though log4j logs.
eg. 
`INFO  om.GrpcOzoneManagerServer (GrpcOzoneManagerServer.java:start(61)) - GrpcOzoneManagerServer is started using port 8981
`
