### PR TITLE
HDDS-5897. Support configuration for including/excluding datanodes for balancing

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -344,12 +344,11 @@ public final class ContainerBalancerConfiguration {
    * @throws IOException if an I/O error occurs when opening the file
    */
   public void setIncludeNodes(File includeNodes) throws IOException {
-    try (Stream<String> strings = Files.lines(includeNodes.toPath(),
-        StandardCharsets.UTF_8)) {
-      this.includeNodes = strings.collect(Collectors.joining(","));
+    try {
+      this.includeNodes = readFile(includeNodes);
     } catch (IOException e) {
-      LOG.debug("Could not read the specified includeNodes file.");
-      throw new IOException(e);
+      LOG.info("Could not read includeNodes file: {}.", includeNodes.getPath());
+      throw e;
     }
   }
 
@@ -383,12 +382,11 @@ public final class ContainerBalancerConfiguration {
    * @throws IOException if an I/O error occurs when opening the file
    */
   public void setExcludeNodes(File excludeNodes) throws IOException {
-    try (Stream<String> strings = Files.lines(excludeNodes.toPath(),
-        StandardCharsets.UTF_8)) {
-      this.excludeNodes = strings.collect(Collectors.joining(","));
+    try {
+      this.excludeNodes = readFile(excludeNodes);
     } catch (IOException e) {
-      LOG.debug("Could not read the specified excludeNodes file.");
-      throw new IOException(e);
+      LOG.info("Could not read excludeNodes file: {}.", excludeNodes.getPath());
+      throw e;
     }
   }
 
@@ -399,6 +397,13 @@ public final class ContainerBalancerConfiguration {
    */
   public OzoneConfiguration getOzoneConfiguration() {
     return this.ozoneConfiguration;
+  }
+
+  private String readFile(File file) throws IOException {
+    try (Stream<String> strings = Files.lines(file.toPath(),
+        StandardCharsets.UTF_8)) {
+      return strings.collect(Collectors.joining(","));
+    }
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -32,6 +32,10 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,6 +43,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This class contains configuration values for the ContainerBalancer.
@@ -333,6 +338,22 @@ public final class ContainerBalancerConfiguration {
   }
 
   /**
+   * Sets the datanodes that will be the exclusive participants in balancing.
+   * Applicable only if the specified file is non-empty.
+   * @param includeNodes a File of datanode hostnames or ip addresses
+   * @throws IOException if an I/O error occurs when opening the file
+   */
+  public void setIncludeNodes(File includeNodes) throws IOException {
+    try (Stream<String> strings = Files.lines(includeNodes.toPath(),
+        StandardCharsets.UTF_8)) {
+      this.includeNodes = strings.collect(Collectors.joining(","));
+    } catch (IOException e) {
+      LOG.debug("Could not read the specified includeNodes file.");
+      throw new IOException(e);
+    }
+  }
+
+  /**
    * Gets a set of datanode hostnames or ip addresses that will be excluded
    * from balancing.
    * @return Set of hostname or ip address strings, or an empty set if the
@@ -354,6 +375,21 @@ public final class ContainerBalancerConfiguration {
    */
   public void setExcludeNodes(String excludeNodes) {
     this.excludeNodes = excludeNodes;
+  }
+
+  /**
+   * Sets the datanodes that will be excluded from balancing.
+   * @param excludeNodes a File of datanode hostnames or ip addresses
+   * @throws IOException if an I/O error occurs when opening the file
+   */
+  public void setExcludeNodes(File excludeNodes) throws IOException {
+    try (Stream<String> strings = Files.lines(excludeNodes.toPath(),
+        StandardCharsets.UTF_8)) {
+      this.excludeNodes = strings.collect(Collectors.joining(","));
+    } catch (IOException e) {
+      LOG.debug("Could not read the specified excludeNodes file.");
+      throw new IOException(e);
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -32,10 +32,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,7 +39,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * This class contains configuration values for the ContainerBalancer.
@@ -338,21 +333,6 @@ public final class ContainerBalancerConfiguration {
   }
 
   /**
-   * Sets the datanodes that will be the exclusive participants in balancing.
-   * Applicable only if the specified file is non-empty.
-   * @param includeNodes a File of datanode hostnames or ip addresses
-   * @throws IOException if an I/O error occurs when opening the file
-   */
-  public void setIncludeNodes(File includeNodes) throws IOException {
-    try {
-      this.includeNodes = readFile(includeNodes);
-    } catch (IOException e) {
-      LOG.info("Could not read includeNodes file: {}.", includeNodes.getPath());
-      throw e;
-    }
-  }
-
-  /**
    * Gets a set of datanode hostnames or ip addresses that will be excluded
    * from balancing.
    * @return Set of hostname or ip address strings, or an empty set if the
@@ -377,33 +357,12 @@ public final class ContainerBalancerConfiguration {
   }
 
   /**
-   * Sets the datanodes that will be excluded from balancing.
-   * @param excludeNodes a File of datanode hostnames or ip addresses
-   * @throws IOException if an I/O error occurs when opening the file
-   */
-  public void setExcludeNodes(File excludeNodes) throws IOException {
-    try {
-      this.excludeNodes = readFile(excludeNodes);
-    } catch (IOException e) {
-      LOG.info("Could not read excludeNodes file: {}.", excludeNodes.getPath());
-      throw e;
-    }
-  }
-
-  /**
    * Gets the {@link OzoneConfiguration} using which this configuration was
    * constructed.
    * @return the {@link OzoneConfiguration} being used by this configuration
    */
   public OzoneConfiguration getOzoneConfiguration() {
     return this.ozoneConfiguration;
-  }
-
-  private String readFile(File file) throws IOException {
-    try (Stream<String> strings = Files.lines(file.toPath(),
-        StandardCharsets.UTF_8)) {
-      return strings.collect(Collectors.joining(","));
-    }
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -109,6 +109,20 @@ public final class ContainerBalancerConfiguration {
       "iteration of Container Balancer.")
   private long balancingInterval;
 
+  @Config(key = "include.datanodes", type = ConfigType.STRING, defaultValue =
+      "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +
+      "hostnames or ip addresses separated by commas. Only the Datanodes " +
+      "specified in this list are balanced. This configuration is empty by " +
+      "default.")
+  private String includeNodes = "";
+
+  @Config(key = "exclude.datanodes", type = ConfigType.STRING, defaultValue =
+      "", tags = ConfigTag.BALANCER, description = "A list of Datanode " +
+      "hostnames or ip addresses separated by commas. The Datanodes specified" +
+      " in this list are excluded from balancing. This configuration is empty" +
+      " by default.")
+  private String excludeNodes = "";
+
   private DUFactory.Conf duConf;
 
   /**
@@ -290,6 +304,42 @@ public final class ContainerBalancerConfiguration {
       LOG.warn("Balancing interval duration must be greater than du refresh " +
           "period, {} milliseconds", duConf.getRefreshPeriod().toMillis());
     }
+  }
+
+  /**
+   * Gets a set of datanode hostnames or ip addresses that will be the exclusive
+   * participants in balancing.
+   * @return Set of hostname strings
+   */
+  public Set<String> getIncludeNodes() {
+    if (includeNodes.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(includeNodes.split(","))
+        .map(String::trim)
+        .collect(Collectors.toSet());
+  }
+
+  public void setIncludeNodes(String includeNodes) {
+    this.includeNodes = includeNodes;
+  }
+
+  /**
+   * Gets a set of datanode hostnames or ip addresses that will be excluded
+   * from balancing.
+   * @return Set of hostname strings
+   */
+  public Set<String> getExcludeNodes() {
+    if (excludeNodes.isEmpty()) {
+      return new HashSet<>();
+    }
+    return Arrays.stream(excludeNodes.split(","))
+        .map(String::trim)
+        .collect(Collectors.toSet());
+  }
+
+  public void setExcludeNodes(String excludeNodes) {
+    this.excludeNodes = excludeNodes;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerConfiguration.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -113,7 +114,7 @@ public final class ContainerBalancerConfiguration {
       "", tags = {ConfigTag.BALANCER}, description = "A list of Datanode " +
       "hostnames or ip addresses separated by commas. Only the Datanodes " +
       "specified in this list are balanced. This configuration is empty by " +
-      "default.")
+      "default and is applicable only if it is non-empty.")
   private String includeNodes = "";
 
   @Config(key = "exclude.datanodes", type = ConfigType.STRING, defaultValue =
@@ -309,17 +310,24 @@ public final class ContainerBalancerConfiguration {
   /**
    * Gets a set of datanode hostnames or ip addresses that will be the exclusive
    * participants in balancing.
-   * @return Set of hostname strings
+   * @return Set of hostname or ip address strings, or an empty set if the
+   * configuration is empty
    */
   public Set<String> getIncludeNodes() {
     if (includeNodes.isEmpty()) {
-      return new HashSet<>();
+      return Collections.emptySet();
     }
     return Arrays.stream(includeNodes.split(","))
         .map(String::trim)
         .collect(Collectors.toSet());
   }
 
+  /**
+   * Sets the datanodes that will be the exclusive participants in balancing.
+   * Applicable only if the specified string is non-empty.
+   * @param includeNodes a String of datanode hostnames or ip addresses
+   *                     separated by commas
+   */
   public void setIncludeNodes(String includeNodes) {
     this.includeNodes = includeNodes;
   }
@@ -327,17 +335,23 @@ public final class ContainerBalancerConfiguration {
   /**
    * Gets a set of datanode hostnames or ip addresses that will be excluded
    * from balancing.
-   * @return Set of hostname strings
+   * @return Set of hostname or ip address strings, or an empty set if the
+   * configuration is empty
    */
   public Set<String> getExcludeNodes() {
     if (excludeNodes.isEmpty()) {
-      return new HashSet<>();
+      return Collections.emptySet();
     }
     return Arrays.stream(excludeNodes.split(","))
         .map(String::trim)
         .collect(Collectors.toSet());
   }
 
+  /**
+   * Sets the datanodes that will be excluded from balancing.
+   * @param excludeNodes a String of datanode hostnames or ip addresses
+   *                     separated by commas
+   */
   public void setExcludeNodes(String excludeNodes) {
     this.excludeNodes = excludeNodes;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -573,9 +573,8 @@ public class TestContainerBalancer {
             nodesInCluster.get(secondExcludeIndex).getDatanodeDetails()
                 .getHostName();
     // create a file to test specifying config using a file
-    File excludeNodesFile = null;
     try {
-      excludeNodesFile = tempFolder.newFile("excludeNodesFile");
+      File excludeNodesFile = tempFolder.newFile("excludeNodesFile");
       Files.write(excludeNodesFile.toPath(),
           excludeNodes.getBytes(StandardCharsets.UTF_8),
           StandardOpenOption.WRITE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -52,11 +52,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import java.io.File;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -572,19 +567,8 @@ public class TestContainerBalancer {
             .getIpAddress() + ", " +
             nodesInCluster.get(secondExcludeIndex).getDatanodeDetails()
                 .getHostName();
-    // create a file to test specifying config using a file
-    try {
-      File excludeNodesFile = tempFolder.newFile("excludeNodesFile");
-      Files.write(excludeNodesFile.toPath(),
-          excludeNodes.getBytes(StandardCharsets.UTF_8),
-          StandardOpenOption.WRITE);
-      balancerConfiguration.setExcludeNodes(excludeNodesFile);
-    } catch (IOException e) {
-      LOG.info("Could not create a file for specifying excludeNodes while " +
-          "testing ContainerBalancer. Using a String instead.");
-      balancerConfiguration.setExcludeNodes(excludeNodes);
-    }
 
+    balancerConfiguration.setExcludeNodes(excludeNodes);
     balancerConfiguration.setIncludeNodes(includeNodes);
     containerBalancer.start(balancerConfiguration);
     sleepWhileBalancing(500);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes to support excluding certain Datanodes from balancing. The configurations can be provided as a list of comma separated host names or IP addresses.

Include Nodes: Include only these nodes in the balancing process.
Exclude Nodes: Exclude these nodes from the balancing process.
Nodes that are specified in both these lists should be excluded.

The configurations are read and these nodes are excluded in the `initializeIteration` method in `ContainerBalancer`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5897

## How was this patch tested?

Added a UT to `TestContainerBalancer`
