### PR TITLE
HDDS-5883 Change S3G client to set S3 Auth per req

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -752,4 +753,22 @@ public interface ClientProtocol {
    */
   OzoneKey headObject(String volumeName, String bucketName,
       String keyName) throws IOException;
+
+  /**
+   * Sets the S3 Authentication information for the requests executed on behalf
+   * of the S3 API implementation within Ozone.
+   * @param s3Authentication authentication information for each S3 API call.
+   */
+  void setTheadLocalS3Authentication(S3Authentication s3Authentication);
+
+  /**
+   * Gets the S3 Authentication information that is attached to the thread.
+   * @return S3 Authentication information.
+   */
+  S3Authentication getThreadLocalS3Authentication();
+
+  /**
+   * Clears the S3 Authentication information attached to the thread.
+   */
+  void clearTheadLocalS3Authentication();
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -48,7 +48,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
@@ -757,18 +757,18 @@ public interface ClientProtocol {
   /**
    * Sets the S3 Authentication information for the requests executed on behalf
    * of the S3 API implementation within Ozone.
-   * @param s3Authentication authentication information for each S3 API call.
+   * @param s3Auth authentication information for each S3 API call.
    */
-  void setTheadLocalS3Authentication(S3Authentication s3Authentication);
+  void setTheadLocalS3Auth(S3Auth s3Auth);
 
   /**
    * Gets the S3 Authentication information that is attached to the thread.
    * @return S3 Authentication information.
    */
-  S3Authentication getThreadLocalS3Authentication();
+  S3Auth getThreadLocalS3Auth();
 
   /**
    * Clears the S3 Authentication information attached to the thread.
    */
-  void clearTheadLocalS3Authentication();
+  void clearTheadLocalS3Auth();
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -105,7 +105,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerClientProtocol;
@@ -544,10 +544,10 @@ public class RpcClient implements ClientProtocol {
    * @return listOfAcls
    * */
   private List<OzoneAcl> getAclList() {
-    if (ozoneManagerClient.getThreadLocalS3Authentication() != null) {
+    if (ozoneManagerClient.getThreadLocalS3Auth() != null) {
       UserGroupInformation aclUgi =
           UserGroupInformation.createRemoteUser(
-             ozoneManagerClient.getThreadLocalS3Authentication().getAccessID());
+             ozoneManagerClient.getThreadLocalS3Auth().getAccessID());
       return OzoneAclUtil.getAclList(
           aclUgi.getUserName(),
           aclUgi.getGroupNames(),
@@ -1506,18 +1506,18 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void setTheadLocalS3Authentication(
-      S3Authentication ozoneSharedSecretAuth) {
-    ozoneManagerClient.setThreadLocalS3Authentication(ozoneSharedSecretAuth);
+  public void setTheadLocalS3Auth(
+      S3Auth ozoneSharedSecretAuth) {
+    ozoneManagerClient.setThreadLocalS3Auth(ozoneSharedSecretAuth);
   }
 
   @Override
-  public S3Authentication getThreadLocalS3Authentication() {
-    return ozoneManagerClient.getThreadLocalS3Authentication();
+  public S3Auth getThreadLocalS3Auth() {
+    return ozoneManagerClient.getThreadLocalS3Auth();
   }
 
   @Override
-  public void clearTheadLocalS3Authentication() {
-    ozoneManagerClient.clearThreadLocalS3Authentication();
+  public void clearTheadLocalS3Auth() {
+    ozoneManagerClient.clearThreadLocalS3Auth();
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -105,8 +105,10 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransportFactory;
+import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerClientProtocol;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.security.GDPRSymmetricKey;
@@ -147,7 +149,7 @@ public class RpcClient implements ClientProtocol {
       LoggerFactory.getLogger(RpcClient.class);
 
   private final ConfigurationSource conf;
-  private final OzoneManagerProtocol ozoneManagerClient;
+  private final OzoneManagerClientProtocol ozoneManagerClient;
   private final XceiverClientFactory xceiverClientManager;
   private final int chunkSize;
   private final UserGroupInformation ugi;
@@ -183,11 +185,10 @@ public class RpcClient implements ClientProtocol {
     this.clientConfig = conf.getObject(OzoneClientConfig.class);
 
     OmTransport omTransport = createOmTransport(omServiceId);
-
     this.ozoneManagerClient = TracingUtil.createProxy(
         new OzoneManagerProtocolClientSideTranslatorPB(omTransport,
             clientId.toString()),
-        OzoneManagerProtocol.class, conf
+        OzoneManagerClientProtocol.class, conf
     );
     dtService = omTransport.getDelegationTokenService();
     ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
@@ -543,6 +544,15 @@ public class RpcClient implements ClientProtocol {
    * @return listOfAcls
    * */
   private List<OzoneAcl> getAclList() {
+    if (ozoneManagerClient.getThreadLocalS3Authentication() != null) {
+      UserGroupInformation aclUgi =
+          UserGroupInformation.createRemoteUser(
+             ozoneManagerClient.getThreadLocalS3Authentication().getAccessID());
+      return OzoneAclUtil.getAclList(
+          aclUgi.getUserName(),
+          aclUgi.getGroupNames(),
+         userRights, groupRights);
+    }
     return OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
         userRights, groupRights);
   }
@@ -782,7 +792,6 @@ public class RpcClient implements ClientProtocol {
         .addAllMetadata(metadata)
         .setAcls(getAclList())
         .setLatestVersionLocation(getLatestVersionLocation);
-
     if (Boolean.parseBoolean(metadata.get(OzoneConsts.GDPR_FLAG))) {
       try{
         GDPRSymmetricKey gKey = new GDPRSymmetricKey(new SecureRandom());
@@ -1494,5 +1503,21 @@ public class RpcClient implements ClientProtocol {
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
         keyInfo.getModificationTime(), keyInfo.getReplicationConfig());
 
+  }
+
+  @Override
+  public void setTheadLocalS3Authentication(
+      S3Authentication ozoneSharedSecretAuth) {
+    ozoneManagerClient.setThreadLocalS3Authentication(ozoneSharedSecretAuth);
+  }
+
+  @Override
+  public S3Authentication getThreadLocalS3Authentication() {
+    return ozoneManagerClient.getThreadLocalS3Authentication();
+  }
+
+  @Override
+  public void clearTheadLocalS3Authentication() {
+    ozoneManagerClient.clearThreadLocalS3Authentication();
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Auth.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Auth.java
@@ -18,15 +18,15 @@
 package org.apache.hadoop.ozone.om.protocol;
 
 /**
- * S3Authentication wraps the data needed for S3 Authentication.
+ * S3Auth wraps the data needed for S3 Authentication.
  */
-public class S3Authentication {
+public class S3Auth {
   private String stringToSign;
   private String signature;
   private String accessID;
 
-  public S3Authentication(final String stringToSign,
-                          final String signature, final String accessID) {
+  public S3Auth(final String stringToSign,
+                final String signature, final String accessID) {
     this.accessID = accessID;
     this.stringToSign = stringToSign;
     this.signature = signature;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Authentication.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Authentication.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.protocol;
+
+/**
+ * S3Authentication wraps the data needed for S3 Authentication.
+ */
+public class S3Authentication {
+  private String stringToSign;
+  private String signature;
+  private String accessID;
+
+  public S3Authentication(final String stringToSign,
+                          final String signature, final String accessID) {
+    this.accessID = accessID;
+    this.stringToSign = stringToSign;
+    this.signature = signature;
+  }
+  public String getStringTosSign() {
+    return stringToSign;
+  }
+
+  public String getSignature() {
+    return signature;
+  }
+
+  public String getAccessID() {
+    return accessID;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerClientProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerClientProtocol.java
@@ -19,7 +19,7 @@
 package org.apache.hadoop.ozone.om.protocolPB;
 
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 
 /**
  * OzoneManagerClientProtocol defines interfaces needed on the client side
@@ -32,7 +32,7 @@ public interface OzoneManagerClientProtocol extends OzoneManagerProtocol {
    * authentication information on a per-request basis which is attached as
    * a thread local variable.
    */
-  void setThreadLocalS3Authentication(S3Authentication ozoneSharedSecretAuth);
-  S3Authentication getThreadLocalS3Authentication();
-  void clearThreadLocalS3Authentication();
+  void setThreadLocalS3Auth(S3Auth s3Auth);
+  S3Auth getThreadLocalS3Auth();
+  void clearThreadLocalS3Auth();
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerClientProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerClientProtocol.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.protocolPB;
+
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+
+/**
+ * OzoneManagerClientProtocol defines interfaces needed on the client side
+ * when communicating with Ozone Manager.
+ */
+public interface OzoneManagerClientProtocol extends OzoneManagerProtocol {
+  /**
+   * Sets the S3 Authentication information when OM request is generated as
+   * part of the S3 API implementation from Ozone. S3 Gateway needs to add
+   * authentication information on a per-request basis which is attached as
+   * a thread local variable.
+   */
+  void setThreadLocalS3Authentication(S3Authentication ozoneSharedSecretAuth);
+  S3Authentication getThreadLocalS3Authentication();
+  void clearThreadLocalS3Authentication();
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -56,7 +56,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
@@ -177,7 +177,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private final String clientID;
 
   private OmTransport transport;
-  private ThreadLocal<S3Authentication> threadLocalS3Authentication
+  private ThreadLocal<S3Auth> threadLocalS3Auth
       = new ThreadLocal<>();
   public OzoneManagerProtocolClientSideTranslatorPB(OmTransport omTransport,
       String clientId) {
@@ -226,16 +226,15 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       throws IOException {
     OMRequest.Builder  builder = OMRequest.newBuilder(omRequest);
     // Insert S3 Authentication information for each request.
-    if (getThreadLocalS3Authentication() != null) {
+    if (getThreadLocalS3Auth() != null) {
       builder.setS3Authentication(
-          org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
-              S3Authentication.newBuilder()
+          S3Authentication.newBuilder()
               .setSignature(
-                  threadLocalS3Authentication.get().getSignature())
+                  threadLocalS3Auth.get().getSignature())
               .setStringToSign(
-                  threadLocalS3Authentication.get().getStringTosSign())
+                  threadLocalS3Auth.get().getStringTosSign())
               .setAccessId(
-                  threadLocalS3Authentication.get().getAccessID())
+                  threadLocalS3Auth.get().getAccessID())
               .build());
     }
     OMResponse response =
@@ -1274,17 +1273,17 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public void setThreadLocalS3Authentication(
-      S3Authentication ozoneSharedSecretAuth) {
-    this.threadLocalS3Authentication.set(ozoneSharedSecretAuth);
+  public void setThreadLocalS3Auth(
+      S3Auth s3Auth) {
+    this.threadLocalS3Auth.set(s3Auth);
   }
   @Override
-  public void clearThreadLocalS3Authentication() {
-    this.threadLocalS3Authentication.remove();
+  public void clearThreadLocalS3Auth() {
+    this.threadLocalS3Auth.remove();
   }
   @Override
-  public S3Authentication getThreadLocalS3Authentication() {
-    return this.threadLocalS3Authentication.get();
+  public S3Auth getThreadLocalS3Auth() {
+    return this.threadLocalS3Auth.get();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -25,9 +25,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos
     .UpgradeFinalizationStatus;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.Text;
@@ -56,7 +56,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockRequest;
@@ -172,12 +172,13 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 
 @InterfaceAudience.Private
 public final class OzoneManagerProtocolClientSideTranslatorPB
-    implements OzoneManagerProtocol {
+    implements OzoneManagerClientProtocol {
 
   private final String clientID;
 
   private OmTransport transport;
-
+  private ThreadLocal<S3Authentication> threadLocalS3Authentication
+      = new ThreadLocal<>();
   public OzoneManagerProtocolClientSideTranslatorPB(OmTransport omTransport,
       String clientId) {
     this.clientID = clientId;
@@ -223,11 +224,24 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    */
   private OMResponse submitRequest(OMRequest omRequest)
       throws IOException {
-    OMRequest payload = OMRequest.newBuilder(omRequest)
-        .setTraceID(TracingUtil.exportCurrentSpan())
-        .build();
-
-    return transport.submitRequest(payload);
+    OMRequest.Builder  builder = OMRequest.newBuilder(omRequest);
+    // Insert S3 Authentication information for each request.
+    if (getThreadLocalS3Authentication() != null) {
+      builder.setS3Authentication(
+          org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
+              S3Authentication.newBuilder()
+              .setSignature(
+                  threadLocalS3Authentication.get().getSignature())
+              .setStringToSign(
+                  threadLocalS3Authentication.get().getStringTosSign())
+              .setAccessId(
+                  threadLocalS3Authentication.get().getAccessID())
+              .build());
+    }
+    OMResponse response =
+        transport.submitRequest(
+            builder.setTraceID(TracingUtil.exportCurrentSpan()).build());
+    return response;
   }
 
   /**
@@ -1257,6 +1271,20 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
       throw new OMException("Cancel delegation token failed.", e,
           TOKEN_ERROR_OTHER);
     }
+  }
+
+  @Override
+  public void setThreadLocalS3Authentication(
+      S3Authentication ozoneSharedSecretAuth) {
+    this.threadLocalS3Authentication.set(ozoneSharedSecretAuth);
+  }
+  @Override
+  public void clearThreadLocalS3Authentication() {
+    this.threadLocalS3Authentication.remove();
+  }
+  @Override
+  public S3Authentication getThreadLocalS3Authentication() {
+    return this.threadLocalS3Authentication.get();
   }
 
   /**

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1346,7 +1346,7 @@ message UpdateGetS3SecretRequest {
 }
 
 /**
-  This will be used by OM to authenicate S3 gateway requests on a per request basis.
+  This will be used by OM to authenticate S3 gateway requests on a per request basis.
 */
 message S3Authentication {
     optional string stringToSign = 1;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo.Version;
@@ -81,10 +81,10 @@ public class OzoneClientProducer {
 
   @PreDestroy
   public void destroy() throws IOException {
-    client.getObjectStore().getClientProxy().clearTheadLocalS3Authentication();
+    client.getObjectStore().getClientProxy().clearTheadLocalS3Auth();
   }
   @Produces
-  public S3Authentication getSignature() {
+  public S3Auth getSignature() {
     try {
       SignatureInfo signatureInfo = signatureProcessor.parseSignature();
       String stringToSign = "";
@@ -95,7 +95,7 @@ public class OzoneClientProducer {
 
       String awsAccessId = signatureInfo.getAwsAccessId();
       validateAccessId(awsAccessId);
-      return new S3Authentication(stringToSign,
+      return new S3Auth(stringToSign,
           signatureInfo.getSignature(),
           awsAccessId);
     } catch (OS3Exception ex) {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -25,30 +25,24 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.security.PrivilegedExceptionAction;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo.Version;
 import org.apache.hadoop.ozone.s3.signature.SignatureProcessor;
 import org.apache.hadoop.ozone.s3.signature.StringToSignProducer;
-import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
-import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.token.Token;
-
-import com.google.common.annotations.VisibleForTesting;
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 
 /**
  * This class creates the OzoneClient for the Rest endpoints.
@@ -59,7 +53,7 @@ public class OzoneClientProducer {
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneClientProducer.class);
 
-  private OzoneClient client;
+  private static OzoneClient client;
 
   @Inject
   private SignatureProcessor signatureProcessor;
@@ -77,23 +71,22 @@ public class OzoneClientProducer {
   private ContainerRequestContext context;
 
   @Produces
-  public OzoneClient createClient() throws WebApplicationException,
+  public synchronized OzoneClient createClient() throws WebApplicationException,
       IOException {
-    client = getClient(ozoneConfiguration);
+    if (client == null) {
+      client = createOzoneClient();
+    }
     return client;
   }
 
   @PreDestroy
   public void destroy() throws IOException {
-    client.close();
+    client.getObjectStore().getClientProxy().clearTheadLocalS3Authentication();
   }
-
-  private OzoneClient getClient(OzoneConfiguration config)
-      throws WebApplicationException {
-    OzoneClient ozoneClient = null;
+  @Produces
+  public S3Authentication getSignature() {
     try {
       SignatureInfo signatureInfo = signatureProcessor.parseSignature();
-
       String stringToSign = "";
       if (signatureInfo.getVersion() == Version.V4) {
         stringToSign =
@@ -102,48 +95,18 @@ public class OzoneClientProducer {
 
       String awsAccessId = signatureInfo.getAwsAccessId();
       validateAccessId(awsAccessId);
-
-      UserGroupInformation remoteUser =
-          UserGroupInformation.createRemoteUser(awsAccessId);
-      if (OzoneSecurityUtil.isSecurityEnabled(config)) {
-        LOG.debug("Creating s3 auth info for client.");
-
-        if (signatureInfo.getVersion() == Version.NONE) {
-          throw MALFORMED_HEADER;
-        }
-
-        OzoneTokenIdentifier identifier = new OzoneTokenIdentifier();
-        identifier.setTokenType(S3AUTHINFO);
-        identifier.setStrToSign(stringToSign);
-        identifier.setSignature(signatureInfo.getSignature());
-        identifier.setAwsAccessId(awsAccessId);
-        identifier.setOwner(new Text(awsAccessId));
-        LOG.trace("Adding token for service:{}", omService);
-
-        Token<OzoneTokenIdentifier> token = new Token(identifier.getBytes(),
-            identifier.getSignature().getBytes(StandardCharsets.UTF_8),
-            identifier.getKind(),
-            omService);
-        remoteUser.addToken(token);
-
-      }
-      ozoneClient =
-          remoteUser.doAs((PrivilegedExceptionAction<OzoneClient>) () -> {
-            return createOzoneClient();
-          });
+      return new S3Authentication(stringToSign,
+          signatureInfo.getSignature(),
+          awsAccessId);
     } catch (OS3Exception ex) {
       LOG.debug("Error during Client Creation: ", ex);
       throw wrapOS3Exception(ex);
-    } catch(InterruptedException ex){
-      LOG.debug("Error during Client Creation: ", ex);
-      Thread.currentThread().interrupt();
     } catch (Exception e) {
       // For any other critical errors during object creation throw Internal
       // error.
       LOG.debug("Error during Client Creation: ", e);
       throw wrapOS3Exception(INTERNAL_ERROR);
     }
-    return ozoneClient;
   }
 
   @NotNull

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -602,4 +602,9 @@ public class BucketEndpoint extends EndpointBase {
     keyMetadata.setLastModified(next.getModificationTime());
     response.addKey(keyMetadata);
   }
+
+  @Override
+  public void init() {
+
+  }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
-import org.apache.hadoop.ozone.om.protocol.S3Authentication;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -46,7 +46,7 @@ public abstract class EndpointBase {
   @Inject
   private OzoneClient client;
   @Inject
-  private S3Authentication s3Authentication;
+  private S3Auth s3Auth;
   private static final Logger LOG =
       LoggerFactory.getLogger(EndpointBase.class);
 
@@ -71,10 +71,10 @@ public abstract class EndpointBase {
    */
   @PostConstruct
   public void initialization() {
-    LOG.debug("S3 access id: {}", s3Authentication.getAccessID());
+    LOG.debug("S3 access id: {}", s3Auth.getAccessID());
     getClient().getObjectStore().
         getClientProxy().
-        setTheadLocalS3Authentication(s3Authentication);
+        setTheadLocalS3Auth(s3Auth);
     init();
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.s3.endpoint;
 
+import javax.annotation.PostConstruct;
 import javax.inject.Inject;
 import java.io.IOException;
 import java.util.Collections;
@@ -29,18 +30,25 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
+import org.apache.hadoop.ozone.om.protocol.S3Authentication;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Basic helpers for all the REST endpoints.
  */
-public class EndpointBase {
+public abstract class EndpointBase {
 
   @Inject
   private OzoneClient client;
+  @Inject
+  private S3Authentication s3Authentication;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(EndpointBase.class);
 
   protected OzoneBucket getBucket(OzoneVolume volume, String bucketName)
       throws OS3Exception, IOException {
@@ -56,6 +64,21 @@ public class EndpointBase {
     }
     return bucket;
   }
+
+  /**
+   * Initializes the object post construction. Calls init() from any
+   * child classes to work around the issue of only one method can be annotated.
+   */
+  @PostConstruct
+  public void initialization() {
+    LOG.debug("S3 access id: {}", s3Authentication.getAccessID());
+    getClient().getObjectStore().
+        getClientProxy().
+        setTheadLocalS3Authentication(s3Authentication);
+    init();
+  }
+
+  public abstract void init();
 
   protected OzoneBucket getBucket(String bucketName)
       throws OS3Exception, IOException {
@@ -170,5 +193,9 @@ public class EndpointBase {
   @VisibleForTesting
   public void setClient(OzoneClient ozoneClient) {
     this.client = ozoneClient;
+  }
+
+  public OzoneClient getClient() {
+    return client;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -119,6 +119,7 @@ public class ObjectEndpoint extends EndpointBase {
   @Context
   private HttpHeaders headers;
 
+
   private List<String> customizableGetHeaders = new ArrayList<>();
   private int bufferSize;
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -62,4 +62,9 @@ public class RootEndpoint extends EndpointBase {
 
     return Response.ok(response).build();
   }
+
+  @Override
+  public void init() {
+
+  }
 }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.ozone.s3;
 
-import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
+import java.io.IOException;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -128,7 +128,7 @@ public class TestOzoneClientProducer {
       producer.createClient();
       fail("testGetClientFailure");
     } catch (Exception ex) {
-      Assert.assertTrue(ex instanceof WebApplicationException);
+      Assert.assertTrue(ex instanceof IOException);
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3G client will now set the S3 Auth information for
each OM Request. S3G itself will authenticate as S3G
identity registered with Kerberos but Request
Processing should be done via the S3 Auth set in the
protobuf request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5883

## How was this patch tested?

This was tested with code for 
https://issues.apache.org/jira/browse/HDDS-5884 and
https://issues.apache.org/jira/browse/HDDS-5885
Objects created were inspected in the OM DB. Objects were created using OM's key tab 
``` "fileName": "key2",
  "acls": [
    {
      "type": "USER",
      "name": "om/om@EXAMPLE.COM",
      "aclBitSet": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        1
      ],
      "aclScope": "ACCESS"
    },
    {
      "type": "GROUP",
      "name": "root",
      "aclBitSet": [
        0,
        0,
        0,
        0,
        0,
        0,
        0,
        1
      ],
      "aclScope": "ACCESS"
    }
  ],
  "parentObjectID": 0,
  "objectID": -9223372036854773504,
  "updateID": 11,
  "metadata": {}
}
```