### PR TITLE
HDDS-5891. OFS mkdir -p does not work as expected for bucket creation when volume exists due to volume create ACL check

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -195,7 +195,7 @@ public class TestRootedOzoneFileSystem {
         .build();
     cluster.waitForClusterToBeReady();
     objectStore = cluster.getClient().getObjectStore();
-    
+
     // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
     OzoneBucket bucket =
         TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
@@ -1533,7 +1533,8 @@ public class TestRootedOzoneFileSystem {
   public void testNonPrivilegedUserMkdirCreateBucket() throws IOException {
     // This test is only meaningful when ACL is enabled
     if (!enableAcl) {
-      LOG.info("Skipping this test as ACL is not enabled");
+      LOG.info("ACL is not enabled. Skipping this test as it requires ACL to " +
+          " be enabled to be meaningful.");
       return;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -38,12 +38,12 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.VolumeArgs;
-import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -59,6 +59,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -1532,11 +1533,8 @@ public class TestRootedOzoneFileSystem {
   @Test
   public void testNonPrivilegedUserMkdirCreateBucket() throws IOException {
     // This test is only meaningful when ACL is enabled
-    if (!enableAcl) {
-      LOG.info("ACL is not enabled. Skipping this test as it requires ACL to " +
-          " be enabled to be meaningful.");
-      return;
-    }
+    Assume.assumeTrue("ACL is not enabled. Skipping this test as it requires " +
+            "ACL to be enabled to be meaningful.", enableAcl);
 
     // This unit test does the correct check. However, the parameterized
     // test is not initialized correctly since HDDS-4998 (or HDDS-4040).

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java
@@ -237,6 +237,12 @@ public class BucketManagerImpl implements BucketManager {
    *
    * @param volumeName - Name of the Volume.
    * @param bucketName - Name of the Bucket.
+   * @return OmBucketInfo
+   * @throws IOException The exception thrown could be:
+   * 1. OMException VOLUME_NOT_FOUND when the parent volume doesn't exist.
+   * 2. OMException BUCKET_NOT_FOUND when the parent volume exists, but bucket
+   * doesn't.
+   * 3. Other exceptions, e.g. IOException thrown from getBucketTable().get().
    */
   @Override
   public OmBucketInfo getBucketInfo(String volumeName, String bucketName)
@@ -251,12 +257,14 @@ public class BucketManagerImpl implements BucketManager {
       if (value == null) {
         LOG.debug("bucket: {} not found in volume: {}.", bucketName,
             volumeName);
-        // Check volume existence, because we need to throw VOLUME_NOT_FOUND
-        //  if the parent volume doesn't exist.
-        if (metadataManager.getVolumeTable().get(volumeName) == null) {
+        // Check parent volume existence
+        final String dbVolumeKey = metadataManager.getVolumeKey(volumeName);
+        if (metadataManager.getVolumeTable().get(dbVolumeKey) == null) {
+          // Parent volume doesn't exist, throw VOLUME_NOT_FOUND
           throw new OMException("Volume not found when getting bucket info",
               VOLUME_NOT_FOUND);
         } else {
+          // Parent volume exists, throw BUCKET_NOT_FOUND
           throw new OMException("Bucket not found", BUCKET_NOT_FOUND);
         }
       }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -45,7 +45,6 @@ import org.mockito.runners.MockitoJUnitRunner;
  * Tests BucketManagerImpl, mocks OMMetadataManager for testing.
  */
 @RunWith(MockitoJUnitRunner.class)
-@Ignore("Bucket Manager does not use cache, Disable it for now.")
 public class TestBucketManagerImpl {
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -102,6 +101,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testCreateBucket() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
 
@@ -136,6 +136,7 @@ public class TestBucketManagerImpl {
 
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testCreateEncryptedBucket() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
 
@@ -151,6 +152,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testCreateAlreadyExistingBucket() throws Exception {
     thrown.expectMessage("Bucket already exist");
     OmMetadataManagerImpl metaMgr = createSampleVol();
@@ -173,6 +175,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testGetBucketInfoForInvalidBucket() throws Exception {
     thrown.expectMessage("Bucket not found");
     OmMetadataManagerImpl metaMgr = createSampleVol();
@@ -246,6 +249,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testSetBucketPropertyChangeStorageType() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
 
@@ -274,6 +278,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testSetBucketPropertyChangeVersioning() throws Exception {
     OmMetadataManagerImpl metaMgr = createSampleVol();
 
@@ -300,6 +305,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testDeleteBucket() throws Exception {
     thrown.expectMessage("Bucket not found");
     OmMetadataManagerImpl metaMgr = createSampleVol();
@@ -334,6 +340,7 @@ public class TestBucketManagerImpl {
   }
 
   @Test
+  @Ignore("Bucket Manager does not use cache, Disable it for now.")
   public void testDeleteNonEmptyBucket() throws Exception {
     thrown.expectMessage("Bucket is not empty");
     OmMetadataManagerImpl metaMgr = createSampleVol();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -229,7 +229,7 @@ public class BasicRootedOzoneClientAdapterImpl
         // when ACL is disabled. Both exceptions need to be handled.
         switch (ex.getResult()) {
         case VOLUME_NOT_FOUND:
-        case BUCKET_NOT_FOUND:
+          // Create the volume first when the volume doesn't exist
           try {
             objectStore.createVolume(volumeStr);
           } catch (OMException newVolEx) {
@@ -238,7 +238,11 @@ public class BasicRootedOzoneClientAdapterImpl
               throw newVolEx;
             }
           }
-
+          // No break here. Proceed to create the bucket
+        case BUCKET_NOT_FOUND:
+          // When BUCKET_NOT_FOUND is thrown, we expect the parent volume
+          // exists, so that we don't call create volume and incur
+          // unnecessary ACL checks which could lead to unwanted behavior.
           OzoneVolume volume = proxy.getVolumeDetails(volumeStr);
           // Create the bucket
           try {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-5891

1. `BucketManagerImpl#getBucketInfo` can now throw `VOLUME_NOT_FOUND` if the parent volume **doesn't exist**, and will only throw `BUCKET_NOT_FOUND` if the parent volume **exists** but the bucket doesn't. Before this change it throws `BUCKET_NOT_FOUND` regardless of whether parent volume exists. Related prior comment: https://github.com/apache/ozone/pull/2412#discussion_r672513719
  - And the new behavior is more in line with [BucketManagerImpl#createBucket](https://github.com/apache/ozone/blob/18f0fe14034c048a810365f130e3147001c27da8/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/BucketManagerImpl.java#L126-L137). Thanks @fapifta for pointing this out.

2. With the patch, `BasicRootedOzoneClientAdapterImpl#getBucket` will no longer attempt to create the volume if the volume exists. Previously, it can't distinguish `VOLUME_NOT_EXIST` from `BUCKET_NOT_EXIST` due to the API limitation mentioned in (1). This fixes the issue mentioned in the jira title, where `getBucket` can fail if a non-privileged user tries to `mkdir -p` over a new bucket but fail because the user would fail the volume `CREATE` permission check -- which doesn't make sense to be checked in the first place in this case.

## Testing

- ~~Some integration/acceptance tests might be broken as a result of (1).~~ Actually the CI goes fine as soon as I fixed the get from VolumeTable logic. In the code logic the volume key was missing the leading `/`.
- Added a unit test for the change in behavior in `BucketManagerImpl#getBucketInfo` in OM, that it could throw `VOLUME_NOT_FOUND` now if the parent volume doesn't exist (previously `getBucketInfo` would throw `BUCKET_NOT_FOUND` in this case).
- Added a new integration test for the scenario in the jira description. To verify that a regular user will be able to create a bucket with OFS `mkdir -p` now even though this user don't have volume `CREATE` permission on the parent volume.