### PR TITLE
HDDS-5722 [HTTPFSGGW] junit.jar and json-simple in jar report

### DIFF
--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -146,7 +146,6 @@ share/ozone/lib/json-smart.jar
 share/ozone/lib/jsp-api.jar
 share/ozone/lib/jsr305.jar
 share/ozone/lib/jsr311-api.jar
-share/ozone/lib/junit.jar
 share/ozone/lib/kerb-admin.jar
 share/ozone/lib/kerb-client.jar
 share/ozone/lib/kerb-common.jar

--- a/hadoop-ozone/httpfsgateway/pom.xml
+++ b/hadoop-ozone/httpfsgateway/pom.xml
@@ -52,6 +52,12 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.sun.jersey</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The HTTPFS branch contains junit.jar and json-simple.jar in its jar-report.txt and we wanted to investigate this and try to remove/replace them. 
We wanted to replace json-simple with json-smart, as it is already in the jar-report. I found that the json-smart.jar is added as a "hack". In the ozone-main pom.xml a comment says that it is added as transitive dependency for nimbus-jose-jwt, it is needed for packaging. We agreed not to use json-smart instead of json-simple, as json-smart is planned to be removed in the future. Classes in the httpfsgateway are using json-simple (JSONObject, JSONArray, JSONParser, etc.), so that will stay in the jar-report.
The junit.jar is coming from the json-simple.jar as a compile time dependency, so I excluded it in the pom.xml. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5722

## How was this patch tested?

Run the build manually with skip tests and the build was successful. Also run the dependency.sh from the dev-support directory and it was successful.


