### PR TITLE
HDDS-6010. EC: Create ECBlockInputStreamProxy to choose between reconstruction and normal reads

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BadDataLocationException.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+
+import java.io.IOException;
+
+/**
+ * Exception used to indicate a problem with a specific block location, allowing
+ * the failed location to be communicated back to the caller.
+ */
+public class BadDataLocationException extends IOException {
+
+  private DatanodeDetails failedLocation;
+
+  public BadDataLocationException(DatanodeDetails dn) {
+    super();
+    failedLocation = dn;
+  }
+
+  public BadDataLocationException(DatanodeDetails dn, String message) {
+    super(message);
+    failedLocation = dn;
+  }
+
+  public BadDataLocationException(DatanodeDetails dn, String message,
+      Throwable ex) {
+    super(message, ex);
+    failedLocation = dn;
+  }
+
+  public BadDataLocationException(DatanodeDetails dn, Throwable ex) {
+    super(ex);
+    failedLocation = dn;
+  }
+
+  public DatanodeDetails getFailedLocation() {
+    return failedLocation;
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
@@ -36,8 +36,15 @@ import java.util.function.Function;
  */
 public class BlockInputStreamFactoryImpl implements BlockInputStreamFactory {
 
+  private ECBlockInputStreamFactory ecBlockStreamFactory;
+
   public static BlockInputStreamFactory getInstance() {
     return new BlockInputStreamFactoryImpl();
+  }
+
+  public BlockInputStreamFactoryImpl() {
+    this.ecBlockStreamFactory =
+        ECBlockInputStreamFactoryImpl.getInstance(this);
   }
 
   /**
@@ -59,8 +66,9 @@ public class BlockInputStreamFactoryImpl implements BlockInputStreamFactory {
       XceiverClientFactory xceiverFactory,
       Function<BlockID, Pipeline> refreshFunction) {
     if (repConfig.getReplicationType().equals(HddsProtos.ReplicationType.EC)) {
-      return new ECBlockInputStream((ECReplicationConfig)repConfig, blockInfo,
-          verifyChecksum, xceiverFactory, refreshFunction, this);
+      return new ECBlockInputStreamProxy((ECReplicationConfig)repConfig,
+          blockInfo, verifyChecksum, xceiverFactory, refreshFunction,
+          ecBlockStreamFactory);
     } else {
       return new BlockInputStream(blockInfo.getBlockID(), blockInfo.getLength(),
           pipeline, token, verifyChecksum, xceiverFactory, refreshFunction);

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+
+import java.util.function.Function;
+
+/**
+ * Interface used by factories which create ECBlockInput streams for
+ * reconstruction or non-reconstruction reads.
+ */
+public interface ECBlockInputStreamFactory {
+
+  /**
+   * Create a new BlockInputStream based on the replication Config. If the
+   * replication Config indicates the block is EC, then it will create an
+   * ECBlockInputStream, otherwise a BlockInputStream will be returned.
+   * @param missingLocations Indicates if all the data locations are available
+   *                         or not, controlling the type of stream created
+   * @param repConfig The replication Config
+   * @param blockInfo The blockInfo representing the block.
+   * @param verifyChecksum Whether to verify checksums or not.
+   * @param xceiverFactory Factory to create the xceiver in the client
+   * @param refreshFunction Function to refresh the pipeline if needed
+   * @return BlockExtendedInputStream of the correct type.
+   */
+  BlockExtendedInputStream create(boolean missingLocations,
+      ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
+      boolean verifyChecksum, XceiverClientFactory xceiverFactory,
+      Function<BlockID, Pipeline> refreshFunction);
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
@@ -35,11 +35,14 @@ import java.util.function.Function;
 public interface ECBlockInputStreamFactory {
 
   /**
-   * Create a new BlockInputStream based on the replication Config. If the
-   * replication Config indicates the block is EC, then it will create an
-   * ECBlockInputStream, otherwise a BlockInputStream will be returned.
+   * Create a new EC InputStream based on the missingLocations boolean. If it is
+   * set to false, it indicates all locations are available and aa
+   * ECBlockInputStream will be created. Otherwise an
+   * ECBlockReconstructedInputStream will be created.
    * @param missingLocations Indicates if all the data locations are available
    *                         or not, controlling the type of stream created
+   * @param failedLocations List of DatanodeDetails indicating locations we
+   *                        know are bad and should not be used.
    * @param repConfig The replication Config
    * @param blockInfo The blockInfo representing the block.
    * @param verifyChecksum Whether to verify checksums or not.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
@@ -19,11 +19,13 @@ package org.apache.hadoop.ozone.client.io;
 
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -46,7 +48,8 @@ public interface ECBlockInputStreamFactory {
    * @return BlockExtendedInputStream of the correct type.
    */
   BlockExtendedInputStream create(boolean missingLocations,
-      ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
-      boolean verifyChecksum, XceiverClientFactory xceiverFactory,
+      List<DatanodeDetails> failedLocations, ReplicationConfig repConfig,
+      OmKeyLocationInfo blockInfo, boolean verifyChecksum,
+      XceiverClientFactory xceiverFactory,
       Function<BlockID, Pipeline> refreshFunction);
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactory.java
@@ -36,7 +36,7 @@ public interface ECBlockInputStreamFactory {
 
   /**
    * Create a new EC InputStream based on the missingLocations boolean. If it is
-   * set to false, it indicates all locations are available and aa
+   * set to false, it indicates all locations are available and an
    * ECBlockInputStream will be created. Otherwise an
    * ECBlockReconstructedInputStream will be created.
    * @param missingLocations Indicates if all the data locations are available

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
@@ -32,26 +32,29 @@ import java.util.function.Function;
 /**
  * Factory class to create various BlockStream instances.
  */
-public final class ECBlockStreamFactoryImpl implements
+public final class ECBlockInputStreamFactoryImpl implements
     ECBlockInputStreamFactory {
 
   private final BlockInputStreamFactory inputStreamFactory;
 
   public static ECBlockInputStreamFactory getInstance(
       BlockInputStreamFactory streamFactory) {
-    return new ECBlockStreamFactoryImpl(streamFactory);
+    return new ECBlockInputStreamFactoryImpl(streamFactory);
   }
 
-  private ECBlockStreamFactoryImpl(BlockInputStreamFactory streamFactory) {
+  private ECBlockInputStreamFactoryImpl(BlockInputStreamFactory streamFactory) {
     this.inputStreamFactory = streamFactory;
   }
 
   /**
-   * Create a new BlockInputStream based on the replication Config. If the
-   * replication Config indicates the block is EC, then it will create an
-   * ECBlockInputStream, otherwise a BlockInputStream will be returned.
+   * Create a new EC InputStream based on the missingLocations boolean. If it is
+   * set to false, it indicates all locations are available and aa
+   * ECBlockInputStream will be created. Otherwise an
+   * ECBlockReconstructedInputStream will be created.
    * @param missingLocations Indicates if all the data locations are available
    *                         or not, controlling the type of stream created
+   * @param failedLocations List of DatanodeDetails indicating locations we
+   *                        know are bad and should not be used.
    * @param repConfig The replication Config
    * @param blockInfo The blockInfo representing the block.
    * @param verifyChecksum Whether to verify checksums or not.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
@@ -48,7 +48,7 @@ public final class ECBlockInputStreamFactoryImpl implements
 
   /**
    * Create a new EC InputStream based on the missingLocations boolean. If it is
-   * set to false, it indicates all locations are available and aa
+   * set to false, it indicates all locations are available and an
    * ECBlockInputStream will be created. Otherwise an
    * ECBlockReconstructedInputStream will be created.
    * @param missingLocations Indicates if all the data locations are available

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -106,13 +106,12 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
     int expected = expectedDataLocations(repConfig, getLength());
     int available = availableDataLocations(repConfig, blockInfo.getPipeline());
     reconstructionReader = available < expected;
-
   }
 
   private void createBlockReader() {
     blockReader = ecBlockInputStreamFactory.create(reconstructionReader,
-        repConfig, blockInfo, verifyChecksum, xceiverClientFactory,
-        refreshFunction);
+        failedLocations, repConfig, blockInfo, verifyChecksum,
+        xceiverClientFactory, refreshFunction);
   }
 
   @Override
@@ -174,7 +173,6 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
     blockReader.close();
     reconstructionReader = true;
     createBlockReader();
-    // TODO - set the bad location or pass into create block reader
     if (lastPosition != 0) {
       blockReader.seek(lastPosition);
     }
@@ -187,10 +185,6 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   protected synchronized int readWithStrategy(ByteReaderStrategy strategy)
       throws IOException {
     throw new IOException("Not Implemented");
-  }
-
-  private boolean hasRemaining() {
-    return blockReader.getRemaining() > 0;
   }
 
   @Override
@@ -206,5 +200,6 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   @Override
   public void seek(long pos) throws IOException {
     // TODO handle seek - does it need to deal with IOExceptions too?
+    blockReader.seek(pos);
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
+import org.apache.hadoop.hdds.scm.storage.ByteReaderStrategy;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Top level class used to read data from EC Encoded blocks. This class decides,
+ * based on the block availability, whether to use a reconstruction or non
+ * reconstruction read and also handles errors from the non-reconstruction reads
+ * failing over to a reconstruction read when they happen.
+ */
+public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
+
+  private final ECReplicationConfig repConfig;
+  private final boolean verifyChecksum;
+  private final XceiverClientFactory xceiverClientFactory;
+  private final Function<BlockID, Pipeline> refreshFunction;
+  private final OmKeyLocationInfo blockInfo;
+  private final ECBlockInputStreamFactory ecBlockInputStreamFactory;
+
+  private BlockExtendedInputStream blockReader;
+  private boolean reconstructionReader = false;
+  private List<DatanodeDetails> failedLocations = new ArrayList<>();
+
+  /**
+   * Given the ECReplicationConfig and the block length, calculate how many
+   * data locations the block should have.
+   * @param repConfig The EC Replication Config
+   * @param blockLength The length of the data block in bytes
+   * @return The number of expected data locations
+   */
+  public static int expectedDataLocations(ECReplicationConfig repConfig,
+      long blockLength) {
+    return (int)Math.min(
+        Math.ceil((double)blockLength / repConfig.getEcChunkSize()),
+        repConfig.getData());
+  }
+
+  /**
+   * From ECReplicationConfig and Pipeline with the block locations and location
+   * indexes, determine the number of data locations available.
+   * @param repConfig The EC Replication Config
+   * @param pipeline The pipeline for the data block, givings its locations and
+   *                 the index of each location.
+   * @return The number of locations available
+   */
+  public static int availableDataLocations(ECReplicationConfig repConfig,
+      Pipeline pipeline) {
+    Set<Integer> locations = new HashSet<>();
+    for (DatanodeDetails dn : pipeline.getNodes()) {
+      int index = pipeline.getReplicaIndex(dn);
+      if (index > 0 && index <= repConfig.getData()) {
+        locations.add(index);
+      }
+    }
+    return locations.size();
+  }
+
+  public ECBlockInputStreamProxy(ECReplicationConfig repConfig,
+      OmKeyLocationInfo blockInfo, boolean verifyChecksum,
+      XceiverClientFactory xceiverClientFactory, Function<BlockID,
+      Pipeline> refreshFunction, ECBlockInputStreamFactory streamFactory) {
+    this.repConfig = repConfig;
+    this.verifyChecksum = verifyChecksum;
+    this.blockInfo = blockInfo;
+    this.ecBlockInputStreamFactory = streamFactory;
+    this.xceiverClientFactory = xceiverClientFactory;
+    this.refreshFunction = refreshFunction;
+
+    setReaderType();
+    createBlockReader();
+  }
+
+  private void setReaderType() {
+    int expected = expectedDataLocations(repConfig, getLength());
+    int available = availableDataLocations(repConfig, blockInfo.getPipeline());
+    reconstructionReader = available < expected;
+
+  }
+
+  private void createBlockReader() {
+    blockReader = ecBlockInputStreamFactory.create(reconstructionReader,
+        repConfig, blockInfo, verifyChecksum, xceiverClientFactory,
+        refreshFunction);
+  }
+
+  @Override
+  public BlockID getBlockID() {
+    return blockInfo.getBlockID();
+  }
+
+  @Override
+  public long getRemaining() {
+    return blockReader.getRemaining();
+  }
+
+  @Override
+  public long getLength() {
+    return blockInfo.getLength();
+  }
+
+  @Override
+  public synchronized int read(byte[] b, int off, int len)
+      throws IOException {
+    return read(ByteBuffer.wrap(b, off, len));
+  }
+
+  @Override
+  public synchronized int read(ByteBuffer buf) throws IOException {
+    if (blockReader.getRemaining() == 0) {
+      return EOF;
+    }
+    int totalRead = 0;
+    long lastPosition = 0;
+    try {
+      while (buf.hasRemaining() && getRemaining() > 0) {
+        buf.mark();
+        lastPosition = blockReader.getPos();
+        totalRead += blockReader.read(buf);
+      }
+    } catch (IOException e) {
+      if (reconstructionReader) {
+        // If we get an error from the reconstruction reader, there
+        // is nothing left to try. It will re-try until it has insufficient
+        // locations internally, so if an error comes here, just re-throw it.
+        throw e;
+      }
+      if (e instanceof BadDataLocationException) {
+        failoverToReconstructionRead(
+            ((BadDataLocationException) e).getFailedLocation(), lastPosition);
+        buf.reset();
+        totalRead += read(buf);
+      } else {
+        throw e;
+      }
+    }
+    return totalRead;
+  }
+
+  private void failoverToReconstructionRead(DatanodeDetails badLocation,
+      long lastPosition) throws IOException {
+    failedLocations.add(badLocation);
+    blockReader.close();
+    reconstructionReader = true;
+    createBlockReader();
+    // TODO - set the bad location or pass into create block reader
+    if (lastPosition != 0) {
+      blockReader.seek(lastPosition);
+    }
+  }
+
+  /**
+   * Should never be called in this class.
+   */
+  @Override
+  protected synchronized int readWithStrategy(ByteReaderStrategy strategy)
+      throws IOException {
+    throw new IOException("Not Implemented");
+  }
+
+  private boolean hasRemaining() {
+    return blockReader.getRemaining() > 0;
+  }
+
+  @Override
+  public void unbuffer() {
+    blockReader.unbuffer();
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return blockReader != null ? blockReader.getPos() : 0;
+  }
+
+  @Override
+  public void seek(long pos) throws IOException {
+    // TODO handle seek - does it need to deal with IOExceptions too?
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -25,6 +25,8 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.ByteReaderStrategy;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -41,6 +43,9 @@ import java.util.function.Function;
  * failing over to a reconstruction read when they happen.
  */
 public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ECBlockInputStreamProxy.class);
 
   private final ECReplicationConfig repConfig;
   private final boolean verifyChecksum;
@@ -156,6 +161,8 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         throw e;
       }
       if (e instanceof BadDataLocationException) {
+        LOG.warn("Failing over to reconstruction read due to an error in " +
+            "ECBlockReader", e);
         failoverToReconstructionRead(
             ((BadDataLocationException) e).getFailedLocation(), lastPosition);
         buf.reset();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockStreamFactoryImpl.java
@@ -20,11 +20,13 @@ package org.apache.hadoop.ozone.client.io;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
+import java.util.List;
 import java.util.function.Function;
 
 /**
@@ -58,8 +60,9 @@ public final class ECBlockStreamFactoryImpl implements
    * @return BlockExtendedInputStream of the correct type.
    */
   public BlockExtendedInputStream create(boolean missingLocations,
-      ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
-      boolean verifyChecksum, XceiverClientFactory xceiverFactory,
+      List<DatanodeDetails> failedLocations, ReplicationConfig repConfig,
+      OmKeyLocationInfo blockInfo, boolean verifyChecksum,
+      XceiverClientFactory xceiverFactory,
       Function<BlockID, Pipeline> refreshFunction) {
     if (missingLocations) {
       // We create the reconstruction reader
@@ -67,6 +70,9 @@ public final class ECBlockStreamFactoryImpl implements
           new ECBlockReconstructedStripeInputStream(
               (ECReplicationConfig)repConfig, blockInfo, verifyChecksum,
               xceiverFactory, refreshFunction, inputStreamFactory);
+      if (failedLocations != null) {
+        sis.addFailedDatanodes(failedLocations);
+      }
       return new ECBlockReconstructedInputStream(
           (ECReplicationConfig) repConfig, sis);
     } else {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockStreamFactoryImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.io;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+
+import java.util.function.Function;
+
+/**
+ * Factory class to create various BlockStream instances.
+ */
+public final class ECBlockStreamFactoryImpl implements
+    ECBlockInputStreamFactory {
+
+  private final BlockInputStreamFactory inputStreamFactory;
+
+  public static ECBlockInputStreamFactory getInstance(
+      BlockInputStreamFactory streamFactory) {
+    return new ECBlockStreamFactoryImpl(streamFactory);
+  }
+
+  private ECBlockStreamFactoryImpl(BlockInputStreamFactory streamFactory) {
+    this.inputStreamFactory = streamFactory;
+  }
+
+  /**
+   * Create a new BlockInputStream based on the replication Config. If the
+   * replication Config indicates the block is EC, then it will create an
+   * ECBlockInputStream, otherwise a BlockInputStream will be returned.
+   * @param missingLocations Indicates if all the data locations are available
+   *                         or not, controlling the type of stream created
+   * @param repConfig The replication Config
+   * @param blockInfo The blockInfo representing the block.
+   * @param verifyChecksum Whether to verify checksums or not.
+   * @param xceiverFactory Factory to create the xceiver in the client
+   * @param refreshFunction Function to refresh the pipeline if needed
+   * @return BlockExtendedInputStream of the correct type.
+   */
+  public BlockExtendedInputStream create(boolean missingLocations,
+      ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
+      boolean verifyChecksum, XceiverClientFactory xceiverFactory,
+      Function<BlockID, Pipeline> refreshFunction) {
+    if (missingLocations) {
+      // We create the reconstruction reader
+      ECBlockReconstructedStripeInputStream sis =
+          new ECBlockReconstructedStripeInputStream(
+              (ECReplicationConfig)repConfig, blockInfo, verifyChecksum,
+              xceiverFactory, refreshFunction, inputStreamFactory);
+      return new ECBlockReconstructedInputStream(
+          (ECReplicationConfig) repConfig, sis);
+    } else {
+      // Otherwise create the more efficient non-reconstruction reader
+      return new ECBlockInputStream((ECReplicationConfig)repConfig, blockInfo,
+          verifyChecksum, xceiverFactory, refreshFunction, inputStreamFactory);
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -263,6 +263,7 @@ public final class ECStreamTestUtil {
     private long length;
     private boolean shouldError = false;
     private int shouldErrorPosition = 0;
+    private boolean shouldErrorOnSeek = false;
     private IOException errorToThrow = null;
     private int ecReplicaIndex = 0;
     private static final byte EOF = -1;
@@ -282,6 +283,10 @@ public final class ECStreamTestUtil {
 
     public boolean isClosed() {
       return closed;
+    }
+
+    public void setShouldErrorOnSeek(boolean val) {
+      this.shouldErrorOnSeek = val;
     }
 
     public void setShouldError(boolean val) {
@@ -368,7 +373,10 @@ public final class ECStreamTestUtil {
     }
 
     @Override
-    public void seek(long pos) {
+    public void seek(long pos) throws IOException {
+      if (shouldErrorOnSeek) {
+        throw new IOException("Simulated exception");
+      }
       data.position((int)pos);
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -245,7 +245,7 @@ public final class ECStreamTestUtil {
       int repInd = currentPipeline.getReplicaIndex(pipeline.getNodes().get(0));
       TestBlockInputStream stream = new TestBlockInputStream(
           blockInfo.getBlockID(), blockInfo.getLength(),
-          blockStreamData.get(repInd - 1));
+          blockStreamData.get(repInd - 1), repInd);
       blockStreams.add(stream);
       return stream;
     }
@@ -264,12 +264,19 @@ public final class ECStreamTestUtil {
     private boolean shouldError = false;
     private int shouldErrorPosition = 0;
     private IOException errorToThrow = null;
+    private int ecReplicaIndex = 0;
     private static final byte EOF = -1;
 
     TestBlockInputStream(BlockID blockId, long blockLen, ByteBuffer data) {
+      this(blockId, blockLen, data, 0);
+    }
+
+    TestBlockInputStream(BlockID blockId, long blockLen, ByteBuffer data,
+        int replicaIndex) {
       this.blockID = blockId;
       this.length = blockLen;
       this.data = data;
+      this.ecReplicaIndex = replicaIndex;
       data.position(0);
     }
 
@@ -287,6 +294,10 @@ public final class ECStreamTestUtil {
       this.shouldError = val;
       this.shouldErrorPosition = position;
       this.errorToThrow = errorThrowable;
+    }
+
+    public int getEcReplicaIndex() {
+      return ecReplicaIndex;
     }
 
     @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestBlockInputStreamFactoryImpl.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactory;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactoryImpl;
-import org.apache.hadoop.ozone.client.io.ECBlockInputStream;
+import org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.junit.Test;
 import org.junit.Assert;
@@ -73,7 +73,7 @@ public class TestBlockInputStreamFactoryImpl {
     BlockExtendedInputStream stream =
         factory.create(repConfig, blockInfo, blockInfo.getPipeline(),
             blockInfo.getToken(), true, null, null);
-    Assert.assertTrue(stream instanceof ECBlockInputStream);
+    Assert.assertTrue(stream instanceof ECBlockInputStreamProxy);
     Assert.assertEquals(stream.getBlockID(), blockInfo.getBlockID());
     Assert.assertEquals(stream.getLength(), blockInfo.getLength());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
@@ -1,0 +1,283 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.client.rpc.read;
+
+import org.apache.hadoop.hdds.client.BlockID;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.XceiverClientFactory;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
+import org.apache.hadoop.ozone.client.io.BadDataLocationException;
+import org.apache.hadoop.ozone.client.io.ECBlockInputStreamFactory;
+import org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy;
+import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.SplittableRandom;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Function;
+
+/**
+ * Unit tests for the  ECBlockInputStreamProxy class.
+ */
+public class TestECBlockInputStreamProxy {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestECBlockInputStreamProxy.class);
+
+  private static final int ONEMB = 1024 * 1024;
+  private ECReplicationConfig repConfig;
+  private TestECBlockInputStreamFactory streamFactory;
+
+  private long randomSeed;
+  private ThreadLocalRandom random = ThreadLocalRandom.current();
+  private SplittableRandom dataGenerator;
+
+  @Before
+  public void setup() {
+    repConfig = new ECReplicationConfig(3, 2);
+    streamFactory = new TestECBlockInputStreamFactory();
+    randomSeed = random.nextLong();
+    dataGenerator = new SplittableRandom(randomSeed);
+  }
+
+  @Test
+  public void testExpectedDataLocations() {
+    Assert.assertEquals(1,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 1));
+    Assert.assertEquals(2,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, ONEMB + 1));
+    Assert.assertEquals(3,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 3 * ONEMB));
+    Assert.assertEquals(3,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 10 * ONEMB));
+
+    repConfig = new ECReplicationConfig(6, 3);
+    Assert.assertEquals(1,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 1));
+    Assert.assertEquals(2,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, ONEMB + 1));
+    Assert.assertEquals(3,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 3 * ONEMB));
+    Assert.assertEquals(6,
+        ECBlockInputStreamProxy.expectedDataLocations(repConfig, 10 * ONEMB));
+  }
+
+  @Test
+  public void testAvailableDataLocations() {
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(1, 2, 4, 5);
+    OmKeyLocationInfo blockInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
+    Assert.assertEquals(2, ECBlockInputStreamProxy.availableDataLocations(
+        repConfig, blockInfo.getPipeline()));
+
+    dnMap = ECStreamTestUtil.createIndexMap(1, 4, 5);
+    blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
+    Assert.assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
+        repConfig, blockInfo.getPipeline()));
+
+    dnMap = ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
+    blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
+    Assert.assertEquals(3, ECBlockInputStreamProxy.availableDataLocations(
+        repConfig, blockInfo.getPipeline()));
+  }
+
+  @Test
+  public void testCorrectStreamCreatedDependingOnDataLocations()
+      throws IOException {
+    int blockLength = 5 * ONEMB;
+    ByteBuffer data = ByteBuffer.allocate(blockLength);
+    ECStreamTestUtil.randomFill(data, dataGenerator);
+    streamFactory.setData(data);
+
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
+    OmKeyLocationInfo blockInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+
+    try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
+      // Not all locations present, so we expect on;y the "missing=true" stream
+      // to be present.
+      Assert.assertTrue(streamFactory.getStreams().containsKey(false));
+      Assert.assertFalse(streamFactory.getStreams().containsKey(true));
+    }
+
+    streamFactory = new TestECBlockInputStreamFactory();
+    streamFactory.setData(data);
+    dnMap = ECStreamTestUtil.createIndexMap(2, 3, 4, 5);
+    blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+
+    try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
+      // Not all locations present, so we expect on;y the "missing=true" stream
+      // to be present.
+      Assert.assertFalse(streamFactory.getStreams().containsKey(false));
+      Assert.assertTrue(streamFactory.getStreams().containsKey(true));
+    }
+  }
+
+  @Test
+  public void testCanReadNonReconstructionToEOF()
+      throws IOException {
+    int blockLength = 5 * ONEMB;
+    ByteBuffer data = ByteBuffer.allocate(blockLength);
+    ECStreamTestUtil.randomFill(data, dataGenerator);
+    streamFactory.setData(data);
+
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
+    OmKeyLocationInfo blockInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+
+    ByteBuffer readBuffer = ByteBuffer.allocate(100);
+    dataGenerator = new SplittableRandom(randomSeed);
+    try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
+      while(true) {
+        int read = bis.read(readBuffer);
+        ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
+        readBuffer.clear();
+        if (read < 100) {
+          break;
+        }
+      }
+      readBuffer.clear();
+      int read = bis.read(readBuffer);
+      Assert.assertEquals(-1, read);
+    }
+  }
+
+  @Test
+  public void testCanReadReconstructionToEOF()
+      throws IOException {
+    int blockLength = 5 * ONEMB;
+    ByteBuffer data = ByteBuffer.allocate(blockLength);
+    ECStreamTestUtil.randomFill(data, dataGenerator);
+    streamFactory.setData(data);
+
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(2, 3, 4, 5);
+    OmKeyLocationInfo blockInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+
+    ByteBuffer readBuffer = ByteBuffer.allocate(100);
+    dataGenerator = new SplittableRandom(randomSeed);
+    try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
+      while(true) {
+        int read = bis.read(readBuffer);
+        ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
+        readBuffer.clear();
+        if (read < 100) {
+          break;
+        }
+      }
+      readBuffer.clear();
+      int read = bis.read(readBuffer);
+      Assert.assertEquals(-1, read);
+    }
+  }
+
+  @Test
+  public void testCanHandleErrorAndFailOverToReconstruction()
+      throws IOException {
+    int blockLength = 5 * ONEMB;
+    ByteBuffer data = ByteBuffer.allocate(blockLength);
+    ECStreamTestUtil.randomFill(data, dataGenerator);
+    streamFactory.setData(data);
+
+    Map<DatanodeDetails, Integer> dnMap =
+        ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
+    OmKeyLocationInfo blockInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
+
+    ByteBuffer readBuffer = ByteBuffer.allocate(100);
+    DatanodeDetails badDN = blockInfo.getPipeline().getFirstNode();
+
+    dataGenerator = new SplittableRandom(randomSeed);
+    try (ECBlockInputStreamProxy bis = createBISProxy(repConfig, blockInfo)) {
+      // Perform one read to get the stream created
+      int read = bis.read(readBuffer);
+      Assert.assertEquals(100, read);
+      ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
+      // Setup an error to be thrown part through a read, so the dataBuffer
+      // will have been advanced by 50 bytes before the error. This tests it
+      // correctly rewinds and the same data is loaded again from the other
+      // stream.
+      streamFactory.getStreams().get(false).setShouldError(true, 151,
+          new BadDataLocationException(badDN, "Simulated Error"));
+      while(true) {
+        readBuffer.clear();
+        read = bis.read(readBuffer);
+        ECStreamTestUtil.assertBufferMatches(readBuffer, dataGenerator);
+        if (read < 100) {
+          break;
+        }
+      }
+      readBuffer.clear();
+      read = bis.read(readBuffer);
+      Assert.assertEquals(-1, read);
+    }
+  }
+
+  private ECBlockInputStreamProxy createBISProxy(ECReplicationConfig rConfig,
+      OmKeyLocationInfo blockInfo) {
+    return new ECBlockInputStreamProxy(
+        rConfig, blockInfo, true, null, null, streamFactory);
+  }
+
+  private static class TestECBlockInputStreamFactory
+      implements ECBlockInputStreamFactory {
+
+    private ByteBuffer data;
+
+    private Map<Boolean, ECStreamTestUtil.TestBlockInputStream> streams
+        = new HashMap<>();
+
+    public void setData(ByteBuffer data) {
+      this.data = data;
+    }
+
+    public Map<Boolean, ECStreamTestUtil.TestBlockInputStream> getStreams() {
+      return streams;
+    }
+
+    @Override
+    public BlockExtendedInputStream create(boolean missingLocations,
+        ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
+        boolean verifyChecksum, XceiverClientFactory xceiverFactory,
+        Function<BlockID, Pipeline> refreshFunction) {
+      ByteBuffer wrappedBuffer =
+          ByteBuffer.wrap(data.array(), 0, data.capacity());
+      ECStreamTestUtil.TestBlockInputStream is =
+          new ECStreamTestUtil.TestBlockInputStream(blockInfo.getBlockID(),
+              blockInfo.getLength(), wrappedBuffer);
+      streams.put(missingLocations, is);
+      return is;
+    }
+  }
+
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
@@ -291,8 +291,7 @@ public class TestECBlockInputStreamProxy {
   }
 
   @Test
-  public void testCanSeekToNewPosition()
-      throws IOException {
+  public void testCanSeekToNewPosition() throws IOException {
     int blockLength = 5 * ONEMB;
     generateData(blockLength);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When all data locations are available, the most efficient reader is ECBlockInputStream. It also uses less memory as it does not need to buffer the full stripe. When some data locations are missing, we need to use ECBlockReconstructedStripeInputStream and ECBlockReconstructedInputStream together. There needs to be a wrapper class which creates and uses the correct underlying stream depending on data location availability.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6010

## How was this patch tested?

New tests
