### PR TITLE
HDDS-6148. Validate ContainerBalancerConfiguration before start ContainerBalancer

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -155,11 +155,11 @@ public class ContainerBalancer {
         return false;
       }
 
-      balancerRunning = true;
       this.config = balancerConfiguration;
       if (!validateConfiguration(config)) {
         return false;
       }
+      balancerRunning = true;
       LOG.info("Starting Container Balancer...{}", this);
 
       //we should start a new balancer thread async

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -157,7 +157,9 @@ public class ContainerBalancer {
 
       balancerRunning = true;
       this.config = balancerConfiguration;
-      validateConfiguration(config);
+      if (!validateConfiguration(config)) {
+        return false;
+      }
       LOG.info("Starting Container Balancer...{}", this);
 
       //we should start a new balancer thread async
@@ -766,7 +768,7 @@ public class ContainerBalancer {
     LOG.info("Container Balancer stopped successfully.");
   }
 
-  private void validateConfiguration(ContainerBalancerConfiguration conf) {
+  private boolean validateConfiguration(ContainerBalancerConfiguration conf) {
     // maxSizeEnteringTarget and maxSizeLeavingSource should by default be
     // greater than container size
     long size = (long) ozoneConfiguration.getStorageSize(
@@ -776,10 +778,12 @@ public class ContainerBalancer {
     if (conf.getMaxSizeEnteringTarget() <= size) {
       LOG.info("MaxSizeEnteringTarget should be larger than " +
           "ozone.scm.container.size");
+      return false;
     }
     if (conf.getMaxSizeLeavingSource() <= size) {
       LOG.info("MaxSizeLeavingSource should be larger than " +
           "ozone.scm.container.size");
+      return false;
     }
 
     // balancing interval should be greater than DUFactory refresh period
@@ -788,7 +792,9 @@ public class ContainerBalancer {
     if (conf.getBalancingInterval().toMillis() <= balancingInterval) {
       LOG.info("balancing.iteration.interval should be larger than " +
           "hdds.datanode.du.refresh.period.");
+      return false;
     }
+    return true;
   }
 
   public void setNodeManager(NodeManager nodeManager) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -109,7 +109,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setIdleIteration(1);
     balancerConfiguration.setMaxDatanodesRatioToInvolvePerIteration(1.0d);
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * OzoneConsts.GB);
-    balancerConfiguration.setMaxSizeEnteringTarget(5 * OzoneConsts.GB);
+    balancerConfiguration.setMaxSizeEnteringTarget(50 * OzoneConsts.GB);
     conf.setFromObject(balancerConfiguration);
     GenericTestUtils.setLogLevel(ContainerBalancer.LOG, Level.DEBUG);
 
@@ -390,7 +390,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setThreshold(0.1);
     balancerConfiguration.setMaxDatanodesRatioToInvolvePerIteration(1.0d);
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * OzoneConsts.GB);
-    balancerConfiguration.setMaxSizeEnteringTarget(5 * OzoneConsts.GB);
+    balancerConfiguration.setMaxSizeEnteringTarget(50 * OzoneConsts.GB);
     containerBalancer.start(balancerConfiguration);
 
     // waiting for balance completed.
@@ -417,7 +417,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setThreshold(0.1);
     balancerConfiguration.setMaxDatanodesRatioToInvolvePerIteration(1.0d);
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * OzoneConsts.GB);
-    balancerConfiguration.setMaxSizeEnteringTarget(5 * OzoneConsts.GB);
+    balancerConfiguration.setMaxSizeEnteringTarget(50 * OzoneConsts.GB);
 
     containerBalancer.start(balancerConfiguration);
 
@@ -443,7 +443,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setThreshold(0.1);
     balancerConfiguration.setMaxDatanodesRatioToInvolvePerIteration(1.0d);
     balancerConfiguration.setMaxSizeToMovePerIteration(50 * OzoneConsts.GB);
-    balancerConfiguration.setMaxSizeEnteringTarget(5 * OzoneConsts.GB);
+    balancerConfiguration.setMaxSizeEnteringTarget(50 * OzoneConsts.GB);
     balancerConfiguration.setExcludeContainers("1, 4, 5");
 
     containerBalancer.start(balancerConfiguration);
@@ -473,38 +473,17 @@ public class TestContainerBalancer {
 
     // no containers should be selected when the limit is zero
     balancerConfiguration.setMaxSizeEnteringTarget(0);
-    containerBalancer.start(balancerConfiguration);
+    boolean startResult = containerBalancer.start(balancerConfiguration);
 
-    // waiting for balance completed.
-    // TODO: this is a temporary implementation for now
-    // modify this after balancer is fully completed
-    try {
-      Thread.sleep(500);
-    } catch (InterruptedException e) {}
-
-    containerBalancer.stop();
-    // balancer should have identified unbalanced nodes
-    Assert.assertFalse(containerBalancer.getUnBalancedNodes().isEmpty());
-    // no container should have been selected
-    Assert.assertTrue(containerBalancer.getSourceToTargetMap().isEmpty());
+    Assert.assertFalse(startResult);
 
     // some containers should be selected when using default values
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ContainerBalancerConfiguration cbc = ozoneConfiguration.
         getObject(ContainerBalancerConfiguration.class);
-    containerBalancer.start(cbc);
+    startResult = containerBalancer.start(cbc);
 
-    // waiting for balance completed.
-    // TODO: this is a temporary implementation for now
-    // modify this after balancer is fully completed
-    try {
-      Thread.sleep(500);
-    } catch (InterruptedException e) {}
-
-    containerBalancer.stop();
-    // balancer should have identified unbalanced nodes
-    Assert.assertFalse(containerBalancer.getUnBalancedNodes().isEmpty());
-    Assert.assertFalse(containerBalancer.getSourceToTargetMap().isEmpty());
+    Assert.assertFalse(startResult);
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -481,9 +481,19 @@ public class TestContainerBalancer {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ContainerBalancerConfiguration cbc = ozoneConfiguration.
         getObject(ContainerBalancerConfiguration.class);
-    startResult = containerBalancer.start(cbc);
+    containerBalancer.start(cbc);
 
-    Assert.assertFalse(startResult);
+    // waiting for balance completed.
+    // TODO: this is a temporary implementation for now
+    // modify this after balancer is fully completed
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException e) {}
+
+    containerBalancer.stop();
+    // balancer should have identified unbalanced nodes
+    Assert.assertFalse(containerBalancer.getUnBalancedNodes().isEmpty());
+    Assert.assertFalse(containerBalancer.getSourceToTargetMap().isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

In HDDS-6070, we did some refactoring on ContainerBalancerConfiguration, and we added a method called validateConfiguration to check the configurations. 

Currently the method returns "void", but it's more reasonable to return a boolean to indicate the validate result of the configurations.

This ticket is to change the return parameter from "void" to boolean to check the parameters before doing container balancer work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6148

## How was this patch tested?

unit test
