### PR TITLE
HDDS-6119. Reset the property name to configure the datanode kerberos keytab

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
@@ -69,8 +69,12 @@ public final class DFSConfigKeysLegacy {
   public static final String DFS_DATANODE_KERBEROS_PRINCIPAL_KEY =
       "dfs.datanode.kerberos.principal";
 
+  @Deprecated
   public static final String DFS_DATANODE_KEYTAB_FILE_KEY =
       "dfs.datanode.keytab.file";
+
+  public static final String DFS_DATANODE_KERBEROS_KEYTAB_FILE_KEY =
+          "dfs.datanode.kerberos.keytab.file";
 
   public static final String DFS_METRICS_PERCENTILES_INTERVALS_KEY =
       "dfs.metrics.percentiles.intervals";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DFSConfigKeysLegacy.java
@@ -74,7 +74,7 @@ public final class DFSConfigKeysLegacy {
       "dfs.datanode.keytab.file";
 
   public static final String DFS_DATANODE_KERBEROS_KEYTAB_FILE_KEY =
-          "dfs.datanode.kerberos.keytab.file";
+      "dfs.datanode.kerberos.keytab.file";
 
   public static final String DFS_METRICS_PERCENTILES_INTERVALS_KEY =
       "dfs.metrics.percentiles.intervals";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 
 import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.ratis.server.RaftServerConfigKeys;
 
 import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFIX_KEY;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -37,11 +37,13 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.LegacyHadoopConfigurationSource;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdfs.DFSConfigKeys;
 import org.apache.ratis.server.RaftServerConfigKeys;
 
 import static org.apache.hadoop.hdds.ratis.RatisHelper.HDDS_DATANODE_RATIS_PREFIX_KEY;
@@ -301,7 +303,9 @@ public class OzoneConfiguration extends Configuration
         new DeprecationDelta(HDDS_DATANODE_RATIS_PREFIX_KEY + "."
            + RaftServerConfigKeys.PREFIX + "." + "rpcslowness.timeout",
            HDDS_DATANODE_RATIS_PREFIX_KEY + "."
-           + RaftServerConfigKeys.PREFIX + "." + "rpc.slowness.timeout")
+           + RaftServerConfigKeys.PREFIX + "." + "rpc.slowness.timeout"),
+        new DeprecationDelta("dfs.datanode.keytab.file",
+            DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_KEYTAB_FILE_KEY)
     });
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -244,12 +244,14 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
           LOG.info("Ozone security is enabled. Attempting login for Hdds " +
                   "Datanode user. Principal: {},keytab: {}", conf.get(
               DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY),
-              conf.get(DFSConfigKeysLegacy.DFS_DATANODE_KEYTAB_FILE_KEY));
+              conf.get(
+                  DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_KEYTAB_FILE_KEY));
 
           UserGroupInformation.setConfiguration(conf);
 
           SecurityUtil
-              .login(conf, DFSConfigKeysLegacy.DFS_DATANODE_KEYTAB_FILE_KEY,
+              .login(conf,
+                  DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_KEYTAB_FILE_KEY,
                   DFSConfigKeysLegacy.DFS_DATANODE_KERBEROS_PRINCIPAL_KEY,
                   hostname);
         } else {

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.md
@@ -38,7 +38,7 @@ that is setup in  hdfs-site.xml.
 Property|Description
 --------|--------------
 dfs.datanode.kerberos.principal|The datanode service principal. <br/> e.g. dn/_HOST@REALM.COM
-dfs.datanode.keytab.file| The keytab file used by datanode daemon to login as its service principal.
+dfs.datanode.kerberos.keytab.file| The keytab file used by datanode daemon to login as its service principal.
 hdds.datanode.http.auth.kerberos.principal| Datanode http server service principal.
 hdds.datanode.http.auth.kerberos.keytab| The keytab file used by datanode http server to login as its service principal.
 

--- a/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringDatanodes.zh.md
@@ -30,7 +30,7 @@ Hadoop 中 datanode 的安全机制是通过给每个节点创建 Keytab 文件�
 参数名|描述
 --------|--------------
 dfs.datanode.kerberos.principal| datanode 的服务主体名 <br/> 比如：dn/_HOST@REALM.COM
-dfs.datanode.keytab.file| datanode 进程所使用的 keytab 文件
+dfs.datanode.kerberos.keytab.file| datanode 进程所使用的 keytab 文件
 hdds.datanode.http.auth.kerberos.principal| datanode http 服务器的服务主体名
 hdds.datanode.http.auth.kerberos.keytab| datanode http 服务器的服务主体登录所使用的 keytab 文件
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -82,7 +82,7 @@ OZONE-SITE.XML_ozone.s3g.kerberos.keytab.file=/etc/security/keytabs/s3g.keytab
 OZONE-SITE.XML_ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
-HDFS-SITE.XML_dfs.datanode.keytab.file=/etc/security/keytabs/dn.keytab
+HDFS-SITE.XML_dfs.datanode.kerberos.keytab.file=/etc/security/keytabs/dn.keytab
 HDFS-SITE.XML_dfs.web.authentication.kerberos.principal=HTTP/ozone@EXAMPLE.COM
 HDFS-SITE.XML_dfs.web.authentication.kerberos.keytab=/etc/security/keytabs/HTTP.keytab
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -51,7 +51,7 @@ OZONE-SITE.XML_ozone.s3g.kerberos.keytab.file=/etc/security/keytabs/s3g.keytab
 OZONE-SITE.XML_ozone.s3g.kerberos.principal=s3g/s3g@EXAMPLE.COM
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
-HDFS-SITE.XML_dfs.datanode.keytab.file=/etc/security/keytabs/dn.keytab
+HDFS-SITE.XML_dfs.datanode.kerberos.keytab.file=/etc/security/keytabs/dn.keytab
 HDFS-SITE.XML_dfs.web.authentication.kerberos.principal=HTTP/dn@EXAMPLE.COM
 HDFS-SITE.XML_dfs.web.authentication.kerberos.keytab=/etc/security/keytabs/dn.keytab
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -72,7 +72,7 @@ OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 OZONE-SITE.XML_hdds.container.report.interval=60s
 
 HDFS-SITE.XML_dfs.datanode.kerberos.principal=dn/dn@EXAMPLE.COM
-HDFS-SITE.XML_dfs.datanode.keytab.file=/etc/security/keytabs/dn.keytab
+HDFS-SITE.XML_dfs.datanode.kerberos.keytab.file=/etc/security/keytabs/dn.keytab
 HDFS-SITE.XML_dfs.web.authentication.kerberos.principal=HTTP/ozone@EXAMPLE.COM
 HDFS-SITE.XML_dfs.web.authentication.kerberos.keytab=/etc/security/keytabs/HTTP.keytab
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current settings to configure the keytab file to be used by the datanode follows the same naming convention as the other components.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6119

## How was this patch tested?

Local hugo test.
![1640699296(1)](https://user-images.githubusercontent.com/72794035/147572802-0632ceb0-8c51-4904-b819-3fb9661b0303.png)

