### PR TITLE
HDDS-6075. OzoneConfiguration constructor overrides input configuration keys.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -108,6 +108,7 @@ public class OzoneConfiguration extends Configuration
     setClassLoader(conf.getClassLoader());
     if (!(conf instanceof OzoneConfiguration)) {
       loadDefaults();
+      addResource(conf);
     }
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -126,6 +126,7 @@ public class OzoneConfiguration extends Configuration
     } catch (IOException e) {
       e.printStackTrace();
     }
+    addResource("ozone-default.xml");
     // Adding core-site here because properties from core-site are
     // distributed to executors by spark driver. Ozone properties which are
     // added to core-site, will be overridden by properties from adding Resource
@@ -242,7 +243,6 @@ public class OzoneConfiguration extends Configuration
     // adds the default resources
     Configuration.addDefaultResource("hdfs-default.xml");
     Configuration.addDefaultResource("hdfs-site.xml");
-    Configuration.addDefaultResource("ozone-default.xml");
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -206,14 +206,16 @@ public class TestOzoneConfiguration {
       appendProperty(out, key, val);
       endConfig(out);
     }
-    configuration.addResource(new URL("file:///" + ozoneSite.getAbsolutePath()));
+    configuration
+        .addResource(new URL("file:///" + ozoneSite.getAbsolutePath()));
 
-    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration(configuration);
+    OzoneConfiguration ozoneConfiguration =
+        new OzoneConfiguration(configuration);
     // ozoneConfig value matches input config value for the corresponding key
     Assert.assertEquals(val, ozoneConfiguration.get(key));
     Assert.assertEquals(val, configuration.get(key));
 
-    Assert.assertNotEquals(new OzoneConfiguration().get(key), val);
+    Assert.assertNotEquals(val, new OzoneConfiguration().get(key));
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -22,9 +22,11 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.TimeUnit;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
 import org.junit.Assert;
@@ -188,6 +190,30 @@ public class TestOzoneConfiguration {
         subject.getInt("test.scm.client.port", 123));
     Assert.assertEquals(TimeUnit.MINUTES.toSeconds(30),
         subject.getTimeDuration("test.scm.client.wait", 555, TimeUnit.SECONDS));
+  }
+
+  @Test
+  public void testInstantiationWithInputConfiguration() throws IOException {
+    String key = "hdds.scm.init.default.layout.version";
+    String val = "Test1";
+    Configuration configuration = new Configuration(true);
+
+    File ozoneSite = tempConfigs.newFile("ozone-site.xml");
+    FileOutputStream ozoneSiteStream = new FileOutputStream(ozoneSite);
+    try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
+        ozoneSiteStream, StandardCharsets.UTF_8))) {
+      startConfig(out);
+      appendProperty(out, key, val);
+      endConfig(out);
+    }
+    configuration.addResource(new URL("file:///" + ozoneSite.getAbsolutePath()));
+
+    OzoneConfiguration ozoneConfiguration = new OzoneConfiguration(configuration);
+    // ozoneConfig value matches input config value for the corresponding key
+    Assert.assertEquals(val, ozoneConfiguration.get(key));
+    Assert.assertEquals(val, configuration.get(key));
+
+    Assert.assertNotEquals(new OzoneConfiguration().get(key), val);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

OzoneConfiguration constructor which takes a configuration as parameter can override input configuration keys with default resources.

```
public OzoneConfiguration(Configuration conf) {
  super(conf);
  //load the configuration from the classloader of the original conf.
  setClassLoader(conf.getClassLoader());
  if (!(conf instanceof OzoneConfiguration)) {
    loadDefaults();
  }
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6075

## How was this patch tested?

Adds a UT.