### PR TITLE
HDDS-5529. For any IOexception from @Replicated method we should throw it

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -224,7 +224,6 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
     } catch (PipelineNotFoundException pnfe) {
       LOG.warn("Pipeline {} is not found in the pipeline Map. Pipeline"
           + " may have been deleted already.", pipelineIDProto.getId());
-      throw pnfe;
     } finally {
       lock.writeLock().unlock();
     }
@@ -273,7 +272,6 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
     } catch (PipelineNotFoundException pnfe) {
       LOG.warn("Pipeline {} is not found in the pipeline Map. Pipeline"
           + " may have been deleted already.", pipelineID);
-      throw pnfe;
     } catch (IOException ex) {
       LOG.warn("Pipeline {} state update failed", pipelineID);
       throw ex;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -273,7 +273,7 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
       LOG.warn("Pipeline {} is not found in the pipeline Map. Pipeline"
           + " may have been deleted already.", pipelineID);
     } catch (IOException ex) {
-      LOG.warn("Pipeline {} state update failed", pipelineID);
+      LOG.error("Pipeline {} state update failed", pipelineID);
       throw ex;
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -224,6 +224,7 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
     } catch (PipelineNotFoundException pnfe) {
       LOG.warn("Pipeline {} is not found in the pipeline Map. Pipeline"
           + " may have been deleted already.", pipelineIDProto.getId());
+      throw pnfe;
     } finally {
       lock.writeLock().unlock();
     }
@@ -258,10 +259,8 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
       HddsProtos.PipelineID pipelineIDProto, HddsProtos.PipelineState newState)
       throws IOException {
     PipelineID pipelineID = PipelineID.getFromProtobuf(pipelineIDProto);
-    Pipeline.PipelineState oldState = null;
     lock.writeLock().lock();
     try {
-      oldState = getPipeline(pipelineID).getPipelineState();
       // null check is here to prevent the case where SCM store
       // is closed but the staleNode handlers/pipeline creations
       // still try to access it.
@@ -274,10 +273,10 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
     } catch (PipelineNotFoundException pnfe) {
       LOG.warn("Pipeline {} is not found in the pipeline Map. Pipeline"
           + " may have been deleted already.", pipelineID);
+      throw pnfe;
     } catch (IOException ex) {
       LOG.warn("Pipeline {} state update failed", pipelineID);
-      // revert back to old state in memory
-      pipelineStateMap.updatePipelineState(pipelineID, oldState);
+      throw ex;
     } finally {
       lock.writeLock().unlock();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

for any exception thrown from `@Replicated` methods, we should throw it, so that scm statemachine can catch this exception and terminate scm process, which will avoid diverging of scms in HA case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5529

## How was this patch tested?

current UT
