### PR TITLE
HDDS-5983. Prefix Parser tool should only work for FSO buckets.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -148,6 +148,14 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
       return;
     }
 
+    BucketLayout bucketLayout = info.getBucketLayout();
+    if (!bucketLayout.isFileSystemOptimized()) {
+      System.out.println("Prefix tool only works for FileSystem Optimized" +
+              "bucket. Bucket Type is:" + bucketLayout);
+      metadataManager.stop();
+      return;
+    }
+
     long lastObjectId = info.getObjectID();
     WithParentObjectId objectBucketId = new WithParentObjectId();
     objectBucketId.setObjectID(lastObjectId);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -151,7 +151,7 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
     BucketLayout bucketLayout = info.getBucketLayout();
     if (!bucketLayout.isFileSystemOptimized()) {
       System.out.println("Prefix tool only works for FileSystem Optimized" +
-              "bucket. Bucket Type is:" + bucketLayout);
+              "bucket. Bucket Layout is:" + bucketLayout);
       metadataManager.stop();
       return;
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Prefix Parser tool will only work against FSO buckets, this jira adds a check for that

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5983

## How was this patch tested?
Existing tests