### PR TITLE
HDDS-6204. Cleanup handling malformed authorization header

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -26,7 +26,7 @@ import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static java.net.HttpURLConnection.HTTP_NOT_IMPLEMENTED;
-import static java.net.HttpURLConnection.HTTP_SERVER_ERROR;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_NOT_SATISFIABLE;
 
 /**
@@ -65,7 +65,7 @@ public final class S3ErrorTable {
 
   public static final OS3Exception MALFORMED_HEADER = new OS3Exception(
       "AuthorizationHeaderMalformed", "The authorization header you provided " +
-      "is invalid.", HTTP_NOT_FOUND);
+      "is invalid.", HTTP_BAD_REQUEST);
 
   public static final OS3Exception NO_SUCH_KEY = new OS3Exception(
       "NoSuchKey", "The specified key does not exist", HTTP_NOT_FOUND);
@@ -106,7 +106,7 @@ public final class S3ErrorTable {
 
   public static final OS3Exception INTERNAL_ERROR = new OS3Exception(
       "InternalError", "We encountered an internal error. Please try again.",
-      HTTP_SERVER_ERROR);
+      HTTP_INTERNAL_ERROR);
 
   public static final OS3Exception ACCESS_DENIED = new OS3Exception(
       "AccessDenied", "User doesn't have the right to access this " +

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -134,7 +134,7 @@ public class TestOzoneClientProducer {
     try {
       producer.createClient();
       fail("testGetClientFailure");
-    } catch (IOException ex) {
+    } catch (Exception ex) {
       Assert.assertTrue(ex instanceof IOException);
     }
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -30,7 +30,6 @@ import java.util.Collection;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
-import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.signature.AWSSignatureProcessor;
 
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently in some cases where the authorization header is wrong, S3Gateway returns wrong status code. For example,

1. 500 for no such bucket, or
2. 404 for malformed request.

Some cases are not reproducible for me, but it's apparently wrong in code. 1. is because OS3Exception is doubly wrapped by WebApplicationError and thus failing to catch in the `catch (OS3Exception ex)`  clause and goes through to `catch (Exception ex)` clause. 2. just comes from wrong definition in S3ErrorTable.

Here are some examples against our production cluster for case 1:

```sh
$ curl -H "Authorization: invalid" https://ozone.example.com/no-such-bucket
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 Internal Server Error</title>
</head>
<body><h2>HTTP ERROR 500 Internal Server Error</h2>
<table>
<tr><th>URI:</th><td>/no-such-bucket</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>Internal Server Error</td></tr>
<tr><th>SERVLET:</th><td>jaxrs</td></tr>
</table>

</body>
</html>
$ curl -H "Authorization: " https://ozoene.example.com/no-such-bucket
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 Internal Server Error</title>
</head>
<body><h2>HTTP ERROR 500 Internal Server Error</h2>
<table>
<tr><th>URI:</th><td>/no-such-bucket</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>Internal Server Error</td></tr>
<tr><th>SERVLET:</th><td>jaxrs</td></tr>
</table>

</body>
</html>
[kuenishi@nausicaa ozone-master]$ curl https://ozone.example.com/no-such-bucket
<html>
<head>
<meta http-equiv="Content-Type" content="text/html;charset=utf-8"/>
<title>Error 500 Internal Server Error</title>
</head>
<body><h2>HTTP ERROR 500 Internal Server Error</h2>
<table>
<tr><th>URI:</th><td>/no-such-bucket</td></tr>
<tr><th>STATUS:</th><td>500</td></tr>
<tr><th>MESSAGE:</th><td>Internal Server Error</td></tr>
<tr><th>SERVLET:</th><td>jaxrs</td></tr>
</table>

</body>
</html>
```

## What is the link to the Apache JIRA

HDDS-6204

## How was this patch tested?

- Unit test added
- Manual tests with IntelliJ
- Production environment
