### PR TITLE
HDDS-3227. Ensure eviction of stateMachineData from cache only when both followers catch up

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -52,6 +52,9 @@ public class DatanodeConfiguration {
   public static final String DISK_CHECK_TIMEOUT_KEY =
       "hdds.datanode.disk.check.timeout";
 
+  public static final String WAIT_ON_ALL_FOLLOWERS =
+      "hdds.datanode.wait.on.all.followers";
+
   static final boolean CHUNK_DATA_VALIDATION_CHECK_DEFAULT = false;
 
   static final int REPLICATION_MAX_STREAMS_DEFAULT = 10;
@@ -59,6 +62,8 @@ public class DatanodeConfiguration {
   static final long PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT = 60;
 
   static final int FAILED_VOLUMES_TOLERATED_DEFAULT = -1;
+
+  static final boolean WAIT_ON_ALL_FOLLOWERS_DEFAULT = false;
 
   static final long DISK_CHECK_MIN_GAP_DEFAULT =
       Duration.ofMinutes(15).toMillis();
@@ -237,6 +242,25 @@ public class DatanodeConfiguration {
   )
   private boolean isChunkDataValidationCheck =
       CHUNK_DATA_VALIDATION_CHECK_DEFAULT;
+
+  @Config(key = "wait.on.all.followers",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      tags = { DATANODE },
+      description = "Defines whether the leader datanode will wait for both"
+          + "followers to catch up before removing the stateMachineData from "
+          + "the cache."
+  )
+
+  private boolean waitOnAllFollowers = WAIT_ON_ALL_FOLLOWERS_DEFAULT;
+
+  public boolean waitOnAllFollowers() {
+    return waitOnAllFollowers;
+  }
+
+  public void setWaitOnAllFollowers(boolean val) {
+    this.waitOnAllFollowers = val;
+  }
 
   @PostConstruct
   public void validate() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -750,7 +750,7 @@ public class ContainerStateMachine extends BaseStateMachine {
     try {
       if (ratisServer.getServer().getDivision(gid).getInfo().isLeader()
           && Arrays.stream(ratisServer.getServer().getDivision(gid).getInfo()
-          .getFollowerNextIndices()).allMatch(i -> i >= index) ) {
+          .getFollowerNextIndices()).allMatch(i -> i >= index)) {
         stateMachineDataCache.remove(index);
       }
       DispatcherContext.Builder builder =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -757,7 +757,7 @@ public class ContainerStateMachine extends BaseStateMachine {
             .allMatch(i -> i >= index)) {
           LOG.debug("Removing data corresponding to log index {} from cache",
               index);
-          stateMachineDataCache.remove(index);
+          stateMachineDataCache.removeIf(k -> k >= index);
         }
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -765,7 +765,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       // if waitOnBothFollower is false, remove the entry from the cache
       // as soon as its applied and such entry exists in the cache.
     } else {
-      stateMachineDataCache.remove(index);
+      stateMachineDataCache.removeIf(k -> k >= index);
     }
   }
 
@@ -779,7 +779,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       // Remove the stateMachine data once both followers have caught up. If any
       // one of the follower is behind, the pending queue will max out as
       // configurable limit on pending request size and count and then will
-      // block and client wull backoff as a result of that.
+      // block and client will backoff as a result of that.
       removeStateMachineDataIfNeeded(index);
       DispatcherContext.Builder builder =
           new DispatcherContext.Builder().setTerm(trx.getLogEntry().getTerm())

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -425,7 +425,7 @@ public class ContainerStateMachine extends BaseStateMachine {
       }
     } catch (InterruptedException ioe) {
       Thread.currentThread().interrupt();
-      return completeExceptionally(ioe);a
+      return completeExceptionally(ioe);
     } catch (IOException ioe) {
       return completeExceptionally(ioe);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -752,12 +752,12 @@ public class ContainerStateMachine extends BaseStateMachine {
           index);
       try {
         RaftServer.Division division = ratisServer.getServer().getDivision(gid);
-        if (division.getInfo().isLeader() && Arrays
-            .stream(division.getInfo().getFollowerNextIndices())
-            .allMatch(i -> i >= index)) {
-          LOG.debug("Removing data corresponding to log index {} from cache",
-              index);
-          stateMachineDataCache.removeIf(k -> k >= index);
+        if (division.getInfo().isLeader()) {
+          long minIndex = Arrays.stream(division.getInfo()
+              .getFollowerNextIndices()).min().getAsLong();
+          LOG.debug("Removing data corresponding to log index {} min index {} "
+                  + "from cache", index, minIndex);
+          stateMachineDataCache.removeIf(k -> k >= (Math.min(minIndex, index)));
         }
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -748,8 +748,6 @@ public class ContainerStateMachine extends BaseStateMachine {
   // to the particular index.
   private void removeStateMachineDataIfNeeded(long index) {
     if (waitOnBothFollowers) {
-      LOG.info("Removing data corresponding to log index {} from cache",
-          index);
       try {
         RaftServer.Division division = ratisServer.getServer().getDivision(gid);
         if (division.getInfo().isLeader()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -760,10 +760,6 @@ public class ContainerStateMachine extends BaseStateMachine {
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
-      // if waitOnBothFollower is false, remove the entry from the cache
-      // as soon as its applied and such entry exists in the cache.
-    } else {
-      stateMachineDataCache.removeIf(k -> k >= index);
     }
   }
 
@@ -779,6 +775,11 @@ public class ContainerStateMachine extends BaseStateMachine {
       // configurable limit on pending request size and count and then will
       // block and client will backoff as a result of that.
       removeStateMachineDataIfNeeded(index);
+      // if waitOnBothFollower is false, remove the entry from the cache
+      // as soon as its applied and such entry exists in the cache.
+      if (!waitOnBothFollowers) {
+        stateMachineDataCache.removeIf(k -> k >= index);
+      }
       DispatcherContext.Builder builder =
           new DispatcherContext.Builder().setTerm(trx.getLogEntry().getTerm())
               .setLogIndex(index);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -23,7 +23,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION


## What changes were proposed in this pull request?
Changing the stateMachine caching gurantees.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-3227

## How was this patch tested?

Existing UTs
