### PR TITLE
HDDS-6247. Avoid logging stack trace for user input problems

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -291,12 +291,7 @@ public class BucketEndpoint extends EndpointBase {
   @HEAD
   public Response head(@PathParam("bucket") String bucketName)
       throws OS3Exception, IOException {
-    try {
-      getBucket(bucketName);
-    } catch (OS3Exception ex) {
-      LOG.error("Exception occurred in headBucket", ex);
-      throw ex;
-    }
+    getBucket(bucketName);
     return Response.ok().build();
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -241,12 +241,12 @@ public class BucketEndpoint extends EndpointBase {
       return Response.status(HttpStatus.SC_OK).header("Location", location)
           .build();
     } catch (OMException exception) {
-      LOG.error("Error in Create Bucket Request for bucket: {}", bucketName,
-          exception);
       if (exception.getResult() == ResultCodes.INVALID_BUCKET_NAME) {
         throw S3ErrorTable.newError(S3ErrorTable.INVALID_BUCKET_NAME,
             bucketName);
       }
+      LOG.error("Error in Create Bucket Request for bucket: {}", bucketName,
+          exception);
       throw exception;
     }
   }
@@ -507,8 +507,6 @@ public class BucketEndpoint extends EndpointBase {
         volume.addAcl(acl);
       }
     } catch (OMException exception) {
-      LOG.error("Error in set ACL Request for bucket: {}", bucketName,
-          exception);
       if (exception.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET,
             bucketName);
@@ -516,6 +514,8 @@ public class BucketEndpoint extends EndpointBase {
         throw S3ErrorTable.newError(S3ErrorTable
             .ACCESS_DENIED, bucketName);
       }
+      LOG.error("Error in set ACL Request for bucket: {}", bucketName,
+          exception);
       throw exception;
     }
     return Response.status(HttpStatus.SC_OK).build();

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -208,23 +208,20 @@ public class ObjectEndpoint extends EndpointBase {
 
       return Response.ok().status(HttpStatus.SC_OK)
           .build();
-    } catch (IOException ex) {
-      LOG.error("Exception occurred in PutObject", ex);
-      if (ex instanceof  OMException) {
-        if (((OMException) ex).getResult() == ResultCodes.NOT_A_FILE) {
-          OS3Exception os3Exception = S3ErrorTable.newError(INVALID_REQUEST,
-              keyPath);
-          os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
-              "when calling the PutObject/MPU PartUpload operation: " +
-              OZONE_OM_ENABLE_FILESYSTEM_PATHS + " is enabled Keys are" +
-              " considered as Unix Paths. Path has Violated FS Semantics " +
-              "which caused put operation to fail.");
-          throw os3Exception;
-        } else if ((((OMException) ex).getResult() ==
-            ResultCodes.PERMISSION_DENIED)) {
-          throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
-        }
+    } catch (OMException ex) {
+      if (ex.getResult() == ResultCodes.NOT_A_FILE) {
+        OS3Exception os3Exception = S3ErrorTable.newError(INVALID_REQUEST,
+            keyPath);
+        os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
+            "when calling the PutObject/MPU PartUpload operation: " +
+            OZONE_OM_ENABLE_FILESYSTEM_PATHS + " is enabled Keys are" +
+            " considered as Unix Paths. Path has Violated FS Semantics " +
+            "which caused put operation to fail.");
+        throw os3Exception;
+      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
       }
+      LOG.error("Exception occurred in PutObject", ex);
       throw ex;
     } finally {
       if (output != null) {
@@ -497,11 +494,11 @@ public class ObjectEndpoint extends EndpointBase {
       return Response.status(Status.OK).entity(
           multipartUploadInitiateResponse).build();
     } catch (OMException ex) {
-      LOG.error("Error in Initiate Multipart Upload Request for bucket: {}, " +
-          "key: {}", bucket, key, ex);
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
         throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, key);
       }
+      LOG.error("Error in Initiate Multipart Upload Request for bucket: {}, " +
+          "key: {}", bucket, key, ex);
       throw ex;
     }
   }
@@ -544,8 +541,6 @@ public class ObjectEndpoint extends EndpointBase {
       return Response.status(Status.OK).entity(completeMultipartUploadResponse)
           .build();
     } catch (OMException ex) {
-      LOG.error("Error in Complete Multipart Upload Request for bucket: {}, " +
-          ", key: {}", bucket, key, ex);
       if (ex.getResult() == ResultCodes.INVALID_PART) {
         throw S3ErrorTable.newError(S3ErrorTable.INVALID_PART, key);
       } else if (ex.getResult() == ResultCodes.INVALID_PART_ORDER) {
@@ -569,6 +564,8 @@ public class ObjectEndpoint extends EndpointBase {
             "given KeyName caused failure for MPU");
         throw os3Exception;
       }
+      LOG.error("Error in Complete Multipart Upload Request for bucket: {}, " +
+          ", key: {}", bucket, key, ex);
       throw ex;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up for HDDS-6206: avoid logging exception as error when they are known cases (e.g. invalid bucket name, checking existence (`head`) of non-existing bucket, permission denied, etc.).

https://issues.apache.org/jira/browse/HDDS-6247

## How was this patch tested?

Ran S3 acceptance tests before and after the change.  Verified S3 Gateway logs no longer have verbose stack trace for these requests.  We can still see request problems by setting log level to DEBUG, e.g.:

```
s3g_1       | 2022-02-03 12:54:57,459 [qtp690052870-16] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>InvalidBucketName</Code>
s3g_1       |   <Message>The specified bucket is not valid.</Message>
s3g_1       |   <Resource>a_b_c</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
...
s3g_1       | 2022-02-03 12:59:56,517 [qtp690052870-20] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>NoSuchBucket</Code>
s3g_1       |   <Message>The specified bucket does not exist</Message>
s3g_1       |   <Resource>dont-exist</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1787777620