### PR TITLE
HDDS-5770. Silent failures of k3s install are difficult to debug

### DIFF
--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -43,8 +43,12 @@ _install_tool() {
   if [[ ! -d "${dir}" ]]; then
     mkdir -pv "${dir}"
     pushd "${dir}"
-    eval "${func}"
-    echo "Installed ${tool} in ${dir}"
+    if eval "${func}"; then
+      echo "Installed ${tool} in ${dir}"
+    else
+      echo "Failed to install ${tool}"
+      exit 1
+    fi
     popd
   fi
 
@@ -74,11 +78,6 @@ install_k3s() {
 
 _install_k3s() {
   curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.21.2+k3s1" sh -
-  if [ $? -ne 0 ]
-  then
-    echo k3s install failed
-    exit 1
-  fi
   sudo chmod a+r $KUBECONFIG
 }
 

--- a/hadoop-ozone/dev-support/checks/_lib.sh
+++ b/hadoop-ozone/dev-support/checks/_lib.sh
@@ -74,6 +74,11 @@ install_k3s() {
 
 _install_k3s() {
   curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.21.2+k3s1" sh -
+  if [ $? -ne 0 ]
+  then
+    echo k3s install failed
+    exit 1
+  fi
   sudo chmod a+r $KUBECONFIG
 }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fail immediately when k3s install fails.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5770


## How was this patch tested?

kubernetes tests correctly report the failure here:
https://github.com/GeorgeJahad/ozone/runs/3659216789?check_suite_focus=true
