### PR TITLE
HDDS-2919. Remove intermittent TestRDBStore#testRocksDBKeyMayExistApi

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStore.java
@@ -288,42 +288,6 @@ public class TestRDBStore {
     }
   }
 
-  /**
-   * Not strictly a unit test. Just a confirmation of the expected behavior
-   * of RocksDB keyMayExist API.
-   * Expected behavior - On average, keyMayExist latency < key.get() latency
-   * for invalid keys.
-   * @throws Exception if unable to read from RocksDB.
-   */
-  @Test
-  public void testRocksDBKeyMayExistApi() throws Exception {
-    try (RDBStore newStore =
-             new RDBStore(folder.newFolder(), options, configSet)) {
-      RocksDB db = newStore.getDb();
-
-      //Test with 50 invalid keys.
-      long start = System.nanoTime();
-      for (int i = 0; i < 50; i++) {
-        Assert.assertTrue(db.get(
-            org.apache.commons.codec.binary.StringUtils
-                .getBytesUtf16("key" + i)) == null);
-      }
-      long end = System.nanoTime();
-      long keyGetLatency = end - start;
-
-      start = System.nanoTime();
-      for (int i = 0; i < 50; i++) {
-        Assert.assertFalse(db.keyMayExist(
-            org.apache.commons.codec.binary.StringUtils
-                .getBytesUtf16("key" + i), null));
-      }
-      end = System.nanoTime();
-      long keyMayExistLatency = end - start;
-
-      Assert.assertTrue(keyMayExistLatency < keyGetLatency);
-    }
-  }
-
   @Test
   public void testGetDBUpdatesSince() throws Exception {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove intermittent `testRocksDBKeyMayExistApi`, which was an "integration" test checking if RocksDB `keyMayExist` call is cheaper than `get` call for the same key.

There are several problems with it:

* No warmup, so order matters. (Adding warmup reduces time of both calls.)
* Same key names are used for both `get` and `keyMayExist` calls, the result of get might be cached at RocksDB level. (This should help `keyMayExist` due to current order. Reordering the loops indicates that `keyMayExist` takes longer than `get`.)
* Too few measurements, no check of whether the difference is statistically significant.
* Tests a completely empty database (does not match real life usage)
* Measured time includes `getBytesUtf16` calls, not only the RocksDB call being tested.

A real JMH-based microbenchmark would be better for that purpose.

https://issues.apache.org/jira/browse/HDDS-2919

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1768566838