### PR TITLE
HDDS-5728. ContainerBalancer should use remaining space to calculate utilization.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -271,7 +271,7 @@ public class ContainerBalancer {
 
     // find over and under utilized nodes
     for (DatanodeUsageInfo datanodeUsageInfo : datanodeUsageInfos) {
-      double utilization = calculateUtilization(datanodeUsageInfo);
+      double utilization = datanodeUsageInfo.calculateUtilization();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Utilization for node {} is {}",
             datanodeUsageInfo.getDatanodeDetails().getUuidString(),
@@ -636,23 +636,6 @@ public class ContainerBalancer {
     clusterRemaining = aggregatedStats.getRemaining().get();
 
     return (clusterCapacity - clusterRemaining) / (double) clusterCapacity;
-  }
-
-  /**
-   * Calculates the utilization, that is (capacity - remaining) divided by
-   * capacity, for the given datanodeUsageInfo.
-   *
-   * @param datanodeUsageInfo DatanodeUsageInfo to calculate utilization for
-   * @return Utilization value
-   */
-  public static double calculateUtilization(
-      DatanodeUsageInfo datanodeUsageInfo) {
-    SCMNodeStat stat = datanodeUsageInfo.getScmNodeStat();
-    double capacity = stat.getCapacity().get();
-    double remaining = stat.getRemaining().get();
-    double numerator = capacity - remaining;
-
-    return numerator / capacity;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -620,7 +620,7 @@ public class ContainerBalancer {
    * @param nodes List of DatanodeUsageInfo to find the average utilization for
    * @return Average utilization value
    */
-  private double calculateAvgUtilization(List<DatanodeUsageInfo> nodes) {
+  double calculateAvgUtilization(List<DatanodeUsageInfo> nodes) {
     if (nodes.size() == 0) {
       LOG.warn("No nodes to calculate average utilization for in " +
           "ContainerBalancer.");
@@ -753,7 +753,7 @@ public class ContainerBalancer {
    *
    * @return List of DatanodeUsageInfo containing unBalanced nodes.
    */
-  public List<DatanodeUsageInfo> getUnBalancedNodes() {
+  List<DatanodeUsageInfo> getUnBalancedNodes() {
     return unBalancedNodes;
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -83,6 +83,7 @@ public class ContainerBalancer {
   private ContainerBalancerMetrics metrics;
   private long clusterCapacity;
   private long clusterUsed;
+  private long clusterRemaining;
   private double clusterAvgUtilisation;
   private volatile boolean balancerRunning;
   private Thread currentBalancingThread;
@@ -237,6 +238,7 @@ public class ContainerBalancer {
     this.totalNodesInCluster = datanodeUsageInfos.size();
     this.clusterCapacity = 0L;
     this.clusterUsed = 0L;
+    this.clusterRemaining = 0L;
     this.selectedContainers.clear();
     this.overUtilizedNodes.clear();
     this.underUtilizedNodes.clear();
@@ -429,6 +431,8 @@ public class ContainerBalancer {
                 moveSelection.getContainerID(), e);
           }
           metrics.incrementMovedContainersNum(1);
+          // TODO incrementing size balanced this way incorrectly counts the
+          //  size moved twice
           metrics.incrementDataSizeBalancedGB(sizeMovedPerIteration);
         }
       } catch (InterruptedException e) {
@@ -584,6 +588,8 @@ public class ContainerBalancer {
       Collection<DatanodeDetails> potentialTargets,
       Set<DatanodeDetails> selectedTargets,
       ContainerMoveSelection moveSelection, DatanodeDetails source) {
+    // TODO: counting datanodes involved this way is incorrect when the same
+    //  datanode is involved in different moves
     countDatanodesInvolvedPerIteration += 2;
     incSizeSelectedForMoving(source, moveSelection);
     sourceToTargetMap.put(source, moveSelection);
@@ -592,7 +598,7 @@ public class ContainerBalancer {
     selectionCriteria.setSelectedContainers(selectedContainers);
 
     return potentialTargets.stream()
-        .filter(node -> sizeEnteringNode.get(node) <=
+        .filter(node -> sizeEnteringNode.get(node) <
             config.getMaxSizeEnteringTarget()).collect(Collectors.toList());
   }
 
@@ -609,7 +615,7 @@ public class ContainerBalancer {
 
   /**
    * Calculates the average utilization for the specified nodes.
-   * Utilization is used space divided by capacity.
+   * Utilization is (capacity - remaining) divided by capacity.
    *
    * @param nodes List of DatanodeUsageInfo to find the average utilization for
    * @return Average utilization value
@@ -627,13 +633,14 @@ public class ContainerBalancer {
     }
     clusterCapacity = aggregatedStats.getCapacity().get();
     clusterUsed = aggregatedStats.getScmUsed().get();
+    clusterRemaining = aggregatedStats.getRemaining().get();
 
-    return clusterUsed / (double) clusterCapacity;
+    return (clusterCapacity - clusterRemaining) / (double) clusterCapacity;
   }
 
   /**
-   * Calculates the utilization, that is used space divided by capacity, for
-   * the given datanodeUsageInfo.
+   * Calculates the utilization, that is (capacity - remaining) divided by
+   * capacity, for the given datanodeUsageInfo.
    *
    * @param datanodeUsageInfo DatanodeUsageInfo to calculate utilization for
    * @return Utilization value
@@ -641,9 +648,11 @@ public class ContainerBalancer {
   public static double calculateUtilization(
       DatanodeUsageInfo datanodeUsageInfo) {
     SCMNodeStat stat = datanodeUsageInfo.getScmNodeStat();
+    double capacity = stat.getCapacity().get();
+    double remaining = stat.getRemaining().get();
+    double numerator = capacity - remaining;
 
-    return stat.getScmUsed().get().doubleValue() /
-        stat.getCapacity().get().doubleValue();
+    return numerator / capacity;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/metrics/SCMNodeStat.java
@@ -138,27 +138,4 @@ public class SCMNodeStat implements NodeStat {
   public int hashCode() {
     return Long.hashCode(capacity.get() ^ scmUsed.get() ^ remaining.get());
   }
-
-  /**
-   * Compares this SCMNodeStat with other on the basis of remaining to
-   * capacity ratio.
-   *
-   * @param other The SCMNodeStat object to compare with this object.
-   * @return A value greater than 0 if this has lesser remaining ratio than the
-   * specified other, a value lesser than 0 if this has greater remaining ratio
-   * than the specified other, and 0 if remaining ratios are equal.
-   */
-  public int compareByRemainingRatio(SCMNodeStat other) {
-    Preconditions.checkNotNull(other, "Argument cannot be null");
-
-    // if capacity is zero, replace with 1 for division to work
-    double thisCapacity = Math.max(this.getCapacity().get().doubleValue(), 1d);
-    double otherCapacity = Math.max(
-        other.getCapacity().get().doubleValue(), 1d);
-
-    double thisRemainingRatio = this.getRemaining().get() / thisCapacity;
-    double otherRemainingRatio = other.getRemaining().get() / otherCapacity;
-
-    return Double.compare(otherRemainingRatio, thisRemainingRatio);
-  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -46,23 +46,39 @@ public class DatanodeUsageInfo {
   }
 
   /**
-   * Compares two DatanodeUsageInfo on the basis of remaining space to capacity
-   * ratio.
+   * Compares two DatanodeUsageInfo on the basis of their utilization values,
+   * calculated using {@link DatanodeUsageInfo#calculateUtilization()}.
    *
    * @param first DatanodeUsageInfo
    * @param second DatanodeUsageInfo
-   * @return a value greater than 0 if second has higher remaining to
-   * capacity ratio, a value lesser than 0 if first has higher remaining to
-   * capacity ratio, and 0 if both have equal ratios or first.equals(second)
-   * is true
+   * @return a value greater than 0 first is more utilized, lesser than 0 if
+   * first is less utilized, and 0 if both have equal utilization values or
+   * first.equals(second) is true.
    */
-  private static int compareByRemainingRatio(DatanodeUsageInfo first,
+  private static int compareByUtilization(DatanodeUsageInfo first,
                              DatanodeUsageInfo second) {
     if (first.equals(second)) {
       return 0;
     }
-    return first.getScmNodeStat()
-        .compareByRemainingRatio(second.getScmNodeStat());
+    return Double.compare(first.calculateUtilization(),
+        second.calculateUtilization());
+  }
+
+  /**
+   * Calculates utilization of a datanode. Utilization of a datanode is defined
+   * as its used space divided by its capacity. Here, we prefer calculating
+   * used space as (capacity - remaining), instead of using
+   * {@link SCMNodeStat#getScmUsed()} (see HDDS-5728).
+   *
+   * @return (capacity - remaining) / capacity of this datanode
+   */
+  public double calculateUtilization() {
+    double capacity = scmNodeStat.getCapacity().get();
+    if (capacity == 0) {
+      return 0;
+    }
+    double numerator = capacity - scmNodeStat.getRemaining().get();
+    return numerator / capacity;
   }
 
   /**
@@ -105,16 +121,17 @@ public class DatanodeUsageInfo {
 
   /**
    * Gets Comparator that compares two DatanodeUsageInfo on the basis of
-   * remaining space to capacity ratio.
+   * their utilization values. Utilization is (capacity - remaining) divided
+   * by capacity.
    *
    * @return Comparator to compare two DatanodeUsageInfo. The comparison
-   * function returns a value greater than 0 if second DatanodeUsageInfo has
-   * greater remaining space to capacity ratio, a value lesser than 0 if
-   * first DatanodeUsageInfo has greater remaining space to capacity ratio,
-   * and 0 if both have equal ratios or first.equals(second) is true
+   * function returns a value greater than 0 if first DatanodeUsageInfo has
+   * greater utilization, a value lesser than 0 if first DatanodeUsageInfo
+   * has lesser utilization, and 0 if both have equal utilization values or
+   * first.equals(second) is true
    */
-  public static Comparator<DatanodeUsageInfo> getMostUsedByRemainingRatio() {
-    return DatanodeUsageInfo::compareByRemainingRatio;
+  public static Comparator<DatanodeUsageInfo> getMostUtilized() {
+    return DatanodeUsageInfo::compareByUtilization;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -17,26 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm.node;
 
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY_READONLY;
-
-import javax.management.ObjectName;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Collections;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ScheduledFuture;
-import java.util.stream.Collectors;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -47,8 +27,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
-import org.apache.hadoop.hdds.protocol.proto
-    .StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto.ErrorCode;
@@ -88,6 +67,26 @@ import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.management.ObjectName;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY_READONLY;
 
 /**
  * Maintains information about the Datanodes on SCM side.
@@ -695,10 +694,10 @@ public class SCMNodeManager implements NodeManager {
     // sort the list according to appropriate comparator
     if (mostUsed) {
       datanodeUsageInfoList.sort(
-          DatanodeUsageInfo.getMostUsedByRemainingRatio().reversed());
+          DatanodeUsageInfo.getMostUtilized().reversed());
     } else {
       datanodeUsageInfoList.sort(
-          DatanodeUsageInfo.getMostUsedByRemainingRatio());
+          DatanodeUsageInfo.getMostUtilized());
     }
     return datanodeUsageInfoList;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -384,9 +384,9 @@ public class MockNodeManager implements NodeManager {
     }
     Comparator<DatanodeUsageInfo> comparator;
     if (mostUsed) {
-      comparator = DatanodeUsageInfo.getMostUsedByRemainingRatio().reversed();
+      comparator = DatanodeUsageInfo.getMostUtilized().reversed();
     } else {
-      comparator = DatanodeUsageInfo.getMostUsedByRemainingRatio();
+      comparator = DatanodeUsageInfo.getMostUtilized();
     }
 
     return datanodeDetailsList.stream()

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -140,6 +140,19 @@ public class TestContainerBalancer {
         replicationManager, conf, SCMContext.emptyContext(), placementPolicy);
   }
 
+  @Test
+  public void testCalculationOfUtilization() {
+    Assert.assertEquals(nodesInCluster.size(), nodeUtilizations.size());
+    for (int i = 0; i < nodesInCluster.size(); i++) {
+      Assert.assertEquals(nodeUtilizations.get(i),
+          nodesInCluster.get(i).calculateUtilization(), 0.0001);
+    }
+
+    // should be equal to average utilization of the cluster
+    Assert.assertEquals(averageUtilization,
+        containerBalancer.calculateAvgUtilization(nodesInCluster), 0.0001);
+  }
+
   /**
    * Checks whether ContainerBalancer is correctly updating the list of
    * unBalanced nodes with varying values of Threshold.


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerBalancer gets a list of datanodes sorted according to their utilizations using `NodeManager#getMostOrLeastUsedDatanodes`.

There are two ways of calculating utilization:
1.  ```used space / capacity```
2.  ```(capacity - remaining) / capacity```

`Used` space is obtained using the DU or DF command (`SpaceUsageSource`), while `remaining` can either be `capacity - used` or calculated using the `java.io.File#getUsableSpace` method. This means the two ways of calculating utilization might give different results (when `used` is not equal to `capacity - remaining`).

Currently, `NodeManager#getMostOrLeastUsed` uses method 2 while balancer uses method 1.
Instead, both should consistently use the same approach. We prefer method 2 since the `remaining` space calculation will also account for space used by processes other than Ozone. See the documentation in `VolumeInfo` for further details on calculating `remaining` space.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5728

## How was this patch tested?

Existing UT `TestContainerBalancer`
