### PR TITLE
HDDS-6103. Avoid refresh pipeline for key override in Key/File Create.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -187,15 +187,19 @@ public final class OmKeyLocationInfo {
         if (this.token != null) {
           builder.setToken(OzonePBHelper.protoFromToken(token));
         }
-        // Pipeline can be null when key create with override and
-        // on a versioning enabled on bucket. for older versions of key
-        // We do not need to return pipeline as part of createKey,
-        // so we do not refresh pipeline in createKey, so for the old version
-        // of blocks pipeline can be null.
 
-        // And also currently, we donot support bucket versioning.
+        // Pipeline can be null when key create with override and
+        // on a versioning enabled bucket. for older versions of blocks
+        // We do not need to return pipeline as part of createKey,
+        // so we do not refresh pipeline in createKey, because of this reason
+        // for older version of blocks pipeline can be null.
+        // And also for key create we never need to return pipeline info
+        // for older version of blocks irrespective of versioning.
+
+        // Currently, we do not completely support bucket versioning.
         // TODO: this needs to be revisited when bucket versioning
         //  implementation is handled.
+
         if (this.pipeline != null) {
           builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
         }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfo.java
@@ -187,7 +187,18 @@ public final class OmKeyLocationInfo {
         if (this.token != null) {
           builder.setToken(OzonePBHelper.protoFromToken(token));
         }
-        builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
+        // Pipeline can be null when key create with override and
+        // on a versioning enabled on bucket. for older versions of key
+        // We do not need to return pipeline as part of createKey,
+        // so we do not refresh pipeline in createKey, so for the old version
+        // of blocks pipeline can be null.
+
+        // And also currently, we donot support bucket versioning.
+        // TODO: this needs to be revisited when bucket versioning
+        //  implementation is handled.
+        if (this.pipeline != null) {
+          builder.setPipeline(pipeline.getProtobufMessage(clientVersion));
+        }
       } catch (UnknownPipelineStateException e) {
         //TODO: fix me: we should not return KeyLocation without pipeline.
       }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -1,0 +1,152 @@
+package org.apache.hadoop.ozone.client.rpc;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION;
+import static org.junit.Assert.fail;
+
+/**
+ * Main purpose of this test is with OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION
+ * set/unset key create/read works properly or not for buckets
+ * with/with out versioning.
+ */
+@RunWith(Parameterized.class)
+public class TestOzoneRpcClientWithKeyLatestVersion {
+
+  private static MiniOzoneCluster cluster;
+
+  private static ObjectStore objectStore;
+
+  private static OzoneClient ozClient;
+
+
+  @Parameterized.Parameters
+  public static Collection<Object> data() {
+    return Arrays.asList(true, false);
+  }
+
+  public TestOzoneRpcClientWithKeyLatestVersion(boolean getLatestVersion) {
+    try {
+      setup(getLatestVersion);
+    } catch (Exception ex) {
+      fail("Unexpected exception during setup:" + ex);
+    }
+  }
+
+
+  public static void setup(boolean getLatestVersion) throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
+    conf.setBoolean(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION, getLatestVersion);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .setScmId(UUID.randomUUID().toString())
+        .setClusterId(UUID.randomUUID().toString())
+        .build();
+    cluster.waitForClusterToBeReady();
+    ozClient = OzoneClientFactory.getRpcClient(conf);
+    objectStore = ozClient.getObjectStore();
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    if(ozClient != null) {
+      ozClient.close();
+    }
+
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+
+  @Test
+  public void testOverrideAndReadKey() throws Exception {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    // Test checks key override and read are working with
+    // bucket versioning false.
+    String value = "sample value";
+    createRequiredForVersioningTest(volumeName, bucketName, keyName, false, value);
+
+    // read key and test
+    testReadKey(volumeName, bucketName, keyName, value);
+
+
+    // Versioning turned on
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+    keyName = UUID.randomUUID().toString();
+
+    // Test checks key override and read are working with
+    // bucket versioning true.
+    createRequiredForVersioningTest(volumeName, bucketName, keyName, true, value);
+
+    // read key and test
+    testReadKey(volumeName, bucketName, keyName, value);
+  }
+
+  private void createRequiredForVersioningTest(String volumeName,
+      String bucketName, String keyName, boolean versioning, String value) throws Exception {
+
+    ReplicationConfig replicationConfig = ReplicationConfig
+        .fromProtoTypeAndFactor(RATIS, HddsProtos.ReplicationFactor.THREE);
+
+    objectStore.createVolume(volumeName);
+    OzoneVolume volume = objectStore.getVolume(volumeName);
+
+    // Bucket created with versioning false.
+    volume.createBucket(bucketName,
+        BucketArgs.newBuilder().setVersioning(versioning).build());
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    OzoneOutputStream out = bucket.createKey(keyName,
+        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
+    out.write(value.getBytes(UTF_8));
+    out.close();
+
+    // Override key
+    out = bucket.createKey(keyName,
+        value.getBytes(UTF_8).length, replicationConfig, new HashMap<>());
+    out.write(value.getBytes(UTF_8));
+    out.close();
+  }
+
+  private void testReadKey(String volumeName, String bucketName,
+      String keyName, String value) throws Exception {
+    OzoneVolume volume = objectStore.getVolume(volumeName);
+    OzoneBucket ozoneBucket = volume.getBucket(bucketName);
+    OzoneInputStream is = ozoneBucket.readKey(keyName);
+    byte[] fileContent = new byte[value.getBytes(UTF_8).length];
+    is.read(fileContent);
+    Assert.assertEquals(value, new String(fileContent, UTF_8));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.client.rpc;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.jooq.meta.derby.sys.Sys;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -88,17 +87,20 @@ public class TestOzoneRpcClientWithKeyLatestVersion {
 
   @Test
   public void testWithGetLatestVersion() throws Exception {
+    getLatestVersion = false;
+    setupClient();
+    testOverrideAndReadKey();
+
+    getLatestVersion = true;
+    setupClient();
+    testOverrideAndReadKey();
+  }
+
+  private void setupClient() throws Exception {
     OzoneConfiguration conf = cluster.getConf();
     conf.setBoolean(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION, getLatestVersion);
     ozClient = OzoneClientFactory.getRpcClient(conf);
     objectStore = ozClient.getObjectStore();
-    testOverrideAndReadKey();
-
-    conf = cluster.getConf();
-    getLatestVersion = true;
-    ozClient = OzoneClientFactory.getRpcClient(conf);
-    objectStore = ozClient.getObjectStore();
-    testOverrideAndReadKey();
   }
 
   public void testOverrideAndReadKey() throws Exception {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientWithKeyLatestVersion.java
@@ -72,7 +72,6 @@ public class TestOzoneRpcClientWithKeyLatestVersion {
         .setClusterId(UUID.randomUUID().toString())
         .build();
     cluster.waitForClusterToBeReady();
-    System.out.println("done");
   }
 
   @AfterClass

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -229,10 +229,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
       OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
           .getIfExist(ozoneKey);
 
-      if (dbKeyInfo != null) {
-        ozoneManager.getKeyManager().refresh(dbKeyInfo);
-      }
-
       OMFileRequest.OMPathInfo pathInfo =
           OMFileRequest.verifyFilesInPath(omMetadataManager, volumeName,
               bucketName, keyName, Paths.get(keyName));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -141,9 +141,6 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
                 pathInfoFSO.getLeafNodeName());
         dbFileInfo = OMFileRequest.getOmKeyInfoFromFileTable(false,
                 omMetadataManager, dbFileKey, keyName);
-        if (dbFileInfo != null) {
-          ozoneManager.getKeyManager().refresh(dbFileInfo);
-        }
       }
 
       // check if the file or directory already existed in OM

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -234,10 +234,6 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       OmKeyInfo dbKeyInfo = omMetadataManager.getKeyTable(getBucketLayout())
           .getIfExist(dbKeyName);
 
-      if (dbKeyInfo != null) {
-        ozoneManager.getKeyManager().refresh(dbKeyInfo);
-      }
-
       OmBucketInfo bucketInfo = omMetadataManager.getBucketTable().get(
           omMetadataManager.getBucketKey(volumeName, bucketName));
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -120,9 +120,6 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
                 pathInfoFSO.getLeafNodeName());
         dbFileInfo = OMFileRequest.getOmKeyInfoFromFileTable(false,
                 omMetadataManager, dbFileKey, keyName);
-        if (dbFileInfo != null) {
-          ozoneManager.getKeyManager().refresh(dbFileInfo);
-        }
       }
 
       // Check if a file or directory exists with same key name.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -587,6 +587,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setBucketName(keyArgs.getBucketName())
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
+        .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
         .build();
     List<OzoneFileStatus> statuses =
         impl.listStatus(omKeyArgs, request.getRecursive(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

We do not need to refresh pipeline info when a key is override. As older version of blocks are not really useful, we have a client side flag(OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION) to return all versions or only latest version.

But irrespective of this flag or versioning we do not need to refresh pipeline for older version of blocks, as we require only latest version of blocks with pipeline information.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6103

## How was this patch tested?

Added tests
