### PR TITLE
HDDS-5917. S3 acceptance test failure due to too wide assertion

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectdelete.robot
@@ -31,12 +31,10 @@ Delete file with s3api
                         Execute                    date > /tmp/testfile
     ${result} =         Execute AWSS3ApiCli        put-object --bucket ${BUCKET} --key ${PREFIX}/deletetestapi/f1 --body /tmp/testfile
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/deletetestapi/
-                        Should contain             ${result}         f1
+                        Should contain             ${result}         "${PREFIX}/deletetestapi/f1"
     ${result} =         Execute AWSS3APICli        delete-object --bucket ${BUCKET} --key ${PREFIX}/deletetestapi/f1
     ${result} =         Execute AWSS3ApiCli        list-objects --bucket ${BUCKET} --prefix ${PREFIX}/deletetestapi/
-                        Should not contain         ${result}         f1
-#In case of HTTP 500, the error code is printed out to the console.
-                        Should not contain         ${result}         500
+                        Should not contain         ${result}         "${PREFIX}/deletetestapi/f1"
 
 Delete file with s3api, file doesn't exist
     ${result} =         Execute AWSS3Cli           ls s3://${BUCKET}/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove an assertion from S3 delete-object test, where the response from S3G was expected not to contain `500`.  Values of `Key`, `LastModified` or `ETag` headers may contain this substring, causing the test to fail unnecessarily, as observed in these runs:

* https://github.com/elek/ozone-build-results/tree/master/2021/07/14/8932/acceptance-unsecure/
* https://github.com/elek/ozone-build-results/tree/master/2021/10/29/11160/acceptance-unsecure/
* https://github.com/elek/ozone-build-results/tree/master/2021/11/02/11195/acceptance-unsecure/

I have not found any other test that checks for HTTP 500 code.  The result code of `aws` command reflects whether it was successful or not, and `Execute` checks for that code, expecting `0`.  Thus I think the assertion is not needed.

On the other hand, we can make the assertions about the specific key being present/absent a bit more strict by checking for the entire key name.

https://issues.apache.org/jira/browse/HDDS-5917

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/4079032078