### PR TITLE
HDDS-6069: Fix XmlRootElement for CopyObjectResponse

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/CopyObjectResponse.java
@@ -31,7 +31,7 @@ import java.time.Instant;
  * Copy object Response.
  */
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlRootElement(name = "ListAllMyBucketsResult",
+@XmlRootElement(name = "CopyObjectResult",
     namespace = "http://s3.amazonaws.com/doc/2006-03-01/")
 public class CopyObjectResponse {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR renames the root element of `CopyObjectResponse` to "CopyObjectResult".
(https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#API_CopyObject_ResponseSyntax)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6069

## How was this patch tested?

Since this modification is trivial, I didn't run any tests.