### PR TITLE
HDDS-6163. Change env vars for docker container image

### DIFF
--- a/hadoop-ozone/dist/src/main/docker/Dockerfile
+++ b/hadoop-ozone/dist/src/main/docker/Dockerfile
@@ -16,7 +16,6 @@
 
 FROM apache/ozone-runner:@docker.ozone-runner.version@
 
-ENV PATH=/opt/hadoop/libexec:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
 
 ADD --chown=hadoop . /opt/hadoop
 

--- a/hadoop-ozone/dist/src/main/docker/Dockerfile
+++ b/hadoop-ozone/dist/src/main/docker/Dockerfile
@@ -16,7 +16,11 @@
 
 FROM apache/ozone-runner:@docker.ozone-runner.version@
 
-ENV PATH /opt/hadoop/libexec:${PATH}
+ENV PATH=/opt/hadoop/libexec:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
+ENV HADOOP_LOG_DIR=
+ENV HADOOP_CONF_DIR=
+ENV OZONE_LOG_DIR=/var/log/hadoop
+ENV OZONE_CONF_DIR=/etc/hadoop
 
 ADD --chown=hadoop . /opt/hadoop
 

--- a/hadoop-ozone/dist/src/main/docker/Dockerfile
+++ b/hadoop-ozone/dist/src/main/docker/Dockerfile
@@ -17,10 +17,6 @@
 FROM apache/ozone-runner:@docker.ozone-runner.version@
 
 ENV PATH=/opt/hadoop/libexec:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin
-ENV HADOOP_LOG_DIR=
-ENV HADOOP_CONF_DIR=
-ENV OZONE_LOG_DIR=/var/log/hadoop
-ENV OZONE_CONF_DIR=/etc/hadoop
 
 ADD --chown=hadoop . /opt/hadoop
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change environment variables assigned to self-built Docker image generated by
```
$ mvn -Pdocker -Ddocker.image=<name>:<version> -DskipTests -Pdist clean package
```

Without these changes, StatefulSets which reside in `kubernetes/examples/ozone` never start since the init container fails in finding the file `ozone` in its `$PATH`:

```
$ kubectl logs scm-0 -c init
/opt/hadoop/libexec/entrypoint.sh: line 162: exec: ozone: not found
```

According to the `apache/ozone:1.2.0` container image, I believe that

- `HADDOP_LOG_DIR` and `HADOOP_CONF_DIR` should NOT be defined
- `OZONE_LOG_DIR` and `OZONE_CONF_DIR` should be defined instead

but it seems there's no way to unset environment variables already defined in the underlying container image. So I changed the values of `HADOOP_LOG_DIR` and `HADOOP_CONF_DIR` to empty value.

```
$ docker inspect apache/ozone:1.2.0
(snip)
            "Env": [
                "PATH=/opt/hadoop/libexec:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/hadoop/bin",
                "JAVA_HOME=/usr/lib/jvm/jre/",
                "LD_LIBRARY_PATH=/usr/local/lib",
                "OZONE_LOG_DIR=/var/log/hadoop",
                "OZONE_CONF_DIR=/etc/hadoop"
            ],
(snip)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6163

## How was this patch tested?

Manually tested with kind.

```
$ mvn -Pdocker -Ddocker.image=pfnmaru/ozone:1.3.0-SNAPSHOT -DskipTests -Pdist clean package
$ kind load docker-image pfnmaru/ozone:1.3.0-SNAPSHOT
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/kubernetes/examples/ozone
$ kubectl apply -f config-configmap.yaml
configmap/config created

$ kubectl apply -f scm-statefulset.yaml
statefulset.apps/scm created

$ kubectl get pods
NAME    READY   STATUS    RESTARTS   AGE
scm-0   1/1     Running   0          20s

$ kubectl logs scm-0 -c init
No '-XX:...' jvm parameters are set. Adding safer GC settings '-XX:ParallelGCThreads=8 -XX:+UseConcMarkSweepGC -XX:CMSInitiatingOccupancyFraction=70 -XX:+CMSParallelRemarkEnabled' to the OZONE_OPTS
OpenJDK 64-Bit Server VM warning: Option UseConcMarkSweepGC was deprecated in version 9.0 and will likely be removed in a future release.
2022-01-07 12:12:17 INFO  StorageContainerManagerStarter:112 - STARTUP_MSG: 
/************************************************************
STARTUP_MSG: Starting StorageContainerManager
STARTUP_MSG:   host = scm-0/10.244.7.6
STARTUP_MSG:   args = [--init]
STARTUP_MSG:   version = 1.3.0-SNAPSHOT
STARTUP_MSG:   classpath = /opt/hadoop/etc/hadoop:/opt/hadoop/share/ozone/lib/jackson-annotations-2.12.1.jar:/opt/hadoop/share/ozone/lib/kerb-simplekdc-1.0.1.jar:/opt/hadoop/share/ozone/lib/slf4j-log4j12-1.7.30.jar:/opt/hadoop/share/ozone/lib/protobuf-java-2.5.0.jar:/opt/hadoop/share/ozone/lib/jaxb-core-2.3.0.1.jar:/opt/hadoop/share/ozone/lib/istack-commons-runtime-3.0.5.jar:/opt/hadoop/share/ozone/lib/commons-validator-1.6.jar:/opt/hadoop/share/ozone/lib/bcpkix-jdk15on-1.67.jar:/opt/hadoop/share/ozone/lib/hdds-interface-admin-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/jetty-security-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/kerb-core-1.0.1.jar:/opt/hadoop/share/ozone/lib/hadoop-shaded-protobuf_3_7-1.1.1.jar:/opt/hadoop/share/ozone/lib/hdds-container-service-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/okhttp-4.9.0.jar:/opt/hadoop/share/ozone/lib/jsr305-3.0.0.jar:/opt/hadoop/share/ozone/lib/j2objc-annotations-1.3.jar:/opt/hadoop/share/ozone/lib/json-smart-2.3.1.jar:/opt/hadoop/share/ozone/lib/picocli-4.6.1.jar:/opt/hadoop/share/ozone/lib/javassist-3.21.0-GA.jar:/opt/hadoop/share/ozone/lib/jaxb-api-2.3.0.jar:/opt/hadoop/share/ozone/lib/htrace-core4-4.1.0-incubating.jar:/opt/hadoop/share/ozone/lib/kerb-util-1.0.1.jar:/opt/hadoop/share/ozone/lib/kotlin-stdlib-common-1.4.31.jar:/opt/hadoop/share/ozone/lib/checker-qual-3.8.0.jar:/opt/hadoop/share/ozone/lib/hadoop-shaded-guava-1.1.1.jar:/opt/hadoop/share/ozone/lib/log4j-core-2.17.1.jar:/opt/hadoop/share/ozone/lib/commons-logging-1.2.jar:/opt/hadoop/share/ozone/lib/kerby-xdr-1.0.1.jar:/opt/hadoop/share/ozone/lib/netty-buffer-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/txw2-2.3.0.1.jar:/opt/hadoop/share/ozone/lib/jackson-datatype-jsr310-2.12.1.jar:/opt/hadoop/share/ozone/lib/httpcore-4.4.13.jar:/opt/hadoop/share/ozone/lib/opentracing-tracerresolver-0.1.8.jar:/opt/hadoop/share/ozone/lib/commons-net-3.6.jar:/opt/hadoop/share/ozone/lib/libthrift-0.14.1.jar:/opt/hadoop/share/ozone/lib/snakeyaml-1.26.jar:/opt/hadoop/share/ozone/lib/stax-ex-1.7.8.jar:/opt/hadoop/share/ozone/lib/error_prone_annotations-2.2.0.jar:/opt/hadoop/share/ozone/lib/httpclient-4.5.13.jar:/opt/hadoop/share/ozone/lib/jetty-servlet-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/jaeger-client-1.6.0.jar:/opt/hadoop/share/ozone/lib/kerby-config-1.0.1.jar:/opt/hadoop/share/ozone/lib/commons-io-2.11.0.jar:/opt/hadoop/share/ozone/lib/metrics-core-3.2.4.jar:/opt/hadoop/share/ozone/lib/kerby-pkix-1.0.1.jar:/opt/hadoop/share/ozone/lib/hdds-interface-client-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/netty-codec-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/jsr311-api-1.1.1.jar:/opt/hadoop/share/ozone/lib/commons-beanutils-1.9.4.jar:/opt/hadoop/share/ozone/lib/jetty-webapp-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/rocksdbjni-6.25.3.jar:/opt/hadoop/share/ozone/lib/hdds-server-framework-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/javax.servlet-api-3.1.0.jar:/opt/hadoop/share/ozone/lib/kerb-server-1.0.1.jar:/opt/hadoop/share/ozone/lib/guava-30.1.1-jre.jar:/opt/hadoop/share/ozone/lib/hdds-common-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/kerb-client-1.0.1.jar:/opt/hadoop/share/ozone/lib/jackson-core-2.12.1.jar:/opt/hadoop/share/ozone/lib/netty-transport-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/ratis-grpc-2.2.0.jar:/opt/hadoop/share/ozone/lib/ratis-common-2.2.0.jar:/opt/hadoop/share/ozone/lib/netty-common-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/disruptor-3.4.2.jar:/opt/hadoop/share/ozone/lib/reflections-0.9.11.jar:/opt/hadoop/share/ozone/lib/jetty-io-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/hdds-interface-server-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/hadoop-hdfs-3.3.1.jar:/opt/hadoop/share/ozone/lib/annotations-13.0.jar:/opt/hadoop/share/ozone/lib/jetty-server-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/simpleclient_common-0.7.0.jar:/opt/hadoop/share/ozone/lib/jackson-databind-2.12.1.jar:/opt/hadoop/share/ozone/lib/jaeger-thrift-1.6.0.jar:/opt/hadoop/share/ozone/lib/hadoop-common-3.3.1.jar:/opt/hadoop/share/ozone/lib/dnsjava-2.1.7.jar:/opt/hadoop/share/ozone/lib/bcprov-jdk15on-1.67.jar:/opt/hadoop/share/ozone/lib/commons-configuration2-2.1.1.jar:/opt/hadoop/share/ozone/lib/ratis-proto-2.2.0.jar:/opt/hadoop/share/ozone/lib/ratis-client-2.2.0.jar:/opt/hadoop/share/ozone/lib/token-provider-1.0.1.jar:/opt/hadoop/share/ozone/lib/log4j-1.2.17.jar:/opt/hadoop/share/ozone/lib/commons-daemon-1.0.13.jar:/opt/hadoop/share/ozone/lib/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar:/opt/hadoop/share/ozone/lib/jaeger-tracerresolver-1.6.0.jar:/opt/hadoop/share/ozone/lib/jetty-xml-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/ratis-netty-2.2.0.jar:/opt/hadoop/share/ozone/lib/commons-lang3-3.7.jar:/opt/hadoop/share/ozone/lib/re2j-1.1.jar:/opt/hadoop/share/ozone/lib/commons-math3-3.1.1.jar:/opt/hadoop/share/ozone/lib/ratis-thirdparty-misc-0.7.0.jar:/opt/hadoop/share/ozone/lib/simpleclient_dropwizard-0.7.0.jar:/opt/hadoop/share/ozone/lib/simpleclient-0.7.0.jar:/opt/hadoop/share/ozone/lib/asm-5.0.4.jar:/opt/hadoop/share/ozone/lib/kerby-util-1.0.1.jar:/opt/hadoop/share/ozone/lib/failureaccess-1.0.1.jar:/opt/hadoop/share/ozone/lib/okio-2.8.0.jar:/opt/hadoop/share/ozone/lib/hdds-config-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/jsp-api-2.1.jar:/opt/hadoop/share/ozone/lib/jsch-0.1.54.jar:/opt/hadoop/share/ozone/lib/jetty-http-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/jakarta.activation-api-1.2.1.jar:/opt/hadoop/share/ozone/lib/slf4j-api-1.7.30.jar:/opt/hadoop/share/ozone/lib/hadoop-hdfs-client-3.3.1.jar:/opt/hadoop/share/ozone/lib/nimbus-jose-jwt-7.9.jar:/opt/hadoop/share/ozone/lib/commons-codec-1.11.jar:/opt/hadoop/share/ozone/lib/commons-pool2-2.6.0.jar:/opt/hadoop/share/ozone/lib/gson-2.2.4.jar:/opt/hadoop/share/ozone/lib/jetty-util-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/netty-handler-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/opentracing-api-0.33.0.jar:/opt/hadoop/share/ozone/lib/jetty-util-ajax-9.4.43.v20210629.jar:/opt/hadoop/share/ozone/lib/jcip-annotations-1.0-1.jar:/opt/hadoop/share/ozone/lib/kerb-admin-1.0.1.jar:/opt/hadoop/share/ozone/lib/netty-resolver-4.1.63.Final.jar:/opt/hadoop/share/ozone/lib/kotlin-stdlib-1.4.31.jar:/opt/hadoop/share/ozone/lib/opentracing-noop-0.33.0.jar:/opt/hadoop/share/ozone/lib/jersey-core-1.19.jar:/opt/hadoop/share/ozone/lib/commons-compress-1.21.jar:/opt/hadoop/share/ozone/lib/jaxb-runtime-2.3.0.1.jar:/opt/hadoop/share/ozone/lib/ratis-metrics-2.2.0.jar:/opt/hadoop/share/ozone/lib/accessors-smart-2.3.1.jar:/opt/hadoop/share/ozone/lib/ratis-server-api-2.2.0.jar:/opt/hadoop/share/ozone/lib/opentracing-util-0.33.0.jar:/opt/hadoop/share/ozone/lib/hdds-client-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/hdds-hadoop-dependency-client-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/snappy-java-1.1.8.2.jar:/opt/hadoop/share/ozone/lib/commons-cli-1.2.jar:/opt/hadoop/share/ozone/lib/log4j-api-2.17.1.jar:/opt/hadoop/share/ozone/lib/woodstox-core-5.0.3.jar:/opt/hadoop/share/ozone/lib/javax.annotation-api-1.2.jar:/opt/hadoop/share/ozone/lib/kerby-asn1-1.0.1.jar:/opt/hadoop/share/ozone/lib/hadoop-annotations-3.3.1.jar:/opt/hadoop/share/ozone/lib/stax2-api-3.1.4.jar:/opt/hadoop/share/ozone/lib/commons-digester-1.8.1.jar:/opt/hadoop/share/ozone/lib/commons-collections-3.2.2.jar:/opt/hadoop/share/ozone/lib/jaeger-core-1.6.0.jar:/opt/hadoop/share/ozone/lib/commons-text-1.4.jar:/opt/hadoop/share/ozone/lib/jersey-servlet-1.19.jar:/opt/hadoop/share/ozone/lib/ratis-server-2.2.0.jar:/opt/hadoop/share/ozone/lib/hadoop-auth-3.3.1.jar:/opt/hadoop/share/ozone/lib/kerb-identity-1.0.1.jar:/opt/hadoop/share/ozone/lib/FastInfoset-1.2.13.jar:/opt/hadoop/share/ozone/lib/kerb-common-1.0.1.jar:/opt/hadoop/share/ozone/lib/jersey-server-1.19.jar:/opt/hadoop/share/ozone/lib/hdds-hadoop-dependency-server-1.3.0-SNAPSHOT.jar:/opt/hadoop/share/ozone/lib/kerb-crypto-1.0.1.jar:/opt/hadoop/share/ozone/web:/opt/hadoop/share/ozone/lib/hdds-server-scm-1.3.0-SNAPSHOT.jar
STARTUP_MSG:   build = git@github.com:kmizumar/ozone.git/62c818b390ff0a4aa777203cf23e15a6c4f5e0ac ; compiled by 'maru' on 2022-01-07T11:51Z
STARTUP_MSG:   java = 11.0.10
************************************************************/
2022-01-07 12:12:17 INFO  StorageContainerManagerStarter:90 - registered UNIX signal handlers for [TERM, HUP, INT]
2022-01-07 12:12:17 WARN  ServerUtils:148 - ozone.scm.db.dirs is not configured. We recommend adding this setting. Falling back to ozone.metadata.dirs instead.
2022-01-07 12:12:17 INFO  SCMHANodeDetails:157 - ServiceID for StorageContainerManager is null
2022-01-07 12:12:17 INFO  SCMHANodeDetails:162 - ozone.scm.default.service.id is not defined, falling back to ozone.scm.service.ids to find serviceID for StorageContainerManager if it is HA enabled cluster
2022-01-07 12:12:17 INFO  AbstractLayoutVersionManager:79 - Initializing Layout version manager with metadata layout = SCM_HA (version = 2), software layout = SCM_HA (version = 2)
2022-01-07 12:12:17 INFO  Reflections:232 - Reflections took 57 ms to scan 3 urls, producing 103 keys and 217 values 
2022-01-07 12:12:17 INFO  StorageContainerManager:1115 - SCM already initialized. Reusing existing cluster id for sd=/data/metadata/scm;cid=CID-71c88d22-135e-4ddb-89b5-519110b2266b; layoutVersion=2; HAEnabled=false
2022-01-07 12:12:17 INFO  StorageContainerManagerStarter:124 - SHUTDOWN_MSG: 
/************************************************************
SHUTDOWN_MSG: Shutting down StorageContainerManager at scm-0/10.244.7.6
************************************************************/
```
