### PR TITLE
HDDS-6080. Simplify the logic in SimpleContainerDownloader.getContainerDataFromReplicas

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ContainerDownloader.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.container.replication;
 import java.io.Closeable;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
@@ -34,7 +33,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
  */
 public interface ContainerDownloader extends Closeable {
 
-  CompletableFuture<Path> getContainerDataFromReplicas(long containerId,
+  Path getContainerDataFromReplicas(long containerId,
       List<DatanodeDetails> sources);
 
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/DownloadAndImportReplicator.java
@@ -22,8 +22,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
@@ -107,18 +105,15 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
     LOG.info("Starting replication of container {} from {}", containerID,
         sourceDatanodes);
 
-    CompletableFuture<Path> tempTarFile = downloader
-        .getContainerDataFromReplicas(containerID,
-            sourceDatanodes);
-    if (tempTarFile == null) {
+    // Wait for the download. This thread pool is limiting the parallel
+    // downloads, so it's ok to block here and wait for the full download.
+    Path path =
+        downloader.getContainerDataFromReplicas(containerID, sourceDatanodes);
+    if (path == null) {
       task.setStatus(Status.FAILED);
     } else {
       try {
-        // Wait for the download. This thread pool is limiting the parallel
-        // downloads, so it's ok to block here and wait for the full download.
-        Path path = tempTarFile.get();
         long bytes = Files.size(path);
-
         LOG.info("Container {} is downloaded with size {}, starting to import.",
                 containerID, bytes);
         task.setTransferredBytes(bytes);
@@ -126,11 +121,9 @@ public class DownloadAndImportReplicator implements ContainerReplicator {
         importContainer(containerID, path);
         LOG.info("Container {} is replicated successfully", containerID);
         task.setStatus(Status.DONE);
-      } catch (ExecutionException | IOException e) {
+      } catch (IOException e) {
         LOG.error("Container {} replication was unsuccessful.", containerID, e);
         task.setStatus(Status.FAILED);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
       }
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -71,7 +71,7 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   }
 
   @Override
-  public CompletableFuture<Path> getContainerDataFromReplicas(
+  public Path getContainerDataFromReplicas(
       long containerId, List<DatanodeDetails> sourceDatanodes) {
 
     final List<DatanodeDetails> shuffledDatanodes =
@@ -81,11 +81,10 @@ public class SimpleContainerDownloader implements ContainerDownloader {
       try {
         CompletableFuture<Path> result =
             downloadContainer(containerId, datanode);
-        result.get();
-        return result;
-      } catch (ExecutionException e) {
+        return result.get();
+      } catch (ExecutionException | IOException e) {
         LOG.error("Error on replicating container: {} from {}/{}", containerId,
-            datanode.getHostName(), datanode.getIpAddress(), e.getCause());
+            datanode.getHostName(), datanode.getIpAddress(), e);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (Exception ex) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -84,8 +84,8 @@ public class SimpleContainerDownloader implements ContainerDownloader {
         result.get();
         return result;
       } catch (ExecutionException e) {
-        LOG.error("Error on replicating container: {}",
-            containerId, e.getCause());
+        LOG.error("Error on replicating container: {} from {}/{}", containerId,
+            datanode.getHostName(), datanode.getIpAddress(), e.getCause());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (Exception ex) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/SimpleContainerDownloader.java
@@ -74,38 +74,28 @@ public class SimpleContainerDownloader implements ContainerDownloader {
   public CompletableFuture<Path> getContainerDataFromReplicas(
       long containerId, List<DatanodeDetails> sourceDatanodes) {
 
-    CompletableFuture<Path> result = null;
-
     final List<DatanodeDetails> shuffledDatanodes =
         shuffleDatanodes(sourceDatanodes);
 
     for (DatanodeDetails datanode : shuffledDatanodes) {
       try {
-        if (result == null) {
-          result = downloadContainer(containerId, datanode);
-        } else {
-
-          result = result.exceptionally(t -> {
-            LOG.error("Error on replicating container: " + containerId, t);
-            try {
-              return downloadContainer(containerId, datanode).get();
-            } catch (ExecutionException | IOException e) {
-              LOG.error("Error on replicating container: " + containerId,
-                  e);
-            } catch (InterruptedException e) {
-              Thread.currentThread().interrupt();
-            }
-            return null;
-          });
-        }
+        CompletableFuture<Path> result =
+            downloadContainer(containerId, datanode);
+        result.get();
+        return result;
+      } catch (ExecutionException e) {
+        LOG.error("Error on replicating container: {}",
+            containerId, e.getCause());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
       } catch (Exception ex) {
-        LOG.error(String.format(
-            "Container %s download from datanode %s was unsuccessful. "
-                + "Trying the next datanode", containerId, datanode), ex);
+        LOG.error("Container {} download from datanode {} was unsuccessful. "
+                + "Trying the next datanode", containerId, datanode, ex);
       }
     }
-    return result;
-
+    LOG.error("Container {} could not be downloaded from any datanode",
+        containerId);
+    return null;
   }
 
   //There is a chance for the download is successful but import is failed,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationSupervisor.java
@@ -23,7 +23,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.AbstractExecutorService;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -237,8 +236,7 @@ public class TestReplicationSupervisor {
     // Mock to fetch an exception in the importContainer method.
     SimpleContainerDownloader moc =
         Mockito.mock(SimpleContainerDownloader.class);
-    CompletableFuture<Path> res = new CompletableFuture<>();
-    res.complete(Paths.get("file:/tmp/no-such-file"));
+    Path res = Paths.get("file:/tmp/no-such-file");
     Mockito.when(
         moc.getContainerDataFromReplicas(Mockito.anyLong(), Mockito.anyList()))
         .thenReturn(res);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestSimpleContainerDownloader.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -53,8 +52,7 @@ public class TestSimpleContainerDownloader {
 
     //WHEN
     final Path result =
-        downloader.getContainerDataFromReplicas(1L, datanodes)
-            .get(1L, TimeUnit.SECONDS);
+        downloader.getContainerDataFromReplicas(1L, datanodes);
 
     //THEN
     Assert.assertEquals(datanodes.get(0).getUuidString(), result.toString());
@@ -72,8 +70,7 @@ public class TestSimpleContainerDownloader {
 
     //WHEN
     final Path result =
-        downloader.getContainerDataFromReplicas(1L, datanodes)
-            .get(1L, TimeUnit.SECONDS);
+        downloader.getContainerDataFromReplicas(1L, datanodes);
 
     //THEN
     //first datanode is failed, second worked
@@ -91,8 +88,7 @@ public class TestSimpleContainerDownloader {
 
     //WHEN
     final Path result =
-        downloader.getContainerDataFromReplicas(1L, datanodes)
-            .get(1L, TimeUnit.SECONDS);
+        downloader.getContainerDataFromReplicas(1L, datanodes);
 
     //THEN
     //first datanode is failed, second worked
@@ -125,8 +121,7 @@ public class TestSimpleContainerDownloader {
     //WHEN executed, THEN at least once the second datanode should be
     //returned.
     for (int i = 0; i < 10000; i++) {
-      Path path =
-          downloader.getContainerDataFromReplicas(1L, datanodes).get();
+      Path path = downloader.getContainerDataFromReplicas(1L, datanodes);
       if (path.toString().equals(datanodes.get(1).getUuidString())) {
         return;
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The logic in `SimpleContainerDownloader.getContainerDataFromReplicas()` is hard to follow and could be written in a simpler way, with the same functionality.

This Jira is a small refactor of the logic in the above method, which hopefully makes it easier to understand.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6080

## How was this patch tested?

No functionality changes. Existing tests cover this.
