### PR TITLE
HDDS-5788. Reduce run time for TestOzoneManagerHA tests

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -52,7 +52,6 @@ import java.net.ConnectException;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.HashMap;
-import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -37,8 +37,10 @@ import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.BeforeClass;
 import org.junit.Before;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Assert;
 
@@ -50,6 +52,7 @@ import java.net.ConnectException;
 import java.time.Duration;
 import java.util.UUID;
 import java.util.HashMap;
+import java.util.concurrent.TimeoutException;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.IPC_CLIENT_CONNECT_MAX_RETRIES_KEY;
@@ -68,14 +71,14 @@ import static org.junit.Assert.fail;
  */
 public abstract class TestOzoneManagerHA {
 
-  private MiniOzoneOMHAClusterImpl cluster = null;
-  private MiniOzoneCluster.Builder clusterBuilder = null;
-  private ObjectStore objectStore;
-  private OzoneConfiguration conf;
-  private String clusterId;
-  private String scmId;
-  private String omId;
-  private String omServiceId;
+  private static MiniOzoneOMHAClusterImpl cluster = null;
+  private static MiniOzoneCluster.Builder clusterBuilder = null;
+  private static ObjectStore objectStore;
+  private static OzoneConfiguration conf;
+  private static String clusterId;
+  private static String scmId;
+  private static String omId;
+  private static String omServiceId;
   private static int numOfOMs = 3;
   private static final int LOG_PURGE_GAP = 50;
   /* Reduce max number of retries to speed up unit test. */
@@ -88,7 +91,7 @@ public abstract class TestOzoneManagerHA {
   public ExpectedException exception = ExpectedException.none();
 
   @Rule
-  public Timeout timeout = Timeout.seconds(300);;
+  public Timeout timeout = Timeout.seconds(300);
 
   public MiniOzoneOMHAClusterImpl getCluster() {
     return cluster;
@@ -137,8 +140,8 @@ public abstract class TestOzoneManagerHA {
    *
    * @throws IOException
    */
-  @Before
-  public void init() throws Exception {
+  @BeforeClass
+  public static void init() throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
@@ -171,7 +174,6 @@ public abstract class TestOzoneManagerHA {
      */
     conf.set(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, "10s");
     conf.set(OZONE_KEY_DELETING_LIMIT_PER_TASK, "2");
-    additionalConfiguration();
 
     clusterBuilder = MiniOzoneCluster.newOMHABuilder(conf)
         .setClusterId(clusterId)
@@ -179,12 +181,20 @@ public abstract class TestOzoneManagerHA {
         .setOMServiceId(omServiceId)
         .setOmId(omId)
         .setNumOfOzoneManagers(numOfOMs);
-    additionalClusterSettings();
 
-    cluster = (MiniOzoneOMHAClusterImpl)clusterBuilder.build();
+    cluster = (MiniOzoneOMHAClusterImpl) clusterBuilder.build();
     cluster.waitForClusterToBeReady();
     objectStore = OzoneClientFactory.getRpcClient(omServiceId, conf)
         .getObjectStore();
+  }
+
+  /**
+   * Apply additional configuration between tests.
+   */
+  @Before
+  public void setupTest() {
+    additionalConfiguration();
+    additionalClusterSettings();
   }
 
   /**
@@ -202,10 +212,21 @@ public abstract class TestOzoneManagerHA {
   }
 
   /**
-   * Shutdown MiniDFSCluster.
+   * Reset cluster between tests.
    */
   @After
-  public void shutdown() {
+  public void resetCluster()
+      throws IOException {
+    if (cluster != null) {
+      cluster.restartOzoneManager();
+    }
+  }
+
+  /**
+   * Shutdown MiniDFSCluster after all tests of a class have run.
+   */
+  @AfterClass
+  public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
     }
@@ -213,6 +234,7 @@ public abstract class TestOzoneManagerHA {
 
   /**
    * Create a key in the bucket.
+   *
    * @return the key name.
    */
   public static String createKey(OzoneBucket ozoneBucket) throws IOException {
@@ -256,6 +278,7 @@ public abstract class TestOzoneManagerHA {
 
   /**
    * Stop the current leader OM.
+   *
    * @throws Exception
    */
   protected void stopLeaderOM() {
@@ -316,6 +339,7 @@ public abstract class TestOzoneManagerHA {
   /**
    * This method createFile and verifies the file is successfully created or
    * not.
+   *
    * @param ozoneBucket
    * @param keyName
    * @param data
@@ -324,7 +348,8 @@ public abstract class TestOzoneManagerHA {
    * @throws Exception
    */
   protected void testCreateFile(OzoneBucket ozoneBucket, String keyName,
-      String data, boolean recursive, boolean overwrite)
+                                String data, boolean recursive,
+                                boolean overwrite)
       throws Exception {
 
     OzoneOutputStream ozoneOutputStream = ozoneBucket.createFile(keyName,
@@ -347,6 +372,62 @@ public abstract class TestOzoneManagerHA {
     byte[] fileContent = new byte[data.getBytes(UTF_8).length];
     ozoneInputStream.read(fileContent);
     Assert.assertEquals(data, new String(fileContent, UTF_8));
+  }
+
+  protected void createKeyTest(boolean checkSuccess) throws Exception {
+    String userName = "user" + RandomStringUtils.randomNumeric(5);
+    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
+    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
+
+    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
+        .setOwner(userName)
+        .setAdmin(adminName)
+        .build();
+
+    try {
+      getObjectStore().createVolume(volumeName, createVolumeArgs);
+
+      OzoneVolume retVolumeinfo = getObjectStore().getVolume(volumeName);
+
+      Assert.assertTrue(retVolumeinfo.getName().equals(volumeName));
+      Assert.assertTrue(retVolumeinfo.getOwner().equals(userName));
+      Assert.assertTrue(retVolumeinfo.getAdmin().equals(adminName));
+
+      String bucketName = UUID.randomUUID().toString();
+      String keyName = UUID.randomUUID().toString();
+      retVolumeinfo.createBucket(bucketName);
+
+      OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
+
+      Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
+      Assert.assertTrue(ozoneBucket.getVolumeName().equals(volumeName));
+
+      String value = "random data";
+      OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(keyName,
+          value.length(), ReplicationType.STAND_ALONE,
+          ReplicationFactor.ONE, new HashMap<>());
+      ozoneOutputStream.write(value.getBytes(UTF_8), 0, value.length());
+      ozoneOutputStream.close();
+
+      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName);
+
+      byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+      ozoneInputStream.read(fileContent);
+      Assert.assertEquals(value, new String(fileContent, UTF_8));
+
+    } catch (ConnectException | RemoteException e) {
+      if (!checkSuccess) {
+        // If the last OM to be tried by the RetryProxy is down, we would get
+        // ConnectException. Otherwise, we would get a RemoteException from the
+        // last running OM as it would fail to get a quorum.
+        if (e instanceof RemoteException) {
+          GenericTestUtils.assertExceptionContains(
+              "OMNotLeaderException", e);
+        }
+      } else {
+        throw e;
+      }
+    }
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServerConfig;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.BeforeClass;
-import org.junit.Before;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Rule;
@@ -187,28 +186,6 @@ public abstract class TestOzoneManagerHA {
         .getObjectStore();
   }
 
-  /**
-   * Apply additional configuration between tests.
-   */
-  @Before
-  public void setupTest() {
-    additionalConfiguration();
-    additionalClusterSettings();
-  }
-
-  /**
-   * Override this method in sub-classes to additional test specific
-   * configuration. Add settings to the conf instance variable.
-   */
-  protected void additionalConfiguration() {
-  }
-
-  /**
-   * Override this method in sub-classes to additional test specific
-   * mini-cluster settings. Add settings the clusterBuilder instance variable.
-   */
-  protected void additionalClusterSettings() {
-  }
 
   /**
    * Reset cluster between tests.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -1,4 +1,4 @@
-  /**
+/**
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -17,11 +17,8 @@
 package org.apache.hadoop.ozone.om;
 
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.hadoop.hdds.HddsConfigKeys;
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdfs.LogVerificationAppender;
-import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -76,20 +73,6 @@ import static org.junit.Assert.fail;
  */
 public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
-  @Override
-  protected void additionalConfiguration() {
-    OzoneConfiguration conf = getConf();
-    // These test do not use any features of SCM, so we can skip safemode
-    // which gets the cluster to come up much faster.
-    conf.setBoolean(HddsConfigKeys.HDDS_SCM_SAFEMODE_ENABLED, false);
-  }
-
-  @Override
-  protected void additionalClusterSettings() {
-    MiniOzoneCluster.Builder builder = getClusterBuilder();
-    builder.setNumDatanodes(0);
-  }
-
   private OzoneVolume createAndCheckVolume(String volumeName)
       throws Exception {
     String userName = "user" + RandomStringUtils.randomNumeric(5);
@@ -110,6 +93,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
 
     return retVolume;
   }
+
   @Test
   public void testAllVolumeOperations() throws Exception {
 
@@ -342,7 +326,7 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
     ObjectStore objectStore = getObjectStore();
 
     Set<String> expectedVolumes = new TreeSet<>();
-    for (int i=0; i < 100; i++) {
+    for (int i = 0; i < 100; i++) {
       String volumeName = "vol" + i;
       expectedVolumes.add(volumeName);
       VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -19,8 +19,6 @@ package org.apache.hadoop.ozone.om;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
-import org.apache.hadoop.ipc.RemoteException;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
@@ -38,7 +36,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -399,6 +399,10 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
 
   @Test
   public void testOMRestart() throws Exception {
+    // start fresh cluster
+    shutdown();
+    init();
+
     ObjectStore objectStore = getObjectStore();
     // Get the leader OM
     String leaderOMNodeId = OmFailoverProxyUtil

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -280,40 +280,6 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     Assert.assertTrue(!leaderOMNodeId.equals(newLeaderOMNodeId));
   }
 
-  /**
-   * 1. Stop one of the OM
-   * 2. make a call to OM, this will make failover attempts to find new node.
-   * a) if LE finishes but leader not ready, it retries to same node
-   * b) if LE not done, it will failover to new node and check
-   * 3. Try failover to same OM explicitly.
-   * Now #3 should wait additional waitBetweenRetries time.
-   * LE: Leader Election.
-   */
-  @Test
-  public void testIncrementalWaitTimeWithSameNodeFailover() throws Exception {
-    long waitBetweenRetries = getConf().getLong(
-        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_KEY,
-        OzoneConfigKeys.OZONE_CLIENT_WAIT_BETWEEN_RETRIES_MILLIS_DEFAULT);
-    OMFailoverProxyProvider omFailoverProxyProvider =
-        OmFailoverProxyUtil
-            .getFailoverProxyProvider(getObjectStore().getClientProxy());
-
-    // The OMFailoverProxyProvider will point to the current leader OM node.
-    String leaderOMNodeId = omFailoverProxyProvider.getCurrentProxyOMNodeId();
-
-    getCluster().stopOzoneManager(leaderOMNodeId);
-    Thread.sleep(NODE_FAILURE_TIMEOUT * 4);
-    createKeyTest(true); // failover should happen to new node
-
-    long numTimesTriedToSameNode = omFailoverProxyProvider.getWaitTime()
-        / waitBetweenRetries;
-    omFailoverProxyProvider.performFailoverIfRequired(omFailoverProxyProvider.
-        getCurrentProxyOMNodeId());
-    Assert.assertEquals((numTimesTriedToSameNode + 1) * waitBetweenRetries,
-        omFailoverProxyProvider.getWaitTime());
-  }
-
-
   private String initiateMultipartUpload(OzoneBucket ozoneBucket,
       String keyName) throws Exception {
 
@@ -351,63 +317,6 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     byte[] fileContent = new byte[value.getBytes(UTF_8).length];
     ozoneInputStream.read(fileContent);
     Assert.assertEquals(value, new String(fileContent, UTF_8));
-  }
-
-
-  private void createKeyTest(boolean checkSuccess) throws Exception {
-    String userName = "user" + RandomStringUtils.randomNumeric(5);
-    String adminName = "admin" + RandomStringUtils.randomNumeric(5);
-    String volumeName = "volume" + RandomStringUtils.randomNumeric(5);
-
-    VolumeArgs createVolumeArgs = VolumeArgs.newBuilder()
-        .setOwner(userName)
-        .setAdmin(adminName)
-        .build();
-
-    try {
-      getObjectStore().createVolume(volumeName, createVolumeArgs);
-
-      OzoneVolume retVolumeinfo = getObjectStore().getVolume(volumeName);
-
-      Assert.assertTrue(retVolumeinfo.getName().equals(volumeName));
-      Assert.assertTrue(retVolumeinfo.getOwner().equals(userName));
-      Assert.assertTrue(retVolumeinfo.getAdmin().equals(adminName));
-
-      String bucketName = UUID.randomUUID().toString();
-      String keyName = UUID.randomUUID().toString();
-      retVolumeinfo.createBucket(bucketName);
-
-      OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
-
-      Assert.assertTrue(ozoneBucket.getName().equals(bucketName));
-      Assert.assertTrue(ozoneBucket.getVolumeName().equals(volumeName));
-
-      String value = "random data";
-      OzoneOutputStream ozoneOutputStream = ozoneBucket.createKey(keyName,
-          value.length(), ReplicationType.STAND_ALONE,
-          ReplicationFactor.ONE, new HashMap<>());
-      ozoneOutputStream.write(value.getBytes(UTF_8), 0, value.length());
-      ozoneOutputStream.close();
-
-      OzoneInputStream ozoneInputStream = ozoneBucket.readKey(keyName);
-
-      byte[] fileContent = new byte[value.getBytes(UTF_8).length];
-      ozoneInputStream.read(fileContent);
-      Assert.assertEquals(value, new String(fileContent, UTF_8));
-
-    } catch (ConnectException | RemoteException e) {
-      if (!checkSuccess) {
-        // If the last OM to be tried by the RetryProxy is down, we would get
-        // ConnectException. Otherwise, we would get a RemoteException from the
-        // last running OM as it would fail to get a quorum.
-        if (e instanceof RemoteException) {
-          GenericTestUtils.assertExceptionContains(
-              "OMNotLeaderException", e);
-        }
-      } else {
-        throw e;
-      }
-    }
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
@@ -25,8 +25,9 @@ import static org.apache.hadoop.ozone.MiniOzoneOMHAClusterImpl.NODE_FAILURE_TIME
 
 /**
  * Test Ozone Manager operation in distributed handler scenario with failover.
- * NOTE: Do not add new tests to this class since testIncrementalWaitTimeWithSameNodeFailover
- * does not leave the cluster in a reusable state.
+ * NOTE: Do not add new tests to this class since
+ * testIncrementalWaitTimeWithSameNodeFailove does not leave the cluster in a
+ * reusable state.
  */
 public class TestOzoneManagerHAWithFailover extends TestOzoneManagerHA {
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
@@ -1,3 +1,19 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.ozone.OzoneConfigKeys;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithFailover.java
@@ -25,6 +25,8 @@ import static org.apache.hadoop.ozone.MiniOzoneOMHAClusterImpl.NODE_FAILURE_TIME
 
 /**
  * Test Ozone Manager operation in distributed handler scenario with failover.
+ * NOTE: Do not add new tests to this class since testIncrementalWaitTimeWithSameNodeFailover
+ * does not leave the cluster in a reusable state.
  */
 public class TestOzoneManagerHAWithFailover extends TestOzoneManagerHA {
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -186,6 +186,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
   public void testPrepareWithRestart() throws Exception {
     // Create fresh cluster for this test to prevent timeout from restarting
     // modified cluster.
+    shutdown();
     init();
     setup();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -184,6 +184,11 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
 
   @Test
   public void testPrepareWithRestart() throws Exception {
+    // Create fresh cluster for this test to prevent timeout from restarting
+    // modified cluster.
+    init();
+    setup();
+
     String volumeName = VOLUME + UUID.randomUUID().toString();
     writeKeysAndWaitForLogs(volumeName, 10);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently tests under TestOzoneManagerHA take long to execute since MiniOzoneClusterHA is setting up freshly for each test case.

This is a proposal to spin up a shared MiniOzoneClusterHA for all the tests extending TestOzoneManagerHA, allowing them to reuse the same cluster and not have to spin up a new one every time.

This brings down the cumulative time to run all suites extending TestOzoneManagerHA down from ~720s to ~260s

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5788

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Manual Testing
