### PR TITLE
HDDS-6071. ResourceLimitCache leaks permits

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ResourceLimitCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ResourceLimitCache.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import java.util.ArrayList;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -79,7 +78,7 @@ public class ResourceLimitCache<K, V> implements Cache<K, V> {
   @Override
   public void removeIf(Predicate<K> predicate) {
     Objects.requireNonNull(predicate);
-    for (K key : new ArrayList<>(map.keySet())) {
+    for (K key : map.keySet()) {
       if (predicate.test(key)) {
         remove(key);
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ResourceLimitCache.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/utils/ResourceLimitCache.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-
+import java.util.ArrayList;
 import java.util.Objects;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -79,7 +79,11 @@ public class ResourceLimitCache<K, V> implements Cache<K, V> {
   @Override
   public void removeIf(Predicate<K> predicate) {
     Objects.requireNonNull(predicate);
-    map.keySet().removeIf(predicate);
+    for (K key : new ArrayList<>(map.keySet())) {
+      if (predicate.test(key)) {
+        remove(key);
+      }
+    }
   }
 
   @Override

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -32,7 +32,7 @@ import java.util.function.Consumer;
  */
 public class TestResourceLimitCache {
 
-  public static final String ANY_VALUE = "asdf";
+  private static final String ANY_VALUE = "asdf";
 
   @Test
   public void testResourceLimitCache()

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with this
  * work for additional information regarding copyright ownership.  The ASF
@@ -25,11 +25,14 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 /**
  * Test for ResourceLimitCache.
  */
 public class TestResourceLimitCache {
+
+  public static final String ANY_VALUE = "asdf";
 
   @Test
   public void testResourceLimitCache()
@@ -88,4 +91,45 @@ public class TestResourceLimitCache {
     resourceCache.remove(1);
     Assert.assertNull(resourceCache.get(4));
   }
+
+  @Test(timeout = 5000)
+  public void testRemove() throws Exception {
+    testRemove(cache -> cache.remove(2), 2);
+  }
+
+  @Test(timeout = 5000)
+  public void testRemoveIf() throws Exception {
+    testRemove(cache -> cache.removeIf(k -> k <= 2), 1, 2);
+  }
+
+  @Test(timeout = 5000)
+  public void testClear() throws Exception {
+    testRemove(Cache::clear, 1, 2, 3);
+  }
+
+  private static void testRemove(Consumer<Cache<Integer, String>> op,
+      int... removedKeys) throws InterruptedException {
+
+    // GIVEN
+    final int maxSize = 3;
+    Cache<Integer, String> resourceCache =
+        new ResourceLimitCache<>(new ConcurrentHashMap<>(),
+            (k, v) -> new int[] {1}, maxSize);
+    for (int i = 1; i <= maxSize; ++i) {
+      resourceCache.put(i, ANY_VALUE);
+    }
+
+    // WHEN: remove some entries
+    op.accept(resourceCache);
+
+    // THEN
+    for (Integer k : removedKeys) {
+      Assert.assertNull(resourceCache.get(k));
+    }
+    // can put new entries
+    for (int i = 1; i <= removedKeys.length; ++i) {
+      resourceCache.put(maxSize + i, ANY_VALUE);
+    }
+  }
+
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ResourceLimitCache` limits its size by using a group of permits.  `put` requires free permit before it can add data.  However, `removeIf` does not release permits.

https://issues.apache.org/jira/browse/HDDS-6071

## How was this patch tested?

Added unit test.

Also, previously `TestRandomKeyGenerator` has been [timing out](https://github.com/apache/ozone/runs/4440507728?check_suite_focus=true#step:4:3010) since HDDS-3227 was merged.  It is passing with the patch.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1549379969
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1549427103