### PR TITLE
HDDS-6099. Ozone fails to build on Apple Silicon / M1.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- the version of Hadoop declared in the version resources; can be overridden
     so that Hadoop 3.x can declare itself a 2.x artifact. -->
     <declared.hadoop.version>${hadoop.version}</declared.hadoop.version>
-    <proto-backwards-compatibility.version>1.0.5</proto-backwards-compatibility.version>
+    <proto-backwards-compatibility.version>1.0.7</proto-backwards-compatibility.version>
 
     <swagger-annotations-version>1.5.4</swagger-annotations-version>
     <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The support for m1 is added in version 1.0.7 in
proto-backwards-compat-maven-plugin by this PR

https://github.com/salesforce/proto-backwards-compat-maven-plugin/pull/27

This Jira is to update proto-backwards-compatibility.version from 1.0.5 to 1.0.7

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6099

## How was this patch tested?

After this update build continued.
