### PR TITLE
HDDS-5748. Reuse mini-clusters in TestOzoneFSWithObjectStoreCreate

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -37,9 +37,11 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -70,7 +72,7 @@ public class TestOzoneFSWithObjectStoreCreate {
 
   private String rootPath;
 
-  private MiniOzoneCluster cluster = null;
+  private static MiniOzoneCluster cluster = null;
 
   private OzoneFileSystem o3fs;
 
@@ -78,12 +80,8 @@ public class TestOzoneFSWithObjectStoreCreate {
 
   private String bucketName;
 
-
-  @Before
-  public void init() throws Exception {
-    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
-
+  @BeforeClass
+  public static void initClass() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
 
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
@@ -91,6 +89,21 @@ public class TestOzoneFSWithObjectStoreCreate {
         .setNumDatanodes(3)
         .build();
     cluster.waitForClusterToBeReady();
+  }
+
+  @AfterClass
+  public static void teardownClass() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  @Before
+  public void init() throws Exception {
+    volumeName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+    bucketName = RandomStringUtils.randomAlphabetic(10).toLowerCase();
+
+    OzoneConfiguration conf = cluster.getConf();
 
     // create a volume and a bucket to be used by OzoneFileSystem
     TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
@@ -102,9 +115,6 @@ public class TestOzoneFSWithObjectStoreCreate {
 
   @After
   public void teardown() {
-    if (cluster != null) {
-      cluster.shutdown();
-    }
     IOUtils.closeQuietly(o3fs);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneFSWithObjectStoreCreate typically runs in about 212 seconds:

```
[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 212.789 s - in org.apache.hadoop.fs.ozone.TestOzoneFSWithObjectStoreCreate
[INFO] Running org.apache.hadoop.fs.ozone.TestOzoneFileSystem
```

Refactoring to re-use the mini-cluster across all tests should greatly reduce this runtime.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5748

## How was this patch tested?

Existing tests
