### PR TITLE
HDDS-6083. EC: Fix flakyness of tests around nodefailures.

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -44,7 +44,6 @@ import org.junit.Test;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
## What changes were proposed in this pull request?
The problem is with the selection of failing nodes in TestOzoneECClient#testNodeFailuresWhileWriting.
If we write two chunks only after a failure, and If we select for example node3 in the block group to fail, then the write will not fail, as we don't actually write to node3 in this case.
Similarly, if we write one chunk after a failure, and if we select node 2 or node 3 to fail, then as we don't actually will write to these nodes the write won't fail.

The selection logic itself is easy, we get the keyset of the storages map from the MockXCieverClientFactory which maps DataNodeDetails to MockDataNodeStorages, and we go over the keyset, and set numFailureToInject nodes to fail.
I have modified this logic to sort the keyset and put the nodes that we won't write to at the back of the list.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6083

## How was this patch tested?
Put up a loop, and ran the test 1000 times, evaluated the nodes selected to fail, and I saw all the nodes that we write to as selected, but none of the nodes that we won't write to, in case when testNodeFailuresWhileWriting method is called with parameters (2, 1), (2, 2), (1, 1), (1, 2). Also ran all tests in TestOzoneECClient.