### PR TITLE
HDDS-5766. Speed up some OM tests by skipping SCM safemode check

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -65,6 +65,8 @@ public class TestOmMetrics {
   @Rule
   public Timeout timeout = Timeout.seconds(300);
   private MiniOzoneCluster cluster;
+  private MiniOzoneCluster.Builder clusterBuilder;
+  private OzoneConfiguration conf;
   private OzoneManager ozoneManager;
 
   /**
@@ -77,20 +79,19 @@ public class TestOmMetrics {
    */
   @Before
   public void setup() throws Exception {
-    OzoneConfiguration conf = createConf();
-    // These test do not use any features of SCM, so we can skip safemode
-    // which gets the cluster to come up much faster.
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
-    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(0).build();
-    cluster.waitForClusterToBeReady();
-    ozoneManager = cluster.getOzoneManager();
-  }
-
-  private OzoneConfiguration createConf() {
-    OzoneConfiguration conf = new OzoneConfiguration();
+    conf = new OzoneConfiguration();
     conf.setTimeDuration(OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL,
         1000, TimeUnit.MILLISECONDS);
-    return conf;
+    // Most tests in this class do not use any features of SCM, so we can skip
+    // safemode which gets the cluster to come up much faster.
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
+    clusterBuilder = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(0);
+  }
+
+  private void startCluster() throws Exception {
+    cluster = clusterBuilder.build();
+    cluster.waitForClusterToBeReady();
+    ozoneManager = cluster.getOzoneManager();
   }
 
   /**
@@ -106,7 +107,8 @@ public class TestOmMetrics {
 
 
   @Test
-  public void testVolumeOps() throws IOException {
+  public void testVolumeOps() throws Exception {
+    startCluster();
     VolumeManager volumeManager =
         (VolumeManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "volumeManager");
@@ -183,7 +185,8 @@ public class TestOmMetrics {
   }
 
   @Test
-  public void testBucketOps() throws IOException {
+  public void testBucketOps() throws Exception {
+    startCluster();
     BucketManager bucketManager =
         (BucketManager) HddsWhiteboxTestUtils.getInternalState(
             ozoneManager, "bucketManager");
@@ -249,7 +252,8 @@ public class TestOmMetrics {
   }
 
   @Test
-  public void testKeyOps() throws IOException {
+  public void testKeyOps() throws Exception {
+    startCluster();
     KeyManager keyManager = (KeyManager) HddsWhiteboxTestUtils
         .getInternalState(ozoneManager, "keyManager");
     KeyManager mockKm = Mockito.spy(keyManager);
@@ -339,7 +343,8 @@ public class TestOmMetrics {
   }
 
   @Test
-  public void testAclOperations() throws IOException {
+  public void testAclOperations() throws Exception {
+    startCluster();
     try {
       // Create a volume.
       cluster.getClient().getObjectStore().createVolume("volumeacl");
@@ -377,11 +382,9 @@ public class TestOmMetrics {
   @Test
   public void testAclOperationsHA() throws Exception {
     // This test needs a cluster with DNs and SCM to wait on safemode
-    cluster.shutdown();
-    OzoneConfiguration conf = createConf();
-    cluster = MiniOzoneCluster.newBuilder(conf).build();
-    cluster.waitForClusterToBeReady();
-    ozoneManager = cluster.getOzoneManager();
+    clusterBuilder.setNumDatanodes(3);
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, true);
+    startCluster();
 
     ObjectStore objectStore = cluster.getClient().getObjectStore();
     // Create a volume.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -81,7 +81,9 @@ public class TestOzoneManagerConfiguration {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, true);
     conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
         RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
-
+    // These test do not use any features of SCM, so we can skip safemode
+    // which gets the cluster to come up much faster.
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");
     // writes the version file properties
@@ -100,6 +102,7 @@ public class TestOzoneManagerConfiguration {
       .setClusterId(clusterId)
       .setScmId(scmId)
       .setOmId(omId)
+      .setNumDatanodes(0)
       .build();
     cluster.waitForClusterToBeReady();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -69,6 +69,7 @@ import static org.junit.Assert.fail;
 public abstract class TestOzoneManagerHA {
 
   private MiniOzoneOMHAClusterImpl cluster = null;
+  private MiniOzoneCluster.Builder clusterBuilder = null;
   private ObjectStore objectStore;
   private OzoneConfiguration conf;
   private String clusterId;
@@ -99,6 +100,10 @@ public abstract class TestOzoneManagerHA {
 
   public OzoneConfiguration getConf() {
     return conf;
+  }
+
+  public MiniOzoneCluster.Builder getClusterBuilder() {
+    return clusterBuilder;
   }
 
   public String getOmServiceId() {
@@ -166,16 +171,34 @@ public abstract class TestOzoneManagerHA {
      */
     conf.set(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, "10s");
     conf.set(OZONE_KEY_DELETING_LIMIT_PER_TASK, "2");
-    cluster = (MiniOzoneOMHAClusterImpl) MiniOzoneCluster.newOMHABuilder(conf)
+    additionalConfiguration();
+
+    clusterBuilder = MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(clusterId)
         .setScmId(scmId)
         .setOMServiceId(omServiceId)
         .setOmId(omId)
-        .setNumOfOzoneManagers(numOfOMs)
-        .build();
+        .setNumOfOzoneManagers(numOfOMs);
+    additionalClusterSettings();
+
+    cluster = (MiniOzoneOMHAClusterImpl)clusterBuilder.build();
     cluster.waitForClusterToBeReady();
     objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
         .getObjectStore();
+  }
+
+  /**
+   * Override this method in sub-classes to additional test specific
+   * configuration. Add settings to the conf instance variable.
+   */
+  protected void additionalConfiguration() {
+  }
+
+  /**
+   * Override this method in sub-classes to additional test specific
+   * mini-cluster settings. Add settings the clusterBuilder instance variable.
+   */
+  protected void additionalClusterSettings() {
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -17,8 +17,11 @@
 package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdfs.LogVerificationAppender;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -72,6 +75,20 @@ import static org.junit.Assert.fail;
  * Test Ozone Manager Metadata operation in distributed handler scenario.
  */
 public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
+
+  @Override
+  protected void additionalConfiguration() {
+    OzoneConfiguration conf = getConf();
+    // These test do not use any features of SCM, so we can skip safemode
+    // which gets the cluster to come up much faster.
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
+  }
+
+  @Override
+  protected void additionalClusterSettings() {
+    MiniOzoneCluster.Builder builder = getClusterBuilder();
+    builder.setNumDatanodes(0);
+  }
 
   private OzoneVolume createAndCheckVolume(String volumeName)
       throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -97,9 +98,13 @@ public class TestOzoneManagerListVolumes {
 
     // Use native impl here, default impl doesn't do actual checks
     conf.set(OZONE_ACL_AUTHORIZER_CLASS, OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
+    // These test do not use any features of SCM, so we can skip safemode
+    // which gets the cluster to come up much faster.
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
 
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setClusterId(clusterId).setScmId(scmId).setOmId(omId).build();
+        .setClusterId(clusterId).setScmId(scmId).setOmId(omId).
+        setNumDatanodes(0).build();
     cluster.waitForClusterToBeReady();
 
     // Create volumes with non-default owners and ACLs


### PR DESCRIPTION
## What changes were proposed in this pull request?

Many of the OzoneManager integration tests do not really use SCM or the datanodes. Therefore we can skip the safemode check in SCM and start zero datanodes to make the mini-cluster come up faster.

With just this change, on my laptop:

```
TestOzoneManagerConfiguration went from 6min -> 3min 40s.
TestOzoneManagerHAMetadataOnly went from 4min 19s -> 1min 9s.
TestOzoneManagerListVolumes went from 40s -> 20s
TestOMMetrics went from 2min 6 -> 39s 55s
```

The runtime for these tests on Github is:

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 273.591 s - in org.apache.hadoop.ozone.om.TestOzoneManagerConfiguration

Warning: Tests run: 10, Failures: 0, Errors: 0, Skipped: 2, Time elapsed: 363.67 s - in org.apache.hadoop.ozone.om.TestOzoneManagerHAMetadataOnly

[INFO] Tests run: 5, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 181.937 s - in org.apache.hadoop.ozone.om.TestOmMetrics

[INFO] Tests run: 6, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 50.156 s - in org.apache.hadoop.ozone.om.TestOzoneManagerListVolumes
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5766

## How was this patch tested?

Existing tests.
