### PR TITLE
HDDS-5999. Freon datanode chunk validator does not find pipeline from param

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -17,8 +17,8 @@
 package org.apache.hadoop.ozone.freon;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -75,6 +75,7 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
 
 
   @Override
+  @SuppressWarnings("java:S3864") // Stream.peek (for debug)
   public Void call() throws Exception {
 
     init();
@@ -88,18 +89,22 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
 
     try (StorageContainerLocationProtocol scmLocationClient =
                  createStorageContainerLocationClient(ozoneConf)) {
-      List<Pipeline> pipelines = scmLocationClient.listPipelines();
+      Stream<Pipeline> pipelines = scmLocationClient.listPipelines().stream();
+      if (LOG.isDebugEnabled()) {
+        pipelines = pipelines
+            .peek(p -> LOG.debug("Found pipeline {}", p.getId()));
+      }
       Pipeline pipeline;
       if (pipelineId != null && pipelineId.length() > 0) {
-        pipeline = pipelines.stream()
-              .filter(p -> p.getId().toString().equals(pipelineId))
+        pipeline = pipelines
+              .filter(p -> p.getId().getId().toString().equals(pipelineId))
               .findFirst()
               .orElseThrow(() -> new IllegalArgumentException(
                       "Pipeline ID is defined, but there is no such pipeline: "
                               + pipelineId));
 
       } else {
-        pipeline = pipelines.stream()
+        pipeline = pipelines
             .filter(
                 p -> ReplicationConfig.getLegacyFactor(p.getReplicationConfig())
                     == HddsProtos.ReplicationFactor.THREE)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix pipeline ID comparison in datanode chunk validator.  The problem was that the result of `PipelineID.toString()` includes the prefix `PipelineID=`, and this was being compared to the plain pipeline ID provided in command-line argument.  We should be comparing only the actual ID.

https://issues.apache.org/jira/browse/HDDS-5999

## How was this patch tested?

Manual test:

```
$ p=$(ozone admin pipeline list --filterByFactor ONE | cut -f1 -d',' | cut -f3 -d' ' | head -1)
$ ozone freon dcg -n10 -t1 -p dcg1 --pipeline "$p"
...
2021-12-01 07:01:35,208 [main] INFO freon.DatanodeChunkGenerator: Writing to pipeline: PipelineID=6fedc039-b936-43b3-969a-2e3d75331c44
...
Successful executions: 10

$ ozone freon dcv -n10 -t1 -p dcg1 --pipeline "$p"
...
Successful executions: 10
```

CI:
https://github.com/adoroszlai/hadoop-ozone/runs/4377884390