### PR TITLE
HDDS-6226. Run tests for selective CI checks in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -125,6 +125,12 @@ jobs:
     steps:
       - name: Checkout project
         uses: actions/checkout@v2
+        if: matrix.check != 'bats'
+      - name: Checkout project with history
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+        if: matrix.check == 'bats'
       - name: Cache for maven dependencies
         uses: actions/cache@v2
         with:

--- a/hadoop-ozone/dev-support/checks/bats.sh
+++ b/hadoop-ozone/dev-support/checks/bats.sh
@@ -21,13 +21,19 @@ source "${DIR}/_lib.sh"
 
 install_bats
 
+git clone https://github.com/bats-core/bats-assert dev-support/ci/bats-assert
+git clone https://github.com/bats-core/bats-support dev-support/ci/bats-support
+
 REPORT_DIR=${OUTPUT_DIR:-"${DIR}/../../../target/bats"}
 mkdir -p "${REPORT_DIR}"
 REPORT_FILE="${REPORT_DIR}/summary.txt"
 
 rm -f "${REPORT_DIR}/output.log"
 
-find * -path '*/src/test/shell/*' -name '*.bats' -print0 \
+find * \( \
+    -path '*/src/test/shell/*' -name '*.bats' \
+    -or -path dev-support/ci/selective_ci_checks.bats \
+    \) -print0 \
   | xargs -0 -n1 bats --formatter tap \
   | tee -a "${REPORT_DIR}/output.log"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Selective CI checks has a test suite, but currently it needs to be run manually.  This PR adds it to the _bats_ check in CI.

The test verifies the list of selective checks triggered for some known commits.  Thus we need to checkout the repo with full history for the _bats_ check.

https://issues.apache.org/jira/browse/HDDS-6226

## How was this patch tested?

Verified that _bats_ check includes the test for selective checks script:

```
1..16
ok 1 checkstyle and bats
ok 2 compose only
ok 3 compose and robot
ok 4 check script
ok 5 integration only
ok 6 kubernetes only
ok 7 docs only
ok 8 java-only change
ok 9 java and compose change
ok 10 java and docs change
ok 11 pom change
ok 12 CI lib change
ok 13 CI workflow change
ok 14 root README
ok 15 ignored code
ok 16 other README
```

https://github.com/adoroszlai/hadoop-ozone/runs/4951581169#step:5:14