### PR TITLE
HDDS-5889. add suggested LeaderID in NotLeaderException in OM

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -732,6 +732,28 @@ public final class OzoneManagerRatisServer {
   }
 
   /**
+   * get RAFT leader ID.
+   *
+   * @return raft leader ID.
+   */
+  public String getLeaderAddress() {
+    String leaderAddress = null;
+    try {
+      RaftServer.Division division = server.getDivision(raftGroupId);
+      if (division != null) {
+        leaderAddress =
+            division.getInfo().getRoleInfoProto().getFollowerInfo()
+                .getLeaderInfo().getId().getAddress();
+      }
+    } catch (IOException ioe) {
+      // In this case we return not a leader.
+      LOG.warn("Fail to get RaftServer impl and therefore it's not clear " +
+          "whether it's leader. ", ioe);
+    }
+    return leaderAddress;
+  }
+
+  /**
    * Get list of peer NodeIds from Ratis.
    * @return List of Peer NodeId's.
    */

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -184,12 +184,14 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
 
   private ServiceException createNotLeaderException() {
     RaftPeerId raftPeerId = omRatisServer.getRaftPeerId();
-
-    // TODO: Set suggest leaderID. Right now, client is not using suggest
-    // leaderID. Need to fix this.
-
-    OMNotLeaderException notLeaderException =
-        new OMNotLeaderException(raftPeerId);
+    String leaderAddress = omRatisServer.getLeaderAddress();
+    OMNotLeaderException notLeaderException;
+    if (leaderAddress == null) {
+      notLeaderException = new OMNotLeaderException(raftPeerId);
+    } else {
+      notLeaderException =
+          new OMNotLeaderException(raftPeerId, leaderAddress);
+    }
 
     LOG.debug(notLeaderException.getMessage());
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

for now ,  ozone client will not fail over to leader if a notLeader exception is thrown，it just `performFailoverToNextProxy`
this patch adds suggested LeaderID in NotLeaderException , so that ozone client can fail over according to the suggested leader

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5889

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

current UT
