### PR TITLE
HDDS-5931. Broken link in dist/README

### DIFF
--- a/hadoop-hdds/docs/content/feature/Topology.md
+++ b/hadoop-hdds/docs/content/feature/Topology.md
@@ -76,7 +76,7 @@ If implementing an external script, it will be specified with the `net.topology.
 
 ## Write path
 
-Placement of the closed containers can be configured with `ozone.scm.container.placement.impl` configuration key. The available container placement policies can be found in the `org.apache.hdds.scm.container.placement` [package](https://github.com/apache/hadoop-ozone/tree/master/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms). 
+Placement of the closed containers can be configured with `ozone.scm.container.placement.impl` configuration key. The available container placement policies can be found in the `org.apache.hdds.scm.container.placement` [package](https://github.com/apache/ozone/tree/master/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms).
 
 By default the `SCMContainerPlacementRandom` is used for topology-awareness the `SCMContainerPlacementRackAware` can be used:
 

--- a/hadoop-hdds/docs/content/start/FromSource.md
+++ b/hadoop-hdds/docs/content/start/FromSource.md
@@ -36,7 +36,7 @@ If you are a Hadoop ninja, and wise in the ways of Apache, you already know
 that a real Apache release is a source release.
 
 If you want to build from sources, Please untar the source tarball (or clone the latest code 
-from the [git repository](https://github.com/apache/hadoop-ozone)) and run the ozone build command. This instruction assumes that you have all the
+from the [git repository](https://github.com/apache/ozone)) and run the ozone build command. This instruction assumes that you have all the
 dependencies to build Hadoop on your build machine. If you need instructions
 on how to build Hadoop, please look at the Apache Hadoop Website.
 

--- a/hadoop-ozone/dist/README.md
+++ b/hadoop-ozone/dist/README.md
@@ -30,7 +30,7 @@ docker-compose up -d
 ```
 
 More information can be found in the Getting Started Guide:
-* [Getting Started: Run Ozone with Docker Compose](https://hadoop.apache.org/ozone/docs/current/start/runningviadocker.html)
+* [Getting Started: Run Ozone with Docker Compose](https://ozone.apache.org/docs/current/start/runningviadocker.html)
 
 ## Testing on Kubernetes
 
@@ -38,8 +38,8 @@ More information can be found in the Getting Started Guide:
 ### Installation
 
 Please refer to the Getting Started guide for a couple of options for testing Ozone on Kubernetes:
-* [Getting Started: Minikube and Ozone](https://hadoop.apache.org/ozone/docs/current/start/minikube.html)
-* [Getting Started: Ozone on Kubernetes](https://hadoop.apache.org/ozone/docs/current/start/kubernetes.html)
+* [Getting Started: Minikube and Ozone](https://ozone.apache.org/docs/current/start/minikube.html)
+* [Getting Started: Ozone on Kubernetes](https://ozone.apache.org/docs/current/start/kubernetes.html)
 
 ### Monitoring
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix some broken links in `hadoop-ozone/dist/README.md`.

https://issues.apache.org/jira/browse/HDDS-5931

## How was this patch tested?

:eyes:

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1418092516