### PR TITLE
HDDS-5989. Binary content printed for failed chunk write

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -67,6 +67,8 @@ import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.hdds.HddsUtils.processForDebug;
+
 /**
  * A Client for the storageContainer protocol for read object data.
  */
@@ -239,12 +241,12 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       return sendCommandWithTraceIDAndRetry(request, null).
           getResponse().get();
     } catch (ExecutionException e) {
-      throw new IOException("Failed to execute command " + request, e);
+      throw getIOExceptionForSendCommand(request, e);
     } catch (InterruptedException e) {
       LOG.error("Command execution was interrupted.");
       Thread.currentThread().interrupt();
       throw (IOException) new InterruptedIOException(
-          "Command " + request + " was interrupted.")
+          "Command " + processForDebug(request) + " was interrupted.")
           .initCause(e);
     }
   }
@@ -278,7 +280,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       // Re-interrupt the thread while catching InterruptedException
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {
-      LOG.error("Failed to execute command " + request, e);
+      LOG.error("Failed to execute command {}", processForDebug(request), e);
     }
     return responseProtoHashMap;
   }
@@ -292,12 +294,12 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       reply = sendCommandWithTraceIDAndRetry(request, validators);
       return reply.getResponse().get();
     } catch (ExecutionException e) {
-      throw new IOException("Failed to execute command " + request, e);
+      throw getIOExceptionForSendCommand(request, e);
     } catch (InterruptedException e) {
       LOG.error("Command execution was interrupted.");
       Thread.currentThread().interrupt();
       throw (IOException) new InterruptedIOException(
-          "Command " + request + " was interrupted.")
+          "Command " + processForDebug(request) + " was interrupted.")
           .initCause(e);
     }
   }
@@ -368,7 +370,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
     for (DatanodeDetails dn : datanodeList) {
       try {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Executing command {} on datanode {}", request, dn);
+          LOG.debug("Executing command {} on datanode {}",
+              processForDebug(request), dn);
         }
         // In case the command gets retried on a 2nd datanode,
         // sendCommandAsyncCall will create a new channel and async stub
@@ -388,11 +391,15 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       } catch (IOException e) {
         ioException = e;
         responseProto = null;
-        LOG.debug("Failed to execute command {} on datanode {}",
-            request, dn, e);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Failed to execute command {} on datanode {}",
+              processForDebug(request), dn, e);
+        }
       } catch (ExecutionException e) {
-        LOG.debug("Failed to execute command {} on datanode {}",
-            request, dn, e);
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Failed to execute command {} on datanode {}",
+              processForDebug(request), dn, e);
+        }
         if (Status.fromThrowable(e.getCause()).getCode()
             == Status.UNAUTHENTICATED.getCode()) {
           throw new SCMSecurityException("Failed to authenticate with "
@@ -413,8 +420,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       return reply;
     } else {
       Preconditions.checkNotNull(ioException);
-      LOG.error("Failed to execute command {} on the pipeline {}.", request,
-          pipeline);
+      LOG.error("Failed to execute command {} on the pipeline {}.",
+          processForDebug(request), pipeline);
       throw ioException;
     }
   }
@@ -495,7 +502,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
                     cost);
                 if (LOG.isDebugEnabled()) {
                   LOG.debug("Executed command {} on datanode {}, cost = {}, "
-                          + "cmdType = {}", request, dn,
+                          + "cmdType = {}", processForDebug(request), dn,
                       cost, request.getCmdType());
                 }
                 semaphore.release();
@@ -510,7 +517,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
                     System.currentTimeMillis() - requestTime);
                 if (LOG.isDebugEnabled()) {
                   LOG.debug("Executed command {} on datanode {}, cost = {}, "
-                          + "cmdType = {}", request, dn,
+                          + "cmdType = {}", processForDebug(request), dn,
                       cost, request.getCmdType());
                 }
                 semaphore.release();
@@ -520,7 +527,8 @@ public class XceiverClientGrpc extends XceiverClientSpi {
               public void onCompleted() {
                 if (!replyFuture.isDone()) {
                   replyFuture.completeExceptionally(new IOException(
-                      "Stream completed but no reply for request " + request));
+                      "Stream completed but no reply for request " +
+                          processForDebug(request)));
                 }
               }
             });

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
@@ -148,7 +148,7 @@ public abstract class XceiverClientSpi implements Closeable {
     }
   }
 
