### PR TITLE
HDDS-5786 datanode start failed due to empty datanode id file

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
@@ -82,10 +82,18 @@ public final class DatanodeIdYaml {
       }
 
       DatanodeDetails.Builder builder = DatanodeDetails.newBuilder();
-      builder.setUuid(UUID.fromString(datanodeDetailsYaml.getUuid()))
-          .setIpAddress(datanodeDetailsYaml.getIpAddress())
-          .setHostName(datanodeDetailsYaml.getHostName())
-          .setCertSerialId(datanodeDetailsYaml.getCertSerialId());
+      try {
+        builder.setUuid(UUID.fromString(datanodeDetailsYaml.getUuid()))
+            .setIpAddress(datanodeDetailsYaml.getIpAddress())
+            .setHostName(datanodeDetailsYaml.getHostName())
+            .setCertSerialId(datanodeDetailsYaml.getCertSerialId());
+      } catch (NullPointerException e) {
+        DatanodeDetails details = DatanodeDetails.newBuilder()
+            .setUuid(UUID.randomUUID()).build();
+        details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
+        details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+        return details;
+      }
       if (datanodeDetailsYaml.getPersistedOpState() != null) {
         builder.setPersistedOpState(HddsProtos.NodeOperationalState.valueOf(
             datanodeDetailsYaml.getPersistedOpState()));
@@ -106,12 +114,6 @@ public final class DatanodeIdYaml {
           .setCurrentVersion(datanodeDetailsYaml.getCurrentVersion());
 
       datanodeDetails = builder.build();
-    } catch (NullPointerException e) {
-      DatanodeDetails details = DatanodeDetails.newBuilder()
-          .setUuid(UUID.randomUUID()).build();
-      details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
-      details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
-      return details;
     }
 
     return datanodeDetails;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/DatanodeIdYaml.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.apache.hadoop.hdds.DatanodeVersions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.yaml.snakeyaml.DumperOptions;
@@ -105,6 +106,12 @@ public final class DatanodeIdYaml {
           .setCurrentVersion(datanodeDetailsYaml.getCurrentVersion());
 
       datanodeDetails = builder.build();
+    } catch (NullPointerException e) {
+      DatanodeDetails details = DatanodeDetails.newBuilder()
+          .setUuid(UUID.randomUUID()).build();
+      details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
+      details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+      return details;
     }
 
     return datanodeDetails;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -183,7 +183,7 @@ public class TestMiniOzoneCluster {
   @Test
   public void testDatanodeEmptyIdFile() throws Exception {
     // empty datanode id file
-    File file = new File(WRITE_TMP,"test.id");
+    File file = new File(WRITE_TMP, "test.id");
     file.createNewFile();
     ContainerUtils.readDatanodeDetailsFrom(file);
     file.delete();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -180,6 +180,15 @@ public class TestMiniOzoneCluster {
     assertWriteRead(id1);
   }
 
+  @Test
+  public void testDatanodeEmptyIdFile() throws Exception {
+    // empty datanode id file
+    File file = new File(WRITE_TMP,"test.id");
+    file.createNewFile();
+    ContainerUtils.readDatanodeDetailsFrom(file);
+    file.delete();
+  }
+
   private static void assertWriteRead(DatanodeDetails details)
       throws IOException {
     // Write a single ID to the file and read it out


### PR DESCRIPTION
## What changes were proposed in this pull request?

datanode can start successful if empty datanode id file

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5786

## How was this patch tested?

unittest
