### PR TITLE
HDDS-5545. Enable TLS for GRPC OmTransport implementation

### DIFF
--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -49,6 +49,17 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>io.netty</groupId>
       <artifactId>netty-handler-proxy</artifactId>
     </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>2.0.38.Final</version> <!-- See table for correct version -->
+        <scope>runtime</scope>
+      </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <version>2.0.38.Final</version> <!-- See table for correct version -->
+    </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -52,13 +52,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.38.Final</version> <!-- See table for correct version -->
+        <version>${tcnative.version}</version>
         <scope>runtime</scope>
       </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>2.0.38.Final</version> <!-- See table for correct version -->
+      <version>${tcnative.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -308,4 +308,9 @@ public final class OMConfigKeys {
       "org.apache.hadoop.ozone.om.protocolPB"
           + ".Hadoop3OmTransportFactory";
 
+  public static final String OZONE_OM_TRANSPORT_CLASS =
+      "ozone.om.transport.class";
+  public static final String OZONE_OM_TRANSPORT_CLASS_DEFAULT =
+      "org.apache.hadoop.ozone.om.protocolPB"
+          + ".Hadoop3OmTransportFactory";
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -307,10 +307,4 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_TRANSPORT_CLASS_DEFAULT =
       "org.apache.hadoop.ozone.om.protocolPB"
           + ".Hadoop3OmTransportFactory";
-
-  public static final String OZONE_OM_TRANSPORT_CLASS =
-      "ozone.om.transport.class";
-  public static final String OZONE_OM_TRANSPORT_CLASS_DEFAULT =
-      "org.apache.hadoop.ozone.om.protocolPB"
-          + ".Hadoop3OmTransportFactory";
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -83,7 +83,6 @@ public class GrpcOmTransport implements OmTransport {
   private int lastVisited = -1;
   private ConfigurationSource conf;
 
-  //private String host = "om";
   private AtomicReference<String> host;
   private int maxSize;
   private SecurityConfig secConfig;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/GrpcOmTransport.java
@@ -153,13 +153,18 @@ public class GrpcOmTransport implements OmTransport {
     if (secConfig.isGrpcTlsEnabled()) {
       try {
         SslContextBuilder sslContextBuilder = GrpcSslContexts.forClient();
-        if (caCerts != null) {
-          sslContextBuilder.trustManager(caCerts);
+        if (secConfig.isSecurityEnabled()) {
+          if (caCerts != null) {
+            sslContextBuilder.trustManager(caCerts);
+          } else {
+            LOG.error("x509Certicates empty");
+          }
+          channelBuilder.useTransportSecurity().
+              sslContext(sslContextBuilder.build());
         } else {
-          LOG.error("x509Certicates empty");
+          LOG.error("ozone.security not enabled when TLS specified," +
+              " using plaintext");
         }
-        channelBuilder.useTransportSecurity().
-            sslContext(sslContextBuilder.build());
       } catch (Exception ex) {
         LOG.error("cannot establish TLS for grpc om transport client");
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
@@ -46,8 +46,8 @@ public interface OmTransportFactory {
       throws IOException {
     try {
       // if configured transport class is different than the default
-      // Hadoop3OmTransportFactory, then check service loader for
-      // transport class and instantiate it
+      // OmTransportFactory (Hadoop3OmTransportFactory), then
+      // check service loader for transport class and instantiate it
       if (conf
           .get(OZONE_OM_TRANSPORT_CLASS,
               OZONE_OM_TRANSPORT_CLASS_DEFAULT) !=
@@ -61,13 +61,9 @@ public interface OmTransportFactory {
         }
       }
       return OmTransportFactory.class.getClassLoader()
-          .loadClass(
-              "org.apache.hadoop.ozone.om.protocolPB"
-                  + ".Hadoop3OmTransportFactory")
-
+          .loadClass(OZONE_OM_TRANSPORT_CLASS_DEFAULT)
           .asSubclass(OmTransportFactory.class)
           .newInstance();
-
     } catch (Exception ex) {
       throw new IOException(
           "Can't create the default OmTransport implementation", ex);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OmTransportFactory.java
@@ -64,8 +64,10 @@ public interface OmTransportFactory {
           .loadClass(
               "org.apache.hadoop.ozone.om.protocolPB"
                   + ".Hadoop3OmTransportFactory")
+
           .asSubclass(OmTransportFactory.class)
           .newInstance();
+
     } catch (Exception ex) {
       throw new IOException(
           "Can't create the default OmTransport implementation", ex);

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -178,7 +178,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   private OmTransport transport;
   private ThreadLocal<S3Auth> threadLocalS3Auth
       = new ThreadLocal<>();
-
+    
   private boolean s3AuthCheck;
   public OzoneManagerProtocolClientSideTranslatorPB(OmTransport omTransport,
       String clientId) {

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -309,6 +309,8 @@ Apache License
    io.netty:netty-handler
    io.netty:netty-handler-proxy
    io.netty:netty-resolver
+   io.netty:netty-tcnative-boringssl-static
+   io.netty:netty-tcnative
    io.netty:netty-transport
    io.netty:netty-transport-native-epoll
    io.netty:netty-transport-native-unix-common

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -172,6 +172,8 @@ share/ozone/lib/netty-common.Final.jar
 share/ozone/lib/netty-handler.Final.jar
 share/ozone/lib/netty-handler-proxy.Final.jar
 share/ozone/lib/netty-resolver.Final.jar
+share/ozone/lib/netty-tcnative-boringssl-static.Final.jar
+share/ozone/lib/netty-tcnative.Final.jar
 share/ozone/lib/netty-transport.Final.jar
 share/ozone/lib/netty-transport-native-epoll.Final.jar
 share/ozone/lib/netty-transport-native-unix-common.Final.jar

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1350,7 +1350,7 @@ message UpdateGetS3SecretRequest {
 }
 
 /**
-  This will be used by OM to authenicate S3 gateway requests on a per request basis.
+  This will be used by OM to authenticate S3 gateway requests on a per request basis.
 */
 message S3Authentication {
     required string stringToSign = 1;

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -90,12 +90,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>2.0.38.Final</version> <!-- See table for correct version -->
+      <version>${tcnative.version}</version>
     </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>2.0.38.Final</version> <!-- See table for correct version -->
+        <version>${tcnative.version}</version>
         <scope>runtime</scope>
       </dependency>
 

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -87,6 +87,17 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-tcnative</artifactId>
+      <version>2.0.38.Final</version> <!-- See table for correct version -->
+    </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>2.0.38.Final</version> <!-- See table for correct version -->
+        <scope>runtime</scope>
+      </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/GrpcOzoneManagerServer.java
@@ -96,13 +96,19 @@ public class GrpcOzoneManagerServer {
     SecurityConfig secConf = new SecurityConfig(omServerConfig);
     if (secConf.isGrpcTlsEnabled()) {
       try {
-        SslContextBuilder sslClientContextBuilder = SslContextBuilder.forServer(
-            caClient.getPrivateKey(), caClient.getCertificate());
-        SslContextBuilder sslContextBuilder = GrpcSslContexts.configure(
-            sslClientContextBuilder,
-            SslProvider.valueOf(omServerConfig.get(HDDS_GRPC_TLS_PROVIDER,
-                HDDS_GRPC_TLS_PROVIDER_DEFAULT)));
-        nettyServerBuilder.sslContext(sslContextBuilder.build());
+        if (secConf.isSecurityEnabled()) {
+          SslContextBuilder sslClientContextBuilder =
+              SslContextBuilder.forServer(caClient.getPrivateKey(),
+                  caClient.getCertificate());
+          SslContextBuilder sslContextBuilder = GrpcSslContexts.configure(
+              sslClientContextBuilder,
+              SslProvider.valueOf(omServerConfig.get(HDDS_GRPC_TLS_PROVIDER,
+                  HDDS_GRPC_TLS_PROVIDER_DEFAULT)));
+          nettyServerBuilder.sslContext(sslContextBuilder.build());
+        } else {
+          LOG.error("ozone.security not enabled when TLS specified," +
+                            " creating Om S3g GRPC channel using plaintext");
+        }
       } catch (Exception ex) {
         LOG.error("Unable to setup TLS for secure Om S3g GRPC channel.", ex);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -1107,7 +1107,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           throws IOException {
     return new GrpcOzoneManagerServer(conf,
             this.omServerProtocol,
-            this.delegationTokenMgr);
+            this.delegationTokenMgr,
+            this.certClient);
   }
 
   private static boolean isOzoneSecurityEnabled() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestGrpcOzoneManagerServer.java
@@ -49,7 +49,8 @@ public class TestGrpcOzoneManagerServer {
 
     server = new GrpcOzoneManagerServer(conf,
         omServerProtocol,
-        ozoneManager.getDelegationTokenMgr());
+        ozoneManager.getDelegationTokenMgr(),
+        ozoneManager.getCertificateClient());
 
     try {
       server.start();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
@@ -19,15 +19,24 @@ package org.apache.hadoop.ozone.s3;
 
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransport;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_TRANSPORT_CLASS_DEFAULT;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
@@ -43,16 +52,29 @@ public final class OzoneClientCache {
   // for s3g gRPC OmTransport, OmRequest - OmResponse channel
   private static OzoneClientCache instance;
   private OzoneClient client;
+  private SecurityConfig secConfig;
 
   private OzoneClientCache(OzoneConfiguration ozoneConfiguration)
       throws IOException {
-    // S3 Gateway should always set the S3 Auth.
-    ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
     // Set the expected OM version if not set via config.
     ozoneConfiguration.setIfUnset(OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
         OZONE_OM_CLIENT_PROTOCOL_VERSION);
     String omServiceID = OmUtils.getOzoneManagerServiceId(ozoneConfiguration);
+    secConfig = new SecurityConfig(ozoneConfiguration);
+    client = null;
     try {
+      if (secConfig.isGrpcTlsEnabled()) {
+        if (ozoneConfiguration
+            .get(OZONE_OM_TRANSPORT_CLASS,
+                OZONE_OM_TRANSPORT_CLASS_DEFAULT) !=
+            OZONE_OM_TRANSPORT_CLASS_DEFAULT) {
+          // Grpc transport selected
+          // need to get certificate for TLS through
+          // hadoop rpc first via ServiceInfo
+          setCertificate(omServiceID,
+              ozoneConfiguration);
+        }
+      }
       if (omServiceID == null) {
         client = OzoneClientFactory.getRpcClient(ozoneConfiguration);
       } else {
@@ -64,6 +86,8 @@ public final class OzoneClientCache {
       LOG.warn("cannot create OzoneClient", e);
       throw e;
     }
+    // S3 Gateway should always set the S3 Auth.
+    ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
   }
 
   public static OzoneClient getOzoneClientInstance(OzoneConfiguration
@@ -75,8 +99,66 @@ public final class OzoneClientCache {
     return instance.client;
   }
 
+  public static void closeClient() throws IOException {
+    if (instance != null) {
+      instance.client.close();
+      instance = null;
+    }
+  }
+
+  private void setCertificate(String omServiceID,
+                              OzoneConfiguration conf)
+      throws IOException {
+
+    // create local copy of config incase exception occurs
+    // with certificate OmRequest
+    OzoneConfiguration config = new OzoneConfiguration(conf);
+    OzoneClient certClient;
+
+    if (secConfig.isGrpcTlsEnabled()) {
+      // set OmTransport to hadoop rpc to securely,
+      // get certificates with service list request
+      config.set(OZONE_OM_TRANSPORT_CLASS,
+          OZONE_OM_TRANSPORT_CLASS_DEFAULT);
+
+      if (omServiceID == null) {
+        certClient = OzoneClientFactory.getRpcClient(config);
+      } else {
+        // As in HA case, we need to pass om service ID.
+        certClient = OzoneClientFactory.getRpcClient(omServiceID,
+            config);
+      }
+      try {
+        ServiceInfoEx serviceInfoEx = certClient
+            .getObjectStore()
+            .getClientProxy()
+            .getOzoneManagerClient()
+            .getServiceInfo();
+
+        if (OzoneSecurityUtil.isSecurityEnabled(conf)) {
+          String caCertPem = null;
+          List<String> caCertPems = null;
+          caCertPem = serviceInfoEx.getCaCertificate();
+          caCertPems = serviceInfoEx.getCaCertPemList();
+          if (caCertPems == null || caCertPems.isEmpty()) {
+            caCertPems = Collections.singletonList(caCertPem);
+          }
+          GrpcOmTransport.setCaCerts(OzoneSecurityUtil
+              .convertToX509(caCertPems));
+        }
+      } catch (IOException e) {
+        throw e;
+      } finally {
+        if (certClient != null) {
+          certClient.close();
+        }
+      }
+    }
+  }
+
+
   @PreDestroy
   public void destroy() throws IOException {
-    client.close();
+    OzoneClientCache.closeClient();
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientCache.java
@@ -17,6 +17,8 @@
 
 package org.apache.hadoop.ozone.s3;
 
+import com.google.common.base.Preconditions;
+
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
@@ -141,6 +143,7 @@ public final class OzoneClientCache {
           caCertPem = serviceInfoEx.getCaCertificate();
           caCertPems = serviceInfoEx.getCaCertPemList();
           if (caCertPems == null || caCertPems.isEmpty()) {
+            Preconditions.checkNotNull(caCertPem);
             caCertPems = Collections.singletonList(caCertPem);
           }
           GrpcOmTransport.setCaCerts(OzoneSecurityUtil

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -62,7 +62,7 @@ public class OzoneClientProducer {
   private ContainerRequestContext context;
 
   @Produces
-  public synchronized OzoneClient createClient() throws WebApplicationException,
+  public OzoneClient createClient() throws WebApplicationException,
       IOException {
     client = getClient(ozoneConfiguration);      
     return client;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -62,7 +62,7 @@ public class OzoneClientProducer {
   private ContainerRequestContext context;
 
   @Produces
-  public OzoneClient createClient() throws WebApplicationException,
+  public synchronized OzoneClient createClient() throws WebApplicationException,
       IOException {
     client = getClient(ozoneConfiguration);      
     return client;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -58,7 +58,7 @@ public abstract class EndpointBase {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
         throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName);
-      } else if (ex.getResult() == ResultCodes.S3_SECRET_NOT_FOUND) {
+      } else if (ex.getResult() == ResultCodes.INVALID_TOKEN) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
             s3Auth.getAccessID());
       } else if (ex.getResult() == ResultCodes.TIMEOUT ||

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/protocolPB/TestGrpcOmTransport.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/protocolPB/TestGrpcOmTransport.java
@@ -59,6 +59,19 @@ public class TestGrpcOmTransport {
   }
 
   @Test
+  public void testHrpcOmTransportFactory() throws Exception {
+    String omServiceId = "";
+    OzoneConfiguration conf = new OzoneConfiguration();
+
+    UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
+    OmTransport omTransport = OmTransportFactory.create(conf, ugi, omServiceId);
+    // OmTransport should be Hadoop Rpc and
+    // fail equality GrpcOmTransport equality test
+    Assert.assertNotEquals(GrpcOmTransport.class.getSimpleName(),
+        omTransport.getClass().getSimpleName());
+  }
+
+  @Test
   public void testStartStop() throws Exception {
     String omServiceId = "";
     OzoneConfiguration conf = new OzoneConfiguration();

--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,9 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <netty.version>4.1.63.Final</netty.version>
     <io.grpc.version>1.38.0</io.grpc.version>
+    <tcnative.version>2.0.38.Final</tcnative.version> <!-- See table for correct version -->
+    <!-- Table for netty, grpc & tcnative version combinations  -->
+    <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>


### PR DESCRIPTION
…sync with Ozone master containing s3gateway perisistent connection hadoop rpc from HDDS-5881.  This commit also includes functionality to configure omtransport choosiing either hrpc (default) or Grpc OmTransport s3gateway om channel - HDDS-5813.

## What changes were proposed in this pull request?
Support for TLS secured Grpc OmTransport channel between s3gateway, s3g, and the ozone manager, om.  TLS is enabled for the s3g persistent connection between the s3g and the om through the configuration "_**hdds.grpc.tls.enabled**_" boolean.

Included is selection of OmTransport used between s3g and om through configuration "_**ozone.om.transport.class**_", `org.apache.hadoop.ozone.om.protocolPB.Hadoop3OmTransportFactory` (default) or `org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory`.  Allowing use of Hadoop rpc, hrpc, (HDDS-5581) while migrating to the full HDDS-4440 feature using Grpc persistent OmTransport s3g.

The TLS Grpc client connection is established by initially using a temporary secured (kerberos) hrpc connection between the s3g and the om to obtain the CA Certificates `(serviceInfo` `OmRequest`).  The certificates are then used to authenticate the Grpc TLS connection established between the s3g and the om through the `GrpcOmTransport`.   

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5545

## How was this patch tested?

Patch was tested through both unit tests and manually with the secureozone cluster.

1. unit test `TestGrpcOmTransport.testGrpcOmTransportFactory`, `TestGrpcOmTransport.testHrpcOmTransportFactory`

`hadoop-ozone/s3gateway$ mvn -Dtest=TestGrpcOmTransport#testGrpcOmTransportFactory test`
[INFO] Running org.apache.hadoop.ozone.protocolPB.TestGrpcOmTransport
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.97 s - in org.apache.hadoop.ozone.protocolPB.TestGrpcOmTransport
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

`hadoop-ozone/s3gateway$ mvn -Dtest=TestGrpcOmTransport#testHrpcOmTransportFactory test`
[INFO] Running org.apache.hadoop.ozone.protocolPB.TestGrpcOmTransport
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.647 s - in org.apache.hadoop.ozone.protocolPB.TestGrpcOmTransport
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0

2. manual testing with ozonesecure cluster:
`hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/ozonesecure$ docker-compose up -d --scale datanode=3`
setup kdc and get user secret:
```
hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/ozonesecure$ docker-compose exec scm bash
$ kinit -kt /etc/security/keytabs/testuser.keytab testuser/scm@EXAMPLE.COM
$ ozone s3 getsecret -u=testuser/scm@EXAMPLE.COM

```
With user credentials set in profile 'ozone' (aws secret & username testuser/scm@EXAMPLE.COM) through aws cli:
```
$ aws s3api --profile ozone --endpoint http://localhost:9878 list-buckets
{
    "Buckets": []
}
```

Runs s3g with hrpc omtransport.

Now for TLS Grpc rerun with same but with ozone configuration for Grpc om transport through "_**ozone.om.transport.class**_"=`org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory` ie.
**set** in _hadoop-ozone/dist/target/ozone-1.2.0-SNAPSHOT/compose/ozonesecure/docker-config_ : ` OZONE-SITE.XML_ozone.om.transport.class=org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory`

```
$ aws s3api --profile ozone --endpoint http://localhost:9878 list-buckets
{
    "Buckets": []
}
```



