### PR TITLE
HDDS-5901. Delete on volume/bucket throws fatal error on ofs

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OFSPath.java
@@ -316,7 +316,8 @@ public class OFSPath {
    */
   public Path getTrashRoot() {
     if (!this.isKey()) {
-      throw new RuntimeException("Volume or bucket doesn't have trash root.");
+      throw new RuntimeException("Recursive rm of volume or bucket with trash" +
+          " enabled is not permitted. Consider using the -skipTrash option.");
     }
     try {
       final String username =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recursive delete `ozone fs -rm -R ofs://ozone1/absdf`
on a volume or bucket gives the following fatal error as no trash is configured at root level.

> -rm: Fatal internal error
> java.lang.RuntimeException: Volume or bucket doesn't have trash root.
> 	at org.apache.hadoop.ozone.OFSPath.getTrashRoot(OFSPath.java:298)
> 	at org.apache.hadoop.fs.ozone.BasicRootedOzoneFileSystem.getTrashRoot(BasicRootedOzoneFileSystem.java:727)
> 	at org.apache.hadoop.fs.TrashPolicyDefault.moveToTrash(TrashPolicyDefault.java:134)
> 	at org.apache.hadoop.fs.Trash.moveToTrash(Trash.java:110)
> 	at org.apache.hadoop.fs.Trash.moveToAppropriateTrash(Trash.java:96)
> 	at org.apache.hadoop.fs.shell.Delete$Rm.moveToTrash(Delete.java:153)
> 	at org.apache.hadoop.fs.shell.Delete$Rm.processPath(Delete.java:118)
> 	at org.apache.hadoop.fs.shell.Command.processPathInternal(Command.java:367)
> 	at org.apache.hadoop.fs.shell.Command.processPaths(Command.java:331)
> 	at org.apache.hadoop.fs.shell.Command.processPathArgument(Command.java:304)
> 	at org.apache.hadoop.fs.shell.Command.processArgument(Command.java:286)
> 	at org.apache.hadoop.fs.shell.Command.processArguments(Command.java:270)
> 	at org.apache.hadoop.fs.shell.FsCommand.processRawArguments(FsCommand.java:120)
> 	at org.apache.hadoop.fs.shell.Command.run(Command.java:177)
> 	at org.apache.hadoop.fs.FsShell.run(FsShell.java:328)
> 	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
> 	at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:90)
> 	at org.apache.hadoop.fs.ozone.OzoneFsShell.main(OzoneFsShell.java:81)
> 
> 

This patch changes the Fatal error message: 

> Volume or bucket doesn't have trash root.

to something a bit more user friendly:

> Recursive rm of volume or bucket with trash enabled is not permitted. Consider using the -skipTrash option. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5901#

## How was this patch tested?

Manual testing using Docker compose.

<img width="1339" alt="image" src="https://user-images.githubusercontent.com/34305492/139058306-e99edccd-3d8e-4356-9d5a-9058fd1fcc4a.png">

