### PR TITLE
HDDS-6058. Bump aws-java-sdk to latest 1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <checkstyle.version>8.29</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
-    <aws-java-sdk.version>1.11.1034</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.122</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
     <!-- the version of Hadoop declared in the version resources; can be overridden

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <maven-site-plugin.version>3.9.1</maven-site-plugin.version>
     <checkstyle.version>8.29</checkstyle.version>
     <surefire.fork.timeout>1200</surefire.fork.timeout>
-    <aws-java-sdk.version>1.12.122</aws-java-sdk.version>
+    <aws-java-sdk.version>1.12.124</aws-java-sdk.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <frontend-maven-plugin.version>1.12.0</frontend-maven-plugin.version>
     <!-- the version of Hadoop declared in the version resources; can be overridden


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade `aws-java-sdk` to 1.12.

https://issues.apache.org/jira/browse/HDDS-6058

## How was this patch tested?

CI
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1526858610