### PR TITLE
HDDS-6132: EC: HandleStripeFailure should not release the cachebuffers.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
@@ -130,7 +130,7 @@ public class ECBlockOutputStreamEntry extends BlockOutputStreamEntry{
   }
 
   public void useNextBlockStream() {
-    currentStreamIdx++;
+    currentStreamIdx = (currentStreamIdx + 1) % replicationConfig.getRequiredNodes();
   }
 
   public void markFailed(Exception e) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
@@ -130,7 +130,8 @@ public class ECBlockOutputStreamEntry extends BlockOutputStreamEntry{
   }
 
   public void useNextBlockStream() {
-    currentStreamIdx = (currentStreamIdx + 1) % replicationConfig.getRequiredNodes();
+    currentStreamIdx =
+        (currentStreamIdx + 1) % replicationConfig.getRequiredNodes();
   }
 
   public void markFailed(Exception e) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -260,7 +260,6 @@ public class ECKeyOutputStream extends KeyOutputStream {
     newBlockGroupStreamEntry
         .updateBlockGroupToAckedPosition(failedStripeDataSize);
     ecChunkBufferCache.clear(chunkSize);
-    ecChunkBufferCache.release();
 
     if (newBlockGroupStreamEntry.getRemaining() <= 0) {
       // In most cases this should not happen except in the case stripe size and


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the release in handled stripe failure case and added the test to verify.
This is an important issue as it throws NPE if we write additional stripe after failure recovery.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6132

## How was this patch tested?

Added test to verify.
