### PR TITLE
HDDS-5720. Reuse mini-clusters in TestOzoneFileInterfaces

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -56,7 +56,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import static org.apache.hadoop.fs.ozone.Constants.OZONE_DEFAULT_USER;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -121,30 +120,44 @@ public class TestOzoneFileInterfaces {
 
   private OMMetrics omMetrics;
 
+  private static boolean enableFileSystemPaths;
+
   @SuppressWarnings("checkstyle:VisibilityModifier")
-  protected static boolean enableFileSystemPaths;
+  protected boolean enableFileSystemPathsInstance;
 
   public TestOzoneFileInterfaces(boolean setDefaultFs,
       boolean useAbsolutePath, boolean enabledFileSystemPaths)
       throws Exception {
+    enableFileSystemPathsInstance = enabledFileSystemPaths;
     if (this.setDefaultFs != setDefaultFs
         || this.useAbsolutePath != useAbsolutePath
         || this.enableFileSystemPaths != enabledFileSystemPaths) {
-      this.setDefaultFs = setDefaultFs;
-      this.useAbsolutePath = useAbsolutePath;
-      this.enableFileSystemPaths = enabledFileSystemPaths;
+      setParameters(setDefaultFs, useAbsolutePath, enabledFileSystemPaths);
       teardown();
       init();
     }
     GlobalStorageStatistics.INSTANCE.reset();
   }
 
+  private static void setParameters(boolean defaultFs,
+                                    boolean absolutePath,
+                                    boolean fileSystemPaths) {
+    setDefaultFs = defaultFs;
+    useAbsolutePath = absolutePath;
+    enableFileSystemPaths = fileSystemPaths;
+  }
+
+  private static void setCluster(MiniOzoneCluster newCluster) {
+    cluster = newCluster;
+  }
+
   public void init() throws Exception {
     OzoneConfiguration conf = getOzoneConfiguration();
-    cluster = MiniOzoneCluster.newBuilder(conf)
+    MiniOzoneCluster newCluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();
-    cluster.waitForClusterToBeReady();
+    newCluster.waitForClusterToBeReady();
+    setCluster(newCluster);
   }
 
   @Before
@@ -172,7 +185,6 @@ public class TestOzoneFileInterfaces {
     omMetrics = cluster.getOzoneManager().getMetrics();
   }
 
-  @NotNull
   protected OzoneConfiguration getOzoneConfiguration() {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -46,7 +46,8 @@ public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
   }
 
   public TestOzoneFileInterfacesWithFSO(boolean setDefaultFs,
-      boolean useAbsolutePath, boolean enabledFileSystemPaths) {
+      boolean useAbsolutePath, boolean enabledFileSystemPaths)
+      throws Exception {
     super(setDefaultFs, useAbsolutePath, enabledFileSystemPaths);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.fs.ozone;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -51,11 +50,11 @@ public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
     super(setDefaultFs, useAbsolutePath, enabledFileSystemPaths);
   }
 
-  @NotNull
   @Override
   protected OzoneConfiguration getOzoneConfiguration() {
     OzoneConfiguration conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf, enableFileSystemPaths,
+    TestOMRequestUtils.configureFSOptimizedPaths(conf,
+        enableFileSystemPathsInstance,
         OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
     return conf;
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 
 import java.io.IOException;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -42,7 +42,6 @@ import java.util.Iterator;
  */
 public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
 
-  @NotNull
   @Override
   protected OzoneConfiguration getOzoneConfiguration() {
     OzoneConfiguration config = super.getOzoneConfiguration();


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneFileInterfaces currently takes about 563 seconds to run:

```
[INFO] Running org.apache.hadoop.fs.ozone.TestOzoneFileInterfaces
Warning: Tests run: 18, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 563.677 s - in org.apache.hadoop.fs.ozone.TestOzoneFileInterfaces
```

It can be changed quite easily to re-use the same mini-cluster across many tests, saving a lot of run time.

On my laptop, after this change, it runs in less than 60 seconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5720

## How was this patch tested?

Existing tests
