### PR TITLE
HDDS-6240. EC: Container Info command with json switch fails for EC containers

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerInfo.java
@@ -154,10 +154,12 @@ public class ContainerInfo implements Comparator<ContainerInfo>,
     return replicationConfig;
   }
 
+  @JsonIgnore
   public HddsProtos.ReplicationType getReplicationType() {
     return replicationConfig.getReplicationType();
   }
 
+  @JsonIgnore
   public HddsProtos.ReplicationFactor getReplicationFactor() {
     return ReplicationConfig.getLegacyFactor(replicationConfig);
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The replication config, which includes type and factor is already present in the Json output. The getters for ContainerInfo:

```
getReplicationType()
getReplicationFactor()
```
Therefore do not need to be displayed in the JSON output, as they duplicate the replication config information.

Additionally, EC containers do not have a "factor" which causes an error when the JSON is displayed:

```
bash-4.2$ ozone admin container info --json 4      
Replication configuration of type EC does not have a replication factor property. (through reference chain: org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline["containerInfo"]->org.apache.hadoop.hdds.scm.container.ContainerInfo["replicationFactor"])
```

This change simply removes the two getters from the JSON output.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6240

## How was this patch tested?

Existing test - no logic changed.
