### PR TITLE
HDDS-6101. use FileUtils.moveDirectory instead of Files.move when installing snapshot

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -201,7 +201,7 @@ public final class HAUtils {
       // an inconsistent state and this marker file will fail it from
       // starting up.
       Files.createFile(markerFile);
-      Files.move(checkpointPath, oldDB.toPath());
+      FileUtils.moveDirectory(checkpointPath, oldDB.toPath());
       Files.deleteIfExists(markerFile);
     } catch (IOException e) {
       LOG.error("Failed to move downloaded DB checkpoint {} to metadata "

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -180,7 +180,8 @@ public class SCMDatanodeProtocolServer implements
   public void start() {
     LOG.info(
         StorageContainerManager.buildRpcServerStartMessage(
-            "ScmDatanodeProtocol RPC server for DataNodes", datanodeRpcAddress));
+            "ScmDatanodeProtocol RPC server for DataNodes",
+            datanodeRpcAddress));
     protocolMessageMetrics.register();
     datanodeRpcServer.start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -180,7 +180,7 @@ public class SCMDatanodeProtocolServer implements
   public void start() {
     LOG.info(
         StorageContainerManager.buildRpcServerStartMessage(
-            "RPC server for DataNodes", datanodeRpcAddress));
+            "ScmDatanodeProtocl RPC server for DataNodes", datanodeRpcAddress));
     protocolMessageMetrics.register();
     datanodeRpcServer.start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -180,7 +180,7 @@ public class SCMDatanodeProtocolServer implements
   public void start() {
     LOG.info(
         StorageContainerManager.buildRpcServerStartMessage(
-            "ScmDatanodeProtocl RPC server for DataNodes", datanodeRpcAddress));
+            "ScmDatanodeProtocol RPC server for DataNodes", datanodeRpcAddress));
     protocolMessageMetrics.register();
     datanodeRpcServer.start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1320,11 +1320,6 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
     getBlockProtocolServer().start();
 
-    if (LOG.isInfoEnabled()) {
-      LOG.info(buildRpcServerStartMessage("ScmDatanodeProtocl RPC " +
-          "server", getDatanodeProtocolServer().getDatanodeRpcAddress()));
-    }
-
     // If HA is enabled, start datanode protocol server once leader is ready.
     if (!scmStorageConfig.isSCMHAEnabled()) {
       getDatanodeProtocolServer().start();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3332,7 +3332,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       // an inconsistent state and this marker file will fail OM from
       // starting up.
       Files.createFile(markerFile);
-      Files.move(checkpointPath, oldDB.toPath());
+      FileUtils.moveDirectory(checkpointPath, oldDB.toPath());
       Files.deleteIfExists(markerFile);
     } catch (IOException e) {
       LOG.error("Failed to move downloaded DB checkpoint {} to metadata " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

in our cluster , we put scm db and ratis in different directories which in different disk partitions. but when bootstraping this cluster , we found the ozone cluster does not work well because the follower scm fail to install snapshot. after investigating, we found the db checkpoint will be downloaded to the directory the same as the ratis log by default. when replacing the old db, scm will use `files.move` to move the checkpoint to the db directory. but according to the description of `files.move`, When moving a directory requires that its entries be moved then this method fails (by throwing an IOException). 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6101

## How was this patch tested?

current UT
