### PR TITLE
HDDS-5972. [Multi-Tenant] Implement SetSecret: `ozone tenant user setsecret` and `ozone s3 setsecret`

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -375,6 +375,8 @@ public final class OzoneConsts {
   public static final int S3_BUCKET_MIN_LENGTH = 3;
   public static final int S3_BUCKET_MAX_LENGTH = 64;
 
+  public static final int S3_SECRET_KEY_MIN_LENGTH = 8;
+
   //GDPR
   public static final String GDPR_FLAG = "gdprEnabled";
   public static final String GDPR_ALGORITHM_NAME = "AES";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -323,6 +323,7 @@ public final class OzoneConsts {
   public static final String MAX_PARTS = "maxParts";
   public static final String S3_BUCKET = "s3Bucket";
   public static final String S3_GETSECRET_USER = "S3GetSecretUser";
+  public static final String S3_SETSECRET_USER = "S3SetSecretUser";
   public static final String S3_REVOKESECRET_USER = "S3RevokeSecretUser";
   public static final String RENAMED_KEYS_MAP = "renamedKeysMap";
   public static final String UNRENAMED_KEYS_MAP = "unRenamedKeysMap";

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -178,6 +178,18 @@ public class ObjectStore {
     return proxy.getS3Secret(kerberosID, createIfNotExist);
   }
 
+  /**
+   * Set secretKey for accessId.
+   * @param accessId
+   * @param secretKey
+   * @return S3SecretValue <accessId, secretKey> pair
+   * @throws IOException
+   */
+  public S3SecretValue setSecret(String accessId, String secretKey)
+          throws IOException {
+    return proxy.setSecret(accessId, secretKey);
+  }
+
   public void revokeS3Secret(String kerberosID) throws IOException {
     proxy.revokeS3Secret(kerberosID);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -185,9 +185,9 @@ public class ObjectStore {
    * @return S3SecretValue <accessId, secretKey> pair
    * @throws IOException
    */
-  public S3SecretValue setSecret(String accessId, String secretKey)
+  public S3SecretValue setS3Secret(String accessId, String secretKey)
           throws IOException {
-    return proxy.setSecret(accessId, secretKey);
+    return proxy.setS3Secret(accessId, secretKey);
   }
 
   public void revokeS3Secret(String kerberosID) throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -571,6 +571,15 @@ public interface ClientProtocol {
           throws IOException;
 
   /**
+   * Set secretKey of a given accessId.
+   * @param accessId
+   * @param secretKey
+   * @return S3SecretValue
+   * @throws IOException
+   */
+  S3SecretValue setSecret(String accessId, String secretKey) throws IOException;
+
+  /**
    * Revoke S3 Secret of given kerberos user.
    * @param kerberosID
    * @throws IOException

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -571,13 +571,14 @@ public interface ClientProtocol {
           throws IOException;
 
   /**
-   * Set secretKey of a given accessId.
+   * Set secret key of a given accessId.
    * @param accessId
    * @param secretKey
    * @return S3SecretValue
    * @throws IOException
    */
-  S3SecretValue setSecret(String accessId, String secretKey) throws IOException;
+  S3SecretValue setS3Secret(String accessId, String secretKey)
+      throws IOException;
 
   /**
    * Revoke S3 Secret of given kerberos user.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -649,7 +649,7 @@ public class RpcClient implements ClientProtocol {
     Preconditions.checkArgument(Strings.isNotBlank(accessId),
             "accessId cannot be null or empty.");
     Preconditions.checkArgument(Strings.isNotBlank(secretKey),
-            "secret cannot be null or empty.");
+            "secretKey cannot be null or empty.");
     return ozoneManagerClient.setSecret(accessId, secretKey);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -644,6 +644,18 @@ public class RpcClient implements ClientProtocol {
   /**
    * {@inheritDoc}
    */
+  public S3SecretValue setSecret(String accessId, String secretKey)
+          throws IOException {
+    Preconditions.checkArgument(Strings.isNotBlank(accessId),
+            "accessId cannot be null or empty.");
+    Preconditions.checkArgument(Strings.isNotBlank(secretKey),
+            "secret cannot be null or empty.");
+    return ozoneManagerClient.setSecret(accessId, secretKey);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void revokeS3Secret(String kerberosID) throws IOException {
     Preconditions.checkArgument(Strings.isNotBlank(kerberosID),

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -644,13 +644,13 @@ public class RpcClient implements ClientProtocol {
   /**
    * {@inheritDoc}
    */
-  public S3SecretValue setSecret(String accessId, String secretKey)
+  public S3SecretValue setS3Secret(String accessId, String secretKey)
           throws IOException {
     Preconditions.checkArgument(Strings.isNotBlank(accessId),
             "accessId cannot be null or empty.");
     Preconditions.checkArgument(Strings.isNotBlank(secretKey),
             "secretKey cannot be null or empty.");
-    return ozoneManagerClient.setSecret(accessId, secretKey);
+    return ozoneManagerClient.setS3Secret(accessId, secretKey);
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -302,7 +302,7 @@ public final class OmUtils {
     case Prepare:
     case CancelPrepare:
     case DeleteOpenKeys:
-    case SetSecret:
+    case SetS3Secret:
     case RevokeS3Secret:
     case PurgePaths:
     case CreateTenant:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -302,6 +302,7 @@ public final class OmUtils {
     case Prepare:
     case CancelPrepare:
     case DeleteOpenKeys:
+    case SetSecret:
     case RevokeS3Secret:
     case PurgePaths:
     case CreateTenant:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/audit/OMAction.java
@@ -71,6 +71,7 @@ public enum OMAction implements AuditAction {
   LIST_STATUS,
 
   GET_S3_SECRET,
+  SET_S3_SECRET,
   REVOKE_S3_SECRET,
 
   CREATE_TENANT,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -27,15 +27,15 @@ public final class OmDBAccessIdInfo {
   /**
    * Name of the tenant.
    */
-  private final String tenantId;
+  private final String tenantName;
   /**
-   * Kerberos principal this accessId belongs to.
+   * User principal this accessId belongs to.
    */
-  private final String kerberosPrincipal;
+  private final String userPrincipal;
   /**
-   * Shared secret of the accessId.
+   * Corresponding secret key for the accessId.
    */
-  private final String sharedSecret;
+  private final String secretKey;
   /**
    * Whether this accessId is an administrator of the tenant.
    */
@@ -49,12 +49,12 @@ public final class OmDBAccessIdInfo {
   // This implies above String fields should NOT contain the split key.
   public static final String SERIALIZATION_SPLIT_KEY = ";";
 
-  public OmDBAccessIdInfo(String tenantId,
-      String kerberosPrincipal, String sharedSecret,
-      boolean isAdmin, boolean isDelegatedAdmin) {
-    this.tenantId = tenantId;
-    this.kerberosPrincipal = kerberosPrincipal;
-    this.sharedSecret = sharedSecret;
+  public OmDBAccessIdInfo(String tenantName,
+                          String userPrincipal, String secretKey,
+                          boolean isAdmin, boolean isDelegatedAdmin) {
+    this.tenantName = tenantName;
+    this.userPrincipal = userPrincipal;
+    this.secretKey = secretKey;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
   }
@@ -64,9 +64,9 @@ public final class OmDBAccessIdInfo {
     Preconditions.checkState(tInfo.length == 3 || tInfo.length == 5,
         "Incorrect accessIdInfoString");
 
-    tenantId = tInfo[0];
-    kerberosPrincipal = tInfo[1];
-    sharedSecret = tInfo[2];
+    tenantName = tInfo[0];
+    userPrincipal = tInfo[1];
+    secretKey = tInfo[2];
     if (tInfo.length == 5) {
       isAdmin = Boolean.parseBoolean(tInfo[3]);
       isDelegatedAdmin = Boolean.parseBoolean(tInfo[4]);
@@ -76,15 +76,15 @@ public final class OmDBAccessIdInfo {
     }
   }
 
-  public String getTenantId() {
-    return tenantId;
+  public String getTenantName() {
+    return tenantName;
   }
 
   private String serialize() {
     final StringBuilder sb = new StringBuilder();
-    sb.append(tenantId);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(kerberosPrincipal);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(sharedSecret);
+    sb.append(tenantName);
+    sb.append(SERIALIZATION_SPLIT_KEY).append(userPrincipal);
+    sb.append(SERIALIZATION_SPLIT_KEY).append(secretKey);
     sb.append(SERIALIZATION_SPLIT_KEY).append(isAdmin);
     sb.append(SERIALIZATION_SPLIT_KEY).append(isDelegatedAdmin);
     return sb.toString();
@@ -106,12 +106,12 @@ public final class OmDBAccessIdInfo {
     return new OmDBAccessIdInfo(tInfo);
   }
 
-  public String getKerberosPrincipal() {
-    return kerberosPrincipal;
+  public String getUserPrincipal() {
+    return userPrincipal;
   }
 
-  public String getSharedSecret() {
-    return sharedSecret;
+  public String getSecretKey() {
+    return secretKey;
   }
 
   public boolean getIsAdmin() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -27,7 +27,7 @@ public final class OmDBAccessIdInfo {
   /**
    * Name of the tenant.
    */
-  private final String tenantName;
+  private final String tenantId;
   /**
    * User principal this accessId belongs to.
    */
@@ -49,10 +49,10 @@ public final class OmDBAccessIdInfo {
   // This implies above String fields should NOT contain the split key.
   public static final String SERIALIZATION_SPLIT_KEY = ";";
 
-  public OmDBAccessIdInfo(String tenantName,
+  public OmDBAccessIdInfo(String tenantId,
                           String userPrincipal, String secretKey,
                           boolean isAdmin, boolean isDelegatedAdmin) {
-    this.tenantName = tenantName;
+    this.tenantId = tenantId;
     this.userPrincipal = userPrincipal;
     this.secretKey = secretKey;
     this.isAdmin = isAdmin;
@@ -64,7 +64,7 @@ public final class OmDBAccessIdInfo {
     Preconditions.checkState(tInfo.length == 3 || tInfo.length == 5,
         "Incorrect accessIdInfoString");
 
-    tenantName = tInfo[0];
+    tenantId = tInfo[0];
     userPrincipal = tInfo[1];
     secretKey = tInfo[2];
     if (tInfo.length == 5) {
@@ -76,13 +76,13 @@ public final class OmDBAccessIdInfo {
     }
   }
 
-  public String getTenantName() {
-    return tenantName;
+  public String getTenantId() {
+    return tenantId;
   }
 
   private String serialize() {
     final StringBuilder sb = new StringBuilder();
-    sb.append(tenantName);
+    sb.append(tenantId);
     sb.append(SERIALIZATION_SPLIT_KEY).append(userPrincipal);
     sb.append(SERIALIZATION_SPLIT_KEY).append(secretKey);
     sb.append(SERIALIZATION_SPLIT_KEY).append(isAdmin);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
@@ -27,7 +27,7 @@ public final class OmDBTenantInfo {
   /**
    * Name of the tenant.
    */
-  private final String tenantName;
+  private final String tenantId;
   /**
    * Name of the tenant's bucket namespace.
    */
@@ -47,10 +47,10 @@ public final class OmDBTenantInfo {
   // Implies above names should NOT contain the split key.
   public static final String TENANT_INFO_SPLIT_KEY = ";";
 
-  public OmDBTenantInfo(String tenantName,
+  public OmDBTenantInfo(String tenantId,
       String bucketNamespaceName, String accountNamespaceName,
       String userPolicyGroupName, String bucketPolicyGroupName) {
-    this.tenantName = tenantName;
+    this.tenantId = tenantId;
     this.bucketNamespaceName = bucketNamespaceName;
     this.accountNamespaceName = accountNamespaceName;
     this.userPolicyGroupName = userPolicyGroupName;
@@ -62,20 +62,20 @@ public final class OmDBTenantInfo {
     Preconditions.checkState(tInfo.length == 5,
         "Incorrect tenantInfoString");
 
-    tenantName = tInfo[0];
+    tenantId = tInfo[0];
     bucketNamespaceName = tInfo[1];
     accountNamespaceName = tInfo[2];
     userPolicyGroupName = tInfo[3];
     bucketPolicyGroupName = tInfo[4];
   }
 
-  public String getTenantName() {
-    return tenantName;
+  public String getTenantId() {
+    return tenantId;
   }
 
   private String generateTenantInfo() {
     StringBuilder sb = new StringBuilder();
-    sb.append(tenantName).append(TENANT_INFO_SPLIT_KEY);
+    sb.append(tenantId).append(TENANT_INFO_SPLIT_KEY);
     sb.append(bucketNamespaceName).append(TENANT_INFO_SPLIT_KEY);
     sb.append(accountNamespaceName).append(TENANT_INFO_SPLIT_KEY);
     sb.append(userPolicyGroupName).append(TENANT_INFO_SPLIT_KEY);
@@ -122,7 +122,7 @@ public final class OmDBTenantInfo {
    */
   @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
-    private String tenantName;
+    private String tenantId;
     private String bucketNamespaceName;
     private String accountNamespaceName;
     private String userPolicyGroupName;
@@ -131,8 +131,8 @@ public final class OmDBTenantInfo {
     private Builder() {
     }
 
-    public Builder setTenantName(String tenantName) {
-      this.tenantName = tenantName;
+    public Builder setTenantId(String tenantId) {
+      this.tenantId = tenantId;
       return this;
     }
 
@@ -157,7 +157,7 @@ public final class OmDBTenantInfo {
     }
 
     public OmDBTenantInfo build() {
-      return new OmDBTenantInfo(tenantName, bucketNamespaceName,
+      return new OmDBTenantInfo(tenantId, bucketNamespaceName,
           accountNamespaceName, userPolicyGroupName, bucketPolicyGroupName);
     }
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantArgs.java
@@ -22,13 +22,14 @@ package org.apache.hadoop.ozone.om.helpers;
  * This class is used for storing Ozone tenant arguments.
  */
 public class OmTenantArgs {
-  private final String tenantName;
+  /* Tenant name */
+  private final String tenantId;
 
-  public OmTenantArgs(String tenantName) {
-    this.tenantName = tenantName;
+  public OmTenantArgs(String tenantId) {
+    this.tenantId = tenantId;
   }
 
-  public String getTenantName() {
-    return tenantName;
+  public String getTenantId() {
+    return tenantId;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantUserArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmTenantUserArgs.java
@@ -19,22 +19,22 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 /**
- * This class is used for storing tenant user arguments.
+ * This class is used for storing tenant user arguments. Unused for now.
  */
 public class OmTenantUserArgs {
   private final String tenantUsername;
-  private final String tenantName;
+  private final String tenantId;
 
-  public OmTenantUserArgs(String tenantUsername, String tenantName) {
+  public OmTenantUserArgs(String tenantUsername, String tenantId) {
     this.tenantUsername = tenantUsername;
-    this.tenantName = tenantName;
+    this.tenantId = tenantId;
   }
 
   public String getTenantUsername() {
     return tenantUsername;
   }
 
-  public String getTenantName() {
-    return tenantName;
+  public String getTenantId() {
+    return tenantId;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/S3SecretValue.java
@@ -25,6 +25,7 @@ import java.util.Objects;
  * S3Secret to be saved in database.
  */
 public class S3SecretValue {
+  // TODO: This field should be renamed to accessId for generalization.
   private String kerberosID;
   private String awsSecret;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
@@ -30,19 +30,18 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantU
  */
 public class TenantUserList {
 
-  private final String tenantName;
+  private final String tenantId;
 
   private final List<TenantUserAccessId> userAccessIds;
-
-
-  public TenantUserList(String tenantName,
+  
+  public TenantUserList(String tenantId,
                         List<TenantUserAccessId> userAccessIds) {
-    this.tenantName = tenantName;
+    this.tenantId = tenantId;
     this.userAccessIds = userAccessIds;
   }
 
-  public String getTenantName() {
-    return tenantName;
+  public String getTenantId() {
+    return tenantId;
   }
 
   public List<TenantUserAccessId> getUserAccessIds() {
@@ -56,7 +55,7 @@ public class TenantUserList {
 
   @Override
   public String toString() {
-    return "tenantName=" + tenantName +
+    return "tenantId=" + tenantId +
         "\nuserAccessIds=" + userAccessIds;
   }
 
@@ -69,12 +68,12 @@ public class TenantUserList {
       return false;
     }
     TenantUserList that = (TenantUserList) o;
-    return tenantName.equals(that.tenantName) &&
+    return tenantId.equals(that.tenantId) &&
         userAccessIds.equals(that.userAccessIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantName, userAccessIds);
+    return Objects.hash(tenantId, userAccessIds);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -462,6 +462,15 @@ public interface OzoneManagerProtocol
           throws IOException;
 
   /**
+   * Set secretKey for accessId.
+   * @param accessId
+   * @param secretKey
+   * @return S3SecretValue
+   * @throws IOException
+   */
+  S3SecretValue setSecret(String accessId, String secretKey) throws IOException;
+
+  /**
    * Revokes s3Secret of given kerberos user.
    * @param kerberosID
    * @throws IOException

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -462,13 +462,14 @@ public interface OzoneManagerProtocol
           throws IOException;
 
   /**
-   * Set secretKey for accessId.
+   * Set secret key for accessId.
    * @param accessId
    * @param secretKey
    * @return S3SecretValue
    * @throws IOException
    */
-  S3SecretValue setSecret(String accessId, String secretKey) throws IOException;
+  S3SecretValue setS3Secret(String accessId, String secretKey)
+      throws IOException;
 
   /**
    * Revokes s3Secret of given kerberos user.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -895,24 +895,22 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public S3SecretValue setSecret(String accessId, String secretKey)
+  public S3SecretValue setS3Secret(String accessId, String secretKey)
           throws IOException {
-    SetSecretRequest request = SetSecretRequest.newBuilder()
-            .setAccessId(accessId)
-            .setSecretKey(secretKey)
-            .build();
-    OMRequest omRequest = createOMRequest(Type.SetSecret)
-            .setSetSecretRequest(request)
-            .build();
-    final SetSecretResponse resp = handleError(submitRequest(omRequest))
-            .getSetSecretResponse();
+    final SetS3SecretRequest request = SetS3SecretRequest.newBuilder()
+        .setAccessId(accessId)
+        .setSecretKey(secretKey)
+        .build();
+    OMRequest omRequest = createOMRequest(Type.SetS3Secret)
+        .setSetS3SecretRequest(request)
+        .build();
+    final SetS3SecretResponse resp = handleError(submitRequest(omRequest))
+        .getSetS3SecretResponse();
 
-    // Because for now the response in SetSecretResponse happens to contain
-    // what S3Secret/Value is suited for, we just re-use it.
     final S3Secret accessIdSecretKeyPair = S3Secret.newBuilder()
-            .setKerberosID(resp.getAccessId())
-            .setAwsSecret(resp.getSecretKey())
-            .build();
+        .setKerberosID(resp.getAccessId())
+        .setAwsSecret(resp.getSecretKey())
+        .build();
 
     return S3SecretValue.fromProtobuf(accessIdSecretKeyPair);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -895,6 +895,29 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
+  public S3SecretValue setSecret(String accessId, String secretKey)
+          throws IOException {
+    SetSecretRequest request = SetSecretRequest.newBuilder()
+            .setAccessId(accessId)
+            .setSecretKey(secretKey)
+            .build();
+    OMRequest omRequest = createOMRequest(Type.SetSecret)
+            .setSetSecretRequest(request)
+            .build();
+    final SetSecretResponse resp = handleError(submitRequest(omRequest))
+            .getSetSecretResponse();
+
+    // Because for now the response in SetSecretResponse happens to contain
+    // what S3Secret/Value is suited for, we just re-use it.
+    final S3Secret accessIdSecretKeyPair = S3Secret.newBuilder()
+            .setKerberosID(resp.getAccessId())
+            .setAwsSecret(resp.getSecretKey())
+            .build();
+
+    return S3SecretValue.fromProtobuf(accessIdSecretKeyPair);
+  }
+
+  @Override
   public void revokeS3Secret(String kerberosID) throws IOException {
     RevokeS3SecretRequest request = RevokeS3SecretRequest.newBuilder()
             .setKerberosID(kerberosID)

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -953,12 +953,12 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    */
   @Override
   public S3SecretValue tenantAssignUserAccessId(
-      String username, String tenantName, String accessId) throws IOException {
+      String username, String tenantId, String accessId) throws IOException {
 
     final TenantAssignUserAccessIdRequest request =
         TenantAssignUserAccessIdRequest.newBuilder()
         .setTenantUsername(username)
-        .setTenantName(tenantName)
+        .setTenantName(tenantId)
         .setAccessId(accessId)
         .build();
     final OMRequest omRequest = createOMRequest(Type.TenantAssignUserAccessId)

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -50,7 +50,7 @@ Secure Tenant SetSecret Success with Cluster Admin
 
 Secure Tenant SetSecret Failure For Invalid Secret Input 1
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user setsecret 'tenantone$bob' --secret='' --export
-                        Should contain   ${output}         Secret key should not be empty
+                        Should contain   ${output}         secretKey cannot be null or empty.
 
 Secure Tenant SetSecret Failure For Invalid Secret Input 2
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user setsecret 'tenantone$bob' --secret=short --export
@@ -67,7 +67,7 @@ Secure Tenant Assign User Failure
 Secure Tenant Create Tenant Failure with Regular (non-admin) user
     Run Keyword   Kinit test user     testuser2    testuser2.keytab
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant create tenanttwo
-                        Should contain   ${output}         Failed to create tenant 'tenanttwo': User 'testuser2' is not an Ozone admin.
+                        Should contain   ${output}         Failed to create tenant 'tenanttwo': User 'testuser2/scm@EXAMPLE.COM' is not an Ozone admin.
 
 Secure Tenant SetSecret Failure with Regular (non-admin) user
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user set-secret 'tenantone$bob' --secret=somesecret2 --export

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -45,7 +45,19 @@ Secure Tenant GetUserInfo Success
                         Should contain   ${output}         Tenant 'tenantone' with accessId 'tenantone$bob'
 
 Secure Tenant SetSecret Success with Cluster Admin
-    ${output} =         Execute          ozone tenant user set-secret 'tenantone$bob' --secret=somesecret1 --export
+    ${output} =         Execute          ozone tenant user setsecret 'tenantone$bob' --secret=somesecret1 --export
+                        Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'
+
+Secure Tenant SetSecret Failure For Invalid Secret Input 1
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user setsecret 'tenantone$bob' --secret='' --export
+                        Should contain   ${output}         Secret key should not be empty
+
+Secure Tenant SetSecret Failure For Invalid Secret Input 2
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user setsecret 'tenantone$bob' --secret=short --export
+                        Should contain   ${output}         Secret key length should be at least 8 characters
+
+Secure Tenant GetSecret Success
+    ${output} =         Execute          ozone tenant user getsecret 'tenantone$bob' --export
                         Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'
 
 Secure Tenant Assign User Failure

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -30,9 +30,9 @@ Init Ranger MockServer
                         Should contain   ${output}         {}
 
 *** Test Cases ***
-Secure Tenant Create Tenant Success
-#    Run Keyword   Kinit test user     testuser     testuser.keytab
+Secure Tenant Create Tenant Success with Cluster Admin
     Run Keyword         Init Ranger MockServer
+    Run Keyword   Kinit test user     testuser     testuser.keytab
     ${output} =         Execute          ozone tenant create tenantone
                         Should contain   ${output}         Created tenant 'tenantone'
 
@@ -44,7 +44,19 @@ Secure Tenant GetUserInfo Success
     ${output} =         Execute          ozone tenant user info bob
                         Should contain   ${output}         Tenant 'tenantone' with accessId 'tenantone$bob'
 
+Secure Tenant SetSecret Success with Cluster Admin
+    ${output} =         Execute          ozone tenant user set-secret tenantone$bob --secret=somesecret1 --export
+                        Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'
+
 Secure Tenant Assign User Failure
     ${rc}  ${result} =  Run And Return Rc And Output  ozone tenant user assign bob --tenant=thistenantdoesnotexist
                         Should contain   ${result}         Tenant 'thistenantdoesnotexist' doesn't exist
 
+Secure Tenant Create Tenant Failure with Regular (non-admin) user
+    Run Keyword   Kinit test user     testuser2    testuser2.keytab
+    ${output} =         Execute          ozone tenant create tenanttwo
+                        Should contain   ${output}         Failed to create tenant 'tenanttwo': User 'testuser2' is not an Ozone admin.
+
+Secure Tenant SetSecret Failure with Regular (non-admin) user
+    ${output} =         Execute          ozone tenant user set-secret tenantone$bob --secret=somesecret2 --export
+                        Should contain   ${output}         Permission denied. Requested accessId

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -45,18 +45,18 @@ Secure Tenant GetUserInfo Success
                         Should contain   ${output}         Tenant 'tenantone' with accessId 'tenantone$bob'
 
 Secure Tenant SetSecret Success with Cluster Admin
-    ${output} =         Execute          ozone tenant user set-secret tenantone$bob --secret=somesecret1 --export
+    ${output} =         Execute          ozone tenant user set-secret 'tenantone$bob' --secret=somesecret1 --export
                         Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'
 
 Secure Tenant Assign User Failure
-    ${rc}  ${result} =  Run And Return Rc And Output  ozone tenant user assign bob --tenant=thistenantdoesnotexist
-                        Should contain   ${result}         Tenant 'thistenantdoesnotexist' doesn't exist
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user assign bob --tenant=thistenantdoesnotexist
+                        Should contain   ${output}         Tenant 'thistenantdoesnotexist' doesn't exist
 
 Secure Tenant Create Tenant Failure with Regular (non-admin) user
     Run Keyword   Kinit test user     testuser2    testuser2.keytab
-    ${output} =         Execute          ozone tenant create tenanttwo
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant create tenanttwo
                         Should contain   ${output}         Failed to create tenant 'tenanttwo': User 'testuser2' is not an Ozone admin.
 
 Secure Tenant SetSecret Failure with Regular (non-admin) user
-    ${output} =         Execute          ozone tenant user set-secret tenantone$bob --secret=somesecret2 --export
+    ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user set-secret 'tenantone$bob' --secret=somesecret2 --export
                         Should contain   ${output}         Permission denied. Requested accessId

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-token.robot
@@ -23,6 +23,7 @@ Test Timeout        5 minutes
 
 *** Keywords ***
 Get and use Token in Secure Cluster
+    Run Keyword   Kinit test user     testuser     testuser.keytab
     Execute                      ozone sh token get -t /tmp/ozone.token
     File Should Not Be Empty     /tmp/ozone.token
     Execute                      kdestroy

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestSecureOzoneCluster.java
@@ -647,10 +647,10 @@ public final class TestSecureOzoneCluster {
       // Revoke the existing secret
       omClient.revokeS3Secret(username);
 
-      // Setsecret should fail since the accessId is revoked
+      // Set secret should fail since the accessId is revoked
       final String secretKeySet = "somesecret1";
       try {
-        omClient.setSecret(username, secretKeySet);
+        omClient.setS3Secret(username, secretKeySet);
       } catch (OMException omEx) {
         assertEquals(OMException.ResultCodes.ACCESSID_NOT_FOUND,
             omEx.getResult());
@@ -666,7 +666,7 @@ public final class TestSecureOzoneCluster {
       assertEquals(attempt3.getAwsAccessKey(), attempt2.getAwsAccessKey());
 
       // Admin can set secret for any user
-      omClient.setSecret(username, secretKeySet);
+      omClient.setS3Secret(username, secretKeySet);
       assertEquals(secretKeySet, omClient.getS3Secret(username).getAwsSecret());
       // Clean up
       omClient.revokeS3Secret(username);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.multitenant.MultiTenantAccessAuthorizerRangerP
 import org.apache.hadoop.ozone.om.request.s3.tenant.OMAssignUserToTenantRequest;
 import org.apache.hadoop.ozone.om.request.s3.tenant.OMTenantCreateRequest;
 import org.apache.hadoop.ozone.shell.tenant.TenantShell;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -52,6 +53,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
+import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
@@ -586,6 +588,112 @@ public class TestOzoneTenantShell {
     // Clean up
     executeHA(tenantShell, new String[] {
         "user", "revoke", "tenant1$alice"});
+    checkOutput(out, "", true);
+    checkOutput(err, "Revoked accessId", false);
+
+    // TODO: Clean up: remove tenant when tenant remove CLI is implemented
+  }
+
+  @Test
+  public void testTenantSetSecret() throws IOException, InterruptedException {
+
+    final String tenantName = "tenant-test-set-secret";
+
+    // Create test tenant
+    executeHA(tenantShell, new String[] {"create", tenantName});
+    checkOutput(out, "Created tenant '" + tenantName + "'.\n", true);
+    checkOutput(err, "", true);
+
+    // Set secret for non-existent accessId. Expect failure
+    executeHA(tenantShell, new String[] {
+        "user", "set-secret", tenantName + "$alice", "--secret=somesecret0"});
+    checkOutput(out, "", true);
+    checkOutput(err, "AccessId '" + tenantName + "$alice' doesn't exist\n",
+        true);
+
+    // Assign a user to the tenant so that we have an accessId entry
+    executeHA(tenantShell, new String[] {
+        "user", "assign", "alice", "--tenant=" + tenantName});
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+        "export AWS_SECRET_ACCESS_KEY='", false);
+    checkOutput(err, "Assigned 'alice' to '" + tenantName + "'" +
+        " with accessId '" + tenantName + "$alice'.\n", true);
+
+    // Set secret as OM admin should succeed
+    executeHA(tenantShell, new String[] {
+        "user", "set-secret", tenantName + "$alice",
+        "--secret=somesecret1", "--export"});
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+        "export AWS_SECRET_ACCESS_KEY='somesecret1'\n", true);
+    checkOutput(err, "", true);
+
+    // Set secret as alice should succeed
+    final UserGroupInformation ugiAlice = UserGroupInformation
+        .createUserForTesting("alice",  new String[] {"usergroup"});
+
+    ugiAlice.doAs((PrivilegedExceptionAction<Void>) () -> {
+      executeHA(tenantShell, new String[] {
+          "user", "set-secret", tenantName + "$alice",
+          "--secret=somesecret2", "--export"});
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+          "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
+      checkOutput(err, "", true);
+      return null;
+    });
+
+    // Set secret as bob should fail
+    executeHA(tenantShell, new String[] {
+        "user", "assign", "bob", "--tenant=" + tenantName});
+    checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$bob'\n" +
+        "export AWS_SECRET_ACCESS_KEY='", false);
+    checkOutput(err, "Assigned 'bob' to '" + tenantName + "'" +
+        " with accessId '" + tenantName + "$bob'.\n", true);
+
+    final UserGroupInformation ugiBob = UserGroupInformation
+        .createUserForTesting("bob",  new String[] {"usergroup"});
+
+    ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
+      executeHA(tenantShell, new String[] {
+          "user", "set-secret", tenantName + "$alice",
+          "--secret=somesecret2", "--export"});
+      checkOutput(out, "", true);
+      checkOutput(err, "", true);
+      // Note: Exception thrown from OM to the client which is not caught by CLI
+      //  handler is somehow not captured in err above, but is printed to the
+      //  console.
+      return null;
+    });
+
+    // Once we make bob an admin of this tenant, set secret should succeed
+    executeHA(tenantShell, new String[] {"user", "assign-admin",
+        tenantName + "$" + ugiBob.getShortUserName(),
+        "--tenant=" + tenantName, "--delegated=true"});
+    checkOutput(out, "", true);
+    checkOutput(err, "Assigned admin", false);
+
+    ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
+      executeHA(tenantShell, new String[] {
+          "user", "set-secret", tenantName + "$alice",
+          "--secret=somesecret2", "--export"});
+      checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
+          "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
+      checkOutput(err, "", true);
+      return null;
+    });
+
+    // Clean up
+    executeHA(tenantShell, new String[] {"user", "revoke-admin",
+        tenantName + "$" + ugiBob.getShortUserName()});
+    checkOutput(out, "", true);
+    checkOutput(err, "Revoked admin", false);
+
+    executeHA(tenantShell, new String[] {
+        "user", "revoke", tenantName + "$bob"});
+    checkOutput(out, "", true);
+    checkOutput(err, "Revoked accessId", false);
+
+    executeHA(tenantShell, new String[] {
+        "user", "revoke", tenantName + "$alice"});
     checkOutput(out, "", true);
     checkOutput(err, "Revoked accessId", false);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -621,10 +621,25 @@ public class TestOzoneTenantShell {
 
     // Set secret as OM admin should succeed
     executeHA(tenantShell, new String[] {
-        "user", "set-secret", tenantName + "$alice",
+        "user", "setsecret", tenantName + "$alice",
         "--secret=somesecret1", "--export"});
     checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
         "export AWS_SECRET_ACCESS_KEY='somesecret1'\n", true);
+    checkOutput(err, "", true);
+
+    // Set empty secret key should fail
+    executeHA(tenantShell, new String[] {
+        "user", "setsecret", tenantName + "$alice",
+        "--secret=short", "--export"});
+    checkOutput(out, "", true);
+    checkOutput(err, "", true);
+    // Note: Exception thrown from OM to the client stderr is somehow not
+    //  captured in err, but is printed to the console output.
+
+    // Get secret should still give the previous secret key
+    executeHA(tenantShell, new String[] {
+        "user", "getsecret", tenantName + "$alice"});
+    checkOutput(out, "somesecret1", false);
     checkOutput(err, "", true);
 
     // Set secret as alice should succeed
@@ -633,7 +648,7 @@ public class TestOzoneTenantShell {
 
     ugiAlice.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
-          "user", "set-secret", tenantName + "$alice",
+          "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2", "--export"});
       checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);
@@ -654,13 +669,12 @@ public class TestOzoneTenantShell {
 
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
-          "user", "set-secret", tenantName + "$alice",
+          "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2", "--export"});
       checkOutput(out, "", true);
       checkOutput(err, "", true);
-      // Note: Exception thrown from OM to the client which is not caught by CLI
-      //  handler is somehow not captured in err above, but is printed to the
-      //  console.
+      // Note: Exception thrown from OM to the client stderr is somehow not
+      //  captured in err, but is printed to the console output.
       return null;
     });
 
@@ -673,7 +687,7 @@ public class TestOzoneTenantShell {
 
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
-          "user", "set-secret", tenantName + "$alice",
+          "user", "setsecret", tenantName + "$alice",
           "--secret=somesecret2", "--export"});
       checkOutput(out, "export AWS_ACCESS_KEY_ID='" + tenantName + "$alice'\n" +
           "export AWS_SECRET_ACCESS_KEY='somesecret2'\n", true);

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -99,6 +99,7 @@ enum Type {
   ListTrash = 91;
   RecoverTrash = 92;
 
+  SetSecret = 106;   // TODO: Renumber this when rebasing?
   RevokeS3Secret = 93;
 
   PurgePaths = 94;
@@ -196,6 +197,7 @@ message OMRequest {
   optional ListTrashRequest                 listTrashRequest               = 91;
   optional RecoverTrashRequest              RecoverTrashRequest            = 92;
 
+  optional SetSecretRequest                 SetSecretRequest               = 106;
   optional RevokeS3SecretRequest            RevokeS3SecretRequest          = 93;
 
   optional PurgePathsRequest                purgePathsRequest              = 94;
@@ -213,7 +215,7 @@ message OMRequest {
   optional TenantRevokeAdminRequest         TenantRevokeAdminRequest       = 102;
 
   optional GetS3VolumeRequest               getS3VolumeRequest             = 104;
-  optional TenantListUserRequest            tenantListUserRequest         = 105;
+  optional TenantListUserRequest            tenantListUserRequest          = 105;
 }
 
 message OMResponse {
@@ -282,6 +284,8 @@ message OMResponse {
   optional RemoveAclResponse                 removeAclResponse             = 76;
   optional SetAclResponse                   setAclResponse                 = 77;
   optional GetAclResponse                    getAclResponse                = 78;
+
+  optional SetSecretResponse                 SetSecretResponse               = 106;
 
   optional PurgeKeysResponse                  purgeKeysResponse            = 81;
 
@@ -1385,11 +1389,12 @@ message GetS3SecretResponse {
 
 message SetSecretRequest {
     optional string accessId = 1;
-    optional string secret = 2;
+    optional string secretKey = 2;
 }
 
 message SetSecretResponse {
-    optional bool success = 1;
+    optional string accessId = 1;
+    optional string secretKey = 2;
 }
 
 message TenantInfo {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -99,7 +99,6 @@ enum Type {
   ListTrash = 91;
   RecoverTrash = 92;
 
-  SetSecret = 106;   // TODO: Renumber this when rebasing?
   RevokeS3Secret = 93;
 
   PurgePaths = 94;
@@ -118,6 +117,8 @@ enum Type {
 
   GetS3Volume = 104;
   TenantListUser = 105;
+
+  SetSecret = 106;
 }
 
 message OMRequest {
@@ -197,7 +198,6 @@ message OMRequest {
   optional ListTrashRequest                 listTrashRequest               = 91;
   optional RecoverTrashRequest              RecoverTrashRequest            = 92;
 
-  optional SetSecretRequest                 SetSecretRequest               = 106;
   optional RevokeS3SecretRequest            RevokeS3SecretRequest          = 93;
 
   optional PurgePathsRequest                purgePathsRequest              = 94;
@@ -216,6 +216,8 @@ message OMRequest {
 
   optional GetS3VolumeRequest               getS3VolumeRequest             = 104;
   optional TenantListUserRequest            tenantListUserRequest          = 105;
+
+  optional SetSecretRequest                 SetSecretRequest               = 106;
 }
 
 message OMResponse {
@@ -285,8 +287,6 @@ message OMResponse {
   optional SetAclResponse                   setAclResponse                 = 77;
   optional GetAclResponse                    getAclResponse                = 78;
 
-  optional SetSecretResponse                 SetSecretResponse               = 106;
-
   optional PurgeKeysResponse                  purgeKeysResponse            = 81;
 
   optional ListMultipartUploadsResponse listMultipartUploadsResponse = 82;
@@ -310,6 +310,8 @@ message OMResponse {
 
   optional GetS3VolumeResponse               getS3VolumeResponse           = 104;
   optional TenantListUserResponse            tenantListUserResponse        = 105;
+
+  optional SetSecretResponse                 SetSecretResponse               = 106;
 }
 
 enum Status {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -118,7 +118,7 @@ enum Type {
   GetS3Volume = 104;
   TenantListUser = 105;
 
-  SetSecret = 106;
+  SetS3Secret = 106;
 }
 
 message OMRequest {
@@ -217,7 +217,7 @@ message OMRequest {
   optional GetS3VolumeRequest               getS3VolumeRequest             = 104;
   optional TenantListUserRequest            tenantListUserRequest          = 105;
 
-  optional SetSecretRequest                 SetSecretRequest               = 106;
+  optional SetS3SecretRequest               SetS3SecretRequest             = 106;
 }
 
 message OMResponse {
@@ -311,7 +311,7 @@ message OMResponse {
   optional GetS3VolumeResponse               getS3VolumeResponse           = 104;
   optional TenantListUserResponse            tenantListUserResponse        = 105;
 
-  optional SetSecretResponse                 SetSecretResponse               = 106;
+  optional SetS3SecretResponse               SetS3SecretResponse           = 106;
 }
 
 enum Status {
@@ -1389,12 +1389,12 @@ message GetS3SecretResponse {
     required S3Secret s3Secret = 2;
 }
 
-message SetSecretRequest {
+message SetS3SecretRequest {
     optional string accessId = 1;
     optional string secretKey = 2;
 }
 
-message SetSecretResponse {
+message SetS3SecretResponse {
     optional string accessId = 1;
     optional string secretKey = 2;
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -301,13 +301,13 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       if (omDBAccessIdInfo == null) {
         throw new OMException(INVALID_ACCESSID);
       }
-      String tenantName = omDBAccessIdInfo.getTenantId();
+      String tenantName = omDBAccessIdInfo.getTenantName();
       if (tenantName == null) {
         LOG.error("Tenant doesn't exist");
         return;
       }
       tenantCache.get(tenantName).getTenantUsers()
-          .remove(new ImmutablePair<>(omDBAccessIdInfo.getKerberosPrincipal(),
+          .remove(new ImmutablePair<>(omDBAccessIdInfo.getUserPrincipal(),
               accessID));
       // TODO: Determine how to replace this code.
 //      final String userID = authorizer.getUserId(userPrincipal);
@@ -327,7 +327,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       OmDBAccessIdInfo omDBAccessIdInfo =
           omMetadataManager.getTenantAccessIdTable().get(accessId);
       if (omDBAccessIdInfo != null) {
-        String userName = omDBAccessIdInfo.getKerberosPrincipal();
+        String userName = omDBAccessIdInfo.getUserPrincipal();
         LOG.debug("Username for accessId {} = {}", accessId, userName);
         return userName;
       }
@@ -398,7 +398,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
     if (omDBAccessIdInfo == null) {
       throw new OMException(INVALID_ACCESSID);
     }
-    return omDBAccessIdInfo.getTenantId();
+    return omDBAccessIdInfo.getTenantName();
   }
 
   public List<String> listAllAccessIDs(String tenantID)
@@ -598,8 +598,8 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
         KeyValue<String, OmDBAccessIdInfo> next = iterator.next();
         String accessId = next.getKey();
         OmDBAccessIdInfo value = next.getValue();
-        String tenantId = value.getTenantId();
-        String user = value.getKerberosPrincipal();
+        String tenantId = value.getTenantName();
+        String user = value.getUserPrincipal();
 
         CachedTenantInfo cachedTenantInfo = tenantCache
             .computeIfAbsent(tenantId, k -> new CachedTenantInfo(tenantId));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -301,7 +301,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       if (omDBAccessIdInfo == null) {
         throw new OMException(INVALID_ACCESSID);
       }
-      String tenantName = omDBAccessIdInfo.getTenantName();
+      String tenantName = omDBAccessIdInfo.getTenantId();
       if (tenantName == null) {
         LOG.error("Tenant doesn't exist");
         return;
@@ -398,7 +398,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
     if (omDBAccessIdInfo == null) {
       throw new OMException(INVALID_ACCESSID);
     }
-    return omDBAccessIdInfo.getTenantName();
+    return omDBAccessIdInfo.getTenantId();
   }
 
   public List<String> listAllAccessIDs(String tenantID)
@@ -598,7 +598,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
         KeyValue<String, OmDBAccessIdInfo> next = iterator.next();
         String accessId = next.getKey();
         OmDBAccessIdInfo value = next.getValue();
-        String tenantId = value.getTenantName();
+        String tenantId = value.getTenantId();
         String user = value.getUserPrincipal();
 
         CachedTenantInfo cachedTenantInfo = tenantCache

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3150,9 +3150,9 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     while (iterator.hasNext()) {
       final Table.KeyValue<String, OmDBTenantInfo> dbEntry = iterator.next();
       final OmDBTenantInfo omDBTenantInfo = dbEntry.getValue();
-      assert(dbEntry.getKey().equals(omDBTenantInfo.getTenantName()));
+      assert(dbEntry.getKey().equals(omDBTenantInfo.getTenantId()));
       tenantInfoList.add(TenantInfo.newBuilder()
-          .setTenantName(omDBTenantInfo.getTenantName())
+          .setTenantName(omDBTenantInfo.getTenantId())
           .setBucketNamespaceName(omDBTenantInfo.getBucketNamespaceName())
           .setAccountNamespaceName(omDBTenantInfo.getAccountNamespaceName())
           .setUserPolicyGroupName(omDBTenantInfo.getUserPolicyGroupName())
@@ -3203,7 +3203,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         assert(accessIdInfo.getUserPrincipal().equals(userPrincipal));
         accessIdInfoList.add(TenantAccessIdInfo.newBuilder()
             .setAccessId(accessId)
-            .setTenantName(accessIdInfo.getTenantName())
+            .setTenantName(accessIdInfo.getTenantId())
             .setIsAdmin(accessIdInfo.getIsAdmin())
             .setIsDelegatedAdmin(accessIdInfo.getIsDelegatedAdmin())
             .build());
@@ -3258,16 +3258,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public OmVolumeArgs getS3Volume(String accessID) throws IOException {
 
-    String tenantName;
+    String tenantId;
     try {
-      tenantName = multiTenantManagr.getTenantForAccessID(accessID);
+      tenantId = multiTenantManagr.getTenantForAccessID(accessID);
       if (LOG.isDebugEnabled()) {
         LOG.debug("Get S3 volume request for access ID {} belonging to tenant" +
-                " {} is directed to the volume {}.", accessID, tenantName,
-            tenantName);
+                " {} is directed to the volume {}.", accessID, tenantId,
+            tenantId);  // TODO: Get volume name from DB. Do not assume the same
       }
       // This call performs acl checks and checks volume existence.
-      return getVolumeInfo(tenantName);
+      return getVolumeInfo(tenantId);
 
     } catch (OMException ex) {
       if (ex.getResult().equals(INVALID_ACCESSID)) {
@@ -4213,7 +4213,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       for (final String accessId : principalInfo.getAccessIds()) {
         final OmDBAccessIdInfo accessIdInfo =
             getMetadataManager().getTenantAccessIdTable().get(accessId);
-        if (tenantName.equals(accessIdInfo.getTenantName())) {
+        if (tenantName.equals(accessIdInfo.getTenantId())) {
           if (!delegated) {
             return accessIdInfo.getIsAdmin();
           } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3287,7 +3287,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public S3SecretValue setSecret(String accessId, String secretKey) {
+  public S3SecretValue setS3Secret(String accessId, String secretKey) {
     throw new UnsupportedOperationException("OzoneManager does not require " +
             "this to be implemented. As write requests use a new approach");
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3200,10 +3200,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
               accessId);
           throw new NullPointerException("accessIdInfo is null");
         }
-        assert(accessIdInfo.getKerberosPrincipal().equals(userPrincipal));
+        assert(accessIdInfo.getUserPrincipal().equals(userPrincipal));
         accessIdInfoList.add(TenantAccessIdInfo.newBuilder()
             .setAccessId(accessId)
-            .setTenantName(accessIdInfo.getTenantId())
+            .setTenantName(accessIdInfo.getTenantName())
             .setIsAdmin(accessIdInfo.getIsAdmin())
             .setIsDelegatedAdmin(accessIdInfo.getIsDelegatedAdmin())
             .build());
@@ -3287,9 +3287,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  /**
-   * {@inheritDoc}
-   */
+  public S3SecretValue setSecret(String accessId, String secretKey) {
+    throw new UnsupportedOperationException("OzoneManager does not require " +
+            "this to be implemented. As write requests use a new approach");
+  }
+
+  @Override
   public void revokeS3Secret(String kerberosID) {
     throw new UnsupportedOperationException("OzoneManager does not require " +
             "this to be implemented. As write requests use a new approach");
@@ -4210,7 +4213,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       for (final String accessId : principalInfo.getAccessIds()) {
         final OmDBAccessIdInfo accessIdInfo =
             getMetadataManager().getTenantAccessIdTable().get(accessId);
-        if (tenantName.equals(accessIdInfo.getTenantId())) {
+        if (tenantName.equals(accessIdInfo.getTenantName())) {
           if (!delegated) {
             return accessIdInfo.getIsAdmin();
           } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -77,6 +77,7 @@ import org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCommitPa
 import org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCommitPartRequestWithFSO;
 import org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequest;
 import org.apache.hadoop.ozone.om.request.s3.multipart.S3MultipartUploadCompleteRequestWithFSO;
+import org.apache.hadoop.ozone.om.request.s3.security.OMSetSecretRequest;
 import org.apache.hadoop.ozone.om.request.s3.security.S3GetSecretRequest;
 import org.apache.hadoop.ozone.om.request.s3.security.S3RevokeSecretRequest;
 import org.apache.hadoop.ozone.om.request.s3.tenant.OMAssignUserToTenantRequest;
@@ -257,6 +258,8 @@ public final class OzoneManagerRatisUtils {
       return new OMPrepareRequest(omRequest);
     case CancelPrepare:
       return new OMCancelPrepareRequest(omRequest);
+    case SetSecret:
+      return new OMSetSecretRequest(omRequest);
     case RevokeS3Secret:
       return new S3RevokeSecretRequest(omRequest);
     case CreateTenant:

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -258,7 +258,7 @@ public final class OzoneManagerRatisUtils {
       return new OMPrepareRequest(omRequest);
     case CancelPrepare:
       return new OMCancelPrepareRequest(omRequest);
-    case SetSecret:
+    case SetS3Secret:
       return new OMSetSecretRequest(omRequest);
     case RevokeS3Secret:
       return new S3RevokeSecretRequest(omRequest);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
@@ -88,6 +88,14 @@ public class OMSetSecretRequest extends OMClientRequest {
               OMException.ResultCodes.INVALID_REQUEST);
     }
 
+    if (secretKey.length() < OzoneConsts.S3_SECRET_KEY_MIN_LENGTH) {
+      throw new OMException("Secret key length should be at least " +
+          OzoneConsts.S3_SECRET_KEY_MIN_LENGTH + " characters",
+          OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    // TODO: Check if secretKey matches other requirements? e.g. combination
+
     final UserGroupInformation ugi = ProtobufRpcEngine.Server.getRemoteUser();
     final String username = ugi.getUserName();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.s3.security;
+
+import com.google.common.base.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ipc.ProtobufRpcEngine;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
+import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.s3.security.OMSetSecretResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.*;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.S3_SECRET_LOCK;
+import static org.apache.hadoop.ozone.om.request.s3.tenant.OMTenantRequestHelper.isUserAccessIdPrincipalOrTenantAdmin;
+
+/**
+ * Handles SetSecret request.
+ */
+public class OMSetSecretRequest extends OMClientRequest {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OMSetSecretRequest.class);
+
+  public OMSetSecretRequest(OMRequest omRequest) {
+    super(omRequest);
+  }
+
+  @Override
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
+    final SetSecretRequest setSecretRequest =
+        getOmRequest().getSetSecretRequest();
+
+    final String accessId = setSecretRequest.getAccessId();
+
+    // First check accessId existence
+    final OmDBAccessIdInfo accessIdInfo = ozoneManager.getMetadataManager()
+            .getTenantAccessIdTable().get(accessId);
+    // TODO: Support old `ozone s3 getsecret` S3SecretTable?
+
+    if (accessIdInfo == null) {
+      throw new OMException("accessId '" + accessId + "' not found.",
+              OMException.ResultCodes.ACCESSID_NOT_FOUND);
+    }
+
+    // Secret should not be empty
+    final String secretKey = setSecretRequest.getSecretKey();
+    if (StringUtils.isEmpty(secretKey)) {
+      throw new OMException("Secret should not be empty",
+              OMException.ResultCodes.INVALID_REQUEST);
+    }
+
+    final UserGroupInformation ugi = ProtobufRpcEngine.Server.getRemoteUser();
+    final String username = ugi.getUserName();
+
+    // Permission check. To pass the check, any one of the following conditions
+    // shall be satisfied:
+    // 1. username matches accessId exactly
+    // 2. user is an OM admin
+    // 3. user is assigned to a tenant under this accessId
+    // 4. user is an admin of the tenant where the accessId is assigned
+
+    if (!username.equals(accessId) && !ozoneManager.isAdmin(ugi)) {
+      // Attempt to retrieve tenant info using the accessId
+      if (!isUserAccessIdPrincipalOrTenantAdmin(ozoneManager, accessId, ugi)) {
+        throw new OMException("Permission denied. Requested accessId '" +
+                accessId + "' and user doesn't satisfy any of:\n" +
+                "1) accessId match current username: '" + username + "';\n" +
+                "2) is an OM admin;\n" +
+                "3) user is assigned to a tenant under this accessId;\n" +
+                "4) user is an admin of the tenant where the accessId is " +
+                "assigned", OMException.ResultCodes.PERMISSION_DENIED);
+      }
+    }
+
+    return getOmRequest();
+  }
+
+  @Override
+  public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
+      long transactionLogIndex,
+      OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper) {
+
+    OMClientResponse omClientResponse = null;
+    OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
+        getOmRequest());
+    boolean acquiredLock = false;
+    IOException exception = null;
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+
+    final SetSecretRequest setSecretRequest =
+            getOmRequest().getSetSecretRequest();
+    final String accessId = setSecretRequest.getAccessId();
+    final String secretKey = setSecretRequest.getSecretKey();
+
+    try {
+      acquiredLock = omMetadataManager.getLock().acquireWriteLock(
+              S3_SECRET_LOCK, accessId);
+
+      // Get accessId entry from multi-tenant TenantAccessIdTable
+      final OmDBAccessIdInfo omDBAccessIdInfo =
+          omMetadataManager.getTenantAccessIdTable().get(accessId);
+
+      // Double check accessId existence
+      if (omDBAccessIdInfo == null) {
+        throw new OMException("accessId '" + accessId + "' not found.",
+                OMException.ResultCodes.ACCESSID_NOT_FOUND);
+      }
+
+      // Build new OmDBAccessIdInfo with updated secret
+      final OmDBAccessIdInfo newDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
+              .setTenantId(omDBAccessIdInfo.getTenantName())
+              .setKerberosPrincipal(omDBAccessIdInfo.getUserPrincipal())
+              .setSharedSecret(secretKey)
+              .setIsAdmin(omDBAccessIdInfo.getIsAdmin())
+              .setIsDelegatedAdmin(omDBAccessIdInfo.getIsDelegatedAdmin())
+              .build();
+
+      // Update cache entry
+      omMetadataManager.getTenantAccessIdTable().addCacheEntry(
+              new CacheKey<>(accessId),
+              new CacheValue<>(Optional.of(newDBAccessIdInfo),
+                      transactionLogIndex));
+
+      // Compose response
+      final SetSecretResponse.Builder setSecretResponse =
+              SetSecretResponse.newBuilder()
+                      .setAccessId(accessId)
+                      .setSecretKey(secretKey);
+
+      omClientResponse = new OMSetSecretResponse(accessId, newDBAccessIdInfo,
+              omResponse.setSetSecretResponse(setSecretResponse).build());
+
+    } catch (IOException ex) {
+      exception = ex;
+      omClientResponse = new OMSetSecretResponse(
+              createErrorOMResponse(omResponse, ex));
+    } finally {
+      addResponseToDoubleBuffer(transactionLogIndex, omClientResponse,
+          ozoneManagerDoubleBufferHelper);
+      if (acquiredLock) {
+        omMetadataManager.getLock().releaseWriteLock(S3_SECRET_LOCK,
+            accessId);
+      }
+    }
+
+    Map<String, String> auditMap = new HashMap<>();
+    auditMap.put(OzoneConsts.S3_GETSECRET_USER, accessId);
+
+    // audit log
+    auditLog(ozoneManager.getAuditLogger(), buildAuditMessage(
+        OMAction.GET_S3_SECRET, auditMap,
+        exception, getOmRequest().getUserInfo()));
+
+    if (exception == null) {
+      LOG.debug("Success: SetSecret for accessKey '{}'", accessId);
+    } else {
+      LOG.error("Failed to SetSecret for accessKey '{}': {}",
+          accessId, exception);
+    }
+    return omClientResponse;
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
@@ -64,10 +64,10 @@ public class OMSetSecretRequest extends OMClientRequest {
     final OMMetadataManager omMetadataManager =
         ozoneManager.getMetadataManager();
 
-    final SetSecretRequest setSecretRequest =
-        getOmRequest().getSetSecretRequest();
+    final SetS3SecretRequest request =
+        getOmRequest().getSetS3SecretRequest();
 
-    final String accessId = setSecretRequest.getAccessId();
+    final String accessId = request.getAccessId();
 
     // First check accessId existence
     final OmDBAccessIdInfo accessIdInfo = omMetadataManager
@@ -82,7 +82,7 @@ public class OMSetSecretRequest extends OMClientRequest {
     }
 
     // Secret should not be empty
-    final String secretKey = setSecretRequest.getSecretKey();
+    final String secretKey = request.getSecretKey();
     if (StringUtils.isEmpty(secretKey)) {
       throw new OMException("Secret key should not be empty",
               OMException.ResultCodes.INVALID_REQUEST);
@@ -134,14 +134,13 @@ public class OMSetSecretRequest extends OMClientRequest {
     IOException exception = null;
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
 
-    final SetSecretRequest setSecretRequest =
-            getOmRequest().getSetSecretRequest();
-    final String accessId = setSecretRequest.getAccessId();
-    final String secretKey = setSecretRequest.getSecretKey();
+    final SetS3SecretRequest request = getOmRequest().getSetS3SecretRequest();
+    final String accessId = request.getAccessId();
+    final String secretKey = request.getSecretKey();
 
     try {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(
-              S3_SECRET_LOCK, accessId);
+          S3_SECRET_LOCK, accessId);
 
       // Intentionally set to final so they can only be set once.
       final S3SecretValue newS3SecretValue;
@@ -192,14 +191,14 @@ public class OMSetSecretRequest extends OMClientRequest {
       }
 
       // Compose response
-      final SetSecretResponse.Builder setSecretResponse =
-          SetSecretResponse.newBuilder()
+      final SetS3SecretResponse.Builder setSecretResponse =
+          SetS3SecretResponse.newBuilder()
               .setAccessId(accessId)
               .setSecretKey(secretKey);
 
       omClientResponse = new OMSetSecretResponse(accessId,
           newDBAccessIdInfo, newS3SecretValue,
-          omResponse.setSetSecretResponse(setSecretResponse).build());
+          omResponse.setSetS3SecretResponse(setSecretResponse).build());
 
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/OMSetSecretRequest.java
@@ -169,7 +169,7 @@ public class OMSetSecretRequest extends OMClientRequest {
         LOG.debug("Updating TenantAccessIdTable cache entry");
         newS3SecretValue = null;
         newDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
-            .setTenantId(omDBAccessIdInfo.getTenantName())
+            .setTenantId(omDBAccessIdInfo.getTenantId())
             .setKerberosPrincipal(omDBAccessIdInfo.getUserPrincipal())
             .setSharedSecret(secretKey)
             .setIsAdmin(omDBAccessIdInfo.getIsAdmin())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -181,6 +181,8 @@ public class S3GetSecretRequest extends OMClientRequest {
                     new CacheKey<>(accessId),
                     new CacheValue<>(Optional.of(assignS3SecretValue),
                             transactionLogIndex));
+            // TODO: Put accessId entry straight to TenantAccessIdTable
+            //  later when we deprecate the S3SecretTable.
           } else {
             assignS3SecretValue = null;
           }
@@ -191,7 +193,7 @@ public class S3GetSecretRequest extends OMClientRequest {
         }
       } else {
         // Found in TenantAccessIdTable.
-        awsSecret = omDBAccessIdInfo.getSharedSecret();
+        awsSecret = omDBAccessIdInfo.getSecretKey();
         assignS3SecretValue = null;
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
@@ -259,7 +259,7 @@ public class OMAssignUserToTenantRequest extends OMClientRequest {
                 + "Ignoring.", existingAccId);
             throw new NullPointerException("accessIdInfo is null");
           }
-          if (tenantName.equals(accessIdInfo.getTenantName())) {
+          if (tenantName.equals(accessIdInfo.getTenantId())) {
             throw new OMException("The same user is not allowed to be assigned "
                 + "to the same tenant more than once. User '" + principal
                 + "' is already assigned to tenant '" + tenantName + "' with "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
@@ -259,7 +259,7 @@ public class OMAssignUserToTenantRequest extends OMClientRequest {
                 + "Ignoring.", existingAccId);
             throw new NullPointerException("accessIdInfo is null");
           }
-          if (tenantName.equals(accessIdInfo.getTenantId())) {
+          if (tenantName.equals(accessIdInfo.getTenantName())) {
             throw new OMException("The same user is not allowed to be assigned "
                 + "to the same tenant more than once. User '" + principal
                 + "' is already assigned to tenant '" + tenantName + "' with "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -77,7 +77,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
     // If tenantName is not provided, figure it out from the table
     if (StringUtils.isEmpty(tenantName)) {
       tenantName = OMTenantRequestHelper.getTenantNameFromAccessId(
-          ozoneManager.getMetadataManager(), accessId);
+          ozoneManager.getMetadataManager(), accessId, true);
       assert(tenantName != null);
     }
 
@@ -95,7 +95,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
     }
 
     // Check if accessId is assigned to the tenant
-    if (!accessIdInfo.getTenantId().equals(tenantName)) {
+    if (!accessIdInfo.getTenantName().equals(tenantName)) {
       throw new OMException("accessId '" + accessId +
           "' must be assigned to tenant '" + tenantName + "' first.",
           OMException.ResultCodes.INVALID_TENANT_NAME);
@@ -179,14 +179,14 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
             + accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
       }
 
-      assert(oldAccessIdInfo.getTenantId().equals(tenantName));
+      assert(oldAccessIdInfo.getTenantName().equals(tenantName));
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-          .setTenantId(oldAccessIdInfo.getTenantId())
-          .setKerberosPrincipal(oldAccessIdInfo.getKerberosPrincipal())
-          .setSharedSecret(oldAccessIdInfo.getSharedSecret())
+          .setTenantId(oldAccessIdInfo.getTenantName())
+          .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
+          .setSharedSecret(oldAccessIdInfo.getSecretKey())
           .setIsAdmin(true)
           .setIsDelegatedAdmin(delegated)
           .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -95,7 +95,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
     }
 
     // Check if accessId is assigned to the tenant
-    if (!accessIdInfo.getTenantName().equals(tenantName)) {
+    if (!accessIdInfo.getTenantId().equals(tenantName)) {
       throw new OMException("accessId '" + accessId +
           "' must be assigned to tenant '" + tenantName + "' first.",
           OMException.ResultCodes.INVALID_TENANT_NAME);
@@ -179,12 +179,12 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
             + accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
       }
 
-      assert(oldAccessIdInfo.getTenantName().equals(tenantName));
+      assert(oldAccessIdInfo.getTenantId().equals(tenantName));
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-          .setTenantId(oldAccessIdInfo.getTenantName())
+          .setTenantId(oldAccessIdInfo.getTenantId())
           .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
           .setSharedSecret(oldAccessIdInfo.getSecretKey())
           .setIsAdmin(true)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -77,7 +77,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
     // If tenantName is not provided, figure it out from the table
     if (StringUtils.isEmpty(tenantName)) {
       tenantName = OMTenantRequestHelper.getTenantNameFromAccessId(
-          ozoneManager.getMetadataManager(), accessId, true);
+          ozoneManager.getMetadataManager(), accessId);
       assert(tenantName != null);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -142,6 +142,9 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     //  the client's. Maybe move this logic to the client and pass VolumeArgs?
     final String owner = ugi.getShortUserName();
     final String volumeName = tenantName;  // TODO: Configurable
+    // Validate volume name
+    OmUtils.validateVolumeName(volumeName);
+    // TODO: Refactor this and OMVolumeCreateRequest to improve maintainability.
     final VolumeInfo volumeInfo = VolumeInfo.newBuilder()
         .setVolume(volumeName)
         .setAdminName(owner)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -135,9 +135,9 @@ public final class OMTenantRequestHelper {
       }
     }
 
-    final String tenantName = accessIdInfo.getTenantName();
+    final String tenantId = accessIdInfo.getTenantId();
 
-    if (StringUtils.isEmpty(tenantName)) {
+    if (StringUtils.isEmpty(tenantId)) {
       if (throwOnError) {
         throw new OMException("tenantId field is null or empty for accessId '" +
                 accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
@@ -146,7 +146,7 @@ public final class OMTenantRequestHelper {
       }
     }
 
-    return tenantName;
+    return tenantId;
   }
 
   public static boolean isUserAccessIdPrincipalOrTenantAdmin(
@@ -162,7 +162,7 @@ public final class OMTenantRequestHelper {
       return false;
     }
 
-    final String tenantName = accessIdInfo.getTenantName();
+    final String tenantName = accessIdInfo.getTenantId();
     // Sanity check
     if (tenantName == null) {
       throw new OMException("Unexpected error: OmDBAccessIdInfo " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -120,30 +120,21 @@ public final class OMTenantRequestHelper {
   }
 
   public static String getTenantNameFromAccessId(
-          OMMetadataManager omMetadataManager, String accessId,
-          boolean throwOnError) throws IOException {
+      OMMetadataManager omMetadataManager, String accessId) throws IOException {
 
     final OmDBAccessIdInfo accessIdInfo = omMetadataManager
         .getTenantAccessIdTable().get(accessId);
 
     if (accessIdInfo == null) {
-      if (throwOnError) {
-        throw new OMException("OmDBAccessIdInfo is missing for accessId '" +
-                accessId + "' in DB.", OMException.ResultCodes.METADATA_ERROR);
-      } else {
-        return null;
-      }
+      throw new OMException("OmDBAccessIdInfo is missing for accessId '" +
+          accessId + "' in DB.", OMException.ResultCodes.METADATA_ERROR);
     }
 
     final String tenantId = accessIdInfo.getTenantId();
 
     if (StringUtils.isEmpty(tenantId)) {
-      if (throwOnError) {
-        throw new OMException("tenantId field is null or empty for accessId '" +
-                accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
-      } else {
-        return null;
-      }
+      throw new OMException("tenantId field is null or empty for accessId '" +
+          accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
     }
 
     return tenantId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -119,25 +119,76 @@ public final class OMTenantRequestHelper {
     return volumeName;
   }
 
-  static String getTenantNameFromAccessId(OMMetadataManager omMetadataManager,
-      String accessId) throws IOException {
+  public static String getTenantNameFromAccessId(
+          OMMetadataManager omMetadataManager, String accessId,
+          boolean throwOnError) throws IOException {
 
     final OmDBAccessIdInfo accessIdInfo = omMetadataManager
         .getTenantAccessIdTable().get(accessId);
 
     if (accessIdInfo == null) {
-      throw new OMException("OmDBAccessIdInfo entry is missing for accessId '" +
-          accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
+      if (throwOnError) {
+        throw new OMException("OmDBAccessIdInfo is missing for accessId '" +
+                accessId + "' in DB.", OMException.ResultCodes.METADATA_ERROR);
+      } else {
+        return null;
+      }
     }
 
-    final String tenantName = accessIdInfo.getTenantId();
+    final String tenantName = accessIdInfo.getTenantName();
 
     if (StringUtils.isEmpty(tenantName)) {
-      throw new OMException("tenantId field is null or empty for accessId '" +
-          accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
+      if (throwOnError) {
+        throw new OMException("tenantId field is null or empty for accessId '" +
+                accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
+      } else {
+        return null;
+      }
     }
 
     return tenantName;
+  }
+
+  public static boolean isUserAccessIdPrincipalOrTenantAdmin(
+          OzoneManager ozoneManager, String accessId,
+          UserGroupInformation ugi) throws IOException {
+
+    final OmDBAccessIdInfo accessIdInfo = ozoneManager.getMetadataManager()
+            .getTenantAccessIdTable().get(accessId);
+
+    if (accessIdInfo == null) {
+      // Doesn't have the accessId entry in TenantAccessIdTable.
+      // Probably came from `ozone s3 getsecret` with older OM.
+      return false;
+    }
+
+    final String tenantName = accessIdInfo.getTenantName();
+    // Sanity check
+    if (tenantName == null) {
+      throw new OMException("Unexpected error: OmDBAccessIdInfo " +
+              "tenantId field should not have been null",
+              OMException.ResultCodes.METADATA_ERROR);
+    }
+
+    final String accessIdPrincipal = accessIdInfo.getUserPrincipal();
+    // Sanity check
+    if (accessIdPrincipal == null) {
+      throw new OMException("Unexpected error: OmDBAccessIdInfo " +
+              "kerberosPrincipal field should not have been null",
+              OMException.ResultCodes.METADATA_ERROR);
+    }
+
+    // Check if ugi matches the holder of the accessId
+    if (ugi.getShortUserName().equals(accessIdPrincipal)) {
+      return true;
+    }
+
+    // Check if ugi is an admin of this tenant
+    if (ozoneManager.isTenantAdmin(ugi, tenantName, true)) {
+      return true;
+    }
+
+    return false;
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -72,16 +72,16 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
         getOmRequest().getTenantRevokeAdminRequest();
 
     final String accessId = request.getAccessId();
-    String tenantName = request.getTenantName();
+    String tenantId = request.getTenantName();
 
-    // If tenantName is not provided, figure it out from the table
-    if (StringUtils.isEmpty(tenantName)) {
-      tenantName = OMTenantRequestHelper.getTenantNameFromAccessId(
-          ozoneManager.getMetadataManager(), accessId, true);
+    // If tenant name is not specified, try figuring it out from accessId.
+    if (StringUtils.isEmpty(tenantId)) {
+      tenantId = OMTenantRequestHelper.getTenantNameFromAccessId(
+          ozoneManager.getMetadataManager(), accessId);
     }
 
     // Caller should be an Ozone admin or this tenant's delegated admin
-    OMTenantRequestHelper.checkTenantAdmin(ozoneManager, tenantName);
+    OMTenantRequestHelper.checkTenantAdmin(ozoneManager, tenantId);
 
     // TODO: Check tenant existence?
 
@@ -94,9 +94,9 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
     }
 
     // Check if accessId is assigned to the tenant
-    if (!accessIdInfo.getTenantId().equals(tenantName)) {
+    if (!accessIdInfo.getTenantId().equals(tenantId)) {
       throw new OMException("accessId '" + accessId +
-          "' must be assigned to tenant '" + tenantName + "' first.",
+          "' must be assigned to tenant '" + tenantId + "' first.",
           OMException.ResultCodes.INVALID_TENANT_NAME);
     }
 
@@ -107,10 +107,10 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
     final OMRequest.Builder omRequestBuilder = getOmRequest().toBuilder()
         .setUserInfo(getUserInfo())
         .setTenantRevokeAdminRequest(
-                // Regenerate request just in case tenantName is not provided
+                // Regenerate request just in case tenantId is not provided
                 //  by the client
                 TenantRevokeAdminRequest.newBuilder()
-                        .setTenantName(tenantName)
+                        .setTenantName(tenantId)
                         .setAccessId(request.getAccessId())
                         .build())
         .setCmdType(getOmRequest().getCmdType())

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -94,7 +94,7 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
     }
 
     // Check if accessId is assigned to the tenant
-    if (!accessIdInfo.getTenantName().equals(tenantName)) {
+    if (!accessIdInfo.getTenantId().equals(tenantName)) {
       throw new OMException("accessId '" + accessId +
           "' must be assigned to tenant '" + tenantName + "' first.",
           OMException.ResultCodes.INVALID_TENANT_NAME);
@@ -159,12 +159,12 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
             + accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
       }
 
-      assert(oldAccessIdInfo.getTenantName().equals(tenantName));
+      assert(oldAccessIdInfo.getTenantId().equals(tenantName));
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-          .setTenantId(oldAccessIdInfo.getTenantName())
+          .setTenantId(oldAccessIdInfo.getTenantId())
           .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
           .setSharedSecret(oldAccessIdInfo.getSecretKey())
           .setIsAdmin(false)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -96,7 +96,7 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
           OMException.ResultCodes.ACCESSID_NOT_FOUND);
     }
 
-    final String tenantName = accessIdInfo.getTenantId();
+    final String tenantName = accessIdInfo.getTenantName();
     assert(tenantName != null);
     assert(tenantName.length() > 0);
 
@@ -173,7 +173,7 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
       OmDBAccessIdInfo omDBAccessIdInfo =
           omMetadataManager.getTenantAccessIdTable().get(accessId);
       assert(omDBAccessIdInfo != null);
-      userPrincipal = omDBAccessIdInfo.getKerberosPrincipal();
+      userPrincipal = omDBAccessIdInfo.getUserPrincipal();
       assert(userPrincipal != null);
       OmDBKerberosPrincipalInfo principalInfo = omMetadataManager
           .getPrincipalToAccessIdsTable().getIfExist(userPrincipal);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -96,7 +96,7 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
           OMException.ResultCodes.ACCESSID_NOT_FOUND);
     }
 
-    final String tenantName = accessIdInfo.getTenantName();
+    final String tenantName = accessIdInfo.getTenantId();
     assert(tenantName != null);
     assert(tenantName.length() > 0);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.s3.security;
+
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
+import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
+
+/**
+ * Response for SetSecret request.
+ */
+@CleanupTableInfo(cleanupTables = {TENANT_ACCESS_ID_TABLE})
+public class OMSetSecretResponse extends OMClientResponse {
+
+  private String accessId;
+  private OmDBAccessIdInfo dbAccessIdInfo;
+
+  public OMSetSecretResponse(@Nullable String accessId,
+                             @Nullable OmDBAccessIdInfo dbAccessIdInfo,
+                             @Nonnull OMResponse omResponse) {
+    super(omResponse);
+    this.accessId = accessId;
+    this.dbAccessIdInfo = dbAccessIdInfo;
+  }
+
+  /**
+   * For when the request is not successful.
+   * For a successful request, the other constructor should be used.
+   */
+  public OMSetSecretResponse(@Nonnull OMResponse omResponse) {
+    super(omResponse);
+    checkStatusNotOK();
+  }
+
+  @Override
+  public void addToDBBatch(OMMetadataManager omMetadataManager,
+      BatchOperation batchOperation) throws IOException {
+
+    assert(getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK);
+    omMetadataManager.getTenantAccessIdTable().putWithBatch(batchOperation,
+            accessId, dbAccessIdInfo);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -79,7 +79,7 @@ public class OMTenantCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    final String tenantName = omTenantInfo.getTenantName();
+    final String tenantName = omTenantInfo.getTenantId();
     omMetadataManager.getTenantStateTable().putWithBatch(
         batchOperation, tenantName, omTenantInfo);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -348,7 +348,7 @@ public class TestS3GetSecretRequest {
     // Check response
     Assert.assertTrue(omTenantCreateResponse.getOMResponse().getSuccess());
     Assert.assertEquals(TENANT_NAME,
-        omTenantCreateResponse.getOmDBTenantInfo().getTenantName());
+        omTenantCreateResponse.getOmDBTenantInfo().getTenantId());
 
 
     // 2. AssignUserToTenantRequest: Assign "bob@EXAMPLE.COM" to "finance".

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -419,6 +419,6 @@ public class TestS3GetSecretRequest {
     final S3Secret s3Secret = getS3SecretResponse.getS3Secret();
     Assert.assertEquals(ACCESS_ID_BOB, s3Secret.getKerberosID());
     Assert.assertEquals(
-        omDBAccessIdInfo.getSharedSecret(), s3Secret.getAwsSecret());
+        omDBAccessIdInfo.getSecretKey(), s3Secret.getAwsSecret());
   }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -31,6 +31,7 @@ import picocli.CommandLine.Command;
     description = "Shell for S3 specific operations",
     subcommands = {
         GetS3SecretHandler.class,
+        SetS3SecretHandler.class,
         RevokeS3SecretHandler.class
     })
 public class S3Shell extends Shell {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
@@ -39,7 +39,7 @@ public class SetS3SecretHandler extends S3Handler {
           + "(Admins only)'")
   private String username;
 
-  @CommandLine.Option(names = {"-s", "--secret"},
+  @CommandLine.Option(names = {"-s", "--secret", "--secretKey"},
       description = "Secret key", required = true)
   private String secretKey;
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
@@ -61,7 +61,7 @@ public class SetS3SecretHandler extends S3Handler {
     }
 
     final S3SecretValue accessIdSecretKeyPair =
-        client.getObjectStore().setSecret(username, secretKey);
+        client.getObjectStore().setS3Secret(username, secretKey);
     if (export) {
       out().println("export AWS_ACCESS_KEY_ID='" +
           accessIdSecretKeyPair.getAwsAccessKey() + "'");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/SetS3SecretHandler.java
@@ -17,30 +17,35 @@
  */
 package org.apache.hadoop.ozone.shell.s3;
 
-import java.io.IOException;
-
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.security.UserGroupInformation;
-
+import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
+import java.io.IOException;
+
 /**
- * Executes getsecret calls.
+ * ozone s3 setsecret.
  */
-@Command(name = "getsecret", aliases = "get-secret",
-    description = "Returns S3 secret for a user")
-public class GetS3SecretHandler extends S3Handler {
+@Command(name = "setsecret", aliases = "set-secret",
+    description = "Set s3 secret for current user")
+public class SetS3SecretHandler extends S3Handler {
 
   @Option(names = "-u",
-      description = "Specify the user (accessId). Requires admin privilege'")
+      description = "Specify the user to perform the operation on "
+          + "(Admins only)'")
   private String username;
+
+  @CommandLine.Option(names = {"-s", "--secret"},
+      description = "Secret key", required = true)
+  private String secretKey;
 
   @Option(names = "-e",
       description = "Print out variables together with 'export' prefix, to "
-          + "use it from 'eval $(ozone s3 getsecret)'")
+          + "use it from 'eval $(ozone s3 setsecret)'")
   private boolean export;
 
   @Override
@@ -55,14 +60,15 @@ public class GetS3SecretHandler extends S3Handler {
       username = UserGroupInformation.getCurrentUser().getUserName();
     }
 
-    final S3SecretValue secret = client.getObjectStore().getS3Secret(username);
+    final S3SecretValue accessIdSecretKeyPair =
+        client.getObjectStore().setSecret(username, secretKey);
     if (export) {
       out().println("export AWS_ACCESS_KEY_ID='" +
-          secret.getAwsAccessKey() + "'");
+          accessIdSecretKeyPair.getAwsAccessKey() + "'");
       out().println("export AWS_SECRET_ACCESS_KEY='" +
-          secret.getAwsSecret() + "'");
+          accessIdSecretKeyPair.getAwsSecret() + "'");
     } else {
-      out().println(secret);
+      out().println(accessIdSecretKeyPair);
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignAdminHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignAdminHandler.java
@@ -47,7 +47,7 @@ public class TenantAssignAdminHandler extends TenantHandler {
 
   @CommandLine.Option(names = {"-t", "--tenant"},
       description = "Tenant name")
-  private String tenantName;
+  private String tenantId;
 
   @CommandLine.Option(names = {"-d", "--delegated"}, defaultValue = "true",
       description = "Make delegated admin")
@@ -59,13 +59,13 @@ public class TenantAssignAdminHandler extends TenantHandler {
 
     for (final String accessId : accessIds) {
       try {
-        objStore.tenantAssignAdmin(accessId, tenantName, delegated);
+        objStore.tenantAssignAdmin(accessId, tenantId, delegated);
         // TODO: Make tenantAssignAdmin return accessId, tenantName, user later.
         err().println("Assigned admin to '" + accessId +
-            (tenantName != null ? "' in tenant '" + tenantName + "'" : ""));
+            (tenantId != null ? "' in tenant '" + tenantId + "'" : ""));
       } catch (IOException e) {
         err().println("Failed to assign admin to '" + accessId +
-            (tenantName != null ? "' in tenant '" + tenantName + "'" : "") +
+            (tenantId != null ? "' in tenant '" + tenantId + "'" : "") +
             ": " + e.getMessage());
         if (e instanceof OMException) {
           final OMException omEx = (OMException) e;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignUserAccessIdHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantAssignUserAccessIdHandler.java
@@ -47,7 +47,7 @@ public class TenantAssignUserAccessIdHandler extends TenantHandler {
 
   @CommandLine.Option(names = {"-t", "--tenant"},
       description = "Tenant name", required = true)
-  private String tenantName;
+  private String tenantId;
 
   @CommandLine.Option(names = {"-a", "--access-id", "--accessId"},
       description = "(Optional) Specify the accessId for user in this tenant. "
@@ -59,8 +59,8 @@ public class TenantAssignUserAccessIdHandler extends TenantHandler {
   //  `s3 getsecret` and leak the secret if an admin isn't careful.
   private String accessId;
 
-  private String getDefaultAccessId(String principal) {
-    return tenantName + TENANT_NAME_USER_NAME_DELIMITER + principal;
+  private String getDefaultAccessId(String userPrincipal) {
+    return tenantId + TENANT_NAME_USER_NAME_DELIMITER + userPrincipal;
   }
 
   @Override
@@ -83,8 +83,8 @@ public class TenantAssignUserAccessIdHandler extends TenantHandler {
           accessId = getDefaultAccessId(principal);
         }
         final S3SecretValue resp =
-            objStore.tenantAssignUserAccessId(principal, tenantName, accessId);
-        err().println("Assigned '" + principal + "' to '" + tenantName +
+            objStore.tenantAssignUserAccessId(principal, tenantId, accessId);
+        err().println("Assigned '" + principal + "' to '" + tenantId +
             "' with accessId '" + accessId + "'.");
         out().println("export AWS_ACCESS_KEY_ID='" +
             resp.getAwsAccessKey() + "'");
@@ -92,7 +92,7 @@ public class TenantAssignUserAccessIdHandler extends TenantHandler {
             resp.getAwsSecret() + "'");
       } catch (IOException e) {
         err().println("Failed to assign '" + principal + "' to '" +
-            tenantName + "': " + e.getMessage());
+            tenantId + "': " + e.getMessage());
         if (e instanceof OMException) {
           final OMException omException = (OMException) e;
           if (omException.getResult().equals(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantGetSecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantGetSecretHandler.java
@@ -43,7 +43,7 @@ public class TenantGetSecretHandler extends TenantHandler {
   @CommandLine.Parameters(description = "List of accessIds", arity = "1..")
   private List<String> accessIds = new ArrayList<>();
 
-  @CommandLine.Option(names = "-e",
+  @CommandLine.Option(names = {"-e", "--export"},
       description = "Print out variables together with 'export' prefix")
   private boolean export;
 
@@ -55,15 +55,15 @@ public class TenantGetSecretHandler extends TenantHandler {
     for (final String accessId : accessIds) {
 
       try {
-        final S3SecretValue secret =
+        final S3SecretValue accessIdSecretKeyPair =
             objectStore.getS3Secret(accessId, false);
         if (export) {
           out().println("export AWS_ACCESS_KEY_ID='" +
-              secret.getAwsAccessKey() + "'");
+              accessIdSecretKeyPair.getAwsAccessKey() + "'");
           out().println("export AWS_SECRET_ACCESS_KEY='" +
-              secret.getAwsSecret() + "'");
+              accessIdSecretKeyPair.getAwsSecret() + "'");
         } else {
-          out().println(secret);
+          out().println(accessIdSecretKeyPair);
         }
       } catch (OMException omEx) {
         if (omEx.getResult().equals(ACCESSID_NOT_FOUND)) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
@@ -42,7 +42,7 @@ public class TenantListUsersHandler extends S3Handler {
 
   @CommandLine.Option(names = {"-t", "--tenant"},
       description = "Tenant name")
-  private String tenantName;
+  private String tenantId;
 
   @CommandLine.Option(names = {"-p", "--prefix"},
       description = "Filter users with this prefix.")
@@ -52,19 +52,19 @@ public class TenantListUsersHandler extends S3Handler {
   protected void execute(OzoneClient client, OzoneAddress address) {
     final ObjectStore objStore = client.getObjectStore();
 
-    if (StringUtils.isEmpty(tenantName)) {
+    if (StringUtils.isEmpty(tenantId)) {
       err().println("Please specify a tenant name with -t.");
       return;
     }
     try {
       TenantUserList usersInTenant =
-          objStore.listUsersInTenant(tenantName, prefix);
+          objStore.listUsersInTenant(tenantId, prefix);
       for (TenantUserAccessId accessIdInfo : usersInTenant.getUserAccessIds()) {
         out().println("- User '" + accessIdInfo.getUser() +
             "' with accessId '" + accessIdInfo.getAccessId() + "'");
       }
     } catch (IOException e) {
-      err().println("Failed to Get Users in tenant '" + tenantName
+      err().println("Failed to Get Users in tenant '" + tenantId
           + "': " + e.getMessage());
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantRevokeAdminHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantRevokeAdminHandler.java
@@ -42,7 +42,7 @@ public class TenantRevokeAdminHandler extends TenantHandler {
 
   @CommandLine.Option(names = {"-t", "--tenant"},
       description = "Tenant name")
-  private String tenantName;
+  private String tenantId;
 
   @Override
   protected void execute(OzoneClient client, OzoneAddress address) {
@@ -51,12 +51,12 @@ public class TenantRevokeAdminHandler extends TenantHandler {
     for (final String accessId : accessIds) {
       try {
         // TODO: Make tenantRevokeAdmin return accessId, tenantName, user later.
-        objStore.tenantRevokeAdmin(accessId, tenantName);
+        objStore.tenantRevokeAdmin(accessId, tenantId);
         err().println("Revoked admin role of '" + accessId +
-            (tenantName != null ? "' from tenant '" + tenantName + "'" : ""));
+            (tenantId != null ? "' from tenant '" + tenantId + "'" : ""));
       } catch (IOException e) {
         err().println("Failed to revoke admin role of '" + accessId +
-            (tenantName != null ? "' from tenant '" + tenantName + "'" : "") +
+            (tenantId != null ? "' from tenant '" + tenantId + "'" : "") +
             ": " + e.getMessage());
         if (e instanceof OMException) {
           final OMException omEx = (OMException) e;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantSetSecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantSetSecretHandler.java
@@ -55,7 +55,7 @@ public class TenantSetSecretHandler extends TenantHandler {
 
     try {
       final S3SecretValue accessIdSecretKeyPair =
-              objectStore.setSecret(accessId, secretKey);
+              objectStore.setS3Secret(accessId, secretKey);
       if (export) {
         out().println("export AWS_ACCESS_KEY_ID='" +
                 accessIdSecretKeyPair.getAwsAccessKey() + "'");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantSetSecretHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantSetSecretHandler.java
@@ -40,8 +40,8 @@ public class TenantSetSecretHandler extends TenantHandler {
   private String accessId;
 
   @CommandLine.Option(names = {"-s", "--secret"},
-          description = "Secret", required = true)
-  private String secret;
+          description = "Secret key", required = true)
+  private String secretKey;
 
   @CommandLine.Option(names = {"-e", "--export"},
           description = "Print out variables together with 'export' prefix")
@@ -55,7 +55,7 @@ public class TenantSetSecretHandler extends TenantHandler {
 
     try {
       final S3SecretValue accessIdSecretKeyPair =
-              objectStore.setSecret(accessId, secret);
+              objectStore.setSecret(accessId, secretKey);
       if (export) {
         out().println("export AWS_ACCESS_KEY_ID='" +
                 accessIdSecretKeyPair.getAwsAccessKey() + "'");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-5972

- Implemented `ozone tenant user setsecret`.
  - `ozone s3 setsecret` is also implemented.
- Fixed a bug where revoke-admin would fail if tenantName is not given on the CLI.
- Renamed OmDBAccessIdInfo fields.
- Minor refactoring of variable names. e.g. `tenantName` -> `tenantId`, `kerberosPrincipal` -> `userPrincipal`

## Testing

- Added new S3 setsecret test cases.
- Added new integration tests.
- Added new robot(acceptance) test cases.
- [!] Fixed not-so-relevent `ozone-secure-token.robot` -- this acceptance test suite depended on the previous test suite to have kinit'ed as admin (which it should not have assumed so). The fix is simply prepending "kinit as admin".