### PR TITLE
HDDS-6072. Fix increased integration test execution time

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -195,10 +195,10 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
   public void stop() {
     if (isStarted) {
       try {
+        server.shutdown();
         eventLoopGroup.shutdownGracefully().sync();
         readExecutors.shutdown();
         readExecutors.awaitTermination(5L, TimeUnit.SECONDS);
-        server.shutdown();
         server.awaitTermination(5, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         LOG.error("failed to shutdown XceiverServerGrpc", e);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/XceiverServerGrpc.java
@@ -195,11 +195,11 @@ public final class XceiverServerGrpc implements XceiverServerSpi {
   public void stop() {
     if (isStarted) {
       try {
-        server.shutdown();
-        eventLoopGroup.shutdownGracefully().sync();
         readExecutors.shutdown();
         readExecutors.awaitTermination(5L, TimeUnit.SECONDS);
+        server.shutdown();
         server.awaitTermination(5, TimeUnit.SECONDS);
+        eventLoopGroup.shutdownGracefully().sync();
       } catch (InterruptedException e) {
         LOG.error("failed to shutdown XceiverServerGrpc", e);
         Thread.currentThread().interrupt();


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-5962 increased integration test execution time by 20-30 minutes for each split.

With the current order of shutdown, `server.awaitTermination` takes 5 seconds in each case.  No matter how much we increase timeout (e.g. to several minutes), it always takes all specified time.  It seems the event that `awaitTermination` expects does not happen if `eventLoopGroup` has already been shutdown.

https://issues.apache.org/jira/browse/HDDS-6072

## How was this patch tested?

Verified that `XceiverServerGrpc.stop` no longer takes 5 seconds.

Each split of the integration suite still takes ~10 minutes more than before HDDS-5962, but at least they are 10-20 minutes quicker than on current `master`.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1554131459
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1554416354