### PR TITLE
HDDS-5490. Remove an OM node from HA ring

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2342,7 +2342,7 @@
     <tag>OM, MANAGEMENT</tag>
     <description>
       Expert only. The maximum number of retries for Ozone Manager Admin
-      protocol.
+      protocol on each OM.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -458,6 +458,10 @@
       EXAMPLEOMSERVICEID). The OM service ID should be the value (one of the
       values if there are multiple) set for the parameter ozone.om.service.ids.
 
+      Decommissioned nodes (represented by node Ids in
+      ozone.om.decommissioned.nodes config list) will be ignored and not
+      included in the OM HA setup even if added to this list.
+
       Unique identifiers for each OM Node, delimited by commas. This will be
       used by OzoneManagers in HA setup to determine all the OzoneManagers
       belonging to the same OMservice in the cluster. For example, if you
@@ -465,6 +469,15 @@
       use “om1”, “om2” and "om3" as the individual IDs of the OzoneManagers,
       you would configure a property ozone.om.nodes.omService1, and its value
       "om1,om2,om3".
+    </description>
+  </property>
+  <property>
+    <name>ozone.om.decommissioned.nodes.EXAMPLEOMSERVICEID</name>
+    <value/>
+    <tag>OM, HA</tag>
+    <description>
+      Comma-separated list of OM node Ids which have been decommissioned. OMs
+      present in this list will not be included in the OM HA ring.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/ExitManager.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/ExitManager.java
@@ -40,4 +40,8 @@ public class ExitManager {
   public void forceExit(int status, Exception ex, Logger log) {
     ExitUtils.terminate(status, ex.getLocalizedMessage(), ex, log);
   }
+
+  public void forceExit(int status, String exMsg, Logger log) {
+    ExitUtils.terminate(status, exMsg, log);
+  }
 }

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
-import org.apache.hadoop.ipc.Server;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.NativeCodeLoader;
 

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -18,8 +18,11 @@
 package org.apache.hadoop.hdds.cli;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ipc.Server;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.NativeCodeLoader;
 
 import org.apache.log4j.ConsoleAppender;
@@ -43,6 +46,8 @@ public class OzoneAdmin extends GenericCli {
 
   private OzoneConfiguration ozoneConf;
 
+  private UserGroupInformation user;
+
   public OzoneAdmin() {
     super(OzoneAdmin.class);
   }
@@ -58,6 +63,16 @@ public class OzoneAdmin extends GenericCli {
       ozoneConf = createOzoneConfiguration();
     }
     return ozoneConf;
+  }
+
+  public UserGroupInformation getUser() throws IOException {
+    if (user == null) {
+      user = Server.getRemoteUser();
+      if (user == null) {
+        user = UserGroupInformation.getCurrentUser();
+      }
+    }
+    return user;
   }
 
   /**

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -67,10 +67,7 @@ public class OzoneAdmin extends GenericCli {
 
   public UserGroupInformation getUser() throws IOException {
     if (user == null) {
-      user = Server.getRemoteUser();
-      if (user == null) {
-        user = UserGroupInformation.getCurrentUser();
-      }
+      user = UserGroupInformation.getCurrentUser();
     }
     return user;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -39,7 +39,6 @@ import java.util.Set;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
@@ -60,6 +59,7 @@ import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_BIND_HOST_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DECOMMISSIONED_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_BIND_HOST_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTPS_BIND_PORT_DEFAULT;
@@ -69,8 +69,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_BIND_PORT_DE
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_INTERNAL_SERVICE_ID;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_NODES_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_PORT_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
 
 import org.slf4j.Logger;
@@ -123,7 +121,7 @@ public final class OmUtils {
       if (!result.containsKey(serviceId)) {
         result.put(serviceId, new ArrayList<>());
       }
-      for (String nodeId : getOMNodeIds(conf, serviceId)) {
+      for (String nodeId : getActiveOMNodeIds(conf, serviceId)) {
         String rpcAddr = getOmRpcAddress(conf,
             ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
         if (rpcAddr != null) {
@@ -329,12 +327,47 @@ public final class OmUtils {
   }
 
   /**
-   * Get a collection of all omNodeIds for the given omServiceId.
+   * Get a collection of all active omNodeIds (excluding decommissioned nodes)
+   * for the given omServiceId.
    */
