### PR TITLE
HDDS-5970. Remove OMKeyRequest#getBucketLayout overridden method in subclasses

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -93,8 +92,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     if (isBucketFSOptimized) {
-      TestOMRequestUtils.configureFSOptimizedPaths(conf,
-          enabledFileSystemPaths, OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
     } else {
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -210,7 +210,7 @@ public class TestDirectoryDeletingServiceWithFSO {
         cluster.getOzoneManager().getMetadataManager().getDeletedDirTable();
     Table<String, OmKeyInfo> keyTable =
         cluster.getOzoneManager().getMetadataManager()
-            .getKeyTable(getBucketLayout());
+            .getKeyTable(getFSOBucketLayout());
     Table<String, OmDirectoryInfo> dirTable =
         cluster.getOzoneManager().getMetadataManager().getDirectoryTable();
 
@@ -257,7 +257,7 @@ public class TestDirectoryDeletingServiceWithFSO {
         cluster.getOzoneManager().getMetadataManager().getDeletedDirTable();
     Table<String, OmKeyInfo> keyTable =
         cluster.getOzoneManager().getMetadataManager()
-            .getKeyTable(getBucketLayout());
+            .getKeyTable(getFSOBucketLayout());
     Table<String, OmDirectoryInfo> dirTable =
         cluster.getOzoneManager().getMetadataManager().getDirectoryTable();
 
@@ -331,7 +331,7 @@ public class TestDirectoryDeletingServiceWithFSO {
         cluster.getOzoneManager().getMetadataManager().getDeletedDirTable();
     Table<String, OmKeyInfo> keyTable =
         cluster.getOzoneManager().getMetadataManager()
-            .getKeyTable(getBucketLayout());
+            .getKeyTable(getFSOBucketLayout());
     Table<String, OmDirectoryInfo> dirTable =
         cluster.getOzoneManager().getMetadataManager().getDirectoryTable();
     Table<String, RepeatedOmKeyInfo> deletedKeyTable =
@@ -403,7 +403,7 @@ public class TestDirectoryDeletingServiceWithFSO {
     Assert.assertEquals(prevDeletedKeyCount + 5, currentDeletedKeyCount);
   }
 
-  public BucketLayout getBucketLayout() {
+  private static BucketLayout getFSOBucketLayout() {
     return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -169,7 +169,8 @@ public class TestOzoneFileInterfaces {
     OzoneConfiguration conf = cluster.getConf();
 
     // create a volume and a bucket to be used by OzoneFileSystem
-    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName);
+    TestDataUtil.createVolumeAndBucket(cluster, volumeName, bucketName,
+        getBucketLayout());
 
     rootPath = String
         .format("%s://%s.%s/", OzoneConsts.OZONE_URI_SCHEME, bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -30,7 +30,7 @@ import java.io.IOException;
  * Test OzoneFileSystem Interfaces - prefix layout.
  *
  * This test will test the various interfaces i.e.
- * create, read,ra write, getFileStatus
+ * create, read, write, getFileStatus
  */
 @RunWith(Parameterized.class)
 public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -18,9 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,29 +32,15 @@ import java.util.Collection;
  * Test OzoneFileSystem Interfaces - prefix layout.
  *
  * This test will test the various interfaces i.e.
- * create, read, write, getFileStatus
+ * create, read,ra write, getFileStatus
  */
 @RunWith(Parameterized.class)
 public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
-
-  @Parameterized.Parameters
-  public static Collection<Object[]> data() {
-    return Arrays.asList(new Object[][] {{false, true, true}});
-  }
 
   public TestOzoneFileInterfacesWithFSO(boolean setDefaultFs,
       boolean useAbsolutePath, boolean enabledFileSystemPaths)
       throws Exception {
     super(setDefaultFs, useAbsolutePath, enabledFileSystemPaths);
-  }
-
-  @Override
-  protected OzoneConfiguration getOzoneConfiguration() {
-    OzoneConfiguration conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf,
-        enableFileSystemPathsInstance,
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
-    return conf;
   }
 
   @Override
@@ -92,5 +76,9 @@ public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
   @Ignore("TODO:HDDS-2939")
   public void testOzFsReadWrite() {
 
+  }
+
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -76,6 +76,7 @@ public class TestOzoneFileInterfacesWithFSO extends TestOzoneFileInterfaces {
 
   }
 
+  @Override
   public BucketLayout getBucketLayout() {
     return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
@@ -25,8 +25,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 
 /**
  * Test OzoneFileSystem Interfaces - prefix layout.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OpenKeySession;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
-import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -159,8 +158,8 @@ public class TestOzoneFileSystem {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
     if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-      TestOMRequestUtils.configureFSOptimizedPaths(conf, enabledFileSystemPaths,
-          OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          bucketLayout.name());
     } else {
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -50,7 +50,6 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.TrashPolicyOzone;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLIdentityType;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
@@ -170,13 +169,15 @@ public class TestRootedOzoneFileSystem {
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     if (isBucketFSOptimized) {
       bucketLayout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
-      TestOMRequestUtils.configureFSOptimizedPaths(conf,
-          true, OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          bucketLayout.name());
     } else {
       bucketLayout = BucketLayout.LEGACY;
       // We need the OFS buckets to be in LEGACY layout for this test.
       conf.set(OzoneConfigKeys.OZONE_CLIENT_TEST_OFS_DEFAULT_BUCKET_LAYOUT,
           BucketLayout.LEGACY.name());
+      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+          bucketLayout.name());
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -1043,9 +1043,4 @@ public class TestOzoneClientMultipartUploadWithFSO {
     Arrays.fill(chars, val);
     return chars;
   }
-
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
-
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -273,7 +273,7 @@ public class TestKeyManagerImpl {
         .setDataSize(0)
         .setReplicationConfig(keyArgs.getReplicationConfig())
         .setFileEncryptionInfo(null).build();
-    metadataManager.getOpenKeyTable(getBucketLayout()).put(
+    metadataManager.getOpenKeyTable(getDefaultBucketLayout()).put(
         metadataManager.getOpenKey(VOLUME_NAME, BUCKET_NAME, KEY_NAME, 1L),
         omKeyInfo);
     LambdaTestUtils.intercept(OMException.class,
@@ -961,7 +961,7 @@ public class TestKeyManagerImpl {
     for (int i = 1; i <= 100; i += 2) {
       String key = metadataManager
           .getOzoneKey(VOLUME_NAME, BUCKET_NAME, prefixKeyInCache + i);
-      metadataManager.getKeyTable(getBucketLayout())
+      metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(key),
               new CacheValue<>(Optional.absent(), 2L));
     }
@@ -1031,7 +1031,7 @@ public class TestKeyManagerImpl {
       String key = metadataManager.getOzoneKey(
           VOLUME_NAME, BUCKET_NAME,
           keyNameDir1Subdir1 + OZONE_URI_DELIMITER + prefixKeyInCache + i);
-      metadataManager.getKeyTable(getBucketLayout())
+      metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(key),
               new CacheValue<>(Optional.absent(), 2L));
     }
@@ -1059,7 +1059,7 @@ public class TestKeyManagerImpl {
         String key = metadataManager.getOzoneKey(
             VOLUME_NAME, BUCKET_NAME, prefixKey + i);
         // Mark as deleted in cache.
-        metadataManager.getKeyTable(getBucketLayout())
+        metadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(key),
                 new CacheValue<>(Optional.absent(), 2L));
         deletedKeySet.add(key);
@@ -1095,7 +1095,7 @@ public class TestKeyManagerImpl {
       if (doDelete) {
         String ozoneKey =
             metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, key);
-        metadataManager.getKeyTable(getBucketLayout())
+        metadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
                 new CacheValue<>(Optional.absent(), 2L));
         deletedKeySet.add(key);
@@ -1144,7 +1144,7 @@ public class TestKeyManagerImpl {
     for (String key : existKeySet) {
       String ozoneKey =
           metadataManager.getOzoneKey(VOLUME_NAME, BUCKET_NAME, key);
-      metadataManager.getKeyTable(getBucketLayout())
+      metadataManager.getKeyTable(getDefaultBucketLayout())
           .addCacheEntry(new CacheKey<>(ozoneKey),
               new CacheValue<>(Optional.absent(), 2L));
       deletedKeySet.add(key);
@@ -1499,7 +1499,7 @@ public class TestKeyManagerImpl {
         .build();
   }
 
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.LEGACY;
+  private static BucketLayout getDefaultBucketLayout() {
+    return BucketLayout.DEFAULT;
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
@@ -193,7 +193,8 @@ public class TestOMRatisSnapshots {
     Assert.assertNotNull(followerOMMetaMngr.getBucketTable().get(
         followerOMMetaMngr.getBucketKey(volumeName, bucketName)));
     for (String key : keys) {
-      Assert.assertNotNull(followerOMMetaMngr.getKeyTable(getBucketLayout())
+      Assert.assertNotNull(followerOMMetaMngr.getKeyTable(
+          getDefaultBucketLayout())
           .get(followerOMMetaMngr.getOzoneKey(volumeName, bucketName, key)));
     }
   }
@@ -318,7 +319,7 @@ public class TestOMRatisSnapshots {
     return keys;
   }
 
-  public BucketLayout getBucketLayout() {
+  private static BucketLayout getDefaultBucketLayout() {
     return BucketLayout.DEFAULT;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -100,13 +100,14 @@ public class TestObjectStoreWithFSO {
    *
    * @throws IOException
    */
-  @BeforeClass public static void init() throws Exception {
+  @BeforeClass
+  public static void init() throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
     scmId = UUID.randomUUID().toString();
     omId = UUID.randomUUID().toString();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf, true,
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerFSO.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
 import org.apache.hadoop.ozone.container.TestHelper;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.recon.api.NSSummaryEndpoint;
 import org.apache.hadoop.ozone.recon.api.types.NamespaceSummaryResponse;
 import org.apache.hadoop.ozone.recon.api.types.EntityType;
@@ -65,8 +65,8 @@ public class TestReconWithOzoneManagerFSO {
   @BeforeClass
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf, true,
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
     cluster =
             MiniOzoneCluster.newBuilder(conf)
                     .setNumDatanodes(1)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -649,15 +649,20 @@ public class KeyManagerImpl implements KeyManager {
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
-    keyName = OMClientRequest
-        .validateAndNormalizeKey(enableFileSystemPaths, keyName,
-            getBucketLayout(metadataManager, args.getVolumeName(),
-                args.getBucketName()));
+
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
+
+    BucketLayout bucketLayout =
+        getBucketLayout(metadataManager, args.getVolumeName(),
+            args.getBucketName());
+    keyName = OMClientRequest
+        .validateAndNormalizeKey(enableFileSystemPaths, keyName,
+            bucketLayout);
+
     OmKeyInfo value = null;
     try {
-      if (isBucketFSOptimized(volumeName, bucketName)) {
+      if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
         value = getOmKeyInfoFSO(volumeName, bucketName, keyName);
       } else {
         value = getOmKeyInfo(volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -220,9 +220,9 @@ public final class OzoneManagerRatisUtils {
       bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
           keyArgs.getBucketName(), ozoneManager);
       if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-        return new OMKeyRenameRequestWithFSO(omRequest);
+        return new OMKeyRenameRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMKeyRenameRequest(omRequest);
+      return new OMKeyRenameRequest(omRequest, bucketLayout);
     case RenameKeys:
       return new OMKeysRenameRequest(omRequest);
     case CreateDirectory:
@@ -230,21 +230,22 @@ public final class OzoneManagerRatisUtils {
       bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
           keyArgs.getBucketName(), ozoneManager);
       if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-        return new OMDirectoryCreateRequestWithFSO(omRequest);
+        return new OMDirectoryCreateRequestWithFSO(omRequest, bucketLayout);
       }
-      return new OMDirectoryCreateRequest(omRequest);
+      return new OMDirectoryCreateRequest(omRequest, bucketLayout);
     case CreateFile:
       keyArgs = omRequest.getCreateFileRequest().getKeyArgs();
       bucketLayout = getBucketLayout(keyArgs.getVolumeName(),
           keyArgs.getBucketName(), ozoneManager);
       if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-        return new OMFileCreateRequestWithFSO(omRequest);
+        return new OMFileCreateRequestWithFSO(omRequest, bucketLayout);
       }
       return new OMFileCreateRequest(omRequest);
     case PurgeKeys:
       return new OMKeyPurgeRequest(omRequest);
     case PurgePaths:
-      return new OMPathsPurgeRequestWithFSO(omRequest);
+      return new OMPathsPurgeRequestWithFSO(omRequest,
+          BucketLayout.FILE_SYSTEM_OPTIMIZED);
     case InitiateMultiPartUpload:
       keyArgs = omRequest.getInitiateMultiPartUploadRequest().getKeyArgs();
       bucketLayout = getBucketLayout(keyArgs.getVolumeName(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -105,7 +105,8 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     super(omRequest);
   }
 
-  public OMDirectoryCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+  public OMDirectoryCreateRequest(OMRequest omRequest,
+                                  BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -105,6 +105,10 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     super(omRequest);
   }
 
+  public OMDirectoryCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
+  }
+
   @Override
   public OMRequest preExecute(OzoneManager ozoneManager) {
     CreateDirectoryRequest createDirectoryRequest =
@@ -365,9 +369,5 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
 
   static long getMaxNumOfRecursiveDirs() {
     return MAX_NUM_OF_RECURSIVE_DIRS;
-  }
-
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -71,8 +72,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateRequestWithFSO.class);
 
-  public OMDirectoryCreateRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMDirectoryCreateRequestWithFSO(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -72,7 +72,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMDirectoryCreateRequestWithFSO.class);
 
-  public OMDirectoryCreateRequestWithFSO(OMRequest omRequest, BucketLayout bucketLayout) {
+  public OMDirectoryCreateRequestWithFSO(OMRequest omRequest,
+                                         BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
 import org.slf4j.Logger;
@@ -77,6 +78,10 @@ public class OMFileCreateRequest extends OMKeyRequest {
       LoggerFactory.getLogger(OMFileCreateRequest.class);
   public OMFileCreateRequest(OMRequest omRequest) {
     super(omRequest);
+  }
+
+  public OMFileCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -60,13 +60,8 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMFileCreateRequestWithFSO.class);
-  public OMFileCreateRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
-  }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  public OMFileCreateRequestWithFSO(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -60,7 +60,9 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMFileCreateRequestWithFSO.class);
-  public OMFileCreateRequestWithFSO(OMRequest omRequest, BucketLayout bucketLayout) {
+
+  public OMFileCreateRequestWithFSO(OMRequest omRequest,
+                                    BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -72,11 +72,6 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
   }
 
   @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
-
-  @Override
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
       long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -204,9 +204,4 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
 
     return omClientResponse;
   }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -26,6 +26,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -69,6 +70,10 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
   public OMKeyRenameRequest(OMRequest omRequest) {
     super(omRequest);
+  }
+
+  public OMKeyRenameRequest(OMRequest omRequest, BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -66,8 +66,9 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
   private static final Logger LOG =
           LoggerFactory.getLogger(OMKeyRenameRequestWithFSO.class);
 
-  public OMKeyRenameRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMKeyRenameRequestWithFSO(OMRequest omRequest,
+                                   BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -299,10 +300,5 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
     auditMap.put(OzoneConsts.SRC_KEY, keyArgs.getKeyName());
     auditMap.put(OzoneConsts.DST_KEY, renameKeyRequest.getToKeyName());
     return auditMap;
-  }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMPathsPurgeRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMPathsPurgeRequestWithFSO.java
@@ -35,8 +35,9 @@ import java.util.List;
  */
 public class OMPathsPurgeRequestWithFSO extends OMKeyRequest {
 
-  public OMPathsPurgeRequestWithFSO(OMRequest omRequest) {
-    super(omRequest);
+  public OMPathsPurgeRequestWithFSO(OMRequest omRequest,
+                                    BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override
@@ -61,10 +62,5 @@ public class OMPathsPurgeRequestWithFSO extends OMKeyRequest {
         omDoubleBufferHelper);
 
     return omClientResponse;
-  }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -250,9 +250,4 @@ public class S3InitiateMultipartUploadRequestWithFSO
               OMException.ResultCodes.NOT_A_FILE);
     }
   }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequestWithFSO.java
@@ -88,9 +88,4 @@ public class S3MultipartUploadAbortRequestWithFSO
 
     return multipartKey;
   }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequestWithFSO.java
@@ -85,9 +85,4 @@ public class S3MultipartUploadCommitPartRequestWithFSO
         openKey, multipartKeyInfo, oldPartKeyInfo, omKeyInfo,
         ozoneManager.isRatisEnabled(), omBucketInfo);
   }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -167,10 +167,5 @@ public class S3MultipartUploadCompleteRequestWithFSO
     return OMFileRequest
         .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
   }
-
-  @Override
-  public BucketLayout getBucketLayout() {
-    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
-  }
 }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -482,7 +482,7 @@ public class TestOmMetadataManager {
         String key = omMetadataManager.getOzoneKey(volumeNameA,
             ozoneBucket, prefixKeyA + i);
         // Mark as deleted in cache.
-        omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+        omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
             new CacheKey<>(key),
             new CacheValue<>(Optional.absent(), 100L));
         deleteKeySet.add(key);
@@ -540,7 +540,7 @@ public class TestOmMetadataManager {
 
   }
 
-  public BucketLayout getBucketLayout() {
+  private static BucketLayout getDefaultBucketLayout() {
     return BucketLayout.DEFAULT;
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -242,7 +242,8 @@ public final class TestOMRequestUtils {
             .addCacheEntry(new CacheKey<>(ozoneKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
-      omMetadataManager.getKeyTable(getDefaultBucketLayout()).put(ozoneKey, omKeyInfo);
+      omMetadataManager.getKeyTable(getDefaultBucketLayout())
+          .put(ozoneKey, omKeyInfo);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -228,21 +228,21 @@ public final class TestOMRequestUtils {
       String ozoneKey = omMetadataManager.getOpenKey(volumeName, bucketName,
           keyName, clientID);
       if (addToCache) {
-        omMetadataManager.getOpenKeyTable(getBucketLayout())
+        omMetadataManager.getOpenKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
-      omMetadataManager.getOpenKeyTable(getBucketLayout())
+      omMetadataManager.getOpenKeyTable(getDefaultBucketLayout())
           .put(ozoneKey, omKeyInfo);
     } else {
       String ozoneKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
           keyName);
       if (addToCache) {
-        omMetadataManager.getKeyTable(getBucketLayout())
+        omMetadataManager.getKeyTable(getDefaultBucketLayout())
             .addCacheEntry(new CacheKey<>(ozoneKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
-      omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, omKeyInfo);
+      omMetadataManager.getKeyTable(getDefaultBucketLayout()).put(ozoneKey, omKeyInfo);
     }
   }
 
@@ -266,7 +266,7 @@ public final class TestOMRequestUtils {
     OmKeyInfo omKeyInfo = createOmKeyInfo(volumeName, bucketName, keyName,
         replicationType, replicationFactor);
 
-    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+    omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(omMetadataManager.getOzoneKey(volumeName, bucketName,
             keyName)), new CacheValue<>(Optional.of(omKeyInfo), 1L));
   }
@@ -747,10 +747,10 @@ public final class TestOMRequestUtils {
       throws IOException {
     // Retrieve the keyInfo
     OmKeyInfo omKeyInfo =
-        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+        omMetadataManager.getKeyTable(getDefaultBucketLayout()).get(ozoneKey);
 
     // Delete key from KeyTable and put in DeletedKeyTable
-    omMetadataManager.getKeyTable(getBucketLayout()).delete(ozoneKey);
+    omMetadataManager.getKeyTable(getDefaultBucketLayout()).delete(ozoneKey);
 
     RepeatedOmKeyInfo repeatedOmKeyInfo =
         omMetadataManager.getDeletedTable().get(ozoneKey);
@@ -896,8 +896,9 @@ public final class TestOMRequestUtils {
     final String dbKey = omMetadataManager.getOzoneKey(
         omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
         omKeyInfo.getKeyName());
-    omMetadataManager.getKeyTable(getBucketLayout()).put(dbKey, omKeyInfo);
-    omMetadataManager.getKeyTable(getBucketLayout()).addCacheEntry(
+    omMetadataManager.getKeyTable(getDefaultBucketLayout())
+        .put(dbKey, omKeyInfo);
+    omMetadataManager.getKeyTable(getDefaultBucketLayout()).addCacheEntry(
         new CacheKey<>(dbKey),
         new CacheValue<>(Optional.of(omKeyInfo), 1L));
   }
@@ -1075,7 +1076,7 @@ public final class TestOMRequestUtils {
     }
   }
 
-  public static BucketLayout getBucketLayout() {
+  private static BucketLayout getDefaultBucketLayout() {
     return BucketLayout.DEFAULT;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -121,7 +121,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirectoryCreateRequestWithFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmRequest =
             omDirectoryCreateRequestWithFSO.preExecute(ozoneManager);
@@ -149,13 +150,14 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateRequestFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+            new OMDirectoryCreateRequestWithFSO(omRequest, BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq =
         omDirCreateRequestFSO.preExecute(ozoneManager);
 
     omDirCreateRequestFSO =
-        new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+        new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -176,13 +178,15 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateRequestFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmRequest =
         omDirCreateRequestFSO.preExecute(ozoneManager);
 
     omDirCreateRequestFSO =
-        new OMDirectoryCreateRequestWithFSO(modifiedOmRequest);
+        new OMDirectoryCreateRequestWithFSO(modifiedOmRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateRequestFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -207,11 +211,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
     TestOMRequestUtils.addVolumeToDB(volumeName, omMetadataManager);
 
     OMClientResponse omClientResponse =
@@ -259,11 +265,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -312,11 +320,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -385,12 +395,14 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq =
             omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -457,12 +469,14 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq =
             omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMClientResponse omClientResponse =
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -502,11 +516,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     Assert.assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
@@ -535,11 +551,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     Assert.assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =
@@ -573,11 +591,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq = omDirCreateReqFSO.preExecute(ozoneManager);
 
-    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq);
+    omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     Assert.assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -150,7 +150,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateRequestFSO =
-            new OMDirectoryCreateRequestWithFSO(omRequest, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+        new OMDirectoryCreateRequestWithFSO(omRequest,
+            BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     OMRequest modifiedOmReq =
         omDirCreateRequestFSO.preExecute(ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -194,7 +194,8 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
 
   @Override
   protected OMFileCreateRequest getOMFileCreateRequest(OMRequest omRequest) {
-    return new OMFileCreateRequestWithFSO(omRequest);
+    return new OMFileCreateRequestWithFSO(omRequest,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMAllocateBlockRequest.java
@@ -57,7 +57,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
   public void testValidateAndUpdateCache() throws Exception {
     // Add volume, bucket, key entries to DB.
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
+        omMetadataManager, getBucketLayout());
 
     addKeyToOpenKeyTable(volumeName, bucketName);
 
@@ -176,7 +176,7 @@ public class TestOMAllocateBlockRequest extends TestOMKeyRequest {
 
     // Add volume, bucket entries to DB.
     TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager);
+        omMetadataManager, omAllocateBlockRequest.getBucketLayout());
 
 
     OMClientResponse omAllocateBlockResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -60,13 +59,7 @@ public class TestS3MultipartUploadCompleteRequest
     String bucketName = UUID.randomUUID().toString();
     String keyName = getKeyName();
 
-    BucketLayout bucketLayout = BucketLayout.DEFAULT;
-    if (OzoneManagerRatisUtils.isBucketFSOptimized()) {
-      bucketLayout = BucketLayout.FILE_SYSTEM_OPTIMIZED;
-    }
-
-    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
-        omMetadataManager, bucketLayout);
+    addVolumeAndBucket(volumeName, bucketName);
 
     OMRequest initiateMPURequest = doPreExecuteInitiateMPU(volumeName,
         bucketName, keyName);
@@ -125,6 +118,12 @@ public class TestS3MultipartUploadCompleteRequest
     Assert.assertNotNull(omMetadataManager
         .getKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
         .get(getOzoneDBKey(volumeName, bucketName, keyName)));
+  }
+
+  protected void addVolumeAndBucket(String volumeName, String bucketName)
+      throws Exception {
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, BucketLayout.DEFAULT);
   }
 
   @Test

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequestWithFSO.java
@@ -25,13 +25,11 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.util.Time;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -45,17 +43,19 @@ import java.util.UUID;
 public class TestS3MultipartUploadCompleteRequestWithFSO
     extends TestS3MultipartUploadCompleteRequest {
 
-  @BeforeClass
-  public static void init() {
-    OzoneManagerRatisUtils.setBucketFSOptimized(true);
-  }
-
   @Override
   protected String getKeyName() {
     String parentDir = UUID.randomUUID().toString() + "/a/b/c";
     String fileName = "file1";
     String keyName = parentDir + OzoneConsts.OM_KEY_PREFIX + fileName;
     return keyName;
+  }
+
+  @Override
+  protected void addVolumeAndBucket(String volumeName, String bucketName)
+      throws Exception {
+    TestOMRequestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

As part of HDDS-5929, bucketlayout is an object variable in OmKeyRequest and will be initialized in the constructor. With this change, its not required to override the OmKeyRequest#getBucketLayout() method in all its FSO sub classes. This task will refactor and remove the overriding of #getBucketLayout().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5970

## How was this patch tested?
Existing test cases.
