### PR TITLE
HDDS-5902 Ambiguous OM kerberos keytab settings

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -548,14 +548,6 @@
     </description>
   </property>
   <property>
-    <name>ozone.om.keytab.file</name>
-    <value/>
-    <tag>OM, SECURITY</tag>
-    <description>
-      The keytab file for Kerberos authentication in OM.
-    </description>
-  </property>
-  <property>
     <name>ozone.om.db.cache.size.mb</name>
     <value>128</value>
     <tag>OM, PERFORMANCE</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -66,8 +66,6 @@ public final class OMConfigKeys {
       "ozone.om.http-address";
   public static final String OZONE_OM_HTTPS_ADDRESS_KEY =
       "ozone.om.https-address";
-  public static final String OZONE_OM_KEYTAB_FILE =
-      "ozone.om.keytab.file";
   public static final String OZONE_OM_HTTP_BIND_HOST_DEFAULT = "0.0.0.0";
   public static final int OZONE_OM_HTTP_BIND_PORT_DEFAULT = 9874;
   public static final int OZONE_OM_HTTPS_BIND_PORT_DEFAULT = 9875;


### PR DESCRIPTION
## What changes were proposed in this pull request?

"ozone.om.keytab.file" configuration param is not used anymore and has been replaced by "ozone.om.kerberos.keytab.file". I removed unused param to improve clarity on configuration settings.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5902

## How was this patch tested?

all unit tests passed
