### PR TITLE
HDDS-6009. EC: Optimize ECBlockReconstructedStripeInputStream where there are no missing data indexes

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -246,12 +246,19 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         }
       }
     }
-    padBuffers(toRead);
-    flipInputs();
-    decodeStripe();
-    // Reset the buffer positions after padding to the read limits so the client
-    // reads the correct amount of data.
-    setBufferReadLimits(bufs, toRead);
+    if (missingIndexes.length > 0) {
+      padBuffers(toRead);
+      flipInputs();
+      decodeStripe();
+      // Reset the buffer positions and limits to remove any padding added
+      // before EC Decode.
+      setBufferReadLimits(bufs, toRead);
+    } else {
+      // If we have no missing indexes, then we the buffers will be at their
+      // limits after reading so we need to flip them to ensure they are ready
+      // to read by the caller.
+      flipInputs();
+    }
     setPos(getPos() + toRead);
     return toRead;
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -254,7 +254,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
       // before EC Decode.
       setBufferReadLimits(bufs, toRead);
     } else {
-      // If we have no missing indexes, then we the buffers will be at their
+      // If we have no missing indexes, then the buffers will be at their
       // limits after reading so we need to flip them to ensure they are ready
       // to read by the caller.
       flipInputs();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedStripeInputStream.java
@@ -126,6 +126,8 @@ public class TestECBlockReconstructedStripeInputStream {
     locations.add(ECStreamTestUtil.createIndexMap(2, 4, 5));
     // One data and one parity missing
     locations.add(ECStreamTestUtil.createIndexMap(2, 3, 4));
+    // No missing indexes
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5));
 
     for (Map<DatanodeDetails, Integer> dnMap : locations) {
       streamFactory = new TestBlockInputStreamFactory();
@@ -280,6 +282,8 @@ public class TestECBlockReconstructedStripeInputStream {
     locations.add(ECStreamTestUtil.createIndexMap(2, 3, 4));
     // One data and one parity missing
     locations.add(ECStreamTestUtil.createIndexMap(1, 2, 4));
+    // No indexes missing
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5));
 
     for (Map<DatanodeDetails, Integer> dnMap : locations) {
       streamFactory = new TestBlockInputStreamFactory();
@@ -366,6 +370,8 @@ public class TestECBlockReconstructedStripeInputStream {
     locations.add(ECStreamTestUtil.createIndexMap(2, 4, 5));
     // One data and one parity missing
     locations.add(ECStreamTestUtil.createIndexMap(2, 3, 4));
+    // No locations missing
+    locations.add(ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5));
 
     for (Map<DatanodeDetails, Integer> dnMap : locations) {
       streamFactory = new TestBlockInputStreamFactory();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add tests to ensure that ECBlockReconstructedStripeInputStream works when there are no missing indexes. If there are no missing indexes, avoid padding and EC decoding the buffers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6009

## How was this patch tested?

Modified existing tests
