### PR TITLE
HDDS-5656. Move old objects to delete table on overwriting multipart objects

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -219,7 +219,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
       if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
         oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
-            omMetadataManager, omBucketInfo.getIsVersionEnabled(),
+            keyToDelete, omMetadataManager,
             trxnLogIndex, ozoneManager.isRatisEnabled());
       }
       // Add to cache of open key table and key table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -281,40 +281,6 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   }
 
   /**
-   * Prepare key for deletion service on overwrite.
-   *
-   * @param dbOzoneKey key to point to an object in RocksDB
-   * @param omMetadataManager
-   * @param isVersionEnabled
-   * @param trxnLogIndex
-   * @param isRatisEnabled
-   * @return Old keys eligible for deletion.
-   * @throws IOException
-   */
-  protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
-          String dbOzoneKey, OMMetadataManager omMetadataManager,
-          boolean isVersionEnabled, long trxnLogIndex,
-          boolean isRatisEnabled) throws IOException {
-    if (isVersionEnabled) {
-      // Nothing to clean up in case versioning is on.
-      return null;
-    }
-    // Past keys that was deleted but still in deleted table,
-    // waiting for deletion service.
-    RepeatedOmKeyInfo keysToDelete =
-            omMetadataManager.getDeletedTable().get(dbOzoneKey);
-    // Current key to be overwritten
-    OmKeyInfo keyToDelete =
-            omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
-
-    if (keyToDelete != null) {
-      keysToDelete = OmUtils.prepareKeyForDelete(keyToDelete, keysToDelete,
-                trxnLogIndex, isRatisEnabled);
-    }
-    return keysToDelete;
-  }
-
-  /**
    * Process result of om request execution.
    *
    * @param commitKeyRequest commit key request

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -151,11 +151,14 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // creation and key commit, old versions will be just overwritten and
       // not kept. Bucket versioning will be effective from the first key
       // creation after the knob turned on.
-      RepeatedOmKeyInfo keysToDelete = getOldVersionsToCleanUp(dbFileKey,
-              omMetadataManager, omBucketInfo.getIsVersionEnabled(),
-              trxnLogIndex, ozoneManager.isRatisEnabled());
+      RepeatedOmKeyInfo oldKeyVersionsToDelete = null;
       OmKeyInfo keyToDelete =
               omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
+      if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+        oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbFileKey,
+            omMetadataManager, omBucketInfo.getIsVersionEnabled(),
+            trxnLogIndex, ozoneManager.isRatisEnabled());
+      }
 
       // Add to cache of open key table and key table.
       OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager, dbFileKey,
@@ -164,9 +167,9 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       OMFileRequest.addFileTableCacheEntry(omMetadataManager, dbFileKey,
               omKeyInfo, fileName, trxnLogIndex);
 
-      if (keysToDelete != null) {
+      if (oldKeyVersionsToDelete != null) {
         OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbFileKey,
-                keysToDelete, trxnLogIndex);
+                oldKeyVersionsToDelete, trxnLogIndex);
       }
 
       long scmBlockSize = ozoneManager.getScmBlockSize();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -156,7 +156,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
           omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
       if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
         oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbFileKey,
-            omMetadataManager, omBucketInfo.getIsVersionEnabled(),
+            keyToDelete, omMetadataManager,
             trxnLogIndex, ozoneManager.isRatisEnabled());
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -153,7 +153,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // creation after the knob turned on.
       RepeatedOmKeyInfo oldKeyVersionsToDelete = null;
       OmKeyInfo keyToDelete =
-              omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
+          omMetadataManager.getKeyTable(getBucketLayout()).get(dbFileKey);
       if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
         oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbFileKey,
             omMetadataManager, omBucketInfo.getIsVersionEnabled(),
@@ -189,7 +189,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),
               omKeyInfo, dbFileKey, dbOpenFileKey, omBucketInfo.copyObject(),
-              keysToDelete);
+              oldKeyVersionsToDelete);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -777,6 +777,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * Prepare key for deletion service on overwrite.
    *
    * @param dbOzoneKey key to point to an object in RocksDB
+   * @param keyToDelete OmKeyInfo of a key to be in deleteTable
    * @param omMetadataManager
    * @param trxnLogIndex
    * @param isRatisEnabled
@@ -784,7 +785,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
    * @throws IOException
    */
   protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
