### PR TITLE
HDDS-5717. Refactor TestOzoneManagerListVolumes to reuse mini-ozone clusters

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -434,9 +434,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           ResultCodes.OM_NOT_INITIALIZED);
     }
     omMetaDir = OMStorage.getOmDbDir(configuration);
-
-    this.isAclEnabled = conf.getBoolean(OZONE_ACL_ENABLED,
-        OZONE_ACL_ENABLED_DEFAULT);
+    
     this.isSpnegoEnabled = conf.get(OZONE_OM_HTTP_AUTH_TYPE, "simple")
         .equals("kerberos");
     this.scmBlockSize = (long) conf.getStorageSize(OZONE_SCM_BLOCK_SIZE,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -321,7 +321,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private static final int SHUTDOWN_HOOK_PRIORITY = 30;
   private final Runnable shutdownHook;
   private final File omMetaDir;
-  private final boolean isAclEnabled;
+  private boolean isAclEnabled;
   private final boolean isSpnegoEnabled;
   private IAccessAuthorizer accessAuthorizer;
   private JvmPauseMonitor jvmPauseMonitor;
@@ -419,9 +419,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     loginOMUserIfSecurityEnabled(conf);
-
-    this.allowListAllVolumes = conf.getBoolean(OZONE_OM_VOLUME_LISTALL_ALLOWED,
-        OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT);
+    setInstanceVariablesFromConf();
     this.maxUserVolumeCount = conf.getInt(OZONE_OM_USER_MAX_VOLUME,
         OZONE_OM_USER_MAX_VOLUME_DEFAULT);
     Preconditions.checkArgument(this.maxUserVolumeCount > 0,
@@ -532,6 +530,21 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ShutdownHookManager.get().addShutdownHook(shutdownHook,
         SHUTDOWN_HOOK_PRIORITY);
     omState = State.INITIALIZED;
+  }
+
+  /**
+   * This method is used to set selected instance variables in this class from
+   * the passed in config. This allows these variable to be reset when the OM
+   * instance is restarted (normally from a test mini-cluster). Note, not all
+   * variables are added here as variables are selectively added as tests
+   * require.
+   */
+  private void setInstanceVariablesFromConf() {
+    this.isAclEnabled = configuration.getBoolean(OZONE_ACL_ENABLED,
+        OZONE_ACL_ENABLED_DEFAULT);
+    this.allowListAllVolumes = configuration.getBoolean(
+        OZONE_OM_VOLUME_LISTALL_ALLOWED,
+        OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT);
   }
 
   /**
@@ -1349,6 +1362,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   public void restart() throws IOException {
     initFSOLayout();
+    setInstanceVariablesFromConf();
 
     LOG.info(buildRpcServerStartMessage("OzoneManager RPC server",
         omRpcAddress));


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneManagerListVolumes takes about 215 seconds to run, as it has several tests, and each tests creates a new mini-cluster:

```
[INFO] Running org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 215.633 s - in org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes
```
We can refactor the test to use the same Mini-Cluster and just restart the OM component between each test, saving a lot of time.

Note that this requires a small change in the OzoneManagerImpl class too.

On my laptop the runtime went from 176 seconds -> 20 seconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5717

## How was this patch tested?

Existing tests and a changes to existing tests.