### PR TITLE
HDDS-5975. Serve url-encoded key and prefix name for ListObjectResponse

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
@@ -46,3 +46,11 @@ File upload and directory list
                         Should not contain        ${result}         testfile
                         Should not contain        ${result}         dir1
                         Should contain            ${result}         file
+
+File upload with special chars
+                        Execute                   date > /tmp/testfile
+    ${result} =         Execute AWSS3Cli          cp /tmp/testfile s3://${BUCKET}/specialchars/a+b
+                        Should contain            ${result}         upload
+    ${result} =         Execute AWSS3Cli          ls s3://${BUCKET}/specialchars/
+                        Should not contain        ${result}         'a b'
+                        Should contain            ${result}         a+b

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/CommonPrefix.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/CommonPrefix.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.s3.commontypes;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Directory name ("key prefix") in case of listing.
@@ -27,6 +28,7 @@ import javax.xml.bind.annotation.XmlElement;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class CommonPrefix {
 
+  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
   @XmlElement(name = "Prefix")
   private String prefix;
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/KeyMetadata.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/KeyMetadata.java
@@ -29,6 +29,7 @@ import java.time.Instant;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class KeyMetadata {
 
+  @XmlJavaTypeAdapter(ObjectKeyNameAdapter.class)
   @XmlElement(name = "Key")
   private String key; // or the Object Name
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
@@ -17,11 +17,10 @@
  */
 package org.apache.hadoop.ozone.s3.commontypes;
 
+import org.apache.hadoop.ozone.s3.util.S3Utils;
+
 import javax.xml.bind.annotation.adapters.XmlAdapter;
 import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 
 
 /**
@@ -29,29 +28,15 @@ import java.nio.charset.StandardCharsets;
  * ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
  */
 public class ObjectKeyNameAdapter extends XmlAdapter<String, String> {
-
-  private static final Charset UTF_8 = StandardCharsets.UTF_8;
-
-  public ObjectKeyNameAdapter() {
-  }
-
   @Override
   public String unmarshal(String s) throws Exception {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public String marshal(String s) throws Exception {
-    return urlEncode(s);
+  public String marshal(String s)
+      throws UnsupportedEncodingException {
+    return S3Utils.urlEncode(s)
+        .replaceAll("%2F", "/");
   }
-
-  private static String urlEncode(String str) {
-    try {
-      return URLEncoder.encode(str, UTF_8.name())
-          .replaceAll("%2F", "/");
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.s3.commontypes;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+
+/**
+ * A converter to convert raw-String to S3 compliant object key name.
+ * ref: https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html
+ */
+public class ObjectKeyNameAdapter extends XmlAdapter<String, String> {
+
+  private static final Charset UTF_8 = StandardCharsets.UTF_8;
+
+  public ObjectKeyNameAdapter() {
+  }
+
+  @Override
+  public String unmarshal(String s) throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String marshal(String s) throws Exception {
+    return urlEncode(s);
+  }
+
+  private static String urlEncode(String str) {
+    try {
+      return URLEncoder.encode(str, UTF_8.name())
+          .replaceAll("\\+", "%20");
+    } catch (UnsupportedEncodingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
@@ -48,7 +48,7 @@ public class ObjectKeyNameAdapter extends XmlAdapter<String, String> {
   private static String urlEncode(String str) {
     try {
       return URLEncoder.encode(str, UTF_8.name())
-          .replaceAll("\\+", "%20");
+          .replaceAll("%2F", "/");
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/commontypes/ObjectKeyNameAdapter.java
@@ -29,7 +29,7 @@ import java.io.UnsupportedEncodingException;
  */
 public class ObjectKeyNameAdapter extends XmlAdapter<String, String> {
   @Override
-  public String unmarshal(String s) throws Exception {
+  public String unmarshal(String s) {
     throw new UnsupportedOperationException();
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/commontypes/TestObjectKeyNameAdapter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.hadoop.ozone.s3.commontypes;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+/**
+ * Testing on object key name serialization.
+ */
+public class TestObjectKeyNameAdapter {
+  @Test
+  public void testEncodeResult() throws Exception {
+    Assert.assertEquals("abc/",
+        getAdapter().marshal("abc/"));
+    Assert.assertEquals("a+b+c/",
+        getAdapter().marshal("a b c/"));
+    Assert.assertEquals("a%2Bb%2Bc/",
+        getAdapter().marshal("a+b+c/"));
+  }
+
+  private XmlAdapter<String, String> getAdapter(){
+    return (new ObjectKeyNameAdapter());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add an url-encode feature for key and prefix to fix an S3G issue that cannot handle keys named like 'a+b+c'.

The problem is that S3G currently does not care about URL encoding on special meaning characters like '+'. There is a compatibility issue between Ozone and aws cli because it assumes a object key name in ListBucketResponse is served in url-encoded chars.

Example: a bucket has an object named 'a+b+c' -- In this case, `aws s3 ls` or `aws s3 rm --recursive` will not work properly because aws cli decodes 'a+b+c' as 'a b c'.

This patch introduces an encoding feature on special meaning characters and this converts plus '+' char to '%2B'. Here is a example:
- 'a+b+c' (includes plus) --> 'a%2Bb%2Bc'
- 'abc/' (includes a slash) --> 'abc/' (keep slash; not to encode)
- 'a b c' (includes space) --> 'a+b+c' (converts space to +)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5975

## How was this patch tested?
Checked by aws cli & I've attached a unit test for ObjectKeyNameAdapter
