### PR TITLE
HDDS-5557. Fix OzoneBlockTokenSecretManager#ValidateToken.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneBlockTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneBlockTokenSecretManager.java
@@ -125,11 +125,6 @@ public class OzoneBlockTokenSecretManager extends
           "expired, current time: " + Time.formatTime(now) +
           " expiry time: " + identifier.getExpiryDate());
     }
-
-    // FIXME since verifySignature always throws, don't see how this could work
-    if (!verifySignature(identifier, createPassword(identifier))) {
-      throw new InvalidToken("Tampered/Invalid token.");
-    }
     return true;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the ValidateToken which calls verifySignature which is unimplemented.
And also this code path is not used from my understanding, as we donot use BlockTokenSecretManager tokens generated validity with hadoop RPC. The tokens are validated from DN using TokenVerifier by calling (validateToken(msg)) which is called when the command is received to DN. This is not a critical fix, just a clean up which is good to have when reading code causing confusion.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5557

## How was this patch tested?

Existing tests.
