### PR TITLE
HDDS-5929. Make FSO and OBS bucket layouts independent of normalization config flag

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSWithObjectStoreCreate.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -85,6 +86,8 @@ public class TestOzoneFSWithObjectStoreCreate {
     OzoneConfiguration conf = new OzoneConfiguration();
 
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMetrics.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Rule;
 import org.junit.BeforeClass;
 import org.junit.AfterClass;
@@ -69,6 +70,8 @@ public class TestOzoneFileSystemMetrics {
   @BeforeClass
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -648,8 +648,11 @@ public class KeyManagerImpl implements KeyManager {
     Preconditions.checkNotNull(args);
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
-    String keyName = OMClientRequest.validateAndNormalizeKey(
-        enableFileSystemPaths, args.getKeyName());
+    String keyName = args.getKeyName();
+    keyName = OMClientRequest
+        .validateAndNormalizeKey(enableFileSystemPaths, keyName,
+            getBucketLayout(metadataManager, args.getVolumeName(),
+                args.getBucketName()));
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
     OmKeyInfo value = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -142,6 +142,7 @@ public final class OzoneManagerRatisUtils {
    * @return OMClientRequest
    * @throws IOException
    */
+  @SuppressWarnings("checkstyle:methodlength")
   public static OMClientRequest createClientRequest(OMRequest omRequest,
       OzoneManager ozoneManager) {
 
@@ -154,6 +155,7 @@ public final class OzoneManagerRatisUtils {
     // handles it appropriately.
     Type cmdType = omRequest.getCmdType();
     OzoneManagerProtocolProtos.KeyArgs keyArgs;
+    BucketLayout bucketLayout = BucketLayout.DEFAULT;
     switch (cmdType) {
     case CreateVolume:
       return new OMVolumeCreateRequest(omRequest);
@@ -181,38 +183,43 @@ public final class OzoneManagerRatisUtils {
       return new OMBucketSetPropertyRequest(omRequest);
     case AllocateBlock:
       keyArgs = omRequest.getAllocateBlockRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new OMAllocateBlockRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new OMAllocateBlockRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMAllocateBlockRequest(omRequest);
+      return new OMAllocateBlockRequest(omRequest, bucketLayout);
     case CreateKey:
       keyArgs = omRequest.getCreateKeyRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new OMKeyCreateRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new OMKeyCreateRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMKeyCreateRequest(omRequest);
+      return new OMKeyCreateRequest(omRequest, bucketLayout);
     case CommitKey:
       keyArgs = omRequest.getCommitKeyRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new OMKeyCommitRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new OMKeyCommitRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMKeyCommitRequest(omRequest);
+      return new OMKeyCommitRequest(omRequest, bucketLayout);
     case DeleteKey:
       keyArgs = omRequest.getDeleteKeyRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new OMKeyDeleteRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new OMKeyDeleteRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMKeyDeleteRequest(omRequest);
+      return new OMKeyDeleteRequest(omRequest, bucketLayout);
     case DeleteKeys:
       return new OMKeysDeleteRequest(omRequest);
     case RenameKey:
       keyArgs = omRequest.getRenameKeyRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
         return new OMKeyRenameRequestWithFSO(omRequest);
       }
       return new OMKeyRenameRequest(omRequest);
@@ -220,15 +227,17 @@ public final class OzoneManagerRatisUtils {
       return new OMKeysRenameRequest(omRequest);
     case CreateDirectory:
       keyArgs = omRequest.getCreateDirectoryRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
         return new OMDirectoryCreateRequestWithFSO(omRequest);
       }
       return new OMDirectoryCreateRequest(omRequest);
     case CreateFile:
       keyArgs = omRequest.getCreateFileRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
         return new OMFileCreateRequestWithFSO(omRequest);
       }
       return new OMFileCreateRequest(omRequest);
@@ -238,32 +247,40 @@ public final class OzoneManagerRatisUtils {
       return new OMPathsPurgeRequestWithFSO(omRequest);
     case InitiateMultiPartUpload:
       keyArgs = omRequest.getInitiateMultiPartUploadRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new S3InitiateMultipartUploadRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new S3InitiateMultipartUploadRequestWithFSO(omRequest,
+            bucketLayout);
       }
-      return new S3InitiateMultipartUploadRequest(omRequest);
+      return new S3InitiateMultipartUploadRequest(omRequest, bucketLayout);
     case CommitMultiPartUpload:
       keyArgs = omRequest.getCommitMultiPartUploadRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new S3MultipartUploadCommitPartRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
+            bucketLayout);
       }
-      return new S3MultipartUploadCommitPartRequest(omRequest);
+      return new S3MultipartUploadCommitPartRequest(omRequest, bucketLayout);
     case AbortMultiPartUpload:
       keyArgs = omRequest.getAbortMultiPartUploadRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new S3MultipartUploadAbortRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new S3MultipartUploadAbortRequestWithFSO(omRequest,
+            bucketLayout);
       }
-      return new S3MultipartUploadAbortRequest(omRequest);
+      return new S3MultipartUploadAbortRequest(omRequest, bucketLayout);
     case CompleteMultiPartUpload:
       keyArgs = omRequest.getCompleteMultiPartUploadRequest().getKeyArgs();
-      if (isBucketFSOptimized(keyArgs.getVolumeName(), keyArgs.getBucketName(),
-          ozoneManager)) {
-        return new S3MultipartUploadCompleteRequestWithFSO(omRequest);
+      bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
+          keyArgs.getBucketName(), ozoneManager);
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
+        return new S3MultipartUploadCompleteRequestWithFSO(omRequest,
+            bucketLayout);
       }
-      return new S3MultipartUploadCompleteRequest(omRequest);
+      return new S3MultipartUploadCompleteRequest(omRequest, bucketLayout);
     case AddAcl:
     case RemoveAcl:
     case SetAcl:
@@ -495,9 +512,10 @@ public final class OzoneManagerRatisUtils {
    */
 
   private static OmBucketInfo getOmBucketInfo(OzoneManager ozoneManager,
-      OmBucketInfo buckInfo, String volName, String buckName) {
+      String volName, String buckName) {
     String buckKey =
         ozoneManager.getMetadataManager().getBucketKey(volName, buckName);
+    OmBucketInfo buckInfo = null;
     try {
       buckInfo =
           ozoneManager.getMetadataManager().getBucketTable().get(buckKey);
@@ -507,8 +525,9 @@ public final class OzoneManagerRatisUtils {
     return buckInfo;
   }
 
-  private static BucketLayout getBucketLayout(OmBucketInfo buckInfo,
-      String volName, String buckName) {
+  private static BucketLayout getBucketLayout(String volName,
+      String buckName, OzoneManager ozoneManager) {
+    OmBucketInfo buckInfo = getOmBucketInfo(ozoneManager, volName, buckName);
     if (buckInfo != null) {
       return buckInfo.getBucketLayout();
     } else {
@@ -517,14 +536,4 @@ public final class OzoneManagerRatisUtils {
     }
     return BucketLayout.LEGACY;
   }
-
-  private static boolean isBucketFSOptimized(String volName, String buckName,
-      OzoneManager ozoneManager) {
-    BucketLayout bucketLayout = null;
-    OmBucketInfo buckInfo = null;
-    buckInfo = getOmBucketInfo(ozoneManager, buckInfo, volName, buckName);
-    bucketLayout = getBucketLayout(buckInfo, volName, buckName);
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED.equals(bucketLayout);
-  }
-
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -65,8 +66,9 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMAllocateBlockRequest.class);
 
-  public OMAllocateBlockRequest(OMRequest omRequest) {
-    super(omRequest);
+  public OMAllocateBlockRequest(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -78,6 +80,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     Preconditions.checkNotNull(allocateBlockRequest);
 
     KeyArgs keyArgs = allocateBlockRequest.getKeyArgs();
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
 
     ExcludeList excludeList = new ExcludeList();
     if (allocateBlockRequest.hasExcludeList()) {
@@ -106,10 +110,8 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
             ozoneManager.isGrpcBlockTokenEnabled(), ozoneManager.getOMNodeId());
 
     // Set modification time and normalize key if required.
-    KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
-        .setModificationTime(Time.now())
-        .setKeyName(validateAndNormalizeKey(
-            ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
+    KeyArgs.Builder newKeyArgs =
+        keyArgs.toBuilder().setModificationTime(Time.now()).setKeyName(keyPath);
 
     AllocateBlockRequest.Builder newAllocatedBlockRequest =
         AllocateBlockRequest.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -80,8 +80,9 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
     Preconditions.checkNotNull(allocateBlockRequest);
 
     KeyArgs keyArgs = allocateBlockRequest.getKeyArgs();
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     ExcludeList excludeList = new ExcludeList();
     if (allocateBlockRequest.hasExcludeList()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -66,8 +66,9 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
   private static final Logger LOG =
           LoggerFactory.getLogger(OMAllocateBlockRequestWithFSO.class);
 
-  public OMAllocateBlockRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMAllocateBlockRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -70,8 +71,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyCommitRequest.class);
 
-  public OMKeyCommitRequest(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyCommitRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -90,10 +91,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
               OzoneConsts.FS_FILE_COPYING_TEMP_SUFFIX));
     }
 
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+
     KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now())
-            .setKeyName(validateAndNormalizeKey(
-                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
+            .setKeyName(keyPath);
 
     return getOmRequest().toBuilder()
         .setCommitKeyRequest(commitKeyRequest.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -91,8 +91,9 @@ public class OMKeyCommitRequest extends OMKeyRequest {
               OzoneConsts.FS_FILE_COPYING_TEMP_SUFFIX));
     }
 
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -58,8 +58,9 @@ import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_L
  */
 public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
-  public OMKeyCommitRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyCommitRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -210,10 +211,5 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
             exception, omKeyInfo, result);
 
     return omClientResponse;
-  }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.file.OMDirectoryCreateRequest;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -72,11 +73,16 @@ import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryR
  */
 
 public class OMKeyCreateRequest extends OMKeyRequest {
+
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyCreateRequest.class);
 
   public OMKeyCreateRequest(OMRequest omRequest) {
     super(omRequest);
+  }
+
+  public OMKeyCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -94,18 +100,8 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       OmUtils.validateKeyName(keyArgs.getKeyName());
     }
 
-    String keyPath = keyArgs.getKeyName();
-    if (ozoneManager.getEnableFileSystemPaths()) {
-      // If enabled, disallow keys with trailing /. As in fs semantics
-      // directories end with trailing /.
-      keyPath = validateAndNormalizeKey(
-          ozoneManager.getEnableFileSystemPaths(), keyPath);
-      if (keyPath.endsWith("/")) {
-        throw new OMException("Invalid KeyPath, key names with trailing / " +
-            "are not allowed." + keyPath,
-            OMException.ResultCodes.INVALID_KEY_NAME);
-      }
-    }
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
 
     // We cannot allocate block for multipart upload part when
     // createMultipartKey is called, as we will not know type and factor with

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -100,8 +100,9 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       OmUtils.validateKeyName(keyArgs.getKeyName());
     }
 
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     // We cannot allocate block for multipart upload part when
     // createMultipartKey is called, as we will not know type and factor with

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -59,8 +59,9 @@ import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryR
  */
 public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
 
-  public OMKeyCreateRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyCreateRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -230,10 +231,5 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
             numKeysCreated);
 
     return omClientResponse;
-  }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -72,8 +72,9 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
 
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
         keyArgs.toBuilder().setModificationTime(Time.now()).setKeyName(keyPath);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -61,8 +61,8 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyDeleteRequest.class);
 
-  public OMKeyDeleteRequest(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyDeleteRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -72,10 +72,11 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
     OzoneManagerProtocolProtos.KeyArgs keyArgs = deleteKeyRequest.getKeyArgs();
 
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+
     OzoneManagerProtocolProtos.KeyArgs.Builder newKeyArgs =
-        keyArgs.toBuilder().setModificationTime(Time.now())
-            .setKeyName(validateAndNormalizeKey(
-                ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName()));
+        keyArgs.toBuilder().setModificationTime(Time.now()).setKeyName(keyPath);
 
     return getOmRequest().toBuilder()
         .setDeleteKeyRequest(deleteKeyRequest.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -61,8 +61,9 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyDeleteRequestWithFSO.class);
 
-  public OMKeyDeleteRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyDeleteRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -94,13 +94,19 @@ public abstract class OMKeyRequest extends OMClientRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(OMKeyRequest.class);
 
+  private BucketLayout bucketLayout = BucketLayout.DEFAULT;
+
   public OMKeyRequest(OMRequest omRequest) {
     super(omRequest);
   }
 
+  public OMKeyRequest(OMRequest omRequest, BucketLayout bucketLayoutArg) {
+    super(omRequest);
+    this.bucketLayout = bucketLayoutArg;
+  }
+
   public BucketLayout getBucketLayout() {
-    // Returning Bucket.default since this is a non fso code path.
-    return BucketLayout.DEFAULT;
+    return bucketLayout;
   }
 
   protected KeyArgs resolveBucketLink(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -78,8 +78,9 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
 
     KeyArgs keyArgs = multipartInfoInitiateRequest.getKeyArgs();
 
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     KeyArgs.Builder newKeyArgs = keyArgs.toBuilder()
             .setMultipartUploadID(UUID.randomUUID().toString() + "-" +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -61,8 +61,9 @@ import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryR
 public class S3InitiateMultipartUploadRequestWithFSO
         extends S3InitiateMultipartUploadRequest {
 
-  public S3InitiateMultipartUploadRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public S3InitiateMultipartUploadRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -76,8 +76,9 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     KeyArgs keyArgs =
         getOmRequest().getAbortMultiPartUploadRequest().getKeyArgs();
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     return getOmRequest().toBuilder().setAbortMultiPartUploadRequest(
         getOmRequest().getAbortMultiPartUploadRequest().toBuilder().setKeyArgs(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -66,18 +67,22 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
     super(omRequest);
   }
 
+  public S3MultipartUploadAbortRequest(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
+  }
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     KeyArgs keyArgs =
         getOmRequest().getAbortMultiPartUploadRequest().getKeyArgs();
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
 
     return getOmRequest().toBuilder().setAbortMultiPartUploadRequest(
-        getOmRequest().getAbortMultiPartUploadRequest().toBuilder()
-            .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
-                .setKeyName(validateAndNormalizeKey(
-                    ozoneManager.getEnableFileSystemPaths(),
-                    keyArgs.getKeyName()))))
-        .setUserInfo(getUserInfo()).build();
+        getOmRequest().getAbortMultiPartUploadRequest().toBuilder().setKeyArgs(
+            keyArgs.toBuilder().setModificationTime(Time.now())
+                .setKeyName(keyPath))).setUserInfo(getUserInfo()).build();
 
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
@@ -42,8 +42,9 @@ import java.util.Iterator;
 public class S3MultipartUploadAbortRequestWithFSO
     extends S3MultipartUploadAbortRequest {
 
-  public S3MultipartUploadAbortRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public S3MultipartUploadAbortRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -69,8 +70,9 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(S3MultipartUploadCommitPartRequest.class);
 
-  public S3MultipartUploadCommitPartRequest(OMRequest omRequest) {
-    super(omRequest);
+  public S3MultipartUploadCommitPartRequest(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -79,13 +81,13 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         getOmRequest().getCommitMultiPartUploadRequest();
 
     KeyArgs keyArgs = multipartCommitUploadPartRequest.getKeyArgs();
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+
     return getOmRequest().toBuilder().setCommitMultiPartUploadRequest(
-        multipartCommitUploadPartRequest.toBuilder()
-            .setKeyArgs(keyArgs.toBuilder().setModificationTime(Time.now())
-                .setKeyName(validateAndNormalizeKey(
-                    ozoneManager.getEnableFileSystemPaths(),
-                    keyArgs.getKeyName()))))
-        .setUserInfo(getUserInfo()).build();
+        multipartCommitUploadPartRequest.toBuilder().setKeyArgs(
+            keyArgs.toBuilder().setModificationTime(Time.now())
+                .setKeyName(keyPath))).setUserInfo(getUserInfo()).build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -81,8 +81,9 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
         getOmRequest().getCommitMultiPartUploadRequest();
 
     KeyArgs keyArgs = multipartCommitUploadPartRequest.getKeyArgs();
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     return getOmRequest().toBuilder().setCommitMultiPartUploadRequest(
         multipartCommitUploadPartRequest.toBuilder().setKeyArgs(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
@@ -42,8 +42,9 @@ import java.util.Iterator;
 public class S3MultipartUploadCommitPartRequestWithFSO
         extends S3MultipartUploadCommitPartRequest {
 
-  public S3MultipartUploadCommitPartRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public S3MultipartUploadCommitPartRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -83,8 +83,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         getOmRequest().getCompleteMultiPartUploadRequest();
 
     KeyArgs keyArgs = multipartUploadCompleteRequest.getKeyArgs();
-    String keyPath =
-        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
+    String keyPath = keyArgs.getKeyName();
+    keyPath = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        keyPath, getBucketLayout());
 
     return getOmRequest().toBuilder().setCompleteMultiPartUploadRequest(
         multipartUploadCompleteRequest.toBuilder().setKeyArgs(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -71,8 +72,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(S3MultipartUploadCompleteRequest.class);
 
-  public S3MultipartUploadCompleteRequest(OMRequest omRequest) {
-    super(omRequest);
+  public S3MultipartUploadCompleteRequest(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -81,15 +83,13 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         getOmRequest().getCompleteMultiPartUploadRequest();
 
     KeyArgs keyArgs = multipartUploadCompleteRequest.getKeyArgs();
+    String keyPath =
+        validateAndNormalizeKey(ozoneManager, keyArgs, getBucketLayout());
 
-    return getOmRequest().toBuilder()
-        .setCompleteMultiPartUploadRequest(multipartUploadCompleteRequest
-            .toBuilder().setKeyArgs(keyArgs.toBuilder()
-                .setModificationTime(Time.now())
-                .setKeyName(validateAndNormalizeKey(
-                    ozoneManager.getEnableFileSystemPaths(),
-                    keyArgs.getKeyName()))))
-        .setUserInfo(getUserInfo()).build();
+    return getOmRequest().toBuilder().setCompleteMultiPartUploadRequest(
+        multipartUploadCompleteRequest.toBuilder().setKeyArgs(
+            keyArgs.toBuilder().setModificationTime(Time.now())
+                .setKeyName(keyPath))).setUserInfo(getUserInfo()).build();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -51,8 +51,9 @@ public class S3MultipartUploadCompleteRequestWithFSO
   private static final Logger LOG =
       LoggerFactory.getLogger(S3MultipartUploadCompleteRequestWithFSO.class);
 
-  public S3MultipartUploadCompleteRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public S3MultipartUploadCompleteRequestWithFSO(OMRequest omRequest,
+      BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -119,7 +120,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
   @NotNull
   protected OMAllocateBlockRequest getOmAllocateBlockRequest(
           OMRequest modifiedOmRequest) {
-    return new OMAllocateBlockRequest(modifiedOmRequest);
+    return new OMAllocateBlockRequest(modifiedOmRequest, BucketLayout.DEFAULT);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequestWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.util.StringUtils;
@@ -47,7 +46,6 @@ public class TestOMAllocateBlockRequestWithFSO
     // metadata layout prefix will be set while invoking OzoneManager#start()
     // and its not invoked in this test. Hence it is explicitly setting
     // this configuration to populate prefix tables.
-    OzoneManagerRatisUtils.setBucketFSOptimized(true);
     return config;
   }
 
@@ -81,8 +79,9 @@ public class TestOMAllocateBlockRequestWithFSO
   @NotNull
   @Override
   protected OMAllocateBlockRequest getOmAllocateBlockRequest(
-          OzoneManagerProtocolProtos.OMRequest modifiedOmRequest) {
-    return new OMAllocateBlockRequestWithFSO(modifiedOmRequest);
+      OzoneManagerProtocolProtos.OMRequest modifiedOmRequest) {
+    return new OMAllocateBlockRequestWithFSO(modifiedOmRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
@@ -74,14 +75,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
         .collect(Collectors.toList());
 
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
+        omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
     String ozoneKey = addKeyToOpenKeyTable(allocatedLocationList);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -94,11 +96,14 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
     Assert.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNotNull(omKeyInfo);
 
@@ -132,14 +137,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
             .collect(Collectors.toList());
 
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
+        omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
     String ozoneKey = addKeyToOpenKeyTable(allocatedLocationList);
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -152,11 +158,14 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     // Entry should be deleted from openKey Table.
     omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getOpenKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
     Assert.assertNull(omKeyInfo);
 
     // Now entry should be created in key Table.
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNotNull(omKeyInfo);
     // DB keyInfo format
@@ -202,7 +211,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -213,7 +223,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
   }
@@ -234,7 +246,8 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -245,7 +258,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
   }
@@ -260,14 +275,15 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
             getOmKeyCommitRequest(modifiedOmRequest);
 
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
+        omMetadataManager, omKeyCommitRequest.getBucketLayout());
 
     String ozoneKey = getOzonePathKey();
 
     // Key should not be there in key table, as validateAndUpdateCache is
     // still not called.
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -278,7 +294,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.KEY_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
 
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNull(omKeyInfo);
   }
@@ -300,8 +318,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
     String ozoneKey = getOzonePathKey();
     // Key should be there in key table, as validateAndUpdateCache is called.
-    OmKeyInfo omKeyInfo = omMetadataManager
-        .getKeyTable(getBucketLayout()).get(ozoneKey);
+    OmKeyInfo omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNotNull(omKeyInfo);
     // Previously committed version
@@ -323,7 +342,9 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
             omClientResponse.getOMResponse().getStatus());
 
     // New entry should be created in key Table.
-    omKeyInfo = omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+    omKeyInfo =
+        omMetadataManager.getKeyTable(omKeyCommitRequest.getBucketLayout())
+            .get(ozoneKey);
 
     Assert.assertNotNull(omKeyInfo);
     Assert.assertEquals(version,
@@ -458,7 +479,7 @@ public class TestOMKeyCommitRequest extends TestOMKeyRequest {
 
   @NotNull
   protected OMKeyCommitRequest getOmKeyCommitRequest(OMRequest omRequest) {
-    return new OMKeyCommitRequest(omRequest);
+    return new OMKeyCommitRequest(omRequest, BucketLayout.DEFAULT);
   }
 
   protected void verifyKeyName(OmKeyInfo omKeyInfo) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCommitRequestWithFSO.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
@@ -99,7 +100,8 @@ public class TestOMKeyCommitRequestWithFSO extends TestOMKeyCommitRequest {
 
   @NotNull
   protected OMKeyCommitRequest getOmKeyCommitRequest(OMRequest omRequest) {
-    return new OMKeyCommitRequestWithFSO(omRequest);
+    return new OMKeyCommitRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequest.java
@@ -27,6 +27,7 @@ import java.util.UUID;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -86,7 +87,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     // Before calling
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey);
 
     Assert.assertNull(omKeyInfo);
 
@@ -94,7 +96,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
             ozoneManagerDoubleBufferHelper);
 
-    checkResponse(modifiedOmRequest, omKeyCreateResponse, id, false);
+    checkResponse(modifiedOmRequest, omKeyCreateResponse, id, false,
+        omKeyCreateRequest.getBucketLayout());
 
     // Network returns only latest version.
     Assert.assertEquals(1, omKeyCreateResponse.getOMResponse()
@@ -102,12 +105,14 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     // Disk should have 1 version, as it is fresh key create.
     Assert.assertEquals(1,
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey)
-            .getKeyLocationVersions().size());
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey).getKeyLocationVersions().size());
 
     // Write to DB like key commit.
-    omMetadataManager.getKeyTable(getBucketLayout()).put(getOzoneKey(),
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey));
+    omMetadataManager.getKeyTable(omKeyCreateRequest.getBucketLayout())
+        .put(getOzoneKey(), omMetadataManager
+            .getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey));
 
     // Override same key again
     modifiedOmRequest =
@@ -118,7 +123,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     // Before calling
     omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey);
     Assert.assertNull(omKeyInfo);
 
     omKeyCreateRequest =
@@ -128,7 +134,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
         omKeyCreateRequest.validateAndUpdateCache(ozoneManager, 101L,
             ozoneManagerDoubleBufferHelper);
 
-    checkResponse(modifiedOmRequest, omKeyCreateResponse, id, true);
+    checkResponse(modifiedOmRequest, omKeyCreateResponse, id, true,
+        omKeyCreateRequest.getBucketLayout());
 
     // Network returns only latest version
     Assert.assertEquals(1, omKeyCreateResponse.getOMResponse()
@@ -136,14 +143,14 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
 
     // Disk should have 1 versions when bucket versioning is off.
     Assert.assertEquals(1,
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey)
-            .getKeyLocationVersions().size());
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey).getKeyLocationVersions().size());
 
   }
 
   private void checkResponse(OMRequest modifiedOmRequest,
-      OMClientResponse omKeyCreateResponse, long id, boolean override)
-      throws Exception {
+      OMClientResponse omKeyCreateResponse, long id, boolean override,
+      BucketLayout bucketLayout) throws Exception {
 
     Assert.assertEquals(OK,
         omKeyCreateResponse.getOMResponse().getStatus());
@@ -153,7 +160,7 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     // Check open table whether key is added or not.
 
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
+        omMetadataManager.getOpenKeyTable(bucketLayout).get(openKey);
 
     Assert.assertNotNull(omKeyInfo);
 
@@ -559,7 +566,8 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
     String openKey = omMetadataManager.getOpenKey(volumeName, bucketName,
         keyName, omRequest.getCreateKeyRequest().getClientID());
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey);
     Assert.assertNotNull(omKeyInfo);
   }
 
@@ -585,6 +593,6 @@ public class TestOMKeyCreateRequest extends TestOMKeyRequest {
   }
 
   protected OMKeyCreateRequest getOMKeyCreateRequest(OMRequest omRequest) {
-    return new OMKeyCreateRequest(omRequest);
+    return new OMKeyCreateRequest(omRequest, BucketLayout.DEFAULT);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
@@ -48,7 +47,6 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     // Metadata layout prefix will be set while invoking OzoneManager#start()
     // and its not invoked in this test. Hence it is explicitly setting
     // this configuration to populate prefix tables.
-    OzoneManagerRatisUtils.setBucketFSOptimized(true);
     return config;
   }
 
@@ -82,7 +80,8 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
     String openKey = omMetadataManager.getOpenFileName(parentID, fileName,
             omRequest.getCreateKeyRequest().getClientID());
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(openKey);
+        omMetadataManager.getOpenKeyTable(omKeyCreateRequest.getBucketLayout())
+            .get(openKey);
     Assert.assertNotNull(omKeyInfo);
   }
 
@@ -143,7 +142,8 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
 
   @Override
   protected OMKeyCreateRequest getOMKeyCreateRequest(OMRequest omRequest) {
-    return new OMKeyCreateRequestWithFSO(omRequest);
+    return new OMKeyCreateRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
@@ -68,7 +68,8 @@ public class TestOMKeyCreateRequestWithFSO extends TestOMKeyCreateRequest {
   @Override
   protected void checkCreatedPaths(OMKeyCreateRequest omKeyCreateRequest,
       OMRequest omRequest, String keyName) throws Exception {
-    keyName = omKeyCreateRequest.validateAndNormalizeKey(true, keyName);
+    keyName = omKeyCreateRequest.validateAndNormalizeKey(true, keyName,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
     // Check intermediate directories created or not.
     Path keyPath = Paths.get(keyName);
     long parentID = checkIntermediatePaths(keyPath);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 
 import java.util.UUID;
 
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -107,9 +108,10 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
     OMKeyDeleteRequest omKeyDeleteRequest =
             getOmKeyDeleteRequest(modifiedOmRequest);
 
-    OMClientResponse omClientResponse =
-        omKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
-            100L, ozoneManagerDoubleBufferHelper, getBucketLayout());
+    OMClientResponse omClientResponse = omKeyDeleteRequest
+        .validateAndUpdateCache(ozoneManager, 100L,
+            ozoneManagerDoubleBufferHelper,
+            omKeyDeleteRequest.getBucketLayout());
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.VOLUME_NOT_FOUND,
         omClientResponse.getOMResponse().getStatus());
@@ -125,9 +127,10 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
 
     TestOMRequestUtils.addVolumeToDB(volumeName, omMetadataManager);
 
-    OMClientResponse omClientResponse =
-        omKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
-            100L, ozoneManagerDoubleBufferHelper, getBucketLayout());
+    OMClientResponse omClientResponse = omKeyDeleteRequest
+        .validateAndUpdateCache(ozoneManager, 100L,
+            ozoneManagerDoubleBufferHelper,
+            omKeyDeleteRequest.getBucketLayout());
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.BUCKET_NOT_FOUND,
             omClientResponse.getOMResponse().getStatus());
@@ -179,6 +182,6 @@ public class TestOMKeyDeleteRequest extends TestOMKeyRequest {
 
   protected OMKeyDeleteRequest getOmKeyDeleteRequest(
       OMRequest modifiedOmRequest) {
-    return new OMKeyDeleteRequest(modifiedOmRequest);
+    return new OMKeyDeleteRequest(modifiedOmRequest, BucketLayout.DEFAULT);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -43,7 +43,8 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
   @Override
   protected OMKeyDeleteRequest getOmKeyDeleteRequest(
       OMRequest modifiedOmRequest) {
-    return new OMKeyDeleteRequestWithFSO(modifiedOmRequest);
+    return new OMKeyDeleteRequestWithFSO(modifiedOmRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -69,8 +69,9 @@ public class TestS3InitiateMultipartUploadRequest
         modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
 
-    Assert.assertNotNull(
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
+    Assert.assertNotNull(omMetadataManager
+        .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
+        .get(multipartKey));
     Assert.assertNotNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
 
@@ -81,14 +82,14 @@ public class TestS3InitiateMultipartUploadRequest
 
     Assert.assertEquals(
         modifiedRequest.getInitiateMultiPartUploadRequest().getKeyArgs()
-            .getModificationTime(),
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey)
-            .getModificationTime());
+            .getModificationTime(), omMetadataManager
+            .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
+            .get(multipartKey).getModificationTime());
     Assert.assertEquals(
         modifiedRequest.getInitiateMultiPartUploadRequest().getKeyArgs()
-            .getModificationTime(),
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey)
-            .getCreationTime());
+            .getModificationTime(), omMetadataManager
+            .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
+            .get(multipartKey).getCreationTime());
 
   }
 
@@ -118,8 +119,9 @@ public class TestS3InitiateMultipartUploadRequest
         modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
 
-    Assert.assertNull(
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
+    Assert.assertNull(omMetadataManager
+        .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
+        .get(multipartKey));
     Assert.assertNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
   }
@@ -147,8 +149,9 @@ public class TestS3InitiateMultipartUploadRequest
         modifiedRequest.getInitiateMultiPartUploadRequest()
             .getKeyArgs().getMultipartUploadID());
 
-    Assert.assertNull(
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
+    Assert.assertNull(omMetadataManager
+        .getOpenKeyTable(s3InitiateMultipartUploadRequest.getBucketLayout())
+        .get(multipartKey));
     Assert.assertNull(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey));
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
@@ -88,7 +88,8 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
             fileName, modifiedRequest.getInitiateMultiPartUploadRequest()
                     .getKeyArgs().getMultipartUploadID());
 
