### PR TITLE
HDDS 6060 Error getting metrics from source SCMContainerMetrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerAttribute.java
@@ -189,7 +189,11 @@ public class ContainerAttribute<T> {
     Preconditions.checkNotNull(key);
 
     if (this.attributeMap.containsKey(key)) {
-      return Collections.unmodifiableNavigableSet(this.attributeMap.get(key));
+      NavigableSet<ContainerID> returneSet = new TreeSet<>();
+      TreeSet<ContainerID> tmpSet = (TreeSet<ContainerID>)
+              this.attributeMap.get(key);
+      returneSet.addAll(tmpSet);
+      return returneSet;
     }
     if (LOG.isDebugEnabled()) {
       LOG.debug("No such Key. Key {}", key);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Instead of just returning a wrapped set, ContainerAttribute#getCollection is returning NavigableSet.

[## What is the link to the Apache JIRA]
https://issues.apache.org/jira/browse/HDDS-6060

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
