### PR TITLE
HDDS-4819. Configuration property for OM to define bind address

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -495,7 +495,8 @@
     <tag>OM, REQUIRED</tag>
     <description>
       The address of the Ozone OM service. This allows clients to discover
-      the address of the OM.
+      the address of the OM. When ozone.om.bind.host is undefined, it falls
+      back to this configuration for server side port number.
     </description>
   </property>
   <property>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -62,6 +62,7 @@ import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_BIND_HOST_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_BIND_PORT_DEFAULT;
@@ -110,6 +111,15 @@ public final class OmUtils {
   }
 
   /**
+   * Retrieve the socket address that is bound by OM server.
+   * @param conf
+   * @return Target InetSocketAddress for the SCM service endpoint.
+   */
+  public static InetSocketAddress getOmBindAddress(ConfigurationSource conf) {
+    return NetUtils.createSocketAddr(getOmRpcBindAddress(conf));
+  }
+
+  /**
    * Return list of OM addresses by service ids - when HA is enabled.
    *
    * @param conf {@link ConfigurationSource}
@@ -148,6 +158,21 @@ public final class OmUtils {
 
     return host.orElse(OZONE_OM_BIND_HOST_DEFAULT) + ":" +
         getOmRpcPort(conf);
+  }
+
+
+  /**
+   * Retrieve the socket address that is bound by OM. If undefined,
+   * it falls back to the value from OZONE_OM_ADDRESS_KEY.
+   * @param conf
+   * @return Target InetSocketAddress for the SCM service endpoint.
+   */
+  public static String getOmRpcBindAddress(ConfigurationSource conf) {
+    final String host = conf.get(OZONE_OM_BIND_HOST_KEY);
+    if (host != null) {
+      return host;
+    }
+    return getOmRpcAddress(conf);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -51,6 +51,8 @@ public final class OMConfigKeys {
 
   public static final String OZONE_OM_ADDRESS_KEY =
       "ozone.om.address";
+  public static final String OZONE_OM_BIND_HOST_KEY =
+      "ozone.om.bind.host";
   public static final String OZONE_OM_BIND_HOST_DEFAULT =
       "0.0.0.0";
   public static final int OZONE_OM_PORT_DEFAULT = 9862;

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import static org.apache.hadoop.ozone.OmUtils.getOmHostsFromConfig;
 import static org.apache.hadoop.ozone.OmUtils.getOzoneManagerServiceId;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
@@ -183,6 +184,31 @@ public class TestOmUtils {
     Assert.assertTrue(hosts.contains("om1-host"));
 
     Assert.assertTrue(getOmHostsFromConfig(conf, "newId").isEmpty());
+  }
+
+  @Test
+  public void testBindAddressFromConfig() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "1.2.3.4:9999");
+    conf.set(OZONE_OM_BIND_HOST_KEY, "0.0.0.0:10042");
+
+    Assert.assertEquals("1.2.3.4",
+            OmUtils.getOmAddress(conf).getHostName());
+    Assert.assertEquals("0.0.0.0",
+            OmUtils.getOmBindAddress(conf).getHostName());
+    Assert.assertEquals(10042, OmUtils.getOmBindAddress(conf).getPort());
+  }
+
+  @Test
+  public void testBindAddressFromEmptyConfig() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_ADDRESS_KEY, "1.2.3.4:9999");
+
+    Assert.assertEquals("1.2.3.4",
+            OmUtils.getOmAddress(conf).getHostName());
+    Assert.assertEquals("1.2.3.4",
+            OmUtils.getOmBindAddress(conf).getHostName());
+    Assert.assertEquals(9999, OmUtils.getOmBindAddress(conf).getPort());
   }
 }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneHAClusterImpl.java
@@ -463,6 +463,11 @@ public class MiniOzoneHAClusterImpl extends MiniOzoneClusterImpl {
             config.set(OMConfigKeys.OZONE_OM_HTTP_ADDRESS_KEY, "");
             config.set(OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY, "");
 
+            String omBindAddrKey = ConfUtils.addKeySuffixes(
+                    OMConfigKeys.OZONE_OM_ADDRESS_KEY, omServiceId, nodeId);
+            String omBindAddr = config.get(omBindAddrKey);
+            config.set(OMConfigKeys.OZONE_OM_BIND_HOST_KEY, omBindAddr);
+
             // Set metadata/DB dir base path
             String metaDirPath = path + "/" + nodeId;
             config.set(OZONE_METADATA_DIRS, metaDirPath);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -100,7 +100,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_INTERVAL_DELAY,
         ReconServerConfigKeys.RECON_OM_SNAPSHOT_TASK_FLUSH_PARAM,
         OMConfigKeys.OZONE_OM_RATIS_SNAPSHOT_AUTO_TRIGGER_THRESHOLD_KEY,
-        OMConfigKeys.OZONE_OM_HA_PREFIX
+        OMConfigKeys.OZONE_OM_HA_PREFIX,
+        OMConfigKeys.OZONE_OM_BIND_HOST_KEY
         // TODO HDDS-2856
     ));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -57,6 +57,7 @@ public class OMHANodeDetails {
       OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY,
       OMConfigKeys.OZONE_OM_DB_DIRS,
       OMConfigKeys.OZONE_OM_ADDRESS_KEY,
+      OMConfigKeys.OZONE_OM_BIND_HOST_KEY,
   };
 
   public static final Logger LOG =
@@ -192,8 +193,9 @@ public class OMHANodeDetails {
       if (found == 1) {
 
         LOG.info("Found matching OM address with OMServiceId: {}, " +
-                "OMNodeId: {}, RPC Address: {} and Ratis port: {}",
-            localOMServiceId, localOMNodeId,
+                "OMNodeId: {}, RPC Listen Address: {}, RPC Address: {} " +
+                "and Ratis port: {}",
+            localOMServiceId, localOMNodeId, OmUtils.getOmBindAddress(conf),
             NetUtils.getHostPortString(localRpcAddress), localRatisPort);
 
         ConfUtils.setNodeSpecificConfigs(genericConfigKeys, conf,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, "OZONE_OM_ADDRESS_KEY" (="ozone.om.address") is used both for client side and for server side. This is nice for unifying configuration files in both clients and servers, but in case where OM has multiple IP addresses and want to bind "0.0.0.0", the config file cannot be naively copied for clients' usage.

This patch proposes a new configuration key `ozone.om.bind.host` to define the host and port to which OM binds itself. If it is undefined, it falls back to previous behaviour, listening to `ozone.om.address` . For this fallback system, `ozone-default.xml` is not updated. Clients (SCM, S3G) never uses this as an address to connect to.

## What is the link to the Apache JIRA

HDDS-4819

## How was this patch tested?

unit test
