### PR TITLE
HDDS-5736. Update navbar from Hadoop to Ozone on doc page

### DIFF
--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
@@ -34,7 +34,7 @@
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav navbar-right">
         <li><a href="https://github.com/apache/hadoop-ozone">Source</a></li>
-        <li><a href="https://hadoop.apache.org">Apache Hadoop</a></li>
+        <li><a href="https://ozone.apache.org">Apache Ozone</a></li>
         <li><a href="https://apache.org">ASF</a></li>
       </ul>
     </div>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/navbar.html
@@ -27,13 +27,13 @@
         <img src="{{ "ozone-logo-small.png" | relURL }}"/>
       </a>
       <a class="navbar-brand hidden-xs" href="{{ "index.html" | relLangURL }}">
-        Apache Ozone/HDDS documentation
+        Apache Ozone/HDDS Documentation
       </a>
       <a class="navbar-brand visible-xs-inline" href="#">Apache Ozone</a>
     </div>
     <div id="navbar" class="navbar-collapse collapse">
       <ul class="nav navbar-nav navbar-right">
-        <li><a href="https://github.com/apache/hadoop-ozone">Source</a></li>
+        <li><a href="https://github.com/apache/ozone">Source</a></li>
         <li><a href="https://ozone.apache.org">Apache Ozone</a></li>
         <li><a href="https://apache.org">ASF</a></li>
       </ul>

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/partials/sidebar.html
@@ -63,8 +63,8 @@
     <li><a href="{{ "design.html" | relURL }}"><span><b>Design docs</b></span></a></li>
     <li class="visible-xs"><a href="#">References</a>
     <ul class="nav">
-        <li><a href="https://github.com/apache/hadoop"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Source</a></li>
-        <li><a href="https://hadoop.apache.org"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Apache Hadoop</a></li>
+        <li><a href="https://github.com/apache/ozone"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Source</a></li>
+        <li><a href="https://ozone.apache.org"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> Apache Ozone</a></li>
         <li><a href="https://apache.org"><span class="glyphicon glyphicon-new-window" aria-hidden="true"></span> ASF</a></li>
     </ul></li>
   </ul>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update navbar from Hadoop to Ozone on doc page.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5736

## How was this patch tested?

Local hugo test.(as shown below)
![image](https://user-images.githubusercontent.com/72794035/140022525-bbd420e2-289d-4ca0-90d2-59da7517d882.png)

