### PR TITLE
HDDS-5724. Add RaftpeerId when getting scm roles

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -257,7 +257,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
       ratisRoles.add((peer.getAddress() == null ? "" :
               peer.getAddress().concat(isLocal ?
                   ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
-                  ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))));
+                  ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))
+                  .concat(":".concat(peer.getId().toString()))));
     }
     return ratisRoles;
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -29,7 +29,8 @@ import picocli.CommandLine;
  */
 @CommandLine.Command(
     name = "roles",
-    description = "List all SCMs and their respective Ratis server roles",
+    description = "List all SCMs, their respective Ratis server roles " +
+        "and RaftPeerIds",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class GetScmRatisRolesSubcommand extends ScmSubcommand {
@@ -40,6 +41,8 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
   @Override
   protected void execute(ScmClient scmClient) throws IOException {
     List<String> roles = scmClient.getScmRatisRoles();
-    System.out.println(roles);
+    for (String role: roles) {
+      System.out.println(role);
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add RaftpeerId for the shell command " ozone admin scm roles"

In the current scm log files, some of the raft related logs lack explicit Addresses, so it is hard to distinguish the SCM nodes from the abstract UUID.  We can add the RaftPeerId into the command -> ozone admin scm roles, which can help find the SCM node mentioned in logs.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5724

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

CI
