### PR TITLE
HDDS-6088. Implement O3FS/OFS getFileChecksum() using file checksum helpers.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hdds.scm;
 
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -38,6 +37,18 @@ public class OzoneClientConfig {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OzoneClientConfig.class);
+
+  /**
+   * Enum for indicating what mode to use when combining chunk and block
+   * checksums to define an aggregate FileChecksum. This should be considered
+   * a client-side runtime option rather than a persistent property of any
+   * stored metadata, which is why this is not part of ChecksumOpt, which
+   * deals with properties of files at rest.
+   */
+  public enum ChecksumCombineMode {
+    MD5MD5CRC,  // MD5 of block checksums, which are MD5 over chunk CRCs
+    COMPOSITE_CRC  // Block/chunk-independent composite CRC
+  }
 
   @Config(key = "stream.buffer.flush.size",
       defaultValue = "16MB",
@@ -132,7 +143,7 @@ public class OzoneClientConfig {
           + "file checksum. Default checksum type is COMPOSITE_CRC.",
       tags = ConfigTag.CLIENT)
   private String checksumCombineMode =
-      Options.ChecksumCombineMode.COMPOSITE_CRC.name();
+      ChecksumCombineMode.COMPOSITE_CRC.name();
 
   @PostConstruct
   private void validate() {
@@ -238,15 +249,15 @@ public class OzoneClientConfig {
     return bufferIncrement;
   }
 
-  public Options.ChecksumCombineMode getChecksumCombineMode() {
+  public ChecksumCombineMode getChecksumCombineMode() {
     try {
-      return Options.ChecksumCombineMode.valueOf(checksumCombineMode);
+      return ChecksumCombineMode.valueOf(checksumCombineMode);
     } catch(IllegalArgumentException iae) {
       LOG.warn("Bad checksum combine mode: {}. Using default {}",
           checksumCombineMode,
-          Options.ChecksumCombineMode.COMPOSITE_CRC.name());
-      return Options.ChecksumCombineMode.valueOf(
-          Options.ChecksumCombineMode.COMPOSITE_CRC.name());
+          ChecksumCombineMode.COMPOSITE_CRC.name());
+      return ChecksumCombineMode.valueOf(
+          ChecksumCombineMode.COMPOSITE_CRC.name());
     }
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -126,13 +126,13 @@ public class OzoneClientConfig {
   private boolean checksumVerify = true;
 
   @Config(key = "checksum.combine.mode",
-      defaultValue = "MD5MD5CRC",
+      defaultValue = "COMPOSITE_CRC",
       description = "The combined checksum type [MD5MD5CRC / COMPOSITE_CRC] "
           + "determines which algorithm would be used to compute checksum for "
-          + "file checksum. Default checksum type is MD5MD5CRC.",
+          + "file checksum. Default checksum type is COMPOSITE_CRC.",
       tags = ConfigTag.CLIENT)
   private String checksumCombineMode =
-      Options.ChecksumCombineMode.MD5MD5CRC.name();
+      Options.ChecksumCombineMode.COMPOSITE_CRC.name();
 
   @PostConstruct
   private void validate() {
@@ -243,9 +243,10 @@ public class OzoneClientConfig {
       return Options.ChecksumCombineMode.valueOf(checksumCombineMode);
     } catch(IllegalArgumentException iae) {
       LOG.warn("Bad checksum combine mode: {}. Using default {}",
-          checksumCombineMode, Options.ChecksumCombineMode.MD5MD5CRC.name());
+          checksumCombineMode,
+          Options.ChecksumCombineMode.COMPOSITE_CRC.name());
       return Options.ChecksumCombineMode.valueOf(
-          Options.ChecksumCombineMode.MD5MD5CRC.name());
+          Options.ChecksumCombineMode.COMPOSITE_CRC.name());
     }
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm;
 
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.conf.Config;
 import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
@@ -124,6 +125,15 @@ public class OzoneClientConfig {
       tags = ConfigTag.CLIENT)
   private boolean checksumVerify = true;
 
+  @Config(key = "checksum.combine.mode",
+      defaultValue = "MD5MD5CRC",
+      description = "The combined checksum type [MD5MD5CRC / COMPOSITE_CRC] "
+          + "determines which algorithm would be used to compute checksum for "
+          + "file checksum. Default checksum type is MD5MD5CRC.",
+      tags = ConfigTag.CLIENT)
+  private String checksumCombineMode =
+      Options.ChecksumCombineMode.MD5MD5CRC.name();
+
   @PostConstruct
   private void validate() {
     Preconditions.checkState(streamBufferSize > 0);
@@ -226,5 +236,16 @@ public class OzoneClientConfig {
 
   public int getBufferIncrement() {
     return bufferIncrement;
+  }
+
+  public Options.ChecksumCombineMode getChecksumCombineMode() {
+    try {
+      return Options.ChecksumCombineMode.valueOf(checksumCombineMode);
+    } catch(IllegalArgumentException iae) {
+      LOG.warn("Bad checksum combine mode: {}. Using default {}",
+          checksumCombineMode, Options.ChecksumCombineMode.MD5MD5CRC.name());
+      return Options.ChecksumCombineMode.valueOf(
+          Options.ChecksumCombineMode.MD5MD5CRC.name());
+    }
   }
 }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -140,7 +140,12 @@ public class OzoneClientConfig {
       defaultValue = "COMPOSITE_CRC",
       description = "The combined checksum type [MD5MD5CRC / COMPOSITE_CRC] "
           + "determines which algorithm would be used to compute checksum for "
-          + "file checksum. Default checksum type is COMPOSITE_CRC.",
+          + "COMPOSITE_CRC calculates the combined CRC of the whole file, "
+          + "where the lower-level chunk/block checksums are combined into "
+          + "file-level checksum."
+          + "MD5MD5CRC calculates the MD5 of MD5 of checksums of individual "
+          + "chunks."
+          + "Default checksum type is COMPOSITE_CRC.",
       tags = ConfigTag.CLIENT)
   private String checksumCombineMode =
       ChecksumCombineMode.COMPOSITE_CRC.name();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/OzoneClientConfig.java
@@ -139,7 +139,7 @@ public class OzoneClientConfig {
   @Config(key = "checksum.combine.mode",
       defaultValue = "COMPOSITE_CRC",
       description = "The combined checksum type [MD5MD5CRC / COMPOSITE_CRC] "
-          + "determines which algorithm would be used to compute checksum for "
+          + "determines which algorithm would be used to compute file checksum."
           + "COMPOSITE_CRC calculates the combined CRC of the whole file, "
           + "where the lower-level chunk/block checksums are combined into "
           + "file-level checksum."

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3026,7 +3026,7 @@
 
   <property>
     <name>ozone.client.checksum.combine.mode</name>
-    <value>MD5MD5CRC</value>
+    <value>COMPOSITE_CRC</value>
     <tag>OZONE, CLIENT</tag>
     <description>
       The combined checksum type [MD5MD5CRC / COMPOSITE_CRC].
@@ -3035,7 +3035,7 @@
       lower-level chunk/block checksums are combined into file-level checksum.
 
       MD5MD5CRC calculates the MD5 of MD5 of checksums of individual chunks.
-      Default checksum type is MD5MD5CRC.
+      Default checksum type is COMPOSITE_CRC.
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3023,4 +3023,19 @@
       will create intermediate directories.
     </description>
   </property>
+
+  <property>
+    <name>ozone.client.checksum.combine.mode</name>
+    <value>MD5MD5CRC</value>
+    <tag>OZONE, CLIENT</tag>
+    <description>
+      The combined checksum type [MD5MD5CRC / COMPOSITE_CRC].
+      determines which algorithm would be used to compute file checksum.
+      COMPOSITE_CRC calculates the combined CRC of the whole file, where the
+      lower-level chunk/block checksums are combined into file-level checksum.
+
+      MD5MD5CRC calculates the MD5 of MD5 of checksums of individual chunks.
+      Default checksum type is MD5MD5CRC.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3023,19 +3023,4 @@
       will create intermediate directories.
     </description>
   </property>
-
-  <property>
-    <name>ozone.client.checksum.combine.mode</name>
-    <value>COMPOSITE_CRC</value>
-    <tag>OZONE, CLIENT</tag>
-    <description>
-      The combined checksum type [MD5MD5CRC / COMPOSITE_CRC].
-      determines which algorithm would be used to compute file checksum.
-      COMPOSITE_CRC calculates the combined CRC of the whole file, where the
-      lower-level chunk/block checksums are combined into file-level checksum.
-
-      MD5MD5CRC calculates the MD5 of MD5 of checksums of individual chunks.
-      Default checksum type is COMPOSITE_CRC.
-    </description>
-  </property>
 </configuration>

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -161,12 +161,6 @@ public abstract class BaseFileChecksumHelper {
     }
   }
 
-  @VisibleForTesting
-  List<OmKeyLocationInfo> getKeyLocationInfos() {
-    return keyLocationInfos;
-  }
-
-
   /**
    * Compute block checksums block by block and append the raw bytes of the
    * block checksums into getBlockChecksumBuf().

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -50,8 +50,8 @@ public abstract class BaseFileChecksumHelper {
   private final long length;
   private ClientProtocol rpcClient;
 
-  private XceiverClientFactory xceiverClientFactory;
   private final DataOutputBuffer blockChecksumBuf = new DataOutputBuffer();
+  private XceiverClientFactory xceiverClientFactory;
   private FileChecksum fileChecksum;
   private List<OmKeyLocationInfo> keyLocationInfos;
   private long remaining = 0L;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.ozone.client.checksum;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
-import org.apache.hadoop.ozone.client.rpc.RpcClient;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
 
@@ -44,9 +44,9 @@ import java.util.List;
 public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
   private int blockIdx;
 
-  ReplicatedFileChecksumHelper(
+  public ReplicatedFileChecksumHelper(
       OzoneVolume volume, OzoneBucket bucket, String keyName, long length,
-      RpcClient rpcClient) throws IOException {
+      ClientProtocol rpcClient) throws IOException {
     super(volume, bucket, keyName, length, rpcClient);
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -232,7 +232,7 @@ public class TestReplicatedFileChecksumHelper {
     helper.compute();
     FileChecksum fileChecksum = helper.getFileChecksum();
     assertTrue(fileChecksum instanceof MD5MD5CRC32GzipFileChecksum);
-    assertEquals(1, helper.getKeyLocationInfos().size());
+    assertEquals(1, helper.getKeyLocationInfoList().size());
   }
 
   private XceiverClientReply buildValidResponse() {
@@ -317,7 +317,7 @@ public class TestReplicatedFileChecksumHelper {
       helper.compute();
       FileChecksum fileChecksum = helper.getFileChecksum();
       assertTrue(fileChecksum instanceof MD5MD5CRC32GzipFileChecksum);
-      assertEquals(1, helper.getKeyLocationInfos().size());
+      assertEquals(1, helper.getKeyLocationInfoList().size());
     }
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -38,8 +40,10 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
@@ -558,5 +562,17 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public boolean isFSOptimizedBucket() {
     return bucket.getBucketLayout().isFileSystemOptimized();
+  }
+
+  @Override
+  public FileChecksum getFileChecksum(Path f, long length) throws IOException {
+    OFSPath ofsPath = new OFSPath(f);
+    Options.ChecksumCombineMode combineMode =
+        config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
+
+    return OzoneClientUtils.getFileChecksumWithCombineMode(
+        volume, bucket, ofsPath.getKeyName(),
+        length, combineMode, ozoneClient.getObjectStore().getClientProxy());
+
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -563,7 +563,8 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public FileChecksum getFileChecksum(String keyName, long length) throws IOException {
+  public FileChecksum getFileChecksum(String keyName, long length)
+      throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -564,13 +564,12 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   }
 
   @Override
-  public FileChecksum getFileChecksum(Path f, long length) throws IOException {
-    OFSPath ofsPath = new OFSPath(f);
+  public FileChecksum getFileChecksum(String keyName, long length) throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 
     return OzoneClientUtils.getFileChecksumWithCombineMode(
-        volume, bucket, ofsPath.getKeyName(),
+        volume, bucket, keyName,
         length, combineMode, ozoneClient.getObjectStore().getClientProxy());
 
   }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
-import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneClientAdapterImpl.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileChecksum;
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -567,7 +566,7 @@ public class BasicOzoneClientAdapterImpl implements OzoneClientAdapter {
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     OFSPath ofsPath = new OFSPath(f);
-    Options.ChecksumCombineMode combineMode =
+    OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 
     return OzoneClientUtils.getFileChecksumWithCombineMode(

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -800,7 +800,7 @@ public class BasicOzoneFileSystem extends FileSystem {
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     incrementCounter(Statistic.INVOCATION_GET_FILE_CHECKSUM);
-    return super.getFileChecksum(f, length);
+    return adapter.getFileChecksum(f, length);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -800,7 +800,10 @@ public class BasicOzoneFileSystem extends FileSystem {
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     incrementCounter(Statistic.INVOCATION_GET_FILE_CHECKSUM);
-    return adapter.getFileChecksum(f, length);
+    statistics.incrementReadOps(1);
+    Path qualifiedPath = f.makeQualified(uri, workingDir);
+    String key = pathToKey(qualifiedPath);
+    return adapter.getFileChecksum(key, length);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1070,11 +1070,11 @@ public class BasicRootedOzoneClientAdapterImpl
   }
 
   @Override
-  public FileChecksum getFileChecksum(Path f, long length) throws IOException {
+  public FileChecksum getFileChecksum(String keyName, long length) throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 
-    OFSPath ofsPath = new OFSPath(f);
+    OFSPath ofsPath = new OFSPath(keyName);
 
     OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
     OzoneBucket bucket = getBucket(ofsPath, false);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -1072,7 +1071,7 @@ public class BasicRootedOzoneClientAdapterImpl
 
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
-    Options.ChecksumCombineMode combineMode =
+    OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 
     OFSPath ofsPath = new OFSPath(f);

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -36,8 +36,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.crypto.key.KeyProvider;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -47,6 +49,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OFSPath;
@@ -1065,5 +1068,20 @@ public class BasicRootedOzoneClientAdapterImpl
   public boolean isFSOptimizedBucket() {
     // TODO: Need to refine this part.
     return false;
+  }
+
+  @Override
+  public FileChecksum getFileChecksum(Path f, long length) throws IOException {
+    Options.ChecksumCombineMode combineMode =
+        config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
+
+    OFSPath ofsPath = new OFSPath(f);
+
+    OzoneVolume volume = objectStore.getVolume(ofsPath.getVolumeName());
+    OzoneBucket bucket = getBucket(ofsPath, false);
+    return OzoneClientUtils.getFileChecksumWithCombineMode(
+        volume, bucket, ofsPath.getKeyName(),
+        length, combineMode, ozoneClient.getObjectStore().getClientProxy());
+
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -1070,7 +1070,8 @@ public class BasicRootedOzoneClientAdapterImpl
   }
 
   @Override
-  public FileChecksum getFileChecksum(String keyName, long length) throws IOException {
+  public FileChecksum getFileChecksum(String keyName, long length)
+      throws IOException {
     OzoneClientConfig.ChecksumCombineMode combineMode =
         config.getObject(OzoneClientConfig.class).getChecksumCombineMode();
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -832,7 +832,7 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     incrementCounter(Statistic.INVOCATION_GET_FILE_CHECKSUM);
-    return super.getFileChecksum(f, length);
+    return adapter.getFileChecksum(f, length);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -832,7 +832,8 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
   @Override
   public FileChecksum getFileChecksum(Path f, long length) throws IOException {
     incrementCounter(Statistic.INVOCATION_GET_FILE_CHECKSUM);
-    return adapter.getFileChecksum(f, length);
+    String key = pathToKey(f);
+    return adapter.getFileChecksum(key, length);
   }
 
   @Override

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.hadoop.crypto.key.KeyProvider;
+import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.security.token.Token;
@@ -78,4 +79,6 @@ public interface OzoneClientAdapter {
       Path qualifiedPath, String userName) throws IOException;
 
   boolean isFSOptimizedBucket();
+
+  FileChecksum getFileChecksum(Path f, long length) throws IOException;
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientAdapter.java
@@ -80,5 +80,5 @@ public interface OzoneClientAdapter {
 
   boolean isFSOptimizedBucket();
 
-  FileChecksum getFileChecksum(Path f, long length) throws IOException;
+  FileChecksum getFileChecksum(String keyName, long length) throws IOException;
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -16,9 +16,16 @@
  */
 package org.apache.hadoop.fs.ozone;
 
+import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.ozone.client.checksum.BaseFileChecksumHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.checksum.ReplicatedFileChecksumHelper;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 
@@ -63,5 +70,20 @@ public final class OzoneClientUtils {
       }
     }
     return bucket.getBucketLayout();
+  }
+
+  public static FileChecksum getFileChecksumWithCombineMode(OzoneVolume volume,
+      OzoneBucket bucket, String keyName, long length,
+      Options.ChecksumCombineMode combineMode, ClientProtocol rpcClient)
+      throws IOException {
+    Preconditions.checkArgument(length >= 0);
+
+    if (keyName.length() == 0) {
+      return null;
+    }
+    BaseFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
+        volume, bucket, keyName, length, rpcClient);
+    helper.compute();
+    return helper.getFileChecksum();
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -74,8 +74,8 @@ public final class OzoneClientUtils {
 
   public static FileChecksum getFileChecksumWithCombineMode(OzoneVolume volume,
       OzoneBucket bucket, String keyName, long length,
-      OzoneClientConfig.ChecksumCombineMode combineMode, ClientProtocol rpcClient)
-      throws IOException {
+      OzoneClientConfig.ChecksumCombineMode combineMode,
+      ClientProtocol rpcClient) throws IOException {
     Preconditions.checkArgument(length >= 0);
 
     if (keyName.length() == 0) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.fs.ozone;
 import com.google.common.base.Preconditions;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.FileChecksum;
-import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.ozone.client.checksum.BaseFileChecksumHelper;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -74,7 +74,7 @@ public final class OzoneClientUtils {
 
   public static FileChecksum getFileChecksumWithCombineMode(OzoneVolume volume,
       OzoneBucket bucket, String keyName, long length,
-      Options.ChecksumCombineMode combineMode, ClientProtocol rpcClient)
+      OzoneClientConfig.ChecksumCombineMode combineMode, ClientProtocol rpcClient)
       throws IOException {
     Preconditions.checkArgument(length >= 0);
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Unit tests for OzoneClientUtils.
+ */
+public class TestOzoneClientUtils {
+  @Test(expected = IllegalArgumentException.class)
+  public void testNegativeLength() throws IOException {
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+    String keyName = "dummy";
+    ClientProtocol clientProtocol = mock(ClientProtocol.class);
+    OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
+        -1, Options.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
+
+  }
+
+  @Test
+  public void testEmptyKeyName() throws IOException {
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+    String keyName = "";
+    ClientProtocol clientProtocol = mock(ClientProtocol.class);
+    FileChecksum checksum =
+        OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
+            1, Options.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
+
+    assertNull(checksum);
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -17,7 +17,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.fs.FileChecksum;
-import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
@@ -39,7 +39,7 @@ public class TestOzoneClientUtils {
     String keyName = "dummy";
     ClientProtocol clientProtocol = mock(ClientProtocol.class);
     OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
-        -1, Options.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
+        -1, OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
 
   }
 
@@ -51,7 +51,8 @@ public class TestOzoneClientUtils {
     ClientProtocol clientProtocol = mock(ClientProtocol.class);
     FileChecksum checksum =
         OzoneClientUtils.getFileChecksumWithCombineMode(volume, bucket, keyName,
-            1, Options.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
+            1, OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC,
+            clientProtocol);
 
     assertNull(checksum);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Make use of the file checksum helper added in HDDS-6086 to implement Ozone file system getFileChecksum() API.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6088

## How was this patch tested?
Contact test to be added.