### PR TITLE
HDDS-5765. Test cluster provider possibly returns null

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterProvider.java
@@ -158,6 +158,9 @@ public class MiniOzoneClusterProvider {
           + "in the constructor");
     }
     MiniOzoneCluster cluster = clusters.poll(100, SECONDS);
+    if (cluster == null) {
+      throw new IOException("Failed to obtain available cluster in time");
+    }
     createdClusters.add(cluster);
     consumedClusterCount++;
     return cluster;


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MiniOzoneClusterProvider` may timeout (100 seconds) while waiting for a cluster to become available.  In this case it simply returns `null` without warning.  This results in NPE when trying to use the cluster in test.

```
testAllDataNodeFailuresAfterScmPostFinalizeUpgrade  Time elapsed: 100.076 s  <<< ERROR!
java.lang.NullPointerException
	at org.apache.hadoop.hdds.upgrade.TestHDDSUpgrade.init(TestHDDSUpgrade.java:173)
	at org.apache.hadoop.hdds.upgrade.TestHDDSUpgrade.setUp(TestHDDSUpgrade.java:135)
```

This change makes `MiniOzoneClusterProvider` throw exception if cluster could not be started.  This way test failure is a bit more explicit.

https://issues.apache.org/jira/browse/HDDS-5765

## How was this patch tested?

Regular CI.
https://github.com/adoroszlai/hadoop-ozone/runs/3651226035