### PR TITLE
HDDS-5850. Update default value of 'ozone.scm.ha.ratis.segment.size' and 'preallocated.size' to improve SCM write perf.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -477,12 +477,12 @@ public final class ScmConfigKeys {
 
   public static final String OZONE_SCM_HA_RAFT_SEGMENT_SIZE =
           "ozone.scm.ha.ratis.segment.size";
-  public static final String OZONE_SCM_HA_RAFT_SEGMENT_SIZE_DEFAULT = "16KB";
+  public static final String OZONE_SCM_HA_RAFT_SEGMENT_SIZE_DEFAULT = "4MB";
 
   public static final String OZONE_SCM_HA_RAFT_SEGMENT_PRE_ALLOCATED_SIZE =
           "ozone.scm.ha.ratis.segment.preallocated.size";
   public static final String
-          OZONE_SCM_HA_RAFT_SEGMENT_PRE_ALLOCATED_SIZE_DEFAULT = "16KB";
+          OZONE_SCM_HA_RAFT_SEGMENT_PRE_ALLOCATED_SIZE_DEFAULT = "4MB";
 
   public static final String OZONE_SCM_HA_RAFT_LOG_APPENDER_QUEUE_NUM =
       "ozone.scm.ha.ratis.log.appender.queue.num-elements";

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2842,18 +2842,18 @@
   </property>
   <property>
     <name>ozone.scm.ha.ratis.segment.size</name>
-    <value>16KB</value>
+    <value>4MB</value>
     <tag>SCM, OZONE, HA, RATIS</tag>
     <description>The size of the raft segment used by Apache Ratis on
-      SCM. (16 KB by default)
+      SCM. (4 MB by default)
     </description>
   </property>
   <property>
     <name>ozone.scm.ha.ratis.segment.preallocated.size</name>
-    <value>16KB</value>
+    <value>4MB</value>
     <tag>SCM, OZONE, HA, RATIS</tag>
     <description>The size of the buffer which is preallocated for
-      raft segment used by Apache Ratis on SCM.(16 KB by default)
+      raft segment used by Apache Ratis on SCM.(4 MB by default)
     </description>
   </property>
   <property>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update ratis.segment.size and preallocated.size default to 4MB. Similar to OM defaults.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5850

## How was this patch tested?

Config change. Exisiting tests.