### PR TITLE
HDDS-5773. Avoid code duplication for mini cluster without datanodes

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -25,6 +25,7 @@ import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.conf.StorageUnit;
+import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -357,6 +358,17 @@ public interface MiniOzoneCluster {
       clusterId = id;
       path = GenericTestUtils.getTempPath(
           MiniOzoneClusterImpl.class.getSimpleName() + "-" + clusterId);
+      return this;
+    }
+
+    /**
+     * For tests that do not use any features of SCM, we can get by with
+     * 0 datanodes.  Also need to skip safemode in this case.
+     * This allows the cluster to come up much faster.
+     */
+    public Builder withoutDatanodes() {
+      setNumDatanodes(0);
+      conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmMetrics.java
@@ -82,10 +82,7 @@ public class TestOmMetrics {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL,
         1000, TimeUnit.MILLISECONDS);
-    // Most tests in this class do not use any features of SCM, so we can skip
-    // safemode which gets the cluster to come up much faster.
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
-    clusterBuilder = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(0);
+    clusterBuilder = MiniOzoneCluster.newBuilder(conf).withoutDatanodes();
   }
 
   private void startCluster() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerConfiguration.java
@@ -81,9 +81,6 @@ public class TestOzoneManagerConfiguration {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, true);
     conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
         RATIS_RPC_TIMEOUT, TimeUnit.MILLISECONDS);
-    // These test do not use any features of SCM, so we can skip safemode
-    // which gets the cluster to come up much faster.
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId("testClusterId");
     // writes the version file properties
@@ -102,7 +99,7 @@ public class TestOzoneManagerConfiguration {
       .setClusterId(clusterId)
       .setScmId(scmId)
       .setOmId(omId)
-      .setNumDatanodes(0)
+      .withoutDatanodes()
       .build();
     cluster.waitForClusterToBeReady();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerListVolumes.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -98,13 +97,11 @@ public class TestOzoneManagerListVolumes {
 
     // Use native impl here, default impl doesn't do actual checks
     conf.set(OZONE_ACL_AUTHORIZER_CLASS, OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
-    // These test do not use any features of SCM, so we can skip safemode
-    // which gets the cluster to come up much faster.
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
 
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setClusterId(clusterId).setScmId(scmId).setOmId(omId).
-        setNumDatanodes(0).build();
+        .withoutDatanodes()
+        .setClusterId(clusterId).setScmId(scmId).setOmId(omId)
+        .build();
     cluster.waitForClusterToBeReady();
 
     // Create volumes with non-default owners and ACLs

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerRocksDBLogging.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om;
 
 import java.util.concurrent.TimeoutException;
 
-import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.RocksDBConfiguration;
@@ -53,9 +52,8 @@ public class TestOzoneManagerRocksDBLogging {
     conf = new OzoneConfiguration();
     dbConf = conf.getObject(RocksDBConfiguration.class);
     enableRocksDbLogging(false);
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
     cluster =  MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(0).build();
+        .withoutDatanodes().build();
     cluster.waitForClusterToBeReady();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid code duplication by making it a bit easier to start a mini cluster without datanodes.

https://issues.apache.org/jira/browse/HDDS-5773

## How was this patch tested?

Regular CI, but _integration (ozone)_ was not yet run because it
> is waiting for a hosted runner to come online.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1257175959