-    OmKeyInfo omKeyInfo = omMetadataManager.getOpenKeyTable(getBucketLayout())
+    OmKeyInfo omKeyInfo = omMetadataManager
+        .getOpenKeyTable(s3InitiateMultipartUploadReqFSO.getBucketLayout())
         .get(multipartOpenFileKey);
     Assert.assertNotNull("Failed to find the fileInfo", omKeyInfo);
     Assert.assertEquals("FileName mismatches!", fileName,
@@ -141,7 +142,8 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
       OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest);
+    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.junit.After;
 import org.junit.Assert;
@@ -49,7 +48,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Part;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 
-import static org.apache.hadoop.ozone.om.OzoneManager.LOG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -236,7 +234,8 @@ public class TestS3MultipartRequest {
 
     S3InitiateMultipartUploadRequestWithFSO
         s3InitiateMultipartUploadRequestWithFSO =
-            new S3InitiateMultipartUploadRequestWithFSO(omRequest);
+        new S3InitiateMultipartUploadRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedRequest =
             s3InitiateMultipartUploadRequestWithFSO.preExecute(ozoneManager);
@@ -253,40 +252,28 @@ public class TestS3MultipartRequest {
 
   protected S3MultipartUploadCompleteRequest getS3MultipartUploadCompleteReq(
           OMRequest omRequest) {
-    return new S3MultipartUploadCompleteRequest(omRequest);
+    return new S3MultipartUploadCompleteRequest(omRequest,
+        BucketLayout.DEFAULT);
   }
 
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
           OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequest(omRequest);
+    return new S3MultipartUploadCommitPartRequest(omRequest,
+        BucketLayout.DEFAULT);
   }
 
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-          OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequest(initiateMPURequest);
+      OMRequest initiateMPURequest) {
+    return new S3InitiateMultipartUploadRequest(initiateMPURequest,
+        BucketLayout.DEFAULT);
   }
 
   protected S3MultipartUploadAbortRequest getS3MultipartUploadAbortReq(
       OMRequest omRequest) {
-    return new S3MultipartUploadAbortRequest(omRequest);
+    return new S3MultipartUploadAbortRequest(omRequest, BucketLayout.DEFAULT);
   }
 
   public BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
