### PR TITLE
HDDS-6094. Some unit tests are skipped due to using JUnit4 runner

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -167,6 +167,21 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.platform</groupId>
+      <artifactId>junit-platform-launcher</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-client</artifactId>
     </dependency>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestStringCodec.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestStringCodec.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,7 +23,7 @@ import io.jaegertracing.internal.exceptions.MalformedTracerStateStringException;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class TestStringCodec {
 
@@ -44,9 +44,17 @@ class TestStringCodec {
         "String does not match tracer state format",
         () -> codec.extract(sb));
     sb.append(":66");
+
     JaegerSpanContext context = codec.extract(sb);
-    String expectedContextString = "123:456:789:66";
-    assertTrue(context.getTraceId().equals("123"));
-    assertTrue(context.toString().equals(expectedContextString));
+    StringBuilder injected = new StringBuilder();
+    codec.inject(context, injected);
+
+    String expectedTraceId = pad("123");
+    assertEquals(expectedTraceId, context.getTraceId());
+    assertEquals(expectedTraceId + ":456:789:66", injected.toString());
+  }
+
+  private static String pad(String s) {
+    return "0000000000000000".substring(s.length()) + s;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

These unit tests are skipped currently, because they are annotated with JUnit5's `@Test`, which the JUnit4 runner does not know about:

```
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/conf/TestRatisClientConfig.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/conf/TestRaftClientConfig.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestStringCodec.java
```

This PR adds JUnit5 test dependency in the affected module (`hdds-common`).

It also tweaks `TestStringCodec`, which was broken (without noticing it, since it was not being run) by the most recent Jaeger update (HDDS-4980).

https://issues.apache.org/jira/browse/HDDS-6094

## How was this patch tested?

Verified that previously missing tests were executed:
https://github.com/adoroszlai/hadoop-ozone/runs/4484919834#step:4:651
https://github.com/adoroszlai/hadoop-ozone/runs/4484919834#step:4:679

Full CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1563924309