### PR TITLE
HDDS-6083. Fix flakyness of tests around nodefailures.

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MultiNodePipelineBlockAllocator.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MultiNodePipelineBlockAllocator.java
@@ -26,8 +26,10 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 
 /**
  * Allocates the block with required number of nodes in the pipeline.
@@ -52,9 +54,14 @@ public class MultiNodePipelineBlockAllocator implements MockBlockAllocator {
             .setType(keyArgs.getType()).setId(HddsProtos.PipelineID.newBuilder()
             .setUuid128(HddsProtos.UUID.newBuilder().setLeastSigBits(1L)
                 .setMostSigBits(1L).build()).build());
-    final int rand = RANDOM.nextInt(); // used for port and UUID combination.
+    Set<Integer> usedPorts = new HashSet<>();
+    int rand = RANDOM.nextInt(); // used for port and UUID combination.
     // It's ok here for port number limit as don't really create any socket
-    // connection.
+    // connection, but it has to be unique.
+    while (!usedPorts.contains(rand)) {
+      rand = RANDOM.nextInt();
+    }
+    usedPorts.add(rand);
     for (int i = 1; i <= requiredNodes; i++) {
       builder.addMembers(HddsProtos.DatanodeDetailsProto.newBuilder()
           .setUuid128(HddsProtos.UUID.newBuilder().setLeastSigBits(rand)


### PR DESCRIPTION
## What changes were proposed in this pull request?
If we are unlucky enough, and we get the same int twice in MultiNodePipelineBlockAllocator#allocateBlock as the number used in the PipelineID, and as the DN's port, then we will have two pseudo DNs in the pipeline that gets the same MockDNStorage assigned. Which means that if we declare that node to fail, we get a secondary failure during failure handling, and the code is not prepared for that as of now, and also we swallow the exception in handleOutputStreamWrite inside ECKeyOutputStream, which we use from the handleStripeFailure method as well as during the regular write.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6083

## How was this patch tested?
I changed the RAND.nextInt() call in the incriminated method, to RAND.nextInt(4) to ensure there are duplicates, then I was able to reproduce the issue, otherwise it is hard to reproduce it, and I don't know of a better way to test it either, at least none that would worth the effort really.
