### PR TITLE
HDDS-5695 Review ZK and Curator dependencies, and get rid of them.

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -27,11 +27,15 @@ share/ozone/lib/commons-digester.jar
 share/ozone/lib/commons-io.jar
 share/ozone/lib/commons-lang3.jar
 share/ozone/lib/commons-logging.jar
+share/ozone/lib/commons-math.jar
 share/ozone/lib/commons-math3.jar
 share/ozone/lib/commons-net.jar
 share/ozone/lib/commons-pool2.jar
 share/ozone/lib/commons-text.jar
 share/ozone/lib/commons-validator.jar
+share/ozone/lib/curator-client.jar
+share/ozone/lib/curator-framework.jar
+share/ozone/lib/curator-test.jar
 share/ozone/lib/derby.jar
 share/ozone/lib/disruptor.jar
 share/ozone/lib/dnsjava.jar
@@ -130,6 +134,7 @@ share/ozone/lib/jetty-util-ajax.jar
 share/ozone/lib/jetty-util.jar
 share/ozone/lib/jetty-webapp.jar
 share/ozone/lib/jetty-xml.jar
+share/ozone/lib/jline.jar
 share/ozone/lib/jmespath-java.jar
 share/ozone/lib/joda-time.jar
 share/ozone/lib/jooq-codegen.jar
@@ -177,6 +182,7 @@ share/ozone/lib/netty-resolver.Final.jar
 share/ozone/lib/netty-transport.Final.jar
 share/ozone/lib/netty-transport-native-epoll.Final.jar
 share/ozone/lib/netty-transport-native-unix-common.Final.jar
+share/ozone/lib/netty.Final.jar
 share/ozone/lib/nimbus-jose-jwt.jar
 share/ozone/lib/okhttp.jar
 share/ozone/lib/okio.jar
@@ -240,3 +246,4 @@ share/ozone/lib/token-provider.jar
 share/ozone/lib/txw2.jar
 share/ozone/lib/weld-servlet.Final.jar
 share/ozone/lib/woodstox-core.jar
+share/ozone/lib/zookeeper.jar

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -100,7 +100,27 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>runtime</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>apache-curator</artifactId>
+      <version>2.4.0</version>
+      <type>pom</type>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-test</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-client</artifactId>
+      <version>2.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.curator</groupId>
+      <artifactId>curator-framework</artifactId>
+      <version>2.4.0</version>
+    </dependency>
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>


### PR DESCRIPTION
This reverts commit e8b15f4223fe4ac225c41fda832591dedb32b523.

## What changes were proposed in this pull request?

This pull request is reverting the changes in HDDS-5695. Previously the Zookeeper and Curator dependencies were deleted, as we thought they were unnecessary. But later we found out, that in the CI the server couldn't start, because the it is unable to initialize WebAppContext. It happened because the DelegationTokenAuthenticationFilter class is using Zookeeper through curator, as the class is using delegation tokens and the token details are stored in ZooKeeper. So the ZK and the Curator dependencies are needed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5695

## How was this patch tested?

Built it without problems.
