### PR TITLE
HDDS-6211. [Docs] Image styling on deployed site does not replicate local builds.

### DIFF
--- a/hadoop-hdds/docs/themes/ozonedoc/layouts/shortcodes/image.html
+++ b/hadoop-hdds/docs/themes/ozonedoc/layouts/shortcodes/image.html
@@ -16,4 +16,4 @@
 -->
 
 <!-- shortcode to easily scale images according to page width-->
-<img src='{{ .Get "src" }}' style="max-width:100%"/>
+<img src='{{ .Get "src" }}' class="img-responsive"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

It was noticed that the images on the ozone docs website are not responsive despite being rendered with the appropriate CSS applied to their shortcode. This problem is not seen when building the website locally.

This might be due to bootstrap CSS classes being loaded after the inline styles and hence overriding them.

This task makes the image shortcode use a built-in bootstrap class for sizing the images down to prevent such conflicts.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6211

## How was this patch tested?

Screenshot

<img width="500" alt="Screenshot 2022-01-21 at 8 25 01 PM" src="https://user-images.githubusercontent.com/33001894/150548495-a9811b65-d531-4872-9bc1-66daac2b7bb9.png">

