### PR TITLE
HDDS-6252. Datanode Chunk Validator fails on encountering EC pipeline

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -345,19 +346,24 @@ public class BaseFreonGenerator {
     return HAUtils.getScmContainerClient(ozoneConf);
   }
 
+  @SuppressWarnings("java:S3864") // Stream.peek (for debug)
   public static Pipeline findPipelineForTest(String pipelineId,
       StorageContainerLocationProtocol client, Logger log) throws IOException {
-    List<Pipeline> pipelines = client.listPipelines();
+    Stream<Pipeline> pipelines = client.listPipelines().stream();
     Pipeline pipeline;
+    if (log.isDebugEnabled()) {
+      pipelines = pipelines
+          .peek(p -> log.debug("Found pipeline {}", p.getId().getId()));
+    }
     if (pipelineId != null && pipelineId.length() > 0) {
-      pipeline = pipelines.stream()
+      pipeline = pipelines
           .filter(p -> p.getId().toString().equals(pipelineId))
           .findFirst()
           .orElseThrow(() -> new IllegalArgumentException(
               "Pipeline ID is defined, but there is no such pipeline: "
                   + pipelineId));
     } else {
-      pipeline = pipelines.stream()
+      pipeline = pipelines
           .filter(p -> p.getReplicationConfig().getRequiredNodes() == 3)
           .findFirst()
           .orElseThrow(() -> new IllegalArgumentException(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -21,12 +21,10 @@ import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -109,9 +107,7 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
 
       } else {
         pipeline = pipelines
-            .filter(
-                p -> ReplicationConfig.getLegacyFactor(p.getReplicationConfig())
-                    == HddsProtos.ReplicationFactor.THREE)
+              .filter(p -> p.getReplicationConfig().getRequiredNodes() == 3)
               .findFirst()
               .orElseThrow(() -> new IllegalArgumentException(
                       "Pipeline ID is NOT defined, and no pipeline " +

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/DatanodeChunkValidator.java
@@ -87,9 +87,9 @@ public class DatanodeChunkValidator extends BaseFreonGenerator
       );
     }
 
-    try (StorageContainerLocationProtocol scmLocationClient =
+    try (StorageContainerLocationProtocol scmClient =
                  createStorageContainerLocationClient(ozoneConf)) {
-      Pipeline pipeline = findPipelineForTest(pipelineId, scmLocationClient, LOG);
+      Pipeline pipeline = findPipelineForTest(pipelineId, scmClient, LOG);
 
       try (XceiverClientManager xceiverClientManager =
                    new XceiverClientManager(ozoneConf)) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid unnecessarily using `getLegacyFactory`, to make Datanode Chunk Validator work even if there are EC pipelines in the cluster.

https://issues.apache.org/jira/browse/HDDS-6252

## How was this patch tested?

```
$ ozone sh volume create /vol1

# create an EC pipeline
$ ozone sh bucket create --replication rs-3-2-1024k --type EC /vol1/becket
$ ozone sh key put /vol1/becket/passwd /etc/passwd

# test DCG/DCV
$ echo log4j.logger.org.apache.hadoop.ozone.freon=DEBUG >> /etc/hadoop/log4j.properties
$ ozone freon dcg -t1 -n100 -p dcg
...
$ ozone freon dcv -t1 -n100 -p dcg
...
[main] DEBUG freon.DatanodeChunkValidator: Found pipeline PipelineID=47a983b3-6b22-4330-9406-75601aeba8e1
...
[main] INFO freon.DatanodeChunkValidator: Using pipeline PipelineID=28f4f444-a174-4607-8e9e-060339a8801b
...
Successful executions: 100

# check ID of EC pipeline (compare to output of dcv)
$ ozone admin pipeline list | grep 'ReplicationConfig: EC'
Pipeline[ Id: 47a983b3-6b22-4330-9406-75601aeba8e1, ...
```

CI (with no EC pipeline yet) still OK:
https://github.com/adoroszlai/hadoop-ozone/runs/5042702809#step:5:669