### PR TITLE
HDDS-5753. Split parts of misc suite

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -194,6 +194,8 @@ jobs:
         suite:
           - secure
           - unsecure
+          - HA
+          - MR
           - misc
       fail-fast: ${{ github.event_name == 'pull_request' }}
     steps:

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:HA
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:MR
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:MR
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:MR
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:MR
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/test.sh
@@ -14,6 +14,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+#suite:MR
+
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )
 ALL_RESULT_DIR="$SCRIPT_DIR/result"
 mkdir -p "$ALL_RESULT_DIR"

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:HA
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:MR
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extract some tests from _acceptance (misc)_ into separate suites: _acceptance (HA)_ and _acceptance (MR)_.

https://issues.apache.org/jira/browse/HDDS-5753

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1242183045