### PR TITLE
HDDS-5924. Support more detailed error log when handleFlush.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockOutputStream.java
@@ -484,6 +484,10 @@ public class BlockOutputStream extends OutputStream {
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
         handleInterruptedException(ex, true);
+      } catch (Throwable e) {
+        String msg = "Failed to flush. error: " + e.getMessage();
+        LOG.error(msg, e);
+        throw new RuntimeException(msg, e);
       }
     }
   }
@@ -546,6 +550,10 @@ public class BlockOutputStream extends OutputStream {
       } catch (InterruptedException ex) {
         Thread.currentThread().interrupt();
         handleInterruptedException(ex, true);
+      } catch (Throwable e) {
+        String msg = "Failed to flush. error: " + e.getMessage();
+        LOG.error(msg, e);
+        throw new RuntimeException(msg, e);
       } finally {
         cleanup(false);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

HandleFlush involves the write process. The write process is complex, and some unexpected exceptions can occur. For example, the client is missing some JAR dependencies due to misconfiguration. Some NoClassDefFoundError occurs, which is not catch and makes it difficult for the user to know why the write failed.
This PR we will display a more detailed log.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5924

## How was this patch tested?

Existing tests.
