### PR TITLE
HDDS-5768. Skip safemode check in TestOzoneManagerRocksDBLogging

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om;
 
 import java.util.concurrent.TimeoutException;
 
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
@@ -52,8 +53,9 @@ public class TestOzoneManagerRocksDBLogging {
     conf = new OzoneConfiguration();
     dbConf = conf.getObject(RocksDBConfiguration.class);
     enableRocksDbLogging(false);
+    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
     cluster =  MiniOzoneCluster.newBuilder(conf)
-        .build();
+        .setNumDatanodes(0).build();
     cluster.waitForClusterToBeReady();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestOzoneManagerRocksDBLogging can be made faster by skipping the SCM safemode check and setting the number of datanodes to 0 in the mini cluster.

Last runtime was:

```
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 81.735 s - in org.apache.hadoop.ozone.om.TestOzoneManagerRocksDBLogging
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5768

## How was this patch tested?

Existing tests
