### PR TITLE
HDDS-5916. Add IP check when DN register to SCM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -117,13 +117,11 @@ public class DatanodeInfo extends DatanodeDetails {
    * @param lastIp the last ip
    */
   public void updateLastIpAddress(String lastIp) {
-    if (!lastIp.equalsIgnoreCase(getIpAddress())) {
-      try {
-        lock.writeLock().lock();
-        setIpAddress(lastIp);
-      } finally {
-        lock.writeLock().unlock();
-      }
+    try {
+      lock.writeLock().lock();
+      setIpAddress(lastIp);
+    } finally {
+      lock.writeLock().unlock();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -112,6 +112,22 @@ public class DatanodeInfo extends DatanodeDetails {
   }
 
   /**
+   * Update last ip address.
+   *
+   * @param lastIp the last ip
+   */
+  public void updateLastIpAddress(String lastIp) {
+    if (!lastIp.equalsIgnoreCase(getIpAddress())) {
+      try {
+        lock.writeLock().lock();
+        setIpAddress(lastIp);
+      } finally {
+        lock.writeLock().unlock();
+      }
+    }
+  }
+
+  /**
    * Returns the last heartbeat time.
    *
    * @return last heartbeat time.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -390,6 +390,22 @@ public class NodeStateManager implements Runnable, Closeable {
   }
 
   /**
+   * Update last known ip address.
+   *
+   * @param datanodeDetails the datanode details
+   * @throws NodeNotFoundException the node not found exception
+   */
+  public void updateLastKnownIpAddress(DatanodeDetails datanodeDetails)
+      throws NodeNotFoundException {
+    LOG.info("updateLastKnownIpAddress of {} from {} to {}",
+        datanodeDetails.getUuidString(),
+        nodeStateMap.getNodeInfo(datanodeDetails.getUuid()).getIpAddress(),
+        datanodeDetails.getIpAddress());
+    nodeStateMap.getNodeInfo(datanodeDetails.getUuid())
+        .updateLastIpAddress(datanodeDetails.getIpAddress());
+  }
+
+  /**
    * Returns the current state of the node.
    *
    * @param datanodeDetails DatanodeDetails

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeStateManager.java
@@ -397,12 +397,15 @@ public class NodeStateManager implements Runnable, Closeable {
    */
   public void updateLastKnownIpAddress(DatanodeDetails datanodeDetails)
       throws NodeNotFoundException {
-    LOG.info("updateLastKnownIpAddress of {} from {} to {}",
-        datanodeDetails.getUuidString(),
-        nodeStateMap.getNodeInfo(datanodeDetails.getUuid()).getIpAddress(),
-        datanodeDetails.getIpAddress());
-    nodeStateMap.getNodeInfo(datanodeDetails.getUuid())
-        .updateLastIpAddress(datanodeDetails.getIpAddress());
+    if (!nodeStateMap.getNodeInfo(datanodeDetails.getUuid()).getIpAddress()
+        .equalsIgnoreCase(datanodeDetails.getIpAddress())) {
+      nodeStateMap.getNodeInfo(datanodeDetails.getUuid())
+          .updateLastIpAddress(datanodeDetails.getIpAddress());
+      LOG.info("updateLastKnownIpAddress of {} from {} to {}",
+          datanodeDetails.getUuidString(),
+          nodeStateMap.getNodeInfo(datanodeDetails.getUuid()).getIpAddress(),
+          datanodeDetails.getIpAddress());
+    }
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeManager.java
@@ -397,6 +397,15 @@ public class SCMNodeManager implements NodeManager {
         LOG.error("Cannot find datanode {} from nodeStateManager",
             datanodeDetails.toString());
       }
+    } else {
+      // IP address of DN could be changed in K8s env, need to be updated in SCM
+      // once DN restarts
+      try {
+        nodeStateManager.updateLastKnownIpAddress(datanodeDetails);
+      } catch (NodeNotFoundException e) {
+        LOG.error("Cannot find datanode {} from nodeStateManager",
+            datanodeDetails.toString());
+      }
     }
 
     return RegisteredCommand.newBuilder().setErrorCode(ErrorCode.success)


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM doesn't upgrade DN NodeInfo if any DN restarts.
This causes the issue described in the JIRA, which in k8s env would lead to unavailable cluster conditions.
Thus, we should add this case to upgrade the LastknownIpAddress of Datanodes to NodeMap when they register again.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5916


## How was this patch tested?
Manual Test on K8s
