### PR TITLE
HDDS-5937. Inaccurate bucket info returned from bucket list command in Shell

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -761,7 +761,8 @@ public class RpcClient implements ClientProtocol {
         bucket.getUsedBytes(),
         bucket.getUsedNamespace(),
         bucket.getQuotaInBytes(),
-        bucket.getQuotaInNamespace()))
+        bucket.getQuotaInNamespace(),
+        bucket.getBucketLayout()))
         .collect(Collectors.toList());
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -430,7 +430,7 @@ public class TestRootedOzoneFileSystem {
     OzoneBucket ozoneBucket = iterBuc.next();
     Assert.assertNotNull(ozoneBucket);
     Assert.assertEquals(bucketNameLocal, ozoneBucket.getName());
-
+    Assert.assertEquals(bucketLayout, ozoneBucket.getBucketLayout());
     // TODO: Use listStatus to check volume and bucket creation in HDDS-2928.
 
     // Cleanup

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -94,13 +94,6 @@ public class TestRootedOzoneFileSystemWithFSO
   @Override
   @Test
   @Ignore("HDDS-2939")
-  public void testMkdirNonExistentVolumeBucket() {
-    // ignore as this is not relevant to PREFIX layout changes
-  }
-
-  @Override
-  @Test
-  @Ignore("HDDS-2939")
   public void testMkdirNonExistentVolume() {
     // ignore as this is not relevant to PREFIX layout changes
   }


### PR DESCRIPTION
…n Shell

## What changes were proposed in this pull request?

There is a bug in the info being displayed from the Ozone Shell regarding the bucket layouts. The information displayed is inconsistent with the actual underlying behaviour.

The bucketLayout is being listed as LEGACY when you use the list command (which is incorrect) and is being shown as FILE_SYSTEM_OPTIMIZED when using the info command (which is the correct value)

```
bash-4.2$ ozone sh volume create /vol1
bash-4.2$ ozone sh bucket create /vol1/buck1 --type=FILE_SYSTEM_OPTIMIZED

bash-4.2$ ozone sh bucket list /vol1/
 [

{ "metadata" : { }

,
 "volumeName" : "vol1",
 "name" : "buck1",
 "storageType" : "DISK",
 "versioning" : false,
 "usedBytes" : 0,
 "usedNamespace" : 0,
 "creationTime" : "2021-11-02T05:55:35.311Z",
 "modificationTime" : "2021-11-02T05:55:35.311Z",
 "quotaInBytes" : -1,
 "quotaInNamespace" : -1,
 "bucketLayout" : "LEGACY"
 }]

bash-4.2$ ozone sh bucket info /vol1/buck1

{ "metadata" : { }

,
 "volumeName" : "vol1",
 "name" : "buck1",
 "storageType" : "DISK",
 "versioning" : false,
 "usedBytes" : 0,
 "usedNamespace" : 0,
 "creationTime" : "2021-11-02T05:55:35.311Z",
 "modificationTime" : "2021-11-02T05:55:35.311Z",
 "quotaInBytes" : -1,
 "quotaInNamespace" : -1,
 "bucketLayout" : "FILE_SYSTEM_OPTIMIZED"
 }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5937

## How was this patch tested?

Related unit tests + manual testing in shell