### PR TITLE
HDDS-5797. Support setting Datanode Reserved Space in MiniOzoneCluster.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -233,4 +233,9 @@ public final class VolumeInfo {
   public VolumeUsage getUsageForTesting() {
     return usage;
   }
+
+  @VisibleForTesting
+  public long getReservedInBytes() {
+    return reservedInBytes;
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -17,13 +17,6 @@
  */
 package org.apache.hadoop.ozone;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
-
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,6 +30,13 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
 
 /**
  * Interface used for MiniOzoneClusters.
@@ -315,6 +315,7 @@ public interface MiniOzoneCluster {
     protected Optional<String> omId = Optional.empty();
     
     protected Boolean randomContainerPort = true;
+    protected Optional<String> datanodeReservedSpace = Optional.of("0B");
     protected Optional<Integer> chunkSize = Optional.empty();
     protected OptionalInt streamBufferSize = OptionalInt.empty();
     protected Optional<Long> streamBufferFlushSize = Optional.empty();
@@ -495,6 +496,23 @@ public interface MiniOzoneCluster {
      */
     public Builder setTrace(Boolean trace) {
       enableTrace = Optional.of(trace);
+      return this;
+    }
+
+    /**
+     * Sets the reserved space
+     * {@link org.apache.hadoop.hdds.scm.ScmConfigKeys#HDDS_DATANODE_DIR_DU_RESERVED}
+     * for each volume in each datanode.
+     * @param reservedSpace String that contains the numeric size value and
+     *                      ends with a
+     *                      {@link org.apache.hadoop.hdds.conf.StorageUnit}
+     *                      suffix. For example, "50GB". See
+     *                      {@link org.apache.hadoop.ozone.container.common.volume.VolumeInfo}
+     *                      for more details.
+     * @return {@link MiniOzoneCluster} Builder
+     */
+    public Builder setDatanodeReservedSpace(String reservedSpace) {
+      datanodeReservedSpace = Optional.of(reservedSpace);
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -17,6 +17,13 @@
  */
 package org.apache.hadoop.ozone;
 
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -30,13 +37,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-
-import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.UUID;
-import java.util.concurrent.TimeoutException;
 
 /**
  * Interface used for MiniOzoneClusters.
@@ -315,7 +315,7 @@ public interface MiniOzoneCluster {
     protected Optional<String> omId = Optional.empty();
     
     protected Boolean randomContainerPort = true;
-    protected Optional<String> datanodeReservedSpace = Optional.of("0B");
+    protected Optional<String> datanodeReservedSpace = Optional.empty();
     protected Optional<Integer> chunkSize = Optional.empty();
     protected OptionalInt streamBufferSize = OptionalInt.empty();
     protected Optional<Long> streamBufferFlushSize = Optional.empty();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -501,14 +501,15 @@ public interface MiniOzoneCluster {
 
     /**
      * Sets the reserved space
-     * {@link org.apache.hadoop.hdds.scm.ScmConfigKeys#HDDS_DATANODE_DIR_DU_RESERVED}
+     * {@link org.apache.hadoop.hdds.scm.ScmConfigKeys}
+     * HDDS_DATANODE_DIR_DU_RESERVED
      * for each volume in each datanode.
      * @param reservedSpace String that contains the numeric size value and
      *                      ends with a
      *                      {@link org.apache.hadoop.hdds.conf.StorageUnit}
-     *                      suffix. For example, "50GB". See
-     *                      {@link org.apache.hadoop.ozone.container.common.volume.VolumeInfo}
-     *                      for more details.
+     *                      suffix. For example, "50GB".
+     * @see org.apache.hadoop.ozone.container.common.volume.VolumeInfo
+     *
      * @return {@link MiniOzoneCluster} Builder
      */
     public Builder setDatanodeReservedSpace(String reservedSpace) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -17,7 +17,23 @@
  */
 package org.apache.hadoop.ozone;
 
-import org.apache.commons.io.FileUtils;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.UUID;
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
@@ -55,29 +71,8 @@ import org.apache.hadoop.ozone.recon.ConfigurationProvider;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.hadoop.ozone.recon.codegen.ReconSqlDbConfig;
-import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.slf4j.event.Level;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.UUID;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import org.apache.commons.io.FileUtils;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.RATIS;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.RATIS_ADMIN;
@@ -98,6 +93,11 @@ import static org.apache.hadoop.ozone.om.OmUpgradeConfig.ConfigStrings.OZONE_OM_
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_DB_DIR;
+import org.hadoop.ozone.recon.codegen.ReconSqlDbConfig;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * MiniOzoneCluster creates a complete in-process Ozone cluster suitable for
@@ -814,14 +814,15 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         String datanodeBaseDir = path + "/datanode-" + Integer.toString(i);
         Path metaDir = Paths.get(datanodeBaseDir, "meta");
         List<String> dataDirs = new ArrayList<>();
+        List<String> reservedSpaceList = new ArrayList<>();
         for (int j = 0; j < numDataVolumes; j++) {
           Path dir = Paths.get(datanodeBaseDir, "data-" + j, "containers");
           Files.createDirectories(dir);
           dataDirs.add(dir.toString());
           datanodeReservedSpace.ifPresent(
-              s -> dnConf.set(ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED,
-                  dir + ":" + s));
+              s -> reservedSpaceList.add(dir + ":" + s));
         }
+        String reservedSpaceString = String.join(",", reservedSpaceList);
         String listOfDirs = String.join(",", dataDirs);
         Path ratisDir = Paths.get(datanodeBaseDir, "data", "ratis");
         Path workDir = Paths.get(datanodeBaseDir, "data", "replication",
@@ -832,6 +833,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         dnConf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDir.toString());
         dnConf.set(DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY, listOfDirs);
         dnConf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, listOfDirs);
+        dnConf.set(ScmConfigKeys.HDDS_DATANODE_DIR_DU_RESERVED,
+            reservedSpaceString);
         dnConf.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
             ratisDir.toString());
         dnConf.set(OzoneConfigKeys.OZONE_CONTAINER_COPY_WORKDIR,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageSize;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
@@ -44,6 +45,7 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer;
 import org.apache.hadoop.test.PathUtils;
 import org.apache.hadoop.test.TestGenericTestUtils;
@@ -351,16 +353,24 @@ public class TestMiniOzoneCluster {
    */
   @Test (timeout = 60000)
   public void testMultipleDataDirs() throws Exception {
-    // Start a cluster with 3 DN
+    // Start a cluster with 3 DN and configure reserved space in each DN
+    String reservedSpace = "1B";
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(1)
         .setNumDataVolumes(3)
+        .setDatanodeReservedSpace(reservedSpace)
         .build();
     cluster.waitForClusterToBeReady();
 
-    Assert.assertEquals(3, cluster.getHddsDatanodes().get(0)
+    List<StorageVolume> volumeList = cluster.getHddsDatanodes().get(0)
         .getDatanodeStateMachine().getContainer().getVolumeSet()
-        .getVolumesList().size());
+        .getVolumesList();
+
+    Assert.assertEquals(3, volumeList.size());
+
+    volumeList.forEach(storageVolume -> Assert.assertEquals(
+            (long) StorageSize.parse(reservedSpace).getValue(),
+            storageVolume.getVolumeInfo().getReservedInBytes()));
   }
 
   private static void assertDetailsEquals(DatanodeDetails expected,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support setting `org.apache.hadoop.hdds.scm.ScmConfigKeys#HDDS_DATANODE_DIR_DU_RESERVED` for each volume in each Datanode in `MiniOzoneCluster` (sets the same reserved space for each volume).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5797

## How was this patch tested?

Passed `TestMiniOzoneCluster`