### PR TITLE
HDDS-6110. Add hugo lock file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ output.xml
 report.html
 
 hadoop-hdds/docs/public
+hadoop-hdds/docs/.hugo_build.lock
 hadoop-ozone/recon/node_modules
 
 .mvn


### PR DESCRIPTION
## What changes were proposed in this pull request?

With Hugo 0.89 or later, untracked file appears after build:

```
$ mvn -DskipTests clean package
...
$ git status
...
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        hadoop-hdds/docs/.hugo_build.lock
```

https://issues.apache.org/jira/browse/HDDS-6110

## How was this patch tested?

```
$ git status
...
nothing to commit, working tree clean
```