### PR TITLE
HDDS-6183. Intermittent failure in TestKeyDeletingService.checkIfDeleteServiceWithFailingSCM.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -148,19 +148,17 @@ public class TestKeyDeletingService {
           try {
             int numPendingDeletionKeys =
                 keyManager.getPendingDeletionKeys(Integer.MAX_VALUE).size();
-
             if (numPendingDeletionKeys != keyCount) {
               LOG.error("Expected {} keys to be pending deletion, but got {}",
                   keyCount, numPendingDeletionKeys);
               return false;
             }
-
             return true;
           } catch (IOException e) {
             LOG.error("Error while getting pending deletion keys.");
             return false;
           }
-        }, 500, 2000);
+        }, 100, 2000);
     // Make sure that we have run the background thread 5 times more
     GenericTestUtils.waitFor(
         () -> keyDeletingService.getRunCount().get() >= 5,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -149,13 +149,13 @@ public class TestKeyDeletingService {
             int numPendingDeletionKeys =
                 keyManager.getPendingDeletionKeys(Integer.MAX_VALUE).size();
             if (numPendingDeletionKeys != keyCount) {
-              LOG.error("Expected {} keys to be pending deletion, but got {}",
+              LOG.info("Expected {} keys to be pending deletion, but got {}",
                   keyCount, numPendingDeletionKeys);
               return false;
             }
             return true;
           } catch (IOException e) {
-            LOG.error("Error while getting pending deletion keys.");
+            LOG.error("Error while getting pending deletion keys.", e);
             return false;
           }
         }, 100, 2000);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -121,7 +121,7 @@ public class TestKeyDeletingService {
         keyManager.getPendingDeletionKeys(Integer.MAX_VALUE).size(), 0);
   }
 
-  @Test(timeout = 30000)
+  @Test(timeout = 40000)
   public void checkIfDeleteServiceWithFailingSCM()
       throws IOException, TimeoutException, InterruptedException,
       AuthenticationException {
@@ -137,6 +137,10 @@ public class TestKeyDeletingService {
 
     final int keyCount = 100;
     createAndDeleteKeys(keyManager, keyCount, 1);
+    // Wait for the KeyDeletingService to pick up all the keys.
+    // There isn't any time-consuming code after the deleteKey call - which can
+    // cause assertion failures.
+    Thread.sleep(2000);
     KeyDeletingService keyDeletingService =
         (KeyDeletingService) keyManager.getDeletingService();
     Assert.assertEquals(


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestKeyDeletingService.checkIfDeleteServiceWithFailingSCM` seems to be intermittently failing frequently on both CI and local setups.

Attached logs archive from failed CI run.
https://github.com/apache/ozone/runs/4821162701?check_suite_focus=true

Cause:
KeyDeletingService can sometimes take more than a few milliseconds to pick up the keys queued up for deletion. If the assertion runs before this is allowed to happen it can cause a test failure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6183

## How was this patch tested?

Unit Tests.