### PR TITLE
EC: Add Codec and Stripe Size to ECReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -31,10 +31,6 @@ import java.util.stream.Collectors;
  */
 public class ECReplicationConfig implements ReplicationConfig {
 
-  // TODO - should this enum be defined in the protobuf rather than here? Right
-  //        the proto will carry a string. It might be more flexible for the
-  //        constants to be defined in code rather than proto?
-
   /**
    * Enum defining the allowed list of ECCodecs.
    */
@@ -60,12 +56,8 @@ public class ECReplicationConfig implements ReplicationConfig {
 
   private int parity;
 
-  // TODO - the default chunk size is 4MB - is EC defaulting to 1MB or 4MB
-  //        stripe width? Should we default this to the chunk size setting?
   private int ecChunkSize = 1024 * 1024;
 
-  // TODO - should we have a config for the default, or does it matter if we
-  //        always force the client to send rs-3-2-1024k for example?
   private EcCodec codec = EcCodec.RS;
 
   public ECReplicationConfig(int data, int parity) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -19,10 +19,13 @@
 package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.logging.log4j.util.Strings;
 
+import java.util.EnumSet;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Replication configuration for EC replication.
@@ -37,10 +40,22 @@ public class ECReplicationConfig implements ReplicationConfig {
    * Enum defining the allowed list of ECCodecs.
    */
   public enum EcCodec {
-    RS, XOR
+    RS, XOR;
+
+    public static String allValuesAsString() {
+      return EnumSet.allOf(EcCodec.class)
+          .stream()
+          .map(Enum::toString)
+          .collect(Collectors.joining(","));
+    }
   }
 
-  private static final Pattern STRING_FORMAT = Pattern.compile("(\\d+)-(\\d+)");
+  // Acceptable patterns are like:
+  //   rs-3-2-1024k
+  //   RS-3-2-2048
+  //   XOR-10-4-4096K
+  private static final Pattern STRING_FORMAT
+      = Pattern.compile("([a-zA-Z]+)-(\\d+)-(\\d+)-(\\d+)((?:k|K))?");
 
   private int data;
 
@@ -67,19 +82,48 @@ public class ECReplicationConfig implements ReplicationConfig {
     this.stripeSize = stripeSize;
   }
 
+  /**
+   * Create an ECReplicationConfig object from a string representing the
+   * various parameters. Acceptable patterns are like:
+   *     rs-3-2-1024k
+   *     RS-3-2-2048
+   *     XOR-10-4-4096K
+   * IllegalArgumentException will be thrown if the passed string does not
+   * match the defined pattern.
+   * @param string
+   */
   public ECReplicationConfig(String string) {
     final Matcher matcher = STRING_FORMAT.matcher(string);
     if (!matcher.matches()) {
       throw new IllegalArgumentException("EC replication config should be " +
-          "defined in the form 3-2, 6-3 or 10-4");
+          "defined in the form rs-3-2-1024k, rs-6-3-1024; or rs-10-4-1024k");
     }
 
-    data = Integer.parseInt(matcher.group(1));
-    parity = Integer.parseInt(matcher.group(2));
+    try {
+      codec = EcCodec.valueOf(matcher.group(1).toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("The codec " + matcher.group(1) +
+          " is invalid. It must be one of " + EcCodec.allValuesAsString() + ".",
+          e);
+    }
+
+    data = Integer.parseInt(matcher.group(2));
+    parity = Integer.parseInt(matcher.group(3));
     if (data <= 0 || parity <= 0) {
       throw new IllegalArgumentException("Data and parity part in EC " +
           "replication config supposed to be positive numbers");
     }
+
+    int stripe = Integer.parseInt((matcher.group(4)));
+    if (stripe <= 0) {
+      throw new IllegalArgumentException("The stripeSize (" + stripe + ") be " +
+          "greater than zero");
+    }
+    if (matcher.group(5) != null) {
+      // The "k" modifier is present, so multiple by 1024
+      stripe = stripe * 1024;
+    }
+    stripeSize = stripe;
   }
 
   public ECReplicationConfig(

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.logging.log4j.util.Strings;
 
 import java.util.EnumSet;
 import java.util.Objects;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -62,7 +62,7 @@ public class ECReplicationConfig implements ReplicationConfig {
 
   // TODO - the default chunk size is 4MB - is EC defaulting to 1MB or 4MB
   //        stripe width? Should we default this to the chunk size setting?
-  private int stripeSize = 1024 * 1024;
+  private int ecChunkSize = 1024 * 1024;
 
   // TODO - should we have a config for the default, or does it matter if we
   //        always force the client to send rs-3-2-1024k for example?
@@ -74,11 +74,11 @@ public class ECReplicationConfig implements ReplicationConfig {
   }
 
   public ECReplicationConfig(int data, int parity, EcCodec codec,
-      int stripeSize) {
+      int ecChunkSize) {
     this.data = data;
     this.parity = parity;
     this.codec = codec;
-    this.stripeSize = stripeSize;
+    this.ecChunkSize = ecChunkSize;
   }
 
   /**
@@ -113,16 +113,16 @@ public class ECReplicationConfig implements ReplicationConfig {
           "replication config supposed to be positive numbers");
     }
 
-    int stripe = Integer.parseInt((matcher.group(4)));
-    if (stripe <= 0) {
-      throw new IllegalArgumentException("The stripeSize (" + stripe + ") be " +
-          "greater than zero");
+    int chunkSize = Integer.parseInt((matcher.group(4)));
+    if (chunkSize <= 0) {
+      throw new IllegalArgumentException("The ecChunkSize (" + chunkSize +
+          ") be greater than zero");
     }
     if (matcher.group(5) != null) {
       // The "k" modifier is present, so multiple by 1024
-      stripe = stripe * 1024;
+      chunkSize = chunkSize * 1024;
     }
-    stripeSize = stripe;
+    ecChunkSize = chunkSize;
   }
 
   public ECReplicationConfig(
@@ -130,7 +130,7 @@ public class ECReplicationConfig implements ReplicationConfig {
     this.data = ecReplicationConfig.getData();
     this.parity = ecReplicationConfig.getParity();
     this.codec = EcCodec.valueOf(ecReplicationConfig.getCodec().toUpperCase());
-    this.stripeSize = ecReplicationConfig.getStripeSize();
+    this.ecChunkSize = ecReplicationConfig.getEcChunkSize();
   }
 
   @Override
@@ -148,7 +148,7 @@ public class ECReplicationConfig implements ReplicationConfig {
         .setData(data)
         .setParity(parity)
         .setCodec(codec.toString())
-        .setStripeSize(stripeSize)
+        .setEcChunkSize(ecChunkSize)
         .build();
   }
 
@@ -160,8 +160,8 @@ public class ECReplicationConfig implements ReplicationConfig {
     return parity;
   }
 
-  public int getStripeSize() {
-    return stripeSize;
+  public int getEcChunkSize() {
+    return ecChunkSize;
   }
 
   public EcCodec getCodec() {
@@ -178,12 +178,12 @@ public class ECReplicationConfig implements ReplicationConfig {
     }
     ECReplicationConfig that = (ECReplicationConfig) o;
     return data == that.data && parity == that.parity
-        && codec == that.getCodec() && stripeSize == that.getStripeSize();
+        && codec == that.getCodec() && ecChunkSize == that.getEcChunkSize();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(data, parity, codec, stripeSize);
+    return Objects.hash(data, parity, codec, ecChunkSize);
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -48,7 +48,7 @@ public class TestECReplicationConfig {
       Assert.assertEquals(e.getValue().getData(), ec.getData());
       Assert.assertEquals(e.getValue().getParity(), ec.getParity());
       Assert.assertEquals(e.getValue().getCodec(), ec.getCodec());
-      Assert.assertEquals(e.getValue().getStripeSize(), ec.getStripeSize());
+      Assert.assertEquals(e.getValue().getEcChunkSize(), ec.getEcChunkSize());
     }
   }
 
@@ -84,7 +84,7 @@ public class TestECReplicationConfig {
     Assert.assertEquals(orig.getData(), recovered.getData());
     Assert.assertEquals(orig.getParity(), recovered.getParity());
     Assert.assertEquals(orig.getCodec(), recovered.getCodec());
-    Assert.assertEquals(orig.getStripeSize(), recovered.getStripeSize());
+    Assert.assertEquals(orig.getEcChunkSize(), recovered.getEcChunkSize());
     Assert.assertTrue(orig.equals(recovered));
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.client;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,7 +25,6 @@ import org.junit.Test;
  * Unit test for ECReplicationConfig.
  */
 public class TestECReplicationConfig {
-
 
   @Test
   public void testStringParsing() {
@@ -45,5 +45,19 @@ public class TestECReplicationConfig {
     new ECReplicationConfig("3-0");
   }
 
+  @Test
+  public void testSerializeToProtoAndBack() {
+    ECReplicationConfig orig = new ECReplicationConfig(6, 3,
+        ECReplicationConfig.EcCodec.XOR, 1024);
+
+    HddsProtos.ECReplicationConfig proto = orig.toProto();
+
+    ECReplicationConfig recovered = new ECReplicationConfig(proto);
+    Assert.assertEquals(orig.getData(), recovered.getData());
+    Assert.assertEquals(orig.getParity(), recovered.getParity());
+    Assert.assertEquals(orig.getCodec(), recovered.getCodec());
+    Assert.assertEquals(orig.getStripeSize(), recovered.getStripeSize());
+    Assert.assertTrue(orig.equals(recovered));
+  }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -55,12 +55,12 @@ public class TestECReplicationConfig {
   @Test
   public void testUnsuccessfulStringParsing() {
     String[] invalid = {
-      "3-2-1024",
-      "rss-3-2-1024",
-      "rs-3-0-1024",
-      "rs-3-2-0k",
-      "rs-3-2",
-      "x3-2"
+        "3-2-1024",
+        "rss-3-2-1024",
+        "rs-3-0-1024",
+        "rs-3-2-0k",
+        "rs-3-2",
+        "x3-2"
     };
     for (String s : invalid) {
       try {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -21,29 +21,57 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
+import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.XOR;
+import static org.junit.Assert.fail;
+
 /**
  * Unit test for ECReplicationConfig.
  */
 public class TestECReplicationConfig {
 
   @Test
-  public void testStringParsing() {
-    final ECReplicationConfig ec = new ECReplicationConfig("3-2");
-    Assert.assertEquals(ec.getData(), 3);
-    Assert.assertEquals(ec.getParity(), 2);
+  public void testSuccessfulStringParsing() {
+    Map<String, ECReplicationConfig> valid = new HashMap();
+    valid.put("rs-3-2-1024", new ECReplicationConfig(3, 2, RS, 1024));
+    valid.put("RS-3-2-1024", new ECReplicationConfig(3, 2, RS, 1024));
+    valid.put("rs-3-2-1024k", new ECReplicationConfig(3, 2, RS, 1024 * 1024));
+    valid.put("rs-3-2-1024K", new ECReplicationConfig(3, 2, RS, 1024 * 1024));
+    valid.put("xor-10-4-1", new ECReplicationConfig(10, 4, XOR, 1));
+    valid.put("XOR-6-3-12345", new ECReplicationConfig(6, 3, XOR, 12345));
+
+    for (Map.Entry<String, ECReplicationConfig> e : valid.entrySet()) {
+      ECReplicationConfig ec = new ECReplicationConfig(e.getKey());
+      Assert.assertEquals(e.getValue().getData(), ec.getData());
+      Assert.assertEquals(e.getValue().getParity(), ec.getParity());
+      Assert.assertEquals(e.getValue().getCodec(), ec.getCodec());
+      Assert.assertEquals(e.getValue().getStripeSize(), ec.getStripeSize());
+    }
   }
 
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testStringParsingWithString() {
-    new ECReplicationConfig("x3-2");
+  @Test
+  public void testUnsuccessfulStringParsing() {
+    String[] invalid = {
+      "3-2-1024",
+      "rss-3-2-1024",
+      "rs-3-0-1024",
+      "rs-3-2-0k",
+      "rs-3-2",
+      "x3-2"
+    };
+    for (String s : invalid) {
+      try {
+        new ECReplicationConfig(s);
+        fail(s + " should not parse correctly");
+      } catch (IllegalArgumentException e) {
+        // ignore, this expected
+      }
+    }
   }
 
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testStringParsingWithZero() {
-    new ECReplicationConfig("3-0");
-  }
 
   @Test
   public void testSerializeToProtoAndBack() {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -273,6 +273,8 @@ enum ReplicationFactor {
 message ECReplicationConfig {
     required int32 data = 1;
     required int32 parity = 2;
+    required string codec = 3;
+    required int32 stripeSize = 4;
 }
 
 message DefaultReplicationConfig {

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -274,7 +274,7 @@ message ECReplicationConfig {
     required int32 data = 1;
     required int32 parity = 2;
     required string codec = 3;
-    required int32 stripeSize = 4;
+    required int32 ecChunkSize = 4;
 }
 
 message DefaultReplicationConfig {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MultiNodePipelineBlockAllocator.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MultiNodePipelineBlockAllocator.java
@@ -55,6 +55,9 @@ public class MultiNodePipelineBlockAllocator implements MockBlockAllocator {
                 HddsProtos.Port.newBuilder().setName("RATIS").setValue(1234 + i)
                     .build()).build());
       }
+      if (keyArgs.getType() == HddsProtos.ReplicationType.EC) {
+        builder.setEcReplicationConfig(keyArgs.getEcReplicationConfig());
+      }
       pipeline = builder.build();
     }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/SinglePipelineBlockAllocator.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/SinglePipelineBlockAllocator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.client;
 
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.BlockID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerBlockID;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
@@ -48,7 +49,7 @@ public class SinglePipelineBlockAllocator
       KeyArgs keyArgs) {
 
     if (pipeline == null) {
-      pipeline = Pipeline.newBuilder()
+      Pipeline.Builder bldr = Pipeline.newBuilder()
           .setFactor(keyArgs.getFactor())
           .setType(keyArgs.getType())
           .setId(PipelineID.newBuilder()
@@ -68,8 +69,11 @@ public class SinglePipelineBlockAllocator
                   .setName("RATIS")
                   .setValue(1234)
                   .build())
-              .build())
-          .build();
+              .build());
+      if (keyArgs.getType() == HddsProtos.ReplicationType.EC) {
+        bldr.setEcReplicationConfig(keyArgs.getEcReplicationConfig());
+      }
+      pipeline = bldr.build();
     }
 
     List<KeyLocation> results = new ArrayList<>();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -869,7 +869,7 @@ public class TestOzoneShellHA {
     getVolume(volumeName);
     String[] args =
         new String[] {"bucket", "create", "/volume100/bucket0", "-rt", "EC",
-            "-r", "3-2"};
+            "-r", "rs-3-2-1024k"};
     execute(ozoneShell, args);
 
     OzoneVolume volume =


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need to store the codes (rs / xor / etc) and the EC stripe size in ECReplicationConfig.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5775

## How was this patch tested?

New and existing tests
