### PR TITLE
HDDS-5709. do not call removeTransactionsFromDB if nothing to remove

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -416,9 +416,10 @@ public class DeletedBlockLogImpl
             txIDs.add(txn.getTxID());
           }
         }
-
-        deletedBlockLogStateManager.removeTransactionsFromDB(txIDs);
-        metrics.incrBlockDeletionTransactionCompleted(txIDs.size());
+        if (!txIDs.isEmpty()) {
+          deletedBlockLogStateManager.removeTransactionsFromDB(txIDs);
+          metrics.incrBlockDeletionTransactionCompleted(txIDs.size());
+        }
       }
       return transactions;
     } finally {


### PR DESCRIPTION
## What changes were proposed in this pull request?

for now, blockingDeleting service will delete keys periodically and thus `removeTransactionsFromDB` will  be called periodically  , which is generate a raft log when scm ha is enabled.  if nothing to remove, a raft log will also be generated , which will delele nothing. this is not needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5709

## How was this patch tested?

no need 
