### PR TITLE
HDDS-5891 OFS mkdir -p does not work as expected for bucket creation when volume exists due to volume create ACL check.

### DIFF
--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -264,6 +264,8 @@ public class BasicRootedOzoneClientAdapterImpl
         }
         // return the bucket info.
         bucket = volume.getBucket(bucketStr);
+      } else {
+        throw ex;
       }
     }
     return bucket;


### PR DESCRIPTION
## What changes were proposed in this pull request?

We discovered this problem during the implementation of HttpFS Gateway. With OFS mkdir -p if we wanted to create a bucket in an already existing volume with ACLs enabled and a non-admin user as the owner of the volume, we got a permission denied exception. This could happened, because when we wanted to create a bucket and it didn't exist before we tried to create the volume first. In this case we got the permission denied, because the not admin user couldn't create a volume. But as the volume existed and and the not admin user was the owner of it, this shouldn't happen, the user could have created the bucket.

In this change I modified the getBucket() method in the BasicRootedOzoneClientAdapterImpl class, so it first tries to get the VolumeInfo and the BucketInfo; if it was successful, it returns the BucketInfo. If it wasn't and the createIfNotExist is true it checks if the volume is null.
If the volume in null it tries to get the volume again, to figure out if we have permission or not. If the getVolume threw VOLUME_NOT_FOUND we try to create the volume (we ignore if we got VOLUME_ALREADY_EXISTS exception). If the volume creation was successful we get the VolumeInfo. Else we throw the appropriate exceptions.
If the volume wasn't null in the beginning, it tries to create the bucket (we ignore if we got BUCKET_ALREADY_EXISTS exception) and we return the BucketInfo in the end, else we throw the appropriate exception.

I also removed the proxy variable of the class, as it was only used in the getBucket() method and we can get the bucketDetails via the volume.getBucket().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5891

## How was this patch tested?

Built the project successfully. 
