### PR TITLE
HDDS-6031. Add configs to support externalization of root CA

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -130,6 +130,21 @@ public final class HddsConfigKeys {
   public static final String HDDS_DEFAULT_SECURITY_PROVIDER = "BC";
   public static final String HDDS_KEY_DIR_NAME = "hdds.key.dir.name";
   public static final String HDDS_KEY_DIR_NAME_DEFAULT = "keys";
+
+  public static final String HDDS_CUSTOM_ROOT_CA_ENABLED =
+      "hdds.custom.rootca.enabled";
+  public static final boolean HDDS_CUSTOM_ROOT_CA_ENABLED_DEFAULT = false;
+  public static final String HDDS_CUSTOM_KEYSTORE_FILE_PATH =
+      "hdds.custom.keystore.file.path";
+  public static final String HDDS_CUSTOM_KEYSTORE_FILE_PASSWORD =
+      "hdds.custom.keystore.file.password";
+  public static final String HDDS_CUSTOM_KEYSTORE_KEY_PASSWORD =
+      "hdds.custom.keystore.key.password";
+  public static final String HDDS_CUSTOM_TRUSTSTORE_FILE_PATH =
+      "hdds.custom.truststore.file.path";
+  public static final String HDDS_CUSTOM_TRUSTSTORE_PASSWORD =
+      "hdds.custom.truststore.password";
+
   // TODO : Talk to StorageIO classes and see if they can return a secure
   // storage location for each node.
   public static final String HDDS_METADATA_DIR_NAME = "hdds.metadata.dir";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -19,6 +19,16 @@
 
 package org.apache.hadoop.hdds.security.x509;
 
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Provider;
@@ -26,10 +36,6 @@ import java.security.Security;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
-
-import com.google.common.base.Preconditions;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
@@ -69,10 +75,13 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
-import org.apache.ratis.thirdparty.io.netty.handler.ssl.SslProvider;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PASSWORD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PATH;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_KEY_PASSWORD;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_ROOT_CA_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_ROOT_CA_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_FILE_PATH;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_PASSWORD;
 
 /**
  * A class that deals with all Security related configs in HDDS.
@@ -103,6 +112,13 @@ public class SecurityConfig {
   private final boolean isSecurityEnabled;
   private final String crlName;
   private boolean grpcTlsUseTestCert;
+  private final boolean isCustomCAEnabled;
+  // The following configs are used only when custom Root CA is enabled
+  private final String keystoreFilePath;
+  private char[] keystoreFilePassword;
+  private char[] keystoreKeyPassword;
+  private final String truststoreFilePath;
+  private char[] truststorePassword;
 
   /**
    * Constructs a SecurityConfig.
@@ -117,6 +133,9 @@ public class SecurityConfig {
         HDDS_DEFAULT_KEY_ALGORITHM);
     this.providerString = this.configuration.get(HDDS_SECURITY_PROVIDER,
         HDDS_DEFAULT_SECURITY_PROVIDER);
+    this.isCustomCAEnabled =
+        this.configuration.getBoolean(HDDS_CUSTOM_ROOT_CA_ENABLED,
+            HDDS_CUSTOM_ROOT_CA_ENABLED_DEFAULT);
 
     // Please Note: To make it easy for our customers we will attempt to read
     // HDDS metadata dir and if that is not set, we will use Ozone directory.
@@ -174,6 +193,22 @@ public class SecurityConfig {
 
     this.crlName = this.configuration.get(HDDS_X509_CRL_NAME,
                                           HDDS_X509_CRL_NAME_DEFAULT);
+
+    this.keystoreFilePath =
+        this.configuration.get(HDDS_CUSTOM_KEYSTORE_FILE_PATH);
+    this.truststoreFilePath =
+        this.configuration.get(HDDS_CUSTOM_TRUSTSTORE_FILE_PATH);
+    try {
+      this.keystoreFilePassword =
+          this.configuration.getPassword(HDDS_CUSTOM_KEYSTORE_FILE_PASSWORD);
+      this.keystoreKeyPassword =
+          this.configuration.getPassword(HDDS_CUSTOM_KEYSTORE_KEY_PASSWORD);
+      this.truststorePassword =
+          this.configuration.getPassword(HDDS_CUSTOM_TRUSTSTORE_PASSWORD);
+    } catch (IOException ioException) {
+      LOG.error("Error while getting custom Keystore / Truststore password.",
+          ioException);
+    }
 
     // First Startup -- if the provider is null, check for the provider.
     if (SecurityConfig.provider == null) {
@@ -405,5 +440,33 @@ public class SecurityConfig {
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY_DEFAULT,
         TimeUnit.MICROSECONDS);
+  }
+
+  /**
+   * Returns true if custom Root CA is enabled.
+   * @return true if custom Root CA is enabled.
+   */
+  public boolean isCustomCAEnabled() {
+    return isCustomCAEnabled;
+  }
+
+  public String getKeystoreFilePath() {
+    return keystoreFilePath;
+  }
+
+  public char[] getKeystoreFilePassword() {
+    return keystoreFilePassword;
+  }
+
+  public char[] getKeystoreKeyPassword() {
+    return keystoreKeyPassword;
+  }
+
+  public String getTruststoreFilePath() {
+    return truststoreFilePath;
+  }
+
+  public char[] getTruststorePassword() {
+    return truststorePassword;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/SecurityConfig.java
@@ -455,11 +455,11 @@ public class SecurityConfig {
   }
 
   public char[] getKeystoreFilePassword() {
-    return keystoreFilePassword;
+    return keystoreFilePassword.clone();
   }
 
   public char[] getKeystoreKeyPassword() {
-    return keystoreKeyPassword;
+    return keystoreKeyPassword.clone();
   }
 
   public String getTruststoreFilePath() {
@@ -467,6 +467,6 @@ public class SecurityConfig {
   }
 
   public char[] getTruststorePassword() {
-    return truststorePassword;
+    return truststorePassword.clone();
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/utils/CertificateCodec.java
@@ -265,6 +265,20 @@ public class CertificateCodec {
   }
 
   /**
+   * Returns the certificate from the specific PEM encoded file.
+   *
+   * @param certFile - Full path to the certificate file.
+   * @return X%09 Certificate
+   * @throws IOException          - on Error.
+   * @throws SCMSecurityException - on Error.
+   * @throws CertificateException - on Error.
+   */
+  public static X509CertificateHolder readCertificate(File certFile)
+      throws IOException, CertificateException {
+    return getX509CertificateHolder(certFile);
+  }
+
+  /**
    * Helper function to read certificate.
    *
    * @param certificateFile - Full path to certificate file.
@@ -272,8 +286,8 @@ public class CertificateCodec {
    * @throws IOException          - On Error.
    * @throws CertificateException - On Error.
    */
-  private X509CertificateHolder getX509CertificateHolder(File certificateFile)
-      throws IOException, CertificateException {
+  private static X509CertificateHolder getX509CertificateHolder(
+      File certificateFile) throws IOException, CertificateException {
     if (!certificateFile.exists()) {
       throw new IOException("Unable to find the requested certificate. Path: "
           + certificateFile.toString());

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3028,4 +3028,62 @@
       will create intermediate directories.
     </description>
   </property>
+
+  <property>
+    <name>hdds.custom.rootca.enabled</name>
+    <value>false</value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      This configuration is used to enable external root CA for Ozone.
+      If this is set to true, "hdds.custom.keystore.file.path",
+      "hdds.custom.keystore.file.password", "hdds.custom.truststore.file.path", "hdds.custom.truststore.password"
+      are also required to be configured to be able successfully start Ozone.
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.custom.keystore.file.path</name>
+    <value></value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      The keystore file in JCEKS format that contains the key and the certificate signed by the custom Root CA.
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.custom.keystore.file.password</name>
+    <value></value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      The keystore password to access the keystore file specified in "hdds.custom.keystore.file.path"
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.custom.keystore.key.password</name>
+    <value>false</value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      The keystore key password to access the keys store in the keystore file specified in "hdds.custom.keystore.file.path"
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.custom.truststore.file.path</name>
+    <value></value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      The truststore file that contains the trusted root CA and intermediate CA certificates.
+    </description>
+  </property>
+
+  <property>
+    <name>hdds.custom.truststore.password</name>
+    <value></value>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      The password to access the truststore file specified in "hdds.custom.truststore.file.path"
+    </description>
+  </property>
+
 </configuration>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,6 +23,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.tracing.GrpcServerInterceptor;
@@ -62,7 +63,7 @@ public class ReplicationServer {
       ReplicationConfig replicationConfig,
       SecurityConfig secConf,
       CertificateClient caClient
-  ) {
+  ) throws SCMSecurityException {
     this.secConf = secConf;
     this.caClient = caClient;
     this.controller = controller;
@@ -70,7 +71,7 @@ public class ReplicationServer {
     init();
   }
 
-  public void init() {
+  public void init() throws SCMSecurityException {
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
         .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
         .addService(ServerInterceptors.intercept(new GrpcReplicationService(
@@ -93,7 +94,7 @@ public class ReplicationServer {
       } catch (IOException ex) {
         throw new IllegalArgumentException(
             "Unable to setup TLS for secure datanode replication GRPC "
-                + "endpoint.", ex);
+                + "endpoint. Error while getting Certificate.", ex);
       }
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationServer.java
@@ -71,7 +71,7 @@ public class ReplicationServer {
     init();
   }
 
-  public void init() throws SCMSecurityException {
+  public void init() throws IllegalArgumentException {
     NettyServerBuilder nettyServerBuilder = NettyServerBuilder.forPort(port)
         .maxInboundMessageSize(OzoneConsts.OZONE_SCM_CHUNK_MAX_SIZE)
         .addService(ServerInterceptors.intercept(new GrpcReplicationService(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsSecureDatanodeInit.java
@@ -17,6 +17,7 @@
 package org.apache.hadoop.ozone;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.PrivateKey;
@@ -114,7 +115,7 @@ public class TestHddsSecureDatanodeInit {
   }
 
   @Before
-  public void setUpDNCertClient(){
+  public void setUpDNCertClient() throws IOException {
 
     FileUtils.deleteQuietly(Paths.get(
         securityConfig.getKeyLocation(DN_COMPONENT).toString(),

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
@@ -47,7 +48,7 @@ public interface CertificateClient {
    *
    * @return private key or Null if there is no data.
    */
-  PrivateKey getPrivateKey();
+  PrivateKey getPrivateKey() throws SCMSecurityException;
 
   /**
    * Returns the public key of the specified component if it exists on the local
@@ -55,7 +56,7 @@ public interface CertificateClient {
    *
    * @return public key or Null if there is no data.
    */
-  PublicKey getPublicKey();
+  PublicKey getPublicKey() throws SCMSecurityException;
 
   /**
    * Returns the certificate  of the specified component if it exists on the
@@ -73,7 +74,7 @@ public interface CertificateClient {
    *
    * @return certificate or Null if there is no data.
    */
-  X509Certificate getCertificate();
+  X509Certificate getCertificate() throws IOException;
 
   /**
    * Return the latest CA certificate known to the client.
@@ -188,7 +189,7 @@ public interface CertificateClient {
    * Initialize certificate client.
    *
    * */
-  InitResponse init() throws CertificateException;
+  InitResponse init() throws IOException;
 
   /**
    * Represents initialization response of client.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/CertificateClient.java
@@ -20,7 +20,6 @@
 package org.apache.hadoop.hdds.security.x509.certificate.client;
 
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
-import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest;
 import org.apache.hadoop.hdds.security.x509.crl.CRLInfo;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
@@ -48,7 +47,7 @@ public interface CertificateClient {
    *
    * @return private key or Null if there is no data.
    */
-  PrivateKey getPrivateKey() throws SCMSecurityException;
+  PrivateKey getPrivateKey();
 
   /**
    * Returns the public key of the specified component if it exists on the local
@@ -56,7 +55,7 @@ public interface CertificateClient {
    *
    * @return public key or Null if there is no data.
    */
-  PublicKey getPublicKey() throws SCMSecurityException;
+  PublicKey getPublicKey();
 
   /**
    * Returns the certificate  of the specified component if it exists on the

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DNCertificateClient.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 
+import java.io.IOException;
+
 /**
  * Certificate client for DataNodes.
  */
@@ -37,11 +39,11 @@ public class DNCertificateClient extends DefaultCertificateClient {
   public static final String COMPONENT_NAME = "dn";
 
   public DNCertificateClient(SecurityConfig securityConfig,
-      String certSerialId) {
+      String certSerialId) throws IOException {
     super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
   }
 
-  public DNCertificateClient(SecurityConfig securityConfig) {
+  public DNCertificateClient(SecurityConfig securityConfig) throws IOException {
     super(securityConfig, LOG, null, COMPONENT_NAME);
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -264,7 +264,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * @return private key or Null if there is no data.
    */
   @Override
-  public PrivateKey getPrivateKey() throws SCMSecurityException {
+  public PrivateKey getPrivateKey() {
     if (privateKey != null) {
       return privateKey;
     }
@@ -299,7 +299,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
    * @return public key or Null if there is no data.
    */
   @Override
-  public PublicKey getPublicKey() throws SCMSecurityException {
+  public PublicKey getPublicKey() {
     if (publicKey != null) {
       return publicKey;
     }
@@ -508,7 +508,7 @@ public abstract class DefaultCertificateClient implements CertificateClient {
 
       return sign.sign();
     } catch (NoSuchAlgorithmException | NoSuchProviderException
-        | InvalidKeyException | SignatureException | SCMSecurityException e) {
+        | InvalidKeyException | SignatureException e) {
       getLogger().error("Error while signing the stream", e);
       throw new CertificateException("Error while signing the stream", e,
           CRYPTO_SIGN_ERROR);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/DefaultCertificateClient.java
@@ -136,10 +136,13 @@ public abstract class DefaultCertificateClient implements CertificateClient {
           switch (certType) {
           case X509_CERT:
             x509Certificate = cert;
+            break;
           case CA_CERT:
             caCertId = cert.getSerialNumber().toString();
+            break;
           case ROOT_CA_CERT:
             rootCaCertId = cert.getSerialNumber().toString();
+            break;
           default:
             break;
           }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/OMCertificateClient.java
@@ -26,6 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 
+import java.io.IOException;
+
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.GETCERT;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.RECOVER;
@@ -42,24 +44,23 @@ public class OMCertificateClient extends DefaultCertificateClient {
   public static final String COMPONENT_NAME = "om";
 
   public OMCertificateClient(SecurityConfig securityConfig,
-      String certSerialId, String localCrlId) {
+      String certSerialId, String localCrlId) throws IOException {
     super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
     this.setLocalCrlId(localCrlId!=null ?
         Long.parseLong(localCrlId): 0);
   }
 
   public OMCertificateClient(SecurityConfig securityConfig,
-      String certSerialId) {
+      String certSerialId) throws IOException{
     this(securityConfig, certSerialId, null);
   }
 
-  public OMCertificateClient(SecurityConfig securityConfig) {
+  public OMCertificateClient(SecurityConfig securityConfig) throws IOException {
     this(securityConfig, null, null);
   }
 
   @Override
-  protected InitResponse handleCase(InitCase init) throws
-      CertificateException {
+  protected InitResponse handleCase(InitCase init) throws IOException {
     switch (init) {
     case NONE:
       LOG.info("Creating keypair for client as keypair and certificate not " +

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/certificate/client/SCMCertificateClient.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Paths;
 
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
@@ -47,22 +48,23 @@ public class SCMCertificateClient extends DefaultCertificateClient {
           OzoneConsts.SCM_SUB_CA_PATH).toString();
 
   public SCMCertificateClient(SecurityConfig securityConfig,
-      String certSerialId) {
+      String certSerialId) throws IOException {
     super(securityConfig, LOG, certSerialId, COMPONENT_NAME);
   }
 
-  public SCMCertificateClient(SecurityConfig securityConfig) {
+  public SCMCertificateClient(SecurityConfig securityConfig)
+      throws IOException {
     super(securityConfig, LOG, null, COMPONENT_NAME);
   }
 
   public SCMCertificateClient(SecurityConfig securityConfig,
-      String certSerialId, String component) {
+      String certSerialId, String component) throws IOException {
     super(securityConfig, LOG, certSerialId, component);
   }
 
   @Override
   protected InitResponse handleCase(InitCase init)
-      throws CertificateException {
+      throws IOException {
     // This is similar to OM.
     switch (init) {
     case NONE:

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
@@ -22,6 +22,8 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.output.FileWriterWithEncoding;
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemReader;
@@ -41,9 +43,12 @@ import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.security.KeyFactory;
 import java.security.KeyPair;
+import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.PublicKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
@@ -76,6 +81,8 @@ public class KeyCodec {
       Stream.of(OWNER_READ, OWNER_WRITE)
           .collect(Collectors.toSet());
   private Supplier<Boolean> isPosixFileSystem;
+  private PrivateKey customPrivateKey;
+  private PublicKey customPublicKey;
 
   /**
    * Creates a KeyCodec with component name.
@@ -178,11 +185,15 @@ public class KeyCodec {
    * @throws IOException - On I/O failure.
    */
   public void writePublicKey(PublicKey key) throws IOException {
+    if (securityConfig.isCustomCAEnabled()) {
+      throw new SCMSecurityException("Cannot write public key when " +
+          HddsConfigKeys.HDDS_CUSTOM_ROOT_CA_ENABLED + " is set to true.");
+    }
     File publicKeyFile = Paths.get(location.toString(),
         securityConfig.getPublicKeyFileName()).toFile();
 
     if (Files.exists(publicKeyFile.toPath())) {
-      throw new IOException("Private key already exist.");
+      throw new IOException("Public key already exists. Cannot overwrite.");
     }
 
     try (PemWriter keyWriter = new PemWriter(new
@@ -230,30 +241,21 @@ public class KeyCodec {
   private PKCS8EncodedKeySpec readKey(Path basePath, String keyFileName)
       throws IOException {
     File fileName = Paths.get(basePath.toString(), keyFileName).toFile();
-    String keyData = FileUtils.readFileToString(fileName, DEFAULT_CHARSET);
-    final byte[] pemContent;
-    try (PemReader pemReader = new PemReader(new StringReader(keyData))) {
-      PemObject keyObject = pemReader.readPemObject();
-      pemContent = keyObject.getContent();
-    }
-    return new PKCS8EncodedKeySpec(pemContent);
+    return readKey(fileName);
   }
 
   /**
-   * Returns a Private Key from a PEM encoded file.
+   * Returns a Private Key from a PKCS8EncodedKeySpec.
    *
-   * @param basePath - base path
-   * @param privateKeyFileName - private key file name.
+   * @param encodedKeySpec - PKCS8EncodedKeySpec of the Private Key.
    * @return PrivateKey
    * @throws InvalidKeySpecException  - on Error.
    * @throws NoSuchAlgorithmException - on Error.
    * @throws IOException              - on Error.
    */
-  public PrivateKey readPrivateKey(Path basePath, String privateKeyFileName)
+  public PrivateKey readPrivateKey(PKCS8EncodedKeySpec encodedKeySpec)
       throws InvalidKeySpecException, NoSuchAlgorithmException, IOException {
-    PKCS8EncodedKeySpec encodedKeySpec = readKey(basePath, privateKeyFileName);
-    final KeyFactory keyFactory =
-        KeyFactory.getInstance(securityConfig.getKeyAlgo());
+    KeyFactory keyFactory = KeyFactory.getInstance(securityConfig.getKeyAlgo());
     return
         keyFactory.generatePrivate(encodedKeySpec);
   }
@@ -267,34 +269,57 @@ public class KeyCodec {
    */
   public PublicKey readPublicKey() throws InvalidKeySpecException,
       NoSuchAlgorithmException, IOException {
-    return readPublicKey(this.location.toAbsolutePath(),
-        securityConfig.getPublicKeyFileName());
+    PKCS8EncodedKeySpec encodedKeySpec =
+        readKey(this.location.toAbsolutePath(),
+            securityConfig.getPublicKeyFileName());
+    return readPublicKey(encodedKeySpec);
   }
 
   /**
-   * Returns a public key from a PEM encoded file.
+   * Returns a Public Key from a PKCS8EncodedKeySpec.
    *
-   * @param basePath - base path.
-   * @param publicKeyFileName - public key file name.
+   * @param encodedKeySpec - PKCS8EncodedKeySpec of the Public Key.
    * @return PublicKey
    * @throws NoSuchAlgorithmException - on Error.
    * @throws InvalidKeySpecException  - on Error.
    * @throws IOException              - on Error.
    */
-  public PublicKey readPublicKey(Path basePath, String publicKeyFileName)
+  public PublicKey readPublicKey(PKCS8EncodedKeySpec encodedKeySpec)
       throws NoSuchAlgorithmException, InvalidKeySpecException, IOException {
-    PKCS8EncodedKeySpec encodedKeySpec = readKey(basePath, publicKeyFileName);
-    final KeyFactory keyFactory =
-        KeyFactory.getInstance(securityConfig.getKeyAlgo());
+    KeyFactory keyFactory = KeyFactory.getInstance(securityConfig.getKeyAlgo());
     return
         keyFactory.generatePublic(
             new X509EncodedKeySpec(encodedKeySpec.getEncoded()));
 
   }
 
+  private void loadCustomKeys() throws NoSuchAlgorithmException,
+      IOException, KeyStoreException, CertificateException,
+      UnrecoverableKeyException {
+    KeyPair keyPair = SecurityUtil.getCustomKeyPair(securityConfig);
+    assert keyPair != null;
+    customPrivateKey = keyPair.getPrivate();
+    customPublicKey = keyPair.getPublic();
+  }
+  /**
+   * Returns the custom public key for custom Root CA setup.
+   * @return PublicKey.
+   * @throws InvalidKeySpecException - On Error.
+   * @throws NoSuchAlgorithmException - On Error.
+   * @throws IOException - On Error.
+   */
+  public PublicKey readCustomPublicKey() throws InvalidKeySpecException,
+      NoSuchAlgorithmException, IOException, KeyStoreException,
+      CertificateException, UnrecoverableKeyException {
+    if (customPublicKey == null) {
+      loadCustomKeys();
+    }
+
+    return customPublicKey;
+  }
 
   /**
-   * Returns the private key  using defaults.
+   * Returns the private key using defaults.
    * @return PrivateKey.
    * @throws InvalidKeySpecException - On Error.
    * @throws NoSuchAlgorithmException - On Error.
@@ -302,10 +327,10 @@ public class KeyCodec {
    */
   public PrivateKey readPrivateKey() throws InvalidKeySpecException,
       NoSuchAlgorithmException, IOException {
-    return readPrivateKey(this.location.toAbsolutePath(),
+    PKCS8EncodedKeySpec encodedKeySpec = readKey(this.location.toAbsolutePath(),
         securityConfig.getPrivateKeyFileName());
+    return readPrivateKey(encodedKeySpec);
   }
-
 
   /**
    * Helper function that actually writes data to the files.
@@ -406,4 +431,37 @@ public class KeyCodec {
     }
   }
 
+  /**
+   * Returns the custom private key for custom Root CA setup.
+   * @return PrivateKey.
+   * @throws NoSuchAlgorithmException - On Error.
+   * @throws IOException - On Error.
+   */
+  public PrivateKey readCustomPrivateKey() throws NoSuchAlgorithmException,
+      IOException, UnrecoverableKeyException, CertificateException,
+      KeyStoreException {
+    if (customPrivateKey == null) {
+      loadCustomKeys();
+    }
+
+    return customPrivateKey;
+  }
+
+  /**
+   * Reads a Key from the PEM Encoded Store.
+   *
+   * @param path - Path, Location where the Key file is stored.
+   * @return PrivateKey Object.
+   * @throws IOException - on Error.
+   */
+  protected PKCS8EncodedKeySpec readKey(File path)
+      throws IOException {
+    String keyData = FileUtils.readFileToString(path, DEFAULT_CHARSET);
+    byte[] pemContent;
+    try (PemReader pemReader = new PemReader(new StringReader(keyData))) {
+      PemObject keyObject = pemReader.readPemObject();
+      pemContent = keyObject.getContent();
+    }
+    return new PKCS8EncodedKeySpec(pemContent);
+  }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/KeyCodec.java
@@ -342,8 +342,10 @@ public class KeyCodec {
    * @param force - forces overwriting the keys.
    * @throws IOException - On I/O failure.
    */
-  private synchronized void writeKey(Path basePath, KeyPair keyPair,
-      String privateKeyFileName, String publicKeyFileName, boolean force)
+  @VisibleForTesting
+  synchronized void writeKey(Path basePath, KeyPair keyPair,
+                             String privateKeyFileName,
+                             String publicKeyFileName, boolean force)
       throws IOException {
     checkPreconditions(basePath);
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/SecurityUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/SecurityUtil.java
@@ -150,10 +150,12 @@ public final class SecurityUtil {
       NoSuchAlgorithmException {
     String keystorePath = securityConfig.getKeystoreFilePath();
     char[] keystoreFilePassword = securityConfig.getKeystoreFilePassword();
-    FileInputStream is = new FileInputStream(keystorePath);
 
-    KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-    keystore.load(is, keystoreFilePassword);
+    KeyStore keystore;
+    try (FileInputStream is = new FileInputStream(keystorePath)) {
+      keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keystore.load(is, keystoreFilePassword);
+    }
     return keystore;
   }
 
@@ -162,10 +164,12 @@ public final class SecurityUtil {
       java.security.cert.CertificateException {
     String truststorePath = securityConfig.getTruststoreFilePath();
     char[] truststoreFilePassword = securityConfig.getTruststorePassword();
-    FileInputStream is = new FileInputStream(truststorePath);
 
-    KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-    keystore.load(is, truststoreFilePassword);
+    KeyStore keystore;
+    try (FileInputStream is = new FileInputStream(truststorePath)) {
+      keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+      keystore.load(is, truststoreFilePassword);
+    }
     return keystore;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/SecurityUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/security/x509/keys/SecurityUtil.java
@@ -18,14 +18,7 @@
  */
 package org.apache.hadoop.hdds.security.x509.keys;
 
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.PKCS8EncodedKeySpec;
-import java.security.spec.X509EncodedKeySpec;
+import org.apache.hadoop.hdds.security.exception.SCMSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
@@ -36,6 +29,23 @@ import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.security.Key;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
 
 /**
  * Utility functions for Security modules for Ozone.
@@ -118,12 +128,12 @@ public final class SecurityUtil {
   public static PublicKey getPublicKey(byte[] encodedKey,
       SecurityConfig secureConfig) {
     PublicKey key = null;
+    KeyFactory kf = null;
     if (encodedKey == null || encodedKey.length == 0) {
       return null;
     }
 
     try {
-      KeyFactory kf = null;
       kf = KeyFactory.getInstance(secureConfig.getKeyAlgo(),
           secureConfig.getProvider());
       key = kf.generatePublic(new X509EncodedKeySpec(encodedKey));
@@ -135,4 +145,64 @@ public final class SecurityUtil {
     return key;
   }
 
+  public static KeyStore getCustomKeystore(SecurityConfig securityConfig) throws
+      IOException, KeyStoreException, java.security.cert.CertificateException,
+      NoSuchAlgorithmException {
+    String keystorePath = securityConfig.getKeystoreFilePath();
+    char[] keystoreFilePassword = securityConfig.getKeystoreFilePassword();
+    FileInputStream is = new FileInputStream(keystorePath);
+
+    KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+    keystore.load(is, keystoreFilePassword);
+    return keystore;
+  }
+
+  public static KeyStore getCustomTruststore(SecurityConfig securityConfig)
+      throws IOException, KeyStoreException, NoSuchAlgorithmException,
+      java.security.cert.CertificateException {
+    String truststorePath = securityConfig.getTruststoreFilePath();
+    char[] truststoreFilePassword = securityConfig.getTruststorePassword();
+    FileInputStream is = new FileInputStream(truststorePath);
+
+    KeyStore keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+    keystore.load(is, truststoreFilePassword);
+    return keystore;
+  }
+
+  public static KeyPair getCustomKeyPair(SecurityConfig securityConfig) throws
+      IOException, KeyStoreException, java.security.cert.CertificateException,
+      NoSuchAlgorithmException, UnrecoverableKeyException {
+
+    KeyStore keystore = getCustomKeystore(securityConfig);
+    char[] keystoreKeyPassword = securityConfig.getKeystoreKeyPassword();
+
+    String keyAlias = keystore.aliases().nextElement();
+
+    Key key = keystore.getKey(keyAlias, keystoreKeyPassword);
+    if (key instanceof PrivateKey) {
+      // Get certificate of public key
+      Certificate cert = keystore.getCertificate(keyAlias);
+      return new KeyPair(cert.getPublicKey(), (PrivateKey) key);
+    }
+    return null;
+  }
+
+  public static Certificate getCustomCertificate(SecurityConfig securityConfig)
+      throws IOException {
+    try {
+      KeyStore keystore = getCustomKeystore(securityConfig);
+      char[] keystoreKeyPassword = securityConfig.getKeystoreKeyPassword();
+      String keyAlias = keystore.aliases().nextElement();
+
+      Key key = keystore.getKey(keyAlias, keystoreKeyPassword);
+      if (key instanceof PrivateKey) {
+        // Get certificate of public key
+        return keystore.getCertificate(keyAlias);
+      }
+    } catch (Exception ex) {
+      throw new SCMSecurityException("Error while getting Certificate from " +
+          "keystore in " + securityConfig.getKeystoreFilePath(), ex);
+    }
+    return null;
+  }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -111,7 +111,7 @@ public class TestDefaultCertificateClient {
     getCertClient();
   }
 
-  private void getCertClient() {
+  private void getCertClient() throws IOException {
     omCertClient = new OMCertificateClient(omSecurityConfig, certSerialId);
     dnCertClient = new DNCertificateClient(dnSecurityConfig, certSerialId);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/HASecurityUtils.java
@@ -326,7 +326,7 @@ public final class HASecurityUtils {
    * @return
    */
   public static GrpcTlsConfig createSCMRatisTLSConfig(SecurityConfig conf,
-      CertificateClient certificateClient) {
+      CertificateClient certificateClient) throws IOException {
     if (conf.isSecurityEnabled() && conf.isGrpcTlsEnabled()) {
       return new GrpcTlsConfig(
           certificateClient.getPrivateKey(), certificateClient.getCertificate(),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -356,7 +356,9 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     // Authenticate SCM if security is enabled, this initialization can only
     // be done after the metadata store is initialized.
     if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
-      initializeCAnSecurityProtocol(conf, configurator);
+      if (!securityConfig.isCustomCAEnabled()) {
+        initializeCAnSecurityProtocol(conf, configurator);
+      }
     } else {
       // if no Security, we do not create a Certificate Server at all.
       // This allows user to boot SCM without security temporarily
@@ -464,10 +466,11 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
 
   }
 
-  private void initializeCertificateClient() {
+  private void initializeCertificateClient() throws IOException {
     securityConfig = new SecurityConfig(configuration);
     if (OzoneSecurityUtil.isSecurityEnabled(configuration) &&
-        scmStorageConfig.checkPrimarySCMIdInitialized()) {
+        scmStorageConfig.checkPrimarySCMIdInitialized() &&
+        !securityConfig.isCustomCAEnabled()) {
       scmCertificateClient = new SCMCertificateClient(
           securityConfig, scmStorageConfig.getScmCertSerialId());
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -81,6 +81,12 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_KEY_ALGORITHM,
         HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
+        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PASSWORD,
+        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PATH,
+        HddsConfigKeys.HDDS_CUSTOM_ROOT_CA_ENABLED,
+        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_KEY_PASSWORD,
+        HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_PASSWORD,
+        HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_FILE_PATH,
         OMConfigKeys.OZONE_OM_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -81,12 +81,6 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_KEY_ALGORITHM,
         HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
-        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PASSWORD,
-        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_FILE_PATH,
-        HddsConfigKeys.HDDS_CUSTOM_ROOT_CA_ENABLED,
-        HddsConfigKeys.HDDS_CUSTOM_KEYSTORE_KEY_PASSWORD,
-        HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_PASSWORD,
-        HddsConfigKeys.HDDS_CUSTOM_TRUSTSTORE_FILE_PATH,
         OMConfigKeys.OZONE_OM_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/server/TestContainerServer.java
@@ -84,7 +84,7 @@ public class TestContainerServer {
   private static CertificateClient caClient;
 
   @BeforeClass
-  public static void setup() {
+  public static void setup() throws IOException {
     CONF.set(HddsConfigKeys.HDDS_METADATA_DIR_NAME, TEST_DIR);
     caClient = new DNCertificateClient(new SecurityConfig(CONF));
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -245,7 +245,8 @@ public class OzoneDelegationTokenSecretManager
    *
    * @param identifier the identifier to validate
    */
-  private void updateIdentifierDetails(OzoneTokenIdentifier identifier) {
+  private void updateIdentifierDetails(OzoneTokenIdentifier identifier)
+      throws IOException {
     int sequenceNum;
     long now = Time.now();
     sequenceNum = incrementDelegationTokenSeqNum();
@@ -260,7 +261,7 @@ public class OzoneDelegationTokenSecretManager
   /**
    * Get OM certificate serial id.
    * */
-  private String getOmCertificateSerialId() {
+  private String getOmCertificateSerialId() throws IOException {
     if (omCertificateSerialId == null) {
       omCertificateSerialId =
           getCertClient().getCertificate().getSerialNumber().toString();


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add configs to support externalization of root CA
- Introduce a flag to enable external root CA
- Introduce configs to feed in keystore and trust store files for each component
- Update the security bootstrap flow of all the components to honor the flag to enable external root CA

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6031

## How was this patch tested?

This patch was tested by replacing jars in a cluster and updating the configs to work with an external root CA signed certs in JKS and Truststore.
