### PR TITLE
HDDS-6044. [Multi-Tenant] Implement Cross-Tenant Bucket Sharing

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantBucketLinkHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantBucketLinkHandler.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.shell.tenant;
+
+import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.shell.OzoneAddress;
+import org.apache.hadoop.ozone.shell.bucket.BucketUri;
+import picocli.CommandLine;
+import picocli.CommandLine.Parameters;
+
+import java.io.IOException;
+
+/**
+ * ozone tenant bucket-link.
+ *
+ * Note: Currently this command is exactly the same as `ozone sh bucket link`.
+ * We might expand this to add more functionality in the future, and different
+ * ObjectStore API(s) would be used by then.
+ */
+@CommandLine.Command(name = "bucket-link",
+    aliases = {"link-bucket", "bucketlink", "linkbucket"},
+    description = "Create a symlink to another bucket")
+public class TenantBucketLinkHandler extends TenantHandler {
+
+  @Parameters(index = "0", arity = "1..1",
+      description = "The bucket which the link should point to.",
+      converter = BucketUri.class)
+  private OzoneAddress source;
+
+  @Parameters(index = "1", arity = "1..1",
+      description = "Address of the link bucket",
+      converter = BucketUri.class)
+  private OzoneAddress target;
+
+  @Override
+  protected void execute(OzoneClient client, OzoneAddress address)
+      throws IOException {
+
+    BucketArgs.Builder bb = new BucketArgs.Builder()
+        .setStorageType(StorageType.DEFAULT)
+        .setVersioning(false)
+        .setSourceVolume(source.getVolumeName())
+        .setSourceBucket(source.getBucketName());
+
+    String volumeName = target.getVolumeName();
+    String bucketName = target.getBucketName();
+
+    OzoneVolume vol = client.getObjectStore().getVolume(volumeName);
+    vol.createBucket(bucketName, bb.build());
+
+    if (isVerbose()) {
+      OzoneBucket bucket = vol.getBucket(bucketName);
+      printObjectAsJson(bucket);
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -33,7 +33,8 @@ import java.util.function.Supplier;
         TenantModifyHandler.class,
         TenantDeleteHandler.class,
         TenantListHandler.class,
-        TenantUserCommands.class
+        TenantUserCommands.class,
+        TenantBucketLinkHandler.class
     })
 public class TenantShell extends Shell {
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-6044

The patch (as of now) simply adds an alias for `ozone sh bucket link` under `ozone tenant` subcommand, as `ozone tenant link-bucket`.

## How was this patch tested?

- [ ] Pending manual testing for bucket link functionality with s3api via S3G.