### PR TITLE
HDDS-6253. Unnecessary duplicate smoketest after defaulting to FSO

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -53,12 +53,6 @@ execute_robot_test scm admincli
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-fso-ofs-link ozonefs/ozonefs.robot
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-fso-o3fs-bucket ozonefs/ozonefs.robot
 
-execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket}-fso-layout-objectputget s3/objectputget.robot
-execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket}-fso-layout-objectdelete s3/objectdelete.robot
-execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket}-fso-layout-objectcopy s3/objectcopy.robot
-execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket}-fso-layout-objectmultidelete s3/objectmultidelete.robot
-execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket}-fso-layout-MultipartUpload s3/MultipartUpload.robot
-
 stop_docker_env
 
 generate_report


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-6041 changed `ozone` docker-compose environment to use FSO by default.  Some of the FSO-specific test statements were left over, so now they are run twice with the same config.

https://issues.apache.org/jira/browse/HDDS-6253

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/5042337481