### PR TITLE
[Ozone-Streaming] HDDS-6139. Fix incorrect computation of totalAckDataLength.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -182,7 +182,6 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     checksum = new Checksum(config.getChecksumType(),
         config.getBytesPerChecksum());
     metrics = XceiverClientManager.getXceiverClientMetrics();
-    buffersForPutBlock = new ArrayList<>();
   }
 
   private DataStreamOutput setupStream(Pipeline pipeline) throws IOException {

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockDataStreamOutput.java
@@ -133,6 +133,8 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
   private long syncPosition = 0;
   private StreamBuffer currentBuffer;
   private XceiverClientMetrics metrics;
+  // buffers for which putBlock is yet to be executed
+  private List<StreamBuffer> buffersForPutBlock;
   /**
    * Creates a new BlockDataStreamOutput.
    *
@@ -180,6 +182,7 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     checksum = new Checksum(config.getChecksumType(),
         config.getBytesPerChecksum());
     metrics = XceiverClientManager.getXceiverClientMetrics();
+    buffersForPutBlock = new ArrayList<>();
   }
 
   private DataStreamOutput setupStream(Pipeline pipeline) throws IOException {
@@ -287,6 +290,10 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
 
   private void writeChunk(StreamBuffer sb) throws IOException {
     bufferList.add(sb);
+    if (buffersForPutBlock == null) {
+      buffersForPutBlock = new ArrayList<>();
+    }
+    buffersForPutBlock.add(sb);
     ByteBuffer dup = sb.duplicate();
     dup.position(0);
     dup.limit(sb.position());
@@ -392,7 +399,8 @@ public class BlockDataStreamOutput implements ByteBufferStreamOutput {
     final List<StreamBuffer> byteBufferList;
     if (!force) {
       Preconditions.checkNotNull(bufferList);
-      byteBufferList = bufferList;
+      byteBufferList = buffersForPutBlock;
+      buffersForPutBlock = null;
       Preconditions.checkNotNull(byteBufferList);
     } else {
       byteBufferList = null;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockDataStreamOutputEntry.java
@@ -156,7 +156,7 @@ public final class BlockDataStreamOutputEntry
     }
   }
 
-  long getTotalAckDataLength() {
+  public long getTotalAckDataLength() {
     if (byteBufferStreamOutput != null) {
       BlockDataStreamOutput out =
           (BlockDataStreamOutput) this.byteBufferStreamOutput;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.io.BlockDataStreamOutputEntry;
 import org.apache.hadoop.ozone.client.io.KeyDataStreamOutput;
 import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.container.ContainerTestHelper;
@@ -254,6 +255,24 @@ public class TestBlockDataStreamOutput {
     key.close();
     String dataString = new String(data, UTF_8);
     validateData(keyName, dataString.concat(dataString).getBytes(UTF_8));
+  }
+
+  @Test
+  public void testTotalAckDataLength() throws Exception {
+    int dataLength = 400;
+    String keyName = getKeyName();
+    OzoneDataStreamOutput key = createKey(
+        keyName, ReplicationType.RATIS, 0);
+    byte[] data =
+        ContainerTestHelper.getFixedLengthString(keyString, dataLength)
+            .getBytes(UTF_8);
+    KeyDataStreamOutput keyDataStreamOutput =
+        (KeyDataStreamOutput) key.getByteBufStreamOutput();
+    BlockDataStreamOutputEntry stream =
+        keyDataStreamOutput.getStreamEntries().get(0);
+    key.write(ByteBuffer.wrap(data));
+    key.close();
+    Assert.assertTrue(stream.getTotalAckDataLength()==dataLength);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBlockDataStreamOutput.java
@@ -272,7 +272,7 @@ public class TestBlockDataStreamOutput {
         keyDataStreamOutput.getStreamEntries().get(0);
     key.write(ByteBuffer.wrap(data));
     key.close();
-    Assert.assertTrue(stream.getTotalAckDataLength()==dataLength);
+    Assert.assertEquals(dataLength, stream.getTotalAckDataLength());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?
In the current streaming code we maintain only one bufferList for retry. Buffers in the list are removed only during watchForCommit. So there might occur a case if putBlock is followed by another putBlock  the commitInfoMap has the same list for both indexes  which will cause incorrect computation of totalAckDatalength which is used during retry

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6139

## How was this patch tested?
unit test
