### PR TITLE
HDDS-5935. Bump Spring to 5.2.18

### DIFF
--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <spring.version>5.2.17.RELEASE</spring.version>
+    <spring.version>5.2.18.RELEASE</spring.version>
     <jooq.version>3.11.10</jooq.version>
   </properties>
   <modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Spring Framework to most recent release on the same line (5.2.18).

https://issues.apache.org/jira/browse/HDDS-5935

## How was this patch tested?

```
$ mvn -DskipTests clean package
...
$ cd hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/share/ozone/lib
$ ls | grep spring
spring-beans-5.2.18.RELEASE.jar
spring-core-5.2.18.RELEASE.jar
spring-jcl-5.2.18.RELEASE.jar
spring-jdbc-5.2.18.RELEASE.jar
spring-tx-5.2.18.RELEASE.jar
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1420193725