### PR TITLE
HDDS-5906. Fix DBScanner to support Datanode DB

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeSchemaOneDBDefinition.java
@@ -68,7 +68,7 @@ public class DatanodeSchemaOneDBDefinition
             ChunkInfoList.class,
             new SchemaOneChunkInfoListCodec());
 
-  protected DatanodeSchemaOneDBDefinition(String dbPath) {
+  public DatanodeSchemaOneDBDefinition(String dbPath) {
     super(dbPath);
   }
 
@@ -91,7 +91,7 @@ public class DatanodeSchemaOneDBDefinition
 
   @Override
   public DBColumnFamilyDefinition[] getColumnFamilies() {
-    return new DBColumnFamilyDefinition[] {getBlockDataColumnFamily(),
-        getMetadataColumnFamily(), getDeletedBlocksColumnFamily() };
+    return new DBColumnFamilyDefinition[] {getMetadataColumnFamily(),
+        getDeletedBlocksColumnFamily(), getBlockDataColumnFamily()};
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBDefinitionFactory.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaOneDBDefinition;
 import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaTwoDBDefinition;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.recon.scm.ReconSCMDBDefinition;
@@ -43,6 +44,8 @@ public final class DBDefinitionFactory {
   }
 
   private static HashMap<String, DBDefinition> dbMap;
+
+  private static String dnDBSchemaVersion;
 
   static {
     dbMap = new HashMap<>();
@@ -70,8 +73,14 @@ public final class DBDefinitionFactory {
     }
     String dbName = fileName.toString();
     if (dbName.endsWith("-container.db")) {
-      return new DatanodeSchemaTwoDBDefinition(
-          dbPath.toAbsolutePath().toString());
+      switch (dnDBSchemaVersion) {
+      case "V1":
+        return new DatanodeSchemaOneDBDefinition(
+            dbPath.toAbsolutePath().toString());
+      default:
+        return new DatanodeSchemaTwoDBDefinition(
+            dbPath.toAbsolutePath().toString());
+      }
     }
     return getDefinition(dbName);
   }
@@ -83,5 +92,9 @@ public final class DBDefinitionFactory {
       return new OMDBDefinition();
     }
     return null;
+  }
+
+  public static void setDnDBSchemaVersion(String dnDBSchemaVersion) {
+    DBDefinitionFactory.dnDBSchemaVersion = dnDBSchemaVersion;
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/DBScanner.java
@@ -75,6 +75,11 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
       description = "File to dump table scan data")
   private static String fileName;
 
+  @CommandLine.Option(names = {"--dnSchema", "-d"},
+      description = "Datanode DB Schema Version : V1/V2",
+      defaultValue = "V2")
+  private static String dnDBSchemaVersion;
+
   @CommandLine.ParentCommand
   private RDBParser parent;
 
@@ -209,6 +214,7 @@ public class DBScanner implements Callable<Void>, SubcommandWithParent {
                   " number is -1 which is to dump entire table");
     }
     dbPath = removeTrailingSlashIfNeeded(dbPath);
+    DBDefinitionFactory.setDnDBSchemaVersion(dnDBSchemaVersion);
     this.constructColumnFamilyMap(DBDefinitionFactory.
             getDefinition(Paths.get(dbPath)));
     if (this.columnFamilyMap !=null) {

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/debug/TestDBDefinitionFactory.java
@@ -22,6 +22,7 @@ import java.nio.file.Paths;
 
 import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.utils.db.DBDefinition;
+import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaOneDBDefinition;
 import org.apache.hadoop.ozone.container.metadata.DatanodeSchemaTwoDBDefinition;
 import org.apache.hadoop.ozone.om.codec.OMDBDefinition;
 import org.apache.hadoop.ozone.recon.scm.ReconSCMDBDefinition;
@@ -58,9 +59,13 @@ public class TestDBDefinitionFactory {
     definition = DBDefinitionFactory.getDefinition(
         RECON_CONTAINER_KEY_DB + "_1");
     assertTrue(definition instanceof ReconDBDefinition);
-
+    DBDefinitionFactory.setDnDBSchemaVersion("V2");
     definition =
         DBDefinitionFactory.getDefinition(Paths.get("/tmp/test-container.db"));
     assertTrue(definition instanceof DatanodeSchemaTwoDBDefinition);
+    DBDefinitionFactory.setDnDBSchemaVersion("V1");
+    definition =
+        DBDefinitionFactory.getDefinition(Paths.get("/tmp/test-container.db"));
+    assertTrue(definition instanceof DatanodeSchemaOneDBDefinition);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently the LDB DBScanner Tool only supports DatanodeDBDefinition Schema V2. The aim here is to support both schemas V1 and V2.

## What is the link to the Apache JIRA?
https://issues.apache.org/jira/browse/HDDS-5906

## How was this patch tested?
`bin/ozone debug ldb --db=/Users/sadanand.shenoy/4-dn-container.db scan --column_family=default -d=V1
`
<img width="1785" alt="Screenshot 2021-10-28 at 11 42 15 AM" src="https://user-images.githubusercontent.com/31859223/139197477-3b46498c-5a81-4322-bc01-a604873e15d3.png">

