### PR TITLE
HDDS-5742. [Ozone-Streaming] Avoid unnecessary Bytebuffer conversions

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -485,8 +485,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
       throws IOException {
     final int effectiveChunkSize = buf.remaining();
     final long offset = chunkOffset.getAndAdd(effectiveChunkSize);
-    ChecksumData checksumData =
-        checksum.computeChecksum(buf.asReadOnlyBuffer());
+    ChecksumData checksumData = checksum.computeChecksum(buf);
     ChunkInfo chunkInfo = ChunkInfo.newBuilder()
         .setChunkName(blockID.get().getLocalID() + "_chunk_" + ++chunkIndex)
         .setOffset(offset)

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -139,6 +139,10 @@ public class Checksum {
    */
   public ChecksumData computeChecksum(ByteBuffer data)
       throws OzoneChecksumException {
+    if (checksumType == ChecksumType.NONE) {
+      // Since type is set to NONE, we do not need to compute the checksums
+      return new ChecksumData(checksumType, bytesPerChecksum);
+    }
     if (!data.isReadOnly()) {
       data = data.asReadOnlyBuffer();
     }
@@ -154,11 +158,6 @@ public class Checksum {
 
   public ChecksumData computeChecksum(ChunkBuffer data)
       throws OzoneChecksumException {
-    if (checksumType == ChecksumType.NONE) {
-      // Since type is set to NONE, we do not need to compute the checksums
-      return new ChecksumData(checksumType, bytesPerChecksum);
-    }
-
     final Function<ByteBuffer, ByteString> function;
     try {
       function = Algorithm.valueOf(checksumType).newChecksumFunction();


### PR DESCRIPTION
## What changes were proposed in this pull request?

If checksum is disabled, byteBuffer does not need to be converted. We need to advance if judgments to avoid unnecessary conversions

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5742
