### PR TITLE
HDDS-5771. Speed up TestDatanodeHddsVolumeFailureToleration by reducing dead interval

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/dn/volume/TestDatanodeHddsVolumeFailureToleration.java
@@ -39,9 +39,18 @@ import org.junit.rules.Timeout;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_NODE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
 
 /**
@@ -64,6 +73,15 @@ public class TestDatanodeHddsVolumeFailureToleration {
     ozoneConfig.setStorageSize(OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN,
         0, StorageUnit.MB);
     ozoneConfig.setInt(OZONE_REPLICATION, ReplicationFactor.ONE.getValue());
+    ozoneConfig.setTimeDuration(OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL,
+        100, TimeUnit.MILLISECONDS);
+    ozoneConfig.setTimeDuration(HDDS_HEARTBEAT_INTERVAL, 1, SECONDS);
+    ozoneConfig.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1, SECONDS);
+    ozoneConfig.setTimeDuration(HDDS_CONTAINER_REPORT_INTERVAL, 1, SECONDS);
+    ozoneConfig.setTimeDuration(HDDS_NODE_REPORT_INTERVAL, 1, SECONDS);
+    ozoneConfig.setTimeDuration(OZONE_SCM_STALENODE_INTERVAL, 3, SECONDS);
+    ozoneConfig.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, SECONDS);
+
     // set tolerated = 1
     DatanodeConfiguration dnConf =
         ozoneConfig.getObject(DatanodeConfiguration.class);
@@ -85,13 +103,14 @@ public class TestDatanodeHddsVolumeFailureToleration {
   }
 
   @Test
-  public void testTolerationOnStartupSuccess() throws Exception {
+  public void testDNCorrectlyHandlesVolumeFailureOnStartup() throws Exception {
     HddsDatanodeService dn = datanodes.get(0);
     OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
     MutableVolumeSet volSet = oc.getVolumeSet();
     StorageVolume vol0 = volSet.getVolumesList().get(0);
-    // keep the file for restore since we'll do restart
+    StorageVolume vol1 = volSet.getVolumesList().get(1);
     File volRootDir0 = vol0.getStorageDir();
+    File volRootDir1 = vol1.getStorageDir();
 
     // simulate bad volumes <= tolerated
     DatanodeTestUtils.simulateBadRootDir(volRootDir0);
@@ -101,22 +120,7 @@ public class TestDatanodeHddsVolumeFailureToleration {
 
     // no exception is good
 
-    // restore bad volumes
-    DatanodeTestUtils.restoreBadRootDir(volRootDir0);
-  }
-
-  @Test
-  public void testTolerationOnStartupFailure() throws Exception {
-    HddsDatanodeService dn = datanodes.get(0);
-    OzoneContainer oc = dn.getDatanodeStateMachine().getContainer();
-    MutableVolumeSet volSet = oc.getVolumeSet();
-    StorageVolume vol0 = volSet.getVolumesList().get(0);
-    StorageVolume vol1 = volSet.getVolumesList().get(1);
-    File volRootDir0 = vol0.getStorageDir();
-    File volRootDir1 = vol1.getStorageDir();
-
-    // simulate bad volumes > tolerated
-    DatanodeTestUtils.simulateBadRootDir(volRootDir0);
+    // fail a second volume
     DatanodeTestUtils.simulateBadRootDir(volRootDir1);
 
     // restart datanode to test


### PR DESCRIPTION
## What changes were proposed in this pull request?

In TestDatanodeHddsVolumeFailureToleration, the tests wait for a long time on a DN to be marked dead by SCM. This is because the stale, dead and heartbeat intervals have not been set low enough, as they are using default. Changing the various timers, the runtime is reduced from about 4mins to 53 seconds on my laptop.

Further, there are two tests - one that fails one volume on a DN and ensures it can restart ok. Then a test which fails 2 volumes and ensure it fails to start. We can combine these two tests into 1 and save creating a second mini-Cluster. This further reduces the runtime to ??.

On github, this test runs in:

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 236.534 s - in org.apache.hadoop.ozone.dn.volume.TestDatanodeHddsVolumeFailureToleration
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5771

## How was this patch tested?

Existing tests