-  }
-
-  public BucketLayout getBucketLayout(OMMetadataManager metadataManager,
-      String volumeName, String bucketName) {
-    if (metadataManager == null) {
-      return BucketLayout.DEFAULT;
-    }
-    String buckKey = metadataManager.getBucketKey(volumeName, bucketName);
-    try {
-      OmBucketInfo buckInfo = metadataManager.getBucketTable().get(buckKey);
-      return buckInfo.getBucketLayout();
-    } catch (IOException e) {
-      LOG.error("Cannot find the key: " + buckKey);
-    }
     return BucketLayout.DEFAULT;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
@@ -92,7 +92,8 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
         omClientResponse.getOMResponse().getStatus());
     Assert.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
-    Assert.assertNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
+    Assert.assertNull(omMetadataManager
+        .getOpenKeyTable(s3MultipartUploadAbortRequest.getBucketLayout())
         .get(multipartOpenKey));
 
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequestWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 
@@ -37,13 +38,15 @@ public class TestS3MultipartUploadAbortRequestWithFSO
   @Override
   protected S3MultipartUploadAbortRequest getS3MultipartUploadAbortReq(
       OMRequest omRequest) {
-    return new S3MultipartUploadAbortRequestWithFSO(omRequest);
+    return new S3MultipartUploadAbortRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
       OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest);
