### PR TITLE
HDDS-6142. Remove unused dependency: jdom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1331,11 +1331,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <version>0.1.54</version>
       </dependency>
       <dependency>
-        <groupId>org.jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.1</version>
-      </dependency>
-      <dependency>
         <groupId>com.googlecode.json-simple</groupId>
         <artifactId>json-simple</artifactId>
         <version>1.1.1</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Root `pom.xml` includes `org.jdom:jdom` in `dependencyManagement`, but it is not used at all, can be removed.

https://issues.apache.org/jira/browse/HDDS-6142

## How was this patch tested?

```
$ mvn --no-transfer-progress dependency:tree | grep jdom
$
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1630521474