### PR TITLE
HDDS-5725. Catch possible AlreadyExistsException for create pipeline command.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -108,9 +108,13 @@ public class CreatePipelineCommandHandler implements CommandHandler {
             pipelineID);
       }
     } catch (IOException e) {
-      LOG.error("Can't create pipeline {} {} {}",
-          createCommand.getReplicationType(),
-          createCommand.getFactor(), pipelineID, e);
+      // The server.addGroup may exec after a getGroupManagementApi call
+      // from another peer, so we may got an AlreadyExistsException.
+      if (!(e.getCause() instanceof AlreadyExistsException)) {
+        LOG.error("Can't create pipeline {} {} {}",
+            createCommand.getReplicationType(),
+            createCommand.getFactor(), pipelineID, e);
+      }
     } finally {
       long endTime = Time.monotonicNow();
       totalTime += endTime - startTime;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Catch possible AlreadyExistsException for create pipeline command.
Logs in the JIRA below.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5725

## How was this patch tested?

manual test.
