### PR TITLE
HDDS-6145. Include docker-compose output in acceptance test output.log

### DIFF
--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -39,7 +39,7 @@ mkdir -p "$REPORT_DIR"
 export OZONE_ACCEPTANCE_SUITE
 
 cd "$DIST_DIR/compose" || exit 1
-./test-all.sh | tee "${REPORT_DIR}/output.log"
+./test-all.sh 2>&1 | tee "${REPORT_DIR}/output.log"
 RES=$?
 cp result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"

--- a/hadoop-ozone/dev-support/checks/kubernetes.sh
+++ b/hadoop-ozone/dev-support/checks/kubernetes.sh
@@ -47,7 +47,7 @@ fi
 mkdir -p "$REPORT_DIR"
 
 cd "$DIST_DIR/kubernetes/examples" || exit 1
-./test-all.sh | tee "${REPORT_DIR}/output.log"
+./test-all.sh 2>&1 | tee "${REPORT_DIR}/output.log"
 RES=$?
 cp -r result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the problem that _acceptance_ test `output.log` does not include container start/stop messages from Docker Compose.

https://issues.apache.org/jira/browse/HDDS-6145

## How was this patch tested?

Verified `output.log` in _acceptance_ artifacts:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1638682309