### PR TITLE
HDDS-5385. [FSO] Remove ozone.om.metadata.layout config in OM

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2786,18 +2786,6 @@
   </property>
 
   <property>
-    <name>ozone.om.metadata.layout</name>
-    <tag>OZONE, OM</tag>
-    <value>SIMPLE</value>
-    <description>
-      This property is used to define the metadata layout of file system
-      paths. If it is configured as PREFIX in combination with
-      ozone.om.enable.filesystem.paths to true then this allows to perform
-      atomic rename and delete of any directory at any level in the namespace.
-      Defaulting to SIMPLE. Supported values: SIMPLE and PREFIX.
-    </description>
-  </property>
-  <property>
     <name>ozone.directory.deleting.service.interval</name>
     <value>1m</value>
     <tag>OZONE, PERFORMANCE, OM</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -263,12 +263,6 @@ public final class OMConfigKeys {
 //  atomic rename and delete of any directory at any level in the namespace.
 //  Defaulting to SIMPLE. Supported values: SIMPLE and PREFIX.
 
-  public static final String OZONE_OM_METADATA_LAYOUT =
-          "ozone.om.metadata.layout";
-  public static final String OZONE_OM_METADATA_LAYOUT_DEFAULT = "SIMPLE";
-
-  public static final String OZONE_OM_METADATA_LAYOUT_PREFIX = "PREFIX";
-
   // Default bucket layout used by Ozone Manager during bucket creation
   // when a client does not specify the bucket layout option.
   public static final String OZONE_DEFAULT_BUCKET_LAYOUT =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/OzoneContract.java
@@ -89,8 +89,6 @@ class OzoneContract extends AbstractFSContract {
     if (fsOptimizedServer){
       conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
           true);
-      conf.set(OMConfigKeys.OZONE_OM_METADATA_LAYOUT,
-          OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
     }
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         BucketLayout.LEGACY.name());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStandardOutputUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStandardOutputUtil.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Utility class to check standard output.
+ */
+public class TestStandardOutputUtil {
+  private final ByteArrayOutputStream outContent =
+      new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent =
+      new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+
+  /**
+   * Set up fresh output and error streams before test.
+   *
+   * @throws UnsupportedEncodingException
+   */
+  @Before
+  public void setUpStreams() throws UnsupportedEncodingException {
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+  }
+
+  /**
+   * Restore original error and output streams after test.
+   */
+  @After
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  public String getOutContentString()
+      throws UnsupportedEncodingException {
+    return getOutContentString(DEFAULT_ENCODING);
+  }
+
+  public String getErrContentString()
+      throws UnsupportedEncodingException {
+    return getErrContentString(DEFAULT_ENCODING);
+  }
+
+  public String getOutContentString(String encoding)
+      throws UnsupportedEncodingException {
+    return outContent.toString(encoding);
+  }
+
+  public String getErrContentString(String encoding)
+      throws UnsupportedEncodingException {
+    return errContent.toString(encoding);
+  }
+
+  public String getDefaultEncoding() {
+    return DEFAULT_ENCODING;
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -34,7 +34,6 @@ import org.apache.hadoop.ozone.client.OzoneMultipartUploadPartListParts;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientMultipartUploadWithFSO.java
@@ -108,8 +108,7 @@ public class TestOzoneClientMultipartUploadWithFSO {
   @BeforeClass
   public static void init() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf,
-            true, OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    TestOMRequestUtils.configureFSOptimizedPaths(conf, true);
     startCluster(conf);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
@@ -103,8 +104,8 @@ public class TestReadRetries {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
-            new Object[]{OMConfigKeys.OZONE_OM_METADATA_LAYOUT_DEFAULT },
-            new Object[]{OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX });
+            new Object[]{OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT},
+            new Object[]{OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED});
   }
 
   /**
@@ -116,7 +117,7 @@ public class TestReadRetries {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
     TestOMRequestUtils.configureFSOptimizedPaths(conf,
-            true, layoutVersion);
+            true, BucketLayout.fromString(layoutVersion));
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .setScmId(SCM_ID)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -104,8 +104,9 @@ public class TestReadRetries {
   @Parameterized.Parameters
   public static Collection<Object[]> data() {
     return Arrays.asList(
-            new Object[]{OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT},
-            new Object[]{OMConfigKeys.OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED});
+        new Object[]{OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT},
+        new Object[]{OMConfigKeys.
+              OZONE_BUCKET_LAYOUT_FILE_SYSTEM_OPTIMIZED});
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestReadRetries.java
@@ -95,10 +95,10 @@ public class TestReadRetries {
       storageContainerLocationClient;
 
   private static final String SCM_ID = UUID.randomUUID().toString();
-  private String layoutVersion;
+  private String bucketLayout;
 
-  public TestReadRetries(String layoutVersion) {
-    this.layoutVersion = layoutVersion;
+  public TestReadRetries(String bucketLayout) {
+    this.bucketLayout = bucketLayout;
   }
 
   @Parameterized.Parameters
@@ -118,7 +118,7 @@ public class TestReadRetries {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
     TestOMRequestUtils.configureFSOptimizedPaths(conf,
-            true, BucketLayout.fromString(layoutVersion));
+            true, BucketLayout.fromString(bucketLayout));
     cluster = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(3)
         .setScmId(SCM_ID)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGeneratorWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGeneratorWithFSO.java
@@ -28,8 +28,7 @@ public class TestHadoopDirTreeGeneratorWithFSO
 
   protected OzoneConfiguration getOzoneConfiguration() {
     OzoneConfiguration conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf,
-            true, OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    TestOMRequestUtils.configureFSOptimizedPaths(conf, true);
     return conf;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGeneratorWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestHadoopDirTreeGeneratorWithFSO.java
@@ -17,7 +17,6 @@
 package org.apache.hadoop.ozone.freon;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 
 /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -255,8 +255,7 @@ public class TestRecursiveAclWithFSO {
     // Note: OM doesn't support live config reloading
     conf.setBoolean(OZONE_ACL_ENABLED, true);
 
-    TestOMRequestUtils.configureFSOptimizedPaths(conf, true,
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    TestOMRequestUtils.configureFSOptimizedPaths(conf, true);
 
     cluster =
         MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.shell;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -41,8 +41,7 @@ public class TestNSSummaryAdmin {
   @BeforeClass
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
-    TestOMRequestUtils.configureFSOptimizedPaths(conf, true,
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    TestOMRequestUtils.configureFSOptimizedPaths(conf, true);
     conf.set(OZONE_RECON_ADDRESS_KEY, "localhost:9888");
     cluster = MiniOzoneCluster.newBuilder(conf)
         .withoutDatanodes().includeRecon(true).build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -21,21 +21,35 @@ package org.apache.hadoop.ozone.shell;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestStandardOutputUtil;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Assert;
+
+import java.io.UnsupportedEncodingException;
+import java.util.UUID;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
 
 /**
  * Test for Namespace CLI.
  */
-public class TestNSSummaryAdmin {
+public class TestNSSummaryAdmin extends TestStandardOutputUtil {
+  private static ObjectStore store;
 
   private static OzoneAdmin ozoneAdmin;
   private static OzoneConfiguration conf;
   private static MiniOzoneCluster cluster;
+
+  private static String volumeName;
+  private static String bucketOBS;
+  private static String bucketFSO;
 
   @BeforeClass
   public static void init() throws Exception {
@@ -45,8 +59,15 @@ public class TestNSSummaryAdmin {
     cluster = MiniOzoneCluster.newBuilder(conf)
         .withoutDatanodes().includeRecon(true).build();
     cluster.waitForClusterToBeReady();
+    store = cluster.getClient().getObjectStore();
+
     // Client uses server conf for this test
     ozoneAdmin = new OzoneAdmin(conf);
+
+    volumeName = UUID.randomUUID().toString();
+    bucketOBS = UUID.randomUUID().toString();
+    bucketFSO = UUID.randomUUID().toString();
+    createVolumeAndBuckets();
   }
 
   @AfterClass
@@ -56,13 +77,94 @@ public class TestNSSummaryAdmin {
     }
   }
 
+  /**
+   * Create OBS and FSO buckets for the tests.
+   * @throws Exception
+   */
+  private static void createVolumeAndBuckets()
+      throws Exception {
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+
+    // Create OBS bucket.
+    BucketArgs bucketArgsOBS = BucketArgs.newBuilder()
+        .setBucketLayout(BucketLayout.OBJECT_STORE)
+        .build();
+    volume.createBucket(bucketOBS, bucketArgsOBS);
+
+    // Create FSO bucket.
+    BucketArgs bucketArgsFSO = BucketArgs.newBuilder()
+        .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED)
+        .build();
+    volume.createBucket(bucketFSO, bucketArgsFSO);
+  }
+
+  /**
+   * Test NSSummaryCLI on root path.
+   */
   @Test(timeout = 60000)
-  public void testNSSummaryCLI() {
-    String[] summaryArgs = {"namespace", "summary", "/"};
-    String[] duArgs = {"namespace", "du", "/"};
-    String[] duArgsWithOps = {"namespace", "du", "-rfn", "--length=100", "/"};
-    String[] quotaArgs = {"namespace", "quota", "/"};
-    String[] distArgs = {"namespace", "dist", "/"};
+  public void testNSSummaryCLIRoot() throws UnsupportedEncodingException {
+    // Running on root path.
+    String path = "/";
+    executeAdminCommands(path);
+    // Should throw warning - only buckets can have bucket layout.
+    Assert.assertTrue(
+        getOutContentString().contains(
+            "[Warning] Namespace CLI is only designed for FSO mode."));
+    Assert.assertTrue(getOutContentString()
+        .contains("Put more files into it to visualize DU"));
+    Assert.assertTrue(getOutContentString().contains(
+        "Put more files into it to visualize file size distribution"));
+  }
+
+  /**
+   * Test NSSummaryCLI on FILE_SYSTEM_OPTIMIZED bucket.
+   */
+  @Test(timeout = 60000)
+  public void testNSSummaryCLIFSO() throws UnsupportedEncodingException {
+    // Running on FSO Bucket.
+    String path = "/" + volumeName + "/" + bucketFSO;
+    executeAdminCommands(path);
+    // Should not throw warning, since bucket is in FSO bucket layout.
+    Assert.assertFalse(
+        getOutContentString().contains(
+            "[Warning] Namespace CLI is only designed for FSO mode."));
+    Assert.assertTrue(getOutContentString()
+        .contains("Put more files into it to visualize DU"));
+    Assert.assertTrue(getOutContentString().contains(
+        "Put more files into it to visualize file size distribution"));
+  }
+
+  /**
+   * Test NSSummaryCLI on OBJECT_STORE bucket.
+   */
+  @Test(timeout = 60000)
+  public void testNSSummaryCLIOBS() throws UnsupportedEncodingException {
+    // Running on OBS Bucket.
+    String path = "/" + volumeName + "/" + bucketOBS;
+    executeAdminCommands(path);
+    // Should throw warning, since bucket is in OBS bucket layout.
+    Assert.assertTrue(
+        getOutContentString().contains(
+            "[Warning] Namespace CLI is only designed for FSO mode."));
+    Assert.assertTrue(getOutContentString()
+        .contains("Put more files into it to visualize DU"));
+    Assert.assertTrue(getOutContentString().contains(
+        "Put more files into it to visualize file size distribution"));
+  }
+
+  /**
+   * Execute ozoneAdmin commands on given path.
+   *
+   * @param path
+   */
+  private void executeAdminCommands(String path) {
+    String[] summaryArgs = {"namespace", "summary", path};
+    String[] duArgs = {"namespace", "du", path};
+    String[] duArgsWithOps =
+        {"namespace", "du", "-rfn", "--length=100", path};
+    String[] quotaArgs = {"namespace", "quota", path};
+    String[] distArgs = {"namespace", "dist", path};
 
     ozoneAdmin.execute(summaryArgs);
     ozoneAdmin.execute(duArgs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -229,9 +229,6 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HANDLER_COUNT_KEY
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_KEYTAB_FILE_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_KERBEROS_PRINCIPAL_KEY;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METADATA_LAYOUT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METADATA_LAYOUT_DEFAULT;
-import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_METRICS_SAVE_INTERVAL_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_USER_MAX_VOLUME;
@@ -1352,8 +1349,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Start service.
    */
   public void start() throws IOException {
-    initFSOLayout();
-
     if (omState == State.BOOTSTRAPPING) {
       if (isBootstrapping) {
         // Check that all OM configs have been updated with the new OM info.
@@ -1451,7 +1446,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Restarts the service. This method re-initializes the rpc server.
    */
   public void restart() throws IOException {
-    initFSOLayout();
     setInstanceVariablesFromConf();
 
     LOG.info(buildRpcServerStartMessage("OzoneManager RPC server",
@@ -3607,11 +3601,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OZONE_OM_ENABLE_FILESYSTEM_PATHS_DEFAULT);
   }
 
-  public String getOMMetadataLayout() {
-    return configuration
-        .getTrimmed(OZONE_OM_METADATA_LAYOUT, OZONE_OM_METADATA_LAYOUT_DEFAULT);
-  }
-
   public String getOMDefaultBucketLayout() {
     return this.defaultBucketLayout;
   }
@@ -3834,19 +3823,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throws IOException {
     omMetadataManager.getMetaTable().put(LAYOUT_VERSION_KEY,
         String.valueOf(lvm.getMetadataLayoutVersion()));
-  }
-
-  private void initFSOLayout() {
-    // TODO: Temporary workaround for OM upgrade path and will be replaced once
-    //  upgrade HDDS-3698 story reaches consensus. Instead of cluster level
-    //  configuration, OM needs to check this property on every bucket level.
-    String metaLayout = getOMMetadataLayout();
-    boolean omMetadataLayoutPrefix = StringUtils.equalsIgnoreCase(metaLayout,
-        OZONE_OM_METADATA_LAYOUT_PREFIX);
-
-    String status = omMetadataLayoutPrefix ? "enabled" : "disabled";
-    LOG.info("Configured {}={} and {} optimized OM FS operations",
-        OZONE_OM_METADATA_LAYOUT, metaLayout, status);
   }
 
   private BucketLayout getBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -139,7 +139,6 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     OMResponse.Builder omResponse = OmResponseUtil.getOMResponseBuilder(
         getOmRequest());
-    String omLayout = ozoneManager.getOMMetadataLayout();
     OmBucketInfo omBucketInfo = null;
     if (bucketInfo.getBucketLayout() == null || bucketInfo.getBucketLayout()
         .equals(BucketLayoutProto.LEGACY)) {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -551,9 +551,6 @@ public final class TestOMRequestUtils {
     metadataList.add(HddsProtos.KeyValue.newBuilder().setKey("key2").setValue(
             "value2").build());
     metadataList.add(HddsProtos.KeyValue.newBuilder().setKey(
-            OMConfigKeys.OZONE_OM_METADATA_LAYOUT).setValue(
-            OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX).build());
-    metadataList.add(HddsProtos.KeyValue.newBuilder().setKey(
             OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS).setValue(
             "false").build());
     return metadataList;
@@ -1066,15 +1063,16 @@ public final class TestOMRequestUtils {
   }
 
   public static void configureFSOptimizedPaths(Configuration conf,
-      boolean enableFileSystemPaths, String version) {
+                                               boolean enableFileSystemPaths) {
+    configureFSOptimizedPaths(conf, enableFileSystemPaths, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+  }
+
+  public static void configureFSOptimizedPaths(Configuration conf,
+                                               boolean enableFileSystemPaths, BucketLayout bucketLayout) {
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
             enableFileSystemPaths);
-    conf.set(OMConfigKeys.OZONE_OM_METADATA_LAYOUT, version);
-    if (StringUtils.equalsIgnoreCase(
-        OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX, version)) {
-      conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
-          BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
-    }
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+            bucketLayout.name());
   }
 
   private static BucketLayout getDefaultBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/TestOMRequestUtils.java
@@ -1064,11 +1064,13 @@ public final class TestOMRequestUtils {
 
   public static void configureFSOptimizedPaths(Configuration conf,
                                                boolean enableFileSystemPaths) {
-    configureFSOptimizedPaths(conf, enableFileSystemPaths, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    configureFSOptimizedPaths(conf, enableFileSystemPaths,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
   }
 
   public static void configureFSOptimizedPaths(Configuration conf,
-                                               boolean enableFileSystemPaths, BucketLayout bucketLayout) {
+                                               boolean enableFileSystemPaths,
+                                               BucketLayout bucketLayout) {
     conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
             enableFileSystemPaths);
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -79,7 +79,6 @@ public class TestBucketRequest {
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
     Mockito.doNothing().when(auditLogger).logWrite(any(AuditMessage.class));
-    when(ozoneManager.getOMMetadataLayout()).thenReturn(null);
   }
 
   @After

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
@@ -41,8 +41,6 @@ public class TestOMBucketCreateRequestWithFSO
 
   @Test
   public void testValidateAndUpdateCacheWithFSO() throws Exception {
-    when(ozoneManager.getOMMetadataLayout()).thenReturn(
-            OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
     when(ozoneManager.getOMDefaultBucketLayout()).thenReturn(
         BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
     String volumeName = UUID.randomUUID().toString();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequestWithFSO.java
@@ -19,7 +19,6 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
-import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.TestOMRequestUtils;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -90,8 +90,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.set(OMConfigKeys.OZONE_OM_DB_DIRS,
             folder.newFolder().getAbsolutePath());
-    TestOMRequestUtils.configureFSOptimizedPaths(ozoneConfiguration,
-            true, OMConfigKeys.OZONE_OM_METADATA_LAYOUT_PREFIX);
+    TestOMRequestUtils.configureFSOptimizedPaths(ozoneConfiguration, true);
     omMetadataManager = new OmMetadataManagerImpl(ozoneConfiguration);
     when(ozoneManager.getMetrics()).thenReturn(omMetrics);
     when(ozoneManager.getMetadataManager()).thenReturn(omMetadataManager);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -32,7 +32,6 @@ import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getRespo
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -106,10 +105,6 @@ public class DiskUsageSubCommand implements Callable {
     if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (!parent.isFSOEnabled()) {
-        printFSOReminder();
-      }
-
       long totalSize = (long)(double)duResponse.get("size");
 
       if (!noHeader) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -106,7 +106,7 @@ public class DiskUsageSubCommand implements Callable {
     if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (!parent.isFSOEnabled(path)) {
+      if (!parent.isFileSystemOptimizedBucket(path)) {
         printFSOReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/DiskUsageSubCommand.java
@@ -32,6 +32,7 @@ import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getRespo
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
+import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -105,6 +106,10 @@ public class DiskUsageSubCommand implements Callable {
     if (duResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
+      if (!parent.isFSOEnabled(path)) {
+        printFSOReminder();
+      }
+
       long totalSize = (long)(double)duResponse.get("size");
 
       if (!noHeader) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -28,7 +28,6 @@ import java.util.concurrent.Callable;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printSpaces;
@@ -80,10 +79,6 @@ public class FileSizeDistSubCommand implements Callable {
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");
     } else {
-      if (!parent.isFSOEnabled()) {
-        printFSOReminder();
-      }
-
       printWithUnderline("File Size Distribution", true);
       ArrayList fileSizeDist = (ArrayList) distResponse.get("dist");
       double sum = 0;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -80,7 +80,7 @@ public class FileSizeDistSubCommand implements Callable {
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");
     } else {
-      if (!parent.isFSOEnabled(path)) {
+      if (!parent.isFileSystemOptimizedBucket(path)) {
         printFSOReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/FileSizeDistSubCommand.java
@@ -28,6 +28,7 @@ import java.util.concurrent.Callable;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
+import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printSpaces;
@@ -79,6 +80,10 @@ public class FileSizeDistSubCommand implements Callable {
     } else if (distResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("File Size Distribution");
     } else {
+      if (!parent.isFSOEnabled(path)) {
+        printFSOReminder();
+      }
+
       printWithUnderline("File Size Distribution", true);
       ArrayList fileSizeDist = (ArrayList) distResponse.get("dist");
       double sum = 0;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -84,7 +84,7 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
     return OzoneAdmin.class;
   }
 
-  public boolean isFSOEnabled(String path) throws IOException {
+  public boolean isFileSystemOptimizedBucket(String path) throws IOException {
     OFSPath ofsPath = new OFSPath(path);
 
     OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig());
@@ -99,7 +99,7 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
           OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
               new HashSet<>());
 
-      return resolvedBucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+      return resolvedBucketLayout.isFileSystemOptimized();
     } catch (IOException e) {
       System.out.println(
           "Bucket layout couldn't be verified for path: " + ofsPath +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.ozone.admin.nssummary;
 
-import org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl;
-import org.apache.hadoop.fs.ozone.OzoneClientAdapter;
 import org.apache.hadoop.fs.ozone.OzoneClientUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
@@ -32,8 +30,6 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
-import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.ozone.admin.nssummary;
 
+import org.apache.hadoop.fs.ozone.BasicRootedOzoneClientAdapterImpl;
+import org.apache.hadoop.fs.ozone.OzoneClientAdapter;
+import org.apache.hadoop.fs.ozone.OzoneClientUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
@@ -24,8 +27,19 @@ import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.ozone.OFSPath;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.kohsuke.MetaInfServices;
 import picocli.CommandLine;
+
+import java.io.IOException;
+import java.util.HashSet;
 
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_DEFAULT;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
@@ -72,6 +86,30 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
   @Override
   public Class<?> getParentType() {
     return OzoneAdmin.class;
+  }
+
+  public boolean isFSOEnabled(String path) throws IOException {
+    OFSPath ofsPath = new OFSPath(path);
+
+    OzoneClient ozoneClient = OzoneClientFactory.getRpcClient(getOzoneConfig());
+    ObjectStore objectStore = ozoneClient.getObjectStore();
+
+    try {
+      OzoneBucket bucket = objectStore.getVolume(ofsPath.getVolumeName())
+          .getBucket(ofsPath.getBucketName());
+
+      // Resolve the bucket layout in case this is a Link Bucket.
+      BucketLayout resolvedBucketLayout =
+          OzoneClientUtils.resolveLinkBucketLayout(bucket, objectStore,
+              new HashSet<>());
+
+      return resolvedBucketLayout.equals(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    } catch (IOException e) {
+      System.out.println(
+          "Bucket layout couldn't be verified for path: " + ofsPath +
+              ". Exception: " + e);
+      return false;
+    }
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryAdmin.java
@@ -74,12 +74,6 @@ public class NSSummaryAdmin extends GenericCli implements SubcommandWithParent {
     return OzoneAdmin.class;
   }
 
-  public boolean isFSOEnabled() {
-    OzoneConfiguration conf = parent.getOzoneConf();
-    return conf.getBoolean("ozone.om.enable.filesystem.paths", false)
-        && conf.get("ozone.om.metadata.layout").equalsIgnoreCase("PREFIX");
-  }
-
   /**
    * e.g. Input: "0.0.0.0:9891" -> Output: "0.0.0.0"
    */

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -154,9 +154,8 @@ public final class NSSummaryCLIUtils {
 
   public static void printFSOReminder() {
     printNewLines(1);
-    System.out.println("[Warning] FSO is NOT enabled. " +
-        "Namespace CLI is only designed for FSO mode.\n" +
-        "Bucket being accessed must have FILE_SYSTEM_OPTIMIZED bucket layout");
+    System.out.println("[Warning] Namespace CLI is only designed for FSO mode.\n" +
+            "Bucket being accessed must be of type FILE_SYSTEM_OPTIMIZED bucket layout.");
     printNewLines(1);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -154,8 +154,10 @@ public final class NSSummaryCLIUtils {
 
   public static void printFSOReminder() {
     printNewLines(1);
-    System.out.println("[Warning] Namespace CLI is only designed for FSO mode.\n" +
-            "Bucket being accessed must be of type FILE_SYSTEM_OPTIMIZED bucket layout.");
+    System.out.println(
+        "[Warning] Namespace CLI is only designed for FSO mode.\n" +
+            "Bucket being accessed must be of type FILE_SYSTEM_OPTIMIZED" +
+            " bucket layout.");
     printNewLines(1);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -152,15 +152,6 @@ public final class NSSummaryCLIUtils {
     }
   }
 
-  public static void printFSOReminder() {
-    printNewLines(1);
-    System.out.println("[Warning] FSO is NOT enabled. " +
-        "Namespace CLI is only designed for FSO mode.\n" +
-        "To enable FSO set ozone.om.enable.filesystem.paths to true " +
-        "and ozone.om.metadata.layout to PREFIX.");
-    printNewLines(1);
-  }
-
   public static String parseInputPath(String path) {
     if (!path.startsWith("ofs://")) {
       return path;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/NSSummaryCLIUtils.java
@@ -152,6 +152,14 @@ public final class NSSummaryCLIUtils {
     }
   }
 
+  public static void printFSOReminder() {
+    printNewLines(1);
+    System.out.println("[Warning] FSO is NOT enabled. " +
+        "Namespace CLI is only designed for FSO mode.\n" +
+        "Bucket being accessed must have FILE_SYSTEM_OPTIMIZED bucket layout");
+    printNewLines(1);
+  }
+
   public static String parseInputPath(String path) {
     if (!path.startsWith("ofs://")) {
       return path;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -27,7 +27,6 @@ import java.util.concurrent.Callable;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -80,10 +79,6 @@ public class QuotaUsageSubCommand implements Callable {
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");
     } else {
-      if (!parent.isFSOEnabled()) {
-        printFSOReminder();
-      }
-
       printWithUnderline("Quota", true);
       long quotaAllowed = (long)(double)quotaResponse.get("allowed");
       long quotaUsed = (long)(double)quotaResponse.get("used");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -80,7 +80,7 @@ public class QuotaUsageSubCommand implements Callable {
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");
     } else {
-      if (!parent.isFSOEnabled(path)) {
+      if (!parent.isFileSystemOptimizedBucket(path)) {
         printFSOReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/QuotaUsageSubCommand.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getResponseMap;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
+import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -79,6 +80,10 @@ public class QuotaUsageSubCommand implements Callable {
     } else if (quotaResponse.get("status").equals("TYPE_NOT_APPLICABLE")) {
       printTypeNA("Quota");
     } else {
+      if (!parent.isFSOEnabled(path)) {
+        printFSOReminder();
+      }
+
       printWithUnderline("Quota", true);
       long quotaAllowed = (long)(double)quotaResponse.get("allowed");
       long quotaUsed = (long)(double)quotaResponse.get("used");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -27,6 +27,7 @@ import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getRespo
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
+import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -75,6 +76,10 @@ public class SummarySubCommand implements Callable<Void> {
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
+      if (!parent.isFSOEnabled(path)) {
+        printFSOReminder();
+      }
+
       printWithUnderline("Entity Type", false);
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -76,7 +76,7 @@ public class SummarySubCommand implements Callable<Void> {
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (!parent.isFSOEnabled(path)) {
+      if (!parent.isFileSystemOptimizedBucket(path)) {
         printFSOReminder();
       }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/nssummary/SummarySubCommand.java
@@ -27,7 +27,6 @@ import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.getRespo
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.makeHttpCall;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.parseInputPath;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printEmptyPathRequest;
-import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printFSOReminder;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printKVSeparator;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printNewLines;
 import static org.apache.hadoop.ozone.admin.nssummary.NSSummaryCLIUtils.printPathNotFound;
@@ -76,10 +75,6 @@ public class SummarySubCommand implements Callable<Void> {
     if (summaryResponse.get("status").equals("PATH_NOT_FOUND")) {
       printPathNotFound();
     } else {
-      if (!parent.isFSOEnabled()) {
-        printFSOReminder();
-      }
-
       printWithUnderline("Entity Type", false);
       printKVSeparator();
       System.out.println(summaryResponse.get("type"));


### PR DESCRIPTION
## What changes were proposed in this pull request?

This task is to remove the metadata layout config as bucket type will be an argument. Also, will define `ozone.bucket.type.default` to handle a case where the user is not passing any args.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5385

## How was this patch tested?

related integration tests
