### PR TITLE
HDDS-5949. EC: Create reusable buffer pool shared by all EC input and output streams

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.BlockInputStream;
 import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
+import org.apache.hadoop.io.ByteBufferPool;
+import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
 
@@ -37,14 +39,21 @@ import java.util.function.Function;
 public class BlockInputStreamFactoryImpl implements BlockInputStreamFactory {
 
   private ECBlockInputStreamFactory ecBlockStreamFactory;
+  private ByteBufferPool byteBufferPool;
 
-  public static BlockInputStreamFactory getInstance() {
-    return new BlockInputStreamFactoryImpl();
+  public static BlockInputStreamFactory getInstance(
+      ByteBufferPool byteBufferPool) {
+    return new BlockInputStreamFactoryImpl(byteBufferPool);
   }
 
   public BlockInputStreamFactoryImpl() {
+    this(new ElasticByteBufferPool());
+  }
+
+  public BlockInputStreamFactoryImpl(ByteBufferPool byteBufferPool) {
+    this.byteBufferPool = byteBufferPool;
     this.ecBlockStreamFactory =
-        ECBlockInputStreamFactoryImpl.getInstance(this);
+        ECBlockInputStreamFactoryImpl.getInstance(this, byteBufferPool);
   }
 
   /**

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockInputStreamFactoryImpl.java
@@ -39,7 +39,6 @@ import java.util.function.Function;
 public class BlockInputStreamFactoryImpl implements BlockInputStreamFactory {
 
   private ECBlockInputStreamFactory ecBlockStreamFactory;
-  private ByteBufferPool byteBufferPool;
 
   public static BlockInputStreamFactory getInstance(
       ByteBufferPool byteBufferPool) {
@@ -51,7 +50,6 @@ public class BlockInputStreamFactoryImpl implements BlockInputStreamFactory {
   }
 
   public BlockInputStreamFactoryImpl(ByteBufferPool byteBufferPool) {
-    this.byteBufferPool = byteBufferPool;
     this.ecBlockStreamFactory =
         ECBlockInputStreamFactoryImpl.getInstance(this, byteBufferPool);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
@@ -81,7 +81,7 @@ public final class ECBlockInputStreamFactoryImpl implements
         sis.addFailedDatanodes(failedLocations);
       }
       return new ECBlockReconstructedInputStream(
-          (ECReplicationConfig) repConfig, sis);
+          (ECReplicationConfig) repConfig, byteBufferPool, sis);
     } else {
       // Otherwise create the more efficient non-reconstruction reader
       return new ECBlockInputStream((ECReplicationConfig)repConfig, blockInfo,

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
@@ -76,7 +76,8 @@ public final class ECBlockInputStreamFactoryImpl implements
       ECBlockReconstructedStripeInputStream sis =
           new ECBlockReconstructedStripeInputStream(
               (ECReplicationConfig)repConfig, blockInfo, verifyChecksum,
-              xceiverFactory, refreshFunction, inputStreamFactory);
+              xceiverFactory, refreshFunction, inputStreamFactory,
+              byteBufferPool);
       if (failedLocations != null) {
         sis.addFailedDatanodes(failedLocations);
       }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamFactoryImpl.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
+import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 
 import java.util.List;
@@ -36,13 +37,16 @@ public final class ECBlockInputStreamFactoryImpl implements
     ECBlockInputStreamFactory {
 
   private final BlockInputStreamFactory inputStreamFactory;
+  private final ByteBufferPool byteBufferPool;
 
   public static ECBlockInputStreamFactory getInstance(
-      BlockInputStreamFactory streamFactory) {
-    return new ECBlockInputStreamFactoryImpl(streamFactory);
+      BlockInputStreamFactory streamFactory, ByteBufferPool byteBufferPool) {
+    return new ECBlockInputStreamFactoryImpl(streamFactory, byteBufferPool);
   }
 
-  private ECBlockInputStreamFactoryImpl(BlockInputStreamFactory streamFactory) {
+  private ECBlockInputStreamFactoryImpl(BlockInputStreamFactory streamFactory,
+      ByteBufferPool byteBufferPool) {
+    this.byteBufferPool = byteBufferPool;
     this.inputStreamFactory = streamFactory;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -583,22 +583,6 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   public synchronized void close() {
     super.close();
     executor.shutdownNow();
-  }
-
-  @Override
-  public synchronized void seek(long pos) throws IOException {
-    if (pos % getStripeSize() != 0) {
-      // As this reader can only return full stripes, we only seek to the start
-      // stripe offsets
-      throw new IOException("Requested position " + pos
-          + " does not align with a stripe offset");
-    }
-    super.seek(pos);
-  }
-
-  @Override
-  public void close() {
-    super.close();
     // Inside this class, we only allocate buffers to read parity into. Data
     // is reconstructed or read into a set of buffers passed in from the calling
     // class. Therefore we only need to ensure we free the parity buffers here.
@@ -610,6 +594,17 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         decoderInputBuffers[i] = null;
       }
     }
+  }
+
+  @Override
+  public synchronized void seek(long pos) throws IOException {
+    if (pos % getStripeSize() != 0) {
+      // As this reader can only return full stripes, we only seek to the start
+      // stripe offsets
+      throw new IOException("Requested position " + pos
+          + " does not align with a stripe offset");
+    }
+    super.seek(pos);
   }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.ByteReaderStrategy;
+import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.ozone.erasurecode.CodecRegistry;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder;
@@ -108,6 +109,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   private List<Integer> dataIndexes = new ArrayList<>();
   // Data Indexes we have tried to read from, and failed for some reason
   private Set<Integer> failedDataIndexes = new HashSet<>();
+  private ByteBufferPool byteBufferPool;
 
   private final RawErasureDecoder decoder;
 
@@ -118,9 +120,11 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   public ECBlockReconstructedStripeInputStream(ECReplicationConfig repConfig,
       OmKeyLocationInfo blockInfo, boolean verifyChecksum,
        XceiverClientFactory xceiverClientFactory, Function<BlockID,
-      Pipeline> refreshFunction, BlockInputStreamFactory streamFactory) {
+      Pipeline> refreshFunction, BlockInputStreamFactory streamFactory,
+      ByteBufferPool byteBufferPool) {
     super(repConfig, blockInfo, verifyChecksum, xceiverClientFactory,
         refreshFunction, streamFactory);
+    this.byteBufferPool = byteBufferPool;
 
     decoder = CodecRegistry.getInstance()
         .getCodecFactory(repConfig.getCodec().toString())
@@ -435,7 +439,8 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   private ByteBuffer allocateBuffer(ECReplicationConfig repConfig) {
-    ByteBuffer buf = ByteBuffer.allocate(repConfig.getEcChunkSize());
+    ByteBuffer buf = byteBufferPool.getBuffer(
+        false, repConfig.getEcChunkSize());
     return buf;
   }
 
@@ -589,6 +594,22 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
           + " does not align with a stripe offset");
     }
     super.seek(pos);
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    // Inside this class, we only allocate buffers to read parity into. Data
+    // is reconstructed or read into a set of buffers passed in from the calling
+    // class. Therefore we only need to ensure we free the parity buffers here.
+    for (int i = getRepConfig().getData();
+         i < getRepConfig().getRequiredNodes(); i++) {
+      ByteBuffer buf = decoderInputBuffers[i];
+      if (buf != null) {
+        byteBufferPool.putBuffer(buf);
+        decoderInputBuffers[i] = null;
+      }
+    }
   }
 
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -209,7 +209,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
       failedDataStripeChunkLens[i] = dataBuffers[i].limit();
     }
     final ByteBuffer[] parityBuffers = ecChunkBufferCache.getParityBuffers();
-    for (int i = 0; i <  numParityBlks; i++) {
+    for (int i = 0; i < numParityBlks; i++) {
       failedParityStripeChunkLens[i] = parityBuffers[i].limit();
     }
 
@@ -365,11 +365,13 @@ public class ECKeyOutputStream extends KeyOutputStream {
 
   void writeParityCells(int parityCellSize) throws IOException {
     final ByteBuffer[] buffers = ecChunkBufferCache.getDataBuffers();
-    ecChunkBufferCache.allocateParityBuffers(parityCellSize);
     final ByteBuffer[] parityBuffers = ecChunkBufferCache.getParityBuffers();
 
-    for(int i=0; i< buffers.length; i++){
-      buffers[i].flip();
+    for (ByteBuffer b : parityBuffers) {
+      b.limit(parityCellSize);
+    }
+    for (ByteBuffer b : buffers) {
+      b.flip();
     }
     encoder.encode(buffers, parityBuffers);
     blockOutputStreamEntryPool
@@ -713,6 +715,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
       parityBuffers = new ByteBuffer[numParity];
       this.byteBufferPool = byteBufferPool;
       allocateBuffers(dataBuffers, this.cellSize);
+      allocateBuffers(parityBuffers, this.cellSize);
     }
 
     private ByteBuffer[] getDataBuffers() {
@@ -721,10 +724,6 @@ public class ECKeyOutputStream extends KeyOutputStream {
 
     private ByteBuffer[] getParityBuffers() {
       return parityBuffers;
-    }
-
-    public void allocateParityBuffers(int size){
-      allocateBuffers(parityBuffers, size);
     }
 
     private int addToDataBuffer(int i, byte[] b, int off, int len) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -260,7 +260,6 @@ public class ECKeyOutputStream extends KeyOutputStream {
     newBlockGroupStreamEntry
         .updateBlockGroupToAckedPosition(failedStripeDataSize);
     ecChunkBufferCache.clear();
-    ecChunkBufferCache.release();
 
     if (newBlockGroupStreamEntry.getRemaining() <= 0) {
       // In most cases this should not happen except in the case stripe size and

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.scm.storage.ECBlockOutputStream;
 import org.apache.hadoop.io.ByteBufferPool;
-import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -56,7 +55,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
   private int ecChunkSize;
   private final int numDataBlks;
   private final int numParityBlks;
-  private static final ByteBufferPool BUFFER_POOL = new ElasticByteBufferPool();
+  private final ByteBufferPool bufferPool;
   private final RawErasureEncoder encoder;
 
   private enum StripeWriteStatus {
@@ -96,8 +95,9 @@ public class ECKeyOutputStream extends KeyOutputStream {
       XceiverClientFactory xceiverClientManager, OzoneManagerProtocol omClient,
       int chunkSize, String requestId, ECReplicationConfig replicationConfig,
       String uploadID, int partNumber, boolean isMultipart,
-      boolean unsafeByteBufferConversion) {
+      boolean unsafeByteBufferConversion, ByteBufferPool byteBufferPool) {
     this.config = config;
+    this.bufferPool = byteBufferPool;
     // For EC, cell/chunk size and buffer size can be same for now.
     ecChunkSize = replicationConfig.getEcChunkSize();
     this.config.setStreamBufferMaxSize(ecChunkSize);
@@ -105,8 +105,8 @@ public class ECKeyOutputStream extends KeyOutputStream {
     this.config.setStreamBufferSize(ecChunkSize);
     this.numDataBlks = replicationConfig.getData();
     this.numParityBlks = replicationConfig.getParity();
-    ecChunkBufferCache =
-        new ECChunkBuffers(ecChunkSize, numDataBlks, numParityBlks);
+    ecChunkBufferCache = new ECChunkBuffers(
+        ecChunkSize, numDataBlks, numParityBlks, bufferPool);
     OmKeyInfo info = handler.getKeyInfo();
     blockOutputStreamEntryPool =
         new ECBlockOutputStreamEntryPool(config, omClient, requestId,
@@ -613,6 +613,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
     private boolean unsafeByteBufferConversion;
     private OzoneClientConfig clientConfig;
     private ECReplicationConfig replicationConfig;
+    private ByteBufferPool byteBufferPool;
 
     public Builder setMultipartUploadID(String uploadID) {
       this.multipartUploadID = uploadID;
@@ -670,10 +671,17 @@ public class ECKeyOutputStream extends KeyOutputStream {
       return this;
     }
 
+    public ECKeyOutputStream.Builder setByteBufferPool(
+        ByteBufferPool bufferPool) {
+      this.byteBufferPool = bufferPool;
+      return this;
+    }
+
     public ECKeyOutputStream build() {
       return new ECKeyOutputStream(clientConfig, openHandler, xceiverManager,
           omClient, chunkSize, requestID, replicationConfig, multipartUploadID,
-          multipartNumber, isMultipartKey, unsafeByteBufferConversion);
+          multipartNumber, isMultipartKey, unsafeByteBufferConversion,
+          byteBufferPool);
     }
   }
 
@@ -695,12 +703,15 @@ public class ECKeyOutputStream extends KeyOutputStream {
     private final ByteBuffer[] dataBuffers;
     private final ByteBuffer[] parityBuffers;
     private int cellSize;
+    private ByteBufferPool byteBufferPool;
 
-    ECChunkBuffers(int cellSize, int numData, int numParity) {
+    ECChunkBuffers(int cellSize, int numData, int numParity,
+        ByteBufferPool byteBufferPool) {
       this.cellSize = cellSize;
       dataBuffers = new ByteBuffer[numData];
       parityBuffers = new ByteBuffer[numParity];
-      allocateBuffers(cellSize, dataBuffers);
+      this.byteBufferPool = byteBufferPool;
+      allocateBuffers(dataBuffers);
     }
 
     private ByteBuffer[] getDataBuffers() {
@@ -712,7 +723,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
     }
 
     public void allocateParityBuffers(int size){
-      allocateBuffers(size, parityBuffers);
+      allocateBuffers(parityBuffers);
     }
 
     private int addToDataBuffer(int i, byte[] b, int off, int len) {
@@ -725,8 +736,8 @@ public class ECKeyOutputStream extends KeyOutputStream {
     }
 
     private void clear(int size) {
-      clearBuffers(size, dataBuffers);
-      clearBuffers(size, parityBuffers);
+      clearBuffers(dataBuffers);
+      clearBuffers(parityBuffers);
     }
 
     private void release() {
@@ -734,24 +745,24 @@ public class ECKeyOutputStream extends KeyOutputStream {
       releaseBuffers(parityBuffers);
     }
 
-    private static void allocateBuffers(int cellSize, ByteBuffer[] buffers) {
+    private void allocateBuffers(ByteBuffer[] buffers) {
       for (int i = 0; i < buffers.length; i++) {
-        buffers[i] = BUFFER_POOL.getBuffer(false, cellSize);
+        buffers[i] = byteBufferPool.getBuffer(false, cellSize);
         buffers[i].limit(cellSize);
       }
     }
 
-    private static void clearBuffers(int cellSize, ByteBuffer[] buffers) {
+    private void clearBuffers(ByteBuffer[] buffers) {
       for (int i = 0; i < buffers.length; i++) {
         buffers[i].clear();
         buffers[i].limit(cellSize);
       }
     }
 
-    private static void releaseBuffers(ByteBuffer[] buffers) {
+    private void releaseBuffers(ByteBuffer[] buffers) {
       for (int i = 0; i < buffers.length; i++) {
         if (buffers[i] != null) {
-          BUFFER_POOL.putBuffer(buffers[i]);
+          byteBufferPool.putBuffer(buffers[i]);
           buffers[i] = null;
         }
       }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -895,7 +895,7 @@ public class RpcClient implements ClientProtocol {
     }
 
     OpenKeySession openKey = ozoneManagerClient.openKey(builder.build());
-    return createOutputStream(openKey, requestId, replicationConfig);
+    return createOutputStream(openKey, requestId);
   }
 
   private KeyProvider.KeyVersion getDEK(FileEncryptionInfo feInfo)
@@ -1356,8 +1356,7 @@ public class RpcClient implements ClientProtocol {
         .build();
     OpenKeySession keySession =
         ozoneManagerClient.createFile(keyArgs, overWrite, recursive);
-    return createOutputStream(keySession, UUID.randomUUID().toString(),
-        replicationConfig);
+    return createOutputStream(keySession, UUID.randomUUID().toString());
   }
 
   @Override
@@ -1487,8 +1486,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   private OzoneOutputStream createOutputStream(OpenKeySession openKey,
-      String requestId, ReplicationConfig replicationConfig)
-      throws IOException {
+      String requestId) throws IOException {
     KeyOutputStream keyOutputStream = null;
 
     if (openKey.getKeyInfo().getReplicationConfig()
@@ -1499,7 +1497,9 @@ public class RpcClient implements ClientProtocol {
           .setReplicationConfig(
               (ECReplicationConfig)openKey.getKeyInfo().getReplicationConfig())
           .enableUnsafeByteBufferConversion(unsafeByteBufferConversion)
-          .setConfig(clientConfig).build();
+          .setConfig(clientConfig)
+          .setByteBufferPool(byteBufferPool)
+          .build();
     } else {
       keyOutputStream = new KeyOutputStream.Builder().setHandler(openKey)
           .setXceiverClientManager(xceiverClientManager)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedInputStream.java
@@ -66,7 +66,7 @@ public class TestECBlockReconstructedInputStream {
         ECStreamTestUtil.createKeyInfo(repConfig, blockLength, dnMap);
     streamFactory.setCurrentPipeline(keyInfo.getPipeline());
     return new ECBlockReconstructedStripeInputStream(repConfig, keyInfo, true,
-        null, null, streamFactory);
+        null, null, streamFactory, bufferPool);
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockReconstructedInputStream.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.client.rpc.read;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.io.ByteBufferPool;
+import org.apache.hadoop.io.ElasticByteBufferPool;
 import org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream;
 import org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
@@ -47,6 +49,7 @@ public class TestECBlockReconstructedInputStream {
   private long randomSeed;
   private ThreadLocalRandom random = ThreadLocalRandom.current();
   private SplittableRandom dataGenerator;
+  private ByteBufferPool bufferPool = new ElasticByteBufferPool();
 
   @Before
   public void setup() throws IOException {
@@ -73,7 +76,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
         = createStripeInputStream(dnMap, 12345L)) {
       try (ECBlockReconstructedInputStream stream =
-          new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         Assert.assertEquals(12345L, stream.getLength());
       }
     }
@@ -86,7 +90,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, 12345L)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         Assert.assertEquals(new BlockID(1, 1), stream.getBlockID());
       }
     }
@@ -110,7 +115,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, blockLength)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         ByteBuffer b = ByteBuffer.allocate(readBufferSize);
         int totalRead = 0;
         dataGenerator = new SplittableRandom(randomSeed);
@@ -147,7 +153,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, blockLength)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         ByteBuffer b = ByteBuffer.allocate(readBufferSize);
         dataGenerator = new SplittableRandom(randomSeed);
         long read = stream.read(b);
@@ -178,7 +185,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, blockLength)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
 
         dataGenerator = new SplittableRandom(randomSeed);
         int totalRead = 0;
@@ -213,7 +221,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, blockLength)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         int totalRead = 0;
         dataGenerator = new SplittableRandom(randomSeed);
         while (totalRead < blockLength) {
@@ -249,7 +258,8 @@ public class TestECBlockReconstructedInputStream {
     try(ECBlockReconstructedStripeInputStream stripeStream
             = createStripeInputStream(dnMap, blockLength)) {
       try (ECBlockReconstructedInputStream stream =
-               new ECBlockReconstructedInputStream(repConfig, stripeStream)) {
+          new ECBlockReconstructedInputStream(repConfig, bufferPool,
+              stripeStream)) {
         ByteBuffer b = ByteBuffer.allocate(readBufferSize);
 
         int seekPosition = 0;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When reading and writing EC, we often have to allocate chunk sized Bytebuffers. It would be good if we could reuse them across multiple input / output instances to save freeing and re-allocating memory.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5949

## How was this patch tested?

Existing tests
