### PR TITLE
HDDS-5898 S3G in secure mode checks OM version.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -461,6 +461,12 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_TEST_OFS_BUCKET_LAYOUT_DEFAULT =
       "FILE_SYSTEM_OPTIMIZED";
 
+  public static final String OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY =
+      "ozone.om.client.protocol.version";
+  // The version of the protocol for Client (S3G/OFS) to OM Communication.
+  // The protocol starts at 2.0.0 and a null or empty value for older versions.
+  public static final String OZONE_OM_CLIENT_PROTOCOL_VERSION = "2.0.0";
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -130,8 +130,10 @@ import com.google.common.cache.RemovalNotification;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
 import static org.apache.hadoop.ozone.OzoneConsts.OLD_QUOTA_DEFAULT;
 
+import org.apache.hadoop.util.ComparableVersion;
 import org.apache.logging.log4j.util.Strings;
 import org.apache.ratis.protocol.ClientId;
 import org.jetbrains.annotations.NotNull;
@@ -198,8 +200,23 @@ public class RpcClient implements ClientProtocol {
       ServiceInfoEx serviceInfoEx = ozoneManagerClient.getServiceInfo();
       // If the client is authenticating using S3 style auth, all future
       // requests serviced by this client will need S3 Auth set.
-      ozoneManagerProtocolClientSideTranslatorPB.setS3AuthCheck(
-          conf.getBoolean(S3Auth.S3_AUTH_CHECK, false));
+      boolean isS3 = conf.getBoolean(S3Auth.S3_AUTH_CHECK, false);
+      ozoneManagerProtocolClientSideTranslatorPB.setS3AuthCheck(isS3);
+      if (isS3) {
+        // S3 Auth works differently and needs OM version to be at 2.0.0
+        String omVersion = conf.get(OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY);
+        if (!validateOmVersion(omVersion, serviceInfoEx.getServiceInfoList())) {
+          if (LOG.isDebugEnabled()) {
+            for (ServiceInfo s : serviceInfoEx.getServiceInfoList()) {
+              LOG.debug("Node {} version {}", s.getHostname(),
+                  s.getProtobuf().getOMProtocolVersion());
+            }
+          }
+          throw new RuntimeException("OmVersion expected "
+              + omVersion
+              + ", not found in ServiceList");
+        }
+      }
       String caCertPem = null;
       List<String> caCertPems = null;
       caCertPem = serviceInfoEx.getCaCertificate();
@@ -261,6 +278,29 @@ public class RpcClient implements ClientProtocol {
             }
           }
         }).build();
+  }
+
+  static boolean validateOmVersion(String expectedVersion,
+                                   List<ServiceInfo> serviceInfoList) {
+    if (expectedVersion == null || expectedVersion.isEmpty()) {
+      // Empty strings assumes client is fine with any OM version.
+      return true;
+    }
+    boolean found = false; // At min one OM should be present.
+    for (ServiceInfo s: serviceInfoList) {
+      if (s.getNodeType() == HddsProtos.NodeType.OM) {
+        ComparableVersion comparableExpectedVersion =
+            new ComparableVersion(expectedVersion);
+        ComparableVersion comparableOMVersion =
+            new ComparableVersion(s.getProtobuf().getOMProtocolVersion());
+        if (comparableOMVersion.compareTo(comparableExpectedVersion) < 0) {
+          return false;
+        } else {
+          found = true;
+        }
+      }
+    }
+    return found;
   }
 
   @NotNull

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/RpcClientTest.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/RpcClientTest.java
@@ -149,7 +149,27 @@ public class RpcClientTest {
         OZONE_OM_CLIENT_PROTOCOL_VERSION,
         "1.0.1",
         "1.0.1",
-        false);;
+        false),
+    VALID_EXPECTED_TWO_OM_ONE_LOWER_VERSION(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        "2.0.1",
+        false),
+    VALID_EXPECTED_TWO_OM_SECOND_EMPTY(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        "",
+        false),
+    VALID_EXPECTED_TWO_OM_FIRST_EMPTY(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "",
+        "1.0.1",
+        false),
+    VALID_EXPECTED_TWO_OM_BOTH_EMPTY(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "",
+        "",
+        false),;
 
     private static final List<ValidateOmVersionTestCases>
         TEST_CASES = new LinkedList<>();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/RpcClientTest.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/rpc/RpcClientTest.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.client.rpc;
