### PR TITLE
HDDS-6169. Selective checks: skip junit tests on ozone-runner image update

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -66,6 +66,17 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=true
 }
 
+@test "runner image update" {
+  run dev-support/ci/selective_ci_checks.sh b95eeba82a
+
+  assert_output -p 'basic-checks=["rat"]'
+  assert_output -p needs-build=true
+  assert_output -p needs-compose-tests=true
+  assert_output -p needs-dependency-check=true
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=true
+}
+
 @test "check script" {
   run dev-support/ci/selective_ci_checks.sh 316899152
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -219,7 +219,10 @@ function get_count_compose_files() {
     start_end::group_start "Count compose files"
     local pattern_array=(
         "^hadoop-ozone/dev-support/checks/acceptance.sh"
-        "^hadoop-ozone/dist/src/main/compose"
+        "^hadoop-ozone/dist"
+    )
+    local ignore_array=(
+        "^hadoop-ozone/dist/src/main/k8s"
     )
     filter_changed_files true
     COUNT_COMPOSE_CHANGED_FILES=${match_count}
@@ -258,7 +261,10 @@ function get_count_kubernetes_files() {
     start_end::group_start "Count kubernetes files"
     local pattern_array=(
         "^hadoop-ozone/dev-support/checks/kubernetes.sh"
-        "^hadoop-ozone/dist/src/main/k8s"
+        "^hadoop-ozone/dist"
+    )
+    local ignore_array=(
+        "^hadoop-ozone/dist/src/main/compose"
     )
     filter_changed_files true
     COUNT_KUBERNETES_CHANGED_FILES=${match_count}
@@ -332,6 +338,9 @@ function check_needs_checkstyle() {
         "pom.xml"
         "src/..../java"
     )
+    local ignore_array=(
+        "^hadoop-ozone/dist"
+    )
     filter_changed_files
 
     if [[ ${match_count} != "0" ]]; then
@@ -373,6 +382,9 @@ function check_needs_findbugs() {
         "pom.xml"
         "src/..../java"
     )
+    local ignore_array=(
+        "^hadoop-ozone/dist"
+    )
     filter_changed_files
 
     if [[ ${match_count} != "0" ]]; then
@@ -390,6 +402,9 @@ function check_needs_unit_test() {
         "pom.xml"
         "src/..../java"
         "src/..../resources"
+    )
+    local ignore_array=(
+        "^hadoop-ozone/dist"
     )
     filter_changed_files
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozone-runner` image version is defined in `hadoop-ozone/dist/pom.xml`.  Changing it triggers a complete CI run, although it does not affect unit or integration tests in any way.  Actually, `hadoop-ozone/dist` does not have any Java code, as it assembles other modules after build.  So we can skip all Java-specific checks.

https://issues.apache.org/jira/browse/HDDS-6169

## How was this patch tested?

Added test case in `selective_ci_checks.bats`.

```
$ bats dev-support/ci/selective_ci_checks.bats
...
 ✓ runner image update
...
17 tests, 0 failures
```

The script includes instructions on how to run:
https://github.com/apache/ozone/blob/a31b79a0cf0677a11dda1e9d3de70cf22f7b045a/dev-support/ci/selective_ci_checks.bats#L17-L31