### PR TITLE
HDDS-5824. `ozone sh volume list` should print valid JSON array

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/Handler.java
@@ -118,6 +118,10 @@ public abstract class Handler implements Callable<Void> {
     out().println(JsonUtils.toJsonStringWithDefaultPrettyPrinter(o));
   }
 
+  protected String objectToJsonString(Object o) throws IOException {
+    return JsonUtils.toJsonStringWithDefaultPrettyPrinter(o);
+  }
+
   protected void printMsg(String msg) {
     out().println(msg);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/volume/ListVolumeHandler.java
@@ -85,10 +85,17 @@ public class ListVolumeHandler extends Handler {
     }
 
     int counter = 0;
+    final StringBuilder res = new StringBuilder("[ ");  // Mark JSON array start
     while (listOptions.getLimit() > counter && volumeIterator.hasNext()) {
-      printObjectAsJson(volumeIterator.next());
+      if (counter > 0) {
+        res.append(", ");
+      }
+      res.append(objectToJsonString(volumeIterator.next()));
       counter++;
     }
+
+    res.append(" ]");  // Mark JSON array end
+    out().println(res);
 
     if (isVerbose()) {
       out().printf("Found : %d volumes for user : %s ", counter,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Right now the output is just a bunch of separate JSONs (not a valid one as a whole).

This patch improves it by grouping them into one JSON array. This should make it easier to be parsed by `jq` and other utilies.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5824

## How was this patch tested?

- [x] Added integration test.