### PR TITLE
HDDS-5402 Support list node based on NodeOperationalState and NodeState options in printTopology CLI

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/topology/cli.robot
@@ -31,3 +31,9 @@ Run printTopology -o
     ${output} =         Execute          ozone admin printTopology -o
                         Should contain   ${output}         Location: /rack2
                         Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net) IN_SERVICE
+Run printTopology --operational-state IN_SERVICE
+    ${output} =         Execute          ozone admin printTopology --operational-state IN_SERVICE
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2
+Run printTopology --node-state HEALTHY
+    ${output} =         Execute          ozone admin printTopology --node-state HEALTHY
+                        Should contain   ${output}         10.5.0.7(ozone-topology_datanode_4_1.ozone-topology_net)    IN_SERVICE    /rack2


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, printTopology CLI display all DN information as output.
This task is to add NodeOperationalState and NodeState as the CLI options to the command, and display the DN accordingly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5402

## How was this patch tested?

bin/ozone admin printTopology -n IN_SERVICE
