### PR TITLE
HDDS-5833: EC: Fix TestRootedOzoneFileSystem.testBucketDefaultsShouldBeInheritedToFileForEC failure in branch

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1557,7 +1557,7 @@ public class TestRootedOzoneFileSystem {
     builder.setBucketLayout(BucketLayout.LEGACY);
     builder.setDefaultReplicationConfig(
         new DefaultReplicationConfig(ReplicationType.EC,
-            new ECReplicationConfig(3, 2)));
+            new ECReplicationConfig("RS-3-2-1024")));
     BucketArgs omBucketArgs = builder.build();
     String vol = UUID.randomUUID().toString();
     String buck = UUID.randomUUID().toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

This test was added in arallel to ECREplicationCOnfig change. Since pr CI's ran independetly they both got green. But one change impacted other without conflicts. 
Now fixed the test to adapt the ECReplicationConfig change. Besically ECKeyOutputStream#close has issue with partial chunk size(HDDS-5825). So, keeping the chunk config to match 1024.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5833

## How was this patch tested?

Failed test passing.
