### PR TITLE
HDDS-6131: EC: Replication config from bucket should be refreshed in o3fs

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -472,6 +472,13 @@ public final class OzoneConfigKeys {
   // The protocol starts at 2.0.0 and a null or empty value for older versions.
   public static final String OZONE_OM_CLIENT_PROTOCOL_VERSION = "2.0.0";
 
+  public static final String
+      OZONE_CLIENT_BUCKET_REPLICATION_CONFIG_REFRESH_PERIOD_MS =
+      "ozone.client.bucket.replication.config.refresh.time.ms";
+  public static final long
+      OZONE_CLIENT_BUCKET_REPLICATION_CONFIG_REFRESH_PERIOD_DEFAULT_MS =
+      300 * 1000;
+
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1180,6 +1180,18 @@
   </property>
 
   <property>
+    <name>ozone.client.bucket.replication.config.refresh.time.ms</name>
+    <value>30000</value>
+    <tag>OZONE</tag>
+    <description>
+      Default time period to refresh the bucket replication config in o3fs
+      clients. Until the bucket replication config refreshed, client will
+      continue to use existing replication config irrespective of whether bucket
+      replication config updated at OM or not.
+    </description>
+  </property>
+
+  <property>
     <name>hdds.container.close.threshold</name>
     <value>0.9f</value>
     <tag>OZONE, DATANODE</tag>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2557,10 +2557,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       metrics.incNumBucketInfos();
       final OmBucketInfo bucketInfo =
           bucketManager.getBucketInfo(volume, bucket);
-      if (bucketInfo != null && bucketInfo
-          .getDefaultReplicationConfig() == null) {
-        bucketInfo.setDefaultReplicationConfig(getDefaultReplicationConfig());
-      }
       return bucketInfo;
     } catch (Exception ex) {
       metrics.incNumBucketInfoFails();

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -99,7 +99,7 @@ public class BasicRootedOzoneClientAdapterImpl
   private OzoneClient ozoneClient;
   private ObjectStore objectStore;
   private ClientProtocol proxy;
-  private ReplicationConfig replicationConfig;
+  private ReplicationConfig clientConfiguredReplicationConfig;
   private boolean securityEnabled;
   private int configuredDnPort;
   private BucketLayout defaultOFSBucketLayout;
@@ -169,7 +169,7 @@ public class BasicRootedOzoneClientAdapterImpl
         this.securityEnabled = true;
       }
 
-      replicationConfig =
+      clientConfiguredReplicationConfig =
           OzoneClientUtils.getClientConfiguredReplicationConfig(conf);
 
       if (OmUtils.isOmHAServiceId(conf, omHost)) {
@@ -289,13 +289,13 @@ public class BasicRootedOzoneClientAdapterImpl
 
   @Override
   public short getDefaultReplication() {
-    if (replicationConfig == null) {
+    if (clientConfiguredReplicationConfig == null) {
       // to provide backward compatibility, we are just retuning 3;
       // However we need to handle with the correct behavior.
       // TODO: Please see HDDS-5646
       return (short) ReplicationFactor.THREE.getValue();
     }
-    return (short) replicationConfig.getRequiredNodes();
+    return (short) clientConfiguredReplicationConfig.getRequiredNodes();
   }
 
   @Override
@@ -340,8 +340,8 @@ public class BasicRootedOzoneClientAdapterImpl
       OzoneBucket bucket = getBucket(ofsPath, recursive);
       OzoneOutputStream ozoneOutputStream = bucket.createFile(key, 0,
           OzoneClientUtils.resolveClientSideReplicationConfig(replication,
-              this.replicationConfig, bucket.getReplicationConfig(), config),
-          overWrite, recursive);
+              this.clientConfiguredReplicationConfig,
+              bucket.getReplicationConfig(), config), overWrite, recursive);
       return new OzoneFSOutputStream(ozoneOutputStream.getOutputStream());
     } catch (OMException ex) {
       if (ex.getResult() == OMException.ResultCodes.FILE_ALREADY_EXISTS

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneClientAdapterImpl.java
@@ -287,6 +287,11 @@ public class BasicRootedOzoneClientAdapterImpl
     return bucket;
   }
 
+  /**
+   * This API returns the value what is configured at client side only. It could
+   * differ from the server side default values. If no replication config
+   * configured at client, it will return 3.
+   */
   @Override
   public short getDefaultReplication() {
     if (clientConfiguredReplicationConfig == null) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -17,6 +17,11 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
@@ -25,6 +30,9 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import java.io.IOException;
 import java.util.Set;
 
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS;
 
 /**
@@ -63,5 +71,66 @@ public final class OzoneClientUtils {
       }
     }
     return bucket.getBucketLayout();
+  }
+
+  /**
+   * This API used to resolve the client side configuration preference for file
+   * system layer implementations.
+   *
+   * @param replication                - replication value passed from FS API.
+   * @param clientConfiguredReplConfig - Client side configured replication
+   *                                   config.
+   * @param bucketReplConfig           - server side bucket default replication
+   *                                  config.
+   * @param config                     - Ozone configuration object.
+   * @return client resolved replication config.
+   */
+  public static ReplicationConfig resolveClientSideReplicationConfig(
+      short replication, ReplicationConfig clientConfiguredReplConfig,
+      ReplicationConfig bucketReplConfig, OzoneConfiguration config) {
+    ReplicationConfig clientDeterminedReplConfig = null;
+
+    boolean isECBucket = bucketReplConfig != null && bucketReplConfig
+        .getReplicationType() == HddsProtos.ReplicationType.EC;
+
+    // if bucket replication config configured with EC, we will give high
+    // preference to server side bucket defaults.
+    // Why we give high prefernce to EC is, there is no way for file system
+    // interfaces to pass EC replication. So, if one configures EC at bucket,
+    // we consider EC to take preference. in short, keys created from file
+    // system under EC bucket will always be EC'd.
+    if (isECBucket) {
+      // if bucket is EC, don't bother client provided configs, let's pass
+      // bucket config.
+      clientDeterminedReplConfig = bucketReplConfig;
+    } else {
+      if (clientConfiguredReplConfig != null) {
+        // Uses the replication(short value) passed from file system API and
+        // construct replication config object.
+        // In case if client explicitely configured EC in configurations, we
+        // always take EC as priority as EC replication can't be expressed in
+        // filesystem API.
+        clientDeterminedReplConfig = ReplicationConfig
+            .adjustReplication(clientConfiguredReplConfig, replication, config);
+      } else {
+        // In file system layers, replication parameter always passed.
+        // so, to respect the API provided replication value, we take RATIS as
+        // default type.
+        clientDeterminedReplConfig = ReplicationConfig
+            .parse(ReplicationType.RATIS, Short.toString(replication), config);
+      }
+    }
+    return clientDeterminedReplConfig;
+  }
+
+  static ReplicationConfig getClientConfiguredReplicationConfig(
+      ConfigurationSource config) {
+    String replication = config.get(OZONE_REPLICATION);
+    if (replication == null) {
+      return null;
+    }
+    return ReplicationConfig.parse(ReplicationType.valueOf(
+        config.get(OZONE_REPLICATION_TYPE, OZONE_REPLICATION_TYPE_DEFAULT)),
+        replication, config);
   }
 }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.fs.ozone;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests the behavior of OzoneClientUtils APIs.
+ */
+public class TestOzoneClientUtils {
+  private ReplicationConfig ecReplicationConfig =
+      new ECReplicationConfig("rs-3-2-1024K");
+  private ReplicationConfig ratis3ReplicationConfig =
+      new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE);
+  private ReplicationConfig ratis1ReplicationConfig =
+      new RatisReplicationConfig(HddsProtos.ReplicationFactor.ONE);
+
+  @Test
+  public void testResolveClientSideRepConfigWhenBucketHasEC() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) 3, null,
+            ecReplicationConfig, new OzoneConfiguration());
+    // Bucket default is EC.
+    Assert.assertEquals(ecReplicationConfig, replicationConfig);
+  }
+
+  /**
+   * When bucket replication is null and it should respect fs passed value.
+   */
+  @Test
+  public void testResolveClientSideRepConfigWhenBucketHasNull() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) 3, null, null,
+            new OzoneConfiguration());
+    // Passed replication is 3 - Ozone mapped replication is ratis THREE
+    Assert.assertEquals(ratis3ReplicationConfig, replicationConfig);
+  }
+
+  /**
+   * When bucket replication is null and it should return null if fs passed
+   * value is invalid.
+   */
+  @Test
+  public void testResolveClientSideRepConfigWhenFSPassedReplicationIsInvalid() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) -1, null, null,
+            new OzoneConfiguration());
+    // client configured value also null.
+    // This API caller should leave the decision to server.
+    Assert.assertNull(replicationConfig);
+  }
+
+  /**
+   * When bucket default is non-EC and client side values are not valid, we
+   * would just return null, so servers can make decision in this case.
+   */
+  @Test
+  public void testResolveRepConfWhenFSPassedIsInvalidButBucketDefaultNonEC() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) -1, null, ratis3ReplicationConfig,
+            new OzoneConfiguration());
+    // Configured client config also null.
+    Assert.assertNull(replicationConfig);
+  }
+
+  /**
+   * When bucket default is non-EC and client side value is valid, we
+   * would should return client side valid value.
+   */
+  @Test
+  public void testResolveRepConfWhenFSPassedIsValidButBucketDefaultNonEC() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) 1, null, ratis3ReplicationConfig,
+            new OzoneConfiguration());
+    // Passed value is replication one - Ozone mapped value is ratis ONE
+    Assert.assertEquals(ratis1ReplicationConfig, replicationConfig);
+  }
+
+  /**
+   * When bucket default is EC and client side value also valid, we would just
+   * return bucket default EC.
+   */
+  @Test
+  public void testResolveRepConfWhenFSPassedIsValidButBucketDefaultEC() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) 3, ratis3ReplicationConfig,
+            ecReplicationConfig, new OzoneConfiguration());
+    // Bucket default is EC
+    Assert.assertEquals(ecReplicationConfig, replicationConfig);
+  }
+
+  /**
+   * When bucket default is non-EC and client side passed value also not valid
+   * but configured value is valid, we would just return configured value.
+   */
+  @Test
+  public void testResolveRepConfWhenFSPassedIsInvalidAndBucketDefaultNonEC() {
+    ReplicationConfig replicationConfig = OzoneClientUtils
+        .resolveClientSideReplicationConfig(
+            (short) -1, ratis3ReplicationConfig, ratis1ReplicationConfig,
+            new OzoneConfiguration());
+    // Configured value is ratis THREE
+    Assert.assertEquals(ratis3ReplicationConfig, replicationConfig);
+  }
+}


### PR DESCRIPTION

## What changes were proposed in this pull request?

Client side we are giving bucket defaults preference in case if bucket has non ec configs. 
In other cases, we will determine the client side configs either from configured value or API passed value.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6131

## How was this patch tested?

Running existing test and will add tests
