### PR TITLE
HDDS-5751. Use Mini Cluster Provider to speed up TestHDDSUpgrade

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneClusterProvider;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
@@ -84,8 +85,10 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -120,6 +123,8 @@ public class TestHDDSUpgrade {
       ReplicationConfig.fromTypeAndFactor(HddsProtos.ReplicationType.RATIS,
           HddsProtos.ReplicationFactor.THREE);
 
+  private static MiniOzoneClusterProvider clusterProvider;
+
   /**
    * Create a MiniDFSCluster for testing.
    *
@@ -135,30 +140,46 @@ public class TestHDDSUpgrade {
     shutdown();
   }
 
-  public void init() throws Exception {
-    conf = new OzoneConfiguration();
+  @BeforeClass
+  public static void initClass() {
+    OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1000,
         TimeUnit.MILLISECONDS);
     conf.set(OZONE_DATANODE_PIPELINE_LIMIT, "1");
-    cluster = MiniOzoneCluster.newBuilder(conf)
+
+    MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(NUM_DATA_NODES)
         // allow only one FACTOR THREE pipeline.
         .setTotalPipelineNumLimit(NUM_DATA_NODES + 1)
         .setHbInterval(500)
         .setHbProcessorInterval(500)
         .setScmLayoutVersion(INITIAL_VERSION.layoutVersion())
-        .setDnLayoutVersion(INITIAL_VERSION.layoutVersion())
-        .build();
-    cluster.waitForClusterToBeReady();
+        .setDnLayoutVersion(INITIAL_VERSION.layoutVersion());
+
+    // Setting the provider to a max of 100 clusters. Some of the tests here
+    // use multiple clusters, so its hard to know exactly how many will be
+    // needed. This means the provider will create 1 extra cluster than needed
+    // but that will not greatly affect runtimes.
+    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 100);
+  }
+
+  @AfterClass
+  public static void afterClass() throws InterruptedException {
+    clusterProvider.shutdown();
+  }
+
+  public void init() throws Exception {
+    cluster = clusterProvider.provide();
+    conf = cluster.getConf();
     loadSCMState();
   }
 
   /**
    * Shutdown MiniDFSCluster.
    */
-  public void shutdown() {
+  public void shutdown() throws IOException, InterruptedException {
     if (cluster != null) {
-      cluster.shutdown();
+      clusterProvider.destroy(cluster);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestHDDSUpgrade is one of the longest running test suits as it creates many mini-clusters:

```
[INFO] Running org.apache.hadoop.hdds.upgrade.TestHDDSUpgrade
Warning:  Tests run: 13, Failures: 0, Errors: 0, Skipped: 4, Time elapsed: 694.753 s - in org.apache.hadoop.hdds.upgrade.TestHDDSUpgrade
```

It is not possible to reuse the same clusters across multiple tests here, so we can use the MiniClusterProvider to create the clusters in the background and speed things up.

On my laptop the test runtime went from 9min 14s to 5min 12s.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5751

## How was this patch tested?

Existing tests