-  public static Collection<String> getOMNodeIds(ConfigurationSource conf,
+  public static Collection<String> getActiveOMNodeIds(ConfigurationSource conf,
       String omServiceId) {
-    String key = ConfUtils.addSuffix(OZONE_OM_NODES_KEY, omServiceId);
-    return conf.getTrimmedStringCollection(key);
+    String nodeIdsKey = ConfUtils.addSuffix(OZONE_OM_NODES_KEY, omServiceId);
+    Collection<String> nodeIds = conf.getTrimmedStringCollection(nodeIdsKey);
+    String decommNodesKey = ConfUtils.addKeySuffixes(
+        OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId);
+    Collection<String> decommNodeIds = conf.getTrimmedStringCollection(
+        decommNodesKey);
+    nodeIds.removeAll(decommNodeIds);
+
+    return nodeIds;
+  }
+
+  /**
+   * Get a collection of all omNodeIds (active and decommissioned) for a
+   * gived omServiceId.
+   */
+  public static Collection<String> getAllOMNodeIds(ConfigurationSource conf,
+      String omServiceId) {
+    Set<String> nodeIds = new HashSet<>();
+    String nodeIdsKey = ConfUtils.addSuffix(OZONE_OM_NODES_KEY, omServiceId);
+    String decommNodesKey = ConfUtils.addKeySuffixes(
+        OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId);
+
+    nodeIds.addAll(conf.getTrimmedStringCollection(nodeIdsKey));
+    nodeIds.addAll(conf.getTrimmedStringCollection(decommNodesKey));
+
+    return nodeIds;
+  }
+
+  /**
+   * Get a collection of nodeIds of all decommissioned OMs for a given
+   * omServideId.
+   */
+  public static Collection<String> getDecommissionedNodes(
+      ConfigurationSource conf, String omServiceId) {
+    return conf.getTrimmedStringCollection(ConfUtils.addKeySuffixes(
+        OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId));
   }
 
   /**
@@ -657,14 +690,14 @@ public final class OmUtils {
 
 
   /**
-   * For a given service ID, return th of configured OM hosts.
+   * For a given service ID, return list of configured OM hosts.
    * @param conf configuration
    * @param omServiceId service id
    * @return Set of hosts.
    */
   public static Set<String> getOmHostsFromConfig(OzoneConfiguration conf,
                                                  String omServiceId) {
-    Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf,
+    Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf,
         omServiceId);
     Set<String> omHosts = new HashSet<>();
     for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {
@@ -680,44 +713,33 @@ public final class OmUtils {
   /**
    * Get a list of all OM details (address and ports) from the specified config.
    */
-  public static List<OMNodeDetails> getAllOMAddresses(OzoneConfiguration conf,
-      String omServiceId, String currentOMNodeId) {
+  public static List<OMNodeDetails> getAllOMHAAddresses(OzoneConfiguration conf,
+      String omServiceId, boolean includeDecommissionedNodes) {
 
     List<OMNodeDetails> omNodesList = new ArrayList<>();
-    Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, omServiceId);
+    Collection<String> omNodeIds;
+    if (includeDecommissionedNodes) {
+      omNodeIds = OmUtils.getAllOMNodeIds(conf, omServiceId);
+    } else {
+      omNodeIds = OmUtils.getActiveOMNodeIds(conf, omServiceId);
+    }
+    Collection<String> decommNodeIds = OmUtils.getDecommissionedNodes(conf,
+        omServiceId);
 
     String rpcAddrStr, hostAddr, httpAddr, httpsAddr;
     int rpcPort, ratisPort;
     if (omNodeIds.size() == 0) {
-      //Check if it is non-HA cluster
-      rpcAddrStr = OmUtils.getOmRpcAddress(conf, OZONE_OM_ADDRESS_KEY);
-      if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
-        return omNodesList;
-      }
-      hostAddr = HddsUtils.getHostName(rpcAddrStr).orElse(null);
-      rpcPort = HddsUtils.getHostPort(rpcAddrStr).orElse(0);
-      ratisPort = conf.getInt(OZONE_OM_RATIS_PORT_KEY,
-          OZONE_OM_RATIS_PORT_DEFAULT);
-      httpAddr = OmUtils.getHttpAddressForOMPeerNode(conf,
-          null, null, hostAddr);
-      httpsAddr = OmUtils.getHttpsAddressForOMPeerNode(conf,
-          null, null, hostAddr);
-
-      omNodesList.add(new OMNodeDetails.Builder()
-          .setOMNodeId(currentOMNodeId)
-          .setHostAddress(hostAddr)
-          .setRpcPort(rpcPort)
-          .setRatisPort(ratisPort)
-          .setHttpAddress(httpAddr)
-          .setHttpsAddress(httpsAddr)
-          .build());
-      return omNodesList;
+      // If there are no nodeIds present, return empty list
+      return Collections.EMPTY_LIST;
     }
 
     for (String nodeId : omNodeIds) {
       try {
         OMNodeDetails omNodeDetails = OMNodeDetails.getOMNodeDetailsFromConf(
             conf, omServiceId, nodeId);
+        if (decommNodeIds.contains(omNodeDetails.getNodeId())) {
+          omNodeDetails.setDecommissioningState();
+        }
         omNodesList.add(omNodeDetails);
       } catch (IOException e) {
         String omRpcAddressStr = OMNodeDetails.getOMNodeAddressFromConf(conf,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -49,6 +49,8 @@ public final class OMConfigKeys {
       "ozone.om.nodes";
   public static final String OZONE_OM_NODE_ID_KEY =
       "ozone.om.node.id";
+  public static final String OZONE_OM_DECOMMISSIONED_NODES_KEY =
+      "ozone.om.decommissioned.nodes";
 
   public static final String OZONE_OM_ADDRESS_KEY =
       "ozone.om.address";

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -132,7 +132,8 @@ public class OMFailoverProxyProvider<T> implements
     Collection<String> omServiceIds = Collections.singletonList(omSvcId);
 
     for (String serviceId : OmUtils.emptyAsSingletonNull(omServiceIds)) {
-      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(config, serviceId);
+      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(config,
+          serviceId);
 
       for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMFailoverProxyProvider.java
@@ -132,7 +132,7 @@ public class OMFailoverProxyProvider<T> implements
     Collection<String> omServiceIds = Collections.singletonList(omSvcId);
 
     for (String serviceId : OmUtils.emptyAsSingletonNull(omServiceIds)) {
-      Collection<String> omNodeIds = OmUtils.getOMNodeIds(config, serviceId);
+      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(config, serviceId);
 
       for (String nodeId : OmUtils.emptyAsSingletonNull(omNodeIds)) {
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMAdminProtocol.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.protocol;
 import java.io.Closeable;
 import java.io.IOException;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.security.KerberosInfo;
 
 /**
@@ -33,4 +34,9 @@ public interface OMAdminProtocol extends Closeable {
    * Get the OM configuration.
    */
   OMConfiguration getOMConfiguration() throws IOException;
+
+  /**
+   * Remove OM from HA ring.
+   */
+  void decommission(OMNodeDetails removeOMNode) throws IOException;
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMConfiguration.java
@@ -80,10 +80,10 @@ public final class OMConfiguration {
   }
 
   /**
-   * Reload configuration from disk and return all the OM nodes present in
-   * the new conf under current serviceId.
+   * Reload configuration from disk and return all active OM nodes (excludes
+   * decommissioned nodes) present in the new conf under current serviceId.
    */
-  public Map<String, OMNodeDetails> getOmNodesInNewConf() {
+  public Map<String, OMNodeDetails> getActiveOmNodesInNewConf() {
     return omNodesInNewConf.stream()
         .filter(omNodeDetails -> !omNodeDetails.isDecommissioned())
         .collect(Collectors.toMap(NodeDetails::getNodeId,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMConfiguration.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OMConfiguration.java
@@ -32,9 +32,9 @@ import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
  */
 public final class OMConfiguration {
 
-  // OM nodes present in OM's memory
+  // OM nodes present in OM's memory (does not include Decommissioned nodes)
   private List<OMNodeDetails> omNodesInMemory = new ArrayList<>();
-  // OM nodes reloaded from new config on disk
+  // OM nodes reloaded from new config on disk (includes Decommissioned nodes)
   private List<OMNodeDetails> omNodesInNewConf = new ArrayList<>();
 
   private OMConfiguration(List<OMNodeDetails> inMemoryNodeList,
@@ -84,9 +84,21 @@ public final class OMConfiguration {
    * the new conf under current serviceId.
    */
   public Map<String, OMNodeDetails> getOmNodesInNewConf() {
-    return omNodesInNewConf.stream().collect(Collectors.toMap(
-        NodeDetails::getNodeId,
-        omNodeDetails -> omNodeDetails,
-        (nodeId, omNodeDetails) -> omNodeDetails));
+    return omNodesInNewConf.stream()
+        .filter(omNodeDetails -> !omNodeDetails.isDecommissioned())
+        .collect(Collectors.toMap(NodeDetails::getNodeId,
+            omNodeDetails -> omNodeDetails,
+            (nodeId, omNodeDetails) -> omNodeDetails));
+  }
+
+  /**
+   * Return all decommissioned nodes in the reloaded config.
+   */
+  public Map<String, OMNodeDetails> getDecommissionedNodesInNewConf() {
+    return omNodesInNewConf.stream()
+        .filter(omNodeDetails -> omNodeDetails.isDecommissioned())
+        .collect(Collectors.toMap(NodeDetails::getNodeId,
+            omNodeDetails -> omNodeDetails,
+            (nodeId, omNodeDetails) -> omNodeDetails));
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -20,14 +20,15 @@ package org.apache.hadoop.ozone.om.protocolPB;
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 import java.io.IOException;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
 import org.apache.hadoop.io.retry.RetryProxy;
+import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
@@ -36,6 +37,11 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocol.OMConfiguration;
 import org.apache.hadoop.ozone.om.protocol.OMAdminProtocol;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
+import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.DecommissionOMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.DecommissionOMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMConfigurationRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMConfigurationResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMNodeInfo;
@@ -56,17 +62,26 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMAdminProtocolClientSideImpl.class);
 
-  private final OMNodeDetails remoteOmNodeDetails;
   private final OMAdminProtocolPB rpcProxy;
+  private final String omPrintInfo; // For targeted OM proxy
 
-  public OMAdminProtocolClientSideImpl(ConfigurationSource conf,
-      UserGroupInformation ugi, OMNodeDetails omNodeDetails)
-      throws IOException {
+  private OMAdminProtocolClientSideImpl(OMAdminProtocolPB proxy,
+      String printInfo) {
+    this.rpcProxy = proxy;
+    this.omPrintInfo = printInfo;
+  }
+
+  /**
+   * Create OM Admin Protocol Client for contacting the given OM (does not
+   * failover to different OM). Use for admin commands such as
+   * getOMConfiguration which are targeted to a specific OM.
+   */
+  public static OMAdminProtocolClientSideImpl createProxyForSingleOM(
+      OzoneConfiguration conf, UserGroupInformation ugi,
+      OMNodeDetails omNodeDetails) throws IOException {
 
     RPC.setProtocolEngine(OzoneConfiguration.of(conf),
         OMAdminProtocolPB.class, ProtobufRpcEngine.class);
-
-    this.remoteOmNodeDetails = omNodeDetails;
 
     int maxRetries = conf.getInt(
         OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_MAX_RETRIES_KEY,
@@ -86,7 +101,7 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
     OMAdminProtocolPB proxy = RPC.getProtocolProxy(
         OMAdminProtocolPB.class,
         RPC.getProtocolVersion(OMAdminProtocolPB.class),
-        remoteOmNodeDetails.getRpcAddress(), ugi, hadoopConf,
+        omNodeDetails.getRpcAddress(), ugi, hadoopConf,
         NetUtils.getDefaultSocketFactory(hadoopConf),
         (int) OmUtils.getOMClientRpcTimeOut(conf), connectionRetryPolicy)
         .getProxy();
@@ -94,8 +109,45 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
     RetryPolicy retryPolicy = RetryPolicies.retryUpToMaximumCountWithFixedSleep(
         10, 1000, TimeUnit.MILLISECONDS);
 
-    this.rpcProxy = (OMAdminProtocolPB) RetryProxy.create(
+    OMAdminProtocolPB rpcProxy = (OMAdminProtocolPB) RetryProxy.create(
         OMAdminProtocolPB.class, proxy, retryPolicy);
+
+    return new OMAdminProtocolClientSideImpl(rpcProxy,
+        omNodeDetails.getOMPrintInfo());
+  }
+
+  /**
+   * Create OM Admin Protocol Client for contacting the OM ring (failover
+   * till the current OM leader is reached). Use for admin commands such as
+   * decommissionOM which are should reach the OM leader.
+   */
+  public static OMAdminProtocolClientSideImpl createProxyForOMHA(
+      OzoneConfiguration conf, UserGroupInformation ugi, String omServiceId)
+      throws IOException {
+
+    RPC.setProtocolEngine(OzoneConfiguration.of(conf),
+        OMInterServiceProtocolPB.class, ProtobufRpcEngine.class);
+
+    OMFailoverProxyProvider omFailoverProxyProvider =
+        new OMFailoverProxyProvider(conf, ugi, omServiceId,
+            OMInterServiceProtocolPB.class);
+
+    // Multiple the max number of retries with number of OMs to calculate the
+    // max number of failovers.
+    int maxFailovers = conf.getInt(
+        OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_MAX_RETRIES_KEY,
+        OMConfigKeys.OZONE_OM_ADMIN_PROTOCOL_MAX_RETRIES_DEFAULT) *
+        omFailoverProxyProvider.getOMProxies().size();
+
+    OMAdminProtocolPB retryProxy = (OMAdminProtocolPB) RetryProxy.create(
+        OMAdminProtocolPB.class, omFailoverProxyProvider,
+        omFailoverProxyProvider.getRetryPolicy(maxFailovers));
+
+    List<OMNodeDetails> allOMNodeDetails = OmUtils.getAllOMHAAddresses(conf,
+        omServiceId, false);
+
+    return new OMAdminProtocolClientSideImpl(retryProxy,
+        OmUtils.getOMAddressListPrintString(allOMNodeDetails));
   }
 
   @Override
@@ -123,10 +175,45 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
       }
       return omMedatataBuilder.build();
     } catch (ServiceException e) {
-      LOG.error("Failed to retrieve configuration of OM {}",
-          remoteOmNodeDetails.getOMPrintInfo(), e);
+      LOG.error("Failed to retrieve configuration of OM {}", omPrintInfo, e);
     }
     return null;
+  }
+
+  @Override
+  public void decommission(OMNodeDetails removeOMNode) throws IOException {
+    DecommissionOMRequest decommOMRequest = DecommissionOMRequest.newBuilder()
+        .setNodeId(removeOMNode.getNodeId())
+        .setNodeAddress(removeOMNode.getHostAddress())
+        .build();
+
+    DecommissionOMResponse response;
+    try {
+      response = rpcProxy.decommission(NULL_RPC_CONTROLLER, decommOMRequest);
+    } catch (ServiceException e) {
+      OMNotLeaderException notLeaderException =
+          OMFailoverProxyProvider.getNotLeaderException(e);
+      if (notLeaderException != null) {
+        throwException(notLeaderException.getMessage());
+      }
+
+      OMLeaderNotReadyException leaderNotReadyException =
+          OMFailoverProxyProvider.getLeaderNotReadyException(e);
+      if (leaderNotReadyException != null) {
+        throwException(leaderNotReadyException.getMessage());
+      }
+      throw ProtobufHelper.getRemoteException(e);
+    }
+
+    if (!response.getSuccess()) {
+      throwException("Decommission Request to " + omPrintInfo +
+          "failed with error: " + response.getErrorMsg());
+    }
+  }
+
+  private void throwException(String errorMsg)
+      throws IOException {
+    throw new IOException("Failed to Decommission OM. Error: " + errorMsg);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -126,11 +126,11 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
       throws IOException {
 
     RPC.setProtocolEngine(OzoneConfiguration.of(conf),
-        OMInterServiceProtocolPB.class, ProtobufRpcEngine.class);
+        OMAdminProtocolPB.class, ProtobufRpcEngine.class);
 
     OMFailoverProxyProvider omFailoverProxyProvider =
         new OMFailoverProxyProvider(conf, ugi, omServiceId,
-            OMInterServiceProtocolPB.class);
+            OMAdminProtocolPB.class);
 
     // Multiple the max number of retries with number of OMs to calculate the
     // max number of failovers.
@@ -207,7 +207,7 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
 
     if (!response.getSuccess()) {
       throwException("Decommission Request to " + omPrintInfo +
-          "failed with error: " + response.getErrorMsg());
+          " failed with error: " + response.getErrorMsg());
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -119,7 +119,7 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
   /**
    * Create OM Admin Protocol Client for contacting the OM ring (failover
    * till the current OM leader is reached). Use for admin commands such as
-   * decommissionOM which are should reach the OM leader.
+   * decommissionOM which should reach the OM leader.
    */
   public static OMAdminProtocolClientSideImpl createProxyForOMHA(
       OzoneConfiguration conf, UserGroupInformation ugi, String omServiceId)
@@ -206,8 +206,9 @@ public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
     }
 
     if (!response.getSuccess()) {
-      throwException("Decommission Request to " + omPrintInfo +
-          " failed with error: " + response.getErrorMsg());
+      throwException("Request to decommission" + removeOMNode.getOMPrintInfo() +
+          ", sent to " + omPrintInfo + " failed with error: " +
+          response.getErrorMsg());
     }
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OMAdminProtocolClientSideImpl.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Protocol implementation for OM admin operations.
  */
-public class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
+public final class OMAdminProtocolClientSideImpl implements OMAdminProtocol {
 
   /**
    * RpcController is not used and hence is set to null.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -59,6 +59,8 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     errorIfMissingXmlProps = true;
     xmlPropsToSkipCompare.add("hadoop.tags.custom");
     xmlPropsToSkipCompare.add("ozone.om.nodes.EXAMPLEOMSERVICEID");
+    xmlPropsToSkipCompare.add("ozone.om.decommissioned.nodes" +
+        ".EXAMPLEOMSERVICEID");
     xmlPropsToSkipCompare.add("ozone.scm.nodes.EXAMPLESCMSERVICEID");
     xmlPrefixToSkipCompare.add("ipc.client.rpc-timeout.ms");
     xmlPropsToSkipCompare.add("ozone.om.leader.election.minimum.timeout" +
@@ -82,6 +84,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         HddsConfigKeys.HDDS_SECURITY_PROVIDER,
         HddsConfigKeys.HDDS_X509_CRL_NAME, // HDDS-2873
         OMConfigKeys.OZONE_OM_NODES_KEY,
+        OMConfigKeys.OZONE_OM_DECOMMISSIONED_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_NODES_KEY,
         ScmConfigKeys.OZONE_SCM_ADDRESS_KEY,
         OMConfigKeys.OZONE_FS_TRASH_INTERVAL_KEY,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -37,7 +38,11 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.grpc.server.GrpcLogAppender;
 import org.apache.ratis.server.leader.FollowerInfo;
@@ -56,25 +61,27 @@ import static org.apache.hadoop.ozone.om.TestOzoneManagerHA.createKey;
 /**
  * Test for OM bootstrap process.
  */
-public class TestOzoneManagerBootstrap {
+public class TestAddRemoveOzoneManager {
 
   @Rule
   public ExpectedException exception = ExpectedException.none();
 
   @Rule
-  public Timeout timeout = new Timeout(500_000);
+  public Timeout timeout = new Timeout(5000_000);
 
   private MiniOzoneHAClusterImpl cluster = null;
   private ObjectStore objectStore;
   private OzoneConfiguration conf;
   private final String clusterId = UUID.randomUUID().toString();
   private final String scmId = UUID.randomUUID().toString();
+  private long lastTransactionIndex;
+  private UserGroupInformation user;
 
-  private static final String OM_SERVICE_ID = "om-bootstrap";
+  private static final String OM_SERVICE_ID = "om-add-remove";
   private static final String VOLUME_NAME;
   private static final String BUCKET_NAME;
-
-  private long lastTransactionIndex;
+  private static final String DECOMM_NODES_CONFIG_KEY =
+      "ozone.om.decommissioned.nodes." + OM_SERVICE_ID;
 
   static {
     VOLUME_NAME = "volume" + RandomStringUtils.randomNumeric(5);
@@ -118,12 +125,12 @@ public class TestOzoneManagerBootstrap {
     // server's peer list
     for (OzoneManager om : cluster.getOzoneManagersList()) {
       Assert.assertTrue("New OM node " + nodeId + " not present in Peer list " +
-              "of OM " + om.getOMNodeId(), om.doesPeerExist(nodeId));
+          "of OM " + om.getOMNodeId(), om.doesPeerExist(nodeId));
       Assert.assertTrue("New OM node " + nodeId + " not present in Peer list " +
-          "of OM " + om.getOMNodeId() + " RatisServer",
+              "of OM " + om.getOMNodeId() + " RatisServer",
           om.getOmRatisServer().doesPeerExist(nodeId));
       Assert.assertTrue("New OM node " + nodeId + " not present in " +
-          "OM " + om.getOMNodeId() + "RatisServer's RaftConf",
+              "OM " + om.getOMNodeId() + "RatisServer's RaftConf",
           om.getOmRatisServer().getCurrentPeersFromRaftConf().contains(nodeId));
     }
 
@@ -164,8 +171,8 @@ public class TestOzoneManagerBootstrap {
 
   /**
    * 1. Add 2 new OMs to an existing 1 node OM cluster.
-   * 2. Verify that one of the new OMs must becomes the leader by stopping
-   * the old OM.
+   * 2. Verify that one of the new OMs becomes the leader by stopping the old
+   * OM.
    */
   @Test
   public void testBootstrap() throws Exception {
@@ -332,5 +339,79 @@ public class TestOzoneManagerBootstrap {
 
     // Verify that the newly bootstrapped OM is running
     Assert.assertTrue(newOM.isRunning());
+  }
+
+  /**
+   * Decommissioning Tests:
+   * 1. Stop an OM and decommission it from a 3 node cluster
+   * 2. Decommission another OM without stopping it.
+   * 3.
+   */
+  @Test
+  public void testDecommission() throws Exception {
+    setupCluster(3);
+    user = UserGroupInformation.getCurrentUser();
+
+    // Stop the 3rd OM and decommission it
+    String omNodeId3 = cluster.getOzoneManager(2).getOMNodeId();
+    cluster.stopOzoneManager(omNodeId3);
+    decommissionOM(omNodeId3);
+
+    // Decommission an OM and then stop it. Stopping OM before will lead
+    // to no quorum and there will not be a elected leader OM to process the
+    // decommission request.
+    String omNodeId2 = cluster.getOzoneManager(1).getOMNodeId();
+    decommissionOM(omNodeId2);
+    cluster.stopOzoneManager(omNodeId2);
+
+    // Verify that we can read/ write to the cluster with only 1 OM.
+    OzoneVolume volume = objectStore.getVolume(VOLUME_NAME);
+    OzoneBucket bucket = volume.getBucket(BUCKET_NAME);
+    String key = createKey(bucket);
+
+    Assert.assertNotNull(bucket.getKey(key));
+
+  }
+
+  /**
+   * Decommission given OM and verify that the other OM's peer nodes are
+   * updated after decommissioning.
+   */
+  private void decommissionOM(String decommNodeId) throws Exception {
+    Collection<String> decommNodes = conf.getTrimmedStringCollection(
+        DECOMM_NODES_CONFIG_KEY);
+    decommNodes.add(decommNodeId);
+    conf.set(DECOMM_NODES_CONFIG_KEY, StringUtils.join(",", decommNodes));
+    List<OzoneManager> activeOMs = new ArrayList<>();
+    for (OzoneManager om : cluster.getOzoneManagersList()) {
+      String omNodeId = om.getOMNodeId();
+      if (cluster.isOMActive(omNodeId)) {
+        om.setConfiguration(conf);
+        activeOMs.add(om);
+      }
+    }
+
+    // Create OMAdmin protocol client to send decommission request
+    OMAdminProtocolClientSideImpl omAdminProtocolClient =
+        OMAdminProtocolClientSideImpl.createProxyForOMHA(conf, user,
+            OM_SERVICE_ID);
+    OMNodeDetails decommNodeDetails = new OMNodeDetails.Builder()
+        .setOMNodeId(decommNodeId)
+        .setHostAddress("localhost")
+        .build();
+    omAdminProtocolClient.decommission(decommNodeDetails);
+
+    // Verify decomm node is removed from the HA ring
+    GenericTestUtils.waitFor(() -> {
+      for (OzoneManager om : activeOMs) {
+        if (om.getPeerNodes().contains(decommNodeId)) {
+          return false;
+        }
+      }
+      return true;
+    }, 100, 100000);
+
+    // Wait for new leader election if required
+    GenericTestUtils.waitFor(() -> cluster.getOMLeader() != null, 500, 30000);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -357,10 +357,16 @@ public class TestAddRemoveOzoneManager {
     cluster.stopOzoneManager(omNodeId3);
     decommissionOM(omNodeId3);
 
-    // Decommission an OM and then stop it. Stopping OM before will lead
-    // to no quorum and there will not be a elected leader OM to process the
-    // decommission request.
-    String omNodeId2 = cluster.getOzoneManager(1).getOMNodeId();
+    // Decommission the non leader OM and then stop it. Stopping OM before will
+    // lead to no quorum and there will not be a elected leader OM to process
+    // the decommission request.
+    String omNodeId2;
+    if (cluster.getOzoneManager().getOMNodeId().equals(
+        cluster.getOzoneManager(1).getOMNodeId())) {
+      omNodeId2 = cluster.getOzoneManager(0).getOMNodeId();
+    } else {
+      omNodeId2 = cluster.getOzoneManager(1).getOMNodeId();
+    }
     decommissionOM(omNodeId2);
     cluster.stopOzoneManager(omNodeId2);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestAddRemoveOzoneManager.java
@@ -361,7 +361,7 @@ public class TestAddRemoveOzoneManager {
     // lead to no quorum and there will not be a elected leader OM to process
     // the decommission request.
     String omNodeId2;
-    if (cluster.getOzoneManager().getOMNodeId().equals(
+    if (cluster.getOMLeader().getOMNodeId().equals(
         cluster.getOzoneManager(1).getOMNodeId())) {
       omNodeId2 = cluster.getOzoneManager(0).getOMNodeId();
     } else {

--- a/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OMAdminProtocol.proto
@@ -30,8 +30,8 @@ option java_generate_equals_and_hash = true;
 package hadoop.ozone;
 
 /**
-This file contains the admin protocol for Ozone Manager(s). This involves
-getting the meta information about an individual OM.
+This file contains the admin protocol for Ozone Manager(s). These
+communications should be instantiated only via the Admin Cli or through an OM.
 */
 
 message OMConfigurationRequest {
@@ -40,11 +40,10 @@ message OMConfigurationRequest {
 message OMConfigurationResponse {
     required bool success = 1;
     optional string errorMsg = 2;
-    // OM nodes present in OM's memory
+    // OM nodes present in OM's memory (does not include Decommissioned nodes)
     repeated OMNodeInfo nodesInMemory = 3;
-    // OM nodes reloaded from new config on disk
+    // OM nodes reloaded from new config on disk (includes Decommissioned nodes)
     repeated OMNodeInfo nodesInNewConf = 4;
-
 }
 
 message OMNodeInfo {
@@ -52,6 +51,22 @@ message OMNodeInfo {
     required string hostAddress = 2;
     required uint32 rpcPort = 3;
     required uint32 ratisPort = 4;
+    optional NodeState nodeState = 5 [default=ACTIVE];
+}
+
+enum NodeState {
+    ACTIVE = 1;
+    DECOMMISSIONED = 2;
+}
+
+message DecommissionOMRequest {
+    required string nodeId = 1;
+    required string nodeAddress = 2;
+}
+
+message DecommissionOMResponse {
+    required bool success = 1;
+    optional string errorMsg = 3;
 }
 
 /**
@@ -62,4 +77,8 @@ service OzoneManagerAdminService {
     // and the anticipated nodes list from the config files (upon reloading).
     rpc getOMConfiguration(OMConfigurationRequest)
     returns(OMConfigurationResponse);
+
+    // RPC request from admin to remove an OM from the cluster
+    rpc decommission(DecommissionOMRequest)
+    returns(DecommissionOMResponse);
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1611,8 +1611,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // NodeIds present in current peer list but not in new node list are the
     // decommissioned OMs and should be removed from the peer list
     List<String> decommissionedOMs = new ArrayList<>();
-    bootstrappedOMs.addAll(currentPeers);
-    bootstrappedOMs.removeAll(newPeers);
+    decommissionedOMs.addAll(currentPeers);
+    decommissionedOMs.removeAll(newPeers);
 
     // Add bootstrapped OMs to peer list
     for (String omNodeId : bootstrappedOMs) {
@@ -1723,7 +1723,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     omSnapshotProvider.removeDecommissionedPeerNode(decommNodeId);
     omRatisServer.removeRaftPeer(decommOMNodeDetails);
     peerNodesMap.remove(decommNodeId);
-    LOG.info("Removed OM {} from the Peer list.", decommNodeId);
+    LOG.info("Removed OM {} from OM Peer Nodes.", decommNodeId);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1549,7 +1549,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     OMNodeDetails omNodeDetailsInRemoteConfig = remoteOMConfig
-        .getOmNodesInNewConf().get(getOMNodeId());
+        .getActiveOmNodesInNewConf().get(getOMNodeId());
     if (omNodeDetailsInRemoteConfig == null) {
       throw new IOException("Remote OM " + remoteNodeId + " does not have the" +
           " bootstrapping OM(" + getOMNodeId() + ") information on reloading " +
@@ -1634,7 +1634,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         try {
           addOMNodeToPeers(omNodeId);
         } catch (IOException e) {
-          LOG.error("Fatal Error: Shutting down the system as otherwise it " +
+          LOG.error("Fatal Error while adding bootstrapped node to " +
+              "peer list. Shutting down the system as otherwise it " +
               "could lead to OM state divergence.", e);
           exitManager.forceExit(1, e, LOG);
         }
@@ -1655,7 +1656,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         try {
           removeOMNodeFromPeers(omNodeId);
         } catch (IOException e) {
-          e.printStackTrace();
+          LOG.error("Fatal Error while removing decommissioned node from " +
+              "peer list. Shutting down the system as otherwise it " +
+              "could lead to OM state divergence.", e);
+          exitManager.forceExit(1, e, LOG);
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -124,7 +124,8 @@ public class OMHANodeDetails {
     boolean isOMAddressSet = false;
 
     for (String serviceId : omServiceIds) {
-      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, serviceId);
+      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf,
+          serviceId);
 
       if (omNodeIds.size() == 0) {
         throwConfException("Configuration does not have any value set for %s " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ha/OMHANodeDetails.java
@@ -124,7 +124,7 @@ public class OMHANodeDetails {
     boolean isOMAddressSet = false;
 
     for (String serviceId : omServiceIds) {
-      Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);
+      Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, serviceId);
 
       if (omNodeIds.size() == 0) {
         throwConfException("Configuration does not have any value set for %s " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -335,20 +335,16 @@ public final class OzoneManagerRatisServer {
    */
   public void removeOMFromRatisRing(OMNodeDetails removeOMNode)
       throws IOException {
-    
     Preconditions.checkNotNull(removeOMNode);
 
     String removeNodeId = removeOMNode.getNodeId();
-    RaftPeerId removePeerId = RaftPeerId.valueOf(removeNodeId);
-
     LOG.info("{}: Submitting SetConfiguration request to Ratis server to " +
             "remove OM peer {} from Ratis group {}", ozoneManager.getOMNodeId(),
-        removePeerId,
-        raftGroup);
+        removeNodeId, raftGroup);
 
     List<RaftPeer> newPeersList = new ArrayList<>();
     newPeersList.addAll(raftPeerMap.values());
-    newPeersList.remove(raftPeerMap.get(removePeerId));
+    newPeersList.remove(raftPeerMap.get(removeNodeId));
 
     checkLeaderStatus();
     SetConfigurationRequest request = new SetConfigurationRequest(clientId,
@@ -410,7 +406,7 @@ public final class OzoneManagerRatisServer {
   public void removeRaftPeer(OMNodeDetails omNodeDetails) {
     String removeNodeID = omNodeDetails.getNodeId();
     raftPeerMap.remove(removeNodeID);
-    LOG.info("Removed OM {} from Ratis Peers list.", removeNodeID);
+    LOG.info("{}: Removed OM {} from Ratis Peers list.", this, removeNodeID);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -331,7 +331,7 @@ public final class OzoneManagerRatisServer {
   }
 
   /**
-   * Remove decommissioned OM node from Ratis ring
+   * Remove decommissioned OM node from Ratis ring.
    */
   public void removeOMFromRatisRing(OMNodeDetails removeOMNode)
       throws IOException {
@@ -390,9 +390,9 @@ public final class OzoneManagerRatisServer {
         omNodeDetails.getHostAddress(), omNodeDetails.getRatisPort());
 
     String newNodeId = omNodeDetails.getNodeId();
-    RaftPeerId raftPeerId = RaftPeerId.valueOf(newNodeId);
+    RaftPeerId newPeerId = RaftPeerId.valueOf(newNodeId);
     RaftPeer raftPeer = RaftPeer.newBuilder()
-        .setId(raftPeerId)
+        .setId(newPeerId)
         .setAddress(newOMRatisAddr)
         .build();
     raftPeerMap.put(newNodeId, raftPeer);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.ratis;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.ServiceException;
 
@@ -106,7 +106,7 @@ public final class OzoneManagerRatisServer {
   private final RaftGroupId raftGroupId;
   private final RaftGroup raftGroup;
   private final RaftPeerId raftPeerId;
-  private final List<RaftPeer> raftPeers;
+  private final Map<String, RaftPeer> raftPeerMap;
 
   private final OzoneManager ozoneManager;
   private final OzoneManagerStateMachine omStateMachine;
@@ -144,8 +144,8 @@ public final class OzoneManagerRatisServer {
     this.raftPeerId = localRaftPeerId;
     this.raftGroupId = RaftGroupId.valueOf(
         getRaftGroupIdFromOmServiceId(raftGroupIdStr));
-    this.raftPeers = Lists.newArrayList();
-    this.raftPeers.addAll(peers);
+    this.raftPeerMap = Maps.newHashMap();
+    peers.forEach(e -> raftPeerMap.put(e.getId().toString(), e));
     this.raftGroup = RaftGroup.valueOf(raftGroupId, peers);
 
     if (isBootstrapping) {
@@ -311,7 +311,7 @@ public final class OzoneManagerRatisServer {
         newRaftPeer, raftGroup);
 
     List<RaftPeer> newPeersList = new ArrayList<>();
-    newPeersList.addAll(raftPeers);
+    newPeersList.addAll(raftPeerMap.values());
     newPeersList.add(newRaftPeer);
 
     checkLeaderStatus();
@@ -331,13 +331,48 @@ public final class OzoneManagerRatisServer {
   }
 
   /**
+   * Remove decommissioned OM node from Ratis ring
+   */
+  public void removeOMFromRatisRing(OMNodeDetails removeOMNode)
+      throws IOException {
+    
+    Preconditions.checkNotNull(removeOMNode);
+
+    String removeNodeId = removeOMNode.getNodeId();
+    RaftPeerId removePeerId = RaftPeerId.valueOf(removeNodeId);
+
+    LOG.info("{}: Submitting SetConfiguration request to Ratis server to " +
+            "remove OM peer {} from Ratis group {}", ozoneManager.getOMNodeId(),
+        removePeerId,
+        raftGroup);
+
+    List<RaftPeer> newPeersList = new ArrayList<>();
+    newPeersList.addAll(raftPeerMap.values());
+    newPeersList.remove(raftPeerMap.get(removePeerId));
+
+    checkLeaderStatus();
+    SetConfigurationRequest request = new SetConfigurationRequest(clientId,
+        server.getId(), raftGroupId, nextCallId(), newPeersList);
+
+    RaftClientReply raftClientReply = server.setConfiguration(request);
+    if (raftClientReply.isSuccess()) {
+      LOG.info("Removed OM {} from Ratis group {}.", removeNodeId,
+          raftGroupId);
+    } else {
+      LOG.error("Failed to remove OM {} from Ratis group {}. Ratis " +
+              "SetConfiguration reply: {}", removeNodeId, raftGroupId,
+          raftClientReply);
+      throw new IOException("Failed to remove OM " + removeNodeId + " from " +
+          "Ratis ring.");
+    }
+  }
+
+  /**
    * Return a list of peer NodeIds.
    */
   public List<String> getPeerIds() {
     List<String> peerIds = new ArrayList<>();
-    for (RaftPeer raftPeer : raftPeers) {
-      peerIds.add(raftPeer.getId().toString());
-    }
+    peerIds.addAll(raftPeerMap.keySet());
     return peerIds;
   }
 
@@ -348,12 +383,7 @@ public final class OzoneManagerRatisServer {
    */
   @VisibleForTesting
   public boolean doesPeerExist(String peerId) {
-    for (RaftPeer raftPeer : raftPeers) {
-      if (raftPeer.getId().toString().equals(peerId)) {
-        return true;
-      }
-    }
-    return false;
+    return raftPeerMap.containsKey(peerId);
   }
 
   /**
@@ -363,12 +393,24 @@ public final class OzoneManagerRatisServer {
     InetSocketAddress newOMRatisAddr = new InetSocketAddress(
         omNodeDetails.getHostAddress(), omNodeDetails.getRatisPort());
 
-    raftPeers.add(RaftPeer.newBuilder()
-        .setId(RaftPeerId.valueOf(omNodeDetails.getNodeId()))
+    String newNodeId = omNodeDetails.getNodeId();
+    RaftPeerId raftPeerId = RaftPeerId.valueOf(newNodeId);
+    RaftPeer raftPeer = RaftPeer.newBuilder()
+        .setId(raftPeerId)
         .setAddress(newOMRatisAddr)
-        .build());
+        .build();
+    raftPeerMap.put(newNodeId, raftPeer);
 
-    LOG.info("Added OM {} to Ratis Peers list.", omNodeDetails.getNodeId());
+    LOG.info("Added OM {} to Ratis Peers list.", newNodeId);
+  }
+
+  /**
+   * Remove given node from list of RaftPeers.
+   */
+  public void removeRaftPeer(OMNodeDetails omNodeDetails) {
+    String removeNodeID = omNodeDetails.getNodeId();
+    raftPeerMap.remove(removeNodeID);
+    LOG.info("Removed OM {} from Ratis Peers list.", removeNodeID);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/snapshot/OzoneManagerSnapshotProvider.java
@@ -163,4 +163,11 @@ public class OzoneManagerSnapshotProvider {
   public void addNewPeerNode(OMNodeDetails newOMNode) {
     peerNodesMap.put(newOMNode.getNodeId(), newOMNode);
   }
+
+  /**
+   * When an OM is decommissioned, remove it from the peerNode map.
+   */
+  public void removeDecommissionedPeerNode(String decommNodeId) {
+    peerNodesMap.remove(decommNodeId);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
@@ -18,11 +18,16 @@ package org.apache.hadoop.ozone.protocolPB;
 
 import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolPB;
+import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
+import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.DecommissionOMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.DecommissionOMResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMConfigurationRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMConfigurationResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerAdminProtocolProtos.OMNodeInfo;
@@ -62,5 +67,51 @@ public class OMAdminProtocolServerSideImpl implements OMAdminProtocolPB {
         .addAllNodesInMemory(omNodesInMemory)
         .addAllNodesInNewConf(omNodesInNewConf)
         .build();
+  }
+
+  @Override
+  public DecommissionOMResponse decommission(RpcController controller,
+      DecommissionOMRequest request) throws ServiceException {
+    
+    if (request == null) {
+      return null;
+    }
+    if (!ozoneManager.isRatisEnabled()) {
+      return DecommissionOMResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMsg("OM node cannot be decommissioned as Ratis is " +
+              "not enabled.")
+          .build();
+    }
+
+    OzoneManagerRatisServer omRatisServer = ozoneManager.getOmRatisServer();
+    checkLeaderStatus(omRatisServer);
+
+    OMNodeDetails decommNode = ozoneManager.getPeerNode(request.getNodeId());
+    if (decommNode == null) {
+      return DecommissionOMResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMsg("OM node not present in the OM peer list.")
+          .build();
+    }
+
+    try {
+      omRatisServer.removeOMFromRatisRing(decommNode);
+    } catch (IOException ex) {
+      return DecommissionOMResponse.newBuilder()
+          .setSuccess(false)
+          .setErrorMsg(ex.getMessage())
+          .build();
+    }
+
+    return DecommissionOMResponse.newBuilder()
+        .setSuccess(true)
+        .build();
+  }
+
+  private void checkLeaderStatus(OzoneManagerRatisServer omRatisServer)
+      throws ServiceException {
+    OzoneManagerRatisUtils.checkLeaderStatus(omRatisServer.checkLeaderStatus(),
+        omRatisServer.getRaftPeerId());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OMAdminProtocolServerSideImpl.java
@@ -72,7 +72,6 @@ public class OMAdminProtocolServerSideImpl implements OMAdminProtocolPB {
   @Override
   public DecommissionOMResponse decommission(RpcController controller,
       DecommissionOMRequest request) throws ServiceException {
-    
     if (request == null) {
       return null;
     }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -59,7 +59,8 @@ public class OzoneServiceProvider {
             "configured. " + Arrays.toString(serviceIdList.toArray()));
       } else {
         String serviceId = serviceIdList.iterator().next();
-        Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, serviceId);
+        Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf,
+            serviceId);
         if (omNodeIds.size() == 0) {
           throw new IllegalArgumentException(OZONE_OM_NODES_KEY
               + "." + serviceId + " is not defined");

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneServiceProvider.java
@@ -59,7 +59,7 @@ public class OzoneServiceProvider {
             "configured. " + Arrays.toString(serviceIdList.toArray()));
       } else {
         String serviceId = serviceIdList.iterator().next();
-        Collection<String> omNodeIds = OmUtils.getOMNodeIds(conf, serviceId);
+        Collection<String> omNodeIds = OmUtils.getActiveOMNodeIds(conf, serviceId);
         if (omNodeIds.size() == 0) {
           throw new IllegalArgumentException(OZONE_OM_NODES_KEY
               + "." + serviceId + " is not defined");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.admin.om;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.Collection;
+import java.util.List;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.ha.ConfUtils;
+import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
+import org.apache.hadoop.ozone.om.protocol.OMConfiguration;
+import org.apache.hadoop.ozone.om.protocolPB.OMAdminProtocolClientSideImpl;
+import org.apache.hadoop.security.UserGroupInformation;
+import picocli.CommandLine;
+
+import java.util.concurrent.Callable;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DECOMMISSIONED_NODES_KEY;
+
+/**
+ * Handler of om roles command.
+ */
+@CommandLine.Command(
+    name = "decommission",
+    customSynopsis = "ozone admin om decommission -id=<om-service-id> " +
+        "-nodeid=<decommission-om-node-id> " +
+        "-hostname=<decommission-om-node-address> [options]",
+    description = "Decommission an OzoneManager." +
+        "\nNote - Add the node to be decommissioned to " +
+        OZONE_OM_DECOMMISSIONED_NODES_KEY + "config in ozone-site.xml of all " +
+        "OzoneManagers before proceeding with decommission." +
+        "\nNOTE THAT DECOMMISSIONING AN OM MIGHT RENDER THE CLUSTER TO LOSE " +
+        "HIGH AVAILABILITY",
+    mixinStandardHelpOptions = true,
+    versionProvider = HddsVersionProvider.class)
+public class DecommissionOMSubcommand implements Callable<Void> {
+
+  @CommandLine.ParentCommand
+  private OMAdmin parent;
+
+  @CommandLine.Option(names = {"-id", "--service-id"},
+      description = "OM Service ID",
+      required = true)
+  private String omServiceId;
+
+  @CommandLine.Option(names = {"-nodeid"},
+      description = "NodeID of the OM to be decommissioned.",
+      required = true)
+  private String decommNodeId;
+
+  @CommandLine.Option(names = {"-hostname", "--node-host-address"},
+      description = "Host name/address of the OM to be decommissioned.",
+      required = true)
+  private String hostname;
+
+  private InetAddress hostInetAddress;
+
+  @CommandLine.Option(
+      names = {"--force"},
+      description = "This option will skip checking whether OM configs " +
+          "have been updated with the decommissioned node added to " +
+          "ozone.om.decommissioned.nodes config in ozone-site.xml."
+  )
+  private boolean force;
+
+  private OzoneConfiguration ozoneConf;
+  private UserGroupInformation user;
+
+  @Override
+  public Void call() throws IOException {
+    ozoneConf = parent.getParent().getOzoneConf();
+    user = parent.getParent().getUser();
+
+    verifyNodeIdAndHostAddress();
+    if (!force) {
+      verifyConfigUpdatedOnAllOMs();
+    }
+
+    // Proceed with decommissioning the OM by contacting the current OM
+    // leader.
+    try (OMAdminProtocolClientSideImpl omAdminProtocolClient =
+             OMAdminProtocolClientSideImpl.createProxyForOMHA(ozoneConf, user,
+                 omServiceId)) {
+      OMNodeDetails decommNodeDetails = new OMNodeDetails.Builder()
+          .setOMNodeId(decommNodeId)
+          .setHostAddress(hostInetAddress.getHostAddress())
+          .build();
+      omAdminProtocolClient.decommission(decommNodeDetails);
+
+      System.out.println("Successfully decommissioned OM " + decommNodeId);
+    } catch (IOException e) {
+      System.out.println("Failed to decommission OM " + decommNodeId);
+      throw e;
+    }
+    return null;
+  }
+
+  /**
+   * Verify that the provided nodeId and host address correspond to the same
+   * OM in the configs.
+   */
+  private void verifyNodeIdAndHostAddress() throws IOException {
+    String rpcAddrKey = ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY,
+        omServiceId, decommNodeId);
+    String rpcAddrStr = OmUtils.getOmRpcAddress(ozoneConf, rpcAddrKey);
+    if (rpcAddrStr == null || rpcAddrStr.isEmpty()) {
+      throw new IOException("There is no OM corresponding to " + decommNodeId
+          + "in the configuration.");
+    }
+
+    hostInetAddress = InetAddress.getByName(hostname);
+    InetAddress rpcAddressFromConfig = InetAddress.getByName(
+        rpcAddrStr.split(":")[0]);
+
+    if (!hostInetAddress.equals(rpcAddressFromConfig.getAddress())) {
+      throw new IOException("OM " + decommNodeId + "'s host address in " +
+          "config - " + rpcAddressFromConfig.getAddress() + " does not match " +
+          "the provided host address " + hostInetAddress);
+    }
+  }
+
+  /**
+   * Verify that the to be decommissioned node is added to the
+   * OZONE_OM_DECOMMISSIONED_NODES_KEY.<SERVICE_ID> config in ozone-site.xml
+   * of all OMs.
+   */
+  private void verifyConfigUpdatedOnAllOMs() throws IOException {
+    String decommNodesKey = ConfUtils.addKeySuffixes(
+        OZONE_OM_DECOMMISSIONED_NODES_KEY, omServiceId);
+    Collection<String> decommNodes = ozoneConf.getTrimmedStringCollection(
+        decommNodesKey);
+    if (!decommNodes.contains(decommNodeId)) {
+      throw new IOException("Please add the to be decommissioned OM "
+          + decommNodeId + " to the " + decommNodesKey + " config in " +
+          "ozone-site.xml of all nodes.");
+    }
+
+    // For each OM, we need to get the reloaded config and check that the
+    // decommissioned node is either removed from ozone.om.nodes config or
+    // added to ozone.om.decommissioned.nodes
+    List<OMNodeDetails> activeOMNodeDetails = OmUtils.getAllOMHAAddresses(
+        ozoneConf, omServiceId, false);
+    for (OMNodeDetails nodeDetails : activeOMNodeDetails) {
+      verifyOMConfigUpdate(nodeDetails);
+    }
+  }
+
+  /**
+   * Verify that the to be decommissioned node is added to the
+   * OZONE_OM_DECOMMISSIONED_NODES_KEY.<SERVICE_ID> config in ozone-site.xml
+   * of given OM.
+   */
+  private void verifyOMConfigUpdate(OMNodeDetails omNodeDetails)
+      throws IOException {
+    try (OMAdminProtocolClientSideImpl omAdminProtocolClient =
+             OMAdminProtocolClientSideImpl.createProxyForSingleOM(ozoneConf,
+                 user, omNodeDetails)) {
+      OMConfiguration omConfig = omAdminProtocolClient.getOMConfiguration();
+      OMNodeDetails decommNodeDetails = omConfig
+          .getDecommissionedNodesInNewConf().get(decommNodeId);
+      if (decommNodeDetails == null) {
+        throw new IOException("OM " + omNodeDetails.getNodeId() + "'s " +
+            "reloaded config does not have OM " + decommNodeId + " in the " +
+            "decommissioned nodes list.");
+      }
+      if (!decommNodeDetails.getRpcAddress().getAddress().equals(
+          hostInetAddress)) {
+        throw new IOException("OM " + omNodeDetails.getNodeId() + "'s " +
+            "reloaded config has decommissioning OM " + decommNodeId + "'s " +
+            "address as " + decommNodeDetails.getRpcAddress().getAddress() +
+            " whereas provided host address is " + hostInetAddress);
+      }
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/DecommissionOMSubcommand.java
@@ -47,12 +47,18 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DECOMMISSIONED_NO
     customSynopsis = "ozone admin om decommission -id=<om-service-id> " +
         "-nodeid=<decommission-om-node-id> " +
         "-hostname=<decommission-om-node-address> [options]",
-    description = "Decommission an OzoneManager." +
+    description = "Decommission an OzoneManager. Ensure that the node being " +
+        "decommissioned is shutdown first." +
         "\nNote - Add the node to be decommissioned to " +
         OZONE_OM_DECOMMISSIONED_NODES_KEY + "config in ozone-site.xml of all " +
         "OzoneManagers before proceeding with decommission." +
-        "\nNOTE THAT DECOMMISSIONING AN OM MIGHT RENDER THE CLUSTER TO LOSE " +
-        "HIGH AVAILABILITY",
+        "\nNote - DECOMMISSIONING AN OM MIGHT RENDER THE CLUSTER TO LOSE " +
+        "HIGH AVAILABILITY." +
+        "\nNote - When there are only two OzoneManagers, do not stop the " +
+        "OzoneManager before decommissioning as both OzoneManagers are " +
+        "required to reach quorum." + "\n" +
+        "It is recommended to add another OzoneManager(s) before " +
+        "decommissioning one to maintain HA.",
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)
 public class DecommissionOMSubcommand implements Callable<Void> {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolPB;
-import org.apache.hadoop.security.UserGroupInformation;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_SERVICE_IDS_KEY;
@@ -57,7 +56,8 @@ import java.util.Collection;
         GetServiceRolesSubcommand.class,
         PrepareSubCommand.class,
         CancelPrepareSubCommand.class,
-        FinalizationStatusSubCommand.class
+        FinalizationStatusSubCommand.class,
+        DecommissionOMSubcommand.class
     })
 @MetaInfServices(SubcommandWithParent.class)
 public class OMAdmin extends GenericCli implements SubcommandWithParent {
@@ -110,13 +110,12 @@ public class OMAdmin extends GenericCli implements SubcommandWithParent {
     } else if (omServiceID == null || omServiceID.isEmpty()) {
       omServiceID = getTheOnlyConfiguredOmServiceIdOrThrow();
     }
-    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
     RPC.setProtocolEngine(conf, OzoneManagerProtocolPB.class,
         ProtobufRpcEngine.class);
     String clientId = ClientId.randomId().toString();
     if (!forceHA || (forceHA && OmUtils.isOmHAServiceId(conf, omServiceID))) {
       OmTransport omTransport = new Hadoop3OmTransportFactory()
-          .createOmTransport(conf, ugi, omServiceID);
+          .createOmTransport(conf, parent.getUser(), omServiceID);
       return new OzoneManagerProtocolClientSideTranslatorPB(omTransport,
           clientId);
     } else {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds support to remove an OM node from an HA cluster.

To remove an OM, we need to follow the below steps:
1. Update ozone-site.xml of each OM node by adding the to be decommissioned nodeId to the config `ozone.om.decommissioned.nodes.<om-service-id>`.
2. Run the following command:
`ozone admin om decommission -id=<om-service-id> -nodeid=<decommissioned-node-id> -hostname=<decommissioned-node-hostname [(optional) force]`

The DecommssionOM subcommand will verify that all the existing OMs configs have been updated with the decommissioned node. If the verification is successful, it will send a decommission request via OMAdmin protocol to the leader OM. The Leader OM will submit a SetConfiguration request to Ratis to remove the decommissioned peer from Raft conf and OM state.

If the force option is used in the decommission command,  the check that all OMs have the updated config will be bypassed and the decommission request will be sent to the OM leader.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5490

## How was this patch tested?

Will update unit tests
