### PR TITLE
HDDS-6233. EC: Bucket does not display correct EC replication details

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -842,7 +842,8 @@ public class RpcClient implements ClientProtocol {
         bucket.getQuotaInBytes(),
         bucket.getQuotaInNamespace(),
         bucket.getBucketLayout(),
-        bucket.getOwner()))
+        bucket.getOwner(),
+        bucket.getDefaultReplicationConfig()))
         .collect(Collectors.toList());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

After creating a bucket using the shell:

ozone sh bucket create /vol1/testec -t EC -r rs-3-2-1024k 

And then listing the bucket info, the EC Replication details are not reflected in the output:

```
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "testec",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-01-27T17:29:54.289Z",
  "modificationTime" : "2022-01-27T17:29:54.289Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "hadoop",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  },
  "link" : false
} 
```

The issue is caused by a missing parameter into the new BucketObject from getBucketDetails vs ListBuckets. After this change the CLI works correctly:

```
bash-4.2$ ozone sh volume create /vol1
bash-4.2$ ozone sh bucket create -r rs-3-2-1024k -t EC /vol1/bucket1
bash-4.2$ ozone sh bucket list /vol1
[ {
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-01-27T22:09:21.194Z",
  "modificationTime" : "2022-01-27T22:09:21.194Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "hadoop",
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "requiredNodes" : 5,
    "replicationType" : "EC"
  },
  "link" : false
} ]

```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6233

## How was this patch tested?

Manually via docker compose, but a acceptance test will be added via HDDS-6231
