### PR TITLE
HDDS-3371. Begin Cleanup of old write-path of key in OM

### DIFF
--- a/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
+++ b/hadoop-ozone/integration-test/dev-support/findbugsExcludeFile.xml
@@ -109,6 +109,10 @@
     <Bug pattern="UWF_NULL_FIELD" />
   </Match>
   <Match>
+    <Class name="org.apache.hadoop.ozone.om.TestOmMetrics"/>
+    <Bug pattern="RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT" />
+  </Match>
+  <Match>
     <Class name="org.apache.hadoop.ozone.scm.TestContainerSmallFile"/>
     <Bug pattern="DLS_DEAD_LOCAL_STORE" />
   </Match>

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
@@ -170,8 +169,8 @@ public class TestOzoneFileSystem {
             .build();
     cluster.waitForClusterToBeReady();
 
-    writeClient = new RpcClient(conf, cluster.getOMServiceId())
-      .getOzoneManagerClient();
+    writeClient = cluster.getRpcClient().getObjectStore()
+        .getClientProxy().getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzonePrefixPathImpl;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
@@ -57,6 +58,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
@@ -140,6 +142,7 @@ public class TestOzoneFileSystem {
   private static boolean omRatisEnabled;
 
   private static MiniOzoneCluster cluster;
+  private static OzoneManagerProtocol writeClient;
   private static FileSystem fs;
   private static OzoneFileSystem o3fs;
   private static String volumeName;
@@ -167,6 +170,7 @@ public class TestOzoneFileSystem {
             .build();
     cluster.waitForClusterToBeReady();
 
+    writeClient = new RpcClient(conf, cluster.getOMServiceId()).getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
@@ -583,7 +587,7 @@ public class TestOzoneFileSystem {
 
     // the number of immediate children of root is 1
     Assert.assertEquals(1, fileStatuses.length);
-    cluster.getOzoneManager().deleteKey(keyArgs);
+    writeClient.deleteKey(keyArgs);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -170,7 +170,8 @@ public class TestOzoneFileSystem {
             .build();
     cluster.waitForClusterToBeReady();
 
-    writeClient = new RpcClient(conf, cluster.getOMServiceId()).getOzoneManagerClient();
+    writeClient = new RpcClient(conf, cluster.getOMServiceId())
+      .getOzoneManagerClient();
     // create a volume and a bucket to be used by OzoneFileSystem
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
@@ -159,8 +158,8 @@ public class TestBlockDeletion {
     cluster.waitForClusterToBeReady();
     store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
     om = cluster.getOzoneManager();
-    writeClient = new RpcClient(conf, cluster.getOMServiceId())
-      .getOzoneManagerClient();
+    writeClient = cluster.getRpcClient().getObjectStore()
+        .getClientProxy().getOzoneManagerClient();
     scm = cluster.getStorageContainerManager();
     containerIdsWithDeletedBlocks = new HashSet<>();
     metrics = scm.getScmBlockManager().getSCMBlockDeletingService()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -159,7 +159,8 @@ public class TestBlockDeletion {
     cluster.waitForClusterToBeReady();
     store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
     om = cluster.getOzoneManager();
-    writeClient = new RpcClient(conf, cluster.getOMServiceId()).getOzoneManagerClient();
+    writeClient = new RpcClient(conf, cluster.getOMServiceId())
+      .getOzoneManagerClient();
     scm = cluster.getStorageContainerManager();
     containerIdsWithDeletedBlocks = new HashSet<>();
     metrics = scm.getScmBlockManager().getSCMBlockDeletingService()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -74,8 +74,8 @@ public class TestOmMetrics {
   private MiniOzoneCluster cluster;
   private OzoneManager ozoneManager;
   private OzoneManagerProtocol writeClient;
-  private final String VOLUME_NAME = UUID.randomUUID().toString();
-  private final String BUCKET_NAME = UUID.randomUUID().toString();
+  private final String volumeName = UUID.randomUUID().toString();
+  private final String bucketName = UUID.randomUUID().toString();
   /**
    * The exception used for testing failure metrics.
    */
@@ -95,7 +95,7 @@ public class TestOmMetrics {
     ozoneManager = cluster.getOzoneManager();
     writeClient = new RpcClient(conf, cluster.getOMServiceId())
       .getOzoneManagerClient();
-    TestDataUtil.createVolumeAndBucket(cluster, VOLUME_NAME, BUCKET_NAME);
+    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
   }
 
   /**
@@ -270,7 +270,6 @@ public class TestOmMetrics {
     assertCounter("NumTrashKeyLists", 1L, omMetrics);
     assertCounter("NumKeys", 0L, omMetrics);
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
-
     // Check for failures
     assertCounter("NumKeyAllocateFails", 0L, omMetrics);
     assertCounter("NumKeyLookupFails", 1L, omMetrics);
@@ -280,6 +279,7 @@ public class TestOmMetrics {
     assertCounter("NumInitiateMultipartUploadFails", 0L, omMetrics);
     
 
+    keyArgs = createKeyArgs();
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, keySession.getId());
     keyArgs = createKeyArgs();
@@ -303,11 +303,11 @@ public class TestOmMetrics {
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "keyManager", mockKm);
 
-    OMMetadataManager metadataManager = (OMMetadataManager) HddsWhiteboxTestUtils
-        .getInternalState(ozoneManager, "metadataManager");
+    OMMetadataManager metadataManager = (OMMetadataManager)
+        HddsWhiteboxTestUtils.getInternalState(ozoneManager, "metadataManager");
     OMMetadataManager mockMm = Mockito.spy(metadataManager);
-    Table<String, OmBucketInfo> bucketTable = (Table<String, OmBucketInfo>) HddsWhiteboxTestUtils
-        .getInternalState(metadataManager, "bucketTable");
+    Table<String, OmBucketInfo> bucketTable = (Table<String, OmBucketInfo>)
+        HddsWhiteboxTestUtils.getInternalState(metadataManager, "bucketTable");
     Table<String, OmBucketInfo> mockBTable = Mockito.spy(bucketTable);
     Mockito.doThrow(exception).when(mockBTable).isExist(any());
     Mockito.doReturn(mockBTable).when(mockMm).getBucketTable();
@@ -547,17 +547,17 @@ public class TestOmMetrics {
   }
 
   private OmKeyArgs createKeyArgs() throws IOException {
-    String keyName = UUID.randomUUID().toString();
     OmKeyLocationInfo keyLocationInfo = new OmKeyLocationInfo.Builder()
         .setBlockID(new BlockID(new ContainerBlockID(1, 1)))
         .setPipeline(MockPipeline.createSingleNodePipeline())
         .build();
     keyLocationInfo.setCreateVersion(0);
 
+    String keyName = UUID.randomUUID().toString();
     return new OmKeyArgs.Builder()
         .setLocationInfoList(Collections.singletonList(keyLocationInfo))
-        .setVolumeName(VOLUME_NAME)
-        .setBucketName(BUCKET_NAME)
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
         .setKeyName(keyName)
         .setAcls(Lists.emptyList())
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -40,6 +39,7 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
+import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -47,6 +47,7 @@ import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
+import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -549,33 +550,16 @@ public class TestOmMetrics {
     }
 
   }
-
-  /**
-   * Get Random pipeline.
-   * @return pipeline
-   */
-  private Pipeline getRandomPipeline() {
-    return Pipeline.newBuilder()
-        .setState(Pipeline.PipelineState.OPEN)
-        .setId(PipelineID.randomId())
-        .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.ONE))
-        .setNodes(new ArrayList<>())
-        .build();
-  }
   private OmKeyArgs createKeyArgs() throws IOException {
 
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
-    ObjectStore store = cluster.getClient().getObjectStore();
-    store.createVolume(volumeName);
-    OzoneVolume volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
+    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
 
     String keyName = UUID.randomUUID().toString();
     OmKeyLocationInfo keyLocationInfo = new OmKeyLocationInfo.Builder()
         .setBlockID(new BlockID(new ContainerBlockID(1, 1)))
-        .setPipeline(getRandomPipeline())
+        .setPipeline(MockPipeline.createSingleNodePipeline())
         .build();
     keyLocationInfo.setCreateVersion(0);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -39,9 +39,11 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
@@ -65,6 +67,7 @@ public class TestOmMetrics {
   public Timeout timeout = Timeout.seconds(300);
   private MiniOzoneCluster cluster;
   private OzoneManager ozoneManager;
+  private OzoneManagerProtocol writeClient;
 
   /**
    * The exception used for testing failure metrics.
@@ -82,6 +85,7 @@ public class TestOmMetrics {
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
+    writeClient = new RpcClient(conf, cluster.getOMServiceId()).getOzoneManagerClient();
   }
 
   /**
@@ -284,7 +288,7 @@ public class TestOmMetrics {
     ozoneManager.commitKey(keyArgs, 0);
     ozoneManager.openKey(keyArgs);
     ozoneManager.commitKey(keyArgs, 0);
-    ozoneManager.deleteKey(keyArgs);
+    writeClient.deleteKey(keyArgs);
 
 
     omMetrics = getMetrics("OMMetrics");
@@ -498,7 +502,7 @@ public class TestOmMetrics {
     }
 
     try {
-      ozoneManager.deleteKey(keyArgs);
+      writeClient.deleteKey(keyArgs);
     } catch (IOException ignored) {
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -262,6 +262,16 @@ public class TestOmMetrics {
     doKeyOps(keyArgs);
 
     MetricsRecordBuilder omMetrics = getMetrics("OMMetrics");
+
+    // Check for failures
+    //  The delete and lookup in doKeyOps() always fail
+    assertCounter("NumKeyAllocateFails", 0L, omMetrics);
+    assertCounter("NumKeyLookupFails", 1L, omMetrics);
+    assertCounter("NumKeyDeleteFails", 1L, omMetrics);
+    assertCounter("NumKeyListFails", 0L, omMetrics);
+    assertCounter("NumTrashKeyListFails", 0L, omMetrics);
+    assertCounter("NumInitiateMultipartUploadFails", 0L, omMetrics);
+
     assertCounter("NumKeyOps", 7L, omMetrics);
     assertCounter("NumKeyAllocate", 1L, omMetrics);
     assertCounter("NumKeyLookup", 1L, omMetrics);
@@ -270,13 +280,6 @@ public class TestOmMetrics {
     assertCounter("NumTrashKeyLists", 1L, omMetrics);
     assertCounter("NumKeys", 0L, omMetrics);
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
-    // Check for failures
-    assertCounter("NumKeyAllocateFails", 0L, omMetrics);
-    assertCounter("NumKeyLookupFails", 1L, omMetrics);
-    assertCounter("NumKeyDeleteFails", 1L, omMetrics);
-    assertCounter("NumKeyListFails", 0L, omMetrics);
-    assertCounter("NumTrashKeyListFails", 0L, omMetrics);
-    assertCounter("NumInitiateMultipartUploadFails", 0L, omMetrics);
     
 
     keyArgs = createKeyArgs();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
@@ -255,6 +256,12 @@ public class TestOmMetrics {
     assertCounter("NumBuckets", 2L, omMetrics);
   }
 
+  private OmKeyArgs changeKeyName(OmKeyArgs k) {
+    return k.toBuilder()
+      .setKeyName(UUID.randomUUID().toString())
+      .build();
+  }
+
   @Test
   public void testKeyOps() throws IOException {
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
@@ -279,12 +286,10 @@ public class TestOmMetrics {
 
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, keySession.getId());
-    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
-        .build();
+    keyArgs = changeKeyName(keyArgs);
     keySession = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, keySession.getId());
-    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
-        .build();
+    keyArgs = changeKeyName(keyArgs);
     keySession = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, keySession.getId());
     writeClient.deleteKey(keyArgs);
@@ -314,8 +319,7 @@ public class TestOmMetrics {
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "metadataManager", mockMm);
 
-    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
-        .build();
+    keyArgs = changeKeyName(keyArgs);
     doKeyOps(keyArgs);
 
     omMetrics = getMetrics("OMMetrics");
@@ -511,11 +515,13 @@ public class TestOmMetrics {
     }
 
     try {
+      // Always fails because key is not committed
       writeClient.deleteKey(keyArgs);
     } catch (IOException ignored) {
     }
 
     try {
+      // Always fails because key is not committed
       ozoneManager.lookupKey(keyArgs);
     } catch (IOException ignored) {
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -269,12 +270,16 @@ public class TestOmMetrics {
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
 
 
-    writeClient.openKey(keyArgs);
-    writeClient.commitKey(keyArgs, 0);
-    writeClient.openKey(keyArgs);
-    writeClient.commitKey(keyArgs, 0);
-    writeClient.openKey(keyArgs);
-    writeClient.commitKey(keyArgs, 0);
+    OpenKeySession keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
+    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
+        .build();
+    keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
+    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
+        .build();
+    keySession = writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, keySession.getId());
     writeClient.deleteKey(keyArgs);
 
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -93,8 +93,8 @@ public class TestOmMetrics {
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    writeClient = new RpcClient(conf, cluster.getOMServiceId())
-      .getOzoneManagerClient();
+    writeClient = cluster.getRpcClient().getObjectStore()
+        .getClientProxy().getOzoneManagerClient();
     TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -548,7 +548,6 @@ public class TestOmMetrics {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
 
     String keyName = UUID.randomUUID().toString();
     OmKeyLocationInfo keyLocationInfo = new OmKeyLocationInfo.Builder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -297,7 +297,7 @@ public class TestOmMetrics {
     omMetrics = getMetrics("OMMetrics");
     assertCounter("NumKeys", 2L, omMetrics);
 
-    // inject exception to test for Failure Metrics
+    // inject exception to test for Failure Metrics on the read path
     Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
     Mockito.doThrow(exception).when(mockKm).listKeys(
         any(), any(), any(), any(), anyInt());
@@ -306,6 +306,7 @@ public class TestOmMetrics {
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "keyManager", mockKm);
 
+    // inject exception to test for Failure Metrics on the write path
     OMMetadataManager metadataManager = (OMMetadataManager)
         HddsWhiteboxTestUtils.getInternalState(ozoneManager, "metadataManager");
     OMMetadataManager mockMm = Mockito.spy(metadataManager);
@@ -314,7 +315,6 @@ public class TestOmMetrics {
     Table<String, OmBucketInfo> mockBTable = Mockito.spy(bucketTable);
     Mockito.doThrow(exception).when(mockBTable).isExist(any());
     Mockito.doReturn(mockBTable).when(mockMm).getBucketTable();
-
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "metadataManager", mockMm);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -257,6 +257,9 @@ public class TestOmMetrics {
 
   @Test
   public void testKeyOps() throws IOException {
+    KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
+        .getInternalState(ozoneManager, "keyManager");
+    KeyManager mockKm = Mockito.spy(keyManager);
     OmKeyArgs keyArgs = createKeyArgs();
     doKeyOps(keyArgs);
 
@@ -270,6 +273,9 @@ public class TestOmMetrics {
     assertCounter("NumKeys", 0L, omMetrics);
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
 
+    assertCounter("NumKeyLookupFails", 1L, omMetrics);
+    assertCounter("NumKeyDeleteFails", 1L, omMetrics);
+    
 
     OpenKeySession keySession = writeClient.openKey(keyArgs);
     writeClient.commitKey(keyArgs, keySession.getId());
@@ -287,10 +293,6 @@ public class TestOmMetrics {
     omMetrics = getMetrics("OMMetrics");
     assertCounter("NumKeys", 2L, omMetrics);
 
-    KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
-        .getInternalState(ozoneManager, "keyManager");
-    KeyManager mockKm = Mockito.spy(keyManager);
-
     // inject exception to test for Failure Metrics
     Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
     Mockito.doThrow(exception).when(mockKm).listKeys(
@@ -300,40 +302,20 @@ public class TestOmMetrics {
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "keyManager", mockKm);
 
-    try {
-    mockKm.lookupKey(null, "b");
-    } catch (IOException e) {
-      System.out.println("gbj got :" + e.toString());
-    }
-
-    // md manager
     OMMetadataManager metadataManager = (OMMetadataManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "metadataManager");
     OMMetadataManager mockMm = Mockito.spy(metadataManager);
-    Table<String, OmVolumeArgs> mockVTable = Mockito.spy(metadataManager.getVolumeTable());
-    Mockito.doThrow(exception).when(mockVTable).isExist(any());
     Table<String, OmBucketInfo> bucketTable = (Table<String, OmBucketInfo>) HddsWhiteboxTestUtils
         .getInternalState(metadataManager, "bucketTable");
     Table<String, OmBucketInfo> mockBTable = Mockito.spy(bucketTable);
     Mockito.doThrow(exception).when(mockBTable).isExist(any());
     Mockito.doReturn(mockBTable).when(mockMm).getBucketTable();
 
-   // Mockito.doThrow(exception).when(mockMm).getBucketKey(any(), any());
-    HddsWhiteboxTestUtils.setInternalState(
-        metadataManager, "volumeTable", mockVTable);
-    HddsWhiteboxTestUtils.setInternalState(
-        metadataManager, "bucketTable", mockBTable);
-
     HddsWhiteboxTestUtils.setInternalState(
         ozoneManager, "metadataManager", mockMm);
-    try {
-    mockMm.getBucketTable().isExist("b");
-    } catch (IOException e) {
-      System.out.println("gbj2 got :" + e.toString());
-    }
 
-
-
+    keyArgs = keyArgs.toBuilder().setKeyName(UUID.randomUUID().toString())
+        .build();
     doKeyOps(keyArgs);
 
     omMetrics = getMetrics("OMMetrics");

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -22,9 +22,9 @@ import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
+// import static org.mockito.Matchers.any;
+// import static org.mockito.Matchers.anyInt;
+// import static org.mockito.Matchers.anyLong;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,11 +36,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
+//import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+//import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -49,10 +50,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
-import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
+import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -96,7 +94,8 @@ public class TestOmMetrics {
     cluster = MiniOzoneCluster.newBuilder(conf).build();
     cluster.waitForClusterToBeReady();
     ozoneManager = cluster.getOzoneManager();
-    writeClient = new RpcClient(conf, cluster.getOMServiceId()).getOzoneManagerClient();
+    writeClient = new RpcClient(conf, cluster.getOMServiceId())
+      .getOzoneManagerClient();
   }
 
   /**
@@ -286,19 +285,20 @@ public class TestOmMetrics {
     omMetrics = getMetrics("OMMetrics");
     assertCounter("NumKeys", 2L, omMetrics);
 
+    // KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
+    //     .getInternalState(ozoneManager, "keyManager");
+    // KeyManager mockKm = Mockito.spy(keyManager);
+
     // // inject exception to test for Failure Metrics
-    // Mockito.doThrow(exception).when(mockKm).openKey(any());
-    // Mockito.doThrow(exception).when(mockKm).deleteKey(any());
     // Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
     // Mockito.doThrow(exception).when(mockKm).listKeys(
     //     any(), any(), any(), any(), anyInt());
     // Mockito.doThrow(exception).when(mockKm).listTrash(
     //     any(), any(), any(), any(), anyInt());
-    // Mockito.doThrow(exception).when(mockKm).commitKey(any(), anyLong());
-    // Mockito.doThrow(exception).when(mockKm).initiateMultipartUpload(any());
-
     // HddsWhiteboxTestUtils.setInternalState(
     //     ozoneManager, "keyManager", mockKm);
+
+
     // doKeyOps(keyArgs);
 
     // omMetrics = getMetrics("OMMetrics");
@@ -504,12 +504,14 @@ public class TestOmMetrics {
     }
 
     try {
-      ozoneManager.listKeys(keyArgs.getVolumeName(), keyArgs.getBucketName(), null, null, 0);
+      ozoneManager.listKeys(keyArgs.getVolumeName(),
+                            keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 
     try {
-      ozoneManager.listTrash(keyArgs.getVolumeName(), keyArgs.getBucketName(), null, null, 0);
+      ozoneManager.listTrash(keyArgs.getVolumeName(),
+                             keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -22,9 +22,9 @@ import static org.apache.hadoop.ozone.security.acl.OzoneObj.ResourceType.VOLUME;
 import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-// import static org.mockito.Matchers.any;
-// import static org.mockito.Matchers.anyInt;
-// import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyLong;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -36,12 +36,12 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-//import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-//import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -50,6 +50,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.*;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -81,7 +82,8 @@ public class TestOmMetrics {
   /**
    * The exception used for testing failure metrics.
    */
-  private IOException exception = new IOException();
+  private OMException exception =
+      new OMException("dummyException", OMException.ResultCodes.TIMEOUT);
 
   /**
    * Create a MiniDFSCluster for testing.
@@ -285,43 +287,76 @@ public class TestOmMetrics {
     omMetrics = getMetrics("OMMetrics");
     assertCounter("NumKeys", 2L, omMetrics);
 
-    // KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
-    //     .getInternalState(ozoneManager, "keyManager");
-    // KeyManager mockKm = Mockito.spy(keyManager);
+    KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
+        .getInternalState(ozoneManager, "keyManager");
+    KeyManager mockKm = Mockito.spy(keyManager);
 
-    // // inject exception to test for Failure Metrics
-    // Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
-    // Mockito.doThrow(exception).when(mockKm).listKeys(
-    //     any(), any(), any(), any(), anyInt());
-    // Mockito.doThrow(exception).when(mockKm).listTrash(
-    //     any(), any(), any(), any(), anyInt());
-    // HddsWhiteboxTestUtils.setInternalState(
-    //     ozoneManager, "keyManager", mockKm);
+    // inject exception to test for Failure Metrics
+    Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
+    Mockito.doThrow(exception).when(mockKm).listKeys(
+        any(), any(), any(), any(), anyInt());
+    Mockito.doThrow(exception).when(mockKm).listTrash(
+        any(), any(), any(), any(), anyInt());
+    HddsWhiteboxTestUtils.setInternalState(
+        ozoneManager, "keyManager", mockKm);
+
+    try {
+    mockKm.lookupKey(null, "b");
+    } catch (IOException e) {
+      System.out.println("gbj got :" + e.toString());
+    }
+
+    // md manager
+    OMMetadataManager metadataManager = (OMMetadataManager) HddsWhiteboxTestUtils
+        .getInternalState(ozoneManager, "metadataManager");
+    OMMetadataManager mockMm = Mockito.spy(metadataManager);
+    Table<String, OmVolumeArgs> mockVTable = Mockito.spy(metadataManager.getVolumeTable());
+    Mockito.doThrow(exception).when(mockVTable).isExist(any());
+    Table<String, OmBucketInfo> bucketTable = (Table<String, OmBucketInfo>) HddsWhiteboxTestUtils
+        .getInternalState(metadataManager, "bucketTable");
+    Table<String, OmBucketInfo> mockBTable = Mockito.spy(bucketTable);
+    Mockito.doThrow(exception).when(mockBTable).isExist(any());
+    Mockito.doReturn(mockBTable).when(mockMm).getBucketTable();
+
+   // Mockito.doThrow(exception).when(mockMm).getBucketKey(any(), any());
+    HddsWhiteboxTestUtils.setInternalState(
+        metadataManager, "volumeTable", mockVTable);
+    HddsWhiteboxTestUtils.setInternalState(
+        metadataManager, "bucketTable", mockBTable);
+
+    HddsWhiteboxTestUtils.setInternalState(
+        ozoneManager, "metadataManager", mockMm);
+    try {
+    mockMm.getBucketTable().isExist("b");
+    } catch (IOException e) {
+      System.out.println("gbj2 got :" + e.toString());
+    }
 
 
-    // doKeyOps(keyArgs);
 
-    // omMetrics = getMetrics("OMMetrics");
-    // assertCounter("NumKeyOps", 21L, omMetrics);
-    // assertCounter("NumKeyAllocate", 5L, omMetrics);
-    // assertCounter("NumKeyLookup", 2L, omMetrics);
-    // assertCounter("NumKeyDeletes", 3L, omMetrics);
-    // assertCounter("NumKeyLists", 2L, omMetrics);
-    // assertCounter("NumTrashKeyLists", 2L, omMetrics);
-    // assertCounter("NumInitiateMultipartUploads", 2L, omMetrics);
+    doKeyOps(keyArgs);
 
-    // assertCounter("NumKeyAllocateFails", 1L, omMetrics);
-    // assertCounter("NumKeyLookupFails", 1L, omMetrics);
-    // assertCounter("NumKeyDeleteFails", 1L, omMetrics);
-    // assertCounter("NumKeyListFails", 1L, omMetrics);
-    // assertCounter("NumTrashKeyListFails", 1L, omMetrics);
-    // assertCounter("NumInitiateMultipartUploadFails", 1L, omMetrics);
+    omMetrics = getMetrics("OMMetrics");
+    assertCounter("NumKeyOps", 21L, omMetrics);
+    assertCounter("NumKeyAllocate", 5L, omMetrics);
+    assertCounter("NumKeyLookup", 2L, omMetrics);
+    assertCounter("NumKeyDeletes", 3L, omMetrics);
+    assertCounter("NumKeyLists", 2L, omMetrics);
+    assertCounter("NumTrashKeyLists", 2L, omMetrics);
+    assertCounter("NumInitiateMultipartUploads", 2L, omMetrics);
+
+    assertCounter("NumKeyAllocateFails", 1L, omMetrics);
+    assertCounter("NumKeyLookupFails", 2L, omMetrics);
+    assertCounter("NumKeyDeleteFails", 2L, omMetrics);
+    assertCounter("NumKeyListFails", 1L, omMetrics);
+    assertCounter("NumTrashKeyListFails", 1L, omMetrics);
+    assertCounter("NumInitiateMultipartUploadFails", 1L, omMetrics);
 
 
-    // assertCounter("NumKeys", 2L, omMetrics);
+    assertCounter("NumKeys", 2L, omMetrics);
 
-    // cluster.restartOzoneManager();
-    // assertCounter("NumKeys", 2L, omMetrics);
+    cluster.restartOzoneManager();
+    assertCounter("NumKeys", 2L, omMetrics);
 
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -24,10 +24,8 @@ import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyLong;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -35,13 +33,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
-import org.apache.hadoop.hdds.client.RatisReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationFactor;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
 import org.apache.hadoop.hdds.scm.pipeline.MockPipeline;
-import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
@@ -49,11 +42,12 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.ObjectStore;
-import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -277,8 +271,13 @@ public class TestOmMetrics {
     assertCounter("NumKeys", 0L, omMetrics);
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
 
+    // Check for failures
+    assertCounter("NumKeyAllocateFails", 0L, omMetrics);
     assertCounter("NumKeyLookupFails", 1L, omMetrics);
     assertCounter("NumKeyDeleteFails", 1L, omMetrics);
+    assertCounter("NumKeyListFails", 0L, omMetrics);
+    assertCounter("NumTrashKeyListFails", 0L, omMetrics);
+    assertCounter("NumInitiateMultipartUploadFails", 0L, omMetrics);
     
 
     OpenKeySession keySession = writeClient.openKey(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -94,7 +94,6 @@ public class TestOmMetrics {
     ozoneManager = cluster.getOzoneManager();
     writeClient = cluster.getRpcClient().getObjectStore()
         .getClientProxy().getOzoneManagerClient();
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
   }
 
   /**
@@ -257,6 +256,7 @@ public class TestOmMetrics {
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = Mockito.spy(keyManager);
+    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
     OmKeyArgs keyArgs = createKeyArgs();
     doKeyOps(keyArgs);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -27,18 +27,27 @@ import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ContainerBlockID;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.HddsWhiteboxTestUtils;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
@@ -47,6 +56,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
+import org.assertj.core.util.Lists;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -245,29 +255,6 @@ public class TestOmMetrics {
 
   @Test
   public void testKeyOps() throws IOException {
-    KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
-        .getInternalState(ozoneManager, "keyManager");
-    KeyManager mockKm = Mockito.spy(keyManager);
-    BucketManager mockBm = Mockito.mock(BucketManager.class);
-
-    OmBucketInfo mockBucket = OmBucketInfo.newBuilder()
-        .setVolumeName("").setBucketName("")
-        .build();
-    Mockito.when(mockBm.getBucketInfo(any(), any())).thenReturn(mockBucket);
-    Mockito.doReturn(null).when(mockKm).openKey(any());
-    Mockito.doNothing().when(mockKm).deleteKey(any());
-    Mockito.doReturn(null).when(mockKm).lookupKey(any(), any());
-    Mockito.doReturn(null).when(mockKm).listKeys(any(), any(), any(), any(),
-        anyInt());
-    Mockito.doReturn(null).when(mockKm).listTrash(any(), any(), any(), any(),
-        anyInt());
-    Mockito.doNothing().when(mockKm).commitKey(any(), anyLong());
-    Mockito.doReturn(null).when(mockKm).initiateMultipartUpload(any());
-
-    HddsWhiteboxTestUtils.setInternalState(
-        ozoneManager, "bucketManager", mockBm);
-    HddsWhiteboxTestUtils.setInternalState(
-        ozoneManager, "keyManager", mockKm);
     OmKeyArgs keyArgs = createKeyArgs();
     doKeyOps(keyArgs);
 
@@ -282,54 +269,54 @@ public class TestOmMetrics {
     assertCounter("NumInitiateMultipartUploads", 1L, omMetrics);
 
 
-    ozoneManager.openKey(keyArgs);
-    ozoneManager.commitKey(keyArgs, 0);
-    ozoneManager.openKey(keyArgs);
-    ozoneManager.commitKey(keyArgs, 0);
-    ozoneManager.openKey(keyArgs);
-    ozoneManager.commitKey(keyArgs, 0);
+    writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, 0);
+    writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, 0);
+    writeClient.openKey(keyArgs);
+    writeClient.commitKey(keyArgs, 0);
     writeClient.deleteKey(keyArgs);
 
 
     omMetrics = getMetrics("OMMetrics");
     assertCounter("NumKeys", 2L, omMetrics);
 
-    // inject exception to test for Failure Metrics
-    Mockito.doThrow(exception).when(mockKm).openKey(any());
-    Mockito.doThrow(exception).when(mockKm).deleteKey(any());
-    Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
-    Mockito.doThrow(exception).when(mockKm).listKeys(
-        any(), any(), any(), any(), anyInt());
-    Mockito.doThrow(exception).when(mockKm).listTrash(
-        any(), any(), any(), any(), anyInt());
-    Mockito.doThrow(exception).when(mockKm).commitKey(any(), anyLong());
-    Mockito.doThrow(exception).when(mockKm).initiateMultipartUpload(any());
+    // // inject exception to test for Failure Metrics
+    // Mockito.doThrow(exception).when(mockKm).openKey(any());
+    // Mockito.doThrow(exception).when(mockKm).deleteKey(any());
+    // Mockito.doThrow(exception).when(mockKm).lookupKey(any(), any());
+    // Mockito.doThrow(exception).when(mockKm).listKeys(
+    //     any(), any(), any(), any(), anyInt());
+    // Mockito.doThrow(exception).when(mockKm).listTrash(
+    //     any(), any(), any(), any(), anyInt());
+    // Mockito.doThrow(exception).when(mockKm).commitKey(any(), anyLong());
+    // Mockito.doThrow(exception).when(mockKm).initiateMultipartUpload(any());
 
-    HddsWhiteboxTestUtils.setInternalState(
-        ozoneManager, "keyManager", mockKm);
-    doKeyOps(keyArgs);
+    // HddsWhiteboxTestUtils.setInternalState(
+    //     ozoneManager, "keyManager", mockKm);
+    // doKeyOps(keyArgs);
 
-    omMetrics = getMetrics("OMMetrics");
-    assertCounter("NumKeyOps", 21L, omMetrics);
-    assertCounter("NumKeyAllocate", 5L, omMetrics);
-    assertCounter("NumKeyLookup", 2L, omMetrics);
-    assertCounter("NumKeyDeletes", 3L, omMetrics);
-    assertCounter("NumKeyLists", 2L, omMetrics);
-    assertCounter("NumTrashKeyLists", 2L, omMetrics);
-    assertCounter("NumInitiateMultipartUploads", 2L, omMetrics);
+    // omMetrics = getMetrics("OMMetrics");
+    // assertCounter("NumKeyOps", 21L, omMetrics);
+    // assertCounter("NumKeyAllocate", 5L, omMetrics);
+    // assertCounter("NumKeyLookup", 2L, omMetrics);
+    // assertCounter("NumKeyDeletes", 3L, omMetrics);
+    // assertCounter("NumKeyLists", 2L, omMetrics);
+    // assertCounter("NumTrashKeyLists", 2L, omMetrics);
+    // assertCounter("NumInitiateMultipartUploads", 2L, omMetrics);
 
-    assertCounter("NumKeyAllocateFails", 1L, omMetrics);
-    assertCounter("NumKeyLookupFails", 1L, omMetrics);
-    assertCounter("NumKeyDeleteFails", 1L, omMetrics);
-    assertCounter("NumKeyListFails", 1L, omMetrics);
-    assertCounter("NumTrashKeyListFails", 1L, omMetrics);
-    assertCounter("NumInitiateMultipartUploadFails", 1L, omMetrics);
+    // assertCounter("NumKeyAllocateFails", 1L, omMetrics);
+    // assertCounter("NumKeyLookupFails", 1L, omMetrics);
+    // assertCounter("NumKeyDeleteFails", 1L, omMetrics);
+    // assertCounter("NumKeyListFails", 1L, omMetrics);
+    // assertCounter("NumTrashKeyListFails", 1L, omMetrics);
+    // assertCounter("NumInitiateMultipartUploadFails", 1L, omMetrics);
 
 
-    assertCounter("NumKeys", 2L, omMetrics);
+    // assertCounter("NumKeys", 2L, omMetrics);
 
-    cluster.restartOzoneManager();
-    assertCounter("NumKeys", 2L, omMetrics);
+    // cluster.restartOzoneManager();
+    // assertCounter("NumKeys", 2L, omMetrics);
 
   }
 
@@ -497,7 +484,7 @@ public class TestOmMetrics {
    */
   private void doKeyOps(OmKeyArgs keyArgs) {
     try {
-      ozoneManager.openKey(keyArgs);
+      writeClient.openKey(keyArgs);
     } catch (IOException ignored) {
     }
 
@@ -512,35 +499,63 @@ public class TestOmMetrics {
     }
 
     try {
-      ozoneManager.listKeys("", "", null, null, 0);
+      ozoneManager.listKeys(keyArgs.getVolumeName(), keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 
     try {
-      ozoneManager.listTrash("", "", null, null, 0);
+      ozoneManager.listTrash(keyArgs.getVolumeName(), keyArgs.getBucketName(), null, null, 0);
     } catch (IOException ignored) {
     }
 
     try {
-      ozoneManager.commitKey(keyArgs, 0);
+      writeClient.commitKey(keyArgs, 0);
     } catch (IOException ignored) {
     }
 
     try {
-      ozoneManager.initiateMultipartUpload(keyArgs);
+      writeClient.initiateMultipartUpload(keyArgs);
     } catch (IOException ignored) {
     }
 
   }
 
-  private OmKeyArgs createKeyArgs() {
+  /**
+   * Get Random pipeline.
+   * @return pipeline
+   */
+  private Pipeline getRandomPipeline() {
+    return Pipeline.newBuilder()
+        .setState(Pipeline.PipelineState.OPEN)
+        .setId(PipelineID.randomId())
+        .setReplicationConfig(
+            new RatisReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+        .setNodes(new ArrayList<>())
+        .build();
+  }
+  private OmKeyArgs createKeyArgs() throws IOException {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    ObjectStore store = cluster.getClient().getObjectStore();
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    String keyName = UUID.randomUUID().toString();
     OmKeyLocationInfo keyLocationInfo = new OmKeyLocationInfo.Builder()
         .setBlockID(new BlockID(new ContainerBlockID(1, 1)))
+        .setPipeline(getRandomPipeline())
         .build();
     keyLocationInfo.setCreateVersion(0);
 
     return new OmKeyArgs.Builder()
         .setLocationInfoList(Collections.singletonList(keyLocationInfo))
+        .setVolumeName(volumeName)
+        .setBucketName(bucketName)
+        .setKeyName(keyName)
+        .setAcls(Lists.emptyList())
         .build();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2682,27 +2682,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    */
   @Override
   public void deleteKey(OmKeyArgs args) throws IOException {
-    Map<String, String> auditMap = args.toAuditMap();
-    try {
-      ResolvedBucket bucket = resolveBucketLink(args);
-      args = bucket.update(args);
-
-      if (isAclEnabled) {
-        checkAcls(ResourceType.KEY, StoreType.OZONE, ACLType.DELETE,
-            bucket.realVolume(), bucket.realBucket(), args.getKeyName());
-      }
-
-      metrics.incNumKeyDeletes();
-      keyManager.deleteKey(args);
-      AUDIT.logWriteSuccess(buildAuditMessageForSuccess(OMAction.DELETE_KEY,
-          auditMap));
-      metrics.decNumKeys();
-    } catch (Exception ex) {
-      metrics.incNumKeyDeleteFails();
-      AUDIT.logWriteFailure(buildAuditMessageForFailure(OMAction.DELETE_KEY,
-          auditMap, ex));
-      throw ex;
-    }
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+        "this to be implemented. As write requests use a new approach");
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2683,7 +2683,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public void deleteKey(OmKeyArgs args) throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
-        "this to be implemented. As write requests use a new approach");
+        "deleteKey to be implemented. As write requests use a new approach");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the OM-HA code was added, the tests were not completely updated.  Many of them still call the OzoneManagerProtocol "write-path" methods even though those methods have been superseded by the HA methods.

This PR is a small beginning to the fix.  I didn't want to do too much before getting some feedback, so I just removed a single api call,  OzoneManager.deleteKey(), and fixed the corresponding tests, by changing them to invoke the ozoneManagerClient version.

If there is a less hacky way of doing it, without using the client, please let me know.  I couldn't find one.  I tried creating an alternative, but it looked like a half-baked client, so I just used the real one.

I timed all the tests I changed and didn't notice any running longer.

### Notes on TestOmMetrics.testKeyOps() test

The only test that was difficult to fix was the testKeyOps() test [here](https://github.com/apache/ozone/blob/79a9d39da7f33e71bc00183e280105562354cca4/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java#L243).

This test verifies that keyOps generate the correct number of metrics.  I tried to write the new code so the numbers didn't change.  But there is actually a flaw in the original test that causes it to undercount a few, (*NumKeyLookupFails*, and *NumKeyDeleteFails*).  So you'll see those fixed.

The test depends on mocks of the KeyManager. But now that the OM no longer supports deleteKey(), those mocks won't work.  So I had to replace most of them with actual working code; (because I couldn't find a way to mock the actual write path.)

The test is divided into two halves.  The first half verifies normal metrics; the second half verifies failure metrics.  I removed the mocks in the first half; as mentioned above, those metrics are now generated by real code.  The mocks in the second half are there to force failures, (by generating exceptions).  I modified those to work with the new code.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3371

## How was this patch tested?

All effected tests were updated.
