### PR TITLE
HDDS-5846. The quota should be consistent when use link create new bucket

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
@@ -48,7 +48,7 @@ Create buckets for FS test
 Create links for FS test
     Execute And Ignore Error    ozone sh volume create ${VOLUME}-src --space-quota 100TB
     Execute And Ignore Error    ozone sh volume create ${VOL2}-src --space-quota 100TB
-    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET}-src --space-quota 10GB --namespace-quota=10
+    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET}-src
     Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET2}-src
     Execute                     ozone sh bucket create ${VOL2}-src/${BUCKET_IN_VOL2}-src
     Execute                     ozone sh bucket link ${VOLUME}-src/${BUCKET}-src ${VOLUME}/${BUCKET}
@@ -63,8 +63,6 @@ Sanity check for FS test
     ${result} =         Execute               ozone sh bucket list ${VOLUME}
                         Should contain        ${result}               ${BUCKET}
                         Should contain        ${result}               ${BUCKET2}
-                        Should contain   ${result}               "quotaInBytes" : 107374182400
-                        Should contain   ${result}               "quotaInNamespace" : 10
 
 Assign suite vars for FS test
     ${random} =         Generate Random String  5  [NUMBERS]


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the source bucket set a quota , creating a bucket using link now does not update the quota of new bucket.  We need to keep them the same.

![image](https://user-images.githubusercontent.com/13825159/136658576-4a7c49af-61d5-4524-aa89-784eb08c96ef.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5846

## How was this patch tested?

Added UT
