### PR TITLE
HDDS-4190. Intermittent failure in TestOMVolumeSetOwnerRequest and TestOMVolumeSetQuotaRequest.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetOwnerRequest.java
@@ -98,7 +98,12 @@ public class TestOMVolumeSetOwnerRequest extends TestOMVolumeRequest {
         .get(volumeKey).getCreationTime();
     long modificationTime = omMetadataManager.getVolumeTable()
         .get(volumeKey).getModificationTime();
-    Assert.assertTrue(modificationTime > creationTime);
+
+    // creationTime and modificationTime can be the same to the precision of a
+    // millisecond - since there is no time-consuming operation between
+    // TestOMRequestUtils.addVolumeToDB (sets creationTime) and
+    // preExecute (sets modificationTime).
+    Assert.assertTrue(modificationTime >= creationTime);
 
     OzoneManagerStorageProtos.PersistedUserVolumeInfo newOwnerVolumeList =
         omMetadataManager.getUserTable().get(newOwnerKey);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/volume/TestOMVolumeSetQuotaRequest.java
@@ -108,7 +108,12 @@ public class TestOMVolumeSetQuotaRequest extends TestOMVolumeRequest {
         .getVolumeTable().get(volumeKey).getCreationTime();
     long modificationTime = omMetadataManager
         .getVolumeTable().get(volumeKey).getModificationTime();
-    Assert.assertTrue(modificationTime > creationTime);
+
+    // creationTime and modificationTime can be the same to the precision of a
+    // millisecond - since there is no time-consuming operation between
+    // TestOMRequestUtils.addVolumeToDB (sets creationTime) and
+    // preExecute (sets modificationTime).
+    Assert.assertTrue(modificationTime >= creationTime);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

UT assertions periodically failing locally in:

```java
TestOMVolumeSetQuotaRequest.testValidateAndUpdateCacheSuccess
TestOMVolumeSetOwnerRequest.testValidateAndUpdateCacheSuccess
```

Cause:
The assertion would periodically fail since `modificationTime` and `creationTime` could be the same to the precision of a millisecond.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4190

## How was this patch tested?

Related Unit Tests
