### PR TITLE
HDDS-6206. Application errors must not flood system log

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -130,7 +130,7 @@ public final class S3ErrorTable {
     OS3Exception err =  new OS3Exception(e.getCode(), e.getErrorMessage(),
         e.getHttpCode());
     err.setResource(resource);
-    LOG.error(err.toXml(), e);
+    LOG.debug(err.toXml(), e);
     return err;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -26,7 +26,7 @@ import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_PRECON_FAILED;
 import static java.net.HttpURLConnection.HTTP_NOT_IMPLEMENTED;
-import static java.net.HttpURLConnection.HTTP_SERVER_ERROR;
+import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.RANGE_NOT_SATISFIABLE;
 
 /**
@@ -106,7 +106,7 @@ public final class S3ErrorTable {
 
   public static final OS3Exception INTERNAL_ERROR = new OS3Exception(
       "InternalError", "We encountered an internal error. Please try again.",
-      HTTP_SERVER_ERROR);
+      HTTP_INTERNAL_ERROR);
 
   public static final OS3Exception ACCESS_DENIED = new OS3Exception(
       "AccessDenied", "User doesn't have the right to access this " +
@@ -130,7 +130,11 @@ public final class S3ErrorTable {
     OS3Exception err =  new OS3Exception(e.getCode(), e.getErrorMessage(),
         e.getHttpCode());
     err.setResource(resource);
-    LOG.debug(err.toXml(), e);
+    if (e.getHttpCode() == HTTP_INTERNAL_ERROR) {
+      LOG.error("Internal Error: {}", err.toXml(), e);
+    } else {
+      LOG.debug(err.toXml(), e);
+    }
     return err;
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -132,7 +132,7 @@ public final class S3ErrorTable {
     err.setResource(resource);
     if (e.getHttpCode() == HTTP_INTERNAL_ERROR) {
       LOG.error("Internal Error: {}", err.toXml(), e);
-    } else {
+    } else if (LOG.isDebugEnabled()) {
       LOG.debug(err.toXml(), e);
     }
     return err;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Frequent errors such as NoSuchBucket or NoSuchKey must not be written as errors, while they are. They should be in audit logs in principle, because the system is not wrong, not knowing how to handle them. Otherwise, we may miss important errors like NullPointerException that does not appear in healthy system. To make sure that we can keep eyes on system health than access by applications, errors that stem from applications must not be printed in normal log files.

Update: Internal Errors should be written as ERROR to system log. So, the log in S3ErrorTable will be:

- if it's internal error, it's unexpected, then write as ERROR.
- otherwise, it's known error in S3 API specification, then write as DEBUG.

For auditing purpose, I files another issue as [HDDS-6207](https://issues.apache.org/jira/browse/HDDS-6207).

## What is the link to the Apache JIRA

HDDS-6206

## How was this patch tested?

Unit tests by CI
