### PR TITLE
HDDS-5800. Bucket usedByte was incorrect when deleting duplicate keys.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -941,6 +941,32 @@ public abstract class TestOzoneRpcClientAbstract {
   }
 
   @Test
+  public void testBucketUsedBytes() throws IOException {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneVolume volume = null;
+    String value = "sample value";
+    int valueLength = value.getBytes(UTF_8).length;
+    store.createVolume(volumeName);
+    volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    String keyName = UUID.randomUUID().toString();
+
+    writeKey(bucket, keyName, ONE, value, valueLength);
+    Assert.assertEquals(valueLength,
+        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+
+    writeKey(bucket, keyName, ONE, value, valueLength);
+    Assert.assertEquals(valueLength * 2,
+        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+
+    bucket.deleteKey(keyName);
+    Assert.assertEquals(0L,
+        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+  }
+
+  @Test
   public void testVolumeUsedNamespace() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -552,11 +552,11 @@ public abstract class OMKeyRequest extends OMClientRequest {
   protected static long sumBlockLengths(OmKeyInfo omKeyInfo) {
     long bytesUsed = 0;
     int keyFactor = omKeyInfo.getReplicationConfig().getRequiredNodes();
-    OmKeyLocationInfoGroup keyLocationGroup =
-        omKeyInfo.getLatestVersionLocations();
 
-    for(OmKeyLocationInfo locationInfo: keyLocationGroup.getLocationList()) {
-      bytesUsed += locationInfo.getLength() * keyFactor;
+    for (OmKeyLocationInfoGroup group: omKeyInfo.getKeyLocationVersions()) {
+      for (OmKeyLocationInfo locationInfo : group.getLocationList()) {
+        bytesUsed += locationInfo.getLength() * keyFactor;
+      }
     }
 
     return bytesUsed;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyAclRequestWithFSO.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAclRequest;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeyAddAclRequestWithFSO;
-import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;;
+import org.apache.hadoop.ozone.om.request.key.acl.OMKeyRemoveAclRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.key.acl.OMKeySetAclRequestWithFSO;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.Time;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When we repeatedly write a key and then delete the key. We should count all versions of the key and subtract them from bucket usedBytes.

Previously we only subtracted the key size of the last version, which resulted in inaccurate bucket usedBytes.
![image](https://user-images.githubusercontent.com/13825159/135301962-1792aac9-f39d-4a7a-8130-211854cc2229.png)



## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5800

## How was this patch tested?

UT added
