### PR TITLE
HDDS-5792. Speed up TestNSSummaryAdmin by having zero Datanodes

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -42,7 +42,8 @@ public class TestNSSummaryAdmin {
     conf.setBoolean("ozone.om.enable.filesystem.paths", true);
     conf.set("ozone.om.metadata.layout", "PREFIX");
     conf.set(OZONE_RECON_ADDRESS_KEY, "localhost:9888");
-    cluster = MiniOzoneCluster.newBuilder(conf).includeRecon(true).build();
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .withoutDatanodes().includeRecon(true).build();
     cluster.waitForClusterToBeReady();
     // Client uses server conf for this test
     ozoneAdmin = new OzoneAdmin(conf);


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestNSSummaryAdmin can run successfully with zero datanodes. It current takes about 44 seconds, but should be much faster without any datanodes in the mini-cluster:

[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 44.693 s - in org.apache.hadoop.ozone.shell.TestNSSummaryAdmin

On my laptop it went from 36 -> 10 seconds.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5792

## How was this patch tested?

Existing tests
