### PR TITLE
HDDS-6018 Closing state to quasiclosed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -138,7 +138,7 @@ public abstract class Handler {
       throws IOException;
 
   /**
-   * Marks the container Unhealthy. Moves the container to UHEALTHY state.
+   * Marks the container Unhealthy. Moves the container to UNHEALTHY state.
    *
    * @param container container to update
    * @throws IOException in case of exception

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -111,7 +111,7 @@ public class DatanodeStateMachine implements Closeable {
   private final ReplicationSupervisorMetrics replicationSupervisorMetrics;
 
   /**
-   * Constructs a a datanode state machine.
+   * Constructs a datanode state machine.
    * @param datanodeDetails - DatanodeDetails used to identify a datanode
    * @param conf - Configuration.
    * @param certClient - Datanode Certificate client, required if security is

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -77,10 +77,8 @@ public class CloseContainerCommandHandler implements CommandHandler {
         ((CloseContainerCommand)command).getProto();
     final ContainerController controller = ozoneContainer.getController();
     final long containerId = closeCommand.getContainerID();
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("Processing Close Container command containerID={}",
-          containerId);
-    }
+    LOG.debug("Processing Close Container command container #{}",
+        containerId);
     try {
       final Container container = controller.getContainer(containerId);
 
@@ -119,18 +117,14 @@ public class CloseContainerCommandHandler implements CommandHandler {
         break;
       case UNHEALTHY:
       case INVALID:
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Cannot close the container #{}, the container is"
-              + " in {} state.", containerId, container.getContainerState());
-        }
+        LOG.debug("Cannot close the container #{}, the container is"
+            + " in {} state.", containerId, container.getContainerState());
         break;
       default:
         break;
       }
     } catch (NotLeaderException e) {
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Follower cannot close container #{}.", containerId);
-      }
+      LOG.debug("Follower cannot close container #{}.", containerId);
     } catch (IOException e) {
       LOG.error("Can't close container #{}", containerId, e);
     } finally {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -850,7 +850,7 @@ public final class XceiverServerRatis implements XceiverServerSpi {
     return minIndex == null ? -1 : minIndex.longValue();
   }
 
-  void notifyGroupRemove(RaftGroupId gid) {
+  public void notifyGroupRemove(RaftGroupId gid) {
     raftGids.remove(gid);
     // Remove any entries for group leader map
     groupLeaderMap.remove(gid);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -141,7 +141,7 @@ public class TestCloseContainerCommandHandler {
     // Container in CLOSING state is moved to UNHEALTHY if pipeline does not
     // exist. Container should not exist in CLOSING state without a pipeline.
     verify(containerHandler)
-        .markContainerUnhealthy(container);
+        .quasiCloseContainer(container);
   }
 
   @Test

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerCommandHandler.java
@@ -168,7 +168,7 @@ public class TestCloseContainerCommandHandler {
     // Container in CLOSING state is moved to UNHEALTHY if pipeline does not
     // exist. Container should not exist in CLOSING state without a pipeline.
     verify(containerHandler)
-        .markContainerUnhealthy(container);
+        .quasiCloseContainer(container);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -60,18 +61,24 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerDataYaml;
 import org.apache.hadoop.ozone.container.common.impl.HddsDispatcher;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.ContainerStateMachine;
+import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.ozone.test.LambdaTestUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.QUASI_CLOSED;
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto.State.UNHEALTHY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
+
+import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
 import org.apache.ratis.server.storage.FileInfo;
 import org.apache.ratis.statemachine.impl.SimpleStateMachineStorage;
@@ -167,6 +174,69 @@ public class TestContainerStateMachineFailures {
     if (cluster != null) {
       cluster.shutdown();
     }
+  }
+
+  @Test
+  public void testContainerStateMachineTransitionOnUnhealthyReplicas()
+      throws Exception {
+    // This integration test is a bit of a hack to see if the highly
+    // improbable event where the Datanode does not have the pipeline
+    // in its Ratis channel but still receives a close container command
+    // for a container that is open or in closing state.
+    // Bugs in code can lead to this sequence of events but for this test
+    // to inject this state, it removes the pipeline by directly calling
+    // the underlying method.
+
+    OzoneOutputStream key =
+        objectStore.getVolume(volumeName).getBucket(bucketName)
+            .createKey("ratis", 1024, ReplicationType.RATIS,
+                ReplicationFactor.THREE, new HashMap<>());
+    key.write("ratis".getBytes(UTF_8));
+    key.flush();
+
+    KeyOutputStream groupOutputStream = (KeyOutputStream) key.
+        getOutputStream();
+    List<OmKeyLocationInfo> locationInfoList =
+        groupOutputStream.getLocationInfoList();
+    Assert.assertEquals(1, locationInfoList.size());
+
+    OmKeyLocationInfo omKeyLocationInfo = locationInfoList.get(0);
+
+    Set<HddsDatanodeService> datanodeSet =
+        TestHelper.getDatanodeServices(cluster,
+            omKeyLocationInfo.getPipeline());
+
+    long containerID = omKeyLocationInfo.getContainerID();
+
+    for (HddsDatanodeService dn : datanodeSet) {
+      XceiverServerRatis wc = (XceiverServerRatis)
+          dn.getDatanodeStateMachine().getContainer().getWriteChannel();
+      if (wc == null) {
+        // Test applicable only for RATIS based channel.
+        return;
+      }
+      wc.notifyGroupRemove(RaftGroupId
+          .valueOf(omKeyLocationInfo.getPipeline().getId().getId()));
+      SCMCommand<?> command = new CloseContainerCommand(
+          containerID, omKeyLocationInfo.getPipeline().getId());
+      command.setTerm(
+          cluster
+              .getStorageContainerManager()
+              .getScmContext()
+              .getTermOfLeader());
+      cluster.getStorageContainerManager().getScmNodeManager()
+          .addDatanodeCommand(dn.getDatanodeDetails().getUuid(), command);
+    }
+
+
+    for (HddsDatanodeService dn : datanodeSet) {
+      LambdaTestUtils.await(10000, 1000,
+          () -> (dn.getDatanodeStateMachine()
+                .getContainer().getContainerSet()
+                .getContainer(containerID)
+                .getContainerState().equals(QUASI_CLOSED)));
+    }
+    key.close();
   }
 
   @Test


### PR DESCRIPTION

## What changes were proposed in this pull request?

If a container is in closing state, the next state for it should be
quasi closed for containers without a pipeline.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6018

## How was this patch tested?

- [x] Integration tests
