### PR TITLE
HDDS-6157. More consistent synchronization in InputStreams

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -512,7 +512,7 @@ public class BlockInputStream extends InputStream
   }
 
   @Override
-  public void unbuffer() {
+  public synchronized void unbuffer() {
     storePosition();
     releaseClient();
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/KeyInputStream.java
@@ -351,14 +351,14 @@ public class KeyInputStream extends InputStream
   }
 
   @Override
-  public int available() throws IOException {
+  public synchronized int available() throws IOException {
     checkOpen();
     long remaining = length - getPos();
     return remaining <= Integer.MAX_VALUE ? (int) remaining : Integer.MAX_VALUE;
   }
 
   @Override
-  public void close() throws IOException {
+  public synchronized void close() throws IOException {
     closed = true;
     for (BlockInputStream blockStream : blockStreams) {
       blockStream.close();
@@ -388,7 +388,7 @@ public class KeyInputStream extends InputStream
   }
 
   @Override
-  public long skip(long n) throws IOException {
+  public synchronized long skip(long n) throws IOException {
     if (n <= 0) {
       return 0;
     }
@@ -399,7 +399,7 @@ public class KeyInputStream extends InputStream
   }
 
   @Override
-  public void unbuffer() {
+  public synchronized void unbuffer() {
     for (BlockInputStream is : blockStreams) {
       is.unbuffer();
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Most public methods in `KeyInputStream` and `BlockInputStream` are `synchronized`.  This PR makes a few remaining public methods also `synchronized`:

1. Private methods and member variables need to be protected consistently.
2. Ensure atomicity of public operations.

https://issues.apache.org/jira/browse/HDDS-6157

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1663001708
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1663008249