### PR TITLE
HDDS-5712. make it configurable to trigger refresh datanode usage info before start a new balance iteration

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/RefreshVolumeUsageCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/RefreshVolumeUsageCommand.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.protocol.commands;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos
+    .RefreshVolumeUsageCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+
+/**
+ * Asks datanode to refresh disk usage info immediately.
+ */
+public class RefreshVolumeUsageCommand
+    extends SCMCommand<RefreshVolumeUsageCommandProto> {
+
+  public RefreshVolumeUsageCommand() {
+    super();
+  }
+
+  /**
+   * Returns the type of this command.
+   *
+   * @return Type
+   */
+  @Override
+  public SCMCommandProto.Type getType() {
+    return SCMCommandProto.Type.refreshVolumeUsageInfo;
+  }
+
+  @Override
+  public RefreshVolumeUsageCommandProto getProto() {
+    RefreshVolumeUsageCommandProto.Builder builder =
+        RefreshVolumeUsageCommandProto.newBuilder();
+    return builder.build();
+  }
+
+  public static RefreshVolumeUsageCommand getFromProtobuf(
+      RefreshVolumeUsageCommandProto refreshVolumeUsageProto) {
+    Preconditions.checkNotNull(refreshVolumeUsageProto);
+    return new RefreshVolumeUsageCommand();
+  }
+}

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -325,6 +325,8 @@ message SCMCommandProto {
   optional SetNodeOperationalStateCommandProto setNodeOperationalStateCommandProto = 9;
   optional FinalizeNewLayoutVersionCommandProto
   finalizeNewLayoutVersionCommandProto = 10;
+  optional RefreshVolumeUsageCommandProto refreshVolumeUsageCommandProto = 11;
+
 
   // If running upon Ratis, holds term of underlying RaftServer iff current
   // SCM is a leader. If running without Ratis, holds SCMContext.INVALID_TERM.
@@ -416,6 +418,13 @@ This command asks the datanode to close a pipeline.
 message ClosePipelineCommandProto {
   required PipelineID pipelineID = 1;
   required int64 cmdId = 2;
+}
+
+/**
+This command asks the datanode to refresh disk usage immediately.
+*/
+message RefreshVolumeUsageCommandProto {
+  required int64 cmdId = 1;
 }
 
 message SetNodeOperationalStateCommandProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -131,6 +131,14 @@ public final class ContainerBalancerConfiguration {
           "This configuration is false by default.")
   private boolean networkTopologyEnable = false;
 
+  @Config(key = "trigger.du.before.move.enable", type = ConfigType.BOOLEAN,
+      defaultValue = "false", tags = {ConfigTag.BALANCER},
+      description = "whether to send command to all the data nodes to run du " +
+          "immediately before starting a balance iteration. note that running du " +
+          "is very time consuming , especially when the disk usage rate of a data node" +
+          "is very high")
+  private boolean triggerDuEnable = false;
+
   private DUFactory.Conf duConf;
 
   /**
@@ -210,6 +218,15 @@ public final class ContainerBalancerConfiguration {
    */
   public Boolean getNetworkTopologyEnable() {
     return networkTopologyEnable;
+  }
+
+  /**
+   * Get the triggerDuEnable value for Container Balancer.
+   *
+   * @return the boolean value of triggerDuEnable
+   */
+  public Boolean getTriggerDuEnable() {
+    return triggerDuEnable;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -250,6 +250,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
   private final OzoneConfiguration configuration;
   private SCMContainerMetrics scmContainerMetrics;
   private SCMContainerPlacementMetrics placementMetrics;
+  private PlacementPolicy containerPlacementPolicy;
   private MetricsSystem ms;
   private final Map<String, RatisDropwizardExports> ratisMetricsMap =
       new ConcurrentHashMap<>();
@@ -380,11 +381,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     initializeEventHandlers();
 
-    containerBalancer = new ContainerBalancer(scmNodeManager, containerManager,
-        replicationManager, configuration, scmContext, clusterMap,
-        ContainerPlacementPolicyFactory
-            .getPolicy(conf, scmNodeManager, clusterMap, true,
-                placementMetrics));
+    containerBalancer = new ContainerBalancer(this);
     LOG.info(containerBalancer.toString());
 
     // Emit initial safe mode status, as now handlers are registered.
@@ -565,7 +562,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
 
     placementMetrics = SCMContainerPlacementMetrics.create();
-    PlacementPolicy containerPlacementPolicy =
+    containerPlacementPolicy =
         ContainerPlacementPolicyFactory.getPolicy(conf, scmNodeManager,
             clusterMap, true, placementMetrics);
 
@@ -1606,10 +1603,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     return scmSafeModeManager;
   }
 
-  @VisibleForTesting
   @Override
   public ReplicationManager getReplicationManager() {
     return replicationManager;
+  }
+
+  public PlacementPolicy getContainerPlacementPolicy() {
+    return containerPlacementPolicy;
   }
 
   @VisibleForTesting


### PR DESCRIPTION
## What changes were proposed in this pull request?

for now, when a balance iteration ended, we have to wait `balancingInterval`(default 1 hour , too long) before start the next iteration. this seems too slow!

in this patch , before balancer start a new balance iteration,  it will send a refreshVolumeUsage command to all the datanodes. then balancer will get the latest usage info of all datanodes from  the heartbeat , so that it will get more accurate statistics about the current cluster when initializing Iteration.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5712

## How was this patch tested?

no need
