### PR TITLE
HDDS-5811. Revert HDDS-5360 to work around block deletion error.

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   basic:
     runs-on: ubuntu-18.04
-    timeout-minutes: 240
+    timeout-minutes: 300
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
@@ -47,7 +47,7 @@ jobs:
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh -Dtest=TestBlockDeletion
         env:
-          ITERATIONS: 200
+          ITERATIONS: 100
       - name: Summary of failures
         run: cat target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,11 +14,7 @@
 # limitations under the License.
 name: build-branch
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
   push:
-  schedule:
-    - cron: 30 0,12 * * *
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
@@ -26,101 +22,14 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
-  build-info:
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_CONTEXT: ${{ toJson(github) }}
-    outputs:
-      basic-checks: ${{ steps.selective-checks.outputs.basic-checks }}
-      needs-basic-checks: ${{ steps.selective-checks.outputs.needs-basic-checks }}
-      needs-build: ${{ steps.selective-checks.outputs.needs-build }}
-      needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
-      needs-dependency-check: ${{ steps.selective-checks.outputs.needs-dependency-check }}
-      needs-integration-tests: ${{ steps.selective-checks.outputs.needs-integration-tests }}
-      needs-kubernetes-tests: ${{ steps.selective-checks.outputs.needs-kubernetes-tests }}
-    steps:
-      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
-        uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-      - name: Fetch incoming commit ${{ github.sha }} with its parent
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.sha }}
-          fetch-depth: 2
-          persist-credentials: false
-        if: github.event_name  == 'pull_request'
-      - name: Selective checks
-        id: selective-checks
-        env:
-          PR_LABELS: "${{ toJSON(github.event.pull_request.labels.*.name) }}"
-          PR_DRAFT: "${{ github.event.pull_request.draft }}"
-        run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
-            # Run selective checks
-            dev-support/ci/selective_ci_checks.sh "${GITHUB_SHA}"
-          else
-            # Run all checks
-            dev-support/ci/selective_ci_checks.sh
-          fi
-  compile:
-    needs:
-      - build-info
-    runs-on: ubuntu-18.04
-    timeout-minutes: 30
-    if: needs.build-info.outputs.needs-build == 'true'
-    strategy:
-      matrix:
-        java: [ 8, 11 ]
-      fail-fast: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Cache for npm dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.pnpm-store
-            **/node_modules
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Cache for maven dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
-          restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}
-            maven-repo-
-      - name: Setup java
-        uses: actions/setup-java@v1
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Run a full build
-        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist
-      - name: Store binaries for tests
-        uses: actions/upload-artifact@v2
-        if: matrix.java == '8'
-        with:
-          name: ozone-bin
-          path: hadoop-ozone/dist/target/ozone*.tar.gz
-          retention-days: 1
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
   basic:
-    needs:
-      - build-info
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
-    if: needs.build-info.outputs.needs-basic-checks == 'true'
+    timeout-minutes: 240
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
-        check: ${{ fromJson(needs.build-info.outputs.basic-checks) }}
+        check:
+          - integration
       fail-fast: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout project
@@ -136,7 +45,9 @@ jobs:
             maven-repo-
         if: ${{ !contains('author,bats,docs', matrix.check) }}
       - name: Execute tests
-        run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
+        run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh -Dtest=TestBlockDeletion
+        env:
+          ITERATIONS: 200
       - name: Summary of failures
         run: cat target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
@@ -146,206 +57,6 @@ jobs:
         with:
           name: ${{ matrix.check }}
           path: target/${{ matrix.check }}
