### PR TITLE
HDDS-6067. Improve Debugging around unhealthy container state on Datanode.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -299,6 +299,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } finally {
       writeUnlock();
     }
+    LOG.warn("Moving container {} to state UNHEALTHY from state:{}",
+            containerData.getContainerPath(), containerData.getState(),
+            new Exception());
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -68,6 +68,7 @@ import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Res
 import static org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Result.UNSUPPORTED_REQUEST;
 import static org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil.onFailure;
 
+import org.apache.hadoop.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -299,9 +300,9 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } finally {
       writeUnlock();
     }
-    LOG.warn("Moving container {} to state UNHEALTHY from state:{}",
+    LOG.warn("Moving container {} to state UNHEALTHY from state:{} Trace:{}",
             containerData.getContainerPath(), containerData.getState(),
-            new Exception());
+            StringUtils.getStackTrace(Thread.currentThread()));
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently, we do not have enough debugging information on the datanode to debug unhealthy state.
This patch adds a simple debugging logging statement to help debug the issue

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6067

## How was this patch tested?
Existing tests
