### PR TITLE
HDDS-5947. Remove unused mina-core and sshd-core dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1121,16 +1121,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>${aws-java-sdk.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.mina</groupId>
-        <artifactId>mina-core</artifactId>
-        <version>2.1.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.sshd</groupId>
-        <artifactId>sshd-core</artifactId>
-        <version>1.6.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.ftpserver</groupId>
         <artifactId>ftplet-api</artifactId>
         <version>1.0.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1123,7 +1123,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.apache.mina</groupId>
         <artifactId>mina-core</artifactId>
-        <version>2.0.16</version>
+        <version>2.1.5</version>
       </dependency>
       <dependency>
         <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HDDS-5947

## What changes were proposed in this pull request?

Bump the version of Mina dependency to avoid https://github.com/advisories/GHSA-6mcm-j9cj-3vc3

## How was this patch tested?

Full CI