### PR TITLE
HDDS-5759. Bump aspectj version

### DIFF
--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -33,13 +33,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
-      <version>1.8.9</version>
+      <version>${aspectj.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjweaver</artifactId>
-      <version>1.8.9</version>
+      <version>${aspectj.version}</version>
     </dependency>
 
     <dependency>
@@ -174,13 +174,9 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         </executions>
       </plugin>
       <plugin>
-        <!--
-        https://github.com/mojohaus/aspectj-maven-plugin/issues/24#issuecomment-419077658
         <groupId>org.codehaus.mojo</groupId>
-        -->
-        <groupId>com.github.m50d</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.11.1</version>
+        <version>${aspectj-plugin.version}</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.26</snakeyaml.version>
     <sonar.java.binaries>${basedir}/target/classes</sonar.java.binaries>
+
+    <aspectj.version>1.9.7</aspectj.version>
+    <aspectj-plugin.version>1.14.0</aspectj-plugin.version>
   </properties>
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-4319 temporarily switched to a fork of the `aspectj-maven-plugin` due to lack of Java 11 support in the official one.  A [newer version](https://github.com/mojohaus/aspectj-maven-plugin/releases/tag/aspectj-maven-plugin-1.14.0) is now available, which adds that missing support.  This PR upgrades the plugin, and also AspectJ to match the plugin's expectation.

https://issues.apache.org/jira/browse/HDDS-5759

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1244949654