### PR TITLE
HDDS-6167. Update ozone-runner version to 20211202-1

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20210329-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20211202-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20210419-1</docker.ozone-testkr5b.image>
   </properties>
 

--- a/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
+++ b/hadoop-ozone/dist/src/main/dockerlibexec/entrypoint.sh
@@ -97,7 +97,7 @@ if [ -n "$KERBEROS_ENABLED" ]; then
     sudo sed -i "s/krb5/$KERBEROS_SERVER/g" "/etc/krb5.conf" || true
 fi
 
-CONF_DESTINATION_DIR="${HADOOP_CONF_DIR:-/opt/hadoop/etc/hadoop}"
+CONF_DESTINATION_DIR="${OZONE_CONF_DIR:-/opt/hadoop/etc/hadoop}"
 
 #Try to copy the defaults
 set +e

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -116,7 +116,10 @@ regenerate_resources() {
     OZONE_ROOT=$(realpath ../../..)
   fi
 
-  flekszible generate -t mount:hostPath="$OZONE_ROOT",path=/opt/hadoop -t image:image=apache/ozone-runner:20200420-1 -t ozone/onenode
+  local default_version=${docker.ozone-runner.version} # set at build-time from Maven property
+  local runner_version=${OZONE_RUNNER_VERSION:-${default_version}} # may be specified by user running the test
+
+  flekszible generate -t mount:hostPath="$OZONE_ROOT",path=/opt/hadoop -t image:image=apache/ozone-runner:${runner_version} -t ozone/onenode
 }
 
 revert_resources() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Ozone to latest `ozone-runner` docker image (`20211202-1` currently).

Also apply the same version to K8S tests, as these have been using hard-coded version that got outdated.

https://issues.apache.org/jira/browse/HDDS-6167

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1676705266