### PR TITLE
HDDS-6201. Fix NPE for DataScanner with scanned container deleted by others.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/ContainerController.java
@@ -112,7 +112,12 @@ public class ContainerController {
   public void markContainerUnhealthy(final long containerId)
           throws IOException {
     Container container = containerSet.getContainer(containerId);
-    getHandler(container).markContainerUnhealthy(container);
+    if (container != null) {
+      getHandler(container).markContainerUnhealthy(container);
+    } else {
+      LOG.warn("Container {} not found, may be deleted, skip mark UNHEALTHY",
+          containerId);
+    }
   }
 
   /**
@@ -206,7 +211,12 @@ public class ContainerController {
   void updateDataScanTimestamp(long containerId, Instant timestamp)
       throws IOException {
     Container container = containerSet.getContainer(containerId);
-    container.updateDataScanTimestamp(timestamp);
+    if (container != null) {
+      container.updateDataScanTimestamp(timestamp);
+    } else {
+      LOG.warn("Container {} not found, may be deleted, " +
+          "skip update DataScanTimestamp", containerId);
+    }
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix NPE for DataScanner with scanned container deleted by others.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6201

## How was this patch tested?

CI: https://github.com/guihecheng/ozone/actions/runs/1717838258
The problem and fix should be obvious by reading the error log on the JIRA.