### PR TITLE
HDDS-6014. Add proto.lock files from ozone-1.2 release branch to master

### DIFF
--- a/hadoop-hdds/interface-admin/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-admin/src/main/resources/proto.lock
@@ -18,6 +18,10 @@
               {
                 "name": "CONTAINER_IS_MISSING",
                 "integer": 3
+              },
+              {
+                "name": "SCM_NOT_LEADER",
+                "integer": 4
               }
             ]
           },
@@ -107,6 +111,50 @@
               {
                 "name": "GetSafeModeRuleStatuses",
                 "integer": 21
+              },
+              {
+                "name": "DecommissionNodes",
+                "integer": 22
+              },
+              {
+                "name": "RecommissionNodes",
+                "integer": 23
+              },
+              {
+                "name": "StartMaintenanceNodes",
+                "integer": 24
+              },
+              {
+                "name": "DatanodeUsageInfo",
+                "integer": 25
+              },
+              {
+                "name": "GetExistContainerWithPipelinesInBatch",
+                "integer": 26
+              },
+              {
+                "name": "GetContainerToken",
+                "integer": 27
+              },
+              {
+                "name": "StartContainerBalancer",
+                "integer": 28
+              },
+              {
+                "name": "StopContainerBalancer",
+                "integer": 29
+              },
+              {
+                "name": "GetContainerBalancerStatus",
+                "integer": 30
+              },
+              {
+                "name": "FinalizeScmUpgrade",
+                "integer": 31
+              },
+              {
+                "name": "QueryUpgradeFinalizationProgress",
+                "integer": 32
               }
             ]
           },
@@ -124,6 +172,10 @@
               {
                 "name": "errorContainerMissing",
                 "integer": 3
+              },
+              {
+                "name": "scmNotLeader",
+                "integer": 4
               }
             ]
           },
@@ -154,6 +206,11 @@
                 "id": 2,
                 "name": "traceID",
                 "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "version",
+                "type": "uint32"
               },
               {
                 "id": 6,
@@ -259,6 +316,61 @@
                 "id": 26,
                 "name": "getSafeModeRuleStatusesRequest",
                 "type": "GetSafeModeRuleStatusesRequestProto"
+              },
+              {
+                "id": 27,
+                "name": "decommissionNodesRequest",
+                "type": "DecommissionNodesRequestProto"
+              },
+              {
+                "id": 28,
+                "name": "recommissionNodesRequest",
+                "type": "RecommissionNodesRequestProto"
+              },
+              {
+                "id": 29,
+                "name": "startMaintenanceNodesRequest",
+                "type": "StartMaintenanceNodesRequestProto"
+              },
+              {
+                "id": 30,
+                "name": "DatanodeUsageInfoRequest",
+                "type": "DatanodeUsageInfoRequestProto"
+              },
+              {
+                "id": 31,
+                "name": "getExistContainerWithPipelinesInBatchRequest",
+                "type": "GetExistContainerWithPipelinesInBatchRequestProto"
+              },
+              {
+                "id": 32,
+                "name": "containerTokenRequest",
+                "type": "GetContainerTokenRequestProto"
+              },
+              {
+                "id": 33,
+                "name": "startContainerBalancerRequest",
+                "type": "StartContainerBalancerRequestProto"
+              },
+              {
+                "id": 34,
+                "name": "stopContainerBalancerRequest",
+                "type": "StopContainerBalancerRequestProto"
+              },
+              {
+                "id": 35,
+                "name": "containerBalancerStatusRequest",
+                "type": "ContainerBalancerStatusRequestProto"
+              },
+              {
+                "id": 36,
+                "name": "finalizeScmUpgradeRequest",
+                "type": "FinalizeScmUpgradeRequestProto"
+              },
+              {
+                "id": 37,
+                "name": "queryUpgradeFinalizationProgressRequest",
+                "type": "QueryUpgradeFinalizationProgressRequestProto"
               }
             ]
           },
@@ -400,6 +512,61 @@
                 "id": 26,
                 "name": "getSafeModeRuleStatusesResponse",
                 "type": "GetSafeModeRuleStatusesResponseProto"
+              },
+              {
+                "id": 27,
+                "name": "decommissionNodesResponse",
+                "type": "DecommissionNodesResponseProto"
+              },
+              {
+                "id": 28,
+                "name": "recommissionNodesResponse",
+                "type": "RecommissionNodesResponseProto"
+              },
+              {
+                "id": 29,
+                "name": "startMaintenanceNodesResponse",
+                "type": "StartMaintenanceNodesResponseProto"
+              },
+              {
+                "id": 30,
+                "name": "DatanodeUsageInfoResponse",
+                "type": "DatanodeUsageInfoResponseProto"
+              },
+              {
+                "id": 31,
+                "name": "getExistContainerWithPipelinesInBatchResponse",
+                "type": "GetExistContainerWithPipelinesInBatchResponseProto"
+              },
+              {
+                "id": 32,
+                "name": "containerTokenResponse",
+                "type": "GetContainerTokenResponseProto"
+              },
+              {
+                "id": 33,
+                "name": "startContainerBalancerResponse",
+                "type": "StartContainerBalancerResponseProto"
+              },
+              {
+                "id": 34,
+                "name": "stopContainerBalancerResponse",
+                "type": "StopContainerBalancerResponseProto"
+              },
+              {
+                "id": 35,
+                "name": "containerBalancerStatusResponse",
+                "type": "ContainerBalancerStatusResponseProto"
+              },
+              {
+                "id": 36,
+                "name": "finalizeScmUpgradeResponse",
+                "type": "FinalizeScmUpgradeResponseProto"
+              },
+              {
+                "id": 37,
+                "name": "queryUpgradeFinalizationProgressResponse",
+                "type": "QueryUpgradeFinalizationProgressResponseProto"
               }
             ]
           },
@@ -515,6 +682,22 @@
             ]
           },
           {
+            "name": "GetExistContainerWithPipelinesInBatchRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerIDs",
+                "type": "int64",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "GetSafeModeRuleStatusesRequestProto"
           },
           {
@@ -560,6 +743,17 @@
             ]
           },
           {
+            "name": "GetExistContainerWithPipelinesInBatchResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerWithPipelines",
+                "type": "ContainerWithPipeline",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
             "name": "SCMListContainerRequestProto",
             "fields": [
               {
@@ -576,6 +770,11 @@
                 "id": 3,
                 "name": "traceID",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "state",
+                "type": "LifeCycleState"
               }
             ]
           },
@@ -648,6 +847,11 @@
                 "id": 4,
                 "name": "traceID",
                 "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "opState",
+                "type": "NodeOperationalState"
               }
             ]
           },
@@ -658,6 +862,128 @@
                 "id": 1,
                 "name": "datanodes",
                 "type": "Node",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DatanodeUsageInfoRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ipaddress",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "uuid",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "mostUsed",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "count",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "DatanodeUsageInfoResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "info",
+                "type": "DatanodeUsageInfoProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DecommissionNodesRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hosts",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DatanodeAdminErrorResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "host",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "error",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "DecommissionNodesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "failedHosts",
+                "type": "DatanodeAdminErrorResponseProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RecommissionNodesRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hosts",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RecommissionNodesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "failedHosts",
+                "type": "DatanodeAdminErrorResponseProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "StartMaintenanceNodesRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hosts",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "endInHours",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "StartMaintenanceNodesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "failedHosts",
+                "type": "DatanodeAdminErrorResponseProto",
                 "is_repeated": true
               }
             ]
@@ -890,6 +1216,184 @@
           },
           {
             "name": "ReplicationManagerStatusResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "isRunning",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeScmUpgradeRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "upgradeClientId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeScmUpgradeResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+              }
+            ]
+          },
+          {
+            "name": "QueryUpgradeFinalizationProgressRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "upgradeClientId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "takeover",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "readonly",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "QueryUpgradeFinalizationProgressResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+              }
+            ]
+          },
+          {
+            "name": "ContainerTokenSecretProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "ownerId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "containerId",
+                "type": "ContainerID"
+              },
+              {
+                "id": 3,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "certSerialId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerTokenRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "containerID",
+                "type": "ContainerID"
+              }
+            ]
+          },
+          {
+            "name": "GetContainerTokenResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "token",
+                "type": "TokenProto"
+              }
+            ]
+          },
+          {
+            "name": "StartContainerBalancerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "threshold",
+                "type": "double"
+              },
+              {
+                "id": 3,
+                "name": "idleiterations",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "maxDatanodesRatioToInvolvePerIteration",
+                "type": "double"
+              },
+              {
+                "id": 5,
+                "name": "maxSizeToMovePerIterationInGB",
+                "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "maxSizeEnteringTargetInGB",
+                "type": "int64"
+              },
+              {
+                "id": 7,
+                "name": "maxSizeLeavingSourceInGB",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "StartContainerBalancerResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "start",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "StopContainerBalancerRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "StopContainerBalancerResponseProto"
+          },
+          {
+            "name": "ContainerBalancerStatusRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "traceID",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "ContainerBalancerStatusResponseProto",
             "fields": [
               {
                 "id": 1,

--- a/hadoop-hdds/interface-client/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-client/src/main/resources/proto.lock
@@ -247,6 +247,10 @@
               {
                 "name": "ERROR_IN_DB_SYNC",
                 "integer": 42
+              },
+              {
+                "name": "CHUNK_FILE_INCONSISTENCY",
+                "integer": 43
               }
             ]
           },
@@ -314,6 +318,18 @@
               {
                 "name": "MD5",
                 "integer": 5
+              }
+            ]
+          },
+          {
+            "name": "ReadChunkVersion",
+            "enum_fields": [
+              {
+                "name": "V0"
+              },
+              {
+                "name": "V1",
+                "integer": 1
               }
             ]
           }
@@ -477,6 +493,11 @@
                 "id": 23,
                 "name": "encodedToken",
                 "type": "string"
+              },
+              {
+                "id": 24,
+                "name": "version",
+                "type": "uint32"
               }
             ]
           },
@@ -955,6 +976,17 @@
             ]
           },
           {
+            "name": "ChunkInfoList",
+            "fields": [
+              {
+                "id": 1,
+                "name": "chunks",
+                "type": "ChunkInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
             "name": "ChecksumData",
             "fields": [
               {
@@ -1010,6 +1042,11 @@
                 "id": 2,
                 "name": "chunkData",
                 "type": "ChunkInfo"
+              },
+              {
+                "id": 3,
+                "name": "readChunkVersion",
+                "type": "ReadChunkVersion"
               }
             ]
           },
@@ -1030,6 +1067,22 @@
                 "id": 3,
                 "name": "data",
                 "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "dataBuffers",
+                "type": "DataBuffers"
+              }
+            ]
+          },
+          {
+            "name": "DataBuffers",
+            "fields": [
+              {
+                "id": 1,
+                "name": "buffers",
+                "type": "bytes",
+                "is_repeated": true
               }
             ]
           },
@@ -1119,6 +1172,11 @@
                 "id": 1,
                 "name": "block",
                 "type": "GetBlockRequestProto"
+              },
+              {
+                "id": 2,
+                "name": "readChunkVersion",
+                "type": "ReadChunkVersion"
               }
             ]
           },
@@ -1149,6 +1207,11 @@
                 "id": 3,
                 "name": "len",
                 "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "version",
+                "type": "uint32"
               }
             ]
           },
@@ -1292,6 +1355,35 @@
               {
                 "name": "DEAD",
                 "integer": 3
+              },
+              {
+                "name": "HEALTHY_READONLY",
+                "integer": 6
+              }
+            ]
+          },
+          {
+            "name": "NodeOperationalState",
+            "enum_fields": [
+              {
+                "name": "IN_SERVICE",
+                "integer": 1
+              },
+              {
+                "name": "ENTERING_MAINTENANCE",
+                "integer": 2
+              },
+              {
+                "name": "IN_MAINTENANCE",
+                "integer": 3
+              },
+              {
+                "name": "DECOMMISSIONING",
+                "integer": 4
+              },
+              {
+                "name": "DECOMMISSIONED",
+                "integer": 5
               }
             ]
           },
@@ -1465,6 +1557,31 @@
                 "integer": 4
               }
             ]
+          },
+          {
+            "name": "UpgradeFinalizationStatus.Status",
+            "enum_fields": [
+              {
+                "name": "ALREADY_FINALIZED",
+                "integer": 1
+              },
+              {
+                "name": "STARTING_FINALIZATION",
+                "integer": 2
+              },
+              {
+                "name": "FINALIZATION_IN_PROGRESS",
+                "integer": 3
+              },
+              {
+                "name": "FINALIZATION_DONE",
+                "integer": 4
+              },
+              {
+                "name": "FINALIZATION_REQUIRED",
+                "integer": 5
+              }
+            ]
           }
         ],
         "messages": [
@@ -1523,6 +1640,16 @@
                 "type": "string"
               },
               {
+                "id": 8,
+                "name": "persistedOpState",
+                "type": "NodeOperationalState"
+              },
+              {
+                "id": 9,
+                "name": "persistedOpStateExpiry",
+                "type": "int64"
+              },
+              {
                 "id": 100,
                 "name": "uuid128",
                 "type": "UUID"
@@ -1530,34 +1657,49 @@
             ]
           },
           {
-		"name": "ExtendedDatanodeDetailsProto",
+            "name": "ExtendedDatanodeDetailsProto",
             "fields": [
-			  {
-			    "id": 1,
-				"name": "datanodeDetails",
-				"type": "DatanodeDetailsProto"
-			  },
-			  {
-			    "id": 2,
-				"name": "version",
-				"type": "string"
-			  },
-			  {
-			    "id": 3,
-				"name": "setupTime",
-				"type": "int64"
-			  },
-			  {
-			    "id": 4,
-				"name": "revision",
-				"type": "string"
-			  },
-			  {
-			    "id": 5,
-				"name": "buildDate",
-				"type": "string"
-			  }
-			]
+              {
+                "id": 1,
+                "name": "datanodeDetails",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "version",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "setupTime",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "revision",
+                "type": "string"
+              },
+              {
+                "id": 5,
+                "name": "buildDate",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "MoveDataNodePairProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "src",
+                "type": "DatanodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "tgt",
+                "type": "DatanodeDetailsProto"
+              }
+            ]
           },
           {
             "name": "OzoneManagerDetailsProto",
@@ -1582,6 +1724,26 @@
                 "name": "ports",
                 "type": "Port",
                 "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ScmNodeDetailsProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "scmNodeId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "clusterId",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "hostName",
+                "type": "string"
               }
             ]
           },
@@ -1612,6 +1774,16 @@
                 "id": 100,
                 "name": "uuid128",
                 "type": "UUID"
+              }
+            ]
+          },
+          {
+            "name": "ContainerID",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "uint64"
               }
             ]
           },
@@ -1679,6 +1851,11 @@
                 "type": "uint64"
               },
               {
+                "id": 9,
+                "name": "suggestedLeaderID",
+                "type": "UUID"
+              },
+              {
                 "id": 100,
                 "name": "leaderID128",
                 "type": "UUID"
@@ -1713,6 +1890,12 @@
                 "name": "nodeStates",
                 "type": "NodeState",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "nodeOperationalStates",
+                "type": "NodeOperationalState",
+                "is_repeated": true
               }
             ]
           },
@@ -1724,6 +1907,31 @@
                 "name": "nodes",
                 "type": "Node",
                 "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "DatanodeUsageInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "capacity",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "used",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "remaining",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "node",
+                "type": "DatanodeDetailsProto"
               }
             ]
           },
@@ -1824,6 +2032,47 @@
                 "id": 2,
                 "name": "scmId",
                 "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "peerRoles",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "AddScmRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "scmId",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "ratisAddr",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "AddScmResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "scmId",
+                "type": "string"
               }
             ]
           },
@@ -1862,6 +2111,56 @@
                 "id": 2,
                 "name": "localID",
                 "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "SecretKeyProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "keyId",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "expiryDate",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "privateKeyBytes",
+                "type": "bytes"
+              },
+              {
+                "id": 4,
+                "name": "publicKeyBytes",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "TokenProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "identifier",
+                "type": "bytes"
+              },
+              {
+                "id": 2,
+                "name": "password",
+                "type": "bytes"
+              },
+              {
+                "id": 3,
+                "name": "kind",
+                "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "service",
+                "type": "string"
               }
             ]
           },
@@ -1919,6 +2218,57 @@
                     "value": "0"
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "name": "UpgradeFinalizationStatus",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "Status"
+              },
+              {
+                "id": 2,
+                "name": "messages",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CRLInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "x509CRL",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "creationTimestamp",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "crlSequenceID",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CertInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "x509Certificate",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "timestamp",
+                "type": "uint64"
               }
             ]
           }

--- a/hadoop-hdds/interface-server/src/main/resources/proto.lock
+++ b/hadoop-hdds/interface-server/src/main/resources/proto.lock
@@ -1,6 +1,426 @@
 {
   "definitions": [
     {
+      "protopath": "InterSCMProtocol.proto",
+      "def": {
+        "messages": [
+          {
+            "name": "CopyDBCheckpointRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "flush",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CopyDBCheckpointResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "len",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "eof",
+                "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "data",
+                "type": "bytes"
+              },
+              {
+                "id": 6,
+                "name": "readOffset",
+                "type": "uint64"
+              },
+              {
+                "id": 7,
+                "name": "checksum",
+                "type": "int64"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "InterSCMProtocolService",
+            "rpcs": [
+              {
+                "name": "download",
+                "in_type": "CopyDBCheckpointRequestProto",
+                "out_type": "CopyDBCheckpointResponseProto",
+                "out_streamed": true
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.security"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.scm.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "InterSCMProtocolProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "SCMRatisProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "RequestType",
+            "enum_fields": [
+              {
+                "name": "PIPELINE",
+                "integer": 1
+              },
+              {
+                "name": "CONTAINER",
+                "integer": 2
+              },
+              {
+                "name": "BLOCK",
+                "integer": 3
+              },
+              {
+                "name": "SEQUENCE_ID",
+                "integer": 4
+              },
+              {
+                "name": "CERT_STORE",
+                "integer": 5
+              },
+              {
+                "name": "MOVE",
+                "integer": 6
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "Method",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "args",
+                "type": "MethodArgument",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "MethodArgument",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "bytes"
+              }
+            ]
+          },
+          {
+            "name": "ListArgument",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "value",
+                "type": "bytes",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMRatisRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "type",
+                "type": "RequestType"
+              },
+              {
+                "id": 2,
+                "name": "method",
+                "type": "Method"
+              }
+            ]
+          },
+          {
+            "name": "SCMRatisResponseProto",
+            "fields": [
+              {
+                "id": 2,
+                "name": "type",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "value",
+                "type": "bytes"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.security"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "SCMRatisProtocol"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "SCMUpdateProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "Type",
+            "enum_fields": [
+              {
+                "name": "CRLUpdate",
+                "integer": 1
+              },
+              {
+                "name": "PipelineUpdate",
+                "integer": 2
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "CRLInfoProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "x509CRL",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "creationTimestamp",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "crlSequenceID",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "ClientId",
+            "fields": [
+              {
+                "id": 1,
+                "name": "msb",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "lsb",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "SubscribeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hostname",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SubscribeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clientId",
+                "type": "ClientId"
+              }
+            ]
+          },
+          {
+            "name": "UpdateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "updateType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "clientId",
+                "type": "ClientId"
+              },
+              {
+                "id": 4,
+                "name": "crlUpdateRequest",
+                "type": "CRLUpdateRequest"
+              }
+            ]
+          },
+          {
+            "name": "UpdateResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "updateType",
+                "type": "Type"
+              },
+              {
+                "id": 2,
+                "name": "traceID",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "crlUpdateResponse",
+                "type": "CRLUpdateResponse"
+              }
+            ]
+          },
+          {
+            "name": "CRLUpdateRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "receivedCrlId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "pendingCrlIds",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CRLUpdateResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlInfo",
+                "type": "CRLInfoProto"
+              }
+            ]
+          },
+          {
+            "name": "UnsubscribeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clientId",
+                "type": "ClientId"
+              }
+            ]
+          },
+          {
+            "name": "UnsubscribeResponse"
+          }
+        ],
+        "services": [
+          {
+            "name": "SCMUpdateService",
+            "rpcs": [
+              {
+                "name": "subscribe",
+                "in_type": "SubscribeRequest",
+                "out_type": "SubscribeResponse"
+              },
+              {
+                "name": "updateStatus",
+                "in_type": "UpdateRequest",
+                "out_type": "UpdateResponse",
+                "in_streamed": true,
+                "out_streamed": true
+              },
+              {
+                "name": "unsubscribe",
+                "in_type": "UnsubscribeRequest",
+                "out_type": "UnsubscribeResponse"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.hdds.scm"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.hdds.protocol.scm.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "SCMUpdateServiceProtos"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
       "protopath": "ScmServerDatanodeHeartbeatProtocol.proto",
       "def": {
         "enums": [
@@ -200,6 +620,14 @@
               {
                 "name": "closePipelineCommand",
                 "integer": 7
+              },
+              {
+                "name": "setNodeOperationalStateCommand",
+                "integer": 8
+              },
+              {
+                "name": "finalizeNewLayoutVersionCommand",
+                "integer": 9
               }
             ]
           }
@@ -287,6 +715,21 @@
             ]
           },
           {
+            "name": "LayoutVersionProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "metadataLayoutVersion",
+                "type": "uint32"
+              },
+              {
+                "id": 2,
+                "name": "softwareLayoutVersion",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
             "name": "SCMVersionRequestProto"
           },
           {
@@ -327,6 +770,11 @@
                 "id": 4,
                 "name": "pipelineReports",
                 "type": "PipelineReportsProto"
+              },
+              {
+                "id": 5,
+                "name": "dataNodeLayoutVersion",
+                "type": "LayoutVersionProto"
               }
             ]
           },
@@ -419,6 +867,11 @@
                 "id": 8,
                 "name": "pipelineReports",
                 "type": "PipelineReportsProto"
+              },
+              {
+                "id": 9,
+                "name": "dataNodeLayoutVersion",
+                "type": "LayoutVersionProto"
               }
             ]
           },
@@ -456,6 +909,12 @@
                 "id": 1,
                 "name": "storageReport",
                 "type": "StorageReportProto",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "metadataStorageReport",
+                "type": "MetadataStorageReportProto",
                 "is_repeated": true
               }
             ]
@@ -519,6 +978,71 @@
               },
               {
                 "id": 7,
+                "name": "failed",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "MetadataStorageReportProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "storageLocation",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "storageType",
+                "type": "StorageTypeProto",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "DISK"
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "name": "capacity",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 4,
+                "name": "scmUsed",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 5,
+                "name": "remaining",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "0"
+                  }
+                ]
+              },
+              {
+                "id": 6,
                 "name": "failed",
                 "type": "bool",
                 "options": [
@@ -819,6 +1343,26 @@
                 "id": 8,
                 "name": "closePipelineCommandProto",
                 "type": "ClosePipelineCommandProto"
+              },
+              {
+                "id": 9,
+                "name": "setNodeOperationalStateCommandProto",
+                "type": "SetNodeOperationalStateCommandProto"
+              },
+              {
+                "id": 10,
+                "name": "finalizeNewLayoutVersionCommandProto",
+                "type": "FinalizeNewLayoutVersionCommandProto"
+              },
+              {
+                "id": 15,
+                "name": "term",
+                "type": "int64"
+              },
+              {
+                "id": 16,
+                "name": "encodedToken",
+                "type": "string"
               }
             ]
           },
@@ -1011,6 +1555,12 @@
                 "id": 5,
                 "name": "cmdId",
                 "type": "int64"
+              },
+              {
+                "id": 6,
+                "name": "priority",
+                "type": "int32",
+                "is_repeated": true
               }
             ]
           },
@@ -1024,6 +1574,78 @@
               },
               {
                 "id": 2,
+                "name": "cmdId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "SetNodeOperationalStateCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "cmdId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "nodeOperationalState",
+                "type": "NodeOperationalState"
+              },
+              {
+                "id": 3,
+                "name": "stateExpiryEpochSeconds",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "CRLStatusReport",
+            "fields": [
+              {
+                "id": 1,
+                "name": "receivedCrlId",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "pendingCrlIds",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "ProcessCRLCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlInfo",
+                "type": "CRLInfoProto"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeNewLayoutVersionCommandProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "finalizeNewLayoutVersion",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
+              },
+              {
+                "id": 2,
+                "name": "dataNodeLayoutVersion",
+                "type": "LayoutVersionProto"
+              },
+              {
+                "id": 3,
                 "name": "cmdId",
                 "type": "int64"
               }
@@ -1092,6 +1714,10 @@
               {
                 "name": "SortDatanodes",
                 "integer": 14
+              },
+              {
+                "name": "AddScm",
+                "integer": 15
               }
             ]
           },
@@ -1209,6 +1835,46 @@
               {
                 "name": "INTERNAL_ERROR",
                 "integer": 29
+              },
+              {
+                "name": "FAILED_TO_INIT_PIPELINE_CHOOSE_POLICY",
+                "integer": 30
+              },
+              {
+                "name": "FAILED_TO_INIT_LEADER_CHOOSE_POLICY",
+                "integer": 31
+              },
+              {
+                "name": "SCM_NOT_LEADER",
+                "integer": 32
+              },
+              {
+                "name": "FAILED_TO_REVOKE_CERTIFICATES",
+                "integer": 33
+              },
+              {
+                "name": "PIPELINE_NOT_FOUND",
+                "integer": 34
+              },
+              {
+                "name": "UNKNOWN_PIPELINE_STATE",
+                "integer": 35
+              },
+              {
+                "name": "CONTAINER_NOT_FOUND",
+                "integer": 36
+              },
+              {
+                "name": "CONTAINER_REPLICA_NOT_FOUND",
+                "integer": 37
+              },
+              {
+                "name": "FAILED_TO_CONNECT_TO_CRL_SERVICE",
+                "integer": 38
+              },
+              {
+                "name": "FAILED_TO_ADD_CRL_CLIENT",
+                "integer": 39
               }
             ]
           },
@@ -1254,6 +1920,11 @@
                 "type": "UserInfo"
               },
               {
+                "id": 4,
+                "name": "version",
+                "type": "uint32"
+              },
+              {
                 "id": 11,
                 "name": "allocateScmBlockRequest",
                 "type": "AllocateScmBlockRequestProto"
@@ -1272,6 +1943,11 @@
                 "id": 14,
                 "name": "sortDatanodesRequest",
                 "type": "SortDatanodesRequestProto"
+              },
+              {
+                "id": 15,
+                "name": "addScmRequestProto",
+                "type": "hadoop.hdds.AddScmRequestProto"
               }
             ]
           },
@@ -1315,6 +1991,11 @@
                 "type": "string"
               },
               {
+                "id": 7,
+                "name": "leaderSCMNodeId",
+                "type": "string"
+              },
+              {
                 "id": 11,
                 "name": "allocateScmBlockResponse",
                 "type": "AllocateScmBlockResponseProto"
@@ -1333,6 +2014,11 @@
                 "id": 14,
                 "name": "sortDatanodesResponse",
                 "type": "SortDatanodesResponseProto"
+              },
+              {
+                "id": 15,
+                "name": "addScmResponse",
+                "type": "hadoop.hdds.AddScmResponseProto"
               }
             ]
           },
@@ -1571,6 +2257,34 @@
               {
                 "name": "GetCACertificate",
                 "integer": 4
+              },
+              {
+                "name": "ListCertificate",
+                "integer": 5
+              },
+              {
+                "name": "GetSCMCertificate",
+                "integer": 6
+              },
+              {
+                "name": "GetRootCACertificate",
+                "integer": 7
+              },
+              {
+                "name": "ListCACertificate",
+                "integer": 8
+              },
+              {
+                "name": "GetCrls",
+                "integer": 9
+              },
+              {
+                "name": "GetLatestCrlId",
+                "integer": 10
+              },
+              {
+                "name": "RevokeCertificates",
+                "integer": 11
               }
             ]
           },
@@ -1580,6 +2294,70 @@
               {
                 "name": "OK",
                 "integer": 1
+              },
+              {
+                "name": "INVALID_CSR",
+                "integer": 2
+              },
+              {
+                "name": "UNABLE_TO_ISSUE_CERTIFICATE",
+                "integer": 3
+              },
+              {
+                "name": "GET_DN_CERTIFICATE_FAILED",
+                "integer": 4
+              },
+              {
+                "name": "GET_OM_CERTIFICATE_FAILED",
+                "integer": 5
+              },
+              {
+                "name": "GET_SCM_CERTIFICATE_FAILED",
+                "integer": 6
+              },
+              {
+                "name": "GET_CERTIFICATE_FAILED",
+                "integer": 7
+              },
+              {
+                "name": "GET_CA_CERT_FAILED",
+                "integer": 8
+              },
+              {
+                "name": "CERTIFICATE_NOT_FOUND",
+                "integer": 9
+              },
+              {
+                "name": "PEM_ENCODE_FAILED",
+                "integer": 10
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "integer": 11
+              },
+              {
+                "name": "DEFAULT",
+                "integer": 12
+              },
+              {
+                "name": "MISSING_BLOCK_TOKEN",
+                "integer": 13
+              },
+              {
+                "name": "BLOCK_TOKEN_VERIFICATION_FAILED",
+                "integer": 14
+              },
+              {
+                "name": "GET_ROOT_CA_CERTIFICATE_FAILED",
+                "integer": 15
+              },
+              {
+                "name": "NOT_A_PRIMARY_SCM",
+                "integer": 16
+              },
+              {
+                "name": "REVOKE_CERTIFICATE_FAILED",
+                "integer": 17
               }
             ]
           },
@@ -1597,6 +2375,63 @@
               {
                 "name": "invalidCSR",
                 "integer": 3
+              }
+            ]
+          },
+          {
+            "name": "SCMListCertificateResponseProto.ResponseCode",
+            "enum_fields": [
+              {
+                "name": "success",
+                "integer": 1
+              },
+              {
+                "name": "authenticationFailed",
+                "integer": 2
+              }
+            ]
+          },
+          {
+            "name": "SCMRevokeCertificatesRequestProto.Reason",
+            "enum_fields": [
+              {
+                "name": "unspecified"
+              },
+              {
+                "name": "keyCompromise",
+                "integer": 1
+              },
+              {
+                "name": "cACompromise",
+                "integer": 2
+              },
+              {
+                "name": "affiliationChanged",
+                "integer": 3
+              },
+              {
+                "name": "superseded",
+                "integer": 4
+              },
+              {
+                "name": "cessationOfOperation",
+                "integer": 5
+              },
+              {
+                "name": "certificateHold",
+                "integer": 6
+              },
+              {
+                "name": "removeFromCRL",
+                "integer": 8
+              },
+              {
+                "name": "privilegeWithdrawn",
+                "integer": 9
+              },
+              {
+                "name": "aACompromise",
+                "integer": 10
               }
             ]
           }
@@ -1634,6 +2469,36 @@
                 "id": 6,
                 "name": "getCACertificateRequest",
                 "type": "SCMGetCACertificateRequestProto"
+              },
+              {
+                "id": 7,
+                "name": "listCertificateRequest",
+                "type": "SCMListCertificateRequestProto"
+              },
+              {
+                "id": 8,
+                "name": "getSCMCertificateRequest",
+                "type": "SCMGetSCMCertRequestProto"
+              },
+              {
+                "id": 9,
+                "name": "listCACertificateRequestProto",
+                "type": "SCMListCACertificateRequestProto"
+              },
+              {
+                "id": 10,
+                "name": "getCrlsRequest",
+                "type": "SCMGetCrlsRequestProto"
+              },
+              {
+                "id": 11,
+                "name": "getLatestCrlIdRequest",
+                "type": "SCMGetLatestCrlIdRequestProto"
+              },
+              {
+                "id": 12,
+                "name": "revokeCertificatesRequest",
+                "type": "SCMRevokeCertificatesRequestProto"
               }
             ]
           },
@@ -1675,6 +2540,26 @@
                 "id": 6,
                 "name": "getCertResponseProto",
                 "type": "SCMGetCertResponseProto"
+              },
+              {
+                "id": 7,
+                "name": "listCertificateResponseProto",
+                "type": "SCMListCertificateResponseProto"
+              },
+              {
+                "id": 8,
+                "name": "getCrlsResponseProto",
+                "type": "SCMGetCrlsResponseProto"
+              },
+              {
+                "id": 9,
+                "name": "getLatestCrlIdResponseProto",
+                "type": "SCMGetLatestCrlIdResponseProto"
+              },
+              {
+                "id": 10,
+                "name": "revokeCertificatesResponseProto",
+                "type": "SCMRevokeCertificatesResponseProto"
               }
             ]
           },
@@ -1709,6 +2594,21 @@
             ]
           },
           {
+            "name": "SCMGetSCMCertRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "scmDetails",
+                "type": "ScmNodeDetailsProto"
+              },
+              {
+                "id": 2,
+                "name": "CSR",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "SCMGetCertificateRequestProto",
             "fields": [
               {
@@ -1720,6 +2620,31 @@
           },
           {
             "name": "SCMGetCACertificateRequestProto"
+          },
+          {
+            "name": "SCMListCertificateRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "role",
+                "type": "NodeType"
+              },
+              {
+                "id": 2,
+                "name": "startCertId",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "count",
+                "type": "uint32"
+              },
+              {
+                "id": 4,
+                "name": "isRevoked",
+                "type": "bool"
+              }
+            ]
           },
           {
             "name": "SCMGetCertResponseProto",
@@ -1738,6 +2663,105 @@
                 "id": 3,
                 "name": "x509CACertificate",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "x509RootCACertificate",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "SCMListCertificateResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "responseCode",
+                "type": "ResponseCode"
+              },
+              {
+                "id": 2,
+                "name": "certificates",
+                "type": "string",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMGetRootCACertificateRequestProto"
+          },
+          {
+            "name": "SCMListCACertificateRequestProto"
+          },
+          {
+            "name": "SCMGetCrlsRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlId",
+                "type": "int64",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMGetCrlsResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlInfos",
+                "type": "CRLInfoProto",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "SCMGetLatestCrlIdRequestProto"
+          },
+          {
+            "name": "SCMGetLatestCrlIdResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "SCMRevokeCertificatesRequestProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "certIds",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "reason",
+                "type": "Reason",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "unspecified"
+                  }
+                ]
+              },
+              {
+                "id": 3,
+                "name": "revokeTime",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "SCMRevokeCertificatesResponseProto",
+            "fields": [
+              {
+                "id": 1,
+                "name": "crlId",
+                "type": "int64"
               }
             ]
           }

--- a/hadoop-ozone/interface-client/src/main/resources/proto.lock
+++ b/hadoop-ozone/interface-client/src/main/resources/proto.lock
@@ -84,6 +84,14 @@
                 "integer": 38
               },
               {
+                "name": "RenameKeys",
+                "integer": 39
+              },
+              {
+                "name": "DeleteOpenKeys",
+                "integer": 40
+              },
+              {
                 "name": "InitiateMultiPartUpload",
                 "integer": 45
               },
@@ -114,6 +122,26 @@
               {
                 "name": "DBUpdates",
                 "integer": 53
+              },
+              {
+                "name": "FinalizeUpgrade",
+                "integer": 54
+              },
+              {
+                "name": "FinalizeUpgradeProgress",
+                "integer": 55
+              },
+              {
+                "name": "Prepare",
+                "integer": 56
+              },
+              {
+                "name": "PrepareStatus",
+                "integer": 57
+              },
+              {
+                "name": "CancelPrepare",
+                "integer": 58
               },
               {
                 "name": "GetDelegationToken",
@@ -178,6 +206,14 @@
               {
                 "name": "RecoverTrash",
                 "integer": 92
+              },
+              {
+                "name": "RevokeS3Secret",
+                "integer": 93
+              },
+              {
+                "name": "PurgePaths",
+                "integer": 94
               }
             ]
           },
@@ -419,6 +455,54 @@
               {
                 "name": "PARTIAL_DELETE",
                 "integer": 62
+              },
+              {
+                "name": "DETECTED_LOOP_IN_BUCKET_LINKS",
+                "integer": 63
+              },
+              {
+                "name": "NOT_SUPPORTED_OPERATION",
+                "integer": 64
+              },
+              {
+                "name": "PARTIAL_RENAME",
+                "integer": 65
+              },
+              {
+                "name": "QUOTA_EXCEEDED",
+                "integer": 66
+              },
+              {
+                "name": "QUOTA_ERROR",
+                "integer": 67
+              },
+              {
+                "name": "DIRECTORY_NOT_EMPTY",
+                "integer": 68
+              },
+              {
+                "name": "PERSIST_UPGRADE_TO_LAYOUT_VERSION_FAILED",
+                "integer": 69
+              },
+              {
+                "name": "REMOVE_UPGRADE_TO_LAYOUT_VERSION_FAILED",
+                "integer": 70
+              },
+              {
+                "name": "UPDATE_LAYOUT_VERSION_FAILED",
+                "integer": 71
+              },
+              {
+                "name": "LAYOUT_FEATURE_FINALIZATION_FAILED",
+                "integer": 72
+              },
+              {
+                "name": "PREPARE_FAILED",
+                "integer": 73
+              },
+              {
+                "name": "NOT_SUPPORTED_OPERATION_WHEN_PREPARED",
+                "integer": 74
               }
             ]
           },
@@ -457,6 +541,23 @@
               {
                 "name": "RAM_DISK",
                 "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "BucketLayoutProto",
+            "enum_fields": [
+              {
+                "name": "LEGACY",
+                "integer": 1
+              },
+              {
+                "name": "FILE_SYSTEM_OPTIMIZED",
+                "integer": 2
+              },
+              {
+                "name": "OBJECT_STORE",
+                "integer": 3
               }
             ]
           },
@@ -571,6 +672,23 @@
             ]
           },
           {
+            "name": "PrepareStatusResponse.PrepareStatus",
+            "enum_fields": [
+              {
+                "name": "NOT_PREPARED",
+                "integer": 1
+              },
+              {
+                "name": "PREPARE_GATE_ENABLED",
+                "integer": 2
+              },
+              {
+                "name": "PREPARE_COMPLETED",
+                "integer": 3
+              }
+            ]
+          },
+          {
             "name": "ServicePort.Type",
             "enum_fields": [
               {
@@ -615,6 +733,16 @@
                 "id": 4,
                 "name": "userInfo",
                 "type": "UserInfo"
+              },
+              {
+                "id": 5,
+                "name": "version",
+                "type": "uint32"
+              },
+              {
+                "id": 6,
+                "name": "layoutVersion",
+                "type": "LayoutVersion"
               },
               {
                 "id": 11,
@@ -712,6 +840,16 @@
                 "type": "DeleteKeysRequest"
               },
               {
+                "id": 39,
+                "name": "renameKeysRequest",
+                "type": "RenameKeysRequest"
+              },
+              {
+                "id": 40,
+                "name": "deleteOpenKeysRequest",
+                "type": "DeleteOpenKeysRequest"
+              },
+              {
                 "id": 45,
                 "name": "initiateMultiPartUploadRequest",
                 "type": "MultipartInfoInitiateRequest"
@@ -750,6 +888,31 @@
                 "id": 53,
                 "name": "dbUpdatesRequest",
                 "type": "DBUpdatesRequest"
+              },
+              {
+                "id": 54,
+                "name": "finalizeUpgradeRequest",
+                "type": "FinalizeUpgradeRequest"
+              },
+              {
+                "id": 55,
+                "name": "finalizeUpgradeProgressRequest",
+                "type": "FinalizeUpgradeProgressRequest"
+              },
+              {
+                "id": 56,
+                "name": "prepareRequest",
+                "type": "PrepareRequest"
+              },
+              {
+                "id": 57,
+                "name": "prepareStatusRequest",
+                "type": "PrepareStatusRequest"
+              },
+              {
+                "id": 58,
+                "name": "cancelPrepareRequest",
+                "type": "CancelPrepareRequest"
               },
               {
                 "id": 61,
@@ -845,6 +1008,16 @@
                 "id": 92,
                 "name": "RecoverTrashRequest",
                 "type": "RecoverTrashRequest"
+              },
+              {
+                "id": 93,
+                "name": "RevokeS3SecretRequest",
+                "type": "RevokeS3SecretRequest"
+              },
+              {
+                "id": 94,
+                "name": "purgePathsRequest",
+                "type": "PurgePathsRequest"
               }
             ]
           },
@@ -983,6 +1156,11 @@
                 "type": "DeleteKeysResponse"
               },
               {
+                "id": 39,
+                "name": "renameKeysResponse",
+                "type": "RenameKeysResponse"
+              },
+              {
                 "id": 45,
                 "name": "initiateMultiPartUploadResponse",
                 "type": "MultipartInfoInitiateResponse"
@@ -1021,6 +1199,31 @@
                 "id": 52,
                 "name": "dbUpdatesResponse",
                 "type": "DBUpdatesResponse"
+              },
+              {
+                "id": 54,
+                "name": "finalizeUpgradeResponse",
+                "type": "FinalizeUpgradeResponse"
+              },
+              {
+                "id": 55,
+                "name": "finalizeUpgradeProgressResponse",
+                "type": "FinalizeUpgradeProgressResponse"
+              },
+              {
+                "id": 56,
+                "name": "prepareResponse",
+                "type": "PrepareResponse"
+              },
+              {
+                "id": 57,
+                "name": "prepareStatusResponse",
+                "type": "PrepareStatusResponse"
+              },
+              {
+                "id": 58,
+                "name": "cancelPrepareResponse",
+                "type": "CancelPrepareResponse"
               },
               {
                 "id": 61,
@@ -1101,6 +1304,11 @@
                 "id": 92,
                 "name": "RecoverTrashResponse",
                 "type": "RecoverTrashResponse"
+              },
+              {
+                "id": 93,
+                "name": "purgePathsResponse",
+                "type": "PurgePathsResponse"
               }
             ]
           },
@@ -1234,6 +1442,22 @@
                 "id": 10,
                 "name": "modificationTime",
                 "type": "uint64"
+              },
+              {
+                "id": 11,
+                "name": "quotaInNamespace",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-2"
+                  }
+                ]
+              },
+              {
+                "id": 12,
+                "name": "usedNamespace",
+                "type": "uint64"
               }
             ]
           },
@@ -1342,6 +1566,11 @@
               {
                 "id": 4,
                 "name": "modificationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 5,
+                "name": "quotaInNamespace",
                 "type": "uint64"
               }
             ]
@@ -1519,6 +1748,53 @@
                 "id": 11,
                 "name": "modificationTime",
                 "type": "uint64"
+              },
+              {
+                "id": 12,
+                "name": "sourceVolume",
+                "type": "string"
+              },
+              {
+                "id": 13,
+                "name": "sourceBucket",
+                "type": "string"
+              },
+              {
+                "id": 14,
+                "name": "usedBytes",
+                "type": "uint64"
+              },
+              {
+                "id": 15,
+                "name": "quotaInBytes",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-2"
+                  }
+                ]
+              },
+              {
+                "id": 16,
+                "name": "quotaInNamespace",
+                "type": "int64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-2"
+                  }
+                ]
+              },
+              {
+                "id": 17,
+                "name": "usedNamespace",
+                "type": "uint64"
+              },
+              {
+                "id": 18,
+                "name": "bucketLayout",
+                "type": "BucketLayoutProto"
               }
             ]
           },
@@ -1655,6 +1931,16 @@
                 "name": "metadata",
                 "type": "hadoop.hdds.KeyValue",
                 "is_repeated": true
+              },
+              {
+                "id": 8,
+                "name": "quotaInBytes",
+                "type": "uint64"
+              },
+              {
+                "id": 9,
+                "name": "quotaInNamespace",
+                "type": "uint64"
               }
             ]
           },
@@ -1780,6 +2066,11 @@
                 "id": 2,
                 "name": "acl",
                 "type": "OzoneAclInfo"
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64"
               }
             ]
           },
@@ -1805,6 +2096,11 @@
                 "id": 2,
                 "name": "acl",
                 "type": "OzoneAclInfo"
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64"
               }
             ]
           },
@@ -1831,6 +2127,11 @@
                 "name": "acl",
                 "type": "OzoneAclInfo",
                 "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64"
               }
             ]
           },
@@ -1889,6 +2190,11 @@
                 "id": 1,
                 "name": "bucketArgs",
                 "type": "BucketArgs"
+              },
+              {
+                "id": 2,
+                "name": "modificationTime",
+                "type": "uint64"
               }
             ]
           },
@@ -2029,6 +2335,21 @@
                 "id": 15,
                 "name": "fileEncryptionInfo",
                 "type": "FileEncryptionInfoProto"
+              },
+              {
+                "id": 16,
+                "name": "latestVersionLocation",
+                "type": "bool"
+              },
+              {
+                "id": 17,
+                "name": "recursive",
+                "type": "bool"
+              },
+              {
+                "id": 18,
+                "name": "headOp",
+                "type": "bool"
               }
             ]
           },
@@ -2064,6 +2385,17 @@
                 "id": 7,
                 "name": "pipeline",
                 "type": "hadoop.hdds.Pipeline"
+              },
+              {
+                "id": 9,
+                "name": "partNumber",
+                "type": "int32",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "-1"
+                  }
+                ]
               }
             ]
           },
@@ -2085,6 +2417,17 @@
                 "id": 3,
                 "name": "fileEncryptionInfo",
                 "type": "FileEncryptionInfoProto"
+              },
+              {
+                "id": 4,
+                "name": "isMultipartKey",
+                "type": "bool",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "false"
+                  }
+                ]
               }
             ]
           },
@@ -2167,6 +2510,58 @@
               {
                 "id": 15,
                 "name": "updateID",
+                "type": "uint64"
+              },
+              {
+                "id": 16,
+                "name": "parentID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "DirectoryInfo",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "creationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 3,
+                "name": "modificationTime",
+                "type": "uint64"
+              },
+              {
+                "id": 4,
+                "name": "metadata",
+                "type": "hadoop.hdds.KeyValue",
+                "is_repeated": true
+              },
+              {
+                "id": 5,
+                "name": "acls",
+                "type": "OzoneAclInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "objectID",
+                "type": "uint64"
+              },
+              {
+                "id": 7,
+                "name": "updateID",
+                "type": "uint64"
+              },
+              {
+                "id": 8,
+                "name": "parentID",
                 "type": "uint64"
               }
             ]
@@ -2402,6 +2797,68 @@
             ]
           },
           {
+            "name": "RenameKeysRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "renameKeysArgs",
+                "type": "RenameKeysArgs"
+              }
+            ]
+          },
+          {
+            "name": "RenameKeysArgs",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "renameKeysMap",
+                "type": "RenameKeysMap",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "RenameKeysMap",
+            "fields": [
+              {
+                "id": 1,
+                "name": "fromKeyName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "toKeyName",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "RenameKeysResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "unRenamedKeys",
+                "type": "RenameKeysMap",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "bool"
+              }
+            ]
+          },
+          {
             "name": "RenameKeyRequest",
             "fields": [
               {
@@ -2529,6 +2986,79 @@
           },
           {
             "name": "PurgeKeysResponse"
+          },
+          {
+            "name": "PurgePathsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "deletedDirs",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "deletedSubFiles",
+                "type": "KeyInfo",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "markDeletedSubDirs",
+                "type": "KeyInfo",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PurgePathsResponse"
+          },
+          {
+            "name": "DeleteOpenKeysRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "openKeysPerBucket",
+                "type": "OpenKeyBucket",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "OpenKeyBucket",
+            "fields": [
+              {
+                "id": 1,
+                "name": "volumeName",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "bucketName",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "keys",
+                "type": "OpenKey",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "OpenKey",
+            "fields": [
+              {
+                "id": 1,
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "clientID",
+                "type": "uint64"
+              }
+            ]
           },
           {
             "name": "OMTokenProto",
@@ -2755,6 +3285,12 @@
                 "id": 3,
                 "name": "caCertificate",
                 "type": "string"
+              },
+              {
+                "id": 4,
+                "name": "caCerts",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },
@@ -2773,6 +3309,134 @@
                 "is_repeated": true
               }
             ]
+          },
+          {
+            "name": "FinalizeUpgradeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "upgradeClientId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeUpgradeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeUpgradeProgressRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "upgradeClientId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "takeover",
+                "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "readonly",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "FinalizeUpgradeProgressResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "hadoop.hdds.UpgradeFinalizationStatus"
+              }
+            ]
+          },
+          {
+            "name": "PrepareRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "args",
+                "type": "PrepareRequestArgs"
+              }
+            ]
+          },
+          {
+            "name": "PrepareRequestArgs",
+            "fields": [
+              {
+                "id": 1,
+                "name": "txnApplyWaitTimeoutSeconds",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "300"
+                  }
+                ]
+              },
+              {
+                "id": 2,
+                "name": "txnApplyCheckIntervalSeconds",
+                "type": "uint64",
+                "options": [
+                  {
+                    "name": "default",
+                    "value": "5"
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "name": "PrepareResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "txnID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "PrepareStatusRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "txnID",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "PrepareStatusResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "status",
+                "type": "PrepareStatus"
+              },
+              {
+                "id": 2,
+                "name": "currentTxnIndex",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "CancelPrepareRequest"
+          },
+          {
+            "name": "CancelPrepareResponse"
           },
           {
             "name": "ServicePort",
@@ -2902,6 +3566,11 @@
               {
                 "id": 7,
                 "name": "updateID",
+                "type": "uint64"
+              },
+              {
+                "id": 8,
+                "name": "parentID",
                 "type": "uint64"
               }
             ]
@@ -3253,6 +3922,26 @@
             ]
           },
           {
+            "name": "LayoutVersion",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "RevokeS3SecretRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "kerberosID",
+                "type": "string"
+              }
+            ]
+          },
+          {
             "name": "UpdateGetS3SecretRequest",
             "fields": [
               {
@@ -3299,6 +3988,113 @@
           {
             "name": "java_outer_classname",
             "value": "OzoneManagerProtocolProtos"
+          },
+          {
+            "name": "java_generic_services",
+            "value": "true"
+          },
+          {
+            "name": "java_generate_equals_and_hash",
+            "value": "true"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "OmInterServiceProtocol.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ErrorCode",
+            "enum_fields": [
+              {
+                "name": "RATIS_NOT_ENABLED",
+                "integer": 1
+              },
+              {
+                "name": "LEADER_UNDETERMINED",
+                "integer": 2
+              },
+              {
+                "name": "LEADER_NOT_READY",
+                "integer": 3
+              },
+              {
+                "name": "RATIS_BOOTSTRAP_ERROR",
+                "integer": 4
+              },
+              {
+                "name": "UNDEFINED_ERROR",
+                "integer": 5
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "BootstrapOMRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "nodeId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "hostAddress",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "ratisPort",
+                "type": "uint32"
+              }
+            ]
+          },
+          {
+            "name": "BootstrapOMResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "success",
+                "type": "bool"
+              },
+              {
+                "id": 2,
+                "name": "errorCode",
+                "type": "ErrorCode"
+              },
+              {
+                "id": 3,
+                "name": "errorMsg",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "services": [
+          {
+            "name": "OzoneManagerInterService",
+            "rpcs": [
+              {
+                "name": "bootstrap",
+                "in_type": "BootstrapOMRequest",
+                "out_type": "BootstrapOMResponse"
+              }
+            ]
+          }
+        ],
+        "package": {
+          "name": "hadoop.ozone"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "org.apache.hadoop.ozone.protocol.proto"
+          },
+          {
+            "name": "java_outer_classname",
+            "value": "OzoneManagerInterServiceProtocolProtos"
           },
           {
             "name": "java_generic_services",


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cherry pick proto.lock changes from ozone-1.2 release branch to master, so that all builds will check for protobuf backwards incompatibilities between master and 1.2.0.

[Original commit](https://github.com/apache/ozone/commit/62bbaef9ef44bb78f2f3f29c4ccf5ec5b7151e98)

## What is the link to the Apache JIRA

HDDS-6014

## How was this patch tested?

Normal build process which runs the proto-backwards-compatability check.
