### PR TITLE
HDDS-5789. Enabling container tokens on a upgraded cluster fails SCM to start up.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -243,7 +243,7 @@ public class CertificateCodec {
    * @throws IOException          - on Error.
    */
   public X509CertificateHolder readCertificate() throws
-      CertificateException {
+      CertificateException, IOException {
     return readCertificate(this.location.toAbsolutePath(),
         this.securityConfig.getCertificateFileName());
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -243,7 +243,7 @@ public class CertificateCodec {
    * @throws IOException          - on Error.
    */
   public X509CertificateHolder readCertificate() throws
-      CertificateException, IOException {
+      CertificateException {
     return readCertificate(this.location.toAbsolutePath(),
         this.securityConfig.getCertificateFileName());
   }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -64,9 +64,4 @@ public class DNCertificateClient extends DefaultCertificateClient {
   public Logger getLogger() {
     return LOG;
   }
-
-  @Override
-  public String getComponentName() {
-    return COMPONENT_NAME;
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -868,7 +868,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
   }
 
   public String getComponentName() {
-    return null;
+    return component;
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
@@ -131,9 +131,4 @@ public class OMCertificateClient extends DefaultCertificateClient {
   public Logger getLogger() {
     return LOG;
   }
-
-  @Override
-  public String getComponentName() {
-    return COMPONENT_NAME;
-  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -55,6 +55,11 @@ public class SCMCertificateClient extends DefaultCertificateClient {
     super(securityConfig, LOG, null, COMPONENT_NAME);
   }
 
+  public SCMCertificateClient(SecurityConfig securityConfig,
+      String certSerialId, String component) {
+    super(securityConfig, LOG, certSerialId, component);
+  }
+
   @Override
   protected InitResponse handleCase(InitCase init)
       throws CertificateException {
@@ -131,10 +136,5 @@ public class SCMCertificateClient extends DefaultCertificateClient {
   @Override
   public Logger getLogger() {
     return LOG;
-  }
-
-  @Override
-  public String getComponentName() {
-    return COMPONENT_NAME;
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -761,7 +761,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
     // Means this is an upgraded cluster and it has no sub-ca,
     // so SCM Certificate client is not initialized. To make Tokens
-    // work lets ise root CA cert and create SCM Certificate client with
+    // work let's use root CA cert and create SCM Certificate client with
     // root CA cert.
     if (scmCertificateClient == null) {
       Preconditions.checkState(

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -126,7 +126,6 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.hadoop.ozone.common.Storage.StorageState;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -771,9 +771,12 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
       try {
         certSerialNumber = getScmCertificateServer().getCACertificate()
             .getSerialNumber().toString();
-      } catch (IOException | CertificateException ex) {
+      } catch (CertificateException ex) {
         LOG.error("Get CA Certificate failed", ex);
         throw new IOException(ex);
+      } catch (IOException ex) {
+        LOG.error("Get CA Certificate failed", ex);
+        throw ex;
       }
       scmCertificateClient = new SCMCertificateClient(securityConfig,
           certSerialNumber, SCM_ROOT_CA_COMPONENT_NAME);


### PR DESCRIPTION
## What changes were proposed in this pull request?

On a upgraded cluster with SCM HA version code, SCM fails to start when hdds.container.token.enabled is set to true.
In a upgraded cluster and SCM non-HA SCMCertificateClient is not initialized and sub-CA is not started. Initialize SCMCertificateClient with RootCA Cert and initialize ContainerTokenManager.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5789

## How was this patch tested?

Manually Verified this on a cluster.

**Before fix:**
```
2021-09-28 22:28:01,554 ERROR org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SCM start failed with exception
java.lang.NullPointerException
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createContainerTokenSecretManager(StorageContainerManager.java:726)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.initializeCAnSecurityProtocol(StorageContainerManager.java:674)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.<init>(StorageContainerManager.java:337)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:460)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManager.createSCM(StorageContainerManager.java:472)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter$SCMStarterHelper.start(StorageContainerManagerStarter.java:165)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.startScm(StorageContainerManagerStarter.java:139)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:68)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.call(StorageContainerManagerStarter.java:44)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1933)
        at picocli.CommandLine.access$1100(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2332)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2326)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2291)
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2152)
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:2530)
        at picocli.CommandLine.parseWithHandler(CommandLine.java:2465)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:96)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:87)
        at org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter.main(StorageContainerManagerStarter.java:57)
2021-09-28 22:28:01,604 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: SHUTDOWN_MSG:
```

**After fix:**
```
2021-09-28 11:51:06,790 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManagerStarter: registered UNIX signal handlers for [TERM, HUP, INT]
2021-09-28 11:51:07,295 INFO org.apache.hadoop.security.UserGroupInformation: Login successful for user scm/quasar-afcevv-4.quasar-afcevv.root.hwx.site@QE-AD-1.CLOUDERA.COM using keytab file /var/run/cloudera-scm-agent/process/1546336013-ozone-STORAGE_CONTAINER_MANAGER/ozone.keytab. Keytab auto renewal enabled : false
2021-09-28 11:51:07,295 INFO org.apache.hadoop.hdds.scm.server.StorageContainerManager: SCM login successful.
2021-09-28 11:51:09,131 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:fe80:0:0:0:42:acff:fe1b:bc4d%eth0 not returned.
2021-09-28 11:51:09,131 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: Adding ip:172.27.188.77,host:quasar-afcevv-4.quasar-afcevv.root.hwx.site
2021-09-28 11:51:09,132 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:0:0:0:0:0:0:0:1%lo not returned.
2021-09-28 11:51:09,132 INFO org.apache.hadoop.ozone.OzoneSecurityUtil: ip:127.0.0.1 not returned.
2021-09-28 11:51:09,429 INFO org.apache.hadoop.ipc.CallQueueManager: Using callQueue: class java.util.concurrent.LinkedBlockingQueue queueCapacity: 200 scheduler: class org.apache.hadoop.ipc.DefaultRpcScheduler
2021-09-28 11:51:09,494 INFO org.apache.hadoop.ipc.Server: Starting Socket Reader #1 for port 9961
2021-09-28 11:51:09,761 INFO org.apache.hadoop.hdds.scm.net.NodeSchemaLoader: Loading file from java.lang.CompoundEnumeration@1f966492
2021-09-28 11:51:09,763 INFO org.apache.hadoop.hdds.scm.net.NodeSchemaLoader: Loading network topology layer schema file
2021-09-28 11:51:09,894 INFO org.apache.hadoop.hdds.scm.node.SCMNodeManager: Entering startup safe mode.
2021-09-28 11:51:10,041 INFO org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementPolicyFactory: Create container placement policy of type org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom
2021-09-28 11:51:10,065 INFO org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms.LeaderChoosePolicyFactory: Create leader choose policy of type org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms.MinLeaderCountChoosePolicy
2021-09-28 11:51:10,069 INFO org.apache.hadoop.hdds.scm.pipeline.SCMPipelineManager: No pipeline exists in current db
2021-09-28 11:51:10,092 INFO org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.PipelineChoosePolicyFactory: Create pipeline choose policy of type org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.RandomPipelineChoosePolicy
2021-09-28 11:51:10,149 INFO org.apache.hadoop.hdds.scm.safemode.HealthyPipelineSafeModeRule: Total pipeline count is 0, healthy pipeline threshold count is 0
2021-09-28 11:51:10,151 INFO org.apache.hadoop.hdds.scm.safemode.OneReplicaPipelineSafeModeRule: Total pipeline count is 0, pipeline's with at least one datanode reported threshold count is 0
2021-09-28 11:51:10,935 INFO org.apache.hadoop.ipc.CallQueueManager: Using callQueue: class java.util.concurrent.LinkedBlockingQueue queueCapacity: 10000 scheduler: class org.apache.hadoop.ipc.DefaultRpcScheduler
2021-09-28 11:51:10,946 INFO org.apache.hadoop.ipc.Server: Starting Socket Reader #1 for port 9861
2021-09-28 11:51:11,041 INFO org.apache.hadoop.ipc.CallQueueManager: Using callQueue: class java.util.concurrent.LinkedBlockingQueue queueCapacity: 10000 scheduler: class org.apache.hadoop.ipc.DefaultRpcScheduler
2021-09-28 11:51:11,055 INFO org.apache.hadoop.ipc.Server: Starting Socket Reader #1 for port 9863
2021-09-28 11:51:11,130 INFO org.apache.hadoop.ipc.CallQueueManager: Using callQueue: class java.util.concurrent.LinkedBlockingQueue queueCapacity: 10000 scheduler: class org.apache.hadoop.ipc.DefaultRpcScheduler
2021-09-28 11:51:11,131 INFO org.apache.hadoop.ipc.Server: Starting Socket Reader #1 for port 9860
2021-09-28 11:51:11,192 WARN org.apache.hadoop.hdds.server.http.BaseHttpServer: SSL config ssl.server.truststore.location is missing. If ozone.https.server.keystore.resource is specified, make sure it is a relative path
2021-09-28 11:51:11,901 INFO org.apache.hadoop.hdds.server.http.BaseHttpServer: Starting Web-server for scm at: https://0.0.0.0:9877
2021-09-28 11:51:11,903 INFO org.apache.hadoop.hdds.server.http.BaseHttpServer: Hadoop Security Enabled: true Ozone Security Enabled: true Ozone HTTP Security Enabled: false
2021-09-28 11:51:11,946 INFO org.eclipse.jetty.util.log: Logging initialized @6788ms to org.eclipse.jetty.util.log.Slf4jLog
2021-09-28 11:51:12,151 INFO org.apache.hadoop.security.authentication.server.AuthenticationFilter: Unable to initialize FileSignerSecretProvider, falling back to use random secrets.
2021-09-28 22:29:41,926 INFO org.apache.hadoop.util.JvmPauseMonitor: Starting JVM pause monitor
2021-09-28 22:29:41,941 WARN org.apache.hadoop.hdds.server.http.BaseHttpServer: SSL config ssl.server.truststore.location is missing. If ozone.https.server.keystore.resource is specified, make sure it is a relative path
2021-09-28 22:29:42,358 INFO org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl: Added a new node: /default/1d2fa315-f276-4ab5-9c38-7875ac0eaf95
2021-09-28 22:29:42,359 INFO org.apache.hadoop.hdds.scm.node.SCMNodeManager: Registered Data node : 1d2fa315-f276-4ab5-9c38-7875ac0eaf95{ip: 172.27.27.129, host: quasar-afcevv-5.quasar-afcevv.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9858, RATIS_SERVER=9858, STANDALONE=9859], networkLocation: /default, certSerialId: 13326388815505992, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}
2021-09-28 22:29:42,361 INFO org.apache.hadoop.hdds.scm.pipeline.BackgroundPipelineCreator: trigger a one-shot run on RatisPipelineUtilsThread.
2021-09-28 22:29:42,365 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: ContainerSafeModeRule rule is successfully validated
2021-09-28 22:29:42,365 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: SCM in safe mode. 1 DataNodes registered, 1 required.
2021-09-28 22:29:42,366 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: DataNodeSafeModeRule rule is successfully validated
2021-09-28 22:29:42,367 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: All SCM safe mode pre check rules have passed
2021-09-28 22:29:42,367 WARN org.apache.hadoop.hdds.server.events.EventQueue: No event handler registered for event TypedEvent{payloadType=SafeModeStatus, name='Safe mode status'}
2021-09-28 22:29:42,368 INFO org.apache.hadoop.hdds.scm.ha.SCMContext: Update SafeModeStatus from SafeModeStatus{safeModeStatus=true, preCheckPassed=false} to SafeModeStatus{safeModeStatus=true, preCheckPassed=true}.
2021-09-28 22:29:42,369 INFO org.apache.hadoop.hdds.scm.pipeline.BackgroundPipelineCreator: trigger a one-shot run on RatisPipelineUtilsThread.
2021-09-28 22:29:42,371 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: SCM in safe mode. Pipelines with at least one datanode reported count is 2, required at least one datanode reported per pipeline count is 2
2021-09-28 22:29:42,372 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: AtleastOneDatanodeReportedRule rule is successfully validated
2021-09-28 22:29:42,373 INFO org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager: SCM in safe mode. Healthy pipelines reported count is 0, required healthy pipeline reported count is 1
2021-09-28 22:29:42,395 INFO SecurityLogger.org.apache.hadoop.ipc.Server: Auth successful for om/quasar-afcevv-2.quasar-afcevv.root.hwx.site@QE-AD-1.CLOUDERA.COM (auth:KERBEROS)
2021-09-28 22:29:42,405 INFO SecurityLogger.org.apache.hadoop.security.authorize.ServiceAuthorizationManager: Authorization successful for om/quasar-afcevv-2.quasar-afcevv.root.hwx.site@QE-AD-1.CLOUDERA.COM (auth:KERBEROS) for protocol=interface org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol
2021-09-28 22:29:42,551 INFO org.apache.hadoop.hdds.server.http.BaseHttpServer: Starting Web-server for scm at: https://0.0.0.0:9877
```

**Tested basic write/get**
```

root@quasar-afcevv-4:/var/run/cloudera-scm-agent/process/1546338751-ozone-OZONE_MANAGER# ozone sh volume create /vol1
root@quasar-afcevv-4:/var/run/cloudera-scm-agent/process/1546338751-ozone-OZONE_MANAGER# ozone sh bucket create /vol1/buck1
root@quasar-afcevv-4:/var/run/cloudera-scm-agent/process/1546338751-ozone-OZONE_MANAGER# ozone sh key put /vol1/buck1/key1 /etc/hadoop/conf/ozone-site.xml 
root@quasar-afcevv-4:/var/run/cloudera-scm-agent/process/1546338751-ozone-OZONE_MANAGER# ozone sh key get /vol1/buck1/key1 /tmp/dkey1
root@quasar-afcevv-4:/var/run/cloudera-scm-agent/process/1546338751-ozone-OZONE_MANAGER# cat /tmp/dkey1
<?xml version="1.0" encoding="UTF-8"?>
```

```
<!--Autogenerated by Cloudera Manager-->
<configuration>
  <property>
    <name>ozone.scm.names</name>
    <value>xxx</value>
  </property>
  <property>
```
