### PR TITLE
HDDS-5959. Handles bucket layout validation logic in ofs/o3fs client.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OzoneFSUtils.java
@@ -120,6 +120,23 @@ public final class OzoneFSUtils {
   }
 
   /**
+   * Checks whether the bucket layout is valid for File System operations
+   * otherwise throws IllegalArgumentException.
+   * Allowed bucket layouts are FILE_SYSTEM_OPTIMIZED and LEGACY.
+   */
+  public static void validateBucketLayout(String bucketName,
+                                          BucketLayout bucketLayout) {
+    if (bucketLayout.equals(BucketLayout.OBJECT_STORE)) {
+      throw new IllegalArgumentException(
+          "Bucket: " + bucketName + " has layout: " + bucketLayout +
+              ", which does not support" +
+              " file system semantics. Bucket Layout must be " +
+              BucketLayout.FILE_SYSTEM_OPTIMIZED + " or "
+              + BucketLayout.LEGACY + ".");
+    }
+  }
+
+  /**
    * The function returns leaf node name from the given absolute path. For
    * example, the given key path '/a/b/c/d/e/file1' then it returns leaf node
    * name 'file1'.

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/common-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/common-config
@@ -27,7 +27,6 @@ OZONE-SITE.XML_ozone.metadata.dirs=/data/metadata
 OZONE-SITE.XML_ozone.scm.client.address=scm
 OZONE-SITE.XML_ozone.replication=3
 OZONE-SITE.XML_hdds.scm.safemode.min.datanode=3
-OZONE-SITE.XML_ozone.client.test.ofs.default.bucket.layout=LEGACY
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -34,7 +34,6 @@ OZONE-SITE.XML_hdds.grpc.tls.enabled=true
 OZONE-SITE.XML_ozone.replication=3
 OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
-OZONE-SITE.XML_ozone.client.test.ofs.default.bucket.layout=LEGACY
 
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon

--- a/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/docker-config
@@ -31,5 +31,6 @@ OZONE-SITE.XML_ozone.scm.names=scm
 OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1
 OZONE-SITE.XML_recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
+OZONE-SITE.XML_ozone.default.bucket.layout=FILE_SYSTEM_OPTIMIZED
 
 no_proxy=om,recon,scm,s3g,kdc,localhost,127.0.0.1

--- a/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/createmrenv.robot
@@ -32,7 +32,7 @@ Create volume
     ${result} =     Execute             ozone sh volume create /${volume} --user hadoop --space-quota 100TB --namespace-quota 100
                     Should not contain  ${result}       Failed
 Create bucket
-                    Execute             ozone sh bucket create /${volume}/${bucket}
+                    Execute             ozone sh bucket create /${volume}/${bucket} --layout FILE_SYSTEM_OPTIMIZED
 
 *** Test Cases ***
 Create test volume, bucket and key

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/setup.robot
@@ -41,16 +41,16 @@ Create volumes for FS test
     Execute And Ignore Error    ozone sh volume create ${VOL2} --space-quota 100TB
 
 Create buckets for FS test
-    Execute                     ozone sh bucket create ${VOLUME}/${BUCKET}
-    Execute                     ozone sh bucket create ${VOLUME}/${BUCKET2}
-    Execute                     ozone sh bucket create ${VOL2}/${BUCKET_IN_VOL2}
+    Execute                     ozone sh bucket create ${VOLUME}/${BUCKET} --layout FILE_SYSTEM_OPTIMIZED
+    Execute                     ozone sh bucket create ${VOLUME}/${BUCKET2} --layout FILE_SYSTEM_OPTIMIZED
+    Execute                     ozone sh bucket create ${VOL2}/${BUCKET_IN_VOL2} --layout FILE_SYSTEM_OPTIMIZED
 
 Create links for FS test
     Execute And Ignore Error    ozone sh volume create ${VOLUME}-src --space-quota 100TB
     Execute And Ignore Error    ozone sh volume create ${VOL2}-src --space-quota 100TB
-    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET}-src
-    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET2}-src
-    Execute                     ozone sh bucket create ${VOL2}-src/${BUCKET_IN_VOL2}-src
+    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET}-src --layout FILE_SYSTEM_OPTIMIZED
+    Execute                     ozone sh bucket create ${VOLUME}-src/${BUCKET2}-src --layout FILE_SYSTEM_OPTIMIZED
+    Execute                     ozone sh bucket create ${VOL2}-src/${BUCKET_IN_VOL2}-src --layout FILE_SYSTEM_OPTIMIZED
     Execute                     ozone sh bucket link ${VOLUME}-src/${BUCKET}-src ${VOLUME}/${BUCKET}
     Execute                     ozone sh bucket link ${VOLUME}-src/${BUCKET2}-src ${VOLUME}/${BUCKET2}
     Execute                     ozone sh bucket link ${VOL2}-src/${BUCKET_IN_VOL2}-src ${VOL2}/${BUCKET_IN_VOL2}

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-fs.robot
@@ -49,7 +49,7 @@ Create bucket with non-admin owner(testuser2)
     Run Keyword   Setup volume names
     Execute       ozone sh volume create o3://om/${volume4} -u testuser2
     Run Keyword   Kinit test user     testuser2    testuser2.keytab
-    ${result} =   Execute     ozone sh bucket create o3://om/${volume4}/bucket1
+    ${result} =   Execute     ozone sh bucket create o3://om/${volume4}/bucket1 --layout FILE_SYSTEM_OPTIMIZED
                   Should not contain  ${result}       PERMISSION_DENIED
     ${result} =   Execute     ozone sh key put ${volume4}/bucket1/key1 /opt/hadoop/NOTICE.txt
                   Should not contain  ${result}       PERMISSION_DENIED
@@ -66,9 +66,9 @@ Create volume bucket with credentials
     Run Keyword         Setup volume names
     Execute             ozone sh volume create o3://om/${volume1}
     Execute             ozone sh volume create o3://om/${volume2}
-    Execute             ozone sh bucket create o3://om/${volume1}/bucket1
-    Execute             ozone sh bucket create o3://om/${volume1}/bucket2
-    Execute             ozone sh bucket create o3://om/${volume2}/bucket3
+    Execute             ozone sh bucket create o3://om/${volume1}/bucket1 --layout FILE_SYSTEM_OPTIMIZED
+    Execute             ozone sh bucket create o3://om/${volume1}/bucket2 --layout FILE_SYSTEM_OPTIMIZED
+    Execute             ozone sh bucket create o3://om/${volume2}/bucket3 --layout FILE_SYSTEM_OPTIMIZED
 
 Check volume from ozonefs
     ${result} =         Execute          ozone fs -ls o3fs://bucket1.${volume1}/
@@ -90,7 +90,7 @@ Test Volume Acls
     Should Match Regexp                 ${result}       \"type\" : \"GROUP\",\n.*\"name\" : \"superuser1\",\n.*\"aclScope\" : \"DEFAULT\",\n.*\"aclList\" : . \"ALL\"
 
 Test Bucket Acls
-    ${result} =     Execute             ozone sh bucket create ${volume3}/bk1
+    ${result} =     Execute             ozone sh bucket create ${volume3}/bk1 --layout FILE_SYSTEM_OPTIMIZED
                     Should not contain  ${result}       Failed
     ${result} =     Execute             ozone sh bucket getacl ${volume3}/bk1
     Should Match Regexp                 ${result}       \"type\" : \"USER\",\n.*\"name\" : \".*\",\n.*\"aclScope\" : \"ACCESS\",\n.*\"aclList\" : . \"ALL\" .

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFSInputStream.java
@@ -34,6 +34,8 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -68,6 +70,8 @@ public class TestOzoneFSInputStream {
   @BeforeClass
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .setChunkSize(2) // MB

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -154,6 +154,8 @@ public class TestOzoneFileInterfaces {
 
   public void init() throws Exception {
     OzoneConfiguration conf = getOzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
     MiniOzoneCluster newCluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.fs.BlockLocation;
@@ -43,6 +44,10 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
@@ -534,6 +539,44 @@ public class TestOzoneFileInterfaces {
 
     assertEquals("key1/key2",
         o3fs.pathToKey(new Path("o3fs://test1/key1/key2")));
+  }
+
+
+  /**
+   * Verify that FS throws exception when trying to access bucket with
+   * incompatible layout.
+   * @throws IOException
+   */
+  @Test
+  public void testFileSystemWithObjectStoreLayout() throws IOException {
+    String obsVolume = UUID.randomUUID().toString();
+
+    OzoneClient client = cluster.getClient();
+    ObjectStore store = client.getObjectStore();
+
+    // Create volume and bucket
+    store.createVolume(obsVolume);
+    OzoneVolume volume = store.getVolume(obsVolume);
+    String obsBucket = UUID.randomUUID().toString();
+    // create bucket with OBJECT_STORE bucket layout (incompatible with fs)
+    volume.createBucket(obsBucket,
+        BucketArgs.newBuilder().setBucketLayout(BucketLayout.OBJECT_STORE)
+            .build());
+
+    String obsRootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, obsBucket, obsVolume);
+
+    OzoneConfiguration config = (OzoneConfiguration) fs.getConf();
+    config.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, obsRootPath);
+
+    try {
+      fs = FileSystem.get(fs.getConf());
+      Assert.fail("Should throw Exception due incompatible bucket layout");
+    } catch (IllegalArgumentException iae) {
+      // Expected exception
+      Assert.assertTrue(iae.getMessage().contains(
+          "OBJECT_STORE, which does not support file system semantics"));
+    }
   }
 
   private String getCurrentUser() {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -157,13 +157,12 @@ public class TestOzoneFileSystem {
 
     conf.setBoolean(OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY, omRatisEnabled);
     conf.setBoolean(OZONE_ACL_ENABLED, true);
-    if (bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
-      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
-          bucketLayout.name());
-    } else {
+    if (!bucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED)) {
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           enabledFileSystemPaths);
     }
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        bucketLayout.name());
     cluster = MiniOzoneCluster.newBuilder(conf)
             .setNumDatanodes(3)
             .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -54,6 +54,8 @@ public class TestOzoneFileSystemMissingParent {
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
     cluster.waitForClusterToBeReady();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -220,7 +220,7 @@ public class TestOzoneFileSystemWithLinks {
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
 
     try {
-      fs = FileSystem.get(conf);
+      FileSystem.get(conf);
       Assert.fail("Should throw Exception due to loop in Link Buckets");
     } catch (OMException oe) {
       // Expected exception

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.io.IOUtils;;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.*;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.UUID;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_CHECKPOINT_INTERVAL_KEY;
+import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;;
+
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.Trash;
+
+import static org.junit.Assert.fail;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+
+/**
+ * Ozone file system tests for Link Buckets.
+ */
+public class TestOzoneFileSystemWithLinks {
+
+  private static final float TRASH_INTERVAL = 0.05f; // 3 seconds
+
+  public TestOzoneFileSystemWithLinks() throws Exception {
+    try {
+      teardown();
+      init();
+    } catch (Exception e) {
+      LOG.info("Unexpected exception", e);
+      fail("Unexpected exception:" + e.getMessage());
+    }
+  }
+
+
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOzoneFileSystem.class);
+
+  private static BucketLayout bucketLayout = BucketLayout.DEFAULT;
+
+  private static MiniOzoneCluster cluster;
+  private static OzoneManagerProtocol writeClient;
+  private static FileSystem fs;
+  private static OzoneFileSystem o3fs;
+  private static String volumeName;
+  private static String bucketName;
+  private static Trash trash;
+  private OzoneConfiguration conf;
+
+  private void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setFloat(OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
+    conf.setFloat(FS_TRASH_INTERVAL_KEY, TRASH_INTERVAL);
+    conf.setFloat(FS_TRASH_CHECKPOINT_INTERVAL_KEY, TRASH_INTERVAL / 2);
+
+    conf.setBoolean(OZONE_ACL_ENABLED, true);
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        bucketLayout.name());
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .build();
+    cluster.waitForClusterToBeReady();
+
+    writeClient = cluster.getRpcClient().getObjectStore()
+        .getClientProxy().getOzoneManagerClient();
+    // create a volume and a bucket to be used by OzoneFileSystem
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    volumeName = bucket.getVolumeName();
+    bucketName = bucket.getName();
+
+    String rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, bucketName, volumeName);
+
+    // Set the fs.defaultFS and start the filesystem
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+    // Set the number of keys to be processed during batch operate.
+    conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 5);
+
+    fs = FileSystem.get(conf);
+    trash = new Trash(conf);
+    o3fs = (OzoneFileSystem) fs;
+  }
+
+  @AfterClass
+  public static void teardown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+    IOUtils.closeQuietly(fs);
+  }
+
+  @After
+  public void cleanup() {
+    try {
+      Path root = new Path("/");
+      FileStatus[] fileStatuses = fs.listStatus(root);
+      for (FileStatus fileStatus : fileStatuses) {
+        fs.delete(fileStatus.getPath(), true);
+      }
+    } catch (IOException ex) {
+      fail("Failed to cleanup files.");
+    }
+  }
+
+  public static MiniOzoneCluster getCluster() {
+    return cluster;
+  }
+
+  public static FileSystem getFs() {
+    return fs;
+  }
+
+  public static void setBucketLayout(BucketLayout bLayout) {
+    bucketLayout = bLayout;
+  }
+
+  public static String getBucketName() {
+    return bucketName;
+  }
+
+  public static String getVolumeName() {
+    return volumeName;
+  }
+
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.DEFAULT;
+  }
+
+  @Test
+  public void testLoopInLinkBuckets() throws Exception {
+    String linksVolume = UUID.randomUUID().toString();
+
+    OzoneClient client = cluster.getClient();
+    ObjectStore store = client.getObjectStore();
+
+    // Create volume
+    store.createVolume(linksVolume);
+    OzoneVolume volume = store.getVolume(linksVolume);
+
+    String linkBucket1Name = UUID.randomUUID().toString();
+    String linkBucket2Name = UUID.randomUUID().toString();
+    String linkBucket3Name = UUID.randomUUID().toString();
+
+    // case-1: Create a loop in the link buckets
+    createLinkBucket(volume, linkBucket1Name, linkBucket2Name);
+    createLinkBucket(volume, linkBucket2Name, linkBucket3Name);
+    createLinkBucket(volume, linkBucket3Name, linkBucket1Name);
+
+    // Set the fs.defaultFS and start the filesystem
+
+    String rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, linkBucket1Name, linksVolume);
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    try {
+      fs = FileSystem.get(conf);
+      Assert.fail("Should throw Exception due to loop in Link Buckets");
+    } catch (OMException oe) {
+      // Expected exception
+      Assert.assertEquals(OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS,
+          oe.getResult());
+    }
+
+    // case-2: Dangling link bucket
+    String danglingLinkBucketName = UUID.randomUUID().toString();
+    String sourceBucketName = UUID.randomUUID().toString();
+
+    // danglingLinkBucket is a dangling link over a source bucket that doesn't
+    // exist.
+    createLinkBucket(volume, sourceBucketName, danglingLinkBucketName);
+
+    rootPath = String.format("%s://%s.%s/",
+        OzoneConsts.OZONE_URI_SCHEME, danglingLinkBucketName, linksVolume);
+    conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
+
+    try {
+      fs = FileSystem.get(conf);
+      Assert.fail("Should throw Exception due to loop in Link Buckets");
+    } catch (OMException oe) {
+      // Expected exception
+      Assert.assertEquals(OMException.ResultCodes.BUCKET_NOT_FOUND,
+          oe.getResult());
+    }
+  }
+
+  /**
+   * Helper method to create Link Buckets.
+   *
+   * @param sourceVolume Name of source volume for Link Bucket.
+   * @param sourceBucket Name of source bucket for Link Bucket.
+   * @param linkBucket   Name of Link Bucket
+   * @throws IOException
+   */
+  private void createLinkBucket(OzoneVolume sourceVolume, String sourceBucket,
+                                String linkBucket) throws IOException {
+    BucketArgs.Builder builder = BucketArgs.newBuilder();
+    builder.setBucketLayout(BucketLayout.DEFAULT)
+        .setSourceVolume(sourceVolume.getName())
+        .setSourceBucket(sourceBucket);
+    sourceVolume.createBucket(linkBucket, builder.build());
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemWithLinks.java
@@ -199,7 +199,7 @@ public class TestOzoneFileSystemWithLinks {
     conf.set(CommonConfigurationKeysPublic.FS_DEFAULT_NAME_KEY, rootPath);
 
     try {
-      fs = FileSystem.get(conf);
+      FileSystem.get(conf);
       Assert.fail("Should throw Exception due to loop in Link Buckets");
     } catch (OMException oe) {
       // Expected exception

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFsHAURLs.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.ratis.util.LifeCycle;
@@ -100,6 +101,10 @@ public class TestOzoneFsHAURLs {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, metaDirPath.toString());
     conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY, "127.0.0.1:0");
     conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 3);
+
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS, true);
 
     OMStorage omStore = new OMStorage(conf);
     omStore.setClusterId(clusterId);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.junit.Assert;
 
 /**
@@ -91,6 +92,8 @@ class OzoneContract extends AbstractFSContract {
       conf.set(OMConfigKeys.OZONE_OM_METADATA_LAYOUT,
           OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
     }
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
 
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     try {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGenerator.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
@@ -80,7 +82,8 @@ public class TestHadoopDirTreeGenerator {
    */
   private void startCluster() throws Exception {
     conf = getOzoneConfiguration();
-
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.LEGACY.name());
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopNestedDirGenerator.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.raftlog.RaftLog;
@@ -82,6 +83,8 @@ public class TestHadoopNestedDirGenerator {
 
   private void startCluster() throws Exception {
     conf = new OzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED);
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStore.java
@@ -209,6 +209,8 @@ public class TestObjectStore {
       Assert.fail("Should throw Exception due to loop in Link Buckets");
     } catch (OMException oe) {
       // Expected exception
+      Assert.assertEquals(OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS,
+          oe.getResult());
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -154,8 +154,14 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     this.volume = objectStore.getVolume(volumeStr);
     this.bucket = volume.getBucket(bucketStr);
 
-    OzoneFSUtils.validateBucketLayout(bucket.getName(),
-        bucket.getBucketLayout());
+    OzoneBucket resolvedBucket = bucket;
+    if (bucket.isLink()) {
+      resolvedBucket = objectStore.getVolume(bucket.getSourceVolume())
+          .getBucket(bucket.getSourceBucket());
+    }
+
+    OzoneFSUtils.validateBucketLayout(resolvedBucket.getName(),
+        resolvedBucket.getBucketLayout());
 
     this.configuredDnPort = conf.getInt(
         OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenRenewer;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -153,15 +154,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     this.volume = objectStore.getVolume(volumeStr);
     this.bucket = volume.getBucket(bucketStr);
 
-    // Check if bucket layout is valid, OFS buckets cannot be in
-    // OBJECT_STORE layout
-    BucketLayout bucketLayout = bucket.getBucketLayout();
-    if (bucketLayout.equals(BucketLayout.OBJECT_STORE)) {
-      throw new IllegalArgumentException(bucketLayout + " does not support" +
-          " file system semantics. Bucket Layout must be " +
-          BucketLayout.FILE_SYSTEM_OPTIMIZED + " or "
-          + BucketLayout.LEGACY + ".");
-    }
+    OzoneFSUtils.validateBucketLayout(bucket.getName(),
+        bucket.getBucketLayout());
 
     this.configuredDnPort = conf.getInt(
         OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -152,6 +152,17 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     objectStore = ozoneClient.getObjectStore();
     this.volume = objectStore.getVolume(volumeStr);
     this.bucket = volume.getBucket(bucketStr);
+
+    // Check if bucket layout is valid, OFS buckets cannot be in
+    // OBJECT_STORE layout
+    BucketLayout bucketLayout = bucket.getBucketLayout();
+    if (bucketLayout.equals(BucketLayout.OBJECT_STORE)) {
+      throw new IllegalArgumentException(bucketLayout + " does not support" +
+          " file system semantics. Bucket Layout must be " +
+          BucketLayout.FILE_SYSTEM_OPTIMIZED + " or "
+          + BucketLayout.LEGACY + ".");
+    }
+
     this.configuredDnPort = conf.getInt(
         OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,
         OzoneConfigKeys.DFS_CONTAINER_IPC_PORT_DEFAULT);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.HashSet;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
@@ -52,6 +53,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
@@ -154,14 +156,12 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
     this.volume = objectStore.getVolume(volumeStr);
     this.bucket = volume.getBucket(bucketStr);
 
-    OzoneBucket resolvedBucket = bucket;
-    if (bucket.isLink()) {
-      resolvedBucket = objectStore.getVolume(bucket.getSourceVolume())
-          .getBucket(bucket.getSourceBucket());
-    }
+    // resolve the bucket layout in case of Link Bucket
+    BucketLayout resolvedBucketLayout =
+        OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+            new HashSet<>());
 
-    OzoneFSUtils.validateBucketLayout(resolvedBucket.getName(),
-        resolvedBucket.getBucketLayout());
+    OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
 
     this.configuredDnPort = conf.getInt(
         OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -227,6 +227,12 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket;
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+
+      if (bucket.isLink()) {
+        bucket = proxy.getBucketDetails(bucket.getSourceVolume(),
+            bucket.getSourceBucket());
+      }
+
       OzoneFSUtils.validateBucketLayout(bucket.getName(),
           bucket.getBucketLayout());
     } catch (OMException ex) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -226,6 +226,17 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket;
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
+
+      // Check if bucket layout is valid, OFS buckets cannot be in
+      // OBJECT_STORE layout
+      BucketLayout bucketLayout = bucket.getBucketLayout();
+      if (bucketLayout.equals(BucketLayout.OBJECT_STORE)) {
+        throw new IllegalArgumentException(bucketLayout + " does not support" +
+            " file system semantics. Bucket Layout must be " +
+            BucketLayout.FILE_SYSTEM_OPTIMIZED + " or "
+            + BucketLayout.LEGACY + ".");
+      }
+
     } catch (OMException ex) {
       if (createIfNotExist) {
         // getBucketDetails can throw VOLUME_NOT_FOUND when the parent volume

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.HashSet;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -228,13 +229,12 @@ public class BasicRootedOzoneClientAdapterImpl
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
 
-      if (bucket.isLink()) {
-        bucket = proxy.getBucketDetails(bucket.getSourceVolume(),
-            bucket.getSourceBucket());
-      }
+      // resolve the bucket layout in case of Link Bucket
+      BucketLayout resolvedBucketLayout =
+          OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+              new HashSet<>());
 
-      OzoneFSUtils.validateBucketLayout(bucket.getName(),
-          bucket.getBucketLayout());
+      OzoneFSUtils.validateBucketLayout(bucket.getName(), resolvedBucketLayout);
     } catch (OMException ex) {
       if (createIfNotExist) {
         // getBucketDetails can throw VOLUME_NOT_FOUND when the parent volume

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -66,6 +66,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
@@ -226,17 +227,8 @@ public class BasicRootedOzoneClientAdapterImpl
     OzoneBucket bucket;
     try {
       bucket = proxy.getBucketDetails(volumeStr, bucketStr);
-
-      // Check if bucket layout is valid, OFS buckets cannot be in
-      // OBJECT_STORE layout
-      BucketLayout bucketLayout = bucket.getBucketLayout();
-      if (bucketLayout.equals(BucketLayout.OBJECT_STORE)) {
-        throw new IllegalArgumentException(bucketLayout + " does not support" +
-            " file system semantics. Bucket Layout must be " +
-            BucketLayout.FILE_SYSTEM_OPTIMIZED + " or "
-            + BucketLayout.LEGACY + ".");
-      }
-
+      OzoneFSUtils.validateBucketLayout(bucket.getName(),
+          bucket.getBucketLayout());
     } catch (OMException ex) {
       if (createIfNotExist) {
         // getBucketDetails can throw VOLUME_NOT_FOUND when the parent volume

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS;
+
+/**
+ * Shared Utilities for Ozone FS and related classes.
+ */
+public final class OzoneClientUtils {
+  private OzoneClientUtils(){
+    // Not used.
+  }
+  public static BucketLayout resolveLinkBucketLayout(OzoneBucket bucket,
+                                                     ObjectStore objectStore,
+                                                     Set<Pair<String,
+                                                         String>> visited)
+      throws IOException {
+    if (bucket.isLink()) {
+      if (!visited.add(Pair.of(bucket.getVolumeName(),
+          bucket.getName()))) {
+        throw new OMException("Detected loop in bucket links. Bucket name: " +
+            bucket.getName() + ", Volume name: " + bucket.getVolumeName(),
+            DETECTED_LOOP_IN_BUCKET_LINKS);
+      }
+
+      OzoneBucket sourceBucket =
+          objectStore.getVolume(bucket.getSourceVolume())
+              .getBucket(bucket.getSourceBucket());
+
+      /** If the source bucket is again a link, we recursively resolve the
+       * link bucket.
+       *
+       * For example:
+       * buck-link1 -> buck-link2 -> buck-link3 -> buck-link1 -> buck-src
+       * buck-src has the actual BucketLayout that will be used by the links.
+       */
+      if (sourceBucket.isLink()) {
+        return resolveLinkBucketLayout(sourceBucket, objectStore, visited);
+      }
+    }
+    return bucket.getBucketLayout();
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Throw an exception if a bucket accessed via OFS is in OBJECT_STORE layout. Allowed layouts are FILE_SYSTEM_OPTIMIZED and LEGACY.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5959

## How was this patch tested?

Related integration tests.