### PR TITLE
HDDS-5908. MPU getKey can fail, if completeMPU result is still in cache.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -676,7 +676,8 @@ public final class OmKeyInfo extends WithParentObjectId {
     keyLocationVersions.forEach(keyLocationVersion ->
         builder.addOmKeyLocationInfoGroup(
             new OmKeyLocationInfoGroup(keyLocationVersion.getVersion(),
-                keyLocationVersion.getLocationList())));
+                keyLocationVersion.getLocationList(),
+                keyLocationVersion.isMultipartKey())));
 
     acls.forEach(acl -> builder.addAcl(new OzoneAcl(acl.getType(),
             acl.getName(), (BitSet) acl.getAclBitSet().clone(),

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -108,7 +108,8 @@ public class TestOmKeyInfo {
       Assert.assertEquals(orig.isMultipartKey(), clone.isMultipartKey());
       Assert.assertEquals(orig.getVersion(), clone.getVersion());
 
-      Assert.assertEquals(orig.getLocationList().size(), clone.getLocationList().size());
+      Assert.assertEquals(orig.getLocationList().size(),
+          clone.getLocationList().size());
 
       for (int j = 0; j < orig.getLocationList().size(); j++) {
         OmKeyLocationInfo origLocationInfo = orig.getLocationList().get(j);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is happening due to bug in a copyObject where we are not using Version uploaded isMPU or not.

This issue will cause reads to fail, as the returned OmKeyInfo version will not have MPU flag set.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5908

## How was this patch tested?

Added test