-        continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
-  dependency:
-    needs:
-      - build-info
-      - compile
-    runs-on: ubuntu-18.04
-    timeout-minutes: 5
-    if: needs.build-info.outputs.needs-dependency-check == 'true'
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: ozone-bin
-      - name: Untar binaries
-        run: |
-          mkdir dist
-          tar  -C dist --strip-components 1 -xzf ozone*.tar.gz
-      - name: Execute tests
-        run: |
-          export OZONE_DIST_DIR=`pwd`/dist
-          ./hadoop-ozone/dev-support/checks/dependency.sh
-      - name: Archive build results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: dependency
-          path: target/dependency
-        continue-on-error: true
-  acceptance:
-    needs:
-      - build-info
-      - compile
-    runs-on: ubuntu-18.04
-    timeout-minutes: 150
-    if: needs.build-info.outputs.needs-compose-tests == 'true'
-    strategy:
-      matrix:
-        suite:
-          - secure
-          - unsecure
-          - HA
-          - MR
-          - misc
-      fail-fast: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: ozone-bin
-      - name: Untar binaries
-        run: |
-          mkdir -p hadoop-ozone/dist/target
-          tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
-          sudo chmod -R a+rwX hadoop-ozone/dist/target
-      - name: Execute tests
-        run: |
-          pushd hadoop-ozone/dist/target/ozone-*
-          sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
-          popd
-          ./hadoop-ozone/dev-support/checks/acceptance.sh
-        env:
-          KEEP_IMAGE: false
-          OZONE_ACCEPTANCE_SUITE: ${{ matrix.suite }}
-          OZONE_WITH_COVERAGE: true
-          OZONE_VOLUME_OWNER: 1000
-      - name: Archive build results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: acceptance-${{ matrix.suite }}
-          path: target/acceptance
-        continue-on-error: true
-  kubernetes:
-    needs:
-      - build-info
-      - compile
-    runs-on: ubuntu-18.04
-    timeout-minutes: 60
-    if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Download compiled Ozone binaries
-        uses: actions/download-artifact@v2
-        with:
-          name: ozone-bin
-      - name: Untar binaries
-        run: |
-          mkdir -p hadoop-ozone/dist/target
-          tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
-      - name: Execute tests
-        run: |
-          pushd hadoop-ozone/dist/target/ozone-*
-          sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
-          popd
-          ./hadoop-ozone/dev-support/checks/kubernetes.sh
-      - name: Archive build results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: kubernetes
-          path: target/kubernetes
-        continue-on-error: true
-  integration:
-    needs:
-      - build-info
-    runs-on: ubuntu-18.04
-    timeout-minutes: 150
-    if: needs.build-info.outputs.needs-integration-tests == 'true'
-    strategy:
-      matrix:
-        profile:
-          - client
-          - filesystem-hdds
-          - ozone
-      fail-fast: ${{ github.event_name == 'pull_request' }}
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Cache for maven dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.profile }}
-          restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
-            maven-repo-
-      - name: Execute tests
-        run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
-      - name: Summary of failures
-        run: cat target/${{ github.job }}/summary.txt
-        if: always()
-      - name: Archive build results
-        uses: actions/upload-artifact@v2
-        if: always()
-        with:
-          name: it-${{ matrix.profile }}
-          path: target/integration
-        continue-on-error: true
-      - name: Delete temporary build artifacts before caching
-        run: |
-          #Never cache local artifacts
-          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
-          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
-        if: always()
-  coverage:
-    runs-on: ubuntu-18.04
-    timeout-minutes: 30
-    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
-    needs:
-      - acceptance
-      - basic
-      - integration
-    steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
-      - name: Cache for maven dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ github.job }}
-          restore-keys: |
-            maven-repo-${{ hashFiles('**/pom.xml') }}-8
-            maven-repo-${{ hashFiles('**/pom.xml') }}
-            maven-repo-
-      - name: Download artifacts
-        uses: actions/download-artifact@v2
-        with:
-          path: target/artifacts
-      - name: Untar binaries
-        run: |
-          mkdir -p hadoop-ozone/dist/target
-          tar xzvf target/artifacts/ozone-bin/ozone*.tar.gz -C hadoop-ozone/dist/target
-      - name: Calculate combined coverage
-        run: ./hadoop-ozone/dev-support/checks/coverage.sh
-      - name: Setup java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Upload coverage to Sonar
-        run: ./hadoop-ozone/dev-support/checks/sonar.sh
-        env:
-          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Archive build results
-        uses: actions/upload-artifact@v2
-        with:
-          name: coverage
-          path: target/coverage
         continue-on-error: true
       - name: Delete temporary build artifacts before caching
         run: |

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -14,7 +14,11 @@
 # limitations under the License.
 name: build-branch
 on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
   push:
+  schedule:
+    - cron: 30 0,12 * * *
 env:
   FAIL_FAST: ${{ github.event_name == 'pull_request' }}
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3
@@ -22,14 +26,101 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
-  basic:
+  build-info:
     runs-on: ubuntu-18.04
-    timeout-minutes: 300
-    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    env:
+      GITHUB_CONTEXT: ${{ toJson(github) }}
+    outputs:
+      basic-checks: ${{ steps.selective-checks.outputs.basic-checks }}
+      needs-basic-checks: ${{ steps.selective-checks.outputs.needs-basic-checks }}
+      needs-build: ${{ steps.selective-checks.outputs.needs-build }}
+      needs-compose-tests: ${{ steps.selective-checks.outputs.needs-compose-tests }}
+      needs-dependency-check: ${{ steps.selective-checks.outputs.needs-dependency-check }}
+      needs-integration-tests: ${{ steps.selective-checks.outputs.needs-integration-tests }}
+      needs-kubernetes-tests: ${{ steps.selective-checks.outputs.needs-kubernetes-tests }}
+    steps:
+      - name: "Checkout ${{ github.ref }} ( ${{ github.sha }} )"
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+      - name: Fetch incoming commit ${{ github.sha }} with its parent
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+        if: github.event_name  == 'pull_request'
+      - name: Selective checks
+        id: selective-checks
+        env:
+          PR_LABELS: "${{ toJSON(github.event.pull_request.labels.*.name) }}"
+          PR_DRAFT: "${{ github.event.pull_request.draft }}"
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            # Run selective checks
+            dev-support/ci/selective_ci_checks.sh "${GITHUB_SHA}"
+          else
+            # Run all checks
+            dev-support/ci/selective_ci_checks.sh
+          fi
+  compile:
+    needs:
+      - build-info
+    runs-on: ubuntu-18.04
+    timeout-minutes: 30
+    if: needs.build-info.outputs.needs-build == 'true'
     strategy:
       matrix:
