### PR TITLE
HDDS-6124. Update log4j version to 2.17.0 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
 
     <prometheus.version>0.7.0</prometheus.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update log4j version to 2.17.0.
[CVE-2021-45105](https://logging.apache.org/log4j/2.x/index.html)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-6124

## How was this patch tested?

After updating `log4j2` to `2.17.0`, Ozone can be built with Apache Maven.