+
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
+import static org.apache.hadoop.ozone.client.rpc.RpcClient.validateOmVersion;
+
+/**
+ * Run RPC Client tests.
+ */
+public class RpcClientTest {
+  private enum ValidateOmVersionTestCases {
+    NULL_EXPECTED_NO_OM(
+        null, // Expected version
+        null, // First OM Version
+        null, // Second OM Version
+        true), // Should validation pass
+    NULL_EXPECTED_ONE_OM(
+        null,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        null,
+        true),
+    NULL_EXPECTED_TWO_OM(
+        null,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        true),
+    NULL_EXPECTED_TWO_OM_SECOND_MISMATCH(
+        null,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "invalid",
+        true),
+    NULL_EXPECTED_TWO_OM_BOTH_MISMATCH(
+        null,
+        "invalid",
+        "invalid",
+        true),
+    NULL_EXPECTED_TWO_OM_FIRST_MISMATCH(
+        null,
+        "invalid",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        true),
+    EMPTY_EXPECTED_NO_OM(
+        "",
+        null,
+        null,
+        true),
+    EMPTY_EXPECTED_ONE_OM(
+        "",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        null,
+        true),
+    EMPTY_EXPECTED_TWO_OM(
+        "",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        true),
+    EMPTY_EXPECTED_TWO_OM_MISMATCH(
+        "",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "invalid",
+        true),
+    EMPTY_EXPECTED_TWO_OM_BOTH_MISMATCH(
+        "",
+        "invalid",
+        "invalid",
+        true),
+    VALID_EXPECTED_NO_OM(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        null,
+        null,
+        false),
+    VALID_EXPECTED_ONE_OM(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        null,
+        true),
+    VALID_EXPECTED_TWO_OM(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        true),
+    VALID_EXPECTED_TWO_OM_SECOND_LOWER(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        false),
+    VALID_EXPECTED_TWO_OM_SECOND_HIGHER(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "100.0.1",
+        true),
+    VALID_EXPECTED_TWO_OM_FIRST_OM_LOWER(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        false),
+    VALID_EXPECTED_TWO_OM_FIRST_OM_HIGHER(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "10.0.1",
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        true),
+    VALID_EXPECTED_TWO_OM_BOTH_LOWER(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        "1.9.1",
+        false),
+    VALID_EXPECTED_ONE_OM_HIGHER_VERSION(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "100.0.1",
+        null,
+        true),
+    VALID_EXPECTED_TWO_OM_HIGHER_VERSION(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "100.0.1",
+        "100.0.1",
+        true),
+    VALID_EXPECTED_ONE_OM_LOWER_VERSION(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        null,
+        false),
+    VALID_EXPECTED_TWO_OM_LOWER_VERSION(
+        OZONE_OM_CLIENT_PROTOCOL_VERSION,
+        "1.0.1",
+        "1.0.1",
+        false);;
+
+    private static final List<ValidateOmVersionTestCases>
+        TEST_CASES = new LinkedList<>();
+
+    static {
+      for (ValidateOmVersionTestCases t : values()) {
+        TEST_CASES.add(t);
+      }
+    }
+    private final String expectedVersion;
+    private final String om1Version;
+    private final String om2Version;
+    private final boolean validation;
+    ValidateOmVersionTestCases(String expectedVersion,
+                               String om1Version,
+                               String om2Version,
+                               boolean validation) {
+      this.expectedVersion = expectedVersion;
+      this.om1Version = om1Version;
+      this.om2Version = om2Version;
+      this.validation = validation;
+    }
+
+  }
+  @Test
+  public void testValidateOmVersion() {
+    for (ValidateOmVersionTestCases t: ValidateOmVersionTestCases.TEST_CASES) {
+      List<ServiceInfo> serviceInfoList = new LinkedList<>();
+      ServiceInfo.Builder b1 = new ServiceInfo.Builder();
+      ServiceInfo.Builder b2 = new ServiceInfo.Builder();
+      b1.setNodeType(HddsProtos.NodeType.OM).setHostname("localhost");
+      b2.setNodeType(HddsProtos.NodeType.OM).setHostname("localhost");
+      if (t.om1Version != null) {
+        b1.setOmClientProtocolVersion(t.om1Version);
+        serviceInfoList.add(b1.build());
+      }
+      if (t.om2Version != null) {
+        b2.setOmClientProtocolVersion(t.om2Version);
+        serviceInfoList.add(b2.build());
+      }
+      Assert.assertEquals("Running test " + t, t.validation,
+          validateOmVersion(t.expectedVersion, serviceInfoList));
+    }
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
@@ -48,6 +48,11 @@ public final class ServiceInfo {
   private String hostname;
 
   /**
+   * Protocol version for client.
+   */
+  private String omClientProtocolVersion;
+
+  /**
    * List of ports the service listens to.
    */
   private Map<ServicePort.Type, Integer> ports;
@@ -65,12 +70,16 @@ public final class ServiceInfo {
    * @param hostname hostname of the service
    * @param portList list of ports the service listens to
    */
-  private ServiceInfo(NodeType nodeType, String hostname,
-      List<ServicePort> portList, OMRoleInfo omRole) {
+  private ServiceInfo(NodeType nodeType,
+                      String hostname,
+                      List<ServicePort> portList,
+                      String omClientProtocolVersion,
+                      OMRoleInfo omRole) {
     Preconditions.checkNotNull(nodeType);
     Preconditions.checkNotNull(hostname);
     this.nodeType = nodeType;
     this.hostname = hostname;
+    this.omClientProtocolVersion = omClientProtocolVersion;
     this.ports = new HashMap<>();
     for (ServicePort port : portList) {
       ports.put(port.getType(), port.getValue());
@@ -154,6 +163,9 @@ public final class ServiceInfo {
     builder.setNodeType(nodeType)
         .setHostname(hostname)
         .addAllServicePorts(servicePorts);
+    if (omClientProtocolVersion != null) {
+      builder.setOMProtocolVersion(omClientProtocolVersion);
+    }
     if (nodeType == NodeType.OM && omRoleInfo != null) {
       builder.setOmRole(omRoleInfo);
     }
@@ -171,6 +183,7 @@ public final class ServiceInfo {
     return new ServiceInfo(serviceInfo.getNodeType(),
         serviceInfo.getHostname(),
         serviceInfo.getServicePortsList(),
+        serviceInfo.getOMProtocolVersion(),
         serviceInfo.hasOmRole() ? serviceInfo.getOmRole() : null);
   }
 
@@ -191,6 +204,24 @@ public final class ServiceInfo {
     private String host;
     private List<ServicePort> portList = new ArrayList<>();
     private OMRoleInfo omRoleInfo;
+    private String omClientProtocolVersion;
+
+    /**
+     * Gets the Om Client Protocol Version.
+     * @return om client protocol version as a string.
+     */
+    public String getOmClientProtocolVersion() {
+      return omClientProtocolVersion;
+    }
+
+    /**
+     * Sets the Om Client Protocol Version.
+     * @param omClientProtocolVer the client protocol version supported.
+     */
+    public Builder setOmClientProtocolVersion(String omClientProtocolVer) {
+      this.omClientProtocolVersion = omClientProtocolVer;
+      return this;
+    }
 
     /**
      * Sets the node/service type.
@@ -232,7 +263,11 @@ public final class ServiceInfo {
      * @return {@link ServiceInfo}
      */
     public ServiceInfo build() {
-      return new ServiceInfo(node, host, portList, omRoleInfo);
+      return new ServiceInfo(node,
+          host,
+          portList,
+          omClientProtocolVersion,
+          omRoleInfo);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -65,6 +65,10 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         ".duration"); // Deprecated config
     configurationPropsToSkipCompare
         .add(ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION);
+    configurationPropsToSkipCompare
+        .add(OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY);
+    configurationPropsToSkipCompare
+        .add(OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION);
     // This property is tested in TestHttpServer2 instead
     xmlPropsToSkipCompare.add(HttpServer2.HTTP_IDLE_TIMEOUT_MS_KEY);
     addPropertiesNotInXml();
@@ -84,6 +88,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
+        OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
         ReconConfigKeys.RECON_SCM_CONFIG_PREFIX,
         ReconConfigKeys.OZONE_RECON_ADDRESS_KEY,
         ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY,

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1188,6 +1188,7 @@ message ServiceInfo {
     required string hostname = 2;
     repeated ServicePort servicePorts = 3;
     optional OMRoleInfo omRole = 4;
+    optional string OMProtocolVersion = 5;
 }
 
 message MultipartInfoInitiateRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -211,6 +211,7 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
@@ -2698,6 +2699,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ServiceInfo.Builder omServiceInfoBuilder = ServiceInfo.newBuilder()
         .setNodeType(HddsProtos.NodeType.OM)
         .setHostname(omRpcAddress.getHostName())
+        .setOmClientProtocolVersion(OZONE_OM_CLIENT_PROTOCOL_VERSION)
         .addServicePort(ServicePort.newBuilder()
             .setType(ServicePort.Type.RPC)
             .setValue(omRpcAddress.getPort())
@@ -2738,6 +2740,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         ServiceInfo.Builder peerOmServiceInfoBuilder = ServiceInfo.newBuilder()
             .setNodeType(HddsProtos.NodeType.OM)
             .setHostname(peerNode.getHostName())
+            // For now assume peer is at the same version.
+            // This field needs to be fetched from peer when rolling upgrades
+            // are implemented.
+            .setOmClientProtocolVersion(OZONE_OM_CLIENT_PROTOCOL_VERSION)
             .addServicePort(ServicePort.newBuilder()
                 .setType(ServicePort.Type.RPC)
                 .setValue(peerNode.getRpcPort())

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -41,6 +41,8 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.MALFORMED_HEADER;
 
@@ -114,6 +116,9 @@ public class OzoneClientProducer {
   OzoneClient createOzoneClient() throws IOException {
     // S3 Gateway should always set the S3 Auth.
     ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
+    // Set the expected OM version if not set via config.
+    ozoneConfiguration.setIfUnset(OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
+        OZONE_OM_CLIENT_PROTOCOL_VERSION);
     if (omServiceID == null) {
       return OzoneClientFactory.getRpcClient(ozoneConfiguration);
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

To avoid an S3G that sets S3 Auth via proto messages
talking to an older version of OM. Add a check to
validate OM's client protocol version.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5898


## How was this patch tested?

- [x] Tested with OM not sending a version info, the S3 API calls fail with a 500 error.
