### PR TITLE
HDDS-5710. initialize sequenceIdToLastIdMap when SequenceIdGenerator#StateManager reinitializes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -270,9 +270,9 @@ public class SequenceIdGenerator {
         Table.KeyValue<String, Long> kv = iterator.next();
         final String sequenceIdName = kv.getKey();
         final Long lastId = kv.getValue();
-        org.apache.ratis.util.Preconditions.assertNotNull(sequenceIdName,
+        Preconditions.checkNotNull(sequenceIdName,
             "sequenceIdName should not be null");
-        org.apache.ratis.util.Preconditions.assertNotNull(lastId,
+        Preconditions.checkNotNull(lastId,
             "lastId should not be null");
         sequenceIdToLastIdMap.put(sequenceIdName, lastId);
       }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -159,7 +159,8 @@ public class SequenceIdGenerator {
    * Reinitialize the SequenceIdGenerator with the latest sequenceIdTable
    * during SCM reload.
    */
-  public void reinitialize(Table<String, Long> sequenceIdTable) {
+  public void reinitialize(Table<String, Long> sequenceIdTable)
+      throws IOException {
     lock.lock();
     try {
       LOG.info("reinitialize SequenceIdGenerator.");
@@ -197,7 +198,7 @@ public class SequenceIdGenerator {
      * Reinitialize the SequenceIdGenerator with the latest sequenceIdTable
      * during SCM reload.
      */
-    void reinitialize(Table<String, Long> sequenceIdTable);
+    void reinitialize(Table<String, Long> sequenceIdTable) throws IOException;
   }
 
   /**
@@ -253,9 +254,28 @@ public class SequenceIdGenerator {
     }
 
     @Override
-    public void reinitialize(Table<String, Long> seqIdTable) {
+    public void reinitialize(Table<String, Long> seqIdTable)
+        throws IOException {
       this.sequenceIdTable = seqIdTable;
       this.sequenceIdToLastIdMap.clear();
+      initialize();
+    }
+
+    private void initialize() throws IOException {
+      TableIterator<String,
+          ? extends Table.KeyValue<String, Long>>
+          iterator = sequenceIdTable.iterator();
+
+      while (iterator.hasNext()) {
+        Table.KeyValue<String, Long> kv = iterator.next();
+        final String sequenceIdName = kv.getKey();
+        final Long lastId = kv.getValue();
+        org.apache.ratis.util.Preconditions.assertNotNull(sequenceIdName,
+            "sequenceIdName should not be null");
+        org.apache.ratis.util.Preconditions.assertNotNull(lastId,
+            "lastId should not be null");
+        sequenceIdToLastIdMap.put(sequenceIdName, lastId);
+      }
     }
 
     /**


### PR DESCRIPTION

## What changes were proposed in this pull request?

2021-09-03 12:50:38,632 [1114efaf-c975-4ea0-bc8b-c3309a57cc8d@group-58D600BFB107-StateMachineUpdater] WARN org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator: Failed to allocate a batch for localId, expected lastId is 0, actual lastId is 107544261438510000.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5710

## How was this patch tested?

current unit test
