### PR TITLE
HDDS-6011. Freon datanode chunk generator fails with NPE in secure cluster

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkGenerator.java
@@ -90,7 +90,6 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
       defaultValue = "")
   private String datanodes;
 
-  private XceiverClientManager xceiverClientManager;
   private List<XceiverClientSpi> xceiverClients;
 
   private Timer timer;
@@ -104,8 +103,6 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
 
 
     OzoneConfiguration ozoneConf = createOzoneConfiguration();
-    xceiverClientManager =
-        new XceiverClientManager(ozoneConf);
     if (OzoneSecurityUtil.isSecurityEnabled(ozoneConf)) {
       throw new IllegalArgumentException(
           "Datanode chunk generator is not supported in secure environment");
@@ -118,7 +115,9 @@ public class DatanodeChunkGenerator extends BaseFreonGenerator implements
     Set<Pipeline> pipelines;
 
     try (StorageContainerLocationProtocol scmLocationClient =
-               createStorageContainerLocationClient(ozoneConf)) {
+               createStorageContainerLocationClient(ozoneConf);
+         XceiverClientManager xceiverClientManager =
+             new XceiverClientManager(ozoneConf)) {
       List<Pipeline> pipelinesFromSCM = scmLocationClient.listPipelines();
       Pipeline firstPipeline;
       init();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Freon Datanode Chunk Generator fails with NPE in secure cluster. It is should give a meaningful message about not being supported in secure cluster.  It seems this was broken in HDDS-4475.

```
$ cd hadoop-ozone/dist/target/ozone-*/compose/ozonesecure
$ docker-compose up -d --scale datanode=3
# wait
$ docker-compose exec scm ozone freon dcg -n1 -t1
...
java.lang.NullPointerException
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:880)
	at org.apache.hadoop.hdds.scm.XceiverClientManager.<init>(XceiverClientManager.java:94)
	at org.apache.hadoop.hdds.scm.XceiverClientManager.<init>(XceiverClientManager.java:82)
	at org.apache.hadoop.ozone.freon.DatanodeChunkGenerator.call(DatanodeChunkGenerator.java:107)
	at org.apache.hadoop.ozone.freon.DatanodeChunkGenerator.call(DatanodeChunkGenerator.java:58)
```

https://issues.apache.org/jira/browse/HDDS-6011

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-*/compose/ozonesecure
$ docker-compose up -d --scale datanode=3
# wait
$ docker-compose exec scm ozone freon dcg -n1 -t1
...
Datanode chunk generator is not supported in secure environment
```