-      String dbOzoneKey, OmKeyInfo keyToDelete,
+      @Nonnull String dbOzoneKey, @Nonnull OmKeyInfo keyToDelete,
       OMMetadataManager omMetadataManager, long trxnLogIndex,
       boolean isRatisEnabled) throws IOException {
 
@@ -793,10 +794,7 @@ public abstract class OMKeyRequest extends OMClientRequest {
     RepeatedOmKeyInfo keysToDelete =
         omMetadataManager.getDeletedTable().get(dbOzoneKey);
 
-    if (keyToDelete != null) {
-      keysToDelete = OmUtils.prepareKeyForDelete(keyToDelete, keysToDelete,
+    return OmUtils.prepareKeyForDelete(keyToDelete, keysToDelete,
           trxnLogIndex, isRatisEnabled);
-    }
-    return keysToDelete;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -778,27 +778,20 @@ public abstract class OMKeyRequest extends OMClientRequest {
    *
    * @param dbOzoneKey key to point to an object in RocksDB
    * @param omMetadataManager
-   * @param isVersionEnabled
    * @param trxnLogIndex
    * @param isRatisEnabled
    * @return Old keys eligible for deletion.
    * @throws IOException
    */
   protected RepeatedOmKeyInfo getOldVersionsToCleanUp(
-      String dbOzoneKey, OMMetadataManager omMetadataManager,
-      boolean isVersionEnabled, long trxnLogIndex,
+      String dbOzoneKey, OmKeyInfo keyToDelete,
+      OMMetadataManager omMetadataManager, long trxnLogIndex,
       boolean isRatisEnabled) throws IOException {
-    if (isVersionEnabled) {
-      // Nothing to clean up in case versioning is on.
-      return null;
-    }
+
     // Past keys that was deleted but still in deleted table,
     // waiting for deletion service.
     RepeatedOmKeyInfo keysToDelete =
         omMetadataManager.getDeletedTable().get(dbOzoneKey);
-    // Current key to be overwritten
-    OmKeyInfo keyToDelete =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
 
     if (keyToDelete != null) {
       keysToDelete = OmUtils.prepareKeyForDelete(keyToDelete, keysToDelete,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -228,21 +228,22 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
           usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
         }
 
+        String dbBucketKey = null;
         if (usedBytesDiff != 0) {
           omBucketInfo.incrUsedBytes(usedBytesDiff);
+          dbBucketKey = omMetadataManager.getBucketKey(
+              omBucketInfo.getVolumeName(), omBucketInfo.getBucketName());
         } else {
           // If no bucket size changed, prevent from updating bucket object
           omBucketInfo = null;
         }
 
-        String dbBucketKey = omMetadataManager.getBucketKey(
-            omBucketInfo.getVolumeName(), omBucketInfo.getBucketName());
         updateCache(omMetadataManager, dbBucketKey, omBucketInfo, dbOzoneKey,
             dbMultipartOpenKey, multipartKey, omKeyInfo, trxnLogIndex);
 
         if (oldKeyVersionsToDelete != null) {
           OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbOzoneKey,
-                  oldKeyVersionsToDelete, trxnLogIndex);
+              oldKeyVersionsToDelete, trxnLogIndex);
         }
 
         omResponse.setCompleteMultiPartUploadResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -215,7 +215,8 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         // not kept. Bucket versioning will be effective from the first key
         // creation after the knob turned on.
         RepeatedOmKeyInfo oldKeyVersionsToDelete = null;
-        OmKeyInfo keyToDelete = omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+        OmKeyInfo keyToDelete =
+            omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
           oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
               omMetadataManager, omBucketInfo.getIsVersionEnabled(),
@@ -534,6 +535,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         volume + " bucket: " + bucket + " key: " + keyName;
   }
 
+  @SuppressWarnings("parameternumber")
   private void updateCache(OMMetadataManager omMetadataManager,
       String dbBucketKey, OmBucketInfo omBucketInfo,
       String dbOzoneKey, String dbMultipartOpenKey, String dbMultipartKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -556,7 +556,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         new CacheKey<>(dbMultipartKey),
         new CacheValue<>(Optional.absent(), transactionLogIndex));
 
-    if (omKeyInfo != null) {
+    if (omBucketInfo != null) {
       omMetadataManager.getBucketTable().addCacheEntry(
               new CacheKey<>(dbBucketKey),
               new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -219,7 +219,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
           oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
-              omMetadataManager, omBucketInfo.getIsVersionEnabled(),
+              keyToDelete, omMetadataManager,
               trxnLogIndex, ozoneManager.isRatisEnabled());
         }
         long usedBytesDiff = 0;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -214,11 +214,13 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         // creation and key commit, old versions will be just overwritten and
         // not kept. Bucket versioning will be effective from the first key
         // creation after the knob turned on.
-        RepeatedOmKeyInfo oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
-            omMetadataManager, omBucketInfo.getIsVersionEnabled(),
-            trxnLogIndex, ozoneManager.isRatisEnabled());
-        OmKeyInfo keyToDelete =
-            omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+        RepeatedOmKeyInfo oldKeyVersionsToDelete = null;
+        OmKeyInfo keyToDelete = omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
+        if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
+          oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
+              omMetadataManager, omBucketInfo.getIsVersionEnabled(),
+              trxnLogIndex, ozoneManager.isRatisEnabled());
+        }
         long usedBytesDiff = 0;
         if (keyToDelete != null) {
           long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -66,6 +66,8 @@ import org.apache.hadoop.util.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 
@@ -538,7 +540,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
 
   @SuppressWarnings("parameternumber")
   private void updateCache(OMMetadataManager omMetadataManager,
-      String dbBucketKey, OmBucketInfo omBucketInfo,
+      String dbBucketKey, @Nullable OmBucketInfo omBucketInfo,
       String dbOzoneKey, String dbMultipartOpenKey, String dbMultipartKey,
       OmKeyInfo omKeyInfo, long transactionLogIndex) {
     // Update cache.
@@ -556,10 +558,13 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         new CacheKey<>(dbMultipartKey),
         new CacheValue<>(Optional.absent(), transactionLogIndex));
 
+    // Here, omBucketInfo can be null if its size has not changed. No need to
+    // update the bucket info unless its size has changed. We never want to
+    // delete the bucket info here, but just avoiding unnecessary update.
     if (omBucketInfo != null) {
       omMetadataManager.getBucketTable().addCacheEntry(
-              new CacheKey<>(dbBucketKey),
-              new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
+          new CacheKey<>(dbBucketKey),
+          new CacheValue<>(Optional.of(omBucketInfo), transactionLogIndex));
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -22,7 +22,9 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.om.response.s3.multipart.S3MultipartUploadCompleteResponse;
@@ -35,6 +37,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
@@ -149,11 +152,29 @@ public class S3MultipartUploadCompleteRequestWithFSO
   protected OMClientResponse getOmClientResponse(String multipartKey,
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
       String dbMultipartOpenKey, OmKeyInfo omKeyInfo,
-      List<OmKeyInfo> unUsedParts) {
+      List<OmKeyInfo> unUsedParts, OmBucketInfo omBucketInfo,
+      RepeatedOmKeyInfo keysToDelete) {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout());
+        getBucketLayout(), omBucketInfo, keysToDelete);
+  }
+
+  private long getParentId(OMMetadataManager omMetadataManager,
+      String volumeName, String bucketName, String keyName) throws IOException {
+
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(bucketKey);
+    long bucketId = omBucketInfo.getObjectID();
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+    return OMFileRequest
+        .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
+  }
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -153,23 +153,11 @@ public class S3MultipartUploadCompleteRequestWithFSO
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
       String dbMultipartOpenKey, OmKeyInfo omKeyInfo,
       List<OmKeyInfo> unUsedParts, OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo keysToDelete) {
+      RepeatedOmKeyInfo oldKeyVersionsToDelete) {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, keysToDelete);
-  }
-
-  private long getParentId(OMMetadataManager omMetadataManager,
-      String volumeName, String bucketName, String keyName) throws IOException {
-
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-    OmBucketInfo omBucketInfo =
-        omMetadataManager.getBucketTable().get(bucketKey);
-    long bucketId = omBucketInfo.getObjectID();
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
-    return OMFileRequest
-        .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
+        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -115,8 +115,8 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
           ozoneKey, keyVersionsToDelete);
     }
 
-
-    // update bucket usedBytes, only when total bucket size has changed due to .
+    // update bucket usedBytes, only when total bucket size has changed
+    // due to unused parts cleanup or an overwritten version.
     if (omBucketInfo != null) {
       omMetadataManager.getBucketTable().putWithBatch(batchOperation,
               omMetadataManager.getBucketKey(omBucketInfo.getVolumeName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -21,7 +21,9 @@ package org.apache.hadoop.ozone.om.response.s3.multipart;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
@@ -48,15 +50,18 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 public class S3MultipartUploadCompleteResponseWithFSO
         extends S3MultipartUploadCompleteResponse {
 
+  @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadCompleteResponseWithFSO(
       @Nonnull OMResponse omResponse,
       @Nonnull String multipartKey,
       @Nonnull String multipartOpenKey,
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmKeyInfo> unUsedParts,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull BucketLayout bucketLayout,
+      @Nonnull OmBucketInfo omBucketInfo,
+      RepeatedOmKeyInfo keysToDelete) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
-        bucketLayout);
+        bucketLayout, omBucketInfo, keysToDelete);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -59,10 +59,11 @@ public class TestS3MultipartUploadCompleteRequest
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     String keyName = getKeyName();
+    addVolumeAndBucket(volumeName, bucketName);
+
     checkValidateAndUpdateCacheSuccess(volumeName, bucketName, keyName);
     checkDeleteTableCount(volumeName, bucketName, keyName, 0);
 
-    addVolumeAndBucket(volumeName, bucketName);
     // Do it twice to test overwrite
     checkValidateAndUpdateCacheSuccess(volumeName, bucketName, keyName);
     // After overwrite, one entry must be in delete table
@@ -89,10 +90,6 @@ public class TestS3MultipartUploadCompleteRequest
 
   private void checkValidateAndUpdateCacheSuccess(String volumeName,
       String bucketName, String keyName) throws Exception {
-
-    addVolumeAndBucket(volumeName, bucketName);
-    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
 
     OMRequest initiateMPURequest = doPreExecuteInitiateMPU(volumeName,
         bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -281,7 +282,9 @@ public class TestS3MultipartResponse {
           String volumeName, String bucketName, long parentID, String keyName,
           String multipartUploadID, OmKeyInfo omKeyInfo,
           OzoneManagerProtocolProtos.Status status,
-          List<OmKeyInfo> unUsedParts) {
+          List<OmKeyInfo> unUsedParts,
+          OmBucketInfo omBucketInfo,
+          RepeatedOmKeyInfo keysToDelete) {
 
 
     String multipartKey = omMetadataManager
@@ -300,7 +303,7 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse,
         multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout());
+        getBucketLayout(), omBucketInfo, keysToDelete);
   }
 
   private String getMultipartKey(long parentID, String keyName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.s3.multipart;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -95,6 +96,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     addS3MultipartUploadCommitPartResponseFSO(volumeName, bucketName, keyName,
             multipartUploadID, dbOpenKey);
 
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(bucketKey);
+
     Assert.assertNotNull(
         omMetadataManager.getMultipartInfoTable().get(dbMultipartKey));
     Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
@@ -103,8 +108,9 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     List<OmKeyInfo> unUsedParts = new ArrayList<>();
     S3MultipartUploadCompleteResponse s3MultipartUploadCompleteResponse =
             createS3CompleteMPUResponseFSO(volumeName, bucketName, parentID,
-                    keyName, multipartUploadID, omKeyInfoFSO,
-                OzoneManagerProtocolProtos.Status.OK, unUsedParts);
+                keyName, multipartUploadID, omKeyInfoFSO,
+                OzoneManagerProtocolProtos.Status.OK, unUsedParts,
+                omBucketInfo, null);
 
     s3MultipartUploadCompleteResponse.addToDBBatch(omMetadataManager,
         batchOperation);
@@ -209,6 +215,10 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
             keyName, multipartUploadID, fileName, dbMultipartKey,
             omMultipartKeyInfo, deleteEntryCount);
 
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+            omMetadataManager.getBucketTable().get(bucketKey);
+
     OmKeyInfo omKeyInfo =
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
                     HddsProtos.ReplicationType.RATIS,
@@ -220,7 +230,8 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     S3MultipartUploadCompleteResponse s3MultipartUploadCompleteResponse =
             createS3CompleteMPUResponseFSO(volumeName, bucketName, parentID,
                     keyName, multipartUploadID, omKeyInfoFSO,
-                    OzoneManagerProtocolProtos.Status.OK, unUsedParts);
+                    OzoneManagerProtocolProtos.Status.OK, unUsedParts,
+                    omBucketInfo, null);
 
     s3MultipartUploadCompleteResponse.addToDBBatch(omMetadataManager,
             batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This pull request aims at porting my work in HDDS-5461 ( https://github.com/apache/ozone/pull/2433 ) to multipart-uploaded objects. The change is almost same; on committing multipart objects (moving the OmKeyInfo from multipart table to key table), move the previous version of the key info to delete table.

CC: @bharatviswa504 

## What is the link to the Apache JIRA

HDDS-5656

## How was this patch tested?

Unit tests updated
