### PR TITLE
HDDS-5855. Bump commons-compress to 1.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <commons-cli.version>1.2</commons-cli.version>
     <commons-codec.version>1.11</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
-    <commons-compress.version>1.20</commons-compress.version>
+    <commons-compress.version>1.21</commons-compress.version>
     <commons-configuration2.version>2.1.1</commons-configuration2.version>
     <commons-csv.version>1.0</commons-csv.version>
     <commons-daemon.version>1.0.13</commons-daemon.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump `commons-compress` from 1.20 to 1.21 (latest release).

https://issues.apache.org/jira/browse/HDDS-5855

## How was this patch tested?

```
$ mvn -DskipTests clean package
...
$ cd hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/share/ozone/lib
$ ls | grep compress
commons-compress-1.21.jar
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1337942468