### PR TITLE
HDDS-6073. Document: Fix images alignment in the doc pages

### DIFF
--- a/hadoop-hdds/docs/content/concept/Containers.md
+++ b/hadoop-hdds/docs/content/concept/Containers.md
@@ -28,7 +28,7 @@ Containers are the fundamental replication unit of Ozone/HDDS, they are managed 
 
 Containers are big binary units (5Gb by default) which can contain multiple blocks:
 
-![Containers](Containers.png)
+{{< image src="Containers.png">}}
 
 Blocks are local information and not managed by SCM. Therefore even if billions of small files are created in the system (which means billions of blocks are created), only of the status of the containers will be reported by the Datanodes and containers will be replicated.
  

--- a/hadoop-hdds/docs/content/concept/Datanodes.md
+++ b/hadoop-hdds/docs/content/concept/Datanodes.md
@@ -31,7 +31,7 @@ about the blocks written by the clients.
 
 ## Storage Containers
 
-![FunctionalOzone](ContainerMetadata.png)
+{{< image src="ContainerMetadata.png">}}
 
 A storage container is a self-contained super block. It has a list of Ozone
 blocks that reside inside it, as well as on-disk files which contain the
@@ -50,7 +50,7 @@ that make up that key.
 An Ozone block contains the container ID and a local ID. The figure below
 shows the logical layout out of Ozone block.
 
-![OzoneBlock](OzoneBlock.png)
+{{< image src="OzoneBlock.png">}}
 
 The container ID lets the clients discover the location of the container. The
 authoritative information about where a container is located is with the

--- a/hadoop-hdds/docs/content/concept/OzoneManager.md
+++ b/hadoop-hdds/docs/content/concept/OzoneManager.md
@@ -24,7 +24,7 @@ summary: Ozone Manager is the principal name space service of Ozone. OM manages 
   limitations under the License.
 -->
 
-![Ozone Manager](OzoneManager.png)
+{{< image src="OzoneManager.png">}}
 
 Ozone Manager (OM) is the namespace manager for Ozone.
 
@@ -60,7 +60,7 @@ understood if we trace what happens during a key write and key read.
 
 ### Key Write
 
-![Write Path](OzoneManager-WritePath.png)
+{{< image src="OzoneManager-WritePath.png">}}
 
 * To write a key to Ozone, a client tells Ozone manager that it would like to
 write a key into a bucket that lives inside a specific volume. Once Ozone
@@ -84,7 +84,7 @@ information on Ozone manager.
 
 ### Key Reads
 
-![Read Path](OzoneManager-ReadPath.png)
+{{< image src="OzoneManager-ReadPath.png">}}
 
 * Key reads are simpler, the client requests the block list from the Ozone
 Manager

--- a/hadoop-hdds/docs/content/concept/Recon.md
+++ b/hadoop-hdds/docs/content/concept/Recon.md
@@ -31,7 +31,7 @@ the current state of the cluster through REST based APIs and rich web UI.
 
 ## High Level Design
 
-{{<figure src="/concept/ReconHighLevelDesign.png" width="800px">}}
+{{< image src="/concept/ReconHighLevelDesign.png">}}
 
 <br/>
 
@@ -50,7 +50,7 @@ the web UI.
 
 ## Recon and Ozone Manager
 
-{{<figure src="/concept/ReconOmDesign.png" width="800px">}}
+{{< image src="/concept/ReconOmDesign.png">}}
 
 <br/>
 
@@ -68,7 +68,7 @@ further processing by OM db tasks via [Recon Task Framework](#task-framework).
 
 ## Recon and Storage Container Manager
 
-{{<figure src="/concept/ReconScmDesign.png" width="800px">}}
+{{< image src="/concept/ReconScmDesign.png">}}
 
 <br/>
 

--- a/hadoop-hdds/docs/content/feature/OM-HA.md
+++ b/hadoop-hdds/docs/content/feature/OM-HA.md
@@ -35,7 +35,8 @@ This document explain the HA setup of Ozone Manager (OM) HA, please check [this 
 
 A single Ozone Manager uses [RocksDB](https://github.com/facebook/rocksdb/) to persist metadata (volumes, buckets, keys) locally. HA version of Ozone Manager does exactly the same but all the data is replicated with the help of the RAFT consensus algorithm to follower Ozone Manager instances.
 
-![OM HA](HA-OM.png)
+{{< image src="HA-OM.png">}}
+
 Client connects to the Leader Ozone Manager which process the request and schedule the replication with RAFT. When the request is replicated to all the followers the leader can return with the response.
 
 ## Configuration
@@ -105,7 +106,7 @@ Raft can guarantee the replication of any request if the request is persisted to
 
 RocksDB instance are updated by a background thread with batching transactions (so called "double buffer" as when one of the buffers is used to commit the data the other one collects all the new requests for the next commit.) To make all data available for the next request even if the background process is not yet wrote them the key data is cached in the memory.
 
-![Double buffer](HA-OM-doublebuffer.png)
+{{< image src="HA-OM-doublebuffer.png">}}
 
 The details of this approach discussed in a separated [design doc]({{< ref "design/omha.md" >}}) but it's integral part of the OM HA design.
 

--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -46,18 +46,20 @@ Simple is the existing OM metadata format, which stores key entry with full path
     prefixed by the unique identifier of its parent directory, `<parent
      unique-id>/<filename>`. 
      
-![FSO Format](PrefixFSO-Format.png)
+{{< image src="PrefixFSO-Format.png">}}
 
 
 ### Directory delete operation with prefix layout: ###
 Following picture describes the OM metadata changes while performing a delete
  operation on a directory.
-![FSO Delete](PrefixFSO-Delete.png)
+
+{{< image src="PrefixFSO-Delete.png">}}
 
 ### Directory rename operation with prefix layout: ###
 Following picture describes the OM metadata changes while performing a rename
  operation on a directory.
-![FSO Rename](PrefixFSO-Rename.png)
+
+{{< image src="PrefixFSO-Rename.png">}}
 
 ## Configuration
 By default the feature is disabled. It can be enabled with the following

--- a/hadoop-hdds/docs/content/feature/SCM-HA.md
+++ b/hadoop-hdds/docs/content/feature/SCM-HA.md
@@ -109,7 +109,7 @@ Based on the `ozone.scm.primordial.node.id`, the init process will be ignored on
 
 ## SCM HA Security
 
-![Overview](scm-secure-ha.png)
+{{< image src="scm-secure-ha.png">}}
 
 In a secure SCM HA cluster on the SCM where we perform init, we call this SCM as a primordial SCM. 
 Primordial SCM starts root-CA with self-signed certificates and is used to issue a signed certificate 

--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/shortcodes/image.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/shortcodes/image.html
@@ -1,0 +1,19 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+<!-- shortcode to easily scale images according to page width-->
+<img src='{{ .Get "src" }}' style="max-width:100%"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This task is to fix images' alignment in different docs pages and prevent overflow on x-axis.

<img width="450" alt="Documentation image overflowing" src="https://user-images.githubusercontent.com/33001894/145159814-642e0813-ebcd-4fd6-a4fd-dbed972f683b.png">


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6073

## How was this patch tested?

UI changes

<img width="450" alt="Corrected image which does not overflow" src="https://user-images.githubusercontent.com/33001894/145159881-3e4ab625-a43d-4dbd-9541-7b55efc24a09.png">

