### PR TITLE
HDDS-6098. Add a metric to track amount of data committed.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -159,11 +159,15 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     for (int i = 0; i < 10; i++) {
       String keyName = UUID.randomUUID().toString();
 
+      long committedBytes = ozoneManager.getMetrics().getDataCommittedBytes();
       try (OzoneOutputStream out = bucket.createKey(keyName,
           value.getBytes(UTF_8).length, ReplicationType.RATIS,
           ReplicationFactor.ONE, new HashMap<>())) {
         out.write(value.getBytes(UTF_8));
       }
+
+      Assert.assertEquals(committedBytes + value.getBytes(UTF_8).length,
+              ozoneManager.getMetrics().getDataCommittedBytes());
 
       OzoneKey key = bucket.getKey(keyName);
       Assert.assertEquals(keyName, key.getName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMetrics.java
@@ -122,6 +122,9 @@ public class OMMetrics {
   private @Metric MutableCounterLong numLookupFileFails;
   private @Metric MutableCounterLong numListStatusFails;
 
+  // Metrics for total amount of data written
+  private @Metric MutableCounterLong totalDataCommitted;
+
   // Metrics for total number of volumes, buckets and keys
 
   private @Metric MutableCounterLong numVolumes;
@@ -199,6 +202,9 @@ public class OMMetrics {
     numBucketS3DeleteFails.incr();
   }
 
+  public void incDataCommittedBytes(long bytesWritten) {
+    totalDataCommitted.incr(bytesWritten);
+  }
 
   public void incNumS3Buckets() {
     numS3Buckets.incr();
@@ -842,6 +848,11 @@ public class OMMetrics {
   @VisibleForTesting
   public long getNumListS3BucketsFails() {
     return numBucketS3ListFails.value();
+  }
+
+  @VisibleForTesting
+  public long getDataCommittedBytes() {
+    return totalDataCommitted.value();
   }
 
   public long getNumInitiateMultipartUploads() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -341,6 +341,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // versioning of keys. So, this can be revisited later.
       if (omKeyInfo.getKeyLocationVersions().size() == 1) {
         omMetrics.incNumKeys();
+        omMetrics.incDataCommittedBytes(omKeyInfo.getDataSize());
       }
       LOG.debug("Key committed. Volume:{}, Bucket:{}, Key:{}", volumeName,
               bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -341,8 +341,8 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // versioning of keys. So, this can be revisited later.
       if (omKeyInfo.getKeyLocationVersions().size() == 1) {
         omMetrics.incNumKeys();
-        omMetrics.incDataCommittedBytes(omKeyInfo.getDataSize());
       }
+      omMetrics.incDataCommittedBytes(omKeyInfo.getDataSize());
       LOG.debug("Key committed. Volume:{}, Bucket:{}, Key:{}", volumeName,
               bucketName, keyName);
       break;


### PR DESCRIPTION
## What changes were proposed in this pull request?
This is a simple fix to add a small metric to track amount of data committed into OM. tracking this will help in tracking the amount of write activity in the cluster

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6098

## How was this patch tested?
Added a new test
