### PR TITLE
HDDS-5752. [Ozone-Streaming] Add FileRegion API for Ozone Streaming

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -545,11 +545,11 @@ public class BlockDataStreamOutput
     final long offset = chunkOffset.getAndAdd(effectiveChunkSize);
     ChecksumData checksumData = checksum.noChecksum(); //TODO: support checksum
     ChunkInfo chunkInfo = ChunkInfo.newBuilder()
-            .setChunkName(blockID.get().getLocalID() + "_chunk_" + ++chunkIndex)
-            .setOffset(offset)
-            .setLen(effectiveChunkSize)
-            .setChecksumData(checksumData.getProtoBufMessage())
-            .build();
+        .setChunkName(blockID.get().getLocalID() + "_chunk_" + ++chunkIndex)
+        .setOffset(offset)
+        .setLen(effectiveChunkSize)
+        .setChecksumData(checksumData.getProtoBufMessage())
+        .build();
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Writing chunk {} length {} at offset {}",
@@ -557,23 +557,23 @@ public class BlockDataStreamOutput
     }
 
     CompletableFuture<DataStreamReply> future =
-            (needSync(offset + effectiveChunkSize) ?
-                    out.writeAsync(fpc, StandardWriteOption.SYNC) :
-                    out.writeAsync(fpc))
-                    .whenCompleteAsync((r, e) -> {
-                      if (e != null || !r.isSuccess()) {
-                        if (e == null) {
-                          e = new IOException("result is not success");
-                        }
-                        String msg =
-                                "Failed to write chunk " + chunkInfo.getChunkName() +
-                                        " " + "into block " + blockID;
-                        LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
-                        CompletionException ce = new CompletionException(msg, e);
-                        setIoException(ce);
-                        throw ce;
-                      }
-                    }, responseExecutor);
+        (needSync(offset + effectiveChunkSize) ?
+            out.writeAsync(fpc, StandardWriteOption.SYNC) :
+            out.writeAsync(fpc))
+            .whenCompleteAsync((r, e) -> {
+              if (e != null || !r.isSuccess()) {
+                if (e == null) {
+                  e = new IOException("result is not success");
+                }
+                String msg =
+                    "Failed to write chunk " + chunkInfo.getChunkName() +
+                    " " + "into block " + blockID;
+                LOG.debug("{}, exception: {}", msg, e.getLocalizedMessage());
+                CompletionException ce = new CompletionException(msg, e);
+                setIoException(ce);
+                throw ce;
+              }
+            }, responseExecutor);
 
     futures.add(future);
     containerBlockData.addChunks(chunkInfo);

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/FileRegionStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/FileRegionStreamOutput.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm.storage;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+
+/**
+* This interface is for writing an output stream of ByteBuffers.
+* An ByteBufferStreamOutput accepts nio ByteBuffer and sends them to some sink.
+*/
+public interface FileRegionStreamOutput extends Closeable {
+  /**
+   * Try to write all the bytes in ByteBuf b to DataStream.
+   *
+   * @param f the file.
+   * @exception IOException if an I/O error occurs.
+   */
+  default void write(File f) throws IOException {
+    write(f, 0, f.length());
+  }
+
+  /**
+   * Try to write the [off:off + len) slice in ByteBuf b to DataStream.
+   *
+   * @param f the file.
+   * @param off the start offset in the file.
+   * @param len the number of bytes to write.
+   * @exception  IOException  if an I/O error occurs.
+   */
+  void write(File f, long off, long len) throws IOException;
+
+  /**
+   * Flushes this DataStream output and forces any buffered output bytes
+   * to be written out.
+   *
+   * @exception  IOException  if an I/O error occurs.
+   */
+  void flush() throws IOException;
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -111,6 +111,10 @@ public class Checksum {
     this.bytesPerChecksum = bytesPerChecksum;
   }
 
+  public ChecksumData noChecksum() throws OzoneChecksumException {
+    return new ChecksumData(ChecksumType.NONE, bytesPerChecksum);
+  }
+
   /**
    * Computes checksum for give data.
    * @param data input data.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntry.java
@@ -139,16 +139,14 @@ public final class BlockDataStreamOutputEntry
 
   Collection<DatanodeDetails> getFailedServers() {
     if (blockDataStreamOutput != null) {
-      BlockDataStreamOutput out = this.blockDataStreamOutput;
-      return out.getFailedServers();
+      return this.blockDataStreamOutput.getFailedServers();
     }
     return Collections.emptyList();
   }
 
   long getWrittenDataLength() {
     if (blockDataStreamOutput != null) {
-      BlockDataStreamOutput out = this.blockDataStreamOutput;
-      return out.getWrittenDataLength();
+      return this.blockDataStreamOutput.getWrittenDataLength();
     } else {
       // For a pre allocated block for which no write has been initiated,
       // the ByteBufferStreamOutput will be null here.
@@ -159,15 +157,13 @@ public final class BlockDataStreamOutputEntry
 
   void cleanup(boolean invalidateClient) throws IOException {
     checkStream();
-    BlockDataStreamOutput out = this.blockDataStreamOutput;
-    out.cleanup(invalidateClient);
+    this.blockDataStreamOutput.cleanup(invalidateClient);
 
   }
 
   void writeOnRetry(long len) throws IOException {
     checkStream();
-    BlockDataStreamOutput out = this.blockDataStreamOutput;
-    out.writeOnRetry(len);
+    this.blockDataStreamOutput.writeOnRetry(len);
     this.currentPosition += len;
 
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/OzoneDataStreamOutput.java
@@ -64,12 +64,7 @@ public class OzoneDataStreamOutput
   }
 
   public OmMultipartCommitUploadPartInfo getCommitUploadPartInfo() {
-    if (keyDataStreamOutput instanceof KeyDataStreamOutput) {
-      return ((KeyDataStreamOutput)
-              keyDataStreamOutput).getCommitUploadPartInfo();
-    }
-    // Otherwise return null.
-    return null;
+    return keyDataStreamOutput.getCommitUploadPartInfo();
   }
 
   public ByteBufferStreamOutput getByteBufStreamOutput() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -131,19 +131,9 @@ public class PutKeyHandler extends KeyHandler {
       if (isVerbose()) {
         out().println("API: streaming");
       }
-      try (RandomAccessFile raf = new RandomAccessFile(dataFile, "r");
-           OzoneDataStreamOutput out = bucket.createStreamKey(keyName,
+      try (OzoneDataStreamOutput out = bucket.createStreamKey(keyName,
                dataFile.length(), replicationConfig, keyMetadata)) {
-        FileChannel ch = raf.getChannel();
-        long len = raf.length();
-        long off = 0;
-        while (len > 0) {
-          long writeLen = Math.min(len, chunkSize);
-          ByteBuffer bb = ch.map(FileChannel.MapMode.READ_ONLY, off, writeLen);
-          out.write(bb);
-          off += writeLen;
-          len -= writeLen;
-        }
+        out.write(dataFile);
       }
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -23,9 +23,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.RandomAccessFile;
-import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Introduce and implement FileRegionStreamOutput interface to support zero copy in Ozone streaming.

It uses `writeAsync(FilePositionCount)` API in Ratis streaming to write the data.
Underlying is Netty FileRegion and nio FileChannel.transferTo, which supports zero copy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5752

## How was this patch tested?

Unit test should be added.