### PR TITLE
HDDS-6065: EC: Provide CLI option to reset the bucket replication config

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetReplicationConfigOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetReplicationConfigOptions.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.hadoop.ozone.shell;
 
 import picocli.CommandLine;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetReplicationConfigOptions.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/SetReplicationConfigOptions.java
@@ -1,0 +1,27 @@
+package org.apache.hadoop.ozone.shell;
+
+import picocli.CommandLine;
+
+/**
+ * Common options for set replication config.
+ */
+public class SetReplicationConfigOptions {
+  @CommandLine.Option(names = {"--replication",
+      "-r"}, description = "Replication value. Example: 3 (for Ratis type)"
+      + " or 1 ( for" + " standalone type). In the case of EC, pass"
+      + " DATA-PARITY, eg 3-2," + " 6-3, 10-4")
+  private String replication;
+
+  @CommandLine.Option(names = {"--type",
+      "-t"}, description = "Replication type. Supported types are RATIS,"
+      + " STAND_ALONE, EC")
+  private String replicationType;
+
+  public String getReplication() {
+    return this.replication;
+  }
+
+  public String getType() {
+    return this.replicationType;
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/BucketCommands.java
@@ -48,7 +48,8 @@ import picocli.CommandLine.ParentCommand;
         RemoveAclBucketHandler.class,
         GetAclBucketHandler.class,
         SetAclBucketHandler.class,
-        ClearQuotaHandler.class
+        ClearQuotaHandler.class,
+        SetReplicationConfigHandler.class
     },
     mixinStandardHelpOptions = true,
     versionProvider = HddsVersionProvider.class)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetReplicationConfigHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetReplicationConfigHandler.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
 package org.apache.hadoop.ozone.shell.bucket;
 
 import com.google.common.base.Strings;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetReplicationConfigHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/SetReplicationConfigHandler.java
@@ -1,0 +1,44 @@
+package org.apache.hadoop.ozone.shell.bucket;
+
+import com.google.common.base.Strings;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneIllegalArgumentException;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientException;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.SetReplicationConfigOptions;
+import picocli.CommandLine;
+
+import java.io.IOException;
+
+/**
+ * set replication configuration of the bucket.
+ */
+@CommandLine.Command(name = "set-replication-config",
+    description = "Set replication config on bucket")
+public class SetReplicationConfigHandler extends BucketHandler {
+
+  @CommandLine.Mixin private SetReplicationConfigOptions
+      replicationConfigOptions;
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException, OzoneClientException {
+    if (Strings.isNullOrEmpty(replicationConfigOptions.getType()) || Strings
+        .isNullOrEmpty(replicationConfigOptions.getReplication())) {
+      throw new OzoneIllegalArgumentException(
+          "Replication type or replication factor cannot be null.");
+    }
+    String volumeName = address.getVolumeName();
+    String bucketName = address.getBucketName();
+    OzoneBucket bucket =
+        client.getObjectStore().getVolume(volumeName).getBucket(bucketName);
+    bucket.setReplicationConfig(ReplicationConfig
+        .parse(ReplicationType.valueOf(replicationConfigOptions.getType()),
+            replicationConfigOptions.getReplication(),
+            new OzoneConfiguration()));
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added the CLI options to set the replication config parameters on a bucket.
One can re-set the replication config on bucket with the following arguments on bucket:
"set-replication-config", bucketPath, "-t",  "EC", "-r", "rs-3-2-1024k"

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6065

## How was this patch tested?

Added the test to verify the behavior.