### PR TITLE
HDDS-6125. Support Hugo 0.91.0.

### DIFF
--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -37,3 +37,21 @@ markup:
   goldmark:
     renderer:
       unsafe: true
+security:
+  enableInlineShortcodes: false
+  exec:
+    allow:
+      - ^dart-sass-embedded$
+      - ^go$
+      - ^npx$
+      - ^postcss$
+    osEnv:
+      - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$
+  funcs:
+    getenv:
+      - ^HUGO_|^OZONE_VERSION$
+  http:
+    methods:
+      - (?i)GET|POST
+    urls:
+      - .*

--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -38,15 +38,6 @@ markup:
     renderer:
       unsafe: true
 security:
-  enableInlineShortcodes: false
-  exec:
-    allow:
-      - ^dart-sass-embedded$
-      - ^go$
-      - ^npx$
-      - ^postcss$
-    osEnv:
-      - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$
   funcs:
     getenv:
       - ^HUGO_

--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -51,8 +51,3 @@ security:
     getenv:
       - ^HUGO_
       - ^OZONE_VERSION$
-  http:
-    methods:
-      - (?i)GET|POST
-    urls:
-      - .*

--- a/hadoop-hdds/docs/config.yaml
+++ b/hadoop-hdds/docs/config.yaml
@@ -49,7 +49,8 @@ security:
       - (?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$
   funcs:
     getenv:
-      - ^HUGO_|^OZONE_VERSION$
+      - ^HUGO_
+      - ^OZONE_VERSION$
   http:
     methods:
       - (?i)GET|POST


### PR DESCRIPTION
## What changes were proposed in this pull request?
Update config.yaml for Hugo to whitelist the environment variable OZONE_VERSION following the doc https://gohugo.io/about/security-model/

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6125

## How was this patch tested?
Built locally
