### PR TITLE
HDDS-5735. Prometheus HTTP API Reference cannot be displayed normally

### DIFF
--- a/hadoop-hdds/docs/content/interface/ReconApi.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.md
@@ -629,7 +629,7 @@ response object being the upper cap for file size range.
  
 **Parameters**
 
-Refer to [Prometheus HTTP API Reference](https://prometheus.io/docs/prometheuslatest/querying/api/) 
+Refer to [Prometheus HTTP API Reference](https://prometheus.io/docs/prometheus/latest/querying/api/) 
 for complete documentation on querying. 
 
 **Returns**

--- a/hadoop-hdds/docs/content/interface/ReconApi.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.md
@@ -229,7 +229,7 @@ Returns the UnhealthyContainerMetadata objects for all the unhealthycontainers.
 
 **Returns**
 
-Returns the UnhealthyContainerMetadata objects for the containers in the givenstate.
+Returns the UnhealthyContainerMetadata objects for the containers in the given state.
 Possible unhealthy container states are `MISSING`, `MIS_REPLICATED`,`UNDER_REPLICATED`, `OVER_REPLICATED`.
 The response structure is same as `/containers/unhealthy`.
 

--- a/hadoop-hdds/docs/content/interface/ReconApi.zh.md
+++ b/hadoop-hdds/docs/content/interface/ReconApi.zh.md
@@ -402,7 +402,7 @@ Recon API v1 是一组 HTTP 端点，可以帮助您了解 Ozone 集群的当前
     
 **参数**
 
-请参阅 [Prometheus HTTP API 参考](https://prometheus.io/docs/prometheus/latestquerying/api/) 以获取完整的查询文档。
+请参阅 [Prometheus HTTP API 参考](https://prometheus.io/docs/prometheus/latest/querying/api/) 以获取完整的查询文档。
 
 **回传**
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When I read the Recon API documentation, the current link cannot be linked to the external Prometheus HTTP API Reference.

As shown below:
![微信图片_20210911150910](https://user-images.githubusercontent.com/72794035/132940114-69babf98-1699-413c-8f81-55d568c22448.png)
![微信图片_20210911150918](https://user-images.githubusercontent.com/72794035/132940115-a59f68d7-dab6-48d0-b718-e7d69f60ee45.png)

**It has been replaced by the available Prometheus HTTP API Reference link.**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5735

## How was this patch tested?

Local hugo pass.
