### PR TITLE
HDDS-5267 Merge ICR and FCR for containers if part of the same HB

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/interfaces/Handler.java
@@ -21,18 +21,17 @@ package org.apache.hadoop.ozone.container.common.interfaces;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.function.Consumer;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
+import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueHandler;
@@ -51,12 +50,12 @@ public abstract class Handler {
   protected String clusterId;
   protected final ContainerMetrics metrics;
   protected String datanodeId;
-  private Consumer<ContainerReplicaProto> icrSender;
+  private IncrementalReportSender<Container> icrSender;
 
   protected Handler(ConfigurationSource config, String datanodeId,
       ContainerSet contSet, VolumeSet volumeSet,
       ContainerMetrics containerMetrics,
-      Consumer<ContainerReplicaProto> icrSender) {
+      IncrementalReportSender<Container> icrSender) {
     this.conf = config;
     this.containerSet = contSet;
     this.volumeSet = volumeSet;
@@ -69,7 +68,7 @@ public abstract class Handler {
       final ContainerType containerType, final ConfigurationSource config,
       final String datanodeId, final ContainerSet contSet,
       final VolumeSet volumeSet, final ContainerMetrics metrics,
-      Consumer<ContainerReplicaProto> icrSender) {
+      IncrementalReportSender<Container> icrSender) {
     switch (containerType) {
     case KeyValueContainer:
       return new KeyValueHandler(config,
@@ -98,8 +97,7 @@ public abstract class Handler {
    */
   protected void sendICR(final Container container)
       throws StorageContainerException {
-    ContainerReplicaProto containerReport = container.getContainerReport();
-    icrSender.accept(containerReport);
+    icrSender.send(container);
   }
 
   public abstract ContainerCommandResponseProto handle(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/ContainerReportPublisher.java
@@ -34,7 +34,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys
 
 /**
  * Publishes ContainerReport which will be sent to SCM as part of heartbeat.
- * ContainerReport consist of the following information about each containers:
+ * ContainerReport consist of the following information about each container:
  *   - containerID
  *   - size
  *   - used
@@ -80,7 +80,6 @@ public class ContainerReportPublisher extends
 
   @Override
   protected ContainerReportsProto getReport() throws IOException {
-    return getContext().getParent().getContainer()
-        .getController().getContainerReport();
+    return getContext().getFullContainerReportDiscardPendingICR();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/IncrementalReportSender.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/report/IncrementalReportSender.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.report;
+
+import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
+
+/**
+ * IncrementalReportSender is an interface to send ICRs.
+ * @param <T>
+ */
+@FunctionalInterface
+public interface IncrementalReportSender<T> {
+  void send(T t) throws StorageContainerException;
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -261,7 +261,7 @@ public class DatanodeStateMachine implements Closeable {
   /**
    * Runs the state machine at a fixed frequency.
    */
-  private void start() throws IOException {
+  private void startStateMachineThread() throws IOException {
     long now = 0;
 
     reportManager.init();
@@ -283,7 +283,7 @@ public class DatanodeStateMachine implements Closeable {
         context.execute(executorService, heartbeatFrequency,
             TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
-        // Some one has sent interrupt signal, this could be because
+        // Someone has sent interrupt signal, this could be because
         // 1. Trigger heartbeat immediately
         // 2. Shutdown has be initiated.
         Thread.currentThread().interrupt();
@@ -468,7 +468,7 @@ public class DatanodeStateMachine implements Closeable {
     Runnable startStateMachineTask = () -> {
       try {
         LOG.info("Ozone container server started.");
-        start();
+        startStateMachineThread();
       } catch (Exception ex) {
         LOG.error("Unable to start the DatanodeState Machine", ex);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.container.common.statemachine;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -101,7 +102,7 @@ public class StateContext {
   private final Queue<SCMCommand> commandQueue;
   private final Map<Long, CommandStatus> cmdStatusMap;
   private final Lock lock;
-  private final DatanodeStateMachine parent;
+  private final DatanodeStateMachine parentDatanodeStateMachine;
   private final AtomicLong stateExecutionCount;
   private final ConfigurationSource conf;
   private final Set<InetSocketAddress> endpoints;
@@ -123,7 +124,7 @@ public class StateContext {
   // Endpoint -> ReportType -> Boolean of whether the full report should be
   //  queued in getFullReports call.
   private final Map<InetSocketAddress,
-      Map<String, AtomicBoolean>> fullReportSendIndicator;
+      Map<String, AtomicBoolean>> isFullReportReadyToBeSent;
   // List of supported full report types.
   private final List<String> fullReportTypeList;
   // ReportType -> Report.
@@ -160,14 +161,14 @@ public class StateContext {
           state, DatanodeStateMachine parent) {
     this.conf = conf;
     this.state = state;
-    this.parent = parent;
+    this.parentDatanodeStateMachine = parent;
     commandQueue = new LinkedList<>();
     cmdStatusMap = new ConcurrentHashMap<>();
     incrementalReportsQueue = new HashMap<>();
     containerReports = new AtomicReference<>();
     nodeReport = new AtomicReference<>();
     pipelineReports = new AtomicReference<>();
-    crlStatusReport = new AtomicReference<>();
+    crlStatusReport = new AtomicReference<>(); // Certificate Revocation List
     endpoints = new HashSet<>();
     containerActions = new HashMap<>();
     pipelineActions = new HashMap<>();
@@ -175,7 +176,7 @@ public class StateContext {
     stateExecutionCount = new AtomicLong(0);
     threadPoolNotAvailableCount = new AtomicLong(0);
     lastHeartbeatSent = new AtomicLong(0);
-    fullReportSendIndicator = new HashMap<>();
+    isFullReportReadyToBeSent = new HashMap<>();
     fullReportTypeList = new ArrayList<>();
     type2Reports = new HashMap<>();
     initReportTypeCollection();
@@ -196,12 +197,12 @@ public class StateContext {
   }
 
   /**
-   * Returns the ContainerStateMachine class that holds this state.
+   * Returns the DatanodeStateMachine class that holds this state.
    *
-   * @return ContainerStateMachine.
+   * @return DatanodeStateMachine.
    */
   public DatanodeStateMachine getParent() {
-    return parent;
+    return parentDatanodeStateMachine;
   }
 
   /**
@@ -316,8 +317,8 @@ public class StateContext {
           "not full report message type: " + reportType);
     }
     type2Reports.get(reportType).set(report);
-    if (fullReportSendIndicator != null) {
-      for (Map<String, AtomicBoolean> mp : fullReportSendIndicator.values()) {
+    if (isFullReportReadyToBeSent != null) {
+      for (Map<String, AtomicBoolean> mp : isFullReportReadyToBeSent.values()) {
         mp.get(reportType).set(true);
       }
     }
@@ -357,8 +358,57 @@ public class StateContext {
    * @return List of reports
    */
   public List<GeneratedMessage> getAllAvailableReports(
-      InetSocketAddress endpoint) {
-    return getReports(endpoint, Integer.MAX_VALUE);
+      InetSocketAddress endpoint
+  ) {
+    int maxLimit = Integer.MAX_VALUE;
+    // TODO: It is highly unlikely that we will reach maxLimit for the number
+    //       for the number of reports, specially as it does not apply to the
+    //       number of entries in a report. But if maxLimit is hit, should a
+    //       heartbeat be scheduled ASAP? Should full reports not included be
+    //       dropped? Currently this code will keep the full reports not sent
+    //       and include it in the next heartbeat.
+    return getAllAvailableReportsUpToLimit(endpoint, maxLimit);
+  }
+
+  /**
+   * Gets a point in time snapshot of all containers, any pending incremental
+   * container reports (ICR) for containers will be included in this report
+   * and this call will drop any pending ICRs.
+   * @return Full Container Report
+   */
+  public ContainerReportsProto getFullContainerReportDiscardPendingICR()
+      throws IOException {
+
+    // Block ICRs from being generated
+    synchronized (parentDatanodeStateMachine
+        .getContainer()) {
+      synchronized (incrementalReportsQueue) {
+        for (Map.Entry<InetSocketAddress, List<GeneratedMessage>>
+            entry : incrementalReportsQueue.entrySet()) {
+          if (entry.getValue() != null) {
+            entry.getValue().removeIf(
+                generatedMessage ->
+                    generatedMessage instanceof
+                        IncrementalContainerReportProto);
+          }
+        }
+      }
+      return parentDatanodeStateMachine
+          .getContainer()
+          .getContainerSet()
+          .getContainerReport();
+    }
+  }
+
+  @VisibleForTesting
+  List<GeneratedMessage> getAllAvailableReportsUpToLimit(
+      InetSocketAddress endpoint,
+      int limit) {
+    List<GeneratedMessage> reports = getFullReports(endpoint, limit);
+    List<GeneratedMessage> incrementalReports = getIncrementalReports(endpoint,
+        limit - reports.size()); // get all (MAX_VALUE)
+    reports.addAll(incrementalReports);
+    return reports;
   }
 
   List<GeneratedMessage> getIncrementalReports(
@@ -378,11 +428,15 @@ public class StateContext {
   }
 
   List<GeneratedMessage> getFullReports(
-      InetSocketAddress endpoint) {
-    Map<String, AtomicBoolean> mp = fullReportSendIndicator.get(endpoint);
-    List<GeneratedMessage> nonIncrementalReports = new LinkedList<>();
+      InetSocketAddress endpoint, int maxLimit) {
+    int count = 0;
+    Map<String, AtomicBoolean> mp = isFullReportReadyToBeSent.get(endpoint);
+    List<GeneratedMessage> fullReports = new LinkedList<>();
     if (null != mp) {
       for (Map.Entry<String, AtomicBoolean> kv : mp.entrySet()) {
+        if (count == maxLimit) {
+          break;
+        }
         if (kv.getValue().get()) {
           String reportType = kv.getKey();
           final AtomicReference<GeneratedMessage> ref =
@@ -393,36 +447,16 @@ public class StateContext {
           }
           final GeneratedMessage msg = ref.get();
           if (msg != null) {
-            nonIncrementalReports.add(msg);
+            fullReports.add(msg);
+            // Mark the report as not ready to be sent, until another refresh.
             mp.get(reportType).set(false);
+            count++;
           }
         }
       }
     }
-    return nonIncrementalReports;
+    return fullReports;
   }
-
-  /**
-   * Returns available reports from the report queue with a max limit on
-   * list size, or empty list if the queue is empty.
-   *
-   * @return List of reports
-   */
-  public List<GeneratedMessage> getReports(InetSocketAddress endpoint,
-                                           int maxLimit) {
-    if (maxLimit < 0) {
-      throw new IllegalArgumentException("Illegal maxLimit value: " + maxLimit);
-    }
-    List<GeneratedMessage> reports = getFullReports(endpoint);
-    if (maxLimit <= reports.size()) {
-      return reports.subList(0, maxLimit);
-    } else {
-      reports.addAll(getIncrementalReports(endpoint,
-          maxLimit - reports.size()));
-      return reports;
-    }
-  }
-
 
   /**
    * Adds the ContainerAction to ContainerAction queue.
@@ -450,17 +484,6 @@ public class StateContext {
         }
       }
     }
-  }
-
-  /**
-   * Returns all the pending ContainerActions from the ContainerAction queue,
-   * or empty list if the queue is empty.
-   *
-   * @return {@literal List<ContainerAction>}
-   */
-  public List<ContainerAction> getAllPendingContainerActions(
-      InetSocketAddress endpoint) {
-    return getPendingContainerAction(endpoint, Integer.MAX_VALUE);
   }
 
   /**
@@ -569,10 +592,12 @@ public class StateContext {
   public DatanodeState<DatanodeStateMachine.DatanodeStates> getTask() {
     switch (this.state) {
     case INIT:
-      return new InitDatanodeState(this.conf, parent.getConnectionManager(),
+      return new InitDatanodeState(this.conf,
+          parentDatanodeStateMachine.getConnectionManager(),
           this);
     case RUNNING:
-      return new RunningDatanodeState(this.conf, parent.getConnectionManager(),
+      return new RunningDatanodeState(this.conf,
+          parentDatanodeStateMachine.getConnectionManager(),
           this);
     case SHUTDOWN:
       return null;
@@ -845,7 +870,7 @@ public class StateContext {
       fullReportTypeList.forEach(e -> {
         mp.putIfAbsent(e, new AtomicBoolean(true));
       });
-      this.fullReportSendIndicator.putIfAbsent(endpoint, mp);
+      this.isFullReportReadyToBeSent.putIfAbsent(endpoint, mp);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
@@ -97,7 +97,9 @@ public class RunningDatanodeState implements DatanodeState {
           endPointTask = HeartbeatEndpointTask.newBuilder()
               .setConfig(conf)
               .setEndpointStateMachine(endpoint)
-              .setDatanodeDetails(context.getParent().getDatanodeDetails())
+              .setDatanodeDetails(context
+                  .getParent()
+                  .getDatanodeDetails())
               .setContext(context)
               .build();
           break;
@@ -150,8 +152,8 @@ public class RunningDatanodeState implements DatanodeState {
       } else {
         // This can happen if a task is taking more time than the timeOut
         // specified for the task in await, and when it is completed the task
-        // has set the state to Shutdown, we may see the state as shutdown
-        // here. So, we need to Shutdown DatanodeStateMachine.
+        // has set the state to shut down, we may see the state as shutdown
+        // here. So, we need to shut down DatanodeStateMachine.
         LOG.error("State is Shutdown in RunningDatanodeState");
         context.setState(DatanodeStateMachine.DatanodeStates.SHUTDOWN);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -28,7 +28,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import com.google.common.util.concurrent.Striped;
@@ -45,7 +44,6 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.KeyValue;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutSmallFileRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.ByteStringConversion;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
@@ -65,6 +63,7 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
 import org.apache.hadoop.ozone.container.common.interfaces.VolumeChoosingPolicy;
+import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage;
@@ -127,9 +126,12 @@ public class KeyValueHandler extends Handler {
   // A striped lock that is held during container creation.
   private final Striped<Lock> containerCreationLocks;
 
-  public KeyValueHandler(ConfigurationSource config, String datanodeId,
-      ContainerSet contSet, VolumeSet volSet, ContainerMetrics metrics,
-      Consumer<ContainerReplicaProto> icrSender) {
+  public KeyValueHandler(ConfigurationSource config,
+                         String datanodeId,
+                         ContainerSet contSet,
+                         VolumeSet volSet,
+                         ContainerMetrics metrics,
+                         IncrementalReportSender<Container> icrSender) {
     super(config, datanodeId, contSet, volSet, metrics, icrSender);
     containerType = ContainerType.KeyValueContainer;
     blockManager = new BlockManagerImpl(config);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/impl/TestHddsDispatcher.java
@@ -36,13 +36,13 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos
     .WriteChunkRequestProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerAction;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.common.Checksum;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
+import org.apache.hadoop.ozone.container.common.report.IncrementalReportSender;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -67,7 +67,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.UUID;
-import java.util.function.Consumer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
@@ -82,8 +81,8 @@ import static org.mockito.Mockito.verify;
 @RunWith(Parameterized.class)
 public class TestHddsDispatcher {
 
-  public static final Consumer<ContainerReplicaProto> NO_OP_ICR_SENDER =
-      c -> { };
+  public static final IncrementalReportSender<Container>
+      NO_OP_ICR_SENDER = c -> { };
 
   private final ContainerLayoutVersion layout;
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -70,35 +70,43 @@ public class TestEventQueue {
 
     TestHandler testHandler = new TestHandler();
 
-    queue.addHandler(EVENT1, new FixedThreadPoolExecutor<>(EVENT1.getName(),
-            EventQueue.getExecutorName(EVENT1, testHandler)), testHandler);
+    queue.addHandler(EVENT1,
+        new FixedThreadPoolWithAffinityExecutor<>(
+            EventQueue.getExecutorName(EVENT1, testHandler),
+            FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(
+                EVENT1.getName())),
+        testHandler);
 
     queue.fireEvent(EVENT1, 11L);
     queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
-    queue.fireEvent(EVENT1, 11L);
+    queue.fireEvent(EVENT1, 12L);
+    queue.fireEvent(EVENT1, 13L);
+    queue.fireEvent(EVENT1, 14L);
+    queue.fireEvent(EVENT1, 15L);
+    queue.fireEvent(EVENT1, 16L);
+    queue.fireEvent(EVENT1, 17L);
+    queue.fireEvent(EVENT1, 18L);
+    queue.fireEvent(EVENT1, 19L);
+    queue.fireEvent(EVENT1, 20L);
 
     EventExecutor eventExecutor =
         queue.getExecutorAndHandler(EVENT1).keySet().iterator().next();
 
     // As it is fixed threadpool executor with 10 threads, all should be
     // scheduled.
-    Assert.assertEquals(10, eventExecutor.queuedEvents());
+    Assert.assertEquals(11, eventExecutor.queuedEvents());
 
     // As we don't see all 10 events scheduled.
     Assert.assertTrue(eventExecutor.scheduledEvents() > 1 &&
         eventExecutor.scheduledEvents() <= 10);
 
     queue.processAll(60000);
-    Assert.assertEquals(110, eventTotal.intValue());
 
-    Assert.assertEquals(10, eventExecutor.successfulEvents());
+    Assert.assertTrue(eventExecutor.scheduledEvents() == 11);
+
+    Assert.assertEquals(166, eventTotal.intValue());
+
+    Assert.assertEquals(11, eventExecutor.successfulEvents());
     eventTotal.set(0);
 
   }
@@ -131,5 +139,4 @@ public class TestEventQueue {
     Assert.assertEquals(23, result[1]);
 
   }
-
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
@@ -58,7 +58,7 @@ public final class SCMEvents {
       "Node_Registration_Container_Report");
 
   /**
-   * ContainerReports are send out by Datanodes. This report is received by
+   * ContainerReports are sent out by Datanodes. This report is received by
    * SCMDatanodeHeartbeatDispatcher and Container_Report Event is generated.
    */
   public static final TypedEvent<ContainerReportFromDatanode> CONTAINER_REPORT =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -255,6 +255,16 @@ public final class SCMDatanodeHeartbeatDispatcher {
         ContainerReportsProto report) {
       super(datanodeDetails, report);
     }
+
+    @Override
+    public boolean equals(Object o) {
+      return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+      return this.getDatanodeDetails().getUuid().hashCode();
+    }
   }
 
   /**
@@ -267,6 +277,16 @@ public final class SCMDatanodeHeartbeatDispatcher {
         DatanodeDetails datanodeDetails,
         IncrementalContainerReportProto report) {
       super(datanodeDetails, report);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      return this == o;
+    }
+
+    @Override
+    public int hashCode() {
+      return this.getDatanodeDetails().getUuid().hashCode();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -64,7 +64,8 @@ import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.De
 import org.apache.hadoop.hdds.security.x509.certificate.authority.PKIProfiles.DefaultProfile;
 import org.apache.hadoop.hdds.security.x509.certificate.client.SCMCertificateClient;
 import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
-import org.apache.hadoop.hdds.server.events.FixedThreadPoolExecutor;
+import org.apache.hadoop.hdds.server.events.EventExecutor;
+import org.apache.hadoop.hdds.server.events.FixedThreadPoolWithAffinityExecutor;
 import org.apache.hadoop.hdds.server.http.RatisDropwizardExports;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
@@ -110,6 +111,8 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineReportHandler;
 import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.PipelineChoosePolicyFactory;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
 import org.apache.hadoop.hdds.scm.server.upgrade.SCMUpgradeFinalizer;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerReportFromDatanode;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.IncrementalContainerReportFromDatanode;
 import org.apache.hadoop.hdds.security.OzoneSecurityException;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.authority.CertificateServer;
@@ -160,6 +163,7 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT_DEFAULT;
@@ -438,11 +442,34 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.RETRIABLE_DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.NODE_REPORT, nodeReportHandler);
-    eventQueue.addHandler(SCMEvents.CONTAINER_REPORT,
-        new FixedThreadPoolExecutor<>(SCMEvents.CONTAINER_REPORT.getName(),
+
+    // Use the same executor for both ICR and FCR.
+    // The Executor maps the event to a thread for DN.
+    // Dispatcher should always dispatch FCR first followed by ICR
+    List<ThreadPoolExecutor> executors =
+        FixedThreadPoolWithAffinityExecutor.initializeExecutorPool(
+            SCMEvents.CONTAINER_REPORT.getName()
+                + "_OR_"
+                + SCMEvents.INCREMENTAL_CONTAINER_REPORT.getName());
+
+    EventExecutor<ContainerReportFromDatanode>
+        containerReportExecutors =
+        new FixedThreadPoolWithAffinityExecutor<>(
             EventQueue.getExecutorName(SCMEvents.CONTAINER_REPORT,
-                containerReportHandler)), containerReportHandler);
+                containerReportHandler),
+            executors);
+    EventExecutor<IncrementalContainerReportFromDatanode>
+        incrementalReportExecutors =
+        new FixedThreadPoolWithAffinityExecutor<>(
+            EventQueue.getExecutorName(
+                SCMEvents.INCREMENTAL_CONTAINER_REPORT,
+                incrementalContainerReportHandler),
+            executors);
+
+    eventQueue.addHandler(SCMEvents.CONTAINER_REPORT, containerReportExecutors,
+        containerReportHandler);
     eventQueue.addHandler(SCMEvents.INCREMENTAL_CONTAINER_REPORT,
+        incrementalReportExecutors,
         incrementalContainerReportHandler);
     eventQueue.addHandler(SCMEvents.CONTAINER_ACTIONS, actionsHandler);
     eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is the DB side of changes. It includes
1. Serialization for ICR and FCR generation.
2. Collapsing ICR and FCR if part of the same HB. Such that FCR has the most recent changes.
3. SCM uses the same thread for a given DN serializing processing of ICR and FCR with FCR being processed before ICR.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5267

## How was this patch tested?

ToDo: 

- [x] add relevant tests 
- [x] manually test with load