### PR TITLE
HDDS-5615 Add a simple test suite for HTTPFS GW

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -50,6 +50,7 @@ execute_robot_test scm freon
 execute_robot_test scm cli
 execute_robot_test scm admincli
 
+execute_robot_test scm httpfs
 
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-simple-ofs-bucket ozonefs/ozonefs.robot
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:link -N ozonefs-simple-o3fs-link ozonefs/ozonefs.robot

--- a/hadoop-ozone/dist/src/main/smoketest/httpfs/operations.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/httpfs/operations.robot
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Library             Process
+Library             BuiltIn
+Library             String
+
+*** Variables ***
+${URL}          http://httpfs:14000/webhdfs/v1/
+${USERNAME}     hdfs
+
+*** Keywords ***
+Execute curl command
+    [Arguments]       ${path}           ${operation}    ${extra_commands}
+    ${final_url} =    Catenate          SEPARATOR=      ${URL}  ${path}  ?op=  ${operation}    &user.name=   ${USERNAME}
+    ${output}         Run process       curl ${extra_commands} "${final_url}"    shell=True
+    Should Be Equal As Integers         ${output.rc}    0
+    [return]          ${output}
+
+Execute create file command
+    [Arguments]       ${path}           ${file_name}
+    ${final_url} =    Catenate          SEPARATOR=      ${URL}  ${path}  ?op=CREATE&user.name=  ${USERNAME}
+    ${output}         Run process       curl -X PUT "${final_url}"   shell=True
+    Should Be Equal As Integers         ${output.rc}    0
+    ${final_url2} =   Catenate          SEPARATOR=      ${URL}  ${path}  ?op=CREATE&data=true&user.name=  ${USERNAME}
+    ${output2}        Run process       curl -X PUT -T ${file_name} "${final_url2}" -H"Content-Type: application/octet-stream"   shell=True
+    Should Be Equal As Integers         ${output2.rc}    0
+    [return]          ${output2}
+
+Create file
+    [Arguments]     ${file_name}
+    Run process     touch ${file_name}  shell=True
+    Run process     echo "Hello world!">${file_name}     shell=True

--- a/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/httpfs/operations_tests.robot
@@ -1,0 +1,145 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       HttpFS gateway test with curl commands
+Library             Process
+Library             String
+Library             BuiltIn
+Resource            operations.robot
+
+*** Variables ***
+${URL}                         http://httpfs:14000/webhdfs/v1/
+${USERNAME}                    hdfs
+${volume}                      generated
+
+*** Keywords ***
+Generate volume
+   ${random} =         Generate Random String  5  [LOWER]
+   Set Suite Variable  ${volume}  ${random}
+
+*** Test Cases ***
+Create volume
+    ${volume} =     Execute curl command    ${volume}    MKDIRS      -X PUT
+    Should contain  ${volume.stdout}   true
+
+Create first bucket
+    ${bucket} =     Execute curl command    ${volume}/buck1          MKDIRS      -X PUT
+    Should contain  ${bucket.stdout}   true
+
+Create second bucket
+    ${bucket} =     Execute curl command    ${volume}/buck2          MKDIRS      -X PUT
+    Should contain  ${bucket.stdout}   true
+
+Create local testfile
+    Create file       testfile
+
+Create testfile
+    ${file} =       Execute create file command     ${volume}/buck1/testfile     testfile
+    Should contain     ${file.stdout}     http://httpfs:14000/webhdfs/v1/${volume}/buck1/testfile
+
+Read file
+    ${file} =       Execute curl command    ${volume}/buck1/testfile     OPEN    -L
+    Should contain     ${file.stdout}     Hello world!
+
+# Missing functionality, not working properly yet.
+# List directory iteratively
+    # ${list} =       Execute curl command    vol1          LISTSTATUS_BATCH&startAfter=buck1      ${EMPTY}
+    # Should contain  ${list.stdout}     DirectoryListing    buck2
+    # Should not contain          ${list.stdout}             buck1
+
+Delete bucket
+    ${bucket} =     Execute curl command    ${volume}/buck2          DELETE      -X DELETE
+    Should contain  ${bucket.stdout}   true
+
+Get status of bucket
+    ${status} =     Execute curl command    ${volume}/buck1          GETFILESTATUS      ${EMPTY}
+    Should contain  ${status.stdout}   FileStatus  DIRECTORY
+
+Get status of file
+    ${status} =     Execute curl command    ${volume}/buck1/testfile          GETFILESTATUS      ${EMPTY}
+    Should contain  ${status.stdout}   FileStatus  FILE    13
+
+List bucket
+    ${list} =       Execute curl command    ${volume}/buck1          LISTSTATUS      ${EMPTY}
+    Should contain  ${list.stdout}     FileStatus  testfile    FILE    13
+
+List file
+    ${list} =       Execute curl command    ${volume}/buck1/testfile          LISTSTATUS      ${EMPTY}
+    Should contain  ${list.stdout}     FileStatus  FILE    13
+
+Get content summary of directory
+    ${summary} =    Execute curl command    ${volume}          GETCONTENTSUMMARY      ${EMPTY}
+    Should contain  ${summary.stdout}  ContentSummary      "directoryCount":2      "fileCount":1
+
+Get quota usage of directory
+    ${usage} =      Execute curl command    ${volume}          GETQUOTAUSAGE      ${EMPTY}
+    Should contain  ${usage.stdout}    QuotaUsage          "fileAndDirectoryCount":3
+
+Get home directory
+    ${home} =       Execute curl command    ${EMPTY}          GETHOMEDIRECTORY      ${EMPTY}
+    Should contain  ${home.stdout}     "Path":"\\/user\\/hdfs"
+
+Get trash root
+    ${trash} =      Execute curl command    ${volume}/buck1/testfile          GETTRASHROOT      ${EMPTY}
+    Should contain  ${trash.stdout}    "Path":"\\/${volume}\\/buck1\\/.Trash\\/hdfs"
+
+# Missing functionality, not working yet.
+# Set permission of bucket
+    # ${status} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json} =       Evaluate                json.loads('''${status.stdout}''')          json
+    # ${permission} =     Set Variable     ${json["FileStatus"]["permission"]}
+    # Execute curl command    vol1/buck1          SETPERMISSION&permission=666      -X PUT
+    # ${status_after} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json_after} =       evaluate                json.loads('''${status_after.stdout}''')    json
+    # ${permission_after} =   Set Variable     ${json_after["FileStatus"]["permission"]}
+    # Should be equal As Integers     666   ${permission_after}
+
+# Missing functionality, not working properly yet.
+# Set replication factor of bucket
+    # ${status} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json} =       Evaluate                json.loads('''${status.stdout}''')          json
+    # ${factor} =     Set Variable     ${json["FileStatus"]["replication"]}
+    # ${cmd} =        Execute curl command    vol1/buck1          SETREPLICATION&replication=1      -X PUT
+    # Should contain  ${cmd.stdout}      true
+    # ${status_after} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json_after} =       evaluate                json.loads('''${status_after.stdout}''')    json
+    # ${factor_after} =   Set Variable     ${json_after["FileStatus"]["replication"]}
+    # Should be equal As Integers     1   ${factor_after}
+
+# Missing functionality, not working properly yet.
+#Set access and modification time of bucket
+    # ${status} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json} =       Evaluate                json.loads('''${status.stdout}''')          json
+    # ${access} =     Set Variable     ${json["FileStatus"]["accessTime"]}
+    # ${mod} =     Set Variable     ${json["FileStatus"]["modificationTime"]}
+    # Execute curl command    vol1/buck1          SETTIMES&modificationtime=10&accesstime=10      -X PUT
+    # ${status_after} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json_after} =       evaluate                json.loads('''${status_after.stdout}''')    json
+    # ${access_after} =   Set Variable     ${json_after["FileStatus"]["accessTime"]}
+    # ${mod_after} =   Set Variable     ${json_after["FileStatus"]["modificationTime"]}
+    # Should be equal As Integers     10   ${access_after}
+    # Should be equal As Integers     10   ${mod_after}
+
+# Missing functionality, not working properly yet.
+# Set owner of bucket
+    # ${status} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json} =       Evaluate                json.loads('''${status.stdout}''')          json
+    # ${owner} =     Set Variable     ${json["FileStatus"]["owner"]}
+    # Execute curl command    vol1/buck1          SETOWNER&owner=hadoop      -X PUT
+    # ${status_after} =     Execute curl command    vol1/buck1          GETFILESTATUS      ${EMPTY}
+    # ${json_after} =       evaluate                json.loads('''${status_after.stdout}''')    json
+    # ${owner_after} =   Set Variable     ${json_after["FileStatus"]["owner"]}
+    # Should be equal     hadoop   ${owner_after}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added robot tests for the HttpFS gateway. In the tests we use curl command to try out the operations and check the response for the expected objects. The robot tests are added in the compose/ozone test.sh script.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5615

## How was this patch tested?

The robot tests were run by the test.sh script in the compose/ozone directory and all the test cases passed.
