### PR TITLE
HDDS-6087. Compute composite CRC file checksum using chunk checksums from DataNodes.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -216,13 +216,11 @@ public abstract class BaseFileChecksumHelper {
         CrcComposer.newCrcComposer(DataChecksum.Type.CRC32, blockSizeHint);
     byte[] blockChecksumBytes = blockChecksumBuf.getData();
 
-    long sumBlockLengths = 0;
     for (int i = 0; i < keyLocationInfos.size(); ++i) {
       OmKeyLocationInfo block = keyLocationInfos.get(i);
       // For every LocatedBlock, we expect getBlockSize()
       // to accurately reflect the number of file bytes digested in the block
       // checksum.
-      sumBlockLengths += block.getLength();
       int blockCrc = CrcUtil.readInt(blockChecksumBytes, i * 4);
 
       crcComposer.update(blockCrc, block.getLength());

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -188,12 +188,13 @@ public abstract class BaseFileChecksumHelper {
    */
   private FileChecksum makeFinalResult() throws IOException {
     switch (getCombineMode()) {
-      case MD5MD5CRC:
-        return makeMd5CrcResult();
-      case COMPOSITE_CRC:
-        return makeCompositeCrcResult();
-      default:
-        throw new IOException("Unknown ChecksumCombineMode: " + getCombineMode());
+    case MD5MD5CRC:
+      return makeMd5CrcResult();
+    case COMPOSITE_CRC:
+      return makeCompositeCrcResult();
+    default:
+      throw new IOException("Unknown ChecksumCombineMode: " +
+          getCombineMode());
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.client.checksum;
 import org.apache.hadoop.fs.CompositeCrcFileChecksum;
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
-import org.apache.hadoop.fs.Options;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.MD5Hash;
@@ -54,7 +54,7 @@ public abstract class BaseFileChecksumHelper {
   private final long length;
 
   private ClientProtocol rpcClient;
-  private Options.ChecksumCombineMode combineMode;
+  private OzoneClientConfig.ChecksumCombineMode combineMode;
 
   private final DataOutputBuffer blockChecksumBuf = new DataOutputBuffer();
   private XceiverClientFactory xceiverClientFactory;
@@ -68,7 +68,7 @@ public abstract class BaseFileChecksumHelper {
   BaseFileChecksumHelper(
       OzoneVolume volume, OzoneBucket bucket, String keyName,
       long length,
-      Options.ChecksumCombineMode checksumCombineMode,
+      OzoneClientConfig.ChecksumCombineMode checksumCombineMode,
       ClientProtocol rpcClient) throws IOException {
 
     this.volume = volume;
@@ -97,7 +97,7 @@ public abstract class BaseFileChecksumHelper {
     return rpcClient;
   }
 
-  protected Options.ChecksumCombineMode getCombineMode() {
+  protected OzoneClientConfig.ChecksumCombineMode getCombineMode() {
     return combineMode;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.ozone.client.checksum;
 
 import org.apache.hadoop.fs.PathIOException;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
@@ -33,6 +34,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.CrcUtil;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -46,9 +48,11 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
 
   public ReplicatedFileChecksumHelper(
       OzoneVolume volume, OzoneBucket bucket, String keyName, long length,
+      Options.ChecksumCombineMode checksumCombineMode,
       ClientProtocol rpcClient) throws IOException {
-    super(volume, bucket, keyName, length, rpcClient);
+    super(volume, bucket, keyName, length, checksumCombineMode, rpcClient);
   }
+
 
   @Override
   protected void checksumBlocks() throws IOException {
@@ -64,8 +68,8 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
       }
 
       if (!checksumBlock(keyLocationInfo)) {
-        throw new PathIOException(
-            getSrc(), "Fail to get block MD5 for " + keyLocationInfo);
+        throw new PathIOException(getSrc(),
+            "Fail to get block MD5 for " + keyLocationInfo);
       }
     }
   }
@@ -175,11 +179,33 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
   String populateBlockChecksumBuf(ByteBuffer checksumData)
       throws IOException {
     String blockChecksumForDebug = null;
-    //read md5
-    final MD5Hash md5 = new MD5Hash(checksumData.array());
-    md5.write(getBlockChecksumBuf());
-    if (LOG.isDebugEnabled()) {
-      blockChecksumForDebug = md5.toString();
+    switch (getCombineMode()) {
+    case MD5MD5CRC:
+      //read md5
+      final MD5Hash md5 = new MD5Hash(checksumData.array());
+      md5.write(getBlockChecksumBuf());
+      if (LOG.isDebugEnabled()) {
+        blockChecksumForDebug = md5.toString();
+      }
+      break;
+    case COMPOSITE_CRC:
+      // TODO: abort if chunk checksum type is not CRC32/CRC32C
+      //BlockChecksumType returnedType = PBHelperClient.convert(
+      //    checksumData.getBlockChecksumOptions().getBlockChecksumType());
+      /*if (returnedType != BlockChecksumType.COMPOSITE_CRC) {
+        throw new IOException(String.format(
+            "Unexpected blockChecksumType '%s', expecting COMPOSITE_CRC",
+            returnedType));
+      }*/
+      byte[] crcBytes = checksumData.array();
+      if (LOG.isDebugEnabled()) {
+        blockChecksumForDebug = CrcUtil.toSingleCrcString(crcBytes);
+      }
+      getBlockChecksumBuf().write(crcBytes);
+      break;
+    default:
+      throw new IOException(
+          "Unknown combine mode: " + getCombineMode());
     }
 
     return blockChecksumForDebug;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -18,12 +18,12 @@
 package org.apache.hadoop.ozone.client.checksum;
 
 import org.apache.hadoop.fs.PathIOException;
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
@@ -48,7 +48,7 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
 
   public ReplicatedFileChecksumHelper(
       OzoneVolume volume, OzoneBucket bucket, String keyName, long length,
-      Options.ChecksumCombineMode checksumCombineMode,
+      OzoneClientConfig.ChecksumCombineMode checksumCombineMode,
       ClientProtocol rpcClient) throws IOException {
     super(volume, bucket, keyName, length, checksumCombineMode, rpcClient);
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.XceiverClientGrpc;
 import org.apache.hadoop.hdds.scm.XceiverClientReply;
@@ -145,8 +146,8 @@ public class TestReplicatedFileChecksumHelper {
     OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
-    Options.ChecksumCombineMode combineMode =
-        Options.ChecksumCombineMode.MD5MD5CRC;
+    OzoneClientConfig.ChecksumCombineMode combineMode =
+        OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC;
 
     ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
         mockVolume, bucket, "dummy", 10, combineMode, mockRpcClient);
@@ -230,8 +231,8 @@ public class TestReplicatedFileChecksumHelper {
     OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
-    Options.ChecksumCombineMode combineMode =
-        Options.ChecksumCombineMode.MD5MD5CRC;
+    OzoneClientConfig.ChecksumCombineMode combineMode =
+        OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC;
 
     ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
         mockVolume, bucket, "dummy", 10, combineMode, mockRpcClient);
@@ -318,8 +319,8 @@ public class TestReplicatedFileChecksumHelper {
         out.write(value.getBytes(UTF_8));
       }
 
-      Options.ChecksumCombineMode combineMode =
-          Options.ChecksumCombineMode.MD5MD5CRC;
+      OzoneClientConfig.ChecksumCombineMode combineMode =
+          OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC;
 
       ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
           volume, bucket, keyName, 10, combineMode, rpcClient);

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.checksum;
 
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
+import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -144,8 +145,11 @@ public class TestReplicatedFileChecksumHelper {
     OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
+    Options.ChecksumCombineMode combineMode =
+        Options.ChecksumCombineMode.MD5MD5CRC;
+
     ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
-        mockVolume, bucket, "dummy", 10, mockRpcClient);
+        mockVolume, bucket, "dummy", 10, combineMode, mockRpcClient);
     helper.compute();
     FileChecksum fileChecksum = helper.getFileChecksum();
     assertTrue(fileChecksum instanceof MD5MD5CRC32GzipFileChecksum);
@@ -154,7 +158,7 @@ public class TestReplicatedFileChecksumHelper {
 
     // test negative length
     helper = new ReplicatedFileChecksumHelper(
-        mockVolume, bucket, "dummy", -1, mockRpcClient);
+        mockVolume, bucket, "dummy", -1, combineMode, mockRpcClient);
     helper.compute();
     assertNull(helper.getKeyLocationInfoList());
   }
@@ -226,8 +230,11 @@ public class TestReplicatedFileChecksumHelper {
     OzoneBucket bucket = Mockito.mock(OzoneBucket.class);
     when(bucket.getName()).thenReturn("bucket1");
 
+    Options.ChecksumCombineMode combineMode =
+        Options.ChecksumCombineMode.MD5MD5CRC;
+
     ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
-        mockVolume, bucket, "dummy", 10, mockRpcClient);
+        mockVolume, bucket, "dummy", 10, combineMode, mockRpcClient);
 
     helper.compute();
     FileChecksum fileChecksum = helper.getFileChecksum();
@@ -311,8 +318,11 @@ public class TestReplicatedFileChecksumHelper {
         out.write(value.getBytes(UTF_8));
       }
 
+      Options.ChecksumCombineMode combineMode =
+          Options.ChecksumCombineMode.MD5MD5CRC;
+
       ReplicatedFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
-          volume, bucket, keyName, 10, rpcClient);
+          volume, bucket, keyName, 10, combineMode, rpcClient);
 
       helper.compute();
       FileChecksum fileChecksum = helper.getFileChecksum();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.client.checksum;
 
 import org.apache.hadoop.fs.FileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
-import org.apache.hadoop.fs.Options;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -82,7 +82,7 @@ public final class OzoneClientUtils {
       return null;
     }
     BaseFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
-        volume, bucket, keyName, length, rpcClient);
+        volume, bucket, keyName, length, combineMode, rpcClient);
     helper.compute();
     return helper.getFileChecksum();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initial support for composite CRC. Configured by ozone.client.checksum.combine.mode

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6087

## How was this patch tested?

(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
