### PR TITLE
HDDS-5769. Kubernetes tests failing because github artifact not reachable

### DIFF
--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -73,7 +73,7 @@ install_k3s() {
 }
 
 _install_k3s() {
-  curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.21.2+k3s1" sh -
+  curl -sfL https://get.k3s.io  | sed 's/    download_hash/#    download_hash/' | sed 's/    verify_binary/#   verify_binary/'  | INSTALL_K3S_VERSION="v1.21.2+k3s1" sh -
   sudo chmod a+r $KUBECONFIG
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?



We use the k3s install script to install the k3s tool to run our k8s tests.

That script is broken right now, due to a github outage:
https://github.com/k3s-io/k3s/issues/4054

The suggested workaround is to comment out the hash verification, which is what this PR does.

Hopefully the outage will end soon and this PR won't need to be merged


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5769


## How was this patch tested?
kubernetes tests