### PR TITLE
HDDS-5686. Support transfer leadership in raft based ha cluster

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
@@ -70,6 +71,14 @@ public interface ClientProtocol {
    * @throws IOException
    */
   List<OMRoleInfo> getOmRoleInfos() throws IOException;
+
+  /**
+   * Gets om service info.
+   *
+   * @return the om service infos
+   * @throws IOException the io exception
+   */
+  ServiceInfoEx getOmServiceInfo() throws IOException;
 
   /**
    * Creates a new Volume.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -289,6 +289,11 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
+  public ServiceInfoEx getOmServiceInfo() throws IOException {
+    return ozoneManagerClient.getServiceInfo();
+  }
+
+  @Override
   public void createVolume(String volumeName) throws IOException {
     createVolume(volumeName, VolumeArgs.newBuilder().build());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
@@ -34,6 +34,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
+
 /**
  * Tests failover with SCM HA setup.
  */
@@ -48,6 +50,7 @@ public class TestFailoverShellHA {
   private int numOfSCMs = 3;
 
   private static final long SNAPSHOT_THRESHOLD = 5;
+  private static final String HOST_PORT_LIST_ARG = "--hostPortList";
 
   /**
    * Create a MiniOzoneCluster for testing.
@@ -99,10 +102,10 @@ public class TestFailoverShellHA {
             .stream().map(RaftPeer::getAddress)
             .collect(Collectors.joining(","));
     hostAddress = hostAddress.replaceAll("0\\.0\\.0\\.0", "localhost");
-    conf.set("ozone.scm.ratis.enable", "true");
+    conf.set(OZONE_SCM_HA_ENABLE_KEY, "true");
     OzoneAdmin ozoneAdmin = new OzoneAdmin(conf);
     String[] args = {"failover", "SCM", hostAddress,
-        "--raftHostPortList", ratisAddresses};
+        HOST_PORT_LIST_ARG, ratisAddresses};
     ozoneAdmin.execute(args);
     cluster.waitForSCMToBeReady();
     StorageContainerManager currentLeader = getScmLeader(cluster);
@@ -123,8 +126,8 @@ public class TestFailoverShellHA {
             .collect(Collectors.joining(","));
     hostAddress = hostAddress.replaceAll("0\\.0\\.0\\.0", "localhost");
     OzoneAdmin ozoneAdmin = new OzoneAdmin(conf);
-    String[] args = {"failover", "OM", hostAddress, "--raftHostPortList",
-        ratisAddresses};
+    String[] args = {"failover", "OM", hostAddress, HOST_PORT_LIST_ARG,
+        ratisAddresses, "--service-id", cluster.getOMServiceId()};
     ozoneAdmin.execute(args);
     cluster.waitForClusterToBeReady();
     OzoneManager currentLeader = cluster.getOMLeader();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.shell;
+
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.ratis.protocol.RaftPeer;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Tests failover with SCM HA setup.
+ */
+public class TestFailoverShellHA {
+  private MiniOzoneHAClusterImpl cluster = null;
+  private OzoneConfiguration conf;
+  private String clusterId;
+  private String scmId;
+  private String omServiceId;
+  private String scmServiceId;
+  private int numOfOMs = 3;
+  private int numOfSCMs = 3;
+
+  private static final long SNAPSHOT_THRESHOLD = 5;
+
+  /**
+   * Create a MiniOzoneCluster for testing.
+   *
+   * @throws IOException Exception
+   */
+  @BeforeEach
+  public void init() throws Exception {
+    conf = new OzoneConfiguration();
+    clusterId = UUID.randomUUID().toString();
+    scmId = UUID.randomUUID().toString();
+    omServiceId = "om-service-test1";
+    scmServiceId = "scm-service-test1";
+    conf.setLong(ScmConfigKeys.OZONE_SCM_HA_RATIS_SNAPSHOT_THRESHOLD,
+            SNAPSHOT_THRESHOLD);
+
+    cluster = (MiniOzoneHAClusterImpl) MiniOzoneCluster.newHABuilder(conf)
+            .setClusterId(clusterId).setScmId(scmId).setOMServiceId(omServiceId)
+            .setSCMServiceId(scmServiceId).setNumOfOzoneManagers(numOfOMs)
+            .setNumOfStorageContainerManagers(numOfSCMs)
+            .setNumOfActiveSCMs(numOfSCMs).setNumOfActiveOMs(numOfOMs)
+            .build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterEach
+  public void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    System.setOut(null);
+  }
+
+
+  @Test
+  public void testScmFailover() throws Exception {
+    StorageContainerManager oldLeader = getScmLeader(cluster);
+    List<StorageContainerManager> scmList= cluster.
+            getStorageContainerManagersList();
+    Assert.assertTrue(scmList.contains(oldLeader));
+    scmList.remove(oldLeader);
+    StorageContainerManager newLeader = scmList.get(0);
+    String hostAddress = newLeader.getSCMHANodeDetails().getLocalNodeDetails()
+            .getRatisHostPortStr();
+    String ratisAddresses = newLeader.getScmHAManager().getRatisServer()
+            .getDivision().getGroup().getPeers()
+            .stream().map(RaftPeer::getAddress)
+            .collect(Collectors.joining(","));
+    hostAddress = hostAddress.replaceAll("0\\.0\\.0\\.0", "localhost");
+    conf.set("ozone.scm.ratis.enable", "true");
+    OzoneAdmin ozoneAdmin = new OzoneAdmin(conf);
+    String[] args = {"failover", "SCM", hostAddress,
+        "--raftHostPortList", ratisAddresses};
+    ozoneAdmin.execute(args);
+    cluster.waitForSCMToBeReady();
+    StorageContainerManager currentLeader = getScmLeader(cluster);
+    Assert.assertNotSame(oldLeader, currentLeader);
+  }
+
+  @Test
+  public void testOmFailover() throws Exception {
+    OzoneManager oldLeader = cluster.getOMLeader();
+    List<OzoneManager> omList= cluster.getOzoneManagersList();
+    Assert.assertTrue(omList.contains(oldLeader));
+    omList.remove(oldLeader);
+    OzoneManager newLeader = omList.get(0);
+    String hostAddress = newLeader.getOmRatisServer().getServer()
+            .getPeer().getAddress();
+    String ratisAddresses = newLeader.getOmRatisServer().getRaftGroup()
+            .getPeers().stream().map(RaftPeer::getAddress)
+            .collect(Collectors.joining(","));
+    hostAddress = hostAddress.replaceAll("0\\.0\\.0\\.0", "localhost");
+    OzoneAdmin ozoneAdmin = new OzoneAdmin(conf);
+    String[] args = {"failover", "OM", hostAddress, "--raftHostPortList",
+        ratisAddresses};
+    ozoneAdmin.execute(args);
+    cluster.waitForClusterToBeReady();
+    OzoneManager currentLeader = cluster.getOMLeader();
+    Assert.assertNotSame(oldLeader, currentLeader);
+  }
+
+  static StorageContainerManager getScmLeader(MiniOzoneHAClusterImpl impl) {
+    for (StorageContainerManager scm : impl.getStorageContainerManagers()) {
+      if (scm.checkLeader()) {
+        return scm;
+      }
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestFailoverShellHA.java
@@ -81,7 +81,6 @@ public class TestFailoverShellHA {
     if (cluster != null) {
       cluster.shutdown();
     }
-    System.setOut(null);
   }
 
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.admin.failover;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.hadoop.hdds.NodeDetails;
+import org.apache.hadoop.hdds.cli.GenericCli;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.cli.SubcommandWithParent;
+import org.apache.hadoop.hdds.conf.ConfigurationException;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.ha.OMHANodeDetails;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.client.RaftClientConfigKeys;
+import org.apache.ratis.client.api.GroupManagementApi;
+import org.apache.ratis.conf.Parameters;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.proto.RaftProtos;
+import org.apache.ratis.protocol.*;
+import org.apache.ratis.retry.ExponentialBackoffRetry;
+import org.apache.ratis.util.TimeDuration;
+import org.kohsuke.MetaInfServices;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.*;
+
+/**
+ * Subcommand for admin operations related to failover actions.
+ */
+@CommandLine.Command(
+    name = "failover",
+    description = "manually transfer leadership of raft group to target node",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class
+)
+@MetaInfServices(SubcommandWithParent.class)
+public class FailoverCommand extends GenericCli
+    implements SubcommandWithParent {
+
+  public static final RaftGroupId PSEUDO_RAFT_GROUP_ID = RaftGroupId.randomId();
+  public static final int TRANSFER_LEADER_WAIT_MS = 120_000;
+  public static final String RANDOM = "RANDOM";
+
+  enum Domain {
+    OM,
+    SCM,
+  }
+
+  @CommandLine.ParentCommand
+  private OzoneAdmin parent;
+
+  @CommandLine.Parameters(
+      description = "['om'/'scm']"
+  )
+  private String domain;
+
+  @CommandLine.Parameters(
+      description = "[host/host:port/'random'] ratis rpc address of " +
+      "target domain if 'random' then choose arbitrary follower node "
+  )
+  private String tgtAddress;
+
+  @CommandLine.Option(
+      names = {"-id", "--service-id"},
+      description = "Ozone Manager Service ID, if domain is om, " +
+          "this option is prerequisite"
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+          names = {"--raftHostPortList"},
+          description = "if need to test on given nodes, " +
+                  "pattern like this 'host:port,host:port,host:port'"
+  )
+  private String ratisAddresses;
+
+  public OzoneAdmin getParent() {
+    return parent;
+  }
+
+  @Override
+  public Void call() throws Exception {
+    OzoneConfiguration configuration;
+    if (parent.getOzoneConf() == null) {
+      configuration = new OzoneConfiguration();
+    } else{
+      configuration = parent.getOzoneConf();
+    }
+    try {
+      transferLeadership(configuration);
+    } catch (Exception ex) {
+      ex.printStackTrace();
+      throw ex;
+    }
+    return null;
+  }
+
+  @Override
+  public Class<?> getParentType() {
+    return OzoneAdmin.class;
+  }
+
+
+  /**
+   * Create ratis client raft client.
+   *
+   * @param raftGroupId the raft group id
+   * @param peers       the peers
+   * @return the raft client
+   */
+  public static RaftClient createRatisClient(RaftGroupId raftGroupId,
+                                             Collection<RaftPeer> peers) {
+    RaftProperties properties = new RaftProperties();
+    Parameters parameters = new Parameters();
+    RaftClientConfigKeys.Rpc.setRequestTimeout(properties,
+        TimeDuration.valueOf(15, TimeUnit.SECONDS));
+    ExponentialBackoffRetry retryPolicy = ExponentialBackoffRetry.newBuilder()
+        .setBaseSleepTime(
+                TimeDuration.valueOf(100, TimeUnit.MILLISECONDS))
+        .setMaxAttempts(10)
+        .setMaxSleepTime(
+                TimeDuration.valueOf(100000, TimeUnit.MILLISECONDS))
+        .build();
+    return RaftClient.newBuilder()
+        .setClientId(ClientId.randomId())
+        .setLeaderId(null)
+        .setProperties(properties)
+        .setParameters(parameters)
+        .setRetryPolicy(retryPolicy)
+        .setRaftGroup(RaftGroup.valueOf(raftGroupId, peers))
+        .build();
+  }
+
+  /**
+   * The whole procedure is as following.
+   *
+   *   Pseudo raft client -> get real raft group info -> check address
+   *   whether in raft peers -> real raft client -> set priority -> trigger
+   *   transferleadership -> new raft leader takes office
+   *
+   * @throws IOException IOException
+   */
+  private void transferLeadership(OzoneConfiguration conf) throws IOException {
+    List<String> ratisAddressList;
+    if (ratisAddresses != null) {
+      ratisAddressList = Arrays.asList(ratisAddresses.split(","));
+    } else if (domain.equalsIgnoreCase(Domain.SCM.toString())) {
+      ratisAddressList = getSCMRatisAddressList(conf);
+    } else if (domain.equalsIgnoreCase(Domain.OM.toString())) {
+      ratisAddressList = getOMRatisAddressList(conf);
+    } else {
+      throw new IllegalArgumentException("Invalid domain, should be one of " +
+              Arrays.toString(Domain.values()));
+    }
+    assert ratisAddressList.size() > 0;
+    List<RaftPeer> peerList = ratisAddressList.stream().map(addr-> RaftPeer
+            .newBuilder()
+            .setId(RaftPeerId.valueOf(addr))
+            .setAddress(addr)
+            .build())
+            .collect(Collectors.toList());
+
+    // Pseudo client for inquiry
+    RaftClient raftClient = createRatisClient(PSEUDO_RAFT_GROUP_ID, peerList);
+    RaftGroupId remoteGroupId;
+    GroupManagementApi groupManagementApi = raftClient.getGroupManagementApi(
+            peerList.get(0).getId());
+    List<RaftGroupId> groupIds = groupManagementApi.list().getGroupIds();
+    if (groupIds.size() == 1) {
+      remoteGroupId = groupIds.get(0);
+    } else {
+      throw new IOException("There are more than one raft group.");
+    }
+    GroupInfoReply groupInfoReply = groupManagementApi.info(remoteGroupId);
+    RaftGroup raftGroup = groupInfoReply.getGroup();
+    raftClient = createRatisClient(raftGroup.getGroupId(),
+            raftGroup.getPeers());
+    System.out.println("RaftGroup from raft server: " + raftGroup);
+
+    if (tgtAddress.equalsIgnoreCase(RANDOM)) {
+      tgtAddress = getRandomAddress(groupInfoReply);
+    }
+    getRatisPortHost(conf);
+    // check address passed whether belongs to the peers
+    if (raftGroup.getPeers().stream().noneMatch(raftPeer ->
+        raftPeer.getAddress().contains(tgtAddress))) {
+      throw new IOException(String.format("%s is not part of the " +
+          "quorum %s.", tgtAddress, raftGroup.getPeers().stream().
+              map(RaftPeer::getAddress).collect(Collectors.toList())));
+    }
+    System.out.printf("Trying to transfer to new leader %s", tgtAddress);
+
+    List<RaftPeer> peersWithNewPriorities = new ArrayList<>();
+    for (RaftPeer peer : raftGroup.getPeers()) {
+      peersWithNewPriorities.add(
+          RaftPeer.newBuilder(peer)
+                  .setPriority(peer.getAddress()
+                          .equalsIgnoreCase(tgtAddress) ? 2 : 1)
+                  .build()
+      );
+    }
+    RaftClientReply reply;
+    reply = raftClient.admin().setConfiguration(peersWithNewPriorities);
+    if (reply.isSuccess()) {
+      System.out.printf("Successfully set new priority for division: %s.%n",
+          peersWithNewPriorities);
+    } else {
+      System.out.printf("Failed to set new priority for division: %s." +
+          " Ratis reply: %s%n", peersWithNewPriorities, reply);
+      throw new IOException(reply.getException());
+    }
+
+    RaftPeerId newLeaderPeerId = raftGroup.getPeers().stream().
+        filter(peer -> peer.getAddress().equalsIgnoreCase(tgtAddress))
+            .findAny().get().getId();
+    reply = raftClient.admin().transferLeadership(
+        newLeaderPeerId, TRANSFER_LEADER_WAIT_MS);
+    if (reply.isSuccess()) {
+      System.out.printf("Successfully transferred leadership: %s.%n",
+              tgtAddress);
+    } else {
+      System.out.printf("Failed to transferring leadership: %s." +
+          " Ratis reply: %s%n", tgtAddress, reply);
+      throw new IOException(reply.getException());
+    }
+  }
+
+  private List<String> getOMRatisAddressList(OzoneConfiguration conf)
+          throws IOException {
+    if (OmUtils.isOmHAServiceId(conf, omServiceId)) {
+      OMHANodeDetails omhaNodeDetails = OMHANodeDetails.loadOMHAConfig(conf);
+      assert omhaNodeDetails != null;
+      return omhaNodeDetails.getPeerNodesMap().values().stream()
+              .map(NodeDetails::getRatisHostPortStr)
+              .collect(Collectors.toList());
+    } else {
+      throw new IOException("OM HA not enabled or" +
+              " OM ServiceId not set in option.");
+    }
+  }
+
+  /**
+   * Check SCM HA and get ratis address list.
+   *
+   * @param conf ozoneConfiguration
+   * @return SCMRatisAddressList
+   * @throws IOException IOException
+   */
+  List<String> getSCMRatisAddressList(OzoneConfiguration conf)
+          throws IOException {
+    List<String> addressList = new ArrayList<>();
+    String scmServiceId = SCMHAUtils.getScmServiceId(conf);
+    String scmRatisPort = conf.get(OZONE_SCM_RATIS_PORT_KEY,
+            String.valueOf(OZONE_SCM_RATIS_PORT_DEFAULT));
+
+    if(!SCMHAUtils.isSCMHAEnabled(conf) || scmServiceId == null) {
+      throw new IOException("SCM HA not enabled or cannot find SCM ServiceId.");
+    }
+    ArrayList< String > scmNodeIds = new ArrayList<>(
+            SCMHAUtils.getSCMNodeIds(conf, scmServiceId));
+    if (scmNodeIds.size() == 0) {
+      throw new ConfigurationException(
+              String.format("Configuration does not have any value set for " +
+                      "%s for the SCM serviceId %s. List of SCM Node ID's " +
+                      "should be specified for an SCM HA service",
+                      OZONE_SCM_NODES_KEY, scmServiceId));
+    }
+
+    for (String scmNodeId : scmNodeIds) {
+      String addressKey = ConfUtils.addKeySuffixes(
+              OZONE_SCM_ADDRESS_KEY, scmServiceId, scmNodeId);
+      String scmAddress = conf.get(addressKey);
+      if (scmAddress == null) {
+        throw new ConfigurationException(addressKey + "is not defined");
+      }
+      addressList.add(scmAddress.concat(":").concat(scmRatisPort));
+    }
+    return addressList;
+  }
+
+  /**
+   * adjust the address to Host:Port pattern.
+   *
+   * @param conf the conf
+   * @return the ratis port host
+   */
+  public String getRatisPortHost(OzoneConfiguration conf) {
+    assert EnumUtils.isValidEnum(Domain.class, domain.toUpperCase());
+    int ratisPort;
+    if (domain.equalsIgnoreCase(Domain.SCM.name())) {
+      ratisPort = conf.getInt(
+          ScmConfigKeys.OZONE_SCM_RATIS_PORT_KEY,
+          ScmConfigKeys.OZONE_SCM_RATIS_PORT_DEFAULT);
+    } else {
+      ratisPort = conf.getInt(
+          OMConfigKeys.OZONE_OM_RATIS_PORT_KEY,
+          OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT);
+    }
+
+    if (!tgtAddress.contains(":")) {
+      tgtAddress = tgtAddress.concat(":").concat(
+          String.valueOf(ratisPort));
+    }
+    return tgtAddress;
+  }
+
+  /**
+   * Gets random address.
+   *
+   * @param groupInfoReply the group info reply
+   * @return the random address
+   * @throws IOException the io exception
+   */
+  public static String getRandomAddress(GroupInfoReply groupInfoReply)
+          throws IOException {
+    String targetAddress;
+    String leaderAddr;
+    if (groupInfoReply.getRoleInfoProto().getRole()
+            .equals(RaftProtos.RaftPeerRole.LEADER)) {
+      leaderAddr = groupInfoReply.getRoleInfoProto().getSelf().getAddress();
+    } else {
+      leaderAddr = groupInfoReply.getGroup().getPeers().stream()
+              .filter(raftPeer -> groupInfoReply.getRoleInfoProto()
+                      .getFollowerInfo().getLeaderInfo().getId()
+                      .getId().toStringUtf8()
+                      .equalsIgnoreCase(raftPeer.getId().toString()))
+              .findAny().get().getAddress();
+    }
+    List<String> candidateAddressList = groupInfoReply.getGroup()
+            .getPeers().stream().filter(raftPeer -> !raftPeer.getAddress()
+            .equalsIgnoreCase(leaderAddr)).map(RaftPeer::getAddress)
+            .collect(Collectors.toList());
+    if (candidateAddressList.size() > 0) {
+      Collections.shuffle(candidateAddressList);
+      targetAddress = candidateAddressList.get(0);
+      System.out.println("candidate list: " + candidateAddressList);
+      System.out.println("randomly chosen address: " + targetAddress);
+      return targetAddress;
+    } else {
+      throw new IOException("Not enough Peers for transferring leadership");
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/FailoverCommand.java
@@ -94,7 +94,7 @@ public class FailoverCommand extends GenericCli
   private String omServiceId;
 
   @CommandLine.Option(
-          names = {"--raftHostPortList"},
+          names = {"--hostPortList"},
           description = "if need to test on given nodes, " +
                   "pattern like this 'host:port,host:port,host:port'"
   )
@@ -125,7 +125,6 @@ public class FailoverCommand extends GenericCli
   public Class<?> getParentType() {
     return OzoneAdmin.class;
   }
-
 
   /**
    * Create ratis client raft client.

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/package-info.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/failover/package-info.java
@@ -1,0 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * failover related Admin tools.
+ */
+package org.apache.hadoop.ozone.admin.failover;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetCertificatesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetCertificatesSubcommand.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import picocli.CommandLine;
+
+import java.io.IOException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Handler of om roles command.
+ */
+@CommandLine.Command(
+    name = "certificates", aliases = "certs",
+    description = "List all CA certificates from OM",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class GetCertificatesSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(names = {"-id", "--service-id"},
+      description = "OM Service ID, for HA mode."
+  )
+  private String omServiceId;
+
+  @CommandLine.Option(
+      names = {"-host", "--service-host"},
+      description = "Ozone Manager Host, for non-HA mode."
+  )
+  private String omHost;
+
+  @CommandLine.Option(
+      names = {"--show", "-show"},
+      required = true
+  )
+  private boolean action;
+
+  private OzoneManagerProtocol ozoneManagerClient;
+
+  private static final String OUTPUT_FORMAT = "%-17s %-30s %-30s %-110s";
+
+  @Override
+  public Void call() throws Exception {
+    try {
+      ozoneManagerClient =  parent.createOmClient(omServiceId, omHost, false);
+      List<X509Certificate> certs = getCACertificates(
+          ozoneManagerClient.getServiceInfo());
+      for (X509Certificate cert: certs) {
+        String output = String.format(OUTPUT_FORMAT, cert.getSerialNumber(),
+            cert.getNotBefore(), cert.getNotAfter(), cert.getSubjectDN());
+        System.out.println(output);
+      }
+    } catch (Exception ex) {
+      System.out.printf("Error: %s", ex.getMessage());
+    } finally {
+      if (ozoneManagerClient != null) {
+        ozoneManagerClient.close();
+      }
+    }
+    return null;
+  }
+
+  private List<X509Certificate> getCACertificates(ServiceInfoEx serviceInfoEx)
+      throws IOException {
+    return OzoneSecurityUtil.convertToX509(serviceInfoEx.getCaCertPemList());
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -57,7 +57,8 @@ import java.util.Collection;
         GetServiceRolesSubcommand.class,
         PrepareSubCommand.class,
         CancelPrepareSubCommand.class,
-        FinalizationStatusSubCommand.class
+        FinalizationStatusSubCommand.class,
+        GetCertificatesSubcommand.class
     })
 @MetaInfServices(SubcommandWithParent.class)
 public class OMAdmin extends GenericCli implements SubcommandWithParent {


### PR DESCRIPTION
## What changes were proposed in this pull request?
Background:
In a raft based ha cluster, for some reason, we want to transfer leadership to a specific follower gracefully, now, we have to kill the leader master to transfer leadership, but the leadership could transfer to an unexpected follower, we have to kill the leader master again, this is so tricky.

Usage:
This feature is assumed to utilizing a shell command like ```ozone admin failover  [SCM/OM]  [host/host:port/'random'] ```, with optional IpAddr we can transfer the leadership to the target follower, with 'random' we can transfer leadership to any node except leader node.

The whole procedure is as following:
   *   Pseudo raft client -> get real raft group info -> check address
   *   whether in raft peers -> real raft client -> set priority -> trigger
   *   transferleadership -> new raft leader takes office


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5686

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?
manual tests. 
the Integration test will be added soon

Here are some screenshots
![截屏2021-09-28 下午3 59 40](https://user-images.githubusercontent.com/10106574/135057902-abb104f9-140c-48c2-be36-62d3f2a33944.png)
![截屏2021-09-28 下午3 48 29](https://user-images.githubusercontent.com/10106574/135057915-5b4b74e8-f998-4c41-9ba5-d25c72fcd727.png)
![截屏2021-09-28 下午3 51 06](https://user-images.githubusercontent.com/10106574/135057920-b588a420-cb13-4a16-8ae2-b795991cc54e.png)


