### PR TITLE
HDDS-6107. Exclude hugo lock file from source tarball

### DIFF
--- a/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
+++ b/hadoop-ozone/dist/src/main/assemblies/ozone-src.xml
@@ -73,6 +73,7 @@
       <useDefaultExcludes>true</useDefaultExcludes>
       <excludes>
         <exclude>**/.classpath</exclude>
+        <exclude>**/.hugo_build.lock</exclude>
         <exclude>**/.project</exclude>
         <exclude>**/.settings</exclude>
         <exclude>**/*.iml</exclude>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Hugo 0.89:

> Hugo now writes an empty file named `.hugo_build.lock` to the root of the project when building

We should exclude this lock file from the source tarball of releases.

```
$ mvn -DskipTests -Psrc clean package
$ tar tzvf hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT-src.tar.gz | grep hugo | wc -l
       1
```

https://issues.apache.org/jira/browse/HDDS-6107

## How was this patch tested?

```
$ mvn -DskipTests -Psrc clean package
$ tar tzvf hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT-src.tar.gz | grep hugo | wc -l
       0
```