### PR TITLE
HDDS-6135. SCM Container DB bootstrap on Recon startup for SCM HA

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -365,4 +365,6 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * commands operating on {@code containerID}.
    */
   Token<?> getContainerToken(ContainerID containerID) throws IOException;
+
+  long getSCMContainersCount() throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -366,5 +366,5 @@ public interface StorageContainerLocationProtocol extends Closeable {
    */
   Token<?> getContainerToken(ContainerID containerID) throws IOException;
 
-  long getSCMContainersCount() throws IOException;
+  long getContainerCount() throws IOException;
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -89,7 +89,7 @@ public final class OzoneConsts {
   // OM Http server endpoints
   public static final String OZONE_OM_SERVICE_LIST_HTTP_ENDPOINT =
       "/serviceList";
-  public static final String OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT =
+  public static final String OZONE_DB_CHECKPOINT_HTTP_ENDPOINT =
       "/dbCheckpoint";
 
   // Ozone File System scheme

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2547,6 +2547,24 @@
     </description>
   </property>
   <property>
+    <name>ozone.recon.scm.connection.request.timeout</name>
+    <value>5s</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      Connection request timeout in milliseconds for HTTP call made by Recon to
+      request SCM DB snapshot.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scm.connection.timeout</name>
+    <value>5s</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      Connection timeout for HTTP call in milliseconds made by Recon to request
+      SCM snapshot.
+    </description>
+  </property>
+  <property>
     <name>ozone.recon.om.socket.timeout</name>
     <value>5s</value>
     <tag>OZONE, RECON, OM</tag>
@@ -2577,6 +2595,23 @@
     <tag>OZONE, RECON, OM</tag>
     <description>
       Request to flush the OM DB before taking checkpoint snapshot.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scm.container.threshold</name>
+    <value>100</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      Threshold value for the difference in number of containers
+      in SCM and RECON.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.scm.snapshot.enabled</name>
+    <value>false</value>
+    <tag>OZONE, RECON, SCM</tag>
+    <description>
+      If enabled, SCM DB Snapshot is taken by Recon.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -52,6 +52,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.InSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineResponseProto;
@@ -929,6 +931,18 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
             builder -> builder.setContainerTokenRequest(request))
         .getContainerTokenResponse();
     return OzonePBHelper.tokenFromProto(response.getToken());
+  }
+
+  @Override
+  public long getSCMContainersCount() throws IOException {
+    GetSCMContainersCountRequestProto request =
+        GetSCMContainersCountRequestProto.newBuilder().build();
+
+    GetSCMContainersCountResponseProto response =
+        submitRequest(Type.GetSCMContainersCount,
+          builder -> builder.setGetSCMContainersCountRequest(request))
+        .getGetSCMContainersCountResponse();
+    return response.getContainerCount();
   }
 
   @Override

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -52,8 +52,8 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountRequestProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerCountRequestProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerCountResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.InSafeModeRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.ListPipelineResponseProto;
@@ -934,14 +934,14 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
   }
 
   @Override
