### PR TITLE
HDDS-6090. Collect output.log from acceptance tests

### DIFF
--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -13,6 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+set -u -o pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
@@ -36,7 +39,7 @@ mkdir -p "$REPORT_DIR"
 export OZONE_ACCEPTANCE_SUITE
 
 cd "$DIST_DIR/compose" || exit 1
-./test-all.sh
+./test-all.sh | tee "${REPORT_DIR}/output.log"
 RES=$?
 cp result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"

--- a/hadoop-ozone/dev-support/checks/kubernetes.sh
+++ b/hadoop-ozone/dev-support/checks/kubernetes.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -u -o pipefail
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
@@ -45,7 +47,7 @@ fi
 mkdir -p "$REPORT_DIR"
 
 cd "$DIST_DIR/kubernetes/examples" || exit 1
-./test-all.sh
+./test-all.sh | tee "${REPORT_DIR}/output.log"
 RES=$?
 cp -r result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most CI checks collect standard output to a file, which is then included in the result bundle.  We should have the same for Robot-based checks (acceptance and kubernetes).

https://issues.apache.org/jira/browse/HDDS-6090

## How was this patch tested?

```
$ unzip -t acceptance-misc.zip output.log
Archive:  acceptance-misc.zip
    testing: output.log               OK
No errors detected in acceptance-misc.zip for the 1 file tested.

$ unzip -t kubernetes.zip output.log
Archive:  kubernetes.zip
    testing: output.log               OK
No errors detected in kubernetes.zip for the 1 file tested.
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1562215053