### PR TITLE
HDDS-6200. Provide OM#getSupportedBucketLayout RPC call for BucketLayout upgrade finalization.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
@@ -772,6 +773,13 @@ public interface ClientProtocol {
    * Clears the S3 Authentication information attached to the thread.
    */
   void clearTheadLocalS3Auth();
+
+  /**
+   * Get supported Bucket Layouts based on OM's upgrade state.
+   *
+   * @return Supported Bucket Layouts.
+   */
+  List<BucketLayout> getSupportedBucketLayouts() throws IOException;
 
   /**
    * Sets the owner of bucket.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -104,6 +104,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.om.protocolPB.OmTransport;
@@ -1582,6 +1583,11 @@ public class RpcClient implements ClientProtocol {
   @Override
   public void clearTheadLocalS3Auth() {
     ozoneManagerClient.clearThreadLocalS3Auth();
+  }
+
+  @Override
+  public List<BucketLayout> getSupportedBucketLayouts() throws IOException {
+    return ozoneManagerClient.getSupportedBucketLayouts();
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -263,6 +263,7 @@ public final class OmUtils {
     case ListMultipartUploads:
     case FinalizeUpgradeProgress:
     case PrepareStatus:
+    case GetSupportedBucketLayouts:
       return true;
     case CreateVolume:
     case SetVolumeProperty:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OzoneAclInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse;
@@ -698,6 +699,17 @@ public interface OzoneManagerProtocol
    */
   List<RepeatedOmKeyInfo> listTrash(String volumeName, String bucketName,
       String startKeyName, String keyPrefix, int maxKeys) throws IOException;
+
+  /**
+   * Get supported Bucket Layouts based on upgrade state.
+   * Before finalization, the method returns an empty list. This leads to the
+   * new client's OzoneClientAdapter and CreateBucketHandler receiving an empty
+   * list - which causes them to continue with LEGACY layout.
+   * After finalization, the method returns a list with the new layouts.
+   *
+   * @return Supported Bucket Layouts.
+   */
+  List<BucketLayout> getSupportedBucketLayouts() throws IOException;
 
   /**
    * Recover trash allows the user to recover keys that were marked as deleted,

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -19,9 +19,7 @@ package org.apache.hadoop.ozone.om.protocolPB;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
@@ -56,6 +54,7 @@ import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AddAclResponse;
@@ -1706,5 +1705,34 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
   public void setS3AuthCheck(boolean s3AuthCheck) {
     this.s3AuthCheck = s3AuthCheck;
+  }
+
+  /**
+   * Returns a list of supported bucket layouts based on the upgrade state.
+   *
+   * @return list of supported bucket layouts
+   * @throws IOException
+   */
+  @Override
+  public List<BucketLayout> getSupportedBucketLayouts() throws IOException {
+    GetSupportedBucketLayoutsRequest getSupportedBucketLayoutsRequest =
+        GetSupportedBucketLayoutsRequest.newBuilder().build();
+
+    OMRequest omRequest = createOMRequest(
+        Type.GetSupportedBucketLayouts).setGetSupportedBucketLayoutsRequest(
+        getSupportedBucketLayoutsRequest).build();
+
+    GetSupportedBucketLayoutsResponse getSupportedBucketLayoutsResponse =
+        handleError(
+            submitRequest(omRequest)).getGetSupportedBucketLayoutsResponse();
+
+    List<BucketLayout> supportedLayouts = new ArrayList<>();
+
+    getSupportedBucketLayoutsResponse
+        .getSupportedBucketLayoutsList().forEach(
+            (BucketLayoutProto bucketLayoutProto) -> supportedLayouts.add(
+                BucketLayout.fromProto(bucketLayoutProto)));
+
+    return supportedLayouts;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.ozone.om.protocolPB;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSUpgrade.java
@@ -78,6 +78,10 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.om.upgrade.OMUpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.BasicUpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.InjectedUpgradeFinalizationExecutor;
 import org.apache.hadoop.ozone.upgrade.InjectedUpgradeFinalizationExecutor.UpgradeTestInjectionPoints;
@@ -481,6 +485,46 @@ public class TestHDDSUpgrade {
     store.getVolume("vol1").getBucket("buc1").createKey("key1", 100,
         ReplicationType.RATIS, ReplicationFactor.THREE, new HashMap<>());
 
+  }
+
+  /**
+   * The {@code OzoneManager.getSupportedBucketLayouts()} method should return
+   * an empty list when the OM is in pre-finalize state.
+   * When the upgrade is finalized, the OM should return the list of supported
+   * bucket layouts.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testSupportedBucketLayoutsDuringUpgrade() throws Exception {
+    OzoneManager ozoneManager = cluster.getOzoneManager();
+    OMLayoutVersionManager versionManager = ozoneManager.getVersionManager();
+
+    // Transition into pre-finalization state.
+    versionManager.setUpgradeState(FINALIZATION_REQUIRED);
+
+    // Supported Bucket Layouts list should be empty in pre-finalization state.
+    Assert.assertEquals(0, ozoneManager.getSupportedBucketLayouts().size());
+
+    // finalize the upgrade.
+    versionManager.setUpgradeState(STARTING_FINALIZATION);
+    OMUpgradeFinalizer finalizer = new OMUpgradeFinalizer(versionManager);
+    finalizer.finalize(ozoneManager.getOMNodeId(), ozoneManager);
+
+    // Wait for the upgrade to finalize.
+    GenericTestUtils.waitFor(
+        () -> versionManager.getUpgradeState() != FINALIZATION_DONE, 100,
+        20000);
+
+    // Get the list of supported bucket layouts from OM.
+    List<BucketLayout> supportedLayouts =
+        ozoneManager.getSupportedBucketLayouts();
+
+    // After finalization, OM should support OBS and FSO bucket layouts.
+    Assert.assertEquals(2, supportedLayouts.size());
+    Assert.assertTrue(supportedLayouts.contains(BucketLayout.OBJECT_STORE));
+    Assert.assertTrue(
+        supportedLayouts.contains(BucketLayout.FILE_SYSTEM_OPTIMIZED));
   }
 
   /*

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientSupportedBucketLayouts.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientSupportedBucketLayouts.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.client.rpc;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
+import org.apache.hadoop.ozone.om.upgrade.OMUpgradeFinalizer;
+import org.apache.ozone.test.GenericTestUtils;
+import org.junit.*;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.*;
+
+/**
+ * Client RPC test to validate supported bucket layouts during upgrades.
+ */
+public class TestOzoneClientSupportedBucketLayouts {
+  /**
+   * Set a timeout for each test.
+   */
+  @Rule
+  public Timeout timeout = Timeout.seconds(30);
+
+  private static MiniOzoneCluster cluster;
+  private static OzoneConfiguration conf = new OzoneConfiguration();
+  private static OzoneClient client;
+
+  /**
+   * Create a MiniOzoneCluster for testing.
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    OzoneClientConfig config = new OzoneClientConfig();
+    conf.setFromObject(config);
+
+    cluster = MiniOzoneCluster.newBuilder(conf).build();
+    cluster.waitForClusterToBeReady();
+    //the easiest way to create an open container is creating a key
+    client = OzoneClientFactory.getRpcClient(conf);
+  }
+
+  /**
+   * Shutdown MiniOzoneCluster.
+   */
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * The OM should return an empty list supported layouts when it is in
+   * pre-finalize state.
+   * When the upgrade is finalized, the OM should return the list of supported
+   * bucket layouts.
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testSupportedBucketLayoutsDuringUpgrade() throws Exception {
+    OzoneManager ozoneManager = cluster.getOzoneManager();
+    OMLayoutVersionManager versionManager = ozoneManager.getVersionManager();
+
+    // Transition into pre-finalization state.
+    versionManager.setUpgradeState(FINALIZATION_REQUIRED);
+
+    ClientProtocol proxy = client.getObjectStore().getClientProxy();
+
+    // Supported Bucket Layouts list should be empty in pre-finalization state.
+    Assert.assertEquals(0, proxy.getSupportedBucketLayouts().size());
+
+    // finalize the upgrade.
+    versionManager.setUpgradeState(STARTING_FINALIZATION);
+    OMUpgradeFinalizer finalizer = new OMUpgradeFinalizer(versionManager);
+    finalizer.finalize(ozoneManager.getOMNodeId(), ozoneManager);
+
+    // Wait for the upgrade to finalize.
+    GenericTestUtils.waitFor(
+        () -> versionManager.getUpgradeState() != FINALIZATION_DONE, 100,
+        20000);
+
+    // Get the list of supported bucket layouts from OM.
+    List<BucketLayout> supportedLayouts =
+        ozoneManager.getSupportedBucketLayouts();
+
+    // After finalization, OM should support OBS and FSO bucket layouts.
+    Assert.assertEquals(2, supportedLayouts.size());
+    Assert.assertTrue(supportedLayouts.contains(BucketLayout.OBJECT_STORE));
+    Assert.assertTrue(
+        supportedLayouts.contains(BucketLayout.FILE_SYSTEM_OPTIMIZED));
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientSupportedBucketLayouts.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneClientSupportedBucketLayouts.java
@@ -28,13 +28,19 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.apache.hadoop.ozone.om.upgrade.OMUpgradeFinalizer;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.*;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.Rule;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.*;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_REQUIRED;
+import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.STARTING_FINALIZATION;
 
 /**
  * Client RPC test to validate supported bucket layouts during upgrades.

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -102,6 +102,8 @@ enum Type {
   RevokeS3Secret = 93;
 
   PurgePaths = 94;
+
+  GetSupportedBucketLayouts = 95;
 }
 
 message OMRequest {
@@ -186,6 +188,8 @@ message OMRequest {
   optional PurgePathsRequest                purgePathsRequest              = 94;
 
   optional S3Authentication                 s3Authentication               = 95;
+
+  optional GetSupportedBucketLayoutsRequest getSupportedBucketLayoutsRequest = 96;
 }
 
 message OMResponse {
@@ -262,6 +266,8 @@ message OMResponse {
   optional ListTrashResponse                  listTrashResponse            = 91;
   optional RecoverTrashResponse               RecoverTrashResponse         = 92;
   optional PurgePathsResponse                 purgePathsResponse           = 93;
+
+  optional GetSupportedBucketLayoutsResponse  getSupportedBucketLayoutsResponse = 94;
 }
 
 enum Status {
@@ -1356,6 +1362,14 @@ message S3Authentication {
     optional string stringToSign = 1;
     optional string signature = 2;
     optional string accessId = 3;
+}
+
+message GetSupportedBucketLayoutsRequest {
+
+}
+
+message GetSupportedBucketLayoutsResponse {
+    repeated BucketLayoutProto supportedBucketLayouts = 1;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3900,4 +3900,25 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private BucketLayout getBucketLayout() {
     return BucketLayout.DEFAULT;
   }
+
+  /**
+   * Get supported Bucket Layouts based on upgrade state.
+   * Before finalization, the method returns an empty list. This leads to the
+   * new client's OzoneClientAdapter and CreateBucketHandler receiving an empty
+   * list - which causes them to continue with LEGACY layout.
+   * After finalization, the method returns a list with the new layouts.
+   * @return Supported Bucket Layouts.
+   */
+  public List<BucketLayout> getSupportedBucketLayouts() {
+    // Check if we are in Pre-Finalize upgrade state.
+    if (versionManager.getUpgradeState() ==
+        UpgradeFinalizer.Status.FINALIZATION_REQUIRED) {
+      // We only allow LEGACY buckets to be created in Pre-Finalized state.
+      return Collections.emptyList();
+    }
+
+    // We are out of pre-finalize state, we can use the new layouts.
+    return Arrays.asList(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        BucketLayout.OBJECT_STORE);
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3907,6 +3907,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * new client's OzoneClientAdapter and CreateBucketHandler receiving an empty
    * list - which causes them to continue with LEGACY layout.
    * After finalization, the method returns a list with the new layouts.
+   *
    * @return Supported Bucket Layouts.
    */
   public List<BucketLayout> getSupportedBucketLayouts() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The idea here is to add OM#getSupportedLayouts() RPC call to get the bucket layout values. 
Before finalization OM#getSupportedLayouts() RPC call should return empty values. Now, the new client's OzoneClientAdapter and CreateBucketHandler would get an empty [] list then continue with the existing older version behavior.
After finalization OM#getSupportedLayouts() RPC call will have values FSO/OBS and the client will have the new behavior.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6200

## How was this patch tested?

Added related Integration Test.
