### PR TITLE
HDDS-5808. Update commons-io to 2.11.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1034,7 +1034,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.11.0</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update `commons-io` to 2.11.0.

https://issues.apache.org/jira/browse/HDDS-5808

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1304376420

```
$ mvn -DskipTests -Dskip.installnpx -Dskip.npx -DskipShade clean package
$ find hadoop-ozone/dist/target/ozone* -name 'commons-io*jar'
hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/share/ozone/lib/commons-io-2.11.0.jar
```