### PR TITLE
HDDS-6004. Use changes from HDDS-5881 for volume chroot.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -64,8 +64,6 @@ public class ObjectStore {
    */
   private int listCacheSize;
   private final String defaultS3Volume;
-  // TODO: Using for now for multitenancy but remove when HDDS-4440 is merged.
-  private final String accessID;
 
   /**
    * Creates an instance of ObjectStore.
@@ -73,15 +71,9 @@ public class ObjectStore {
    * @param proxy ClientProtocol proxy.
    */
   public ObjectStore(ConfigurationSource conf, ClientProtocol proxy) {
-    this(conf, proxy, null);
-  }
-
-  public ObjectStore(ConfigurationSource conf, ClientProtocol proxy,
-      String accessID) {
     this.proxy = TracingUtil.createProxy(proxy, ClientProtocol.class, conf);
     this.listCacheSize = HddsClientUtils.getListCacheSize(conf);
     defaultS3Volume = HddsClientUtils.getDefaultS3VolumeName(conf);
-    this.accessID = accessID;
   }
 
   @VisibleForTesting
@@ -90,7 +82,6 @@ public class ObjectStore {
     OzoneConfiguration conf = new OzoneConfiguration();
     proxy = null;
     defaultS3Volume = HddsClientUtils.getDefaultS3VolumeName(conf);
-    this.accessID = null;
   }
 
   @VisibleForTesting
@@ -163,11 +154,7 @@ public class ObjectStore {
   }
 
   public OzoneVolume getS3Volume() throws IOException {
-    if (accessID == null)  {
-      return proxy.getVolumeDetails(defaultS3Volume);
-    } else {
-      return proxy.getS3VolumeDetails(accessID);
-    }
+      return proxy.getS3VolumeDetails();
   }
 
   public S3SecretValue getS3Secret(String kerberosID) throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -154,7 +154,7 @@ public class ObjectStore {
   }
 
   public OzoneVolume getS3Volume() throws IOException {
-      return proxy.getS3VolumeDetails();
+    return proxy.getS3VolumeDetails();
   }
 
   public S3SecretValue getS3Secret(String kerberosID) throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClient.java
@@ -84,13 +84,8 @@ public class OzoneClient implements Closeable {
    * @param proxy ClientProtocol proxy instance
    */
   public OzoneClient(ConfigurationSource conf, ClientProtocol proxy) {
-    this(conf, proxy, null);
-  }
-
-  public OzoneClient(ConfigurationSource conf, ClientProtocol proxy,
-      String accessID) {
     this.proxy = proxy;
-    this.objectStore = new ObjectStore(conf, this.proxy, accessID);
+    this.objectStore = new ObjectStore(conf, this.proxy);
     this.conf = conf;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneClientFactory.java
@@ -107,43 +107,15 @@ public final class OzoneClientFactory {
    */
   public static OzoneClient getRpcClient(String omServiceId,
       ConfigurationSource config) throws IOException {
-    return getRpcClient(getClientProtocol(config, omServiceId), config, null);
-  }
-
-  public static OzoneClient getRpcClient(String omServiceId,
-      ConfigurationSource config, String accessID) throws IOException {
     Preconditions.checkNotNull(omServiceId);
     Preconditions.checkNotNull(config);
     if (OmUtils.isOmHAServiceId(config, omServiceId)) {
-      return getRpcClient(getClientProtocol(config, omServiceId), config,
-          accessID);
+      return getRpcClient(getClientProtocol(config, omServiceId), config);
     } else {
       throw new IOException("Service ID specified " +
           "does not match with " + OZONE_OM_SERVICE_IDS_KEY + " defined in " +
           "the configuration. Configured " + OZONE_OM_SERVICE_IDS_KEY + " are" +
           config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY));
-    }
-  }
-
-  public static OzoneClient getRpcClient(ConfigurationSource config,
-        String accessID) throws IOException {
-    Preconditions.checkNotNull(config);
-
-    // Doing this explicitly so that when service ids are defined in the
-    // configuration, we don't fall back to default ozone.om.address defined
-    // in ozone-default.xml.
-
-    String[] serviceIds = config.getTrimmedStrings(OZONE_OM_SERVICE_IDS_KEY);
-    if (serviceIds.length > 1) {
-      throw new IOException("Following ServiceID's " +
-          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + " are" +
-          " defined in the configuration. Use the method getRpcClient which " +
-          "takes serviceID and configuration as param");
-    } else if (serviceIds.length == 1) {
-      return getRpcClient(getClientProtocol(config, serviceIds[0]), config,
-          accessID);
-    } else {
-      return getRpcClient(getClientProtocol(config), config, accessID);
     }
   }
 
@@ -159,7 +131,23 @@ public final class OzoneClientFactory {
    */
   public static OzoneClient getRpcClient(ConfigurationSource config)
       throws IOException {
-    return getRpcClient(config, null);
+    Preconditions.checkNotNull(config);
+
+    // Doing this explicitly so that when service ids are defined in the
+    // configuration, we don't fall back to default ozone.om.address defined
+    // in ozone-default.xml.
+
+    String[] serviceIds = config.getTrimmedStrings(OZONE_OM_SERVICE_IDS_KEY);
+    if (serviceIds.length > 1) {
+      throw new IOException("Following ServiceID's " +
+          config.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY) + " are" +
+          " defined in the configuration. Use the method getRpcClient which " +
+          "takes serviceID and configuration as param");
+    } else if (serviceIds.length == 1) {
+      return getRpcClient(getClientProtocol(config, serviceIds[0]), config);
+    } else {
+      return getRpcClient(getClientProtocol(config), config);
+    }
   }
 
   /**
@@ -172,13 +160,8 @@ public final class OzoneClientFactory {
    *        Configuration to be used for OzoneClient creation
    */
   private static OzoneClient getRpcClient(ClientProtocol clientProtocol,
-      ConfigurationSource config) {
-    return new OzoneClient(config, clientProtocol, null);
-  }
-
-  private static OzoneClient getRpcClient(ClientProtocol clientProtocol,
-      ConfigurationSource config, String accessID) {
-    return new OzoneClient(config, clientProtocol, accessID);
+                                       ConfigurationSource config) {
+    return new OzoneClient(config, clientProtocol);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -882,7 +882,7 @@ public interface ClientProtocol {
    * of the S3 API implementation within Ozone.
    * @param s3Auth authentication information for each S3 API call.
    */
-  void setTheadLocalS3Auth(S3Auth s3Auth);
+  void setThreadLocalS3Auth(S3Auth s3Auth);
 
   /**
    * Gets the S3 Authentication information that is attached to the thread.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -882,7 +882,7 @@ public interface ClientProtocol {
    * of the S3 API implementation within Ozone.
    * @param s3Auth authentication information for each S3 API call.
    */
-  void setThreadLocalS3Auth(S3Auth s3Auth);
+  void setTheadLocalS3Auth(S3Auth s3Auth);
 
   /**
    * Gets the S3 Authentication information that is attached to the thread.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -124,12 +124,11 @@ public interface ClientProtocol {
       throws IOException;
 
   /**
-   * @param accessID
    * @return The {@link OzoneVolume} that should be used to for this S3
    * request based on its access ID.
    * @throws IOException
    */
-  OzoneVolume getS3VolumeDetails(String accessID) throws IOException;
+  OzoneVolume getS3VolumeDetails() throws IOException;
 
   /**
    * Checks if a Volume exists and the user with a role specified has access

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1742,7 +1742,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void setTheadLocalS3Auth(
+  public void setThreadLocalS3Auth(
       S3Auth ozoneSharedSecretAuth) {
     ozoneManagerClient.setThreadLocalS3Auth(ozoneSharedSecretAuth);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -433,8 +433,8 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public OzoneVolume getS3VolumeDetails(String accessID) throws IOException {
-    OmVolumeArgs volume = ozoneManagerClient.getS3Volume(accessID);
+  public OzoneVolume getS3VolumeDetails() throws IOException {
+    OmVolumeArgs volume = ozoneManagerClient.getS3Volume();
     return buildOzoneVolume(volume);
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1742,7 +1742,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void setThreadLocalS3Auth(
+  public void setTheadLocalS3Auth(
       S3Auth ozoneSharedSecretAuth) {
     ozoneManagerClient.setThreadLocalS3Auth(ozoneSharedSecretAuth);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -17,8 +17,9 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.io.IOException;
 
 /**
  * This class is used for storing Ozone tenant accessId info.
@@ -33,10 +34,6 @@ public final class OmDBAccessIdInfo {
    */
   private final String userPrincipal;
   /**
-   * Corresponding secret key for the accessId.
-   */
-  private final String secretKey;
-  /**
    * Whether this accessId is an administrator of the tenant.
    */
   private final boolean isAdmin;
@@ -49,69 +46,45 @@ public final class OmDBAccessIdInfo {
   // This implies above String fields should NOT contain the split key.
   public static final String SERIALIZATION_SPLIT_KEY = ";";
 
-  public OmDBAccessIdInfo(String tenantId,
-                          String userPrincipal, String secretKey,
+  public OmDBAccessIdInfo(String tenantId, String userPrincipal,
                           boolean isAdmin, boolean isDelegatedAdmin) {
     this.tenantId = tenantId;
     this.userPrincipal = userPrincipal;
-    this.secretKey = secretKey;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
-  }
-
-  private OmDBAccessIdInfo(String accessIdInfoString) {
-    String[] tInfo = accessIdInfoString.split(SERIALIZATION_SPLIT_KEY);
-    Preconditions.checkState(tInfo.length == 3 || tInfo.length == 5,
-        "Incorrect accessIdInfoString");
-
-    tenantId = tInfo[0];
-    userPrincipal = tInfo[1];
-    secretKey = tInfo[2];
-    if (tInfo.length == 5) {
-      isAdmin = Boolean.parseBoolean(tInfo[3]);
-      isDelegatedAdmin = Boolean.parseBoolean(tInfo[4]);
-    } else {
-      isAdmin = false;
-      isDelegatedAdmin = false;
-    }
   }
 
   public String getTenantId() {
     return tenantId;
   }
 
-  private String serialize() {
-    final StringBuilder sb = new StringBuilder();
-    sb.append(tenantId);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(userPrincipal);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(secretKey);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(isAdmin);
-    sb.append(SERIALIZATION_SPLIT_KEY).append(isDelegatedAdmin);
-    return sb.toString();
-  }
-
   /**
-   * Convert OmDBAccessIdInfo to byteArray to be persisted to DB.
-   * @return byte[]
+   * Convert OmDBAccessIdInfo to protobuf to be persisted to DB.
    */
-  public byte[] convertToByteArray() {
-    return StringUtils.string2Bytes(serialize());
+  public OzoneManagerProtocolProtos.OmDBAccessInfo getProtobuf() {
+        return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
+            .setPrincipal(userPrincipal)
+            .setIsAdmin(isAdmin)
+            .setIsDelegatedAdmin(isDelegatedAdmin)
+            .setTenantId(tenantId)
+            .build();
   }
 
   /**
    * Convert byte array to OmDBAccessIdInfo.
    */
-  public static OmDBAccessIdInfo getFromByteArray(byte[] bytes) {
-    String tInfo = StringUtils.bytes2String(bytes);
-    return new OmDBAccessIdInfo(tInfo);
+  public static OmDBAccessIdInfo getFromProtobuf(
+      OzoneManagerProtocolProtos.OmDBAccessInfo infoProto) throws IOException {
+    return new Builder()
+        .setKerberosPrincipal(infoProto.getPrincipal())
+        .setIsAdmin(infoProto.getIsAdmin())
+        .setIsDelegatedAdmin(infoProto.getIsDelegatedAdmin())
+        .setTenantId(infoProto.getTenantId())
+        .build();
   }
 
   public String getUserPrincipal() {
     return userPrincipal;
-  }
-
-  public String getSecretKey() {
-    return secretKey;
   }
 
   public boolean getIsAdmin() {
@@ -129,7 +102,6 @@ public final class OmDBAccessIdInfo {
   public static final class Builder {
     private String tenantId;
     private String kerberosPrincipal;
-    private String sharedSecret;
     private boolean isAdmin;
     private boolean isDelegatedAdmin;
 
@@ -140,11 +112,6 @@ public final class OmDBAccessIdInfo {
 
     public Builder setKerberosPrincipal(String kerberosPrincipal) {
       this.kerberosPrincipal = kerberosPrincipal;
-      return this;
-    }
-
-    public Builder setSharedSecret(String sharedSecret) {
-      this.sharedSecret = sharedSecret;
       return this;
     }
 
@@ -159,7 +126,7 @@ public final class OmDBAccessIdInfo {
     }
 
     public OmDBAccessIdInfo build() {
-      return new OmDBAccessIdInfo(tenantId, kerberosPrincipal, sharedSecret,
+      return new OmDBAccessIdInfo(tenantId, kerberosPrincipal,
           isAdmin, isDelegatedAdmin);
     }
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -63,7 +63,7 @@ public final class OmDBAccessIdInfo {
    */
   public OzoneManagerProtocolProtos.OmDBAccessInfo getProtobuf() {
     return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
-        .setPrincipal(userPrincipal)
+        .setUserPrincipal(userPrincipal)
         .setIsAdmin(isAdmin)
         .setIsDelegatedAdmin(isDelegatedAdmin)
         .setTenantId(tenantId)
@@ -76,7 +76,7 @@ public final class OmDBAccessIdInfo {
   public static OmDBAccessIdInfo getFromProtobuf(
       OzoneManagerProtocolProtos.OmDBAccessInfo infoProto) throws IOException {
     return new Builder()
-        .setKerberosPrincipal(infoProto.getPrincipal())
+        .setKerberosPrincipal(infoProto.getUserPrincipal())
         .setIsAdmin(infoProto.getIsAdmin())
         .setIsDelegatedAdmin(infoProto.getIsDelegatedAdmin())
         .setTenantId(infoProto.getTenantId())

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -62,12 +62,12 @@ public final class OmDBAccessIdInfo {
    * Convert OmDBAccessIdInfo to protobuf to be persisted to DB.
    */
   public OzoneManagerProtocolProtos.OmDBAccessInfo getProtobuf() {
-        return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
-            .setPrincipal(userPrincipal)
-            .setIsAdmin(isAdmin)
-            .setIsDelegatedAdmin(isDelegatedAdmin)
-            .setTenantId(tenantId)
-            .build();
+    return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
+        .setPrincipal(userPrincipal)
+        .setIsAdmin(isAdmin)
+        .setIsDelegatedAdmin(isDelegatedAdmin)
+        .setTenantId(tenantId)
+        .build();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -605,7 +605,7 @@ public interface OzoneManagerProtocol
         "this to be implemented, as write requests use a new approach");
   }
 
-  OmVolumeArgs getS3Volume(String accessID) throws IOException;
+  OmVolumeArgs getS3Volume() throws IOException;
 
   /**
    * Revoke user accessId to a tenant.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1102,9 +1102,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public OmVolumeArgs getS3Volume(String accessID) throws IOException {
+  public OmVolumeArgs getS3Volume() throws IOException {
     final GetS3VolumeRequest request = GetS3VolumeRequest.newBuilder()
-        .setAccessID(accessID)
         .build();
     final OMRequest omRequest = createOMRequest(Type.GetS3Volume)
         .setGetS3VolumeRequest(request)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.rpc.RpcClient;
 import org.apache.hadoop.ozone.om.OMMultiTenantManagerImpl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -150,8 +151,8 @@ public class TestMultiTenantVolume {
     OzoneConfiguration conf = cluster.getOzoneManager().getConfiguration();
     // Manually construct an object store instead of using the cluster
     // provided one so we can specify the access ID.
-    // TODO: Update after HDDS-4440 is merged and this is not necessary.
-    return new ObjectStore(conf, new RpcClient(conf, null),
-        accessID);
+    RpcClient client = new RpcClient(conf, null);
+    client.setThreadLocalS3Auth(new S3Auth("unused1", "unused2", accessID));
+    return new ObjectStore(conf, client);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/multitenant/TestMultiTenantVolume.java
@@ -152,7 +152,7 @@ public class TestMultiTenantVolume {
     // Manually construct an object store instead of using the cluster
     // provided one so we can specify the access ID.
     RpcClient client = new RpcClient(conf, null);
-    client.setThreadLocalS3Auth(new S3Auth("unused1", "unused2", accessID));
+    client.setTheadLocalS3Auth(new S3Auth("unused1", "unused2", accessID));
     return new ObjectStore(conf, client);
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1533,10 +1533,10 @@ message TenantRevokeAdminResponse {
 }
 
 message OmDBAccessInfo {
-  optional string principal = 1;
-  optional bool isAdmin = 2;
-  optional bool isDelegatedAdmin = 3;
-  optional string tenantId = 4;
+  optional string tenantId = 1;
+  optional string userPrincipal = 2;
+  optional bool isAdmin = 3;
+  optional bool isDelegatedAdmin = 4;
 }
 
 message GetS3VolumeResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1532,6 +1532,13 @@ message TenantRevokeAdminResponse {
     optional bool success = 1;  // TODO: Remove this field
 }
 
+message OmDBAccessInfo {
+  optional string principal = 1;
+  optional bool isAdmin = 2;
+  optional bool isDelegatedAdmin = 3;
+  optional string tenantId = 4;
+}
+
 message GetS3VolumeResponse {
   optional VolumeInfo volumeInfo = 1;
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1503,7 +1503,7 @@ message TenantRevokeAdminRequest {
 }
 
 message GetS3VolumeRequest {
-  optional string accessID = 1;
+
 }
 
 message CreateTenantResponse {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class OmDBAccessIdInfoCodec implements Codec<OmDBAccessIdInfo> {
   @Override
   public byte[] toPersistedFormat(OmDBAccessIdInfo object) throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.convertToByteArray();
+    return object.getProtobuf().toByteArray();
   }
 
   @Override
@@ -44,7 +45,8 @@ public class OmDBAccessIdInfoCodec implements Codec<OmDBAccessIdInfo> {
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OmDBAccessIdInfo.getFromByteArray(rawData);
+    return OmDBAccessIdInfo.getFromProtobuf(
+        OzoneManagerProtocolProtos.OmDBAccessInfo.parseFrom(rawData));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om;
 import java.io.IOException;
 import java.util.List;
 
+import com.google.common.base.Optional;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.multitenant.AccessPolicy;
@@ -196,7 +197,7 @@ public interface OMMultiTenantManager {
    * @param accessID
    * @return String tenant name
    */
-  String getTenantForAccessID(String accessID) throws IOException;
+  Optional<String> getTenantForAccessID(String accessID) throws IOException;
 
   /**
    * Given a user, make him an admin of the corresponding Tenant.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -356,8 +356,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
   }
 
   @Override
-  public String getUserSecret(String accessID)
-      throws IOException {
+  public String getUserSecret(String accessID) throws IOException {
     return "";
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -32,7 +32,27 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVA
  */
 public final class OzoneAclUtils {
 
+  private static OMMultiTenantManager multiTenantManager;
+
   private OzoneAclUtils() {
+  }
+
+  public static void setOMMultiTenantManager(OMMultiTenantManager tenantManager) {
+    multiTenantManager = tenantManager;
+  }
+
+  /**
+   * Converts the given access ID to a kerberos principal.
+   * If the access ID does not belong to a tenant, the access ID is returned
+   * as is to be used as the principal.
+   */
+  public static String principalToAccessID(String accessID) throws IOException {
+    String principal = multiTenantManager.getUserNameGivenAccessId(accessID);
+    if (principal == null) {
+      principal = accessID;
+    }
+
+    return principal;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneAclUtils.java
@@ -37,7 +37,8 @@ public final class OzoneAclUtils {
   private OzoneAclUtils() {
   }
 
-  public static void setOMMultiTenantManager(OMMultiTenantManager tenantManager) {
+  public static void setOMMultiTenantManager(
+      OMMultiTenantManager tenantManager) {
     multiTenantManager = tenantManager;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -886,7 +886,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .setS3SecretManager(s3SecretManager)
         .setCertificateClient(certClient)
         .setOmServiceId(omNodeDetails.getServiceId())
-        .setOMMultiTenantManager(multiTenantManagr)
         .build();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3SecretManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/S3SecretManagerImpl.java
@@ -82,22 +82,22 @@ public class S3SecretManagerImpl implements S3SecretManager {
   }
 
   @Override
-  public String getS3UserSecretString(String kerberosID)
+  public String getS3UserSecretString(String awsAccessKey)
       throws IOException {
-    Preconditions.checkArgument(Strings.isNotBlank(kerberosID),
+    Preconditions.checkArgument(Strings.isNotBlank(awsAccessKey),
         "awsAccessKeyId cannot be null or empty.");
-    LOG.trace("Get secret for awsAccessKey:{}", kerberosID);
+    LOG.trace("Get secret for awsAccessKey:{}", awsAccessKey);
 
     S3SecretValue s3Secret;
-    omMetadataManager.getLock().acquireReadLock(S3_SECRET_LOCK, kerberosID);
+    omMetadataManager.getLock().acquireReadLock(S3_SECRET_LOCK, awsAccessKey);
     try {
-      s3Secret = omMetadataManager.getS3SecretTable().get(kerberosID);
+      s3Secret = omMetadataManager.getS3SecretTable().get(awsAccessKey);
       if (s3Secret == null) {
         throw new OzoneSecurityException("S3 secret not found for " +
-            "awsAccessKeyId " + kerberosID, S3_SECRET_NOT_FOUND);
+            "awsAccessKeyId " + awsAccessKey, S3_SECRET_NOT_FOUND);
       }
     } finally {
-      omMetadataManager.getLock().releaseReadLock(S3_SECRET_LOCK, kerberosID);
+      omMetadataManager.getLock().releaseReadLock(S3_SECRET_LOCK, awsAccessKey);
     }
 
     return s3Secret.getAwsSecret();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -113,7 +113,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
   }
 
   @Override
-  public OMRequest preExecute(OzoneManager ozoneManager) {
+  public OMRequest preExecute(OzoneManager ozoneManager) throws IOException {
     CreateDirectoryRequest createDirectoryRequest =
         getOmRequest().getCreateDirectoryRequest();
     Preconditions.checkNotNull(createDirectoryRequest);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -159,41 +159,29 @@ public class S3GetSecretRequest extends OMClientRequest {
     }
 
     try {
-      // Note: We use the same S3_SECRET_LOCK for TenantAccessIdTable.
       acquiredLock = omMetadataManager.getLock()
           .acquireWriteLock(S3_SECRET_LOCK, accessId);
 
-      // Check multi-tenant table first: tenantAccessIdTable
       final S3SecretValue assignS3SecretValue;
-      final OmDBAccessIdInfo omDBAccessIdInfo =
-          omMetadataManager.getTenantAccessIdTable().get(accessId);
-      if (omDBAccessIdInfo == null) {
-        // Not found in TenantAccessIdTable. Fallback to S3SecretTable.
-        final S3SecretValue s3SecretValue =
-            omMetadataManager.getS3SecretTable().get(accessId);
+      final S3SecretValue s3SecretValue =
+          omMetadataManager.getS3SecretTable().get(accessId);
 
-        if (s3SecretValue == null) {
-          if (createIfNotExist) {
-            // Still not found in S3SecretTable. Add new entry in this case
-            assignS3SecretValue = new S3SecretValue(accessId, awsSecret);
-            // Add cache entry first.
-            omMetadataManager.getS3SecretTable().addCacheEntry(
-                    new CacheKey<>(accessId),
-                    new CacheValue<>(Optional.of(assignS3SecretValue),
-                            transactionLogIndex));
-            // TODO: Put accessId entry straight to TenantAccessIdTable
-            //  later when we deprecate the S3SecretTable.
-          } else {
-            assignS3SecretValue = null;
-          }
+      if (s3SecretValue == null) {
+        // Not found in S3SecretTable.
+        if (createIfNotExist) {
+          // Add new entry in this case
+          assignS3SecretValue = new S3SecretValue(accessId, awsSecret);
+          // Add cache entry first.
+          omMetadataManager.getS3SecretTable().addCacheEntry(
+                  new CacheKey<>(accessId),
+                  new CacheValue<>(Optional.of(assignS3SecretValue),
+                          transactionLogIndex));
         } else {
-          // Found in S3SecretTable.
-          awsSecret = s3SecretValue.getAwsSecret();
           assignS3SecretValue = null;
         }
       } else {
-        // Found in TenantAccessIdTable.
-        awsSecret = omDBAccessIdInfo.getSecretKey();
+        // Found in S3SecretTable.
+        awsSecret = s3SecretValue.getAwsSecret();
         assignS3SecretValue = null;
       }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3GetSecretRequest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 
 import com.google.common.base.Optional;
 import org.apache.commons.codec.digest.DigestUtils;
-import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
@@ -328,6 +328,14 @@ public class OMAssignUserToTenantRequest extends OMClientRequest {
       acquiredS3SecretLock = omMetadataManager.getLock()
           .acquireWriteLock(S3_SECRET_LOCK, accessId);
 
+      // Expect accessId absence from S3SecretTable
+      if (omMetadataManager.getS3SecretTable().isExist(accessId)) {
+        LOG.error("accessId '{}' already exists in S3SecretTable", accessId);
+        throw new OMException("accessId '" + accessId +
+            "' already exists in S3SecretTable",
+            OMException.ResultCodes.TENANT_USER_ACCESSID_ALREADY_EXISTS);
+      }
+
       omMetadataManager.getS3SecretTable().addCacheEntry(
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.of(s3SecretValue), transactionLogIndex));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMAssignUserToTenantRequest.java
@@ -289,7 +289,6 @@ public class OMAssignUserToTenantRequest extends OMClientRequest {
       final OmDBAccessIdInfo omDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
           .setTenantId(tenantId)
           .setKerberosPrincipal(principal)
-          .setSharedSecret(s3SecretValue.getAwsSecret())
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
           .build();
@@ -325,21 +324,10 @@ public class OMAssignUserToTenantRequest extends OMClientRequest {
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.of(roleName), transactionLogIndex));
 
-      // Add to S3SecretTable.
-      // Note: S3SecretTable will be deprecated in the future.
+      // Add S3SecretTable cache entry
       acquiredS3SecretLock = omMetadataManager.getLock()
           .acquireWriteLock(S3_SECRET_LOCK, accessId);
 
-      // Expect accessId absence from S3SecretTable
-      // TODO: This table might be merged with tenantAccessIdTable later.
-      if (omMetadataManager.getS3SecretTable().isExist(accessId)) {
-        LOG.error("accessId '{}' already exists in S3SecretTable", accessId);
-        throw new OMException("accessId '" + accessId +
-            "' already exists in S3SecretTable",
-            OMException.ResultCodes.INVALID_REQUEST);
-      }
-
-      // Add S3SecretTable cache entry
       omMetadataManager.getS3SecretTable().addCacheEntry(
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.of(s3SecretValue), transactionLogIndex));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -189,7 +189,6 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
           new OmDBAccessIdInfo.Builder()
           .setTenantId(oldAccessIdInfo.getTenantId())
           .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
-          .setSharedSecret(oldAccessIdInfo.getSecretKey())
           .setIsAdmin(true)
           .setIsDelegatedAdmin(delegated)
           .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -169,7 +169,6 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
           new OmDBAccessIdInfo.Builder()
           .setTenantId(oldAccessIdInfo.getTenantId())
           .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
-          .setSharedSecret(oldAccessIdInfo.getSecretKey())
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
           .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
@@ -39,23 +39,20 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_
 /**
  * Response for SetSecret request.
  */
-@CleanupTableInfo(cleanupTables = {S3_SECRET_TABLE, TENANT_ACCESS_ID_TABLE})
+@CleanupTableInfo(cleanupTables = {S3_SECRET_TABLE})
 public class OMSetSecretResponse extends OMClientResponse {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMSetSecretResponse.class);
 
   private String accessId;
-  private OmDBAccessIdInfo dbAccessIdInfo;
   private S3SecretValue s3SecretValue;
 
   public OMSetSecretResponse(@Nullable String accessId,
-                             @Nullable OmDBAccessIdInfo dbAccessIdInfo,
                              @Nullable S3SecretValue s3SecretValue,
                              @Nonnull OMResponse omResponse) {
     super(omResponse);
     this.accessId = accessId;
-    this.dbAccessIdInfo = dbAccessIdInfo;
     this.s3SecretValue = s3SecretValue;
   }
 
@@ -73,12 +70,6 @@ public class OMSetSecretResponse extends OMClientResponse {
       BatchOperation batchOperation) throws IOException {
 
     assert(getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK);
-
-    if (dbAccessIdInfo != null) {
-      LOG.debug("Updating TenantAccessIdTable");
-      omMetadataManager.getTenantAccessIdTable().putWithBatch(batchOperation,
-          accessId, dbAccessIdInfo);
-    }
 
     if (s3SecretValue != null) {
       LOG.debug("Updating TenantAccessIdTable");

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/security/OMSetSecretResponse.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.response.s3.security;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -34,7 +33,6 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.S3_SECRET_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
 
 /**
  * Response for SetSecret request.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
@@ -90,7 +90,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
 
     if (s3SecretValue != null &&
         getOMResponse().getStatus() == OzoneManagerProtocolProtos.Status.OK) {
-      assert(accessId.equals(s3SecretValue.getKerberosID()));
       // Add S3SecretTable entry
       omMetadataManager.getS3SecretTable().putWithBatch(batchOperation,
           accessId, s3SecretValue);
@@ -109,5 +108,10 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
   @VisibleForTesting
   public OmDBAccessIdInfo getOmDBAccessIdInfo() {
     return omDBAccessIdInfo;
+  }
+
+  @VisibleForTesting
+  public S3SecretValue getS3Secret() {
+    return s3SecretValue;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -229,8 +229,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         responseBuilder.setPrepareStatusResponse(prepareStatusResponse);
         break;
       case GetS3Volume:
-        GetS3VolumeResponse s3VolumeResponse =
-            getS3Volume(request.getGetS3VolumeRequest());
+        GetS3VolumeResponse s3VolumeResponse = getS3Volume();
         responseBuilder.setGetS3VolumeResponse(s3VolumeResponse);
         break;
       case TenantGetUserInfo:
@@ -709,9 +708,9 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setCurrentTxnIndex(prepareState.getIndex()).build();
   }
 
-  private GetS3VolumeResponse getS3Volume(GetS3VolumeRequest request)
+  private GetS3VolumeResponse getS3Volume()
       throws IOException {
-    OmVolumeArgs s3VolArgs = impl.getS3Volume(request.getAccessID());
+    OmVolumeArgs s3VolArgs = impl.getS3Volume();
     return GetS3VolumeResponse.newBuilder()
         .setVolumeInfo(s3VolArgs.getProtobuf())
         .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -80,7 +80,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServiceListResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetS3VolumeRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.GetS3VolumeResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoRequest;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/security/OzoneDelegationTokenSecretManager.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.S3SecretManager;
 import org.apache.hadoop.ozone.om.S3SecretManagerImpl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -72,7 +71,6 @@ public class OzoneDelegationTokenSecretManager
   private final long tokenRemoverScanInterval;
   private String omCertificateSerialId;
   private String omServiceId;
-  private OMMultiTenantManager multiTenantManager;
 
   /**
    * If the delegation token update thread holds this lock, it will not get
@@ -99,7 +97,6 @@ public class OzoneDelegationTokenSecretManager
     isRatisEnabled = b.ozoneConf.getBoolean(
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_KEY,
         OMConfigKeys.OZONE_OM_RATIS_ENABLE_DEFAULT);
-    this.multiTenantManager = b.omMultiTenantManager;
     loadTokenSecretState(store.loadState());
 
   }
@@ -114,7 +111,6 @@ public class OzoneDelegationTokenSecretManager
     private long tokenRemoverScanInterval;
     private Text service;
     private S3SecretManager s3SecretManager;
-    private OMMultiTenantManager omMultiTenantManager;
     private CertificateClient certClient;
     private String omServiceId;
 
@@ -161,23 +157,11 @@ public class OzoneDelegationTokenSecretManager
       this.omServiceId = serviceId;
       return this;
     }
-
-    public Builder setOMMultiTenantManager(OMMultiTenantManager
-                                               multiTenantManager) {
-      this.omMultiTenantManager = multiTenantManager;
-      return this;
-    }
-
   }
 
   @Override
   public OzoneTokenIdentifier createIdentifier() {
-    OzoneTokenIdentifier tokenId = OzoneTokenIdentifier.newInstance();
-    if (multiTenantManager != null) {
-      tokenId.setGetUserForAccessId(
-          multiTenantManager::getUserNameGivenAccessId);
-    }
-    return tokenId;
+    return OzoneTokenIdentifier.newInstance();
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+import com.google.common.base.Optional;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -129,10 +130,9 @@ public class TestOMMultiTenantManagerImpl {
 
   @Test
   public void testGetTenantForAccessID() throws Exception {
-    assertEquals(tenantName, tenantManager.getTenantForAccessID("seed" +
-        "-accessId1"));
-    LambdaTestUtils.intercept(OMException.class, () -> {
-      tenantManager.getTenantForAccessID("invalid-accessId1");
-    });
+    Optional<String> optionalTenant = tenantManager.getTenantForAccessID(
+        "seed-accessId1");
+    assertTrue(optionalTenant.isPresent());
+    assertEquals(tenantName, optionalTenant.get());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -75,7 +75,7 @@ public class TestOMMultiTenantManagerImpl {
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",
         new OmDBAccessIdInfo(tenantName, "seed-user1",
-            "sharedsecret1", false, false));
+            false, false));
 
     tenantManager = new OMMultiTenantManagerImpl(omMetadataManager, conf);
     assertEquals(1, tenantManager.getTenantCache().size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -382,6 +382,9 @@ public class TestS3GetSecretRequest {
     final OmDBAccessIdInfo omDBAccessIdInfo =
         omTenantAssignUserAccessIdResponse.getOmDBAccessIdInfo();
     Assert.assertNotNull(omDBAccessIdInfo);
+    final S3SecretValue originalS3Secret =
+        omTenantAssignUserAccessIdResponse.getS3Secret();
+    Assert.assertNotNull(originalS3Secret);
 
 
     // 3. S3GetSecretRequest: Get secret of "bob@EXAMPLE.COM" (as an admin).
@@ -419,7 +422,9 @@ public class TestS3GetSecretRequest {
         s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
     final S3Secret s3Secret = getS3SecretResponse.getS3Secret();
     Assert.assertEquals(ACCESS_ID_BOB, s3Secret.getKerberosID());
-    Assert.assertEquals(
-        omDBAccessIdInfo.getSecretKey(), s3Secret.getAwsSecret());
+    Assert.assertEquals(originalS3Secret.getAwsSecret(),
+        s3Secret.getAwsSecret());
+    Assert.assertEquals(originalS3Secret.getKerberosID(),
+        s3Secret.getKerberosID());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/TestOzoneTokenIdentifier.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.ozone.security;
 
-import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMTokenProto.Type.S3AUTHINFO;
-
 import javax.crypto.KeyGenerator;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -347,21 +345,5 @@ public class TestOzoneTokenIdentifier {
     }
     Assert.assertEquals("Deserialize Serialized Token should equal.",
         idWrite, idRead);
-  }
-
-  @Test
-  public void testGetUserFromAccessIdInToken() {
-    OzoneTokenIdentifier id = getIdentifierInst();
-    Assert.assertEquals("User1", id.getUser().getUserName());
-
-    id.setTokenType(S3AUTHINFO);
-    Assert.assertEquals("User1", id.getUser().getUserName());
-
-    id.setGetUserForAccessId(s -> "modified-" + s);
-    Assert.assertEquals("modified-User1", id.getUser().getUserName());
-
-    id.setGetUserForAccessId(s -> null);
-    Assert.assertEquals("User1", id.getUser().getUserName());
-
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -97,8 +97,6 @@ public class OzoneClientProducer {
 
       String awsAccessId = signatureInfo.getAwsAccessId();
       validateAccessId(awsAccessId);
-      // TODO: Once HDDS-4440 is merged, access ID should be passed
-      //  through the OM transport. Double check @erose
       return new S3Auth(stringToSign,
           signatureInfo.getSignature(),
           awsAccessId);
@@ -132,11 +130,10 @@ public class OzoneClientProducer {
     }
 
     if (omServiceID == null) {
-      return OzoneClientFactory.getRpcClient(ozoneConfiguration, accessId);
+      return OzoneClientFactory.getRpcClient(ozoneConfiguration);
     } else {
       // As in HA case, we need to pass om service ID.
-      return OzoneClientFactory.getRpcClient(omServiceID,
-          ozoneConfiguration, accessId);
+      return OzoneClientFactory.getRpcClient(omServiceID, ozoneConfiguration);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -120,15 +120,6 @@ public class OzoneClientProducer {
     ozoneConfiguration.setIfUnset(OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
         OZONE_OM_CLIENT_PROTOCOL_VERSION);
 
-    // TODO: Added this snippet for a quick fix due to a conflict with HDDS-5883
-    //  Double check / optimize.
-    String accessId = null;
-    try {
-      accessId = signatureProcessor.parseSignature().getAwsAccessId();
-    } catch (OS3Exception e) {
-      LOG.error("Unable to parse signature to get accessId");
-    }
-
     if (omServiceID == null) {
       return OzoneClientFactory.getRpcClient(ozoneConfiguration);
     } else {
@@ -140,7 +131,7 @@ public class OzoneClientProducer {
   // ONLY validate aws access id when needed.
   private void validateAccessId(String awsAccessId) throws Exception {
     if (awsAccessId == null || awsAccessId.equals("")) {
-      LOG.error("Malformed s3 header. awsAccessID: ", awsAccessId);
+      LOG.error("Malformed s3 header. awsAccessID: {}", awsAccessId);
       throw wrapOS3Exception(MALFORMED_HEADER);
     }
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -73,7 +73,7 @@ public abstract class EndpointBase {
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
     getClient().getObjectStore().
         getClientProxy().
-        setTheadLocalS3Auth(s3Auth);
+        setThreadLocalS3Auth(s3Auth);
     init();
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -73,7 +73,7 @@ public abstract class EndpointBase {
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
     getClient().getObjectStore().
         getClientProxy().
-        setThreadLocalS3Auth(s3Auth);
+        setTheadLocalS3Auth(s3Auth);
     init();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use changes from HDDS-5881 to have the access ID passed to the OM to determine which tenant volume to use for S3 requests. This is a much cleaner solution than the temporary workaround implemented in HDDS-5645. 

## Change Summary

- Deletes many changes from HDDS-5645 (original chroot implementation).
- Reverts HDDS-5476, since the principal of incoming requests will always be that of the s3 gateway, and access IDs are now carried in a proto field.
- Moves s3 secrets for tenants out of the tenant specific table they were in before, and in to the same s3 secret table already used on master.

## Compatibility

Under this PR, we will adopt similar OM <-> S3g compatibility requirements as HDDS-5881:
    - A newer s3g cannot talk to an older OM, since the new s3g will always use its kerberos principal, not a principal the same as the calling user's access ID.
    - An older s3g can talk to a newer OM, because if the s3 auth fields of the proto are not set, the OM will default to using the principal used by s3g as the access ID. 

## What is the link to the Apache JIRA

HDDS-6004

## How was this patch tested?

- Existing integration and acceptance tests that were used to test the original implementation in HDDS-5645.

- The acceptance tests failing after the recent merge with master to the feature branch should pass after this PR.

- Cross compatibility testing and client versioning is a larger item that is being addressed separately as an upgrade task for all features that may need it, like EC, FSO, S3 gateway changes, etc.
    - It is beyond the scope of this PR, which just uses existing changes.