### PR TITLE
HDDS-6121. DatanodeAdminMonitor should log detailed information for a limited number of containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeAdminMonitorImpl.java
@@ -296,7 +296,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
           }
           if (underReplicated < CONTAINER_DETAILS_LOGGING_LIMIT
               || LOG.isDebugEnabled()) {
-            LOG.info("Under Replicated Container {} {}; {}}",
+            LOG.info("Under Replicated Container {} {}; {}",
                 cid, replicaSet, replicaDetails(replicaSet.getReplica()));
           }
           underReplicated++;
@@ -307,7 +307,7 @@ public class DatanodeAdminMonitorImpl implements DatanodeAdminMonitor {
           }
           if (unhealthy < CONTAINER_DETAILS_LOGGING_LIMIT
               || LOG.isDebugEnabled()) {
-            LOG.info("Unhealthy Container {} {}; {}}",
+            LOG.info("Unhealthy Container {} {}; {}",
                 cid, replicaSet, replicaDetails(replicaSet.getReplica()));
           }
           unhealthy++;


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the DatanodeAdminMonitor is processing a host entering decommission or maintenance, we have seen it get stuck due to issues with the containers preventing them replicating. As it stands, the AdminMonitor prints out only a list of problem container IDs, but it does not give any details about the containers or their replicas.

On each pass, when checking a node, we should log detailed information about 5 under replicated and 5 unhealthy containers, which will aid debugging later if there are any problems. There many be many more containers than this, but giving a sample of 5 should be enough for debugging. If we want all the containers, we can set the log level to DEBUG which will print them all.

From docker-compose, these are the log messages, which are very information rich. The main reason, is that existing toString methods on the ContainerReplicaCount, ContainerReplia and datanodedetails are fairly verbose and re-used here.

```
2021-12-17 17:22:27,599 [DatanodeAdminManager-0] INFO node.DatanodeAdminMonitorImpl: Under Replicated Container #1 Container State: QUASI_CLOSED Replica Count: 3 Healthy Count: 2 Decommission Count: 1 Maintenance Count: 0 inFlightAdd Count: 0 inFightDel Count: 0 ReplicationFactor: 3 minMaintenance Count: 2; Replicas{ContainerReplica{containerID=#1, state=QUASI_CLOSED, datanodeDetails=9284cd87-325b-4d6f-915f-476b1609d655{ip: 172.19.0.5, host: ozone_datanode_5.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: DECOMMISSIONING, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=9284cd87-325b-4d6f-915f-476b1609d655, sequenceId=2270, keyCount=658, bytesUsed=6748160},ContainerReplica{containerID=#1, state=QUASI_CLOSED, datanodeDetails=1e77235a-cec4-40ca-8466-706ffde43cb0{ip: 172.19.0.8, host: ozone_datanode_1.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=1e77235a-cec4-40ca-8466-706ffde43cb0, sequenceId=2270, keyCount=658, bytesUsed=6748160},ContainerReplica{containerID=#1, state=CLOSING, datanodeDetails=d2909928-39b6-45f4-91fb-38e2208b69de{ip: 172.19.0.6, host: ozone_datanode_3.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=d2909928-39b6-45f4-91fb-38e2208b69de, sequenceId=2270, keyCount=658, bytesUsed=6748160}}}


2021-12-17 17:22:27,601 [DatanodeAdminManager-0] INFO node.DatanodeAdminMonitorImpl: Unhealthy Container #1 Container State: QUASI_CLOSED Replica Count: 3 Healthy Count: 2 Decommission Count: 1 Maintenance Count: 0 inFlightAdd Count: 0 inFightDel Count: 0 ReplicationFactor: 3 minMaintenance Count: 2; Replicas{ContainerReplica{containerID=#1, state=QUASI_CLOSED, datanodeDetails=9284cd87-325b-4d6f-915f-476b1609d655{ip: 172.19.0.5, host: ozone_datanode_5.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: DECOMMISSIONING, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=9284cd87-325b-4d6f-915f-476b1609d655, sequenceId=2270, keyCount=658, bytesUsed=6748160},ContainerReplica{containerID=#1, state=QUASI_CLOSED, datanodeDetails=1e77235a-cec4-40ca-8466-706ffde43cb0{ip: 172.19.0.8, host: ozone_datanode_1.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=1e77235a-cec4-40ca-8466-706ffde43cb0, sequenceId=2270, keyCount=658, bytesUsed=6748160},ContainerReplica{containerID=#1, state=CLOSING, datanodeDetails=d2909928-39b6-45f4-91fb-38e2208b69de{ip: 172.19.0.6, host: ozone_datanode_3.ozone_default, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default-rack, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=d2909928-39b6-45f4-91fb-38e2208b69de, sequenceId=2270, keyCount=658, bytesUsed=6748160}}}

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6121

## How was this patch tested?

Test manually via docker compose. Generated 10 containers, decommissioned a node. Observed the new logs messages and that they were limited to 5 rather than the 10 containers affected.
