### PR TITLE
HDDS-5831. Remove empty TaskQueue in ContainerStateMachine.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -726,7 +726,12 @@ public class ContainerStateMachine extends BaseStateMachine {
             throw e;
           }
         };
-    return queue.submit(task, executor);
+    final CompletableFuture<ContainerCommandResponseProto> f
+        = queue.submit(task, executor);
+    // after the task is completed, remove the queue if the queue is empty.
+    f.thenAccept(dummy -> containerTaskQueues.computeIfPresent(containerId,
+        (id, q) -> q.isEmpty()? null: q));
+    return f;
   }
 
   /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ContainerStateMachine, remove the container TaskQueue if the queue is empty.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5831

## How was this patch tested?

A new test is added in https://issues.apache.org/jira/browse/RATIS-1414 .