### PR TITLE
HDDS-6047. [Ozone-Streaming] Support merge chunkInfos in client.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -124,11 +124,24 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private boolean checksumVerify = true;
 
+  @Config(key = "streaming.chunk.merge.size",
+      defaultValue = "0",
+      description = "The chunk size of the streaming is usually smaller than "
+          + "4MB, we suggest set to 512KB. In this case, files of the same "
+          + "size will generate more chunkInfo than async write, which "
+          + "increases the size of container DB. So we recommend add merge on "
+          + "the client side. The default value is 0, means merge is not "
+          + "enabled. If the value is 8, it means that every 8 chunkInfo will "
+          + "be merged to one.",
+      tags = ConfigTag.CLIENT)
+  private int chunkMergeSize = 0;
+
   @PostConstruct
   private void validate() {
     Preconditions.checkState(streamBufferSize > 0);
     Preconditions.checkState(streamBufferFlushSize > 0);
     Preconditions.checkState(streamBufferMaxSize > 0);
+    Preconditions.checkState(chunkMergeSize >= 0);
 
     Preconditions.checkArgument(bufferIncrement < streamBufferSize,
         "Buffer increment should be smaller than the size of the stream "
@@ -226,5 +239,13 @@ public class OzoneClientConfig {
 
   public int getBufferIncrement() {
     return bufferIncrement;
+  }
+
+  public int getChunkMergeSize() {
+    return chunkMergeSize;
+  }
+
+  public void setChunkMergeSize(int chunkMergeSize) {
+    this.chunkMergeSize = chunkMergeSize;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -181,6 +181,14 @@ public class Checksum {
     return new ChecksumData(checksumType, bytesPerChecksum, checksumList);
   }
 
+  public ChecksumData mergeChecksum(List<ByteString> checksumList) {
+    if (checksumType == ChecksumType.NONE) {
+      // Since type is set to NONE, we do not need to compute the checksums
+      return new ChecksumData(checksumType, bytesPerChecksum);
+    }
+    return new ChecksumData(checksumType, bytesPerChecksum, checksumList);
+  }
+
   /**
    * Compute checksum using the algorithm for the data upto the max length.
    * @param data input data

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
@@ -85,7 +85,8 @@ public class TestBlockDataStreamOutput {
     blockSize = 2 * maxFlushSize;
 
     OzoneClientConfig clientConfig = conf.getObject(OzoneClientConfig.class);
-    clientConfig.setStreamBufferFlushDelay(false);
+    // enable chunk merge and set to 8.
+    clientConfig.setChunkMergeSize(8);
     conf.setFromObject(clientConfig);
 
     conf.setTimeDuration(HDDS_SCM_WATCHER_TIMEOUT, 1000, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The chunk size of the streaming is usually smaller than 4MB, we suggest set to 512KB for better performance. In this case, files of the same size will generate more chunkInfo than async write, which increases the size of container DB. So we recommend add merge on the client side. The default value is 0, means merge is not enabled. If the value is 8, it means that every 8 chunkInfo will be merged to one.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6047

## How was this patch tested?

UT added.
