### PR TITLE
HDDS-5870. Make Datanode usageinfo command output more readable

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/UsageInfoSubcommand.java
@@ -88,6 +88,7 @@ public class UsageInfoSubcommand extends ScmSubcommand {
           count);
     }
 
+    System.out.printf("Usage Information (%d Datanodes)%n%n", infoList.size());
     infoList.forEach(this::printInfo);
   }
 
@@ -106,26 +107,27 @@ public class UsageInfoSubcommand extends ScmSubcommand {
     percentFormat.setMinimumFractionDigits(2);
     percentFormat.setMaximumFractionDigits(2);
 
-    System.out.printf("Usage info for datanode with UUID %s:%n",
-        info.getNode().getUuid());
+    System.out.printf("%-13s: %s %n", "UUID", info.getNode().getUuid());
+    System.out.printf("%-13s: %s (%s) %n", "IP Address",
+        info.getNode().getIpAddress(), info.getNode().getHostName());
     // print capacity in a readable format
-    System.out.printf("%-13s: %-21s (%s) %n", "Capacity", capacity + " B",
+    System.out.printf("%-13s: %s (%s) %n", "Capacity", capacity + " B",
         StringUtils.byteDesc(capacity));
 
     // print total used space and its percentage in a readable format
-    System.out.printf("%-13s: %-21s (%s) %n", "Total Used", totalUsed + " B",
+    System.out.printf("%-13s: %s (%s) %n", "Total Used", totalUsed + " B",
         StringUtils.byteDesc(totalUsed));
     System.out.printf("%-13s: %s %n", "Total Used %",
         percentFormat.format(1 - remainingRatio));
 
     // print space used by ozone and its percentage in a readable format
-    System.out.printf("%-13s: %-21s (%s) %n", "Ozone Used", used + " B",
+    System.out.printf("%-13s: %s (%s) %n", "Ozone Used", used + " B",
         StringUtils.byteDesc(used));
     System.out.printf("%-13s: %s %n", "Ozone Used %",
         percentFormat.format(usedRatio));
 
     // print total remaining space and its percentage in a readable format
-    System.out.printf("%-13s: %-21s (%s) %n", "Remaining", remaining + " B",
+    System.out.printf("%-13s: %s (%s) %n", "Remaining", remaining + " B",
         StringUtils.byteDesc(remaining));
     System.out.printf("%-13s: %s %n%n", "Remaining %",
         percentFormat.format(remainingRatio));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improved readability of `usageinfo` by showing sizes in appropriate units. Also added the `Total Used` field. Here's a description of the output:

- `Capacity`: Total capacity of the datanode, read from the SCM.
- `Ozone Used`: Space used by Ozone, read from the SCM.
- `Remaining`: Total remaining space, read from the SCM.
- `Total Used`: `Capacity` - `Remaining`, or the total used space.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5870

## How was this patch tested?

Manual testing using docker-compose.
<img width="806" alt="usageinfo" src="https://user-images.githubusercontent.com/34305492/140921938-a156a901-5445-46f6-81c1-d15635426edb.png">