-        check:
-          - integration
+        java: [ 8, 11 ]
+      fail-fast: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Cache for npm dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.pnpm-store
+            **/node_modules
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-${{ matrix.java }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Run a full build
+        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist
+      - name: Store binaries for tests
+        uses: actions/upload-artifact@v2
+        if: matrix.java == '8'
+        with:
+          name: ozone-bin
+          path: hadoop-ozone/dist/target/ozone*.tar.gz
+          retention-days: 1
+      - name: Delete temporary build artifacts before caching
+        run: |
+          #Never cache local artifacts
+          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
+          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
+        if: always()
+  basic:
+    needs:
+      - build-info
+    runs-on: ubuntu-18.04
+    timeout-minutes: 60
+    if: needs.build-info.outputs.needs-basic-checks == 'true'
+    strategy:
+      matrix:
+        check: ${{ fromJson(needs.build-info.outputs.basic-checks) }}
       fail-fast: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout project
@@ -45,9 +136,7 @@ jobs:
             maven-repo-
         if: ${{ !contains('author,bats,docs', matrix.check) }}
       - name: Execute tests
-        run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh -Dtest=TestBlockDeletion
-        env:
-          ITERATIONS: 100
+        run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
       - name: Summary of failures
         run: cat target/${{ matrix.check }}/summary.txt
         if: ${{ !cancelled() }}
@@ -57,6 +146,206 @@ jobs:
         with:
           name: ${{ matrix.check }}
           path: target/${{ matrix.check }}
+        continue-on-error: true
+      - name: Delete temporary build artifacts before caching
+        run: |
+          #Never cache local artifacts
+          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
+          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
+        if: always()
+  dependency:
+    needs:
+      - build-info
+      - compile
+    runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    if: needs.build-info.outputs.needs-dependency-check == 'true'
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Download compiled Ozone binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: ozone-bin
+      - name: Untar binaries
+        run: |
+          mkdir dist
+          tar  -C dist --strip-components 1 -xzf ozone*.tar.gz
+      - name: Execute tests
+        run: |
+          export OZONE_DIST_DIR=`pwd`/dist
+          ./hadoop-ozone/dev-support/checks/dependency.sh
+      - name: Archive build results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: dependency
+          path: target/dependency
+        continue-on-error: true
+  acceptance:
+    needs:
+      - build-info
+      - compile
+    runs-on: ubuntu-18.04
+    timeout-minutes: 150
+    if: needs.build-info.outputs.needs-compose-tests == 'true'
+    strategy:
+      matrix:
+        suite:
+          - secure
+          - unsecure
+          - HA
+          - MR
+          - misc
+      fail-fast: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Download compiled Ozone binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: ozone-bin
+      - name: Untar binaries
+        run: |
+          mkdir -p hadoop-ozone/dist/target
+          tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
+          sudo chmod -R a+rwX hadoop-ozone/dist/target
+      - name: Execute tests
+        run: |
+          pushd hadoop-ozone/dist/target/ozone-*
+          sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
+          popd
+          ./hadoop-ozone/dev-support/checks/acceptance.sh
+        env:
+          KEEP_IMAGE: false
+          OZONE_ACCEPTANCE_SUITE: ${{ matrix.suite }}
+          OZONE_WITH_COVERAGE: true
+          OZONE_VOLUME_OWNER: 1000
+      - name: Archive build results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: acceptance-${{ matrix.suite }}
+          path: target/acceptance
+        continue-on-error: true
+  kubernetes:
+    needs:
+      - build-info
+      - compile
+    runs-on: ubuntu-18.04
+    timeout-minutes: 60
+    if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Download compiled Ozone binaries
+        uses: actions/download-artifact@v2
+        with:
+          name: ozone-bin
+      - name: Untar binaries
+        run: |
+          mkdir -p hadoop-ozone/dist/target
+          tar xzvf ozone*.tar.gz -C hadoop-ozone/dist/target
+      - name: Execute tests
+        run: |
+          pushd hadoop-ozone/dist/target/ozone-*
+          sudo mkdir .aws && sudo chmod 777 .aws && sudo chown 1000 .aws
+          popd
+          ./hadoop-ozone/dev-support/checks/kubernetes.sh
+      - name: Archive build results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: kubernetes
+          path: target/kubernetes
+        continue-on-error: true
+  integration:
+    needs:
+      - build-info
+    runs-on: ubuntu-18.04
+    timeout-minutes: 150
+    if: needs.build-info.outputs.needs-integration-tests == 'true'
+    strategy:
+      matrix:
+        profile:
+          - client
+          - filesystem-hdds
+          - ozone
+      fail-fast: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ matrix.profile }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}-8
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
+      - name: Execute tests
+        run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
+      - name: Summary of failures
+        run: cat target/${{ github.job }}/summary.txt
+        if: always()
+      - name: Archive build results
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: it-${{ matrix.profile }}
+          path: target/integration
+        continue-on-error: true
+      - name: Delete temporary build artifacts before caching
+        run: |
+          #Never cache local artifacts
+          rm -rf ~/.m2/repository/org/apache/ozone/hdds*
+          rm -rf ~/.m2/repository/org/apache/ozone/ozone*
+        if: always()
+  coverage:
+    runs-on: ubuntu-18.04
+    timeout-minutes: 30
+    if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
+    needs:
+      - acceptance
+      - basic
+      - integration
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+      - name: Cache for maven dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: maven-repo-${{ hashFiles('**/pom.xml') }}-8-${{ github.job }}
+          restore-keys: |
+            maven-repo-${{ hashFiles('**/pom.xml') }}-8
+            maven-repo-${{ hashFiles('**/pom.xml') }}
+            maven-repo-
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: target/artifacts
+      - name: Untar binaries
+        run: |
+          mkdir -p hadoop-ozone/dist/target
+          tar xzvf target/artifacts/ozone-bin/ozone*.tar.gz -C hadoop-ozone/dist/target
+      - name: Calculate combined coverage
+        run: ./hadoop-ozone/dev-support/checks/coverage.sh
+      - name: Setup java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Upload coverage to Sonar
+        run: ./hadoop-ozone/dev-support/checks/sonar.sh
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARCLOUD_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Archive build results
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: target/coverage
         continue-on-error: true
       - name: Delete temporary build artifacts before caching
         run: |

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -80,7 +80,6 @@ public class DatanodeConfiguration {
   private int replicationMaxStreams = REPLICATION_MAX_STREAMS_DEFAULT;
 
   static final int CONTAINER_DELETE_THREADS_DEFAULT = 2;
-  static final int BLOCK_DELETE_THREADS_DEFAULT = 5;
 
   /**
    * The maximum number of threads used to delete containers on a datanode
@@ -94,37 +93,6 @@ public class DatanodeConfiguration {
           "on a datanode"
   )
   private int containerDeleteThreads = CONTAINER_DELETE_THREADS_DEFAULT;
-
-  /**
-   * The maximum number of threads used to handle delete block commands.
-   * It takes about 200ms to open a RocksDB with HDD media, so basically DN
-   * can handle 300 individual container delete tx every 60s if RocksDB cache
-   * missed. With max threads 5, optimistically DN can handle 1500 individual
-   * container delete tx in 60s with RocksDB cache miss.
-   */
-  @Config(key = "block.delete.threads.max",
-      type = ConfigType.INT,
-      defaultValue = "5",
-      tags = {DATANODE},
-      description = "The maximum number of threads used to handle delete " +
-          " blocks on a datanode"
-  )
-  private int blockDeleteThreads = BLOCK_DELETE_THREADS_DEFAULT;
-
-  /**
-   * The maximum number of commands in queued list.
-   * 1440 = 60 * 24, which means if SCM send a delete command every minute,
-   * if the commands are pined up for more than 1 day, DN will start to discard
-   * new comming commands.
-   */
-  @Config(key = "block.delete.queue.limit",
-      type = ConfigType.INT,
-      defaultValue = "1440",
-      tags = {DATANODE},
-      description = "The maximum number of block delete commands queued on "+
-          " a datanode"
-  )
-  private int blockDeleteQueueLimit = 60 * 24;
 
   @Config(key = "block.deleting.service.interval",
           defaultValue = "60s",
@@ -337,22 +305,6 @@ public class DatanodeConfiguration {
     this.diskCheckTimeout = duration.toMillis();
   }
 
-  public int getBlockDeleteThreads() {
-    return blockDeleteThreads;
-  }
-
-  public void setBlockDeleteThreads(int threads) {
-    this.blockDeleteThreads = threads;
-  }
-
-  public int getBlockDeleteQueueLimit() {
-    return blockDeleteQueueLimit;
-  }
-
-  public void setBlockDeleteQueueLimit(int queueLimit) {
-    this.blockDeleteQueueLimit = queueLimit;
-  }
-
   public boolean isChunkDataValidationCheck() {
     return isChunkDataValidationCheck;
   }
@@ -360,5 +312,4 @@ public class DatanodeConfiguration {
   public void setChunkDataValidationCheck(boolean writeChunkValidationCheck) {
     isChunkDataValidationCheck = writeChunkValidationCheck;
   }
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -172,8 +172,7 @@ public class DatanodeStateMachine implements Closeable {
     commandDispatcher = CommandDispatcher.newBuilder()
         .addHandler(new CloseContainerCommandHandler())
         .addHandler(new DeleteBlocksCommandHandler(container.getContainerSet(),
-            conf, dnConf.getBlockDeleteThreads(),
-            dnConf.getBlockDeleteQueueLimit()))
+            conf))
         .addHandler(new ReplicateContainerCommandHandler(conf, supervisor))
         .addHandler(new DeleteContainerCommandHandler(
             dnConf.getContainerDeleteThreads()))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -535,9 +535,8 @@ public class TestEndPoint {
     heartbeatTaskHelper(invalidAddress, 1000);
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
-    // 6s is introduced by DeleteBlocksCommandHandler#stop
     Assert.assertThat(end - start,
-        lessThanOrEqualTo(rpcTimeout + tolerance + 6000));
+        lessThanOrEqualTo(rpcTimeout + tolerance));
   }
 
   private StateContext getContext(DatanodeDetails datanodeDetails) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -129,6 +129,7 @@ public class TestContainerReplication {
 
     cluster.shutdownHddsDatanode(keyLocation.getPipeline().getFirstNode());
 
+    waitForReplicaCount(containerID, 2, cluster);
     waitForReplicaCount(containerID, 3, cluster);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-5360 was merged into master, an integration test for block deletion became flaky, as reported in HDDS-5605 (currently still open). This Jira is to revert the change in HDDS-5360 on the ozone-1.2 branch to ensure there are no regressions in block deletion for the 1.2.0 release.

## What is the link to the Apache JIRA

HDDS-5811

## How was this patch tested?

Repeated runs of `TestBlockDeletion` integration test.
I got 108 runs here, but forgot to increase the test timeout, so CI stopped it after 108 runs: https://github.com/errose28/hadoop-ozone/runs/3804695951
A follow up with another 100 runs is here: https://github.com/errose28/hadoop-ozone/runs/3809281595
