### PR TITLE
HDDS-6104. Update log4j version to 2.16.0 version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
 
     <prometheus.version>0.7.0</prometheus.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update log4j version to 2.16.0.
https://lists.apache.org/thread/d6v4r6nosxysyq9rvnr779336yf0woz4

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6104

## How was this patch tested?

Log version only change, exisiting tests
