### PR TITLE
HDDS-5807. [FSO] Merge HDDS-4653 changes to support TDE for MPU Keys in FSO bucket layout.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.Collection;
 
 import com.google.common.cache.Cache;
 import org.apache.hadoop.conf.StorageUnit;
@@ -68,6 +69,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartCommitUploadPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.ozone.test.GenericTestUtils;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
@@ -78,12 +80,22 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import org.mockito.Mockito;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client.
  */
+@RunWith(Parameterized.class)
 public class TestOzoneAtRestEncryption {
+
+  @Parameterized.Parameters
+  public static Collection<BucketLayout> data() {
+    return Arrays.asList(
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        BucketLayout.OBJECT_STORE);
+  }
 
   private static MiniOzoneCluster cluster = null;
   private static MiniKMS miniKMS;
@@ -106,6 +118,11 @@ public class TestOzoneAtRestEncryption {
   private static final int DEFAULT_CRYPTO_BUFFER_SIZE = 8 * 1024; // 8KB
   // (this is the default Crypto Buffer size as determined by the config
   // hadoop.security.crypto.buffer.size)
+  private static BucketLayout bucketLayout;
+
+  public TestOzoneAtRestEncryption(BucketLayout layout) {
+    bucketLayout = layout;
+  }
 
   @BeforeClass
   public static void init() throws Exception {
@@ -186,6 +203,7 @@ public class TestOzoneAtRestEncryption {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setBucketLayout(bucketLayout)
         .setBucketEncryptionKey(TEST_KEY).build();
     volume.createBucket(bucketName, bucketArgs);
     OzoneBucket bucket = volume.getBucket(bucketName);
@@ -253,7 +271,8 @@ public class TestOzoneAtRestEncryption {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     BucketArgs bucketArgs = BucketArgs.newBuilder()
-        .setBucketEncryptionKey(TEST_KEY).build();
+        .setBucketEncryptionKey(TEST_KEY)
+        .setBucketLayout(bucketLayout).build();
     volume.createBucket(bucketName, bucketArgs);
     return volume.getBucket(bucketName);
   }
@@ -263,7 +282,8 @@ public class TestOzoneAtRestEncryption {
     store.createVolume(linkVol);
     OzoneVolume linkVolume = store.getVolume(linkVol);
     BucketArgs linkBucketArgs = BucketArgs.newBuilder()
-        .setSourceVolume(sourceVol).setSourceBucket(sourceBucket).build();
+        .setSourceVolume(sourceVol).setSourceBucket(sourceBucket)
+        .setBucketLayout(bucketLayout).build();
     linkVolume.createBucket(linkBucket, linkBucketArgs);
     return linkVolume.getBucket(linkBucket);
   }
@@ -288,7 +308,8 @@ public class TestOzoneAtRestEncryption {
     //Bucket with Encryption & GDPR enforced
     BucketArgs bucketArgs = BucketArgs.newBuilder()
         .setBucketEncryptionKey(TEST_KEY)
-        .addMetadata(OzoneConsts.GDPR_FLAG, "true").build();
+        .addMetadata(OzoneConsts.GDPR_FLAG, "true")
+        .setBucketLayout(bucketLayout).build();
     volume.createBucket(bucketName, bucketArgs);
     OzoneBucket bucket = volume.getBucket(bucketName);
     Assert.assertEquals(bucketName, bucket.getName());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -118,7 +118,7 @@ public class TestOzoneAtRestEncryption {
   private static final int DEFAULT_CRYPTO_BUFFER_SIZE = 8 * 1024; // 8KB
   // (this is the default Crypto Buffer size as determined by the config
   // hadoop.security.crypto.buffer.size)
-  private static BucketLayout bucketLayout;
+  private final BucketLayout bucketLayout;
 
   public TestOzoneAtRestEncryption(BucketLayout layout) {
     bucketLayout = layout;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -1012,6 +1012,31 @@ public final class OMFileRequest {
   }
 
   /**
+   * Get parent ID for the user given keyName.
+   *
+   * @param omMetadataManager
+   * @param volumeName        - volume name.
+   * @param bucketName        - bucket name.
+   * @param keyName           - key name.
+   * @return
+   * @throws IOException
+   */
+  public static long getParentId(OMMetadataManager omMetadataManager,
+                                 String volumeName, String bucketName,
+                                 String keyName)
+      throws IOException {
+
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(bucketKey);
+
+    long bucketId = omBucketInfo.getObjectID();
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+    return OMFileRequest
+        .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
+  }
+
+  /**
    * Validates volume and bucket existence.
    *
    * @param metadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -257,10 +257,6 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
         getParentId(omMetadataManager, volumeName, bucketName, keyName);
 
     String fileName = OzoneFSUtils.getFileName(keyName);
-    Path filePath = Paths.get(keyName).getFileName();
-    if (filePath != null) {
-      fileName = filePath.toString();
-    }
 
     return omMetadataManager.getMultipartKey(parentId, fileName, uploadID);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -231,5 +232,34 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
             numKeysCreated);
 
     return omClientResponse;
+  }
+
+  /**
+   * Returns the DB key name of a multipart open key in OM metadata store.
+   *
+   * @param volumeName        - volume name.
+   * @param bucketName        - bucket name.
+   * @param keyName           - key name.
+   * @param uploadID          - Multi part upload ID for this key.
+   * @param omMetadataManager
+   * @return
+   * @throws IOException
+   */
+  @Override
+  protected String getDBMultipartOpenKey(String volumeName, String bucketName,
+                                         String keyName, String uploadID,
+                                         OMMetadataManager omMetadataManager)
+      throws IOException {
+
+    long parentId =
+        getParentId(omMetadataManager, volumeName, bucketName, keyName);
+
+    String fileName = keyName;
+    Path filePath = Paths.get(keyName).getFileName();
+    if (filePath != null) {
+      fileName = filePath.toString();
+    }
+
+    return omMetadataManager.getMultipartKey(parentId, fileName, uploadID);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -54,6 +55,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
+import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentId;
 
 /**
  * Handles CreateKey request layout version1.
@@ -254,7 +256,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
     long parentId =
         getParentId(omMetadataManager, volumeName, bucketName, keyName);
 
-    String fileName = keyName;
+    String fileName = OzoneFSUtils.getFileName(keyName);
     Path filePath = Paths.get(keyName).getFileName();
     if (filePath != null) {
       fileName = filePath.toString();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.ozone.om.request.key;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -30,7 +28,6 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Iterator;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -493,31 +490,6 @@ public abstract class OMKeyRequest extends OMClientRequest {
         }
       }
     }
-  }
-
-  /**
-   * Get parent ID for the user given keyName.
-   *
-   * @param omMetadataManager
-   * @param volumeName        - volume name.
-   * @param bucketName        - bucket name.
-   * @param keyName           - key name.
-   * @return
-   * @throws IOException
-   */
-  protected long getParentId(OMMetadataManager omMetadataManager,
-                             String volumeName, String bucketName,
-                             String keyName)
-      throws IOException {
-
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-    OmBucketInfo omBucketInfo =
-        omMetadataManager.getBucketTable().get(bucketKey);
-
-    long bucketId = omBucketInfo.getObjectID();
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
-    return OMFileRequest
-        .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Multipa
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.MultipartInfoInitiateResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.ozone.protocolPB.OMPBHelper;
 
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -51,7 +52,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_SUPPORTED_OPERATION;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 
@@ -111,17 +111,6 @@ public class S3InitiateMultipartUploadRequestWithFSO
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      // If KMS is configured and TDE is enabled on bucket, throw MPU not
-      // supported.
-      if (ozoneManager.getKmsProvider() != null) {
-        if (omMetadataManager.getBucketTable().get(
-            omMetadataManager.getBucketKey(volumeName, bucketName))
-            .getEncryptionKeyInfo() != null) {
-          throw new OMException("MultipartUpload is not yet supported on " +
-              "encrypted buckets", NOT_SUPPORTED_OPERATION);
-        }
-      }
 
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO = OMFileRequest
           .verifyDirectoryKeysInPath(omMetadataManager, volumeName, bucketName,
@@ -187,6 +176,8 @@ public class S3InitiateMultipartUploadRequestWithFSO
           .setAcls(OzoneAclUtil.fromProtobuf(keyArgs.getAclsList()))
           .setObjectID(pathInfoFSO.getLeafNodeObjectId())
           .setUpdateID(transactionLogIndex)
+          .setFileEncryptionInfo(keyArgs.hasFileEncryptionInfo() ?
+              OMPBHelper.convert(keyArgs.getFileEncryptionInfo()) : null)
           .setParentObjectID(pathInfoFSO.getLastKnownParentId())
           .build();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -384,13 +384,6 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
     return omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
   }
 
-  protected String getDBMultipartOpenKey(String volumeName, String bucketName,
-      String keyName, String uploadID, OMMetadataManager omMetadataManager)
-      throws IOException {
-    return omMetadataManager
-        .getMultipartKey(volumeName, bucketName, keyName, uploadID);
-  }
-
   protected OmKeyInfo getOmKeyInfoFromKeyTable(String dbOzoneKey,
       String keyName, OMMetadataManager omMetadataManager) throws IOException {
     return omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -36,7 +35,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
@@ -155,18 +153,6 @@ public class S3MultipartUploadCompleteRequestWithFSO
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
         getBucketLayout());
-  }
-
-  private long getParentId(OMMetadataManager omMetadataManager,
-      String volumeName, String bucketName, String keyName) throws IOException {
-
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-    OmBucketInfo omBucketInfo =
-        omMetadataManager.getBucketTable().get(bucketKey);
-    long bucketId = omBucketInfo.getObjectID();
-    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
-    return OMFileRequest
-        .getParentID(bucketId, pathComponents, keyName, omMetadataManager);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -39,6 +39,7 @@ import java.util.List;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
+import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentId;
 
 /**
  * Handle Multipart upload complete request.


### PR DESCRIPTION
## What changes were proposed in this pull request?

This task is to merge [HDDS-4653](https://issues.apache.org/jira/browse/HDDS-4653) to support Transparent Data Encryption for MPU Keys in FSO bucket layout.

Presently it's throwing a NOT_SUPPORTED exception.

```
10:01:29.283 [OM StateMachine ApplyTransaction Thread - 0] ERROR OMAudit - user=xyz | ip=127.0.0.1 | op=INITIATE_MULTIPART_UPLOAD {volume=d05a32f8-29a0-46f3-9215-d3b8ace658c5, bucket=dcdf3716-970d-4e66-a6ba-f857d9311aa7, key=mpu_test_key_1, dataSize=0, replicationType=STAND_ALONE, replicationFactor=ONE} | ret=FAILURE

org.apache.hadoop.ozone.om.exceptions.OMException: MultipartUpload is not yet supported on encrypted buckets
at org.apache.hadoop.ozone.om.request.s3.multipart.S3InitiateMultipartUploadRequestWithFSO.validateAndUpdateCache(S3InitiateMultipartUploadRequestWithFSO.java:120)
...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5807

## How was this patch tested?

Related integration tests.