### PR TITLE
HDDS-5830. Increase idea.max.intellisense.filesize

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ Checkstyle plugin may help to detect violations directly from the IDE.
 IntelliJ may not pick up protoc generated classes as they can be very huge. If the protoc files can't be compiled try the following:
 
 1. Open _Help_ -> _Edit custom properties_ menu.
-2. Add `idea.max.intellisense.filesize=5000` entry
+2. Add `idea.max.intellisense.filesize=10000` entry
 3. Restart your IDE
 
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

At present, Ozone recommends that `idea.max.intellisense.filesize` is set to `5000`, but it can no longer bear some protoc files in the Ozone project, such as `OzoneManagerProtocolProtos.java`. (As shown below)

![OzoneManangerProtocolProtoscode png](https://user-images.githubusercontent.com/72794035/136178418-9217e218-a5e3-4c3b-89f5-6e7f66f1ff7f.png)
![OzoneManangerProtocolProtos](https://user-images.githubusercontent.com/72794035/136178397-1d4d3b31-0840-4919-b7bc-85590bea23f4.png)

The purpose of this PR is to make the change of **idea.max.intellisense.filesize=10000** in the Apache Ozone Contribution guide more in line with the needs of the current project.
## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-5830

## How was this patch tested?

After increasing `idea.max.intellisense.filesize`, the error message disappeared.
