### PR TITLE
HDDS-5910 Add additional verification for S3 Auth.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -185,15 +185,21 @@ public class RpcClient implements ClientProtocol {
     this.clientConfig = conf.getObject(OzoneClientConfig.class);
 
     OmTransport omTransport = createOmTransport(omServiceId);
-    this.ozoneManagerClient = TracingUtil.createProxy(
+    OzoneManagerProtocolClientSideTranslatorPB
+        ozoneManagerProtocolClientSideTranslatorPB =
         new OzoneManagerProtocolClientSideTranslatorPB(omTransport,
-            clientId.toString()),
-        OzoneManagerClientProtocol.class, conf
-    );
+        clientId.toString());
+    this.ozoneManagerClient = TracingUtil.createProxy(
+        ozoneManagerProtocolClientSideTranslatorPB,
+        OzoneManagerClientProtocol.class, conf);
     dtService = omTransport.getDelegationTokenService();
-    ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
     List<X509Certificate> x509Certificates = null;
     if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+      ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
+      // If the client is authenticating using S3 style aut, all future
+      // requests serviced by this client will need S3 Auth set.
+      ozoneManagerProtocolClientSideTranslatorPB.setS3AuthCheck(
+          conf.getBoolean(S3Auth.S3_AUTH_CHECK, false));
       String caCertPem = null;
       List<String> caCertPems = null;
       caCertPem = serviceInfoEx.getCaCertificate();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -196,7 +196,7 @@ public class RpcClient implements ClientProtocol {
     List<X509Certificate> x509Certificates = null;
     if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
       ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
-      // If the client is authenticating using S3 style aut, all future
+      // If the client is authenticating using S3 style auth, all future
       // requests serviced by this client will need S3 Auth set.
       ozoneManagerProtocolClientSideTranslatorPB.setS3AuthCheck(
           conf.getBoolean(S3Auth.S3_AUTH_CHECK, false));

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Auth.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/S3Auth.java
@@ -24,6 +24,7 @@ public class S3Auth {
   private String stringToSign;
   private String signature;
   private String accessID;
+  public static final String S3_AUTH_CHECK = "ozone.s3.auth.check";
 
   public S3Auth(final String stringToSign,
                 final String signature, final String accessID) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -175,14 +175,16 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     implements OzoneManagerClientProtocol {
 
   private final String clientID;
-
   private OmTransport transport;
   private ThreadLocal<S3Auth> threadLocalS3Auth
       = new ThreadLocal<>();
+
+  private boolean s3AuthCheck;
   public OzoneManagerProtocolClientSideTranslatorPB(OmTransport omTransport,
       String clientId) {
     this.clientID = clientId;
     this.transport = omTransport;
+    this.s3AuthCheck = false;
   }
 
   /**
@@ -236,6 +238,10 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
               .setAccessId(
                   threadLocalS3Auth.get().getAccessID())
               .build());
+    }
+    if (s3AuthCheck && getThreadLocalS3Auth() == null) {
+      throw new IllegalArgumentException("S3 Auth expected to " +
+          "be set but is null " + omRequest.toString());
     }
     OMResponse response =
         transport.submitRequest(
@@ -1670,5 +1676,13 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   @VisibleForTesting
   public OmTransport getTransport() {
     return transport;
+  }
+
+  public boolean isS3AuthCheck() {
+    return s3AuthCheck;
+  }
+
+  public void setS3AuthCheck(boolean s3AuthCheck) {
+    this.s3AuthCheck = s3AuthCheck;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -112,8 +112,7 @@ public class OzoneClientProducer {
   @NotNull
   @VisibleForTesting
   OzoneClient createOzoneClient() throws IOException {
-    // S3 Gateway should always set the S3 Auth. OM can choose to ignore it
-    // based on the security configuration.
+    // S3 Gateway should always set the S3 Auth.
     ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
     if (omServiceID == null) {
       return OzoneClientFactory.getRpcClient(ozoneConfiguration);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -112,6 +112,9 @@ public class OzoneClientProducer {
   @NotNull
   @VisibleForTesting
   OzoneClient createOzoneClient() throws IOException {
+    // S3 Gateway should always set the S3 Auth. OM can choose to ignore it
+    // based on the security configuration.
+    ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
     if (omServiceID == null) {
       return OzoneClientFactory.getRpcClient(ozoneConfiguration);
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ensure that if the client has asked for S3 style auth, each request
sent has S3 Auth information set.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5910

## How was this patch tested?

Set the validation to trip always and insure it catches the missing auth.
