### PR TITLE
HDDS-5960. Change option name to bucketlayout instead of type

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/BucketArgs.java
@@ -63,7 +63,7 @@ public final class BucketArgs {
   private long quotaInNamespace;
 
   /**
-   * Bucket Type.
+   * Bucket Layout.
    */
   private BucketLayout bucketLayout = BucketLayout.DEFAULT;
 
@@ -172,7 +172,7 @@ public final class BucketArgs {
   }
 
   /**
-   * Returns the Bucket Type.
+   * Returns the Bucket Layout.
    */
   public BucketLayout getBucketLayout() {
     return bucketLayout;
@@ -244,8 +244,8 @@ public final class BucketArgs {
       return this;
     }
 
-    public BucketArgs.Builder setBucketLayout(BucketLayout type) {
-      bucketLayout = type;
+    public BucketArgs.Builder setBucketLayout(BucketLayout buckLayout) {
+      bucketLayout = buckLayout;
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -962,7 +962,7 @@ public class TestOzoneShellHA {
   public void testClientBucketLayoutValidation() throws Exception {
     String[] args = new String[]{
         "bucket", "create", "o3://" + omServiceId + "/volume7" + "/bucketTest1",
-        "--bucketlayout", "LEGACY"
+        "--layout", "LEGACY"
     };
     try {
       execute(ozoneShell, args);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -962,7 +962,7 @@ public class TestOzoneShellHA {
   public void testClientBucketLayoutValidation() throws Exception {
     String[] args = new String[]{
         "bucket", "create", "o3://" + omServiceId + "/volume7" + "/bucketTest1",
-        "--type", "LEGACY"
+        "--bucketlayout", "LEGACY"
     };
     try {
       execute(ozoneShell, args);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -53,8 +53,8 @@ public class CreateBucketHandler extends BucketHandler {
 
   enum AllowedBucketLayouts {FILE_SYSTEM_OPTIMIZED, OBJECT_STORE}
 
-  @Option(names = { "--type", "-t" },
-      description = "Allowed Bucket Types: ${COMPLETION-CANDIDATES}",
+  @Option(names = { "--bucketlayout", "-l" },
+      description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}",
       defaultValue = "OBJECT_STORE")
   private AllowedBucketLayouts allowedBucketLayout;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -53,7 +53,7 @@ public class CreateBucketHandler extends BucketHandler {
 
   enum AllowedBucketLayouts {FILE_SYSTEM_OPTIMIZED, OBJECT_STORE}
 
-  @Option(names = { "--bucketlayout", "-l" },
+  @Option(names = { "--layout", "-l" },
       description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}",
       defaultValue = "OBJECT_STORE")
   private AllowedBucketLayouts allowedBucketLayout;


### PR DESCRIPTION
## What changes were proposed in this pull request?

CreateBucketHandler exposes "--type" argument, its good to reflect the layout behavior in the option name.

```
@Option(names = \{ "--type", "-t" },
description = "Allowed Bucket Types: ${COMPLETION-CANDIDATES}",
defaultValue = "OBJECT_STORE")
```
This task is to correct the option name to "-bucketlayout", "-l"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5960

## How was this patch tested?

existing tests