+    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -100,12 +100,14 @@ public class TestS3MultipartUploadCommitPartRequest
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
     Assert.assertTrue(omMetadataManager.getMultipartInfoTable()
         .get(multipartKey).getPartKeyInfoMap().size() == 1);
-    Assert.assertNotNull(omMetadataManager.getOpenKeyTable(getBucketLayout())
+    Assert.assertNotNull(omMetadataManager
+        .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
         .get(multipartOpenKey));
 
     String partKey = getOpenKey(volumeName, bucketName, keyName, clientID);
-    Assert.assertNull(
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(partKey));
+    Assert.assertNull(omMetadataManager
+        .getOpenKeyTable(s3MultipartUploadCommitPartRequest.getBucketLayout())
+        .get(partKey));
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -43,14 +43,16 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
 
   @Override
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-          OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest);
+      OMRequest omRequest) {
+    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-          OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest);
+      OMRequest initiateMPURequest) {
+    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override
@@ -94,7 +96,8 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
                     keyName);
 
     S3InitiateMultipartUploadRequest s3InitiateMultipartUploadRequest =
-            new S3InitiateMultipartUploadRequestWithFSO(omRequest);
+        new S3InitiateMultipartUploadRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedRequest =
             s3InitiateMultipartUploadRequest.preExecute(ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -117,12 +117,13 @@ public class TestS3MultipartUploadCompleteRequest
     String multipartKey = getMultipartKey(volumeName, bucketName, keyName,
             multipartUploadID);
 
-    Assert.assertNull(
-        omMetadataManager.getOpenKeyTable(getBucketLayout()).get(multipartKey));
+    Assert.assertNull(omMetadataManager
+        .getOpenKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
+        .get(multipartKey));
     Assert.assertNull(
         omMetadataManager.getMultipartInfoTable().get(multipartKey));
     Assert.assertNotNull(omMetadataManager
-        .getKeyTable(getBucketLayout(omMetadataManager, volumeName, bucketName))
+        .getKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
         .get(getOzoneDBKey(volumeName, bucketName, keyName)));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -120,19 +121,22 @@ public class TestS3MultipartUploadCompleteRequestWithFSO
   @Override
   protected S3MultipartUploadCompleteRequest getS3MultipartUploadCompleteReq(
           OMRequest omRequest) {
-    return new S3MultipartUploadCompleteRequestWithFSO(omRequest);
+    return new S3MultipartUploadCompleteRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override
   protected S3MultipartUploadCommitPartRequest getS3MultipartUploadCommitReq(
-          OMRequest omRequest) {
-    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest);
+      OMRequest omRequest) {
+    return new S3MultipartUploadCommitPartRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override
   protected S3InitiateMultipartUploadRequest getS3InitiateMultipartUploadReq(
-          OMRequest initiateMPURequest) {
-    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest);
+      OMRequest initiateMPURequest) {
+    return new S3InitiateMultipartUploadRequestWithFSO(initiateMPURequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Presently FILE_SYSTEM_OPTIMIZED("FSO") and OBJECT_STORE("OBS") implementation depends on "ozone.om.enable.filesystem.paths" flag. This flag should be enabled explicitly for the FSO logic and disabled explicitly for the OBS logic. This task is to remove the dependency with the normalization config flag for the FSO and OBS bucket layouts. 

case-1) FSO bucket layout should normalize the given key path irrespective of the above flag value.

case-2) OBS bucket layout shouldn't normalize the given key path irrespective of the above flag value.

case-3) LEGACY bucket layout should read the configuration flag and perform normalize the given key path based on the above config flag.

 

Hint

`// normalize key if required.`
 `String keyName;`
` if (getBucketLayout() == BucketLayout.OBJECT_STORE) {`
      `keyName = keyArgs.getKeyName(); // pure object store semantics.`
 `} else if (getBucketLayout() == BucketLayout.FILE_SYSTEM_OPTIMIZED) {`
      `keyName = validateAndNormalizeKey(true, keyArgs.getKeyName()); // pure FS semantics.`
` } else {`
     ` // legacy bucket, normalize key based on "ozone.om.enable.filesystem.paths" flag value.`
      `keyName = validateAndNormalizeKey(`
     ` ozoneManager.getEnableFileSystemPaths(), keyArgs.getKeyName());`
` }`

 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5929

## How was this patch tested?

Tested Manually 