### PR TITLE
HDDS-5952. EC: ECBlockReconstructedStripeInputStream should read from blocks in parallel

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -131,7 +131,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     decoderInputBuffers = new ByteBuffer[getRepConfig().getRequiredNodes()];
 
     ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat(
-        "ec-reader-for-" + blockInfo.getBlockID() + "-%d").build();
+        "ec-reader-for-" + blockInfo.getBlockID() + "-TID-%d").build();
     executor = Executors.newFixedThreadPool(repConfig.getData(), threadFactory);
   }
 
@@ -489,7 +489,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
       } catch (InterruptedException ie) {
         // Catch each InterruptedException to ensure all the futures have been
         // handled, and then throw the exception later
-        LOG.error("Interrupted while waiting for reads to complete", ie);
+        LOG.debug("Interrupted while waiting for reads to complete", ie);
         Thread.currentThread().interrupt();
       }
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.ozone.client.io;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import javafx.util.Pair;
 import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
@@ -454,9 +454,10 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   protected void loadDataBuffersFromStream() throws IOException {
-    Queue<Pair<Integer, Future<Void>>> pendingReads = new ArrayDeque<>();
+    Queue<ImmutablePair<Integer, Future<Void>>> pendingReads
+        = new ArrayDeque<>();
     for (int i : dataIndexes) {
-      pendingReads.add(new Pair(i, executor.submit(() -> {
+      pendingReads.add(new ImmutablePair<>(i, executor.submit(() -> {
         readIntoBuffer(i, decoderInputBuffers[i]);
         return null;
       })));
@@ -464,7 +465,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     while(!pendingReads.isEmpty()) {
       int index = -1;
       try {
-        Pair<Integer, Future<Void>> pair = pendingReads.poll();
+        ImmutablePair<Integer, Future<Void>> pair = pendingReads.poll();
         index = pair.getKey();
         // Should this future.get() have a timeout? At the end of the call chain
         // we eventually call a grpc or ratis client to read the block data. Its

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -462,6 +462,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         return null;
       })));
     }
+    boolean exceptionOccurred = false;
     while(!pendingReads.isEmpty()) {
       int index = -1;
       try {
@@ -480,10 +481,14 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         LOG.warn("Failed to read from block {} EC index {}. Excluding the " +
             "block", getBlockID(), index + 1, ee.getCause());
         failedDataIndexes.add(index);
+        exceptionOccurred = true;
       } catch (InterruptedException ie) {
         LOG.error("Interrupted waiting for reads to complete", ie);
         throw new IOException("Interrupted waiting for reads to complete", ie);
       }
+    }
+    if (exceptionOccurred) {
+      throw new IOException("One or more errors occurred reading blocks");
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedStripeInputStream.java
@@ -33,7 +33,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SplittableRandom;
@@ -74,11 +73,9 @@ public class TestECBlockReconstructedStripeInputStream {
         keyInfo, true, null, null, new TestBlockInputStreamFactory())) {
       Assert.assertTrue(ecb.hasSufficientLocations());
     }
-
-    Map<DatanodeDetails, Integer> dnMap = new HashMap<>();
-
     // Two Chunks, but missing data block 2.
-    dnMap = ECStreamTestUtil.createIndexMap(1, 4, 5);
+    Map<DatanodeDetails, Integer> dnMap
+        = ECStreamTestUtil.createIndexMap(1, 4, 5);
     keyInfo = ECStreamTestUtil.createKeyInfo(repConfig, ONEMB * 2, dnMap);
     try (ECBlockInputStream ecb =
         new ECBlockReconstructedStripeInputStream(repConfig,


### PR DESCRIPTION
## What changes were proposed in this pull request?

To make reconstruction reads faster, ECBlockReconstructedStripeInputStream could read from the block streams in parallel rather than serially.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5952

## How was this patch tested?

Existing tests