### PR TITLE
HDDS-5718. Refactor TestXceiverClientManager to reuse mini-clusters.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientManager.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -54,16 +54,16 @@ public class TestXceiverClientManager {
     */
   @Rule
   public Timeout timeout = Timeout.seconds(300);
-  private OzoneConfiguration config;
-  private MiniOzoneCluster cluster;
-  private StorageContainerLocationProtocolClientSideTranslatorPB
+  private static OzoneConfiguration config;
+  private static MiniOzoneCluster cluster;
+  private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
-  @Before
-  public void init() throws Exception {
+  @BeforeClass
+  public static void init() throws Exception {
     config = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(config)
         .setNumDatanodes(3)
@@ -73,8 +73,8 @@ public class TestXceiverClientManager {
         .getStorageContainerLocationClient();
   }
 
-  @After
-  public void shutdown() {
+  @AfterClass
+  public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestXceiverClientManager takes about 158 seconds to run:

```
[INFO] Running org.apache.hadoop.ozone.scm.TestXceiverClientManager
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 158.045 s - in org.apache.hadoop.ozone.scm.TestXceiverClientManager
```
It runs 4 tests each in a fresh mini-cluster. We can reuse the same cluster for each test and reduce the runtime to about 25% of the original.

On my laptop the runtime goes form 104 seconds -> 41.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5718

## How was this patch tested?

Existing tests
