### PR TITLE
HDDS-5936. Duplicate Test Ozone Shell invocation

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-single.robot
@@ -24,4 +24,4 @@ Suite Setup         Generate prefix
 *** Test Cases ***
 
 Test ozone shell
-   Test ozone shell       ${EMPTY}            ${EMPTY}     ${prefix}-rpcbasic
+   Test ozone shell       ${EMPTY}            ${EMPTY}     ${prefix}-without-scheme

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -24,19 +24,19 @@ Suite Setup         Generate prefix
 
 *** Test Cases ***
 RpcClient with port
-   Test ozone shell       o3://            om:9862     ${prefix}-rpcwoport
+   Test ozone shell       o3://            om:9862     ${prefix}-with-host
 
 RpcClient volume acls
-   Test Volume Acls       o3://            om:9862     ${prefix}-rpcwoport2
+   Test Volume Acls       o3://            om:9862     ${prefix}-acls
 
 RpcClient bucket acls
-    Test Bucket Acls      o3://            om:9862     ${prefix}-rpcwoport2
+    Test Bucket Acls      o3://            om:9862     ${prefix}-acls
 
 RpcClient key acls
-    Test Key Acls         o3://            om:9862     ${prefix}-rpcwoport2
+    Test Key Acls         o3://            om:9862     ${prefix}-acls
 
 RpcClient prefix acls
-    Test Prefix Acls      o3://            om:9862     ${prefix}-rpcwoport2
+    Test Prefix Acls      o3://            om:9862     ${prefix}-acls
 
 RpcClient without host
-    Test ozone shell      o3://            ${EMPTY}    ${prefix}-rpcwport
+    Test ozone shell      o3://            ${EMPTY}    ${prefix}-without-host

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -40,6 +40,3 @@ RpcClient prefix acls
 
 RpcClient without host
     Test ozone shell      o3://            ${EMPTY}    ${prefix}-rpcwport
-
-RpcClient without scheme
-    Test ozone shell      ${EMPTY}         ${EMPTY}    ${prefix}-rpcwoscheme


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Test ozone shell` is a parameterized test case in `basic` smoketest.  It is executed with arguments `"", ""` (`${EMPTY}, ${EMPTY}`) twice for `ozone` and `ozonesecure` environments (_acceptance (unsecure)_ and _acceptance (secure)_): both by `ozone-shell-single.robot` and `ozone-shell.robot`.  This PR eliminates duplicate execution to save ~3 minutes runtime for these runs.

https://issues.apache.org/jira/browse/HDDS-5936

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/4105130510?check_suite_focus=true#step:5:171
https://github.com/adoroszlai/hadoop-ozone/runs/4105130564?check_suite_focus=true#step:5:233