### PR TITLE
HDDS-5745. EC: Pipeline builder should copy replica indexes from original pipeline

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java
@@ -475,6 +475,15 @@ public final class Pipeline {
       this.leaderId = pipeline.getLeaderId();
       this.creationTimestamp = pipeline.getCreationTimestamp();
       this.suggestedLeaderId = pipeline.getSuggestedLeaderId();
+      this.replicaIndexes = new HashMap<>();
+      if (nodeStatus != null) {
+        for (DatanodeDetails dn : nodeStatus.keySet()) {
+          int index = pipeline.getReplicaIndex(dn);
+          if (index > 0) {
+            replicaIndexes.put(dn, index);
+          }
+        }
+      }
     }
 
     public Builder setId(PipelineID id1) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -87,4 +87,28 @@ public class TestPipeline {
     Pipeline pipeline = MockPipeline.createEcPipeline();
     Assert.assertTrue(pipeline.isHealthy());
   }
+
+  @Test
+  public void testBuilderCopiesAllFieldsFromOtherPipeline() {
+    Pipeline original = MockPipeline.createEcPipeline();
+    Pipeline copied = Pipeline.newBuilder(original).build();
+    Assert.assertEquals(original.getId(), copied.getId());
+    Assert.assertEquals(original.getReplicationConfig(),
+        copied.getReplicationConfig());
+    Assert.assertEquals(original.getPipelineState(), copied.getPipelineState());
+    Assert.assertEquals(original.getId(), copied.getId());
+    Assert.assertEquals(original.getId(), copied.getId());
+    Assert.assertEquals(original.getId(), copied.getId());
+    Assert.assertEquals(original.getNodeSet(), copied.getNodeSet());
+    Assert.assertEquals(original.getNodesInOrder(), copied.getNodesInOrder());
+    Assert.assertEquals(original.getLeaderId(), copied.getLeaderId());
+    Assert.assertEquals(original.getCreationTimestamp(),
+        copied.getCreationTimestamp());
+    Assert.assertEquals(original.getSuggestedLeaderId(),
+        copied.getSuggestedLeaderId());
+    for (DatanodeDetails dn : original.getNodes()) {
+      Assert.assertEquals(original.getReplicaIndex(dn),
+          copied.getReplicaIndex(dn));
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The replica indexes are not copied to the new pipeline when the pipeline is cloned.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5745

## How was this patch tested?

New unit test
