### PR TITLE
HDDS-5847. Make OM Retry Policy configurable for different protocols

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -42,10 +42,13 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
+import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.conf.OMClientConfig;
 import org.apache.hadoop.ozone.ha.ConfUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -775,5 +778,42 @@ public final class OmUtils {
     }
     printString.append("]");
     return printString.toString();
+  }
+
+  /**
+   * Check if exception is OMLeaderNotReadyException.
+   *
+   * @param exception
+   * @return OMLeaderNotReadyException
+   */
+  public static OMLeaderNotReadyException getLeaderNotReadyException(
+      Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause instanceof RemoteException) {
+      IOException ioException =
+          ((RemoteException) cause).unwrapRemoteException();
+      if (ioException instanceof OMLeaderNotReadyException) {
+        return (OMLeaderNotReadyException) ioException;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Check if exception is a OMNotLeaderException.
+   *
+   * @return OMNotLeaderException.
+   */
+  public static OMNotLeaderException getNotLeaderException(
+      Exception exception) {
+    Throwable cause = exception.getCause();
+    if (cause instanceof RemoteException) {
+      IOException ioException =
+          ((RemoteException) cause).unwrapRemoteException();
+      if (ioException instanceof OMNotLeaderException) {
+        return (OMNotLeaderException) ioException;
+      }
+    }
+    return null;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMRetryPolicy.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/ha/OMRetryPolicy.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.ha;
+
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.util.HashMap;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
+import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
+import org.apache.ratis.protocol.exceptions.ReconfigurationInProgressException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Retry Policies for OM proxies.
+ */
+public class OMRetryPolicy {
+
+  public static final Logger LOG = LoggerFactory.getLogger(
+      OMRetryPolicy.class);
+
+  private final int maxFailovers;
+
+  private final HashMap<ExceptionType, RetryAction> defaultRetryRulesMap;
+  private HashMap<ExceptionType, RetryAction> retryRulesMapByType;
+  private HashMap<Class, RetryAction> retryRulesMapByClass;
+
+  public enum ExceptionType {
+    NOT_LEADER,
+    LEADER_NOT_READY,
+    RECONFIGURATION_IN_PROGRESS
+  }
+
+  public enum RetryAction {
+    FAILOVER_AND_RETRY,
+    RETRY_ON_SAME_OM,
+    FAIL,
+    EXHAUSTED_MAX_FAILOVER_ATTEMPTS,
+    UNDETERMINED
+  }
+
+  public OMRetryPolicy(int maxNumFailovers) {
+    this.maxFailovers = maxNumFailovers;
+
+    this.defaultRetryRulesMap = new HashMap<>();
+    this.retryRulesMapByType = new HashMap<>();
+    this.retryRulesMapByClass = new HashMap<>();
+    this.defaultRetryRulesMap.put(ExceptionType.NOT_LEADER,
+        RetryAction.FAILOVER_AND_RETRY);
+    this.defaultRetryRulesMap.put(ExceptionType.LEADER_NOT_READY,
+        RetryAction.RETRY_ON_SAME_OM);
+  }
+
+  /**
+   * Add a Retry rule based on ExceptionType.
+   */
+  public void addRetryRule(ExceptionType exceptionType,
+      RetryAction retryAction) {
+    retryRulesMapByType.put(exceptionType, retryAction);
+  }
+
+  /**
+   * Add a Retry rule based on Exception Class.
+   */
+  public void addRetryRule(Class exceptionClass,
+      RetryAction  retryAction) {
+    if (retryRulesMapByClass == null) {
+      retryRulesMapByClass = new HashMap<>();
+    }
+    retryRulesMapByClass.put(exceptionClass, retryAction);
+  }
+
+  /**
+   * Get the Retry Action based on Exception and failover count.
+   */
+  public RetryAction getRetryAction(Exception exception, int failovers,
+      String currentOMProxy) {
+    if (LOG.isDebugEnabled()) {
+      if (exception.getCause() != null) {
+        LOG.debug("RetryProxy: OM {}: {}: {}", currentOMProxy,
+            exception.getCause().getClass().getSimpleName(),
+            exception.getCause().getMessage());
+      } else {
+        LOG.debug("RetryProxy: OM {}: {}", currentOMProxy,
+            exception.getMessage());
+      }
+    }
+
+    // Check if maxFailovers is reached. If yes, return FAIL irrespective of
+    // type of exception.
+    if (failovers >= maxFailovers) {
+      return RetryAction.EXHAUSTED_MAX_FAILOVER_ATTEMPTS;
+    }
+
+    ExceptionType exceptionType = getExceptionType(exception);
+    RetryAction retryAction = null;
+    if (exceptionType != null) {
+      retryAction = retryRulesMapByType.get(exceptionType);
+      if (retryAction == null) {
+        retryAction = defaultRetryRulesMap.get(exceptionType);
+      }
+    }
+
+    if (retryAction == null) {
+      retryAction = retryRulesMapByClass.get(exception.getClass());
+    }
+
+    if (retryAction != null) {
+      return retryAction;
+    }
+
+    return RetryAction.UNDETERMINED;
+  }
+
+  /**
+   * Get the ExceptioType for the given Exception.
+   */
+  private ExceptionType getExceptionType(Exception exception) {
+    if (exception instanceof ServiceException) {
+      Throwable cause = exception.getCause();
+      if (cause instanceof RemoteException) {
+        IOException ioException =
+            ((RemoteException) cause).unwrapRemoteException();
+        if (ioException instanceof OMNotLeaderException) {
+          return ExceptionType.NOT_LEADER;
+        } else if (ioException instanceof OMLeaderNotReadyException) {
+          return ExceptionType.LEADER_NOT_READY;
+        } else if(ioException instanceof ReconfigurationInProgressException) {
+          return ExceptionType.RECONFIGURATION_IN_PROGRESS;
+        } else {
+          return null;
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/Hadoop3OmTransport.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
@@ -89,7 +90,7 @@ public class Hadoop3OmTransport implements OmTransport {
       return omResponse;
     } catch (ServiceException e) {
       OMNotLeaderException notLeaderException =
-          OMFailoverProxyProvider.getNotLeaderException(e);
+          OmUtils.getNotLeaderException(e);
       if (notLeaderException == null) {
         throw ProtobufHelper.getRemoteException(e);
       }

--- a/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
+++ b/hadoop-ozone/ozonefs-hadoop2/src/main/java/org/apache/hadoop/fs/ozone/Hadoop27RpcTransport.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
 import org.apache.hadoop.ozone.om.ha.OMFailoverProxyProvider;
@@ -83,7 +84,7 @@ public class Hadoop27RpcTransport implements OmTransport {
       return omResponse;
     } catch (ServiceException e) {
       OMNotLeaderException notLeaderException =
-          OMFailoverProxyProvider.getNotLeaderException(e);
+          OmUtils.getNotLeaderException(e);
       if (notLeaderException == null) {
         throw ProtobufHelper.getRemoteException(e);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently we reuse the retry policy in OMFailoverProxyProvider formulated for OM client communication for the Inter Service Protocol and the OM Admin protocol (HDDS-5490). This does not take into account the retry policy required when a ReconfigurationInProgressException is encountered while bootstrapping or decommissioning an OM (please refer to Bharat Viswanadham's comment here). It would be good to separate out the retry policy based on the protocol.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5847

## How was this patch tested?

Existing unit tests
