### PR TITLE
HDDS-5686. Support transfer leadership in raft based ha cluster

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/QuorumInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/QuorumInfo.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.ratis;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ *  Wrapper class for raft group info.
+ */
+public class QuorumInfo {
+  private RaftGroupId raftGroupId;
+  private Collection<RaftPeer> peers;
+  private String leaderRaftPeerId;
+
+  public QuorumInfo(RaftGroupId raftGroupId, Collection<RaftPeer> peers,
+                    String leaderRaftId) {
+    this.raftGroupId = raftGroupId;
+    this.peers = peers;
+    this.leaderRaftPeerId = leaderRaftId;
+  }
+
+  public RaftGroupId getRaftGroupId() {
+    return raftGroupId;
+  }
+
+  public void setRaftGroupId(RaftGroupId raftGroupId) {
+    this.raftGroupId = raftGroupId;
+  }
+
+  public Collection<RaftPeer> getPeers() {
+    return peers;
+  }
+
+  public void setPeers(Collection<RaftPeer> peers) {
+    this.peers = peers;
+  }
+
+  public String getLeaderRaftPeerId() {
+    return leaderRaftPeerId;
+  }
+
+  public void setLeaderRaftPeerId(String leaderRaftPeerId) {
+    this.leaderRaftPeerId = leaderRaftPeerId;
+  }
+
+  @Override
+  public String toString() {
+    return "raftGroupId: " + raftGroupId.toString() +
+          " peers: " + peers.toString() +
+          " leaderAddress: " + leaderRaftPeerId;
+  }
+
+
+  /**
+   * The type Builder.
+   */
+  public static class Builder {
+    private RaftGroupId groupId;
+    private Collection<RaftPeer> peersCollection;
+    private String leaderRaftId;
+
+    public Builder setRaftGroupId(RaftGroupId raftGroupId) {
+      groupId = raftGroupId;
+      return this;
+    }
+
+    public Builder setPeers(Collection<RaftPeer> peers) {
+      peersCollection = peers;
+      return this;
+    }
+
+    public Builder setLeaderRaftId(String id) {
+      leaderRaftId = id;
+      return this;
+    }
+
+    public QuorumInfo build() {
+      return new QuorumInfo(groupId, peersCollection, leaderRaftId);
+    }
+  }
+
+
+  /**
+   * Tool function to Get proto from RaftPeer.
+   *
+   * @param raftPeer the raft peer
+   * @return the protobuf
+   */
+  public static HddsProtos.RaftPeerProto getProtobuf(RaftPeer raftPeer) {
+    Objects.requireNonNull(raftPeer.getId());
+    Objects.requireNonNull(raftPeer.getAddress());
+    return HddsProtos.RaftPeerProto.newBuilder()
+        .setId(raftPeer.getId().toString())
+        .setAddress(raftPeer.getAddress())
+        .setPriority(raftPeer.getPriority())
+        .build();
+  }
+
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmInfo.java
@@ -18,7 +18,11 @@
 
 package org.apache.hadoop.hdds.scm;
 
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -26,9 +30,11 @@ import java.util.List;
  * contains clusterId and the SCM Id.
  */
 public final class ScmInfo {
-  private String clusterId;
-  private String scmId;
-  private List<String> peerRoles;
+  private final String clusterId;
+  private final String scmId;
+  private final List<String> peerRoles;
+  private final RaftGroupId raftGroupId;
+  private final Collection<RaftPeer> peers;
 
   /**
    * Builder for ScmInfo.
@@ -37,6 +43,8 @@ public final class ScmInfo {
     private String clusterId;
     private String scmId;
     private List<String> peerRoles;
+    private RaftGroupId raftGroupId;
+    private Collection<RaftPeer> peers;
 
     public Builder() {
       peerRoles = new ArrayList<>();
@@ -72,15 +80,28 @@ public final class ScmInfo {
       return this;
     }
 
+    public Builder setRaftGroupId(RaftGroupId gid) {
+      this.raftGroupId = gid;
+      return this;
+    }
+
+    public Builder setPeers(Collection<RaftPeer> raftPeers) {
+      this.peers = raftPeers;
+      return this;
+    }
+
     public ScmInfo build() {
-      return new ScmInfo(clusterId, scmId, peerRoles);
+      return new ScmInfo(clusterId, scmId, peerRoles, raftGroupId, peers);
     }
   }
 
-  private ScmInfo(String clusterId, String scmId, List<String> peerRoles) {
+  private ScmInfo(String clusterId, String scmId, List<String> peerRoles,
+                  RaftGroupId raftGroupId, Collection<RaftPeer> peers) {
     this.clusterId = clusterId;
     this.scmId = scmId;
     this.peerRoles = peerRoles;
+    this.raftGroupId = raftGroupId;
+    this.peers = peers;
   }
 
   /**
@@ -105,5 +126,21 @@ public final class ScmInfo {
    */
   public List<String> getRatisPeerRoles() {
     return peerRoles;
+  }
+
+  /**
+   * Gets raft group id.
+   * @return the raft group id
+   */
+  public RaftGroupId getRaftGroupId() {
+    return raftGroupId;
+  }
+
+  /**
+   * Gets Raft peers.
+   * @return the peers
+   */
+  public Collection<RaftPeer> getPeers() {
+    return peers;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/client/ScmClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.client;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.ratis.QuorumInfo;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -333,6 +334,11 @@ public interface ScmClient extends Closeable {
    * returns the list of ratis peer roles. Currently only include peer address.
    */
   List<String> getScmRatisRoles() throws IOException;
+
+  /**
+   *  return the ratis quorum info of scm.
+   */
+  QuorumInfo getQuorumInfo() throws IOException;
 
   /**
    * Get usage information of datanode by ipaddress or uuid.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -25,15 +25,10 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.GetScmInfoResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatus;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.QueryUpgradeFinalizationProgressRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.QueryUpgradeFinalizationProgressResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ActivatePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ClosePipelineRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DatanodeAdminErrorResponseProto;
@@ -42,6 +37,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DeactivatePipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.DecommissionNodesResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.FinalizeScmUpgradeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ForceExitSafeModeResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerRequestProto;
@@ -52,6 +49,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.InSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineResponseProto;
@@ -59,26 +58,27 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.NodeQueryResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.PipelineResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.QueryUpgradeFinalizationProgressRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.QueryUpgradeFinalizationProgressResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.RecommissionNodesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.RecommissionNodesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ReplicationManagerStatusRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ReplicationManagerStatusResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ContainerBalancerStatusResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMCloseContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMDeleteContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMListContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SCMListContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.SafeModeRuleStatusProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationRequest;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationRequest.Builder;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ScmContainerLocationResponse;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartMaintenanceNodesRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartMaintenanceNodesResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartReplicationManagerRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StopReplicationManagerRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StartContainerBalancerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StopContainerBalancerRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.StopReplicationManagerRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.Type;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmInfo;
@@ -96,6 +96,9 @@ import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.security.token.Token;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -104,7 +107,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
 import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
@@ -627,7 +633,6 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
         HddsProtos.GetScmInfoRequestProto.newBuilder()
             .setTraceID(TracingUtil.exportCurrentSpan())
             .build();
-
     GetScmInfoResponseProto resp = submitRequest(Type.GetScmInfo,
         builder -> builder.setGetScmInfoRequest(request))
         .getGetScmInfoResponse();
@@ -635,9 +640,19 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
         .setClusterId(resp.getClusterId())
         .setScmId(resp.getScmId())
         .setRatisPeerRoles(resp.getPeerRolesList());
-
+    if (resp.getGroupId() != null && resp.getGroupId().length() > 0) {
+      builder.setRaftGroupId(RaftGroupId.valueOf(
+          UUID.fromString(resp.getGroupId())));
+    }
+    if (resp.getPeersList() != null && resp.getPeersList().size() > 0) {
+      builder.setPeers(resp.getPeersList().stream().
+          map(raftPeerProto -> RaftPeer.newBuilder()
+              .setId(RaftPeerId.valueOf(raftPeerProto.getId()))
+              .setAddress(raftPeerProto.getAddress())
+              .setPriority(raftPeerProto.getPriority())
+              .build()).collect(Collectors.toList()));
+    }
     return builder.build();
-
   }
 
   /**

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -240,6 +240,8 @@ message GetScmInfoResponseProto {
     required string clusterId = 1;
     required string scmId = 2;
     repeated string peerRoles = 3;
+    optional string groupId = 4;
+    repeated RaftPeerProto peers = 5;
 }
 
 message AddScmRequestProto {
@@ -251,6 +253,15 @@ message AddScmRequestProto {
 message AddScmResponseProto {
     required bool success = 1;
     optional string scmId = 2;
+}
+
+message RaftPeerProto {
+    required string id = 1;      // id of the peer
+    required string address = 2; // e.g. address of the RPC server
+    optional uint32 priority = 3; // priority of the peer
+    optional string dataStreamAddress = 4; // address of the data stream server
+    optional string clientAddress = 5; // address of the client RPC server
+    optional string adminAddress = 6; // address of the admin RPC server
 }
 
 enum ReplicationType {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -80,7 +80,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -591,15 +590,23 @@ public class SCMClientProtocolServer implements
               .setClusterId(scm.getScmStorageConfig().getClusterID())
               .setScmId(scm.getScmStorageConfig().getScmId());
       if (scm.getScmHAManager().getRatisServer() != null) {
+        Preconditions.checkNotNull(scm.getScmHAManager().getRatisServer()
+            .getDivision());
+        Preconditions.checkNotNull(scm.getScmHAManager().getRatisServer()
+            .getDivision().getGroup());
         builder.setRatisPeerRoles(
             scm.getScmHAManager().getRatisServer().getRatisRoles());
+        builder.setRaftGroupId(scm.getScmHAManager().getRatisServer()
+            .getDivision().getGroup().getGroupId());
+        builder.setPeers(scm.getScmHAManager().getRatisServer()
+            .getDivision().getGroup().getPeers());
       } else {
         // In case, there is no ratis, there is no ratis role.
         // This will just print the hostname with ratis port as the default
         // behaviour.
         String adddress = scm.getSCMHANodeDetails().getLocalNodeDetails()
             .getRatisHostPortStr();
-        builder.setRatisPeerRoles(Arrays.asList(adddress));
+        builder.setRatisPeerRoles(Collections.singletonList(adddress));
       }
       return builder.build();
     } catch (Exception ex) {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -26,8 +26,10 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ReadContainerResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.ratis.QuorumInfo;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
@@ -576,6 +578,16 @@ public class ContainerOperationClient implements ScmClient {
   @Override
   public List<String> getScmRatisRoles() throws IOException {
     return storageContainerLocationClient.getScmInfo().getRatisPeerRoles();
+  }
+
+  @Override
+  public QuorumInfo getQuorumInfo() throws IOException {
+    ScmInfo scmInfo = storageContainerLocationClient.getScmInfo();
+    return new QuorumInfo.Builder()
+        .setPeers(scmInfo.getPeers())
+        .setRaftGroupId(scmInfo.getRaftGroupId())
+        .setLeaderRaftId(scmInfo.getScmId())
+        .build();
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -18,16 +18,12 @@
 
 package org.apache.hadoop.ozone.client.protocol;
 
-import java.io.IOException;
-import java.net.URI;
-import java.util.List;
-import java.util.Map;
-
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.hdds.ratis.QuorumInfo;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -54,6 +50,11 @@ import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.security.KerberosInfo;
 import org.apache.hadoop.security.token.Token;
 
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
 /**
  * An implementer of this interface is capable of connecting to Ozone Cluster
  * and perform client operations. The protocol used for communication is
@@ -70,6 +71,13 @@ public interface ClientProtocol {
    * @throws IOException
    */
   List<OMRoleInfo> getOmRoleInfos() throws IOException;
+
+  /**
+   * Gets quorum info, includes RaftGroupId and RaftPeers.
+   * @return the quorum info
+   * @throws IOException the io exception
+   */
+  QuorumInfo getQuorumInfo() throws IOException;
 
   /**
    * Creates a new Volume.

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1179,6 +1179,17 @@ message ServicePort {
 message OMRoleInfo {
     required string nodeId = 1;
     required string serverRole = 2;
+    optional string groupId = 3;
+    repeated RaftPeerProto peers = 4;
+}
+
+message RaftPeerProto {
+  required string id = 1;      // id of the peer
+  required string address = 2; // e.g. address of the RPC server
+  optional uint32 priority = 3; // priority of the peer
+  optional string dataStreamAddress = 4; // address of the data stream server
+  optional string clientAddress = 5; // address of the client RPC server
+  optional string adminAddress = 6; // address of the admin RPC server
 }
 
 message ServiceInfo {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
@@ -1,0 +1,279 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin.failover;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.ratis.QuorumInfo;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.ClientId;
+import org.apache.ratis.protocol.RaftClientReply;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.retry.ExponentialBackoffRetry;
+import org.apache.ratis.util.TimeDuration;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
+
+/**
+ * Subcommand for admin operations related to SCM.
+ */
+@CommandLine.Command(
+    name = "failover",
+    description = "manually transfer leadership of raft group to target node",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class FailoverCommand extends GenericCli
+    implements SubcommandWithParent {
+
+  private final ClientId clientId = ClientId.randomId();
+
+  private static final int TRANSFER_LEADER_WAIT_MS = 120_000;
+  private static final String RANDOM = "RANDOM";
+
+  enum Domain {
+    OM,
+    SCM,
+  }
+
+  @CommandLine.ParentCommand
+  private OzoneAdmin parent;
+
+  @CommandLine.Parameters(
+      description = "['om'/'scm']"
+  )
+  private String domain;
+
+  @CommandLine.Parameters(
+      description = "[host/host:port/'random'] ratis rpc address of " +
+      "target domain if 'random' then choose arbitrary follower node "
+  )
+  private String address;
+
+  @CommandLine.Option(
+      names = {"-id", "--service-id"},
+      description = "Ozone Manager Service ID, if domain is om, " +
+          "this option is prerequisite"
+  )
+  private String omServiceId;
+
+  public OzoneAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    transferLeadership();
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneAdmin.class;
+  }
+
+  public RaftClient createRatisClient(QuorumInfo quorumInfo) {
+    Objects.requireNonNull(quorumInfo);
+    RaftProperties properties = new RaftProperties();
+    Parameters parameters = new Parameters();
+    RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
+        TimeDuration.valueOf(15, TimeUnit.SECONDS));
+    ExponentialBackoffRetry retryPolicy = ExponentialBackoffRetry.newBuilder()
+        .setBaseSleepTime(TimeDuration.valueOf(100, TimeUnit.MILLISECONDS))
+        .setMaxAttempts(10)
+        .setMaxSleepTime(
+            TimeDuration.valueOf(100000, TimeUnit.MILLISECONDS))
+        .build();
+    return RaftClient.newBuilder()
+        .setClientId(clientId)
+        .setLeaderId(null)
+        .setProperties(properties)
+        .setParameters(parameters)
+        .setRetryPolicy(retryPolicy)
+        .setRaftGroup(RaftGroup.valueOf(quorumInfo.getRaftGroupId(),
+            quorumInfo.getPeers()))
+        .build();
+  }
+
+  /**
+   * the whole procedure is as following.
+   * Phase1:
+   *   server client -> get quorumInfo from server -> check address whether
+   *   in quorum
+   *
+   * Phase2:
+   *   raft client -> set priority -> trigger transferLeadership ->
+   *   old leader step down -> new leader take office
+   *
+   *
+   * @throws IOException IOException
+   * @throws OzoneClientException OzoneClientException
+   */
+  private void transferLeadership() throws IOException, OzoneClientException {
+    OzoneConfiguration conf = parent.createOzoneConfiguration();
+
+    QuorumInfo quorumInfo;
+    // get quorumInfo through different clients
+    if (domain.equalsIgnoreCase(Domain.SCM.toString())) {
+      if (SCMHAUtils.isSCMHAEnabled(conf) &&
+          SCMHAUtils.getSCMNodeIds(conf).toArray().length > 0){
+        ContainerOperationClient scmClient = new ContainerOperationClient(conf);
+        quorumInfo = scmClient.getQuorumInfo();
+      } else {
+        throw new OzoneClientException("This command works only on " +
+            "SCM HA cluster. " + OZONE_SCM_HA_ENABLE_KEY + " not true or SCM " +
+            "nodes not found");
+      }
+    } else if (domain.equalsIgnoreCase(Domain.OM.toString())) {
+      if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
+        ClientProtocol omClient =  OzoneClientFactory.
+            getRpcClient(omServiceId, conf).getObjectStore().getClientProxy();
+        quorumInfo = omClient.getQuorumInfo();
+      } else {
+        throw new OzoneClientException("This command works only on " +
+            "OzoneManager HA cluster. Service ID specified: " + omServiceId +
+            " does not match with " + OZONE_OM_SERVICE_IDS_KEY + " defined " +
+            "in the configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY +
+            " are " + conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY)
+            + "\n");
+      }
+    } else {
+      throw new IllegalArgumentException("Invalid domain, should be one of " +
+          Arrays.toString(Domain.values()));
+    }
+    Objects.requireNonNull(quorumInfo);
+    System.out.println("QuorumInfo: " + quorumInfo.toString());
+
+    if (address.equalsIgnoreCase(RANDOM)) {
+      List<String> candidateAddressList = quorumInfo.getPeers().stream().filter(
+          raftPeer -> !quorumInfo.getLeaderRaftPeerId()
+              .equals(raftPeer.getId().toString())).map(RaftPeer::getAddress)
+          .collect(Collectors.toList());
+      if (candidateAddressList.size() > 0) {
+        Collections.shuffle(candidateAddressList);
+        address = candidateAddressList.get(0);
+        System.out.println("candidate list :" + candidateAddressList +
+            "randomly chosen address: " + address);
+      } else {
+        throw new IOException("Not enough Peers for transferring leadership");
+      }
+    }
+
+    getRatisPortHost(conf);
+    // check address passed whether belongs to the peers
+    if (quorumInfo.getPeers().stream().noneMatch(raftPeer ->
+        raftPeer.getAddress().contains(address))) {
+      throw new IOException(String.format("%s is not part of the " +
+          "quorum %s.", address, quorumInfo.getPeers().stream().
+              map(RaftPeer::getAddress).collect(Collectors.toList())));
+    }
+    System.out.printf("Trying to transfer to new leader %s", address);
+
+    RaftClient raftClient = createRatisClient(quorumInfo);
+    List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
+    for (RaftPeer peer : quorumInfo.getPeers()) {
+      peersWithNewPriorities.add(
+          RaftPeer.newBuilder(peer)
+              .setPriority(peer.getAddress().equalsIgnoreCase(address) ? 2 : 1)
+              .build()
+      );
+    }
+    RaftClientReply reply;
+    reply = raftClient.admin().setConfiguration(peersWithNewPriorities);
+    if (reply.isSuccess()) {
+      System.out.printf("Successfully set new priority for division: %s.%n",
+          peersWithNewPriorities);
+    } else {
+      System.out.printf("Failed to set new priority for division: %s." +
+          " Ratis reply: %s%n", peersWithNewPriorities, reply);
+      throw new IOException(reply.getException());
+    }
+
+    RaftPeerId newLeaderPeerId = quorumInfo.getPeers().stream().
+        filter(peer -> peer.getAddress().equalsIgnoreCase(address)).findAny().
+        get().getId();
+
+    reply = raftClient.admin().transferLeadership(
+        newLeaderPeerId, TRANSFER_LEADER_WAIT_MS);
+    if (reply.isSuccess()) {
+      System.out.printf("Successfully transferred leadership: %s.%n",
+          address);
+    } else {
+      System.out.printf("Failed to transferring leadership: %s." +
+          " Ratis reply: %s%n", address, reply);
+      throw new IOException(reply.getException());
+    }
+  }
+
+
+  /**
+   * adjust the address to Host:Port pattern.
+   *
+   * @param conf the conf
+   * @return the ratis port host
+   */
+  public String getRatisPortHost(OzoneConfiguration conf) {
+    assert EnumUtils.isValidEnum(Domain.class, domain);
+    int ratisPort;
+    if (domain.equalsIgnoreCase(Domain.SCM.name())) {
+      ratisPort = conf.getInt(
+          ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+          ScmConfigKeys.OZONE_SCM_RATIS_PORT_DEFAULT);
+    } else {
+      ratisPort = conf.getInt(
+          OMConfigKeys.OZONE_OM_RATIS_PORT_KEY,
+          OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT);
+    }
+
+    if (!address.contains(":")) {
+      address = address.concat(":").concat(
+          String.valueOf(ratisPort));
+    }
+    return address;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * failover related Admin tools.
+ */
+package org.apache.hadoop.ozone.admin.failover;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/scm/GetScmRatisRolesSubcommand.java
@@ -17,12 +17,13 @@
  */
 package org.apache.hadoop.ozone.admin.scm;
 
-import java.io.IOException;
-import java.util.List;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Handler of scm status command.
@@ -40,9 +41,14 @@ public class GetScmRatisRolesSubcommand extends ScmSubcommand {
 
   @Override
   protected void execute(ScmClient scmClient) throws IOException {
-    List<String> roles = scmClient.getScmRatisRoles();
-    for (String role: roles) {
-      System.out.println(role);
+    try {
+      List<String> roles = scmClient.getScmRatisRoles();
+      for (String role: roles) {
+        System.out.println(role);
+      }
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      throw ex;
     }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Background:
In a raft based ha cluster, for some reason, we want to transfer leadership to a specific follower gracefully, now, we have to kill the leader master to transfer leadership, but the leadership could transfer to an unexpected follower, we have to kill the leader master again, this is so tricky.

Usage:
This feature is assumed to utilizing a shell command like ```ozone admin failover  [SCM/OM]  [host/host:port/'random'] ```, with optional IpAddr we can transfer the leadership to the target follower, with 'random' we can transfer leadership to any node except leader node.


Changes:
   * the whole procedure is as following
   * Phase1:
   *   server client -> get QuorumInfo from server -> check address whether in the quorum
   *
   * Phase2:
   *   raft client -> set priority -> trigger transferLeadership -> old leader step down -> new leader take office
  
P.S.Quorum info includes
(
  private RaftGroupId raftGroupId;
  private Collection<RaftPeer> peers;
  private String leaderRaftPeerId;
)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5686

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
manual tests. 
the Integration test will be added soon

Here are some cases shoted

![demo3](https://user-images.githubusercontent.com/10106574/134800158-b03933f5-7c43-45da-9dd2-ffd3e37203c0.png)
![demo2](https://user-images.githubusercontent.com/10106574/134800159-4a7ead4f-cbf5-462c-a79f-30d06bb1cf11.png)
![demo1](https://user-images.githubusercontent.com/10106574/134800154-bc4bd2aa-dd81-4074-9a7b-906c68a38de9.png)

