### PR TITLE
HDDS-6170. Add metrics to replication manager to track container health states

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaCount.java
@@ -269,4 +269,14 @@ public class ContainerReplicaCount {
         .allMatch(r -> ReplicationManager.compareState(
             container.getState(), r.getState()));
   }
+
+  /**
+   * Returns true is there are no replicas of a container available, ie the
+   * set of container replica passed in the constructor has zero entries.
+   *
+   * @return true if there are no replicas, false otherwise.
+   */
+  public boolean isMissing() {
+    return replica.size() == 0;
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -541,6 +541,10 @@ public class ReplicationManager implements SCMService {
           if (!sufficientlyReplicated) {
             report.incrementAndSample(
                 HealthState.UNDER_REPLICATED, container.containerID());
+            if (replicaSet.isMissing()) {
+              report.incrementAndSample(HealthState.MISSING,
+                  container.containerID());
+            }
           }
           if (!placementSatisfied) {
             report.incrementAndSample(HealthState.MIS_REPLICATED,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -162,7 +162,7 @@ public class ReplicationManagerReport {
   private void increment(String stat) {
     LongAdder adder = stats.get(stat);
     if (adder == null) {
-      throw new RuntimeException("Unexpected stat " + stat);
+      throw new IllegalArgumentException("Unexpected stat " + stat);
     }
     adder.increment();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.LongAdder;
+
+/**
+ * This class is used by ReplicationManager. Each time ReplicationManager runs,
+ * it creates a new instance of this class and increments the various counters
+ * to allow for creating a report on the various container states within the
+ * system. There is a counter for each LifeCycleState (open, closing, closed
+ * etc) and the sum of each of the lifecycle state counters should equal the
+ * total number of containers in SCM. Ie, each container can only be in one of
+ * the Lifecycle states at any time.
+ *
+ * Additionally, there are a set of counters for the "health state" of the
+ * containers, defined here in the HealthState enum. It is normal for containers
+ * to be in these health states from time to time, but the presence of a
+ * container in one of these health states generally means cluster is in a
+ * degraded state. Normally, the cluster will recover by itself, but manual
+ * intervention may be needed in some cases.
+ *
+ * To aid debugging, when containers are in one of the health states, a list of
+ * up to SAMPLE_LIMIT container IDs are recorded in the report for each of the
+ * states.
+ */
+public class ReplicationManagerReport {
+
+  private static final int SAMPLE_LIMIT = 100;
+  private long reportTimeStamp;
+
+  /**
+   * Enum representing various health states a container can be in.
+   */
+  public enum HealthState {
+    UNDER_REPLICATED("Containers with insufficient replicas"),
+    MIS_REPLICATED("Containers with insufficient racks"),
+    OVER_REPLICATED("Containers with more replicas than required"),
+    UNHEALTHY(
+        "Containers Closed or Quasi_Closed having some replicas in " +
+            "a different state"),
+    EMPTY("Containers having no blocks"),
+    OPEN_UNHEALTHY(
+        "Containers open and having replicas with different states"),
+    QUASI_CLOSED_STUCK(
+        "Containers Quasi_Closed with insufficient datanode origins");
+
+    private String description;
+
+    HealthState(String desc) {
+      this.description = desc;
+    }
+
+    public String getDescription() {
+      return this.description;
+    }
+  }
+
+  private final Map<String, LongAdder> stats;
+  private final Map<String, List<ContainerID>> containerSample
+      = new HashMap<>();
+
+  public ReplicationManagerReport() {
+    stats = createStatsMap();
+  }
+
+  public void increment(HealthState stat) {
+    increment(stat.toString());
+  }
+
+  public void increment(HddsProtos.LifeCycleState stat) {
+    increment(stat.toString());
+  }
+
+  public void incrementAndSample(HealthState stat, ContainerID container) {
+    incrementAndSample(stat.toString(), container);
+  }
+
+  public void incrementAndSample(HddsProtos.LifeCycleState stat,
+      ContainerID container) {
+    incrementAndSample(stat.toString(), container);
+  }
+
+  public void setComplete() {
+    reportTimeStamp = System.currentTimeMillis();
+  }
+
+  public long getStat(HddsProtos.LifeCycleState stat) {
+    return getStat(stat.toString());
+  }
+
+  public long getStat(HealthState stat) {
+    return getStat(stat.toString());
+  }
+
+  private long getStat(String stat) {
+    return stats.get(stat).longValue();
+  }
+
+  private void increment(String stat) {
+    LongAdder adder = stats.get(stat);
+    if (adder == null) {
+      throw new RuntimeException("Unexpected stat " + stat);
+    }
+    adder.increment();
+  }
+
+  private void incrementAndSample(String stat, ContainerID container) {
+    increment(stat);
+    List<ContainerID> list = containerSample
+        .computeIfAbsent(stat, k -> new ArrayList<>());
+    if (list.size() < SAMPLE_LIMIT) {
+      list.add(container);
+    }
+  }
+
+  private Map<String, LongAdder> createStatsMap() {
+    Map<String, LongAdder> map = new HashMap<>();
+    for (HddsProtos.LifeCycleState s : HddsProtos.LifeCycleState.values()) {
+      map.put(s.toString(), new LongAdder());
+    }
+    for (HealthState s : HealthState.values()) {
+      map.put(s.toString(), new LongAdder());
+    }
+    return map;
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.container;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -54,22 +55,33 @@ public class ReplicationManagerReport {
    * Enum representing various health states a container can be in.
    */
   public enum HealthState {
-    UNDER_REPLICATED("Containers with insufficient replicas"),
-    MIS_REPLICATED("Containers with insufficient racks"),
-    OVER_REPLICATED("Containers with more replicas than required"),
+    UNDER_REPLICATED("Containers with insufficient replicas",
+        "NumUnderReplicatedContainers"),
+    MIS_REPLICATED("Containers with insufficient racks",
+        "NumMisReplicatedContainers"),
+    OVER_REPLICATED("Containers with more replicas than required",
+        "NumOverReplicatedContainers"),
     UNHEALTHY(
         "Containers Closed or Quasi_Closed having some replicas in " +
-            "a different state"),
-    EMPTY("Containers having no blocks"),
+            "a different state", "NumUnhealthyContainers"),
+    EMPTY("Containers having no blocks", "NumEmptyContainers"),
     OPEN_UNHEALTHY(
-        "Containers open and having replicas with different states"),
+        "Containers open and having replicas with different states",
+        "NumOpenUnhealthyContainers"),
     QUASI_CLOSED_STUCK(
-        "Containers Quasi_Closed with insufficient datanode origins");
+        "Containers QuasiClosed with insufficient datanode origins",
+        "NumStuckQuasiClosedContainers");
 
     private String description;
+    private String metricName;
 
-    HealthState(String desc) {
+    HealthState(String desc, String name) {
       this.description = desc;
+      this.metricName = name;
+    }
+
+    public String getMetricName() {
+      return this.metricName;
     }
 
     public String getDescription() {
@@ -116,6 +128,18 @@ public class ReplicationManagerReport {
 
   private long getStat(String stat) {
     return stats.get(stat).longValue();
+  }
+
+  public List<ContainerID> getSample(HddsProtos.LifeCycleState stat) {
+    return getSample(stat.toString());
+  }
+
+  public List<ContainerID> getSample(HealthState stat) {
+    return getSample(stat.toString());
+  }
+
+  private List<ContainerID> getSample(String stat) {
+    return containerSample.getOrDefault(stat, Collections.emptyList());
   }
 
   private void increment(String stat) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.LongAdder;
  */
 public class ReplicationManagerReport {
 
-  private static final int SAMPLE_LIMIT = 100;
+  public static final int SAMPLE_LIMIT = 100;
   private long reportTimeStamp;
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -121,6 +121,14 @@ public class ReplicationManagerReport {
     reportTimeStamp = System.currentTimeMillis();
   }
 
+  /**
+   * The epoch time in milli-seconds when this report was completed.
+   * @return epoch time in milli-seconds.
+   */
+  public long getReportTimeStamp() {
+    return reportTimeStamp;
+  }
+
   public long getStat(HddsProtos.LifeCycleState stat) {
     return getStat(stat.toString());
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -62,6 +62,8 @@ public class ReplicationManagerReport {
         "NumMisReplicatedContainers"),
     OVER_REPLICATED("Containers with more replicas than required",
         "NumOverReplicatedContainers"),
+    MISSING("Containers with no online replicas",
+        "NumMissingContainers"),
     UNHEALTHY(
         "Containers Closed or Quasi_Closed having some replicas in " +
             "a different state", "NumUnhealthyContainers"),

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -1386,6 +1386,18 @@ public class TestReplicationManager {
   }
 
   /**
+   * ReplicationManager should replicate zero replica when all copies
+   * are missing.
+   */
+  @Test
+  public void testContainerWithMissingReplicas()
+      throws IOException {
+    final ContainerInfo container = createContainer(LifeCycleState.CLOSED);
+    assertReplicaScheduled(0);
+    assertUnderReplicatedCount(1);
+    assertMissingCount(1);
+  }
+  /**
    * When a CLOSED container is over replicated, ReplicationManager
    * deletes the excess replicas. While choosing the replica for deletion
    * ReplicationManager should not attempt to remove a DECOMMISSION or
@@ -1851,6 +1863,7 @@ public class TestReplicationManager {
   private ContainerInfo createContainer(LifeCycleState containerState)
       throws IOException {
     final ContainerInfo container = getContainer(containerState);
+    container.setUsedBytes(1234);
     containerStateManager.addContainer(container.getProtobuf());
     return container;
   }
@@ -1923,6 +1936,12 @@ public class TestReplicationManager {
     ReplicationManagerReport report = replicationManager.getContainerReport();
     Assert.assertEquals(count, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  private void assertMissingCount(int count) {
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(count, report.getStat(
+        ReplicationManagerReport.HealthState.MISSING));
   }
 
   private void assertOverReplicatedCount(int count) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -1392,7 +1392,7 @@ public class TestReplicationManager {
   @Test
   public void testContainerWithMissingReplicas()
       throws IOException {
-    final ContainerInfo container = createContainer(LifeCycleState.CLOSED);
+    createContainer(LifeCycleState.CLOSED);
     assertReplicaScheduled(0);
     assertUnderReplicatedCount(1);
     assertMissingCount(1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -263,8 +263,9 @@ public class TestReplicationManager {
     containerStateManager.addContainer(container.getProtobuf());
     replicationManager.processAll();
     eventQueue.processAll(1000);
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.OPEN));
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
-
   }
 
   /**
@@ -308,6 +309,8 @@ public class TestReplicationManager {
     eventQueue.processAll(1000);
     Assert.assertEquals(currentCloseCommandCount + 6, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
   }
 
 
@@ -348,6 +351,8 @@ public class TestReplicationManager {
     Assert.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.closeContainerCommand,
         replicaThree.getDatanodeDetails()));
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
   }
 
   /**
@@ -378,6 +383,10 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
   /**
@@ -459,6 +468,14 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
+    // We should have one under replicated and one quasi_closed_stuck
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+
     // Now we add the missing replica back
     DatanodeDetails targetDn = replicationManager.getInflightReplication()
         .get(id).get(0).getDatanode();
@@ -482,6 +499,13 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumReplicationCmdsCompleted());
     Assert.assertEquals(currentBytesCompleted + 100L,
         replicationManager.getMetrics().getNumReplicationBytesCompleted());
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
   /**
@@ -523,6 +547,13 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+
     // Now we remove the replica according to inflight
     DatanodeDetails targetDn = replicationManager.getInflightDeletion()
         .get(id).get(0).getDatanode();
@@ -554,6 +585,13 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumDeletionCmdsCompleted());
     Assert.assertEquals(deleteBytesCompleted + 101,
         replicationManager.getMetrics().getNumDeletionBytesCompleted());
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
   /**
@@ -600,6 +638,13 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
         .getNumDeletionCmdsCompleted();
     // Now we remove the replica to simulate deletion complete
@@ -613,6 +658,13 @@ public class TestReplicationManager {
     Assert.assertEquals(0, replicationManager.getInflightDeletion().size());
     Assert.assertEquals(0, replicationManager.getMetrics()
         .getInflightDeletion());
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
   /**
@@ -652,6 +704,13 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+
     final long currentReplicateCommandCompleted = replicationManager
         .getMetrics().getNumReplicationCmdsCompleted();
     final long currentReplicateBytesCompleted = replicationManager
@@ -675,6 +734,13 @@ public class TestReplicationManager {
     Assert.assertEquals(0, replicationManager.getInflightReplication().size());
     Assert.assertEquals(0, replicationManager.getMetrics()
         .getInflightReplication());
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
   /**
@@ -740,6 +806,15 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, newNode);
     containerStateManager.updateContainerReplica(id.getProtobuf(), newReplica);
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
+
     /*
      * We have report the replica to SCM, in the next ReplicationManager
      * iteration it should delete the unhealthy replica.
@@ -765,6 +840,15 @@ public class TestReplicationManager {
 
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
         .getNumDeletionCmdsCompleted();
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
     /*
      * We have now removed unhealthy replica, next iteration of
      * ReplicationManager should re-replicate the container as it
@@ -788,6 +872,15 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getInflightReplication().size());
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
+
+    report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
 
@@ -820,6 +913,10 @@ public class TestReplicationManager {
     Assert.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assert.assertEquals(0, report.getStat(
+        ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
 
@@ -844,6 +941,13 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
     Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+    for (ReplicationManagerReport.HealthState s :
+        ReplicationManagerReport.HealthState.values()) {
+      Assert.assertEquals(0, report.getStat(s));
+    }
   }
 
   /**
@@ -871,6 +975,11 @@ public class TestReplicationManager {
     eventQueue.processAll(1000);
     Mockito.verify(closeContainerHandler, Mockito.times(1))
         .onMessage(id, eventQueue);
+
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.OPEN));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.OPEN_UNHEALTHY));
   }
 
   /**
@@ -957,6 +1066,11 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+    Assert.assertEquals(1, report.getStat(
+        ReplicationManagerReport.HealthState.MIS_REPLICATED));
+
     // Now make it so that all containers seem mis-replicated no matter how
     // many replicas. This will test replicas are not scheduled if the new
     // replica does not fix the mis-replication.
@@ -1036,6 +1150,7 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
+    assertOverReplicatedCount(1);
   }
 
   @Test
@@ -1077,6 +1192,8 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
+
+    assertOverReplicatedCount(1);
   }
 
   @Test
@@ -1135,6 +1252,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY), CLOSED);
     assertReplicaScheduled(2);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1148,6 +1266,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY), CLOSED);
     assertReplicaScheduled(3);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1162,6 +1281,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(DECOMMISSIONING, HEALTHY), CLOSED);
     assertReplicaScheduled(0);
+    assertUnderReplicatedCount(0);
   }
 
   /**
@@ -1175,6 +1295,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(1);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1195,6 +1316,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(0);
+    assertUnderReplicatedCount(0);
   }
 
   /**
@@ -1215,6 +1337,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(1);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1228,6 +1351,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(2);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1242,6 +1366,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(0);
+    assertUnderReplicatedCount(0);
   }
 
   /**
@@ -1257,6 +1382,7 @@ public class TestReplicationManager {
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     addReplica(container, new NodeStatus(IN_MAINTENANCE, HEALTHY), CLOSED);
     assertReplicaScheduled(2);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1302,6 +1428,7 @@ public class TestReplicationManager {
           SCMCommandProto.Type.deleteContainerCommand,
           r.getDatanodeDetails()));
     }
+    assertOverReplicatedCount(1);
   }
 
   /**
@@ -1319,6 +1446,7 @@ public class TestReplicationManager {
     // There should be replica scheduled, but as all nodes are stale, nothing
     // gets scheduled.
     assertReplicaScheduled(0);
+    assertUnderReplicatedCount(1);
   }
 
   /**
@@ -1789,6 +1917,18 @@ public class TestReplicationManager {
             SCMCommandProto.Type.deleteContainerCommand));
     Assert.assertEquals(currentDeleteCommandCount + delta,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
+  }
+
+  private void assertUnderReplicatedCount(int count) {
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(count, report.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  private void assertOverReplicatedCount(int count) {
+    ReplicationManagerReport report = replicationManager.getContainerReport();
+    Assert.assertEquals(count, report.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
   @After

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Tests for the ReplicationManagerReport class.
+ */
+public class TestReplicationManagerReport {
+
+  private ReplicationManagerReport report;
+
+  @Before
+  public void setup() {
+    report = new ReplicationManagerReport();
+  }
+
+  @Test
+  public void testMetricCanBeIncremented() {
+    report.increment(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
+    report.increment(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
+    report.increment(ReplicationManagerReport.HealthState.OVER_REPLICATED);
+
+    report.increment(HddsProtos.LifeCycleState.OPEN);
+    report.increment(HddsProtos.LifeCycleState.CLOSED);
+    report.increment(HddsProtos.LifeCycleState.CLOSED);
+
+    Assert.assertEquals(2,
+        report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(0,
+        report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
+
+    Assert.assertEquals(1,
+        report.getStat(HddsProtos.LifeCycleState.OPEN));
+    Assert.assertEquals(2,
+        report.getStat(HddsProtos.LifeCycleState.CLOSED));
+    Assert.assertEquals(0,
+        report.getStat(HddsProtos.LifeCycleState.QUASI_CLOSED));
+  }
+
+  @Test
+  public void testContainerIDsCanBeSampled() {
+    report.incrementAndSample(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+        new ContainerID(1));
+    report.incrementAndSample(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+        new ContainerID(2));
+    report.incrementAndSample(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED,
+        new ContainerID(3));
+
+    Assert.assertEquals(2,
+        report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1,
+        report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
+    Assert.assertEquals(0,
+        report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
+
+    List<ContainerID> sample =
+        report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
+    Assert.assertEquals(new ContainerID(1), sample.get(0));
+    Assert.assertEquals(new ContainerID(2), sample.get(1));
+    Assert.assertEquals(2, sample.size());
+
+    sample =
+        report.getSample(ReplicationManagerReport.HealthState.OVER_REPLICATED);
+    Assert.assertEquals(new ContainerID(3), sample.get(0));
+    Assert.assertEquals(1, sample.size());
+
+    sample =
+        report.getSample(ReplicationManagerReport.HealthState.MIS_REPLICATED);
+    Assert.assertEquals(0, sample.size());
+  }
+
+  @Test
+  public void testSamplesAreLimited() {
+    for (int i = 0; i < ReplicationManagerReport.SAMPLE_LIMIT * 2; i++) {
+      report.incrementAndSample(
+          ReplicationManagerReport.HealthState.UNDER_REPLICATED,
+          new ContainerID(i));
+    }
+    List<ContainerID> sample =
+        report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
+    Assert.assertEquals(ReplicationManagerReport.SAMPLE_LIMIT, sample.size());
+    for (int i = 0; i < ReplicationManagerReport.SAMPLE_LIMIT; i++) {
+      Assert.assertEquals(new ContainerID(i), sample.get(i));
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
+import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
+
+/**
+ * Tests for the ReplicationManagerMetrics class.
+ */
+public class TestReplicationManagerMetrics {
+
+  private ReplicationManager replicationManager;
+  private ReplicationManagerMetrics metrics;
+
+  @Before
+  public void setup() {
+    ReplicationManagerReport report = new ReplicationManagerReport();
+
+    // Each lifecycle state has a value from 1 to N. Set the value of the metric
+    // to the value by incrementing the counter that number of times.
+    for (HddsProtos.LifeCycleState s : HddsProtos.LifeCycleState.values()) {
+      for (int i = 0; i < s.getNumber(); i++) {
+        report.increment(s);
+      }
+    }
+    // The ordinal starts from 0, so each state will have a value of its ordinal
+    for (ReplicationManagerReport.HealthState s :
+        ReplicationManagerReport.HealthState.values()) {
+      for (int i = 0; i < s.ordinal(); i++) {
+        report.increment(s);
+      }
+    }
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    Mockito.when(replicationManager.getContainerReport()).thenReturn(report);
+    metrics = ReplicationManagerMetrics.create(replicationManager);
+  }
+
+  @After
+  public void after() {
+    metrics.unRegister();
+  }
+
+  @Test
+  public void testLifeCycleStateMetricsPresent() {
+    Assert.assertEquals(HddsProtos.LifeCycleState.OPEN.getNumber(),
+        getGauge("NumOpenContainers"));
+    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSING.getNumber(),
+        getGauge("NumClosingContainers"));
+    Assert.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED.getNumber(),
+        getGauge("NumQuasiClosedContainers"));
+    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSED.getNumber(),
+        getGauge("NumClosedContainers"));
+    Assert.assertEquals(HddsProtos.LifeCycleState.DELETING.getNumber(),
+        getGauge("NumDeletingContainers"));
+    Assert.assertEquals(HddsProtos.LifeCycleState.DELETED.getNumber(),
+        getGauge("NumDeletedContainers"));
+  }
+
+  @Test
+  public void testHealthStateMetricsPresent() {
+    for (ReplicationManagerReport.HealthState s :
+        ReplicationManagerReport.HealthState.values()) {
+      Assert.assertEquals(s.ordinal(), getGauge(s.getMetricName()));
+    }
+  }
+
+  private long getGauge(String metricName) {
+    return getLongGauge(metricName,
+        getMetrics(ReplicationManagerMetrics.METRICS_SOURCE_NAME));
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -431,6 +431,16 @@ public class TestContainerReplicaCount {
     assertTrue(rcnt.isHealthy());
   }
 
+  @Test
+  public void testContainerWithNoReplicasIsMissing() {
+    Set<ContainerReplica> replica = new HashSet<>();
+    ContainerInfo container = createContainer(HddsProtos.LifeCycleState.CLOSED);
+    ContainerReplicaCount rcnt =
+        new ContainerReplicaCount(container, replica, 0, 0, 3, 2);
+    assertTrue(rcnt.isMissing());
+    assertFalse(rcnt.isSufficientlyReplicated());
+  }
+
   private void validate(ContainerReplicaCount rcnt,
       boolean sufficientlyReplicated, int replicaDelta,
       boolean overReplicated) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replication Manager processes all the containers in SCM periodically, and so has a view of the health of the system. However it does not count up the replicas in each state and hence that overview of the system health is not easily visible.

This Jira adds a ReplicationManagerReport object, which ReplicationManager can populate by incrementing various counters as it processes the containers. The report allows the number of containers in each lifecycle state to be counted, while also counting the number of containers in various health states, eg under replicated, over replicated etc. The report also allows a sample of the container IDs in the state are stored in the report (max of 100 per state) and these can be extracted later for debugging (a later Jira will provide the extra feature, probably via an Ozone Admin command).

The report is integrated with the ReplicationManagerMetrics class, and will add metrics like the following:

```
{
    "name" : "Hadoop:service=StorageContainerManager,name=ReplicationManagerMetrics",
    "modelerType" : "ReplicationManagerMetrics",
    "tag.Hostname" : "3212ea4aecc5",
    "InflightReplication" : 0,
    "InflightDeletion" : 0,
    "InflightMove" : 0,

## New metrics from here
    "NumOpenContainers" : 1,
    "NumClosingContainers" : 0,
    "NumQuasiClosedContainers" : 2,
    "NumClosedContainers" : 0,
    "NumDeletingContainers" : 0,
    "NumDeletedContainers" : 0,
    "NumUnderReplicatedContainers" : 0,
    "NumMisReplicatedContainers" : 0,
    "NumOverReplicatedContainers" : 0,
    "NumMissingContainers" : 0,
    "NumUnhealthyContainers" : 0,
    "NumEmptyContainers" : 0,
    "NumOpenUnhealthyContainers" : 0,
    "NumStuckQuasiClosedContainers" : 0,
## end of new metrics    
    "NumReplicationCmdsSent" : 0,
    "NumReplicationCmdsCompleted" : 0,
    "NumReplicationCmdsTimeout" : 0,
    "NumDeletionCmdsSent" : 0,
    "NumDeletionCmdsCompleted" : 0,
    "NumDeletionCmdsTimeout" : 0,
    "NumReplicationBytesTotal" : 0,
    "NumReplicationBytesCompleted" : 0,
    "NumDeletionBytesTotal" : 0,
    "NumDeletionBytesCompleted" : 0,
    "ReplicationTimeNumOps" : 0,
    "ReplicationTimeAvgTime" : 0.0,
    "DeletionTimeNumOps" : 0,
    "DeletionTimeAvgTime" : 0.0
  }
```

Note that some of the above metrics (the ones for container LifeCycle state) duplicate others available from a different source in SCM:

```
{
    "name" : "Hadoop:service=StorageContainerManager,name=SCMContainerMetrics",
    "modelerType" : "SCMContainerMetrics",
    "tag.Hostname" : "92503dfbd5db",
    "OpenContainers" : 0,
    "ClosingContainers" : 0,
    "QuasiClosedContainers" : 0,
    "ClosedContainers" : 0,
    "DeletingContainers" : 0,
    "DeletedContainers" : 0,
    "TotalContainers" : 0
  }
```  

I am open to removing these duplicates in the new ReplicationManager metrics, but it may be useful to keep them, as the ReplicationManager counts are captured at a point in time, and they are calculated differently, and hence may be helpful in debugging some problems. For that reason, it is still good to capture them in the Report object, but it is debatable on whether they should be in the metrics or not.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6170

## How was this patch tested?

New unit tests and validated in docker-compose environment.
