### PR TITLE
HDDS-5885. OM Auth Validate for read requests and handle non ratis enabled code.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateVolumeRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.InfoVolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
@@ -259,7 +260,28 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     OMResponse omResponse = cluster.getOzoneManager().getOmServerProtocol()
         .submitRequest(null, omRequest);
 
+    // Read Request
+    omRequest = OMRequest.newBuilder()
+        .setCmdType(OzoneManagerProtocolProtos.Type.InfoVolume)
+        .setVersion(CURRENT_VERSION)
+        .setClientId(UUID.randomUUID().toString())
+        .setInfoVolumeRequest(InfoVolumeRequest.newBuilder()
+            .setVolumeName(volumeName).build())
+        .setS3Authentication(S3Authentication.newBuilder()
+            .setAccessId(accessKey)
+            .setSignature(signature).setStringToSign(strToSign))
+        .build();
     Assert.assertTrue(omResponse.getStatus() == Status.OK);
+
+    // Verify response.
+    VolumeInfo volumeInfo = omResponse.getInfoVolumeResponse().getVolumeInfo();
+    Assert.assertNotNull(volumeInfo);
+    Assert.assertEquals(volumeName, volumeInfo.getVolume());
+    Assert.assertEquals(accessKey, volumeInfo.getAdminName());
+    Assert.assertEquals(accessKey, volumeInfo.getOwnerName());
+
+    cluster.getOzoneManager().getOmServerProtocol()
+        .submitRequest(null, omRequest);
 
 
     // Override secret to S3Secret table with some dummy value

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/S3SecurityUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/S3SecurityUtil.java
@@ -50,20 +50,18 @@ public final class S3SecurityUtil {
   public static void validateS3Credential(OMRequest omRequest,
       OzoneManager ozoneManager) throws OMException {
     if (ozoneManager.isSecurityEnabled()) {
-      if (omRequest.hasS3Authentication()) {
-        OzoneTokenIdentifier s3Token = constructS3Token(omRequest);
-        try {
-          // authenticate user with signature verification through
-          // delegationTokenMgr validateToken via retrievePassword
-          ozoneManager.getDelegationTokenMgr().retrievePassword(s3Token);
-        } catch (SecretManager.InvalidToken e) {
-          // TODO: Just check are we okay to log enitre token in failure case.
-          OzoneManagerProtocolServerSideTranslatorPB.getLog().error(
-              "signatures do NOT match for S3 identifier:{}", s3Token, e);
-          throw new OMException("User " + s3Token.getAwsAccessId()
-              + " request authorization failure: signatures do NOT match",
-              INVALID_TOKEN);
-        }
+      OzoneTokenIdentifier s3Token = constructS3Token(omRequest);
+      try {
+        // authenticate user with signature verification through
+        // delegationTokenMgr validateToken via retrievePassword
+        ozoneManager.getDelegationTokenMgr().retrievePassword(s3Token);
+      } catch (SecretManager.InvalidToken e) {
+        // TODO: Just check are we okay to log enitre token in failure case.
+        OzoneManagerProtocolServerSideTranslatorPB.getLog().error(
+            "signatures do NOT match for S3 identifier:{}", s3Token, e);
+        throw new OMException("User " + s3Token.getAwsAccessId()
+            + " request authorization failure: signatures do NOT match",
+            INVALID_TOKEN);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When OMRequest has S3Authentication for read requests validate S3Authentication and then proceed with processing the request.

Note: This PR is dependent on HDDS-5884, for ease of review included HDDS-5884.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5884

## How was this patch tested?

Added tests
