### PR TITLE
HDDS-5723. Increase time limit of Ozone acceptance tests.

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -187,7 +187,7 @@ jobs:
       - build-info
       - compile
     runs-on: ubuntu-18.04
-    timeout-minutes: 120 # Todo HDDS-5270
+    timeout-minutes: 150
     if: needs.build-info.outputs.needs-compose-tests == 'true'
     strategy:
       matrix:
@@ -261,7 +261,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-18.04
-    timeout-minutes: 150
+    timeout-minutes: 150 # Todo HDDS-5270
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     strategy:
       matrix:

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -261,7 +261,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-18.04
-    timeout-minutes: 150 # Todo HDDS-5270
+    timeout-minutes: 150
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase acceptance test timeout from 120 minutes to 150 minutes, since new upgrade/downgrade acceptance tests sometimes push the acceptance test run time over 2 hours.

## What is the link to the Apache JIRA

HDDS-5723

## How was this patch tested?

- Existing acceptance test run.
