### PR TITLE
HDDS-6161. SCM StateMachine failing to reinitialize doesn't terminate the process.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -220,6 +220,24 @@ public final class HAUtils {
     return dbBackup;
   }
 
+  public static void backUpDB(File oldDB, String dbPrefix,
+      long lastAppliedIndex) throws IOException {
+    // Take a backup of the current DB
+    String dbBackupName =
+        dbPrefix + lastAppliedIndex + "_" + System
+            .currentTimeMillis();
+    File dbDir = oldDB.getParentFile();
+    File dbBackup = new File(dbDir, dbBackupName);
+
+    try {
+      Files.move(oldDB.toPath(), dbBackup.toPath());
+    } catch (IOException e) {
+      LOG.error("Failed to create a backup of the current DB. Aborting "
+          + "snapshot installation.");
+      throw e;
+    }
+  }
+
   /**
    * Obtain SCMTransactionInfo from Checkpoint.
    */

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java
@@ -220,24 +220,6 @@ public final class HAUtils {
     return dbBackup;
   }
 
-  public static void backUpDB(File oldDB, String dbPrefix,
-      long lastAppliedIndex) throws IOException {
-    // Take a backup of the current DB
-    String dbBackupName =
-        dbPrefix + lastAppliedIndex + "_" + System
-            .currentTimeMillis();
-    File dbDir = oldDB.getParentFile();
-    File dbBackup = new File(dbDir, dbBackupName);
-
-    try {
-      Files.move(oldDB.toPath(), dbBackup.toPath());
-    } catch (IOException e) {
-      LOG.error("Failed to create a backup of the current DB. Aborting "
-          + "snapshot installation.");
-      throw e;
-    }
-  }
-
   /**
    * Obtain SCMTransactionInfo from Checkpoint.
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -294,9 +294,9 @@ public class SCMHAManagerImpl implements SCMHAManager {
           LOG.error("Replacing SCM state with Term : {} and Index:",
               termIndex.getTerm(), termIndex.getTerm());
           // This is being done to check before stop with old db
-          // try reload and then finally terminate and also test has assumption for
-          // reverify after corrupt DB loading without this it fails with NPE
-          // when  finding db location.
+          // try to reload and then finally terminate and also test has
+          // assumption for re-verify after corrupt DB loading without
+          // reloadSCMState call test fails with NPE when finding db location.
           reloadSCMState();
         }
       } finally {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -300,7 +300,8 @@ public class SCMHAManagerImpl implements SCMHAManager {
           reloadSCMState();
         }
       } finally {
-        String errorMsg = "Failed to reload SCM state and instantiate services.";
+        String errorMsg = "Failed to reload SCM state and instantiate " +
+            "services.";
         exitManager.exitSystem(1, errorMsg, ex, LOG);
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAManagerImpl.java
@@ -73,6 +73,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
       final StorageContainerManager scm) throws IOException {
     this.conf = conf;
     this.scm = scm;
+    this.exitManager = new ExitManager();
     if (SCMHAUtils.isSCMHAEnabled(conf)) {
       this.transactionBuffer = new SCMHADBTransactionBufferImpl(scm);
       this.ratisServer = new SCMRatisServerImpl(conf, scm,
@@ -240,7 +241,7 @@ public class SCMHAManagerImpl implements SCMHAManager {
       LOG.warn("Cannot proceed with InstallSnapshot as SCM is at TermIndex {} "
           + "and checkpoint has lower TermIndex {}. Reloading old "
           + "state of SCM.", termIndex, checkpointTxnInfo.getTermIndex());
-      throw new IOException("checkpoint is too older to install.");
+      return termIndex;
     }
 
     long term = checkpointTxnInfo.getTerm();
@@ -258,39 +259,21 @@ public class SCMHAManagerImpl implements SCMHAManager {
       throw e;
     }
 
-    File dbBackup = null;
+    File dbBackup;
     try {
       dbBackup = HAUtils
           .replaceDBWithCheckpoint(lastAppliedIndex, oldDBLocation,
               checkpointLocation, OzoneConsts.SCM_DB_BACKUP_PREFIX);
+      LOG.info("Reloaded SCM state with Term: {} and Index: {}", term,
+          lastAppliedIndex);
+      // Reload the DB store with the new checkpoint.
+      reloadSCMState();
       LOG.info("Replaced DB with checkpoint, term: {}, index: {}",
           term, lastAppliedIndex);
     } catch (Exception e) {
       LOG.error("Failed to install Snapshot as SCM failed to replace"
           + " DB with downloaded checkpoint. Reloading old SCM state.", e);
-    }
-    // Reload the DB store with the new checkpoint.
-    // Restart (unpause) the state machine and update its last applied index
-    // to the installed checkpoint's snapshot index.
-    try {
-      reloadSCMState();
-      LOG.info("Reloaded SCM state with Term: {} and Index: {}", term,
-          lastAppliedIndex);
-    } catch (Exception ex) {
-      try {
-        // revert to the old db, since the new db may be a corrupted one,
-        // so that SCM can restart from the old db.
-        if (dbBackup != null) {
-          dbBackup = HAUtils
-              .replaceDBWithCheckpoint(lastAppliedIndex, oldDBLocation,
-                  dbBackup.toPath(), OzoneConsts.SCM_DB_BACKUP_PREFIX);
-          startServices();
-        }
-      } finally {
-        String errorMsg =
-            "Failed to reload SCM state and instantiate services.";
-        exitManager.exitSystem(1, errorMsg, ex, LOG);
-      }
+      throw e;
     }
 
     // Delete the backup DB

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMStateMachine.java
@@ -357,7 +357,7 @@ public class SCMStateMachine extends BaseStateMachine {
   }
 
   @Override
-  public void reinitialize() {
+  public void reinitialize() throws IOException {
     Preconditions.checkNotNull(installingDBCheckpoint);
     DBCheckpoint checkpoint = installingDBCheckpoint;
 
@@ -369,8 +369,8 @@ public class SCMStateMachine extends BaseStateMachine {
       termIndex =
           scm.getScmHAManager().installCheckpoint(checkpoint);
     } catch (Exception e) {
-      LOG.error("Failed to reinitialize SCMStateMachine.");
-      return;
+      LOG.error("Failed to reinitialize SCMStateMachine.", e);
+      throw new IOException(e);
     }
 
     // re-initialize the DBTransactionBuffer and update the lastAppliedIndex.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Initialize exitManager and throw exception when installSnapshot fails, so that we can propogate this error to SM and the ratis handles it appropriately by terminating process.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6161

## How was this patch tested?

Exisiting tests in TestSCMInstallSnapshotWithSCMHA