-  private IOException getIOExceptionForSendCommand(
+  public static IOException getIOExceptionForSendCommand(
       ContainerCommandRequestProto request, Exception e) {
     return new IOException("Failed to execute command "
         + HddsUtils.processForDebug(request), e);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientSpi.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
@@ -149,7 +150,8 @@ public abstract class XceiverClientSpi implements Closeable {
 
   private IOException getIOExceptionForSendCommand(
       ContainerCommandRequestProto request, Exception e) {
-    return new IOException("Failed to execute command " + request, e);
+    return new IOException("Failed to execute command "
+        + HddsUtils.processForDebug(request), e);
   }
   /**
    * Sends a given command to server gets a waitable future back.

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/helpers/ContainerUtils.java
@@ -46,7 +46,6 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
-import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -60,9 +59,6 @@ public final class ContainerUtils {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(ContainerUtils.class);
-
-  private static final ByteString REDACTED =
-      ByteString.copyFromUtf8("<redacted>");
 
   private ContainerUtils() {
     //never constructed.
@@ -250,68 +246,4 @@ public final class ContainerUtils {
     return Long.parseLong(containerBaseDir.getName());
   }
 
-  /**
-   * Remove binary data from request {@code msg}.  (May be incomplete, feel
-   * free to add any missing cleanups.)
-   */
-  public static ContainerCommandRequestProto processForDebug(
-      ContainerCommandRequestProto msg) {
-
-    if (msg == null) {
-      return null;
-    }
-
-    if (msg.hasWriteChunk() || msg.hasPutSmallFile()) {
-      ContainerCommandRequestProto.Builder builder = msg.toBuilder();
-      if (msg.hasWriteChunk()) {
-        builder.getWriteChunkBuilder().setData(REDACTED);
-      }
-      if (msg.hasPutSmallFile()) {
-        builder.getPutSmallFileBuilder().setData(REDACTED);
-      }
-      return builder.build();
-    }
-
-    return msg;
-  }
-
-  /**
-   * Remove binary data from response {@code msg}.  (May be incomplete, feel
-   * free to add any missing cleanups.)
-   */
-  public static ContainerCommandResponseProto processForDebug(
-      ContainerCommandResponseProto msg) {
-
-    if (msg == null) {
-      return null;
-    }
-
-    if (msg.hasReadChunk() || msg.hasGetSmallFile()) {
-      ContainerCommandResponseProto.Builder builder = msg.toBuilder();
-      if (msg.hasReadChunk()) {
-        if (msg.getReadChunk().hasData()) {
-          builder.getReadChunkBuilder().setData(REDACTED);
-        }
-        if (msg.getReadChunk().hasDataBuffers()) {
-          builder.getReadChunkBuilder().getDataBuffersBuilder()
-              .clearBuffers()
-              .addBuffers(REDACTED);
-        }
-      }
-      if (msg.hasGetSmallFile()) {
-        if (msg.getGetSmallFile().getData().hasData()) {
-          builder.getGetSmallFileBuilder().getDataBuilder().setData(REDACTED);
-        }
-        if (msg.getGetSmallFile().getData().hasDataBuffers()) {
-          builder.getGetSmallFileBuilder().getDataBuilder()
-              .getDataBuffersBuilder()
-                  .clearBuffers()
-                  .addBuffers(REDACTED);
-        }
-      }
-      return builder.build();
-    }
-
-    return msg;
-  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -122,8 +122,8 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
         new OzoneProtocolMessageDispatcher<>("DatanodeClient",
             protocolMetrics,
             LOG,
-            ContainerUtils::processForDebug,
-            ContainerUtils::processForDebug);
+            HddsUtils::processForDebug,
+            HddsUtils::processForDebug);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestContainerUtils.java
@@ -29,7 +29,7 @@ import java.nio.ByteBuffer;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type.ReadChunk;
 import static org.apache.hadoop.hdds.scm.protocolPB.ContainerCommandResponseBuilders.getReadChunkResponse;
-import static org.apache.hadoop.ozone.container.common.helpers.ContainerUtils.processForDebug;
+import static org.apache.hadoop.hdds.HddsUtils.processForDebug;
 import static org.apache.hadoop.ozone.container.ContainerTestHelper.getDummyCommandRequestProto;
 import static org.junit.Assert.assertEquals;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove binary data from write chunk requests before printing to log or adding to exception message.

https://issues.apache.org/jira/browse/HDDS-5989

## How was this patch tested?

Added assertion in existing integration test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1470982770