### PR TITLE
HDDS-5767. Unit check may timeout

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -116,7 +116,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-18.04
-    timeout-minutes: 40
+    timeout-minutes: 60
     if: needs.build-info.outputs.needs-basic-checks == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase timeout for _basic_ check to avoid edge case where _basic (unit)_ check timeouts.

https://issues.apache.org/jira/browse/HDDS-5767

## How was this patch tested?

Check completed successfully in ~47 minutes:
https://github.com/adoroszlai/hadoop-ozone/runs/3652391011
