### PR TITLE
HDDS-6053. Fix too short container scrubber data scan interval.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -39,18 +39,18 @@ public class ContainerScrubberConfiguration {
   // only for log
   public static final String HDDS_CONTAINER_SCRUB_ENABLED =
       "hdds.container.scrub.enabled";
-  static final String METADATA_SCAN_INTERVAL_KEY =
+  public static final String METADATA_SCAN_INTERVAL_KEY =
       "hdds.container.scrub.metadata.scan.interval";
-  static final String DATA_SCAN_INTERVAL_KEY =
+  public static final String DATA_SCAN_INTERVAL_KEY =
       "hdds.container.scrub.data.scan.interval";
   public static final String VOLUME_BYTES_PER_SECOND_KEY =
       "hdds.container.scrub.volume.bytes.per.second";
 
-  static final long METADATA_SCAN_INTERVAL_DEFAULT =
+  public static final long METADATA_SCAN_INTERVAL_DEFAULT =
       Duration.ofHours(3).toMillis();
-  static final long DATA_SCAN_INTERVAL_DEFAULT =
+  public static final long DATA_SCAN_INTERVAL_DEFAULT =
       Duration.ofDays(1).toMillis();
-  static final long BANDWIDTH_PER_VOLUME_DEFAULT = 1048576;   // 1MB
+  public static final long BANDWIDTH_PER_VOLUME_DEFAULT = 1048576;   // 1MB
 
   @Config(key = "enabled",
       type = ConfigType.BOOLEAN,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -44,7 +44,7 @@ public class ContainerScrubberConfiguration {
       "hdds.container.scrub.metadata.scan.interval";
   static final String DATA_SCAN_INTERVAL_KEY =
       "hdds.container.scrub.data.scan.interval";
-  static final String VOLUME_BYTES_PER_SECOND_KEY =
+  public static final String VOLUME_BYTES_PER_SECOND_KEY =
       "hdds.container.scrub.volume.bytes.per.second";
 
   static final long METADATA_SCAN_INTERVAL_DEFAULT =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -49,7 +49,7 @@ public class ContainerScrubberConfiguration {
   public static final long METADATA_SCAN_INTERVAL_DEFAULT =
       Duration.ofHours(3).toMillis();
   public static final long DATA_SCAN_INTERVAL_DEFAULT =
-      Duration.ofDays(1).toMillis();
+      Duration.ofDays(7).toMillis();
   public static final long BANDWIDTH_PER_VOLUME_DEFAULT = 1048576;   // 1MB
 
   @Config(key = "enabled",
@@ -70,7 +70,7 @@ public class ContainerScrubberConfiguration {
 
   @Config(key = "data.scan.interval",
       type = ConfigType.TIME,
-      defaultValue = "1d",
+      defaultValue = "7d",
       tags = {ConfigTag.STORAGE},
       description = "Minimum time interval between two iterations of container"
           + " data scanning.  If an iteration takes less time than this, the"

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerScrubberConfiguration.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.container.ozoneimpl;
 
-import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -51,8 +50,7 @@ public class ContainerScrubberConfiguration {
       Duration.ofHours(3).toMillis();
   static final long DATA_SCAN_INTERVAL_DEFAULT =
       Duration.ofDays(1).toMillis();
-  static final long BANDWIDTH_PER_VOLUME_DEFAULT =
-      (long) StorageUnit.MB.toBytes(1);
+  static final long BANDWIDTH_PER_VOLUME_DEFAULT = 1048576;   // 1MB
 
   @Config(key = "enabled",
       type = ConfigType.BOOLEAN,
@@ -81,8 +79,8 @@ public class ContainerScrubberConfiguration {
   private long dataScanInterval = DATA_SCAN_INTERVAL_DEFAULT;
 
   @Config(key = "volume.bytes.per.second",
-      type = ConfigType.SIZE,
-      defaultValue = "1MB",
+      type = ConfigType.LONG,
+      defaultValue = "1048576",
       tags = {ConfigTag.STORAGE},
       description = "Config parameter to throttle I/O bandwidth used"
           + " by scrubber per volume.")

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -66,6 +66,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.VOLUME_BYTES_PER_SECOND_KEY;
 
 import org.apache.hadoop.util.Timer;
 import org.apache.ratis.grpc.GrpcTlsConfig;
@@ -253,6 +254,12 @@ public class OzoneContainer {
       }
       this.metadataScanner.start();
 
+      if (c.getBandwidthPerVolume() == 0L) {
+        LOG.warn(VOLUME_BYTES_PER_SECOND_KEY + " is set to 0, " +
+            "so background container data scanner will not start.");
+        return;
+      }
+
       dataScanners = new ArrayList<>();
       for (StorageVolume v : volumeSet.getVolumesList()) {
         ContainerDataScanner s = new ContainerDataScanner(c, controller,
@@ -272,6 +279,10 @@ public class OzoneContainer {
     }
     metadataScanner.shutdown();
     metadataScanner = null;
+
+    if (dataScanners == null) {
+      return;
+    }
     for (ContainerDataScanner s : dataScanners) {
       s.shutdown();
     }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScrubberConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestContainerScrubberConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.ozoneimpl;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Duration;
+
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.BANDWIDTH_PER_VOLUME_DEFAULT;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.DATA_SCAN_INTERVAL_DEFAULT;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.DATA_SCAN_INTERVAL_KEY;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.METADATA_SCAN_INTERVAL_DEFAULT;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.METADATA_SCAN_INTERVAL_KEY;
+import static org.apache.hadoop.ozone.container.ozoneimpl.ContainerScrubberConfiguration.VOLUME_BYTES_PER_SECOND_KEY;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for {@link ContainerScrubberConfiguration}.
+ */
+public class TestContainerScrubberConfiguration {
+
+  private OzoneConfiguration conf;
+
+  @Before
+  public void setup() {
+    this.conf = new OzoneConfiguration();
+  }
+
+  @Test
+  public void acceptsValidValues() {
+    long validInterval = Duration.ofHours(1).toMillis();
+    long validBandwidth = (long) StorageUnit.MB.toBytes(1);
+
+    conf.setLong(METADATA_SCAN_INTERVAL_KEY, validInterval);
+    conf.setLong(DATA_SCAN_INTERVAL_KEY, validInterval);
+    conf.setLong(VOLUME_BYTES_PER_SECOND_KEY, validBandwidth);
+
+    ContainerScrubberConfiguration csConf =
+        conf.getObject(ContainerScrubberConfiguration.class);
+
+    assertEquals(validInterval, csConf.getMetadataScanInterval());
+    assertEquals(validInterval, csConf.getDataScanInterval());
+    assertEquals(validBandwidth, csConf.getBandwidthPerVolume());
+  }
+
+  @Test
+  public void overridesInvalidValues() {
+    long invalidInterval = -1;
+    long invalidBandwidth = -1;
+
+    conf.setLong(METADATA_SCAN_INTERVAL_KEY, invalidInterval);
+    conf.setLong(DATA_SCAN_INTERVAL_KEY, invalidInterval);
+    conf.setLong(VOLUME_BYTES_PER_SECOND_KEY, invalidBandwidth);
+
+    ContainerScrubberConfiguration csConf =
+        conf.getObject(ContainerScrubberConfiguration.class);
+
+    assertEquals(METADATA_SCAN_INTERVAL_DEFAULT,
+        csConf.getMetadataScanInterval());
+    assertEquals(DATA_SCAN_INTERVAL_DEFAULT,
+        csConf.getDataScanInterval());
+    assertEquals(BANDWIDTH_PER_VOLUME_DEFAULT,
+        csConf.getBandwidthPerVolume());
+  }
+
+  @Test
+  public void isCreatedWitDefaultValues() {
+    ContainerScrubberConfiguration csConf =
+        conf.getObject(ContainerScrubberConfiguration.class);
+
+    assertEquals(false, csConf.isEnabled());
+    assertEquals(METADATA_SCAN_INTERVAL_DEFAULT,
+        csConf.getMetadataScanInterval());
+    assertEquals(DATA_SCAN_INTERVAL_DEFAULT,
+        csConf.getDataScanInterval());
+    assertEquals(BANDWIDTH_PER_VOLUME_DEFAULT,
+        csConf.getBandwidthPerVolume());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix too short container scrubber data scan interval.
1 minute -> 1 day
With some improvement of the default value definitions and config value validations.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6053

## How was this patch tested?

no test.
