### PR TITLE
HDDS-6146. TestDefaultCAServer#testIntermediaryCA failure

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -388,10 +388,7 @@ public class TestDefaultCAServer {
         .atZone(ZoneId.systemDefault())
         .toLocalDate();
     LocalDate now = LocalDate.now();
-    // valid for at least 9 years
-    Assert.assertTrue(0 < invalidAfterDate.compareTo(now.plusYears(9)));
-    // invalid after 10 years
-    Assert.assertTrue(0 <= now.plusYears(10).compareTo(invalidAfterDate));
+    assertEquals(0, invalidAfterDate.compareTo(now.plusDays(3650)));
 
     X509CertificateHolder rootCertHolder = rootCA.getCACertificate();
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/authority/TestDefaultCAServer.java
@@ -384,9 +384,14 @@ public class TestDefaultCAServer {
 
 
     Assert.assertNotNull(certificateHolder);
-    Assert.assertEquals(10, certificateHolder.getNotAfter().toInstant()
+    LocalDate invalidAfterDate = certificateHolder.getNotAfter().toInstant()
         .atZone(ZoneId.systemDefault())
-        .toLocalDate().compareTo(LocalDate.now()));
+        .toLocalDate();
+    LocalDate now = LocalDate.now();
+    // valid for at least 9 years
+    Assert.assertTrue(0 < invalidAfterDate.compareTo(now.plusYears(9)));
+    // invalid after 10 years
+    Assert.assertTrue(0 <= now.plusYears(10).compareTo(invalidAfterDate));
 
     X509CertificateHolder rootCertHolder = rootCA.getCACertificate();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestDefaultCAServer#testIntermediaryCA` started failing on Jan 1st, because the test relies on the exact return value of `LocalDate#compare`:

```
expected:<10> but was:<9>
```

For dates in different years, `LocalDate#compare` seems to return the difference in years, but this is an implementation detail.  Return values of `compare` (and `compareTo`) should only be checked against 0, not specific other values.

A period of 3650 days (`P3650D`) is always less than 10 whole years due to leap years, which have an extra day.  However, "today" + 3650 days usually falls in the 10th year from now, except for the first 2-3 days of each year (depending on the number of leap years in the period).

```
2031-12-30 cmp 2022-01-01 = 9
2031-12-31 cmp 2022-01-02 = 9
```

https://issues.apache.org/jira/browse/HDDS-6146

## How was this patch tested?

```
[INFO] Tests run: 9, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 5.143 s - in org.apache.hadoop.hdds.security.x509.certificate.authority.TestDefaultCAServer
```

https://github.com/adoroszlai/hadoop-ozone/runs/4679914119