### PR TITLE
HDDS-5793. Speed up TestBlockOutputStreamWithFailures by combining test cases

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -161,6 +161,21 @@ public class TestBlockOutputStreamWithFailures {
   }
 
   @Test
+  public void testThreeNode() throws Exception {
+    testWatchForCommitWithCloseContainerException();
+    testWatchForCommitDatanodeFailure();
+    test2DatanodesFailure();
+    testFailureWithPrimeSizedData();
+    testExceptionDuringClose();
+  }
+
+  @Test
+  public void testOneNode() throws Exception {
+    testDatanodeFailureWithSingleNodeRatis();
+    testWatchForCommitWithSingleNodeRatis();
+    testDatanodeFailureWithPreAllocation();
+  }
+
   public void testWatchForCommitWithCloseContainerException()
       throws Exception {
     String keyName = getKeyName();
@@ -250,7 +265,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -336,7 +350,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
   
-  @Test
   public void test2DatanodesFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -441,7 +454,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, data1);
   }
 
-  @Test
   public void testFailureWithPrimeSizedData() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -505,7 +517,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testExceptionDuringClose() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -576,7 +587,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testWatchForCommitWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -667,7 +677,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -760,7 +769,6 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailures.java
@@ -161,22 +161,14 @@ public class TestBlockOutputStreamWithFailures {
   }
 
   @Test
-  public void testThreeNode() throws Exception {
+  public void testContainerClose() throws Exception {
     testWatchForCommitWithCloseContainerException();
-    testWatchForCommitDatanodeFailure();
-    test2DatanodesFailure();
+    testWatchForCommitWithSingleNodeRatis();
     testFailureWithPrimeSizedData();
     testExceptionDuringClose();
   }
 
-  @Test
-  public void testOneNode() throws Exception {
-    testDatanodeFailureWithSingleNodeRatis();
-    testWatchForCommitWithSingleNodeRatis();
-    testDatanodeFailureWithPreAllocation();
-  }
-
-  public void testWatchForCommitWithCloseContainerException()
+  private void testWatchForCommitWithCloseContainerException()
       throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -265,6 +257,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -349,7 +342,8 @@ public class TestBlockOutputStreamWithFailures {
     String dataString = new String(data1, UTF_8);
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
-  
+
+  @Test
   public void test2DatanodesFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -454,7 +448,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, data1);
   }
 
-  public void testFailureWithPrimeSizedData() throws Exception {
+  private void testFailureWithPrimeSizedData() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
     int dataLength = maxFlushSize + 69;
@@ -517,7 +511,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  public void testExceptionDuringClose() throws Exception {
+  private void testExceptionDuringClose() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
     int dataLength = 167;
@@ -587,7 +581,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  public void testWatchForCommitWithSingleNodeRatis() throws Exception {
+  private void testWatchForCommitWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
         createKey(keyName, ReplicationType.RATIS, 0, ReplicationFactor.ONE);
@@ -677,6 +671,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -769,6 +764,7 @@ public class TestBlockOutputStreamWithFailures {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
@@ -162,22 +162,14 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
   }
 
   @Test
-  public void testThreeNode() throws Exception {
+  public void testContainerClose() throws Exception {
     testWatchForCommitWithCloseContainerException();
-    testWatchForCommitDatanodeFailure();
-    test2DatanodesFailure();
+    testWatchForCommitWithSingleNodeRatis();
     testFailureWithPrimeSizedData();
     testExceptionDuringClose();
   }
 
-  @Test
-  public void testOneNode() throws Exception {
-    testDatanodeFailureWithSingleNodeRatis();
-    testWatchForCommitWithSingleNodeRatis();
-    testDatanodeFailureWithPreAllocation();
-  }
-
-  public void testWatchForCommitWithCloseContainerException()
+  private void testWatchForCommitWithCloseContainerException()
       throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -266,6 +258,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -352,6 +345,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void test2DatanodesFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -456,7 +450,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, data1);
   }
 
-  public void testFailureWithPrimeSizedData() throws Exception {
+  private void testFailureWithPrimeSizedData() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
     int dataLength = maxFlushSize + chunkSize;
@@ -519,7 +513,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  public void testExceptionDuringClose() throws Exception {
+  private void testExceptionDuringClose() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
     int dataLength = 167;
@@ -589,7 +583,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  public void testWatchForCommitWithSingleNodeRatis() throws Exception {
+  private void testWatchForCommitWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
         createKey(keyName, ReplicationType.RATIS, 0, ReplicationFactor.ONE);
@@ -679,6 +673,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -771,6 +766,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
+  @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockOutputStreamWithFailuresFlushDelay.java
@@ -162,6 +162,21 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
   }
 
   @Test
+  public void testThreeNode() throws Exception {
+    testWatchForCommitWithCloseContainerException();
+    testWatchForCommitDatanodeFailure();
+    test2DatanodesFailure();
+    testFailureWithPrimeSizedData();
+    testExceptionDuringClose();
+  }
+
+  @Test
+  public void testOneNode() throws Exception {
+    testDatanodeFailureWithSingleNodeRatis();
+    testWatchForCommitWithSingleNodeRatis();
+    testDatanodeFailureWithPreAllocation();
+  }
+
   public void testWatchForCommitWithCloseContainerException()
       throws Exception {
     String keyName = getKeyName();
@@ -251,7 +266,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testWatchForCommitDatanodeFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -337,8 +351,7 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     String dataString = new String(data1, UTF_8);
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
-  
-  @Test
+
   public void test2DatanodesFailure() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -443,7 +456,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, data1);
   }
 
-  @Test
   public void testFailureWithPrimeSizedData() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -507,7 +519,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testExceptionDuringClose() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key = createKey(keyName, ReplicationType.RATIS, 0);
@@ -578,7 +589,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testWatchForCommitWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -669,7 +679,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testDatanodeFailureWithSingleNodeRatis() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =
@@ -762,7 +771,6 @@ public class TestBlockOutputStreamWithFailuresFlushDelay {
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
   }
 
-  @Test
   public void testDatanodeFailureWithPreAllocation() throws Exception {
     String keyName = getKeyName();
     OzoneOutputStream key =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Combine some test cases in `TestBlockOutputStreamWithFailures` and `TestBlockOutputStreamWithFailuresFlushDelay` to reduce cluster creation/startup time.

https://issues.apache.org/jira/browse/HDDS-5793

## How was this patch tested?

Before:

```
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 585.121 s - in org.apache.hadoop.ozone.client.rpc.TestBlockOutputStreamWithFailuresFlushDelay
[INFO] Tests run: 8, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 584.137 s - in org.apache.hadoop.ozone.client.rpc.TestBlockOutputStreamWithFailures
```

https://github.com/apache/ozone/runs/3728055559#step:4:2863

After:

```
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 294.082 s - in org.apache.hadoop.ozone.client.rpc.TestBlockOutputStreamWithFailuresFlushDelay
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 278.229 s - in org.apache.hadoop.ozone.client.rpc.TestBlockOutputStreamWithFailures
```

https://github.com/adoroszlai/hadoop-ozone/runs/3732932406#step:4:2892