### PR TITLE
HDDS-5976. add raftlog IOException notifier for SCM ratis

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
-import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.hadoop.util.Time;
@@ -181,7 +180,7 @@ public class SCMStateMachine extends BaseStateMachine {
                               RaftProtos.LogEntryProto failedEntry) {
     // Should we add retry here?
     LOG.error("SCM statemachine appendLog failed, entry: {}", failedEntry);
-    ExitUtil.terminate(1, ex);
+    ExitUtils.terminate(1, ex.getMessage(), ex, StateMachine.LOG);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.scm.block.DeletedBlockLogImpl;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.util.concurrent.HadoopExecutors;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.hadoop.util.Time;
@@ -173,6 +174,14 @@ public class SCMStateMachine extends BaseStateMachine {
       final Exception targetEx = (Exception) e.getTargetException();
       throw targetEx != null ? targetEx : e;
     }
+  }
+
+  @Override
+  public void notifyLogFailed(Throwable ex,
+                              RaftProtos.LogEntryProto failedEntry) {
+    // Should we add retry here?
+    LOG.error("SCM statemachine appendLog failed, entry: {}", failedEntry);
+    ExitUtil.terminate(1, ex);
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -177,8 +177,7 @@ public class SCMStateMachine extends BaseStateMachine {
 
   @Override
   public void notifyLogFailed(Throwable ex,
-                              RaftProtos.LogEntryProto failedEntry) {
-    // Should we add retry here?
+      RaftProtos.LogEntryProto failedEntry) {
     LOG.error("SCM statemachine appendLog failed, entry: {}", failedEntry);
     ExitUtils.terminate(1, ex.getMessage(), ex, StateMachine.LOG);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the IO exception is met during the raft log being written for the leader SCM, it will endlessly be stuck in the timeout exception.
We should let the leader SCM crash for this kind of IO issue and possibly this will **notice the maintainer**.
After the SCM crashes, there are two scenarios: 
1. IO-err SCM restarted: 
   Most likely, it will become a follower and even it cannot commit a raft log, it won't affect the leader.

2. IO-err SCM not restarted:
  There are two SCMs remain working, which is still doable for ratis.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5976

## How was this patch tested?
manual test in K8S
