### PR TITLE
HDDS-6255. EC: Replication Manager should skip EC Containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -477,6 +477,13 @@ public class ReplicationManager implements SCMService {
           }
         }
 
+        if (container.getReplicationType() == HddsProtos.ReplicationType.EC) {
+          // TODO We do not support replicating EC containers as yet, so at this
+          //      point, after handing the closing etc states, we just return.
+          //      EC Support will be added later.
+          return;
+        }
+
         /*
          * Before processing the container we have to reconcile the
          * inflightReplication and inflightDeletion actions.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Until we get replication and recovery working for EC, we need to tell Replication Manager to ignore EC containers.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6255

## How was this patch tested?

No new tests. This is a simple temporary change which will be removed later when the EC recovery work starts.
