### PR TITLE
HDDS-5866. Discrepancy in Trash directory in ofs vs o3fs.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -180,6 +180,8 @@ public class TestOzoneFileSystem {
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
     // Set the number of keys to be processed during batch operate.
     conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 5);
+    conf.setClass("fs.trash.classname", TrashPolicyOzone.class,
+        TrashPolicy.class);
 
     fs = FileSystem.get(conf);
     trash = new Trash(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1245,7 +1245,6 @@ public class TestRootedOzoneFileSystem {
    * 3.Create a second Key in different bucket and verify deletion.
    * @throws Exception
    */
-  @Ignore
   @Test
   public void testTrash() throws Exception {
     String testKeyName = "keyToBeDeleted";
@@ -1289,12 +1288,13 @@ public class TestRootedOzoneFileSystem {
     String username = UserGroupInformation.getCurrentUser().getShortUserName();
     Path trashRoot = new Path(bucketPath, TRASH_PREFIX);
     Path userTrash = new Path(trashRoot, username);
-    Path trashPath = getTrashKeyPath(keyPath1, userTrash);
+    Path trashPath = getTrashKeyPath(new Path("/" + testKeyName), userTrash);
 
     // Construct paths for second key in different bucket
     Path trashRoot2 = new Path(bucketPath2, TRASH_PREFIX);
     Path userTrash2 = new Path(trashRoot2, username);
-    Path trashPath2 = getTrashKeyPath(keyPath2, userTrash2);
+    Path trashPath2 =
+        getTrashKeyPath(new Path("/" + testKeyName + "1"), userTrash2);
 
 
     // Wait until the TrashEmptier purges the keys

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -60,7 +60,6 @@ import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -458,7 +458,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       super(f);
       this.recursive = recursive;
       if (getStatus().isDirectory()
-          && !this. recursive
+          && !this.recursive
           && listStatus(f).length != 0) {
         throw new PathIsNotEmptyDirectoryException(f.toString());
       }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -433,7 +433,18 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       // if doesn't have TO_TRASH option, just pass the call to super
       super.rename(src, dst, options);
     } else {
-      rename(src, dst);
+      OFSPath dstpath = new OFSPath(dst);
+      String keyName = dstpath.getKeyName();
+      // omit volume name and bucket name from Key
+      String keyNamewithoutVolumeAndBucket = keyName.replace(
+          OZONE_URI_DELIMITER + dstpath.getVolumeName() + OZONE_URI_DELIMITER
+              + dstpath.getBucketName(), "");
+      Path newDest = new Path(
+          OZONE_URI_DELIMITER + dstpath.getVolumeName() + OZONE_URI_DELIMITER
+              + dstpath.getBucketName() + OZONE_URI_DELIMITER
+              + keyNamewithoutVolumeAndBucket);
+      LOG.info("Moved key to destination: {}", newDest);
+      rename(src, newDest);
     }
   }
 
@@ -447,7 +458,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
       super(f);
       this.recursive = recursive;
       if (getStatus().isDirectory()
-          && !this.recursive
+          && !this. recursive
           && listStatus(f).length != 0) {
         throw new PathIsNotEmptyDirectoryException(f.toString());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
When moving a file/dir to trash, the destination path is different for ofs and o3fs.  The change here is to make it same for both.
```

o3fs -> /<vol>/<buck>/.Trash/<user>/Current/..<dir if any>..
ofs -> /<vol>/<buck>/.Trash/<user>/Current/<vol>/<buck>/..<dir if any>..
```

Omitting volume and bucket for ofs key

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5866

## How was this patch tested?
unit test
