### PR TITLE
HDDS-5786 datanode start failed due to empty datanode id file

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -32,9 +32,11 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.hdds.DatanodeVersions;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -177,8 +179,11 @@ public final class ContainerUtils {
         return DatanodeDetails.getFromProtoBuf(
             HddsProtos.DatanodeDetailsProto.parseFrom(in));
       } catch (IOException io) {
-        throw new IOException("Failed to parse DatanodeDetails from "
-            + path.getAbsolutePath(), io);
+        DatanodeDetails details = DatanodeDetails.newBuilder()
+            .setUuid(UUID.randomUUID()).build();
+        details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
+        details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+        return details;
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -32,11 +32,9 @@ import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.UUID;
 
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
-import org.apache.hadoop.hdds.DatanodeVersions;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -179,11 +177,8 @@ public final class ContainerUtils {
         return DatanodeDetails.getFromProtoBuf(
             HddsProtos.DatanodeDetailsProto.parseFrom(in));
       } catch (IOException io) {
-        DatanodeDetails details = DatanodeDetails.newBuilder()
-            .setUuid(UUID.randomUUID()).build();
-        details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
-        details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
-        return details;
+        throw new IOException("Failed to parse DatanodeDetails from "
+            + path.getAbsolutePath(), io);
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.hadoop.hdds.DatanodeVersions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.yaml.snakeyaml.DumperOptions;
@@ -105,6 +106,12 @@ public final class DatanodeIdYaml {
           .setCurrentVersion(datanodeDetailsYaml.getCurrentVersion());
 
       datanodeDetails = builder.build();
+    } catch (NullPointerException e) {
+      DatanodeDetails details = DatanodeDetails.newBuilder()
+          .setUuid(UUID.randomUUID()).build();
+      details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
+      details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+      return details;
     }
 
     return datanodeDetails;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -180,6 +180,15 @@ public class TestMiniOzoneCluster {
     assertWriteRead(id1);
   }
 
+  @Test
+  public void testDatanodeEmptyIdFile() throws Exception {
+    // empty datanode id file
+    File file = new File("test.id");
+    file.createNewFile();
+    ContainerUtils.readDatanodeDetailsFrom(file);
+    file.delete();
+  }
+
   private static void assertWriteRead(DatanodeDetails details)
       throws IOException {
     // Write a single ID to the file and read it out

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -183,7 +183,7 @@ public class TestMiniOzoneCluster {
   @Test
   public void testDatanodeEmptyIdFile() throws Exception {
     // empty datanode id file
-    File file = new File("test.id");
+    File file = new File(WRITE_TMP,"test.id");
     file.createNewFile();
     ContainerUtils.readDatanodeDetailsFrom(file);
     file.delete();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAclRequest;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequestWithFSO;
-import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;;
+import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequestWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;


### PR DESCRIPTION
## What changes were proposed in this pull request?
datanode can start successful if empty datanode id file

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5786

## How was this patch tested?
unit test
