### PR TITLE
HDDS-5825: EC: ECKeyOutputStream#close fails if we write the partial chunk

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -234,7 +234,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
     // executePutBlock for all.
     // TODO: we should alter the put block calls to share CRC to each stream.
     blockOutputStreamEntryPool.executePutBlockForAll();
-    ecChunkBufferCache.clear();
+    ecChunkBufferCache.clear(parityCellSize);
 
     // check if block ends?
     if (shouldEndBlockGroup()) {
@@ -691,9 +691,9 @@ public class ECKeyOutputStream extends KeyOutputStream {
       return pos;
     }
 
-    private void clear() {
-      clearBuffers(cellSize, dataBuffers);
-      clearBuffers(cellSize, parityBuffers);
+    private void clear(int size) {
+      clearBuffers(size, dataBuffers);
+      clearBuffers(size, parityBuffers);
     }
 
     private void release() {

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -275,6 +275,29 @@ public class TestOzoneECClient {
   }
 
   @Test
+  public void testMultipleChunksWithPartialChunkInSigleWripeOp()
+      throws IOException {
+    final int partialChunkLen = 10;
+    final int numFullChunks = 9;
+    final int inputBuffLen = (numFullChunks * chunkSize) + partialChunkLen;
+    byte[] inputData = new byte[inputBuffLen];
+    for (int i = 0; i < numFullChunks; i++) {
+      int start = (i * chunkSize);
+      Arrays.fill(inputData, start, start + chunkSize - 1,
+          String.valueOf(i).getBytes(UTF_8)[0]);
+    }
+    //fill the last partial chunk as well.
+    Arrays.fill(inputData, (numFullChunks * chunkSize),
+        ((numFullChunks * chunkSize)) + partialChunkLen - 1, (byte) 1);
+    final OzoneBucket bucket = writeIntoECKey(inputData, keyName,
+        new DefaultReplicationConfig(ReplicationType.EC,
+            new ECReplicationConfig(dataBlocks, parityBlocks,
+                ECReplicationConfig.EcCodec.RS, chunkSize)));
+    OzoneKey key = bucket.getKey(keyName);
+    validateContent(inputData, bucket, key);
+  }
+
+  @Test
   public void testCommitKeyInfo()
       throws IOException {
     final OzoneBucket bucket = writeIntoECKey(inputChunks, keyName,


### PR DESCRIPTION


## What changes were proposed in this pull request?

At the time of clearing ec chunks if first chunk in striped was partial chunk, buffers would have been created smaller for parity. So when clearing them we should pass the actual size what we created.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5825

## How was this patch tested?

added tests