### PR TITLE
HDDS-5757. balancer should stop when the cluster can not be balanced any more

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -283,7 +283,7 @@ public class ContainerBalancer {
 
     // find over and under utilized nodes
     for (DatanodeUsageInfo datanodeUsageInfo : datanodeUsageInfos) {
-      double utilization = datanodeUsageInfo.calculateUtilization(0);
+      double utilization = datanodeUsageInfo.calculateUtilization();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Utilization for node {} is {}",
             datanodeUsageInfo.getDatanodeDetails().getUuidString(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.balancer;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.conf.StorageUnit;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -29,6 +30,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.LongMetric;
+import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
@@ -85,6 +87,7 @@ public class ContainerBalancer {
   private long clusterUsed;
   private long clusterRemaining;
   private double clusterAvgUtilisation;
+  private double upperLimit;
   private volatile boolean balancerRunning;
   private Thread currentBalancingThread;
   private Lock lock;
@@ -187,7 +190,11 @@ public class ContainerBalancer {
         stop();
         return;
       }
-      doIteration();
+
+      if (doIteration() == IterationResult.CAN_NOT_BALANCE_ANY_MORE) {
+        stop();
+        return;
+      }
 
       // return if balancing has been stopped
       if (!isBalancerRunning()) {
@@ -263,7 +270,7 @@ public class ContainerBalancer {
 
     // over utilized nodes have utilization(that is, used / capacity) greater
     // than upper limit
-    double upperLimit = clusterAvgUtilisation + threshold;
+    this.upperLimit = clusterAvgUtilisation + threshold;
 
     if (LOG.isDebugEnabled()) {
       LOG.debug("Lower limit for utilization is {} and Upper limit for " +
@@ -352,6 +359,7 @@ public class ContainerBalancer {
     Set<DatanodeDetails> selectedTargets =
         new HashSet<>(potentialTargets.size());
     moveSelectionToFutureMap = new HashMap<>(unBalancedNodes.size());
+    boolean isMoveGenerated = false;
 
     // match each overUtilized node with a target
     for (DatanodeUsageInfo datanodeUsageInfo : overUtilizedNodes) {
@@ -365,6 +373,7 @@ public class ContainerBalancer {
       ContainerMoveSelection moveSelection =
           matchSourceWithTarget(source, potentialTargets);
       if (moveSelection != null) {
+        isMoveGenerated = true;
         LOG.info("ContainerBalancer is trying to move container {} from " +
                 "source datanode {} to target datanode {}",
             moveSelection.getContainerID().toString(), source.getUuidString(),
@@ -395,6 +404,7 @@ public class ContainerBalancer {
         ContainerMoveSelection moveSelection =
             matchSourceWithTarget(source, potentialTargets);
         if (moveSelection != null) {
+          isMoveGenerated = true;
           LOG.info("ContainerBalancer is trying to move container {} from " +
                   "source datanode {} to target datanode {}",
               moveSelection.getContainerID().toString(),
@@ -409,6 +419,12 @@ public class ContainerBalancer {
           }
         }
       }
+    }
+
+    if (!isMoveGenerated) {
+      //no move option is generated, so the cluster can not be
+      //balanced any more, just stop iteration and exit
+      return IterationResult.CAN_NOT_BALANCE_ANY_MORE;
     }
 
     // check move results
@@ -652,8 +668,17 @@ public class ContainerBalancer {
    */
   boolean canSizeEnterTarget(DatanodeDetails target, long size) {
     if (sizeEnteringNode.containsKey(target)) {
-      return sizeEnteringNode.get(target) + size <=
-          config.getMaxSizeEnteringTarget();
+      long sizeEnteringAfterMove = sizeEnteringNode.get(target) + size;
+      SCMNodeMetric scmNM = nodeManager.getNodeStat(target);
+      Preconditions.checkNotNull(scmNM);
+      SCMNodeStat scmNodeStat = scmNM.get();
+      double capacity = scmNodeStat.getCapacity().get();
+      Preconditions.checkArgument(capacity > 0);
+      double usedAfterMove =
+          capacity - scmNodeStat.getRemaining().get() + size;
+
+      return sizeEnteringAfterMove <= config.getMaxSizeEnteringTarget() &&
+          usedAfterMove/capacity <= upperLimit;
     }
     return false;
   }
@@ -825,6 +850,7 @@ public class ContainerBalancer {
   enum IterationResult {
     ITERATION_COMPLETED,
     MAX_DATANODES_TO_INVOLVE_REACHED,
-    MAX_SIZE_TO_MOVE_REACHED
+    MAX_SIZE_TO_MOVE_REACHED,
+    CAN_NOT_BALANCE_ANY_MORE
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -191,6 +191,8 @@ public class ContainerBalancer {
         return;
       }
 
+      //if no new move option is generated, it means the cluster can
+      //not be balanced any more , so just stop
       if (doIteration() == IterationResult.CAN_NOT_BALANCE_ANY_MORE) {
         stop();
         return;
@@ -674,8 +676,15 @@ public class ContainerBalancer {
       SCMNodeStat scmNodeStat = scmNM.get();
       double capacity = scmNodeStat.getCapacity().get();
       Preconditions.checkArgument(capacity > 0);
+
+      //size can be moved into target datanode only when the following
+      //two condition are met.
+      //1 sizeEnteringAfterMove does not succeed the configured
+      // MaxSizeEnteringTarget
+      //2 current usage of target datanode plus sizeEnteringAfterMove
+      // is smaller than or equal to upperLimit
       double usedAfterMove =
-          capacity - scmNodeStat.getRemaining().get() + size;
+          capacity - scmNodeStat.getRemaining().get() + sizeEnteringAfterMove;
 
       return sizeEnteringAfterMove <= config.getMaxSizeEnteringTarget() &&
           usedAfterMove/capacity <= upperLimit;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -61,8 +61,8 @@ public class DatanodeUsageInfo {
     if (first.equals(second)) {
       return 0;
     }
-    return Double.compare(first.calculateUtilization(0),
-        second.calculateUtilization(0));
+    return Double.compare(first.calculateUtilization(),
+        second.calculateUtilization());
   }
 
   /**
@@ -82,6 +82,19 @@ public class DatanodeUsageInfo {
     }
     long numerator = capacity - scmNodeStat.getRemaining().get() + plusSize;
     return numerator / (double) capacity;
+  }
+
+  /**
+   * Calculates current utilization of a datanode .
+   * Utilization of a datanode is defined as its used space divided
+   * by its capacity. Here, we prefer calculating
+   * used space as (capacity - remaining), instead of using
+   * {@link SCMNodeStat#getScmUsed()} (see HDDS-5728).
+   *
+   * @return (capacity - remaining) / capacity of this datanode
+   */
+  public double calculateUtilization() {
+    return calculateUtilization(0);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeUsageInfo.java
@@ -47,7 +47,8 @@ public class DatanodeUsageInfo {
 
   /**
    * Compares two DatanodeUsageInfo on the basis of their utilization values,
-   * calculated using {@link DatanodeUsageInfo#calculateUtilization()}.
+   * calculated using
+   * {@link DatanodeUsageInfo#calculateUtilization(long plusSize)}.
    *
    * @param first DatanodeUsageInfo
    * @param second DatanodeUsageInfo
@@ -60,25 +61,27 @@ public class DatanodeUsageInfo {
     if (first.equals(second)) {
       return 0;
     }
-    return Double.compare(first.calculateUtilization(),
-        second.calculateUtilization());
+    return Double.compare(first.calculateUtilization(0),
+        second.calculateUtilization(0));
   }
 
   /**
-   * Calculates utilization of a datanode. Utilization of a datanode is defined
-   * as its used space divided by its capacity. Here, we prefer calculating
+   * Calculates utilization of a datanode after adding a specified size.
+   * Utilization of a datanode is defined as its used space divided
+   * by its capacity. Here, we prefer calculating
    * used space as (capacity - remaining), instead of using
    * {@link SCMNodeStat#getScmUsed()} (see HDDS-5728).
    *
+   * @param plusSize the increased size
    * @return (capacity - remaining) / capacity of this datanode
    */
-  public double calculateUtilization() {
-    double capacity = scmNodeStat.getCapacity().get();
+  public double calculateUtilization(long plusSize) {
+    long capacity = scmNodeStat.getCapacity().get();
     if (capacity == 0) {
       return 0;
     }
-    double numerator = capacity - scmNodeStat.getRemaining().get();
-    return numerator / capacity;
+    long numerator = capacity - scmNodeStat.getRemaining().get() + plusSize;
+    return numerator / (double) capacity;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -153,6 +153,14 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(boolean mostUsed);
 
   /**
+   * Get the usage info of a specified datanode.
+   *
+   * @param dn the usage of which we want to get
+   * @return DatanodeUsageInfo of the specified datanode
+   */
+  DatanodeUsageInfo getUsageInfo(DatanodeDetails dn);
+
+  /**
    * Return the node stat of the specified datanode.
    * @param datanodeDetails DatanodeDetails.
    * @return node stat if it is live/stale, null if it is decommissioned or

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -676,6 +676,7 @@ public class SCMNodeManager implements NodeManager {
    * @param mostUsed true if most used, false if least used
    * @return List of DatanodeUsageInfo
    */
+  @Override
   public List<DatanodeUsageInfo> getMostOrLeastUsedDatanodes(
       boolean mostUsed) {
     List<DatanodeDetails> healthyNodes =
@@ -700,6 +701,18 @@ public class SCMNodeManager implements NodeManager {
           DatanodeUsageInfo.getMostUtilized());
     }
     return datanodeUsageInfoList;
+  }
+
+  /**
+   * Get the usage info of a specified datanode.
+   *
+   * @param dn the usage of which we want to get
+   * @return DatanodeUsageInfo of the specified datanode
+   */
+  @Override
+  public DatanodeUsageInfo getUsageInfo(DatanodeDetails dn) {
+    SCMNodeStat stat = getNodeStatInternal(dn);
+    return new DatanodeUsageInfo(dn, stat);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -396,6 +396,18 @@ public class MockNodeManager implements NodeManager {
   }
 
   /**
+   * Get the usage info of a specified datanode.
+   *
+   * @param datanodeDetails the usage of which we want to get
+   * @return DatanodeUsageInfo of the specified datanode
+   */
+  @Override
+  public DatanodeUsageInfo getUsageInfo(DatanodeDetails datanodeDetails) {
+    SCMNodeStat stat = nodeMetricMap.get(datanodeDetails);
+    return new DatanodeUsageInfo(datanodeDetails, stat);
+  }
+
+  /**
    * Return the node stat of the specified datanode.
    * @param datanodeDetails - datanode details.
    * @return node stat if it is live/stale, null if it is decommissioned or

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -234,6 +234,11 @@ public class SimpleMockNodeManager implements NodeManager {
   }
 
   @Override
+  public DatanodeUsageInfo getUsageInfo(DatanodeDetails datanodeDetails) {
+    return null;
+  }
+
+  @Override
   public SCMNodeMetric getNodeStat(DatanodeDetails datanodeDetails) {
     return null;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -145,7 +145,7 @@ public class TestContainerBalancer {
     Assert.assertEquals(nodesInCluster.size(), nodeUtilizations.size());
     for (int i = 0; i < nodesInCluster.size(); i++) {
       Assert.assertEquals(nodeUtilizations.get(i),
-          nodesInCluster.get(i).calculateUtilization(), 0.0001);
+          nodesInCluster.get(i).calculateUtilization(0), 0.0001);
     }
 
     // should be equal to average utilization of the cluster

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -145,7 +145,7 @@ public class TestContainerBalancer {
     Assert.assertEquals(nodesInCluster.size(), nodeUtilizations.size());
     for (int i = 0; i < nodesInCluster.size(); i++) {
       Assert.assertEquals(nodeUtilizations.get(i),
-          nodesInCluster.get(i).calculateUtilization(0), 0.0001);
+          nodesInCluster.get(i).calculateUtilization(), 0.0001);
     }
 
     // should be equal to average utilization of the cluster

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -177,6 +177,17 @@ public class ReplicationNodeManagerMock implements NodeManager {
   }
 
   /**
+   * Get the usage info of a specified datanode.
+   *
+   * @param dn the usage of which we want to get
+   * @return DatanodeUsageInfo of the specified datanode
+   */
+  @Override
+  public DatanodeUsageInfo getUsageInfo(DatanodeDetails dn){
+    return null;
+  }
+
+  /**
    * Return the node stat of the specified datanode.
    *
    * @param dd - datanode details.


### PR DESCRIPTION
## What changes were proposed in this pull request?

when i test container balancer in k8s cluster,  i use the command line :

./ozone admin containerbalancer start -i -1 -t 0.000001 -d 1 -s 500, and set the contaienr size to 1G.

i found that balancer thread can not stop when the cluster is close to balance.

in my cluster , i have three datanodes d1,d2,d3(disk usage are 67G, 67G, 68G), and the fourth d4 datanode's disk usage is 1G. when i start balancer, it begin to balance and work well, many containers have been moved from d1,d2,d3 to d4. but when the cluster is close to balance(the disk usages of the four datanodes are 50G,52G,50G,51G), the balancer is still running , it will move container among those datanodes again and again.

let us see a general example. if we have two datanode d1 and  d2,  the disk usage are 3G and 7G respectively, then the average usage is 5G. if  we set the threshold to 0.00001(close to 0), the lowerLimit and upperLimit is close to 5G. if we set the container size to 4G,  in the first iteraion, we can recognize the over-utilized datanode d2 and the under-utilized datanode d1, then we schedule a move option from d2 to d1 with a 4G container. after move option is finished , d1 is 7G and d2 is 3G. so the balancer thread will go on for ever.

 so we should let the balancer thread exit when the cluster can not be more balanced

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5757

