### PR TITLE
HDDS-6143. Update log4j version to 2.17.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <!-- SLF4J/LOG4J version -->
     <slf4j.version>1.7.30</slf4j.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.17.0</log4j2.version>
+    <log4j2.version>2.17.1</log4j2.version>
     <disruptor.version>3.4.2</disruptor.version>
 
     <prometheus.version>0.7.0</prometheus.version>


### PR DESCRIPTION
Release notes: https://github.com/apache/logging-log4j2/blob/rel/2.17.1/RELEASE-NOTES.md

Looks like there's another RCE ([CVE-2021-44832](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832)) in 2.17.0. Also according to this article:

https://www.bleepingcomputer.com/news/security/log4j-2171-out-now-fixes-new-remote-code-execution-bug/