### PR TITLE
HDDS-6140. Selective checks: skip unit check for integration-test changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ hadoop-ozone/recon/node_modules
 .mvn
 
 .dev-tools
-
+dev-support/ci/bats-assert
+dev-support/ci/bats-support
 
 hadoop-ozone/dist/src/main/license/current.txt

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -77,10 +77,21 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=true
 }
 
+@test "integration and unit" {
+  run dev-support/ci/selective_ci_checks.sh 9aebf6e25
+
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","unit"]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=true
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "integration only" {
   run dev-support/ci/selective_ci_checks.sh 61396ba9f
 
-  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","unit"]'
+  assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
   assert_output -p needs-build=false
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -391,6 +391,10 @@ function check_needs_unit_test() {
         "src/..../java"
         "src/..../resources"
     )
+    local ignore_array=(
+        "^hadoop-ozone/integration-test"
+        "^hadoop-ozone/fault-injection-test/mini-chaos-tests"
+    )
     filter_changed_files
 
     if [[ ${match_count} != "0" ]]; then


### PR DESCRIPTION
## What changes were proposed in this pull request?

_unit_ and _integration_ checks run tests in mutually exclusive submodules.  We can skip _unit_ check if only integration tests are changed.

(Plus let git ignore the `bats` libraries required for testing the `selective_ci_checks` script.)

https://issues.apache.org/jira/browse/HDDS-6140

## How was this patch tested?

Tweaked `selective_ci_checks.bats` test.

Existing test case becomes integration-only:

```
commit 61396ba9f1b03eb456940aee8b8079841d9abc4a
...
10      3       hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMRatisSnapshots.java
```

New test case added for unit+integration change:

```
commit 9aebf6e2583a17d3bbb62bbb429ae25930f505dc
...
47      22      hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfaces.java
4       4       hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileInterfacesWithFSO.java
0       2       hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyCreateRequestWithFSO.java
```

```
$ bats dev-support/ci/selective_ci_checks.bats
 ✓ checkstyle and bats
 ✓ compose only
 ✓ compose and robot
 ✓ check script
 ✓ integration and unit
 ✓ integration only
 ✓ kubernetes only
 ✓ docs only
 ✓ java-only change
 ✓ java and compose change
 ✓ java and docs change
 ✓ pom change
 ✓ CI lib change
 ✓ CI workflow change
 ✓ root README
 ✓ ignored code
 ✓ other README

17 tests, 0 failures
```