### PR TITLE
HDDS-5867. Fix OMOpenKeysDeleteRequest delete open keys without update usedBytes

### DIFF
--- a/hadoop-ozone/dev-support/intellij/ozone-site.xml
+++ b/hadoop-ozone/dev-support/intellij/ozone-site.xml
@@ -59,6 +59,7 @@
     <name>hdds.prometheus.endpoint.enabled</name>
     <value>true</value>
   </property>
+  <!--
   <property>
     <name>ozone.recon.address</name>
     <value>localhost:9891</value>
@@ -66,9 +67,19 @@
   <property>
     <name>ozone.recon.db.dir</name>
     <value>/tmp/recon</value>
-  </property>
+  </property>-->
   <property>
     <name>datanode.replication.port</name>
     <value>0</value>
+  </property>
+  <property>
+    <name>ozone.open.key.expire.threshold</name>
+    <value>60</value>
+    <tag>OZONE, OM, PERFORMANCE</tag>
+    <description>
+      Controls how long an open key operation is considered active. Specifically, if a key
+      has been open longer than the value of this config entry, that open key is considered as
+      expired (e.g. due to client crash). Default to 24 hours.
+    </description>
   </property>
 </configuration>

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -26,10 +26,12 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetrics;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.key.OMOpenKeysDeleteRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Test;
 import com.google.common.base.Optional;
@@ -161,7 +163,6 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
         makeOpenKeys(volumeName, bucketName, keyName, numExistentKeys);
     OpenKeyBucket nonExistentKeys =
         makeOpenKeys(volumeName, bucketName, keyName, numNonExistentKeys);
-
     addToOpenKeyTableDB(existentKeys);
     deleteOpenKeysFromCache(existentKeys, nonExistentKeys);
 
@@ -184,6 +185,12 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    */
   private void deleteOpenKeysFromCache(OpenKeyBucket... openKeys)
       throws Exception {
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .setCreationTime(Time.now()).build();
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    omMetadataManager.getBucketTable().addCacheEntry(new CacheKey<>(bucketKey),
+        new CacheValue<>(Optional.of(omBucketInfo), Long.MAX_VALUE));
 
     OMRequest omRequest =
         doPreExecute(createDeleteOpenKeyRequest(openKeys));
@@ -222,6 +229,13 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
     for (OpenKeyBucket openKeyBucket: openKeys) {
       String volume = openKeyBucket.getVolumeName();
       String bucket = openKeyBucket.getBucketName();
+      OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+          .setVolumeName(volume).setBucketName(bucket)
+          .setCreationTime(Time.now()).build();
+      String bucketKey = omMetadataManager.getBucketKey(volume, bucket);
+      omMetadataManager.getBucketTable().addCacheEntry(
+          new CacheKey<>(bucketKey), new CacheValue<>(Optional.of(omBucketInfo),
+          Long.MAX_VALUE));
 
       for (OpenKey openKey: openKeyBucket.getKeysList()) {
         if (keySize > 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-4120, we plan to delete expired keys in Open key Table. Request and Response are implemented in HDDS-4122. But we did not update bucket usedBytes in new request, we need to fix this problem.
When these keys are deleted, the bucket usedBytes also need to be updated.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5867

## How was this patch tested?

Existing  UT had fixed, and new CI need add after HDDS-4123 finished.
