### PR TITLE
HDDS-5711. support -1 for running balancer infinitely

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -172,6 +172,10 @@ public class ContainerBalancer {
    */
   private void balance() {
     this.idleIteration = config.getIdleIteration();
+    if(this.idleIteration == -1) {
+      //run balancer infinitely
+      this.idleIteration = Integer.MAX_VALUE;
+    }
     this.threshold = config.getThreshold();
     this.maxDatanodesRatioToInvolvePerIteration =
         config.getMaxDatanodesRatioToInvolvePerIteration();


### PR DESCRIPTION
## What changes were proposed in this pull request?

for container balancer cli, for example
`./ozone admin containerbalancer start -i -1 -t 0.000001 -d 1 -s 5000`

if we specify `-i` with `-1` , balancer should run infinitely
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5711

## How was this patch tested?

unit test
