### PR TITLE
HDDS-5957. Bump proto-backwards-compatibility from 1.0.5 to 1.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- the version of Hadoop declared in the version resources; can be overridden
     so that Hadoop 3.x can declare itself a 2.x artifact. -->
     <declared.hadoop.version>${hadoop.version}</declared.hadoop.version>
-    <proto-backwards-compatibility.version>1.0.5</proto-backwards-compatibility.version>
+    <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
Preparing for the **native** (not using x86 JVM via Rosetta 2) Apple Silicon (darwin/osx aarch64/arm64 architecture) development environment.

See plugin release notes: https://github.com/salesforce/proto-backwards-compat-maven-plugin/releases

Side note: I am able to dev and run tests in IntelliJ with darwin arm64 native JVM after compiling 3 different protobuf versions for arm64, and compiling rocksdbjni 6.25.3 for osx-aarch64. Running native arm64 is significantly faster than using x86 JVM with Rosetta 2 translation layer on an M1-series Mac. Docker [ozone-runner](https://github.com/apache/ozone-docker-runner) still only has x86 containers for now (which can be run in x86 qemu for testing, but slow).