### PR TITLE
HDDS-6239. ozonesecure-mr failing with No URLs in mirrorlist

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -27,6 +27,9 @@ export SECURITY_ENABLED=true
 
 start_docker_env
 
+execute_command_in_container rm sudo bash -c "sed -i -e 's/^mirrorlist/#&/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo"
+execute_command_in_container rm sudo yum install -y krb5-workstation
+
 execute_robot_test om kinit.robot
 
 execute_robot_test om createmrenv.robot
@@ -37,7 +40,6 @@ export OZONE_DIR=/opt/ozone
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-execute_command_in_container rm sudo yum install -y krb5-workstation
 execute_robot_test rm kinit-hadoop.robot
 
 for scheme in o3fs ofs; do


### PR DESCRIPTION
## What changes were proposed in this pull request?

CentOS 8 is EOL, package repository moved to vault.centos.org on Jan/31.  `ozonesecure-mr` test needs to install the `krb5-workstation` package.  This is a quick and dirty workaround to update repository config to access the new location.  (Base image needs to be updated in the long run.)

https://issues.apache.org/jira/browse/HDDS-6239

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/5018254007#step:5:660