### PR TITLE
HDDS-6203. CleanUp incomplete gz files during Container move

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -163,8 +163,14 @@ public class GrpcReplicationClient implements AutoCloseable{
       } catch (IOException e) {
         LOG.error("Failed to write the stream buffer to {} for container {}",
             outputPath, containerId, e);
-        deleteOutputOnFailure();
-        response.completeExceptionally(e);
+        try {
+          stream.close();
+        } catch (IOException ex) {
+          LOG.error("Failed to close OutputStream {}", outputPath, e);
+        } finally {
+          deleteOutputOnFailure();
+          response.completeExceptionally(e);
+        }
       }
     }
 
@@ -179,6 +185,7 @@ public class GrpcReplicationClient implements AutoCloseable{
       } catch (IOException e) {
         LOG.error("Failed to close {} for container {}",
             outputPath, containerId, e);
+        deleteOutputOnFailure();
         response.completeExceptionally(e);
       }
     }
@@ -192,9 +199,9 @@ public class GrpcReplicationClient implements AutoCloseable{
       } catch (IOException e) {
         LOG.error("Downloaded container {} OK, but failed to close {}",
             containerId, outputPath, e);
+        deleteOutputOnFailure();
         response.completeExceptionally(e);
       }
-
     }
 
     private void deleteOutputOnFailure() {
@@ -207,5 +214,4 @@ public class GrpcReplicationClient implements AutoCloseable{
       }
     }
   }
-
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -161,6 +161,9 @@ public class GrpcReplicationClient implements AutoCloseable{
       try {
         chunk.getData().writeTo(stream);
       } catch (IOException e) {
+        LOG.error("Failed to write the stream buffer to {} for container {}",
+            outputPath, containerId, e);
+        deleteOutputOnFailure();
         response.completeExceptionally(e);
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?
If the target temporary directory is small, the concurrent downloading threads will have a contest for space and leave incomplete files. These should be cleaned up.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6203

## How was this patch tested?
manual tests
