### PR TITLE
HDDS 5781. Enable ACLs and support for all s3 file operations.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -69,6 +69,7 @@ OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s
+OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
 HDFS-SITE.XML_dfs.datanode.keytab.file=/etc/security/keytabs/dn.keytab

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -33,9 +33,9 @@ execute_command_in_container kms hadoop key create ${OZONE_BUCKET_KEY_NAME}
 
 execute_robot_test scm kinit.robot
 
-#execute_robot_test scm basic
+execute_robot_test scm basic
 
-#execute_robot_test scm security
+execute_robot_test scm security
 
 for scheme in ofs o3fs; do
   for bucket in link bucket; do
@@ -43,9 +43,9 @@ for scheme in ofs o3fs; do
   done
 done
 
-#for bucket in link generated; do
-#  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
-#done
+for bucket in link generated; do
+  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
+done
 
 #expects 4 pipelines, should be run before
 #admincli which creates STANDALONE pipeline

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4038,7 +4038,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (isAclEnabled) {
         InetAddress remoteIp = Server.getRemoteIp();
         resolved = resolveBucketLink(requested, new HashSet<>(),
-            Server.getRemoteUser(),
+            getRemoteUser(),
             remoteIp,
             remoteIp != null ? remoteIp.getHostName() :
                 omRpcAddress.getHostName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -136,6 +136,11 @@ public abstract class OMClientRequest implements RequestAuditor {
       userInfo.setUserName(user.getUserName());
     }
 
+    // for gRPC s3g omRequests that contain user name
+    if (user == null && omRequest.hasUserInfo()) {
+      userInfo.setUserName(omRequest.getUserInfo().getUserName());
+    }
+
     if (remoteAddress != null) {
       userInfo.setHostName(remoteAddress.getHostName());
       userInfo.setRemoteAddress(remoteAddress.getHostAddress()).build();
@@ -273,15 +278,16 @@ public abstract class OMClientRequest implements RequestAuditor {
     if (userGroupInformation != null) {
       return userGroupInformation;
     }
-
     if (omRequest.hasUserInfo() &&
         !StringUtils.isBlank(omRequest.getUserInfo().getUserName())) {
       userGroupInformation = UserGroupInformation.createRemoteUser(
           omRequest.getUserInfo().getUserName());
+      LOG.debug("creating UGI remote user for acl");
       return userGroupInformation;
     } else {
       // This will never happen, as for every OM request preExecute, we
       // should add userInfo.
+      LOG.debug("NO UGI for acl");
       return null;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -282,10 +282,12 @@ public abstract class OMClientRequest implements RequestAuditor {
         !StringUtils.isBlank(omRequest.getUserInfo().getUserName())) {
       userGroupInformation = UserGroupInformation.createRemoteUser(
           omRequest.getUserInfo().getUserName());
+      LOG.debug("creating UGI remote user for acl");
       return userGroupInformation;
     } else {
       // This will never happen, as for every OM request preExecute, we
       // should add userInfo.
+      LOG.debug("NO UGI for acl");
       return null;
     }
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -282,12 +282,10 @@ public abstract class OMClientRequest implements RequestAuditor {
         !StringUtils.isBlank(omRequest.getUserInfo().getUserName())) {
       userGroupInformation = UserGroupInformation.createRemoteUser(
           omRequest.getUserInfo().getUserName());
-      LOG.debug("creating UGI remote user for acl");
       return userGroupInformation;
     } else {
       // This will never happen, as for every OM request preExecute, we
       // should add userInfo.
-      LOG.debug("NO UGI for acl");
       return null;
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.security.UserGroupInformation;
 
 /**
  * Basic helpers for all the REST endpoints.
@@ -50,6 +51,12 @@ public class EndpointBase {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
         throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName);
+      } else if (ex.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            UserGroupInformation.getCurrentUser().getUserName());
+      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
+          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
+        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR, bucketName);
       } else {
         throw ex;
       }
@@ -66,8 +73,14 @@ public class EndpointBase {
       if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND
           || ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
         throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName);
+      } else if (ex.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            UserGroupInformation.getCurrentUser().getUserName());
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
+          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
+        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR, bucketName);
       } else {
         throw ex;
       }
@@ -95,6 +108,12 @@ public class EndpointBase {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+      } else if (ex.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            UserGroupInformation.getCurrentUser().getUserName());
+      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
+          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
+        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR, bucketName);
       } else if (ex.getResult() != ResultCodes.BUCKET_ALREADY_EXISTS) {
         // S3 does not return error for bucket already exists, it just
         // returns the location.
@@ -117,8 +136,15 @@ public class EndpointBase {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
             s3BucketName);
+      } else if (ex.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            UserGroupInformation.getCurrentUser().getUserName());
+      } else if (ex.getResult() == ResultCodes.TIMEOUT ||
+          ex.getResult() == ResultCodes.INTERNAL_ERROR) {
+        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR, s3BucketName);
+      } else {
+        throw ex;
       }
-      throw ex;
     }
   }
 
@@ -160,6 +186,13 @@ public class EndpointBase {
         return Collections.emptyIterator();
       } else  if (e.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            "listBuckets");
+      } else if (e.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
+            UserGroupInformation.getCurrentUser().getUserName());
+      } else if (e.getResult() == ResultCodes.TIMEOUT ||
+          e.getResult() == ResultCodes.INTERNAL_ERROR) {
+        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR,
             "listBuckets");
       } else {
         throw e;


### PR DESCRIPTION
… error responses to client on error (fixing general 500 response in current gateway).

## What changes were proposed in this pull request?

S3 gateway Gprc support for all ozone s3 supported client requests with security and ACLs enabled.  This PR adds s3g Grpc acl support with patches to the `OMClientRequest` user thread context and to the `ozone manager`.  

Included in this PR are enhancements to the s3 gateway client to return meaningful error responses, http return codes and descriptions, to the caller on error.  For example a user accessing a resource **_without_** permission is returned `HTTP 403` `AccessDenied`.  Previously all errors on client creation return `HTTP 500`.

All secure cluster smoke tests are re-enabled in this PR.  Secure cluster is updated to enable s3g Grpc and to enable all s3 gateway acceptance tests.
 
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5781

## How was this patch tested?
Manual Testing with secure ozone cluster:
s3 request - ozone cluster processing s3 create bucket request with permission _and without_ permission.

With secret key:
`$ cd hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/ozonesecure`
`$ docker-compose up -d --scale datanode=3`
`$ docker-compose run scm bash`
`bash-4.2$ kinit -kt /etc/security/keytabs/testuser.keytab testuser/scm`
`bash-4.2$ ozone s3 getsecret`
`$ export AWS_ACCESS_KEY=testuser/scm@EXAMPLE.COM` `AWS_SECRET_KEY=<key>`
`$ aws s3api --endpoint http://localhost:9878 create-bucket --bucket=bucket1`
_{
"Location": "http://localhost:9878/bucket1"
}_

Without secret key:
`$ export AWS_ACCESS_KEY=`
`$ export AWS_SECRET_KEY=`
`$ aws s3api --endpoint http://localhost:9878 create-bucket --bucket bucket1`

_An error occurred (AccessDenied) when calling the CreateBucket operation: User doesn't have the right to access this resource._