-  public long getSCMContainersCount() throws IOException {
-    GetSCMContainersCountRequestProto request =
-        GetSCMContainersCountRequestProto.newBuilder().build();
+  public long getContainerCount() throws IOException {
+    GetContainerCountRequestProto request =
+        GetContainerCountRequestProto.newBuilder().build();
 
-    GetSCMContainersCountResponseProto response =
-        submitRequest(Type.GetSCMContainersCount,
-          builder -> builder.setGetSCMContainersCountRequest(request))
-        .getGetSCMContainersCountResponse();
+    GetContainerCountResponseProto response =
+        submitRequest(Type.GetContainerCount,
+          builder -> builder.setGetContainerCountRequest(request))
+        .getGetContainerCountResponse();
     return response.getContainerCount();
   }
 

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -74,7 +74,7 @@ message ScmContainerLocationRequest {
   optional ContainerBalancerStatusRequestProto containerBalancerStatusRequest = 35;
   optional FinalizeScmUpgradeRequestProto finalizeScmUpgradeRequest = 36;
   optional QueryUpgradeFinalizationProgressRequestProto queryUpgradeFinalizationProgressRequest = 37;
-  optional GetSCMContainersCountRequestProto getSCMContainersCountRequest = 38;
+  optional GetContainerCountRequestProto getContainerCountRequest = 38;
 }
 
 message ScmContainerLocationResponse {
@@ -120,7 +120,7 @@ message ScmContainerLocationResponse {
   optional ContainerBalancerStatusResponseProto containerBalancerStatusResponse = 35;
   optional FinalizeScmUpgradeResponseProto finalizeScmUpgradeResponse = 36;
   optional QueryUpgradeFinalizationProgressResponseProto queryUpgradeFinalizationProgressResponse = 37;
-  optional GetSCMContainersCountResponseProto getSCMContainersCountResponse = 38;
+  optional GetContainerCountResponseProto getContainerCountResponse = 38;
 
   enum Status {
     OK = 1;
@@ -164,7 +164,7 @@ enum Type {
   GetContainerBalancerStatus = 30;
   FinalizeScmUpgrade = 31;
   QueryUpgradeFinalizationProgress = 32;
-  GetSCMContainersCount = 33;
+  GetContainerCount = 33;
 }
 
 /**
@@ -386,10 +386,10 @@ message GetPipelineResponseProto {
   required Pipeline pipeline = 1;
 }
 
-message GetSCMContainersCountRequestProto {
+message GetContainerCountRequestProto {
 }
 
-message GetSCMContainersCountResponseProto {
+message GetContainerCountResponseProto {
   required int64 containerCount = 1;
 }
 

--- a/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
+++ b/hadoop-hdds/interface-admin/src/main/proto/ScmAdminProtocol.proto
@@ -74,6 +74,7 @@ message ScmContainerLocationRequest {
   optional ContainerBalancerStatusRequestProto containerBalancerStatusRequest = 35;
   optional FinalizeScmUpgradeRequestProto finalizeScmUpgradeRequest = 36;
   optional QueryUpgradeFinalizationProgressRequestProto queryUpgradeFinalizationProgressRequest = 37;
+  optional GetSCMContainersCountRequestProto getSCMContainersCountRequest = 38;
 }
 
 message ScmContainerLocationResponse {
@@ -119,6 +120,7 @@ message ScmContainerLocationResponse {
   optional ContainerBalancerStatusResponseProto containerBalancerStatusResponse = 35;
   optional FinalizeScmUpgradeResponseProto finalizeScmUpgradeResponse = 36;
   optional QueryUpgradeFinalizationProgressResponseProto queryUpgradeFinalizationProgressResponse = 37;
+  optional GetSCMContainersCountResponseProto getSCMContainersCountResponse = 38;
 
   enum Status {
     OK = 1;
@@ -162,6 +164,7 @@ enum Type {
   GetContainerBalancerStatus = 30;
   FinalizeScmUpgrade = 31;
   QueryUpgradeFinalizationProgress = 32;
+  GetSCMContainersCount = 33;
 }
 
 /**
@@ -381,6 +384,13 @@ message GetPipelineRequestProto {
 
 message GetPipelineResponseProto {
   required Pipeline pipeline = 1;
+}
+
+message GetSCMContainersCountRequestProto {
+}
+
+message GetSCMContainersCountResponseProto {
+  required int64 containerCount = 1;
 }
 
 message ActivatePipelineRequestProto {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -258,7 +258,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
               peer.getAddress().concat(isLocal ?
                   ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
                   ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))
-                  .concat(":".concat(peer.getId().toString()))));
+                  .concat(":".concat(peer.getId().toString()))
+                  .concat(":".concat(peerInetAddress.getHostAddress()))));
     }
     return ratisRoles;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
@@ -397,6 +398,13 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setDatanodeUsageInfoResponse(getDatanodeUsageInfo(
                 request.getDatanodeUsageInfoRequest()))
             .build();
+      case GetSCMContainersCount:
+        return ScmContainerLocationResponse.newBuilder()
+          .setCmdType(request.getCmdType())
+          .setStatus(Status.OK)
+          .setGetSCMContainersCountResponse(getSCMContainersCount(
+                  request.getGetSCMContainersCountRequest()))
+          .build();
       default:
         throw new IllegalArgumentException(
             "Unknown command type: " + request.getCmdType());
@@ -831,4 +839,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         .build();
   }
 
+  public GetSCMContainersCountResponseProto getSCMContainersCount(
+      StorageContainerLocationProtocolProtos.GetSCMContainersCountRequestProto
+      request) throws IOException {
+
+    return GetSCMContainersCountResponseProto.newBuilder()
+      .setContainerCount(impl.getSCMContainersCount())
+      .build();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolPro
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerWithPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetExistContainerWithPipelinesInBatchResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSCMContainersCountResponseProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetContainerCountResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetPipelineResponseProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerLocationProtocolProtos.GetSafeModeRuleStatusesRequestProto;
@@ -398,12 +398,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
             .setDatanodeUsageInfoResponse(getDatanodeUsageInfo(
                 request.getDatanodeUsageInfoRequest()))
             .build();
-      case GetSCMContainersCount:
+      case GetContainerCount:
         return ScmContainerLocationResponse.newBuilder()
           .setCmdType(request.getCmdType())
           .setStatus(Status.OK)
-          .setGetSCMContainersCountResponse(getSCMContainersCount(
-                  request.getGetSCMContainersCountRequest()))
+          .setGetContainerCountResponse(getContainerCount(
+                  request.getGetContainerCountRequest()))
           .build();
       default:
         throw new IllegalArgumentException(
@@ -839,12 +839,12 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
         .build();
   }
 
-  public GetSCMContainersCountResponseProto getSCMContainersCount(
-      StorageContainerLocationProtocolProtos.GetSCMContainersCountRequestProto
+  public GetContainerCountResponseProto getContainerCount(
+      StorageContainerLocationProtocolProtos.GetContainerCountRequestProto
       request) throws IOException {
 
-    return GetSCMContainersCountResponseProto.newBuilder()
-      .setContainerCount(impl.getSCMContainersCount())
+    return GetContainerCountResponseProto.newBuilder()
+      .setContainerCount(impl.getContainerCount())
       .build();
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -946,7 +946,7 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public long getSCMContainersCount() throws IOException {
+  public long getContainerCount() throws IOException {
     return scm.getContainerManager().getContainers().size();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -945,6 +945,11 @@ public class SCMClientProtocolServer implements
         .generateToken(remoteUser.getUserName(), containerID);
   }
 
+  @Override
+  public long getSCMContainersCount() throws IOException {
+    return scm.getContainerManager().getContainers().size();
+  }
+
   /**
    * Queries a list of Node that match a set of statuses.
    *

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerHttpServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManagerHttpServer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 import org.apache.hadoop.ozone.OzoneConsts;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 
 /**
  * HttpServer2 wrapper for the Ozone Storage Container Manager.
@@ -34,7 +34,7 @@ public class StorageContainerManagerHttpServer extends BaseHttpServer {
                                            StorageContainerManager scm)
       throws IOException {
     super(conf, "scm");
-    addServlet("dbCheckpoint", OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT,
+    addServlet("dbCheckpoint", OZONE_DB_CHECKPOINT_HTTP_ENDPOINT,
         SCMDBCheckpointServlet.class);
     getWebAppContext().setAttribute(OzoneConsts.SCM_CONTEXT_ATTRIBUTE, scm);
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMNodeDetails.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OMNodeDetails.java
@@ -30,7 +30,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ADDRESS_KEY;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_RATIS_PORT_KEY;
@@ -153,13 +153,13 @@ public final class OMNodeDetails extends NodeDetails {
     if (isHttpPolicy) {
       if (StringUtils.isNotEmpty(getHttpAddress())) {
         return "http://" + getHttpAddress() +
-            OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT +
+            OZONE_DB_CHECKPOINT_HTTP_ENDPOINT +
             "?" + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "=true";
       }
     } else {
       if (StringUtils.isNotEmpty(getHttpsAddress())) {
         return "https://" + getHttpsAddress() +
-            OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT +
+            OZONE_DB_CHECKPOINT_HTTP_ENDPOINT +
             "?" + OZONE_DB_CHECKPOINT_REQUEST_FLUSH + "=true";
       }
     }

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-config
@@ -21,6 +21,7 @@ OZONE-SITE.XML_ozone.csi.socket=/tmp/csi.sock
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.scm.http-address=scm:9876
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -38,6 +38,10 @@ OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.scm.primordial.node.id=scm1
 OZONE-SITE.XML_hdds.container.report.interval=60s
+OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
+OZONE-SITE.XML_ozone.recon.address=recon:9891
+OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888
+OZONE-SITE.XML_ozone.recon.https-address=0.0.0.0:9889
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -19,6 +19,7 @@ CORE-SITE.XML_fs.trash.interval=1
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.scm.http-address=scm:9876
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-config
@@ -16,6 +16,7 @@
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.scm.http-address=scm:9876
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -19,6 +19,7 @@ CORE-SITE.XML_fs.trash.interval=1
 
 OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
+OZONE-SITE.XML_ozone.scm.http-address=scm:9876
 OZONE-SITE.XML_ozone.scm.container.size=1GB
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s
 OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmHASnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmHASnapshot.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test Recon SCM HA Snapshot Download implementation.
+ */
+public class TestReconScmHASnapshot {
+
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(100);
+  private static OzoneConfiguration conf;
+  private static MiniOzoneCluster cluster;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_SCM_HA_ENABLE_KEY, true);
+    conf.setBoolean(
+        ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED, true);
+    conf.setInt(ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD, 0);
+    conf.setInt(ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT, 5);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(4)
+        .includeRecon(true)
+        .build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @Test
+  public void testScmHASnapshot() throws Exception {
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(LoggerFactory.getLogger(
+            ReconStorageContainerManagerFacade.class));
+
+    List<ContainerInfo> reconContainers = cluster.getReconServer()
+        .getReconStorageContainerManager().getContainerManager()
+        .getContainers();
+    assertEquals(0, reconContainers.size());
+
+    ReconNodeManager nodeManager;
+    nodeManager = (ReconNodeManager) cluster.getReconServer()
+        .getReconStorageContainerManager().getScmNodeManager();
+    long keyCountBefore = nodeManager.getNodeDBKeyCount();
+
+    //Stopping Recon to add Containers in SCM
+    cluster.stopRecon();
+
+    ContainerManager containerManager;
+    containerManager = cluster.getStorageContainerManager()
+        .getContainerManager();
+
+    for (int i = 0; i < 10; i++) {
+      containerManager.allocateContainer(new RatisReplicationConfig(
+          HddsProtos.ReplicationFactor.ONE), "testOwner");
+    }
+
+    cluster.startRecon();
+
+    //ContainerCount after Recon DB is updated with SCM DB
+    containerManager = cluster.getStorageContainerManager()
+        .getContainerManager();
+    ContainerManager reconContainerManager = cluster.getReconServer()
+        .getReconStorageContainerManager().getContainerManager();
+    assertTrue(logCapturer.getOutput()
+        .contains("Downloaded SCM Snapshot from Leader SCM"));
+    assertTrue(logCapturer.getOutput()
+        .contains("Recon Container Count: " + reconContainers.size() +
+        ", SCM Container Count: " + containerManager.getContainers().size()));
+    assertEquals(containerManager.getContainers().size(),
+        reconContainerManager.getContainers().size());
+
+    //PipelineCount after Recon DB is updated with SCM DB
+    PipelineManager scmPipelineManager = cluster.getStorageContainerManager()
+        .getPipelineManager();
+    PipelineManager reconPipelineManager = cluster.getReconServer()
+        .getReconStorageContainerManager().getPipelineManager();
+    assertEquals(scmPipelineManager.getPipelines().size(),
+        reconPipelineManager.getPipelines().size());
+
+    //NodeCount after Recon DB updated with SCM DB
+    nodeManager = (ReconNodeManager) cluster.getReconServer()
+        .getReconStorageContainerManager().getScmNodeManager();
+    long keyCountAfter = nodeManager.getNodeDBKeyCount();
+    assertEquals(keyCountAfter, keyCountBefore);
+  }
+
+  @AfterClass
+  public static void shutdown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.recon;
+
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.recon.scm.ReconNodeManager;
+import org.apache.hadoop.ozone.recon.scm.ReconStorageContainerManagerFacade;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test Recon SCM Snapshot Download implementation.
+ */
+public class TestReconScmSnapshot {
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(100);
+  private static OzoneConfiguration conf;
+  private static MiniOzoneCluster cluster;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(
+        ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED, true);
+    conf.setInt(ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD, 0);
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(4)
+        .includeRecon(true)
+        .build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @Test
+  public void  testScmSnapshot() throws Exception {
+    GenericTestUtils.LogCapturer logCapturer = GenericTestUtils.LogCapturer
+        .captureLogs(LoggerFactory.getLogger(
+        ReconStorageContainerManagerFacade.class));
+
+    List<ContainerInfo> reconContainers = cluster.getReconServer()
+        .getReconStorageContainerManager().getContainerManager()
+        .getContainers();
+    assertEquals(0, reconContainers.size());
+
+    ReconNodeManager nodeManager;
+    nodeManager = (ReconNodeManager) cluster.getReconServer()
+        .getReconStorageContainerManager().getScmNodeManager();
+    long keyCountBefore = nodeManager.getNodeDBKeyCount();
+
+    //Stopping Recon to add Containers in SCM
+    cluster.stopRecon();
+
+    ContainerManager containerManager;
+    containerManager = cluster.getStorageContainerManager()
+        .getContainerManager();
+
+    for (int i = 0; i < 10; i++) {
+      containerManager.allocateContainer(new RatisReplicationConfig(
+          HddsProtos.ReplicationFactor.ONE), "testOwner");
+    }
+
+    cluster.startRecon();
+
+    //ContainerCount after Recon DB is updated with SCM DB
+    containerManager = cluster.getStorageContainerManager()
+        .getContainerManager();
+    ContainerManager reconContainerManager = cluster.getReconServer()
+        .getReconStorageContainerManager().getContainerManager();
+    assertTrue(logCapturer.getOutput()
+        .contains("Recon Container Count: " + reconContainers.size() +
+        ", SCM Container Count: " + containerManager.getContainers().size()));
+    assertEquals(containerManager.getContainers().size(),
+        reconContainerManager.getContainers().size());
+
+    //PipelineCount after Recon DB is updated with SCM DB
+    PipelineManager scmPipelineManager = cluster.getStorageContainerManager()
+        .getPipelineManager();
+    PipelineManager reconPipelineManager = cluster.getReconServer()
+        .getReconStorageContainerManager().getPipelineManager();
+    assertEquals(scmPipelineManager.getPipelines().size(),
+        reconPipelineManager.getPipelines().size());
+
+    //NodeCount after Recon DB updated with SCM DB
+    nodeManager = (ReconNodeManager) cluster.getReconServer()
+        .getReconStorageContainerManager().getScmNodeManager();
+    long keyCountAfter = nodeManager.getNodeDBKeyCount();
+    assertEquals(keyCountAfter, keyCountBefore);
+  }
+
+  @AfterClass
+  public static void shutdown() throws Exception {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManagerHA.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.recon;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 
 import java.util.HashMap;
 import java.util.UUID;
@@ -114,7 +114,7 @@ public class TestReconWithOzoneManagerHA {
     String expectedUrl = "http://" +
         (hostname.equals("0.0.0.0") ? "localhost" : hostname) + ":" +
         ozoneManager.get().getHttpServer().getHttpAddress().getPort() +
-        OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+        OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
     String snapshotUrl = impl.getOzoneManagerSnapshotUrl();
     Assert.assertEquals("OM Snapshot should be requested from the leader.",
         expectedUrl, snapshotUrl);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerHttpServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerHttpServer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 import org.apache.hadoop.ozone.OzoneConsts;
 
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_SERVICE_LIST_HTTP_ENDPOINT;
 
 /**
@@ -36,7 +36,7 @@ public class OzoneManagerHttpServer extends BaseHttpServer {
     super(conf, "ozoneManager");
     addServlet("serviceList", OZONE_OM_SERVICE_LIST_HTTP_ENDPOINT,
         ServiceListJSONServlet.class);
-    addServlet("dbCheckpoint", OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT,
+    addServlet("dbCheckpoint", OZONE_DB_CHECKPOINT_HTTP_ENDPOINT,
         OMDBCheckpointServlet.class);
     getWebAppContext().setAttribute(OzoneConsts.OM_CONTEXT_ATTRIBUTE, om);
   }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconConstants.java
@@ -41,6 +41,8 @@ public final class ReconConstants {
   public static final String CONTAINER_KEY_COUNT_TABLE =
       "containerKeyCountTable";
 
+  public static final String RECON_SCM_SNAPSHOT_DB = "scm.snapshot.db";
+
   // By default, limit the number of results returned
   public static final String DEFAULT_FETCH_COUNT = "1000";
   public static final String DEFAULT_BATCH_NUMBER = "1";

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconServerConfigKeys.java
@@ -124,6 +124,22 @@ public final class  ReconServerConfigKeys {
   public static final String
       OZONE_RECON_METRICS_HTTP_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "10s";
 
+  public static final String OZONE_RECON_SCM_CONTAINER_THRESHOLD =
+      "ozone.recon.scm.container.threshold";
+  public static final int OZONE_RECON_SCM_CONTAINER_THRESHOLD_DEFAULT = 100;
+
+  public static final String OZONE_RECON_SCM_SNAPSHOT_ENABLED =
+      "ozone.recon.scm.snapshot.enabled";
+  public static final boolean OZONE_RECON_SCM_SNAPSHOT_ENABLED_DEFAULT = false;
+
+  public static final String OZONE_RECON_SCM_CONNECTION_TIMEOUT =
+      "ozone.recon.scm.connection.timeout";
+  public static final String OZONE_RECON_SCM_CONNECTION_TIMEOUT_DEFAULT = "5s";
+
+  public static final String OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT =
+      "ozone.recon.scm.connection.request.timeout";
+  public static final String
+      OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT_DEFAULT = "5s";
   /**
    * Private constructor for utility class.
    */

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/fsck/ContainerHealthTask.java
@@ -81,6 +81,7 @@ public class ContainerHealthTask extends ReconScmTask {
   public synchronized void run() {
     try {
       while (canRun()) {
+        wait(interval);
         long start = Time.monotonicNow();
         long currentTime = System.currentTimeMillis();
         long existingCount = processExistingDBRecords(currentTime);
@@ -97,7 +98,6 @@ public class ContainerHealthTask extends ReconScmTask {
                 " processing {} containers.", Time.monotonicNow() - start,
             containers.size());
         processedContainers.clear();
-        wait(interval);
       }
     } catch (Throwable t) {
       LOG.error("Exception in Missing Container task Thread.", t);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
@@ -298,5 +299,10 @@ public class ReconNodeManager extends SCMNodeManager {
   public void reinitialize(Table<UUID, DatanodeDetails> nodeTable) {
     this.nodeDB = nodeTable;
     loadExistingNodes();
+  }
+
+  @VisibleForTesting
+  public long getNodeDBKeyCount() throws IOException {
+    return nodeDB.getEstimatedKeyCount();
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -294,4 +294,9 @@ public class ReconNodeManager extends SCMNodeManager {
     return currentTime - getLastHeartbeat(datanodeDetails) >=
         reconDatanodeOutdatedTime;
   }
+
+  public void reinitialize(Table<UUID, DatanodeDetails> nodeTable) {
+    this.nodeDB = nodeTable;
+    loadExistingNodes();
+  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -18,14 +18,18 @@
 
 package org.apache.hadoop.ozone.recon.scm;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.block.BlockManager;
 import org.apache.hadoop.hdds.scm.container.CloseContainerEventHandler;
@@ -59,9 +63,15 @@ import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.DBColumnFamilyDefinition;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.io.IOUtils;
+import org.apache.hadoop.ozone.recon.ReconServerConfigKeys;
 import org.apache.hadoop.ozone.recon.fsck.ContainerHealthTask;
 import org.apache.hadoop.ozone.recon.persistence.ContainerHealthSchemaManager;
 import org.apache.hadoop.ozone.recon.spi.ReconContainerMetadataManager;
@@ -70,6 +80,8 @@ import org.apache.hadoop.ozone.recon.tasks.ReconTaskConfig;
 import com.google.inject.Inject;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.RECON_SCM_CONFIG_PREFIX;
 import static org.apache.hadoop.hdds.scm.server.StorageContainerManager.buildRpcServerStartMessage;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
+
 import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -90,11 +102,11 @@ public class ReconStorageContainerManagerFacade
   private final EventQueue eventQueue;
   private final SCMContext scmContext;
   private final SCMStorageConfig scmStorageConfig;
-  private final DBStore dbStore;
   private final SCMNodeDetails reconNodeDetails;
   private final SCMHAManager scmhaManager;
   private final SequenceIdGenerator sequenceIdGen;
 
+  private DBStore dbStore;
   private ReconNodeManager nodeManager;
   private ReconPipelineManager pipelineManager;
   private ReconContainerManager containerManager;
@@ -249,7 +261,15 @@ public class ReconStorageContainerManagerFacade
           "Recon ScmDatanodeProtocol RPC server",
           getDatanodeProtocolServer().getDatanodeRpcAddress()));
     }
-    initializePipelinesFromScm();
+    boolean isSCMSnapshotEnabled = ozoneConfiguration.getBoolean(
+        ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED,
+        ReconServerConfigKeys.OZONE_RECON_SCM_SNAPSHOT_ENABLED_DEFAULT);
+    if(isSCMSnapshotEnabled) {
+      initializeSCMDB();
+      LOG.info("SCM DB initialized");
+    } else {
+      initializePipelinesFromScm();
+    }
     getDatanodeProtocolServer().start();
     this.reconScmTasks.forEach(ReconScmTask::start);
   }
@@ -305,6 +325,106 @@ public class ReconStorageContainerManagerFacade
       LOG.error("Exception encountered while getting pipelines from SCM.",
           ioEx);
     }
+  }
+
+  private void initializeSCMDB() {
+    try {
+      long scmContainersCount = scmServiceProvider.getSCMContainersCount();
+      long reconContainerCount = containerManager.getContainers().size();
+      long threshold = ozoneConfiguration.getInt(
+          ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD,
+          ReconServerConfigKeys.OZONE_RECON_SCM_CONTAINER_THRESHOLD_DEFAULT);
+
+      if(Math.abs(scmContainersCount - reconContainerCount) > threshold) {
+        updateReconSCMDBWithNewSnapshot();
+        LOG.info("Update Recon DB with SCM DB");
+      } else {
+        initializePipelinesFromScm();
+      }
+    } catch (IOException e) {
+      LOG.error("Exception encountered while getting SCM DB.");
+    }
+  }
+
+  public void updateReconSCMDBWithNewSnapshot() throws IOException {
+    DBCheckpoint dbSnapshot = scmServiceProvider.getSCMDBSnapshot();
+    if (dbSnapshot != null && dbSnapshot.getCheckpointLocation() != null) {
+      LOG.info("Got new checkpoint from SCM : " +
+          dbSnapshot.getCheckpointLocation());
+      try {
+        initializeNewRdbStore(dbSnapshot.getCheckpointLocation().toFile());
+      } catch (IOException e) {
+        LOG.error("Unable to refresh Recon SCM DB Snapshot. ", e);
+      }
+    } else {
+      LOG.error("Null snapshot location got from SCM.");
+    }
+  }
+
+  private void deleteOldSCMDB() throws IOException {
+    if (dbStore != null) {
+      File oldDBLocation = dbStore.getDbLocation();
+      if (oldDBLocation.exists()) {
+        LOG.info("Cleaning up old SCM snapshot db at {}.",
+            oldDBLocation.getAbsolutePath());
+        FileUtils.deleteDirectory(oldDBLocation);
+      }
+    }
+  }
+
+  private void initializeNewRdbStore(File dbFile) throws IOException {
+    try {
+      DBStore newStore = createDBAndAddSCMTablesAndCodecs(
+          dbFile, new ReconSCMDBDefinition());
+      Table<UUID, DatanodeDetails> nodeTable =
+          ReconSCMDBDefinition.NODES.getTable(dbStore);
+      Table<UUID, DatanodeDetails> newNodeTable =
+          ReconSCMDBDefinition.NODES.getTable(newStore);
+      TableIterator<UUID, ? extends KeyValue<UUID,
+          DatanodeDetails>> iterator = nodeTable.iterator();
+      while (iterator.hasNext()) {
+        KeyValue<UUID, DatanodeDetails> keyValue = iterator.next();
+        newNodeTable.put(keyValue.getKey(), keyValue.getValue());
+      }
+      deleteOldSCMDB();
+      setDbStore(newStore);
+      sequenceIdGen.reinitialize(
+          ReconSCMDBDefinition.SEQUENCE_ID.getTable(dbStore));
+      pipelineManager.reinitialize(
+          ReconSCMDBDefinition.PIPELINES.getTable(dbStore));
+      containerManager.reinitialize(
+          ReconSCMDBDefinition.CONTAINERS.getTable(dbStore));
+      nodeManager.reinitialize(
+          ReconSCMDBDefinition.NODES.getTable(dbStore));
+      File newDb = new File(dbFile.getParent() +
+          OZONE_URI_DELIMITER + ReconSCMDBDefinition.RECON_SCM_DB_NAME);
+      dbFile.renameTo(newDb);
+      LOG.info("Created SCM DB handle from snapshot at {}.",
+          dbFile.getAbsolutePath());
+    } catch (IOException ioEx) {
+      LOG.error("Unable to initialize Recon SCM DB snapshot store.", ioEx);
+    }
+  }
+
+  private DBStore createDBAndAddSCMTablesAndCodecs(File dbFile,
+      ReconSCMDBDefinition definition) throws IOException {
+    DBStoreBuilder dbStoreBuilder =
+        DBStoreBuilder.newBuilder(ozoneConfiguration)
+            .setName(dbFile.getName())
+            .setPath(dbFile.toPath().getParent());
+    for (DBColumnFamilyDefinition columnFamily :
+        definition.getColumnFamilies()) {
+      dbStoreBuilder.addTable(columnFamily.getName());
+      dbStoreBuilder.addCodec(columnFamily.getKeyType(),
+          columnFamily.getKeyCodec());
+      dbStoreBuilder.addCodec(columnFamily.getValueType(),
+          columnFamily.getValueCodec());
+    }
+    return dbStoreBuilder.build();
+  }
+
+  public void setDbStore(DBStore dbStore) {
+    this.dbStore = dbStore;
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPla
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.MockSCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeDetails;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
@@ -349,7 +350,13 @@ public class ReconStorageContainerManagerFacade
   }
 
   public void updateReconSCMDBWithNewSnapshot() throws IOException {
-    DBCheckpoint dbSnapshot = scmServiceProvider.getSCMDBSnapshot();
+    DBCheckpoint dbSnapshot;
+    if(!SCMHAUtils.isSCMHAEnabled(ozoneConfiguration)) {
+      dbSnapshot = scmServiceProvider.getSCMDBSnapshot();
+    } else {
+      dbSnapshot = scmServiceProvider.getSCMDBSnapshotHA();
+      LOG.info("Downloaded SCM Snapshot from Leader SCM");
+    }
     if (dbSnapshot != null && dbSnapshot.getCheckpointLocation() != null) {
       LOG.info("Got new checkpoint from SCM : " +
           dbSnapshot.getCheckpointLocation());

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -398,7 +398,10 @@ public class ReconStorageContainerManagerFacade
           ReconSCMDBDefinition.NODES.getTable(dbStore));
       File newDb = new File(dbFile.getParent() +
           OZONE_URI_DELIMITER + ReconSCMDBDefinition.RECON_SCM_DB_NAME);
-      dbFile.renameTo(newDb);
+      boolean success = dbFile.renameTo(newDb);
+      if (success) {
+        LOG.info("SCM snapshot linked to Recon DB.");
+      }
       LOG.info("Created SCM DB handle from snapshot at {}.",
           dbFile.getAbsolutePath());
     } catch (IOException ioEx) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 
 /**
  * Interface to access SCM endpoints.
@@ -66,4 +67,7 @@ public interface StorageContainerServiceProvider {
    */
   List<HddsProtos.Node> getNodes() throws IOException;
 
+  long getSCMContainersCount() throws IOException;
+
+  DBCheckpoint getSCMDBSnapshot();
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
@@ -67,7 +67,15 @@ public interface StorageContainerServiceProvider {
    */
   List<HddsProtos.Node> getNodes() throws IOException;
 
-  long getSCMContainersCount() throws IOException;
+  /**
+   * Requests SCM for container count.
+   * @return Total number of containers in SCM.
+   */
+  long getContainerCount() throws IOException;
 
+  /**
+   * Requests SCM for DB Snapshot.
+   * @return DBCheckpoint from SCM.
+   */
   DBCheckpoint getSCMDBSnapshot();
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/StorageContainerServiceProvider.java
@@ -78,4 +78,10 @@ public interface StorageContainerServiceProvider {
    * @return DBCheckpoint from SCM.
    */
   DBCheckpoint getSCMDBSnapshot();
+
+  /**
+   * Requests Leader SCM for DB Snapshot.
+   * @return DBCheckpoint from Leader SCM.
+   */
+  DBCheckpoint getSCMDBSnapshotHA() throws IOException;
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java
@@ -58,7 +58,7 @@ import org.apache.hadoop.util.Time;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.FileUtils;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_OM_SNAPSHOT_DB;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SNAPSHOT_DB_DIR;
@@ -151,11 +151,11 @@ public class OzoneManagerServiceProviderImpl
     HttpConfig.Policy policy = HttpConfig.getHttpPolicy(configuration);
 
     omDBSnapshotUrl = "http://" + ozoneManagerHttpAddress +
-        OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+        OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 
     if (policy.isHttpsEnabled()) {
       omDBSnapshotUrl = "https://" + ozoneManagerHttpsAddress +
-          OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+          OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
     }
 
     boolean flushParam = configuration.getBoolean(
@@ -271,7 +271,7 @@ public class OzoneManagerServiceProviderImpl
           omLeaderUrl = (policy.isHttpsEnabled() ?
               "https://" + info.getServiceAddress(Type.HTTPS) :
               "http://" + info.getServiceAddress(Type.HTTP)) +
-              OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+              OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
         }
       }
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
-import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_SNAPSHOT_DB;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
@@ -98,11 +98,11 @@ public class StorageContainerServiceProviderImpl
     scmSnapshotDBParentDir = ReconUtils.getReconScmDbDir(configuration);
 
     scmDBSnapshotUrl = "http://" + scmHttpAddress +
-            OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+        OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 
     if (policy.isHttpsEnabled()) {
       scmDBSnapshotUrl = "https://" + scmHttpsAddress +
-              OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+          OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
     }
 
     this.reconUtils = reconUtils;
@@ -140,8 +140,8 @@ public class StorageContainerServiceProviderImpl
   }
 
   @Override
-  public long getSCMContainersCount() throws IOException {
-    return scmClient.getSCMContainersCount();
+  public long getContainerCount() throws IOException {
+    return scmClient.getContainerCount();
   }
 
   public String getScmDBSnapshotUrl() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -18,18 +18,41 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
+import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_AUTH_TYPE;
 import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+import static org.apache.hadoop.ozone.OzoneConsts.OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_SNAPSHOT_DB;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_TIMEOUT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_TIMEOUT_DEFAULT;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import javax.inject.Inject;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.hdds.server.http.HttpConfig;
+import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
+import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
+import org.apache.hadoop.hdfs.web.URLConnectionFactory;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
+import org.apache.hadoop.security.SecurityUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Implementation for StorageContainerServiceProvider that talks with actual
@@ -38,12 +61,53 @@ import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
 public class StorageContainerServiceProviderImpl
     implements StorageContainerServiceProvider {
 
+  private static final Logger LOG =
+      LoggerFactory.getLogger(StorageContainerServiceProviderImpl.class);
   private StorageContainerLocationProtocol scmClient;
+  private final OzoneConfiguration configuration;
+  private String scmDBSnapshotUrl;
+  private File scmSnapshotDBParentDir;
+  private URLConnectionFactory connectionFactory;
+  private ReconUtils reconUtils;
 
   @Inject
   public StorageContainerServiceProviderImpl(
-      StorageContainerLocationProtocol scmClient) {
+      StorageContainerLocationProtocol scmClient,
+      ReconUtils reconUtils,
+      OzoneConfiguration configuration) {
+
+    int connectionTimeout = (int) configuration.getTimeDuration(
+        OZONE_RECON_SCM_CONNECTION_TIMEOUT,
+        OZONE_RECON_SCM_CONNECTION_TIMEOUT_DEFAULT, TimeUnit.MILLISECONDS);
+    int connectionRequestTimeout = (int) configuration.getTimeDuration(
+        OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT,
+        OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT_DEFAULT,
+        TimeUnit.MILLISECONDS);
+    connectionFactory =
+        URLConnectionFactory.newDefaultURLConnectionFactory(connectionTimeout,
+                connectionRequestTimeout, configuration);
+
+    String scmHttpAddress = configuration.get(ScmConfigKeys
+        .OZONE_SCM_HTTP_ADDRESS_KEY);
+
+    String scmHttpsAddress = configuration.get(ScmConfigKeys
+        .OZONE_SCM_HTTPS_ADDRESS_KEY);
+
+    HttpConfig.Policy policy = HttpConfig.getHttpPolicy(configuration);
+
+    scmSnapshotDBParentDir = ReconUtils.getReconScmDbDir(configuration);
+
+    scmDBSnapshotUrl = "http://" + scmHttpAddress +
+            OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+
+    if (policy.isHttpsEnabled()) {
+      scmDBSnapshotUrl = "https://" + scmHttpsAddress +
+              OZONE_OM_DB_CHECKPOINT_HTTP_ENDPOINT;
+    }
+
+    this.reconUtils = reconUtils;
     this.scmClient = scmClient;
+    this.configuration = configuration;
   }
 
   @Override
@@ -73,5 +137,46 @@ public class StorageContainerServiceProviderImpl
   public List<HddsProtos.Node> getNodes() throws IOException {
     return scmClient.queryNode(null, null, HddsProtos.QueryScope.CLUSTER,
         "", CURRENT_VERSION);
+  }
+
+  @Override
+  public long getSCMContainersCount() throws IOException {
+    return scmClient.getSCMContainersCount();
+  }
+
+  public String getScmDBSnapshotUrl() {
+    return scmDBSnapshotUrl;
+  }
+
+  private boolean isOmSpnegoEnabled() {
+    return configuration.get(HDDS_SCM_HTTP_AUTH_TYPE, "simple")
+        .equals("kerberos");
+  }
+
+  public DBCheckpoint getSCMDBSnapshot() {
+    String snapshotFileName = RECON_SCM_SNAPSHOT_DB + "_" +
+        System.currentTimeMillis();
+    File targetFile = new File(scmSnapshotDBParentDir, snapshotFileName +
+            ".tar.gz");
+
+    try {
+      SecurityUtil.doAsLoginUser(() -> {
+        try (InputStream inputStream = reconUtils.makeHttpCall(
+            connectionFactory, getScmDBSnapshotUrl(),
+            isOmSpnegoEnabled()).getInputStream()) {
+          FileUtils.copyInputStreamToFile(inputStream, targetFile);
+        }
+        return null;
+      });
+
+      Path untarredDbDir = Paths.get(scmSnapshotDBParentDir.getAbsolutePath(),
+          snapshotFileName);
+      reconUtils.untarCheckpointFile(targetFile, untarredDbDir);
+      FileUtils.deleteQuietly(targetFile);
+      return new RocksDBCheckpoint(untarredDbDir);
+    } catch (IOException e) {
+      LOG.error("Unable to obtain SCM DB Snapshot. ", e);
+    }
+    return null;
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestStorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestStorageContainerServiceProviderImpl.java
@@ -24,13 +24,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
 import java.io.IOException;
 
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
+import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -55,6 +60,10 @@ public class TestStorageContainerServiceProviderImpl {
         try {
           StorageContainerLocationProtocol mockScmClient = mock(
               StorageContainerLocationProtocol.class);
+          ReconUtils reconUtils =  new ReconUtils();
+          File testDir = GenericTestUtils.getRandomizedTestDir();
+          OzoneConfiguration conf = new OzoneConfiguration();
+          conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getPath());
           pipelineID = PipelineID.randomId().getProtobuf();
           when(mockScmClient.getPipeline(pipelineID))
               .thenReturn(mock(Pipeline.class));
@@ -62,6 +71,9 @@ public class TestStorageContainerServiceProviderImpl {
               .toInstance(mockScmClient);
           bind(StorageContainerServiceProvider.class)
               .to(StorageContainerServiceProviderImpl.class);
+          bind(OzoneConfiguration.class).
+              toInstance(conf);
+          bind(ReconUtils.class).toInstance(reconUtils);
         } catch (Exception e) {
           Assert.fail();
         }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When Recon startup, Based on a threshold value we need to get SCM DB using gRPC and populate the Recon DB in SCM HA enabled cluster.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6135

## How was this patch tested?

This patch was tested manually and using integration tests.
