### PR TITLE
HDDS-5374: [FSO] Handle rename and delete operation from an old client to a FSO bucket type

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/.env
+++ b/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/.env
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+HDDS_VERSION=${hdds.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}

--- a/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/clients.yaml
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+services:
+  old_client_1_1_0:
+    image: apache/ozone:1.1.0
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/ozone
+    environment:
+      HADOOP_OPTS:
+    command: ["sleep","1000000"]
+  new_client:
+    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    env_file:
+      - docker-config
+    volumes:
+      - ../..:/opt/hadoop
+    environment:
+      OZONE_OPTS:
+    command: ["sleep","1000000"]

--- a/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/docker-config
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
+OZONE-SITE.XML_hdds.scm.safemode.min.datanode=3
+OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
+OZONE-SITE.XML_ozone.om.address=om
+OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.om.metadata.layout=PREFIX
+OZONE-SITE.XML_ozone.om.enable.filesystem.paths=true
+OZONE-SITE.XML_ozone.recon.address=recon:9891
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_ozone.replication=3
+OZONE-SITE.XML_ozone.scm.block.client.address=scm
+OZONE-SITE.XML_ozone.scm.client.address=scm
+OZONE-SITE.XML_ozone.scm.container.size=1GB
+OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
+OZONE-SITE.XML_ozone.scm.datanode.id.dir=/data
+OZONE-SITE.XML_ozone.scm.names=scm
+OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1
+OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+
+no_proxy=om,recon,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/new-cluster.yaml
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: "3.4"
+
+# reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
+x-new-config:
+  &new-config
+  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  env_file:
+    - docker-config
+  volumes:
+    - ../..:/opt/hadoop
+
+services:
+  datanode:
+    <<: *new-config
+    ports:
+      - 9864
+      - 9882
+    environment:
+      OZONE_OPTS:
+    command: ["ozone","datanode"]
+  om:
+    <<: *new-config
+    environment:
+      ENSURE_OM_INITIALIZED: /data/metadata/om/current/VERSION
+      OZONE_OPTS:
+    ports:
+      - 9874:9874
+      - 9862:9862
+    command: ["ozone","om"]
+  recon:
+    <<: *new-config
+    ports:
+      - 9888:9888
+    environment:
+      OZONE_OPTS:
+    command: ["ozone","recon"]
+  s3g:
+    <<: *new-config
+    environment:
+      OZONE_OPTS:
+    ports:
+      - 9878:9878
+    command: ["ozone","s3g"]
+  scm:
+    <<: *new-config
+    ports:
+      - 9876:9876
+    environment:
+      ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
+      OZONE_OPTS:
+    command: ["ozone","scm"]

--- a/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat-bucklayout/test.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+basename=$(basename ${COMPOSE_DIR})
+
+current_version=1.2.0
+previous_version=1.1.0
+
+# shellcheck source=hadoop-ozone/dist/src/main/compose/testlib.sh
+source "${COMPOSE_DIR}/../testlib.sh"
+
+old_client() {
+  OZONE_DIR=/opt/ozone
+  container=${client}
+  "$@"
+}
+
+new_client() {
+  OZONE_DIR=/opt/hadoop
+  container=new_client
+  client_version=${current_version}
+  "$@"
+}
+
+_init() {
+  execute_command_in_container ${container} ozone freon ockg -n1 -t1 -p warmup
+}
+
+_createbucket() {
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-createbucket" -v SUFFIX:${cluster_version} compatibility/createbucket.robot
+}
+
+_createdirs() {
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-createbucket" -v SUFFIX:${cluster_version} compatibility/createdirs.robot
+}
+
+_rename() {
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-rename" -v SUFFIX:${cluster_version} compatibility/rename.robot
+}
+
+_delete() {
+  execute_robot_test ${container} -N "xcompat-cluster-${cluster_version}-client-${client_version}-delete" -v SUFFIX:${cluster_version} compatibility/delete.robot
+}
+
+test_cross_compat_buck_layout() {
+  echo "Starting cluster with COMPOSE_FILE=${COMPOSE_FILE}"
+
+  OZONE_KEEP_RESULTS=true start_docker_env
+
+  # execute_command_in_container scm ozone freon ockg -n1 -t1 -p warmup
+  new_client _createbucket
+  new_client _createdirs
+
+  client=$(docker ps | grep _old_client_ | awk '{ print $NF }')
+  echo "Client=${client}"
+
+  client=${client#${basename}_}
+  client=${client%_1}
+  client_version=${client#old_client_}
+  client_version=${client_version//_/.}
+
+  echo "Client-Version=${client_version}"
+  old_client _rename
+  old_client _delete
+
+  stop_docker_env
+}
+
+create_results_dir
+
+# current cluster with various clients
+COMPOSE_FILE=new-cluster.yaml:clients.yaml cluster_version=${current_version} test_cross_compat_buck_layout
+
+generate_report

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/createbucket.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/createbucket.robot
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Create bucket and volume for any other testings
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Test Timeout        2 minute
+
+
+*** Variables ***
+${VOLUME}       volume1
+${BUCKET}       bucketfso1
+${BUCK_LAYOUT}  FILE_SYSTEM_OPTIMIZED
+
+*** Keywords ***
+Create volume
+    ${result} =     Execute             ozone sh volume create /${VOLUME} --user hadoop --space-quota 100TB --namespace-quota 100
+                    Should not contain  ${result}       Failed
+Create bucket
+                    Execute             ozone sh bucket create --type=${BUCK_LAYOUT} /${VOLUME}/${BUCKET}
+
+*** Test Cases ***
+Test ozone shell
+    ${result} =     Execute And Ignore Error             ozone sh bucket info /${VOLUME}/${BUCKET}
+                    Run Keyword if      "VOLUME_NOT_FOUND" in """${result}"""       Create volume
+                    Run Keyword if      "VOLUME_NOT_FOUND" in """${result}"""       Create bucket
+                    Run Keyword if      "BUCKET_NOT_FOUND" in """${result}"""       Create bucket
+    ${result} =     Execute             ozone sh bucket info /${VOLUME}/${BUCKET}
+                    Should not contain  ${result}  NOT_FOUND

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/createdirs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/createdirs.robot
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Create dirs and files
+Resource            ../ozone-lib/shell.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${SUFFIX}    ${EMPTY}
+${VOLUME}    volume1
+${BUCKET}    bucketfso1
+
+*** Test Cases ***
+Key Can Be Written
+    Create Key    /${VOLUME}/${BUCKET}/key-${SUFFIX}    /etc/passwd
+
+Dir Can Be Created
+    Execute    ozone fs -mkdir o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX}
+    Execute    ozone fs -mkdir o3fs://${BUCKET}.${VOLUME}/newdir-${SUFFIX}
+    FOR     ${INDEX}    IN RANGE    5
+        Execute    ozone fs -mkdir o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX}/subdir-0${INDEX}-${SUFFIX}
+    END
+
+Put Multiple Files
+    FOR     ${INDEX}    IN RANGE    5
+        Execute    ozone fs -put /etc/passwd o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX}/file-${INDEX}
+    END

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/delete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/delete.robot
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Delete Compatibility
+Resource            ../ozone-lib/shell.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${SUFFIX}    ${EMPTY}
+${VOLUME}    volume1
+${BUCKET}    bucketfso1
+
+*** Test Cases ***
+Delete Dir
+    Execute    ozone fs -rm -r -f -skipTrash o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX}/subdir-03-${SUFFIX}
+    Execute    ozone fs -rm -r -f -skipTrash o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/rename.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/rename.robot
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Rename Compatibility
+Resource            ../ozone-lib/shell.robot
+Test Timeout        5 minutes
+
+*** Variables ***
+${SUFFIX}    ${EMPTY}
+${VOLUME}    volume1
+${BUCKET}    bucketfso1
+
+*** Test Cases ***
+Rename Dir
+    Execute    ozone fs -mv o3fs://${BUCKET}.${VOLUME}/key-${SUFFIX} o3fs://${BUCKET}.${VOLUME}/newkey-${SUFFIX}
+    Execute    ozone fs -mv o3fs://${BUCKET}.${VOLUME}/dir-${SUFFIX} o3fs://${BUCKET}.${VOLUME}/newdir-${SUFFIX}
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

Suppose a new client creates a FSO type bucket and create set of files(for ex: /dir1/dir2/dir3/file-1, /dir1/dir2/dir3/file-2, /dir1/dir2/dir3/file-3, /dir1/dir2/dir3/file-4) into it.
Now old client(who hasn't upgraded to the newer version) should be able to perform rename/delete operations on the FSO type bucket created by the new client.
For ex:
#rename(/dir1/dir2, /dir1/newdir2)
#delete(/dir1).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5374

## How was this patch tested?

Added integration tests.