### PR TITLE
HDDS-5980. [S3- TDE] Get on a key which is overwrite through MPU on a TDE bucket, the data does not match with uploaded data.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -701,6 +701,14 @@ public final class OmKeyInfo extends WithParentObjectId {
     this.encInfo = null;
   }
 
+  /**
+   * Set the file encryption info.
+   * @param fileEncryptionInfo
+   */
+  public void setFileEncryptionInfo(FileEncryptionInfo fileEncryptionInfo) {
+    this.encInfo = fileEncryptionInfo;
+  }
+
   public String getPath() {
     if (StringUtils.isBlank(getFileName())) {
       return getKeyName();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -412,6 +412,17 @@ public class TestOzoneAtRestEncryption {
     testMultipartUploadWithEncryption(bucket, 2);
   }
 
+  @Test
+  public void testMPUwithThreePartsOverride() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    OzoneBucket bucket = createVolumeAndBucket(volumeName, bucketName);
+    testMultipartUploadWithEncryption(bucket, 3);
+
+    // override the key and check content
+    testMultipartUploadWithEncryption(bucket, 3);
+  }
+
 
   @Test
   public void testMPUwithLinkBucket() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -348,10 +348,21 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       updatePrefixFSOInfo(dbOpenKeyInfo, builder);
       omKeyInfo = builder.build();
     } else {
+      OmKeyInfo dbOpenKeyInfo = getOmKeyInfoFromOpenKeyTable(multipartOpenKey,
+          keyName, omMetadataManager);
+
       // Already a version exists, so we should add it as a new version.
       // But now as versioning is not supported, just following the commit
       // key approach. When versioning support comes, then we can uncomment
       // below code keyInfo.addNewVersion(locations);
+
+      // As right now versioning is not supported, we can set encryption info
+      // at KeyInfo level, but once we start supporting versioning,
+      // encryption info needs to be set at KeyLocation level, as each version
+      // will have it's own file encryption info.
+      if (dbOpenKeyInfo.getFileEncryptionInfo() != null) {
+        omKeyInfo.setFileEncryptionInfo(dbOpenKeyInfo.getFileEncryptionInfo());
+      }
       omKeyInfo.updateLocationInfoList(partLocationInfos, true, true);
       omKeyInfo.setModificationTime(keyArgs.getModificationTime());
       omKeyInfo.setDataSize(dataSize);


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should reset the file encryption info during MPU complete request.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5980

## How was this patch tested?

Updated test.

