### PR TITLE
HDDS-6250. EC: Add replica index to the output in the container info command

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaInfo.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplicaInfo.java
@@ -34,6 +34,7 @@ public final class ContainerReplicaInfo {
   private long sequenceId;
   private long keyCount;
   private long bytesUsed;
+  private int replicaIndex = -1;
 
   public static ContainerReplicaInfo fromProto(
       HddsProtos.SCMContainerReplicaProto proto) {
@@ -45,7 +46,9 @@ public final class ContainerReplicaInfo {
         .setPlaceOfBirth(UUID.fromString(proto.getPlaceOfBirth()))
         .setSequenceId(proto.getSequenceID())
         .setKeyCount(proto.getKeyCount())
-        .setBytesUsed(proto.getBytesUsed());
+        .setBytesUsed(proto.getBytesUsed())
+        .setReplicaIndex(
+            proto.hasReplicaIndex() ? (int)proto.getReplicaIndex() : -1);
     return builder.build();
   }
 
@@ -78,6 +81,10 @@ public final class ContainerReplicaInfo {
 
   public long getBytesUsed() {
     return bytesUsed;
+  }
+
+  public int getReplicaIndex() {
+    return replicaIndex;
   }
 
   /**
@@ -119,6 +126,11 @@ public final class ContainerReplicaInfo {
 
     public Builder setBytesUsed(long bytesUsed) {
       subject.bytesUsed = bytesUsed;
+      return this;
+    }
+
+    public Builder setReplicaIndex(int replicaIndex) {
+      subject.replicaIndex = replicaIndex;
       return this;
     }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplicaInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplicaInfo.java
@@ -55,5 +55,36 @@ public class TestContainerReplicaInfo {
         proto.getDatanodeDetails()), info.getDatanodeDetails());
     Assert.assertEquals(proto.getSequenceID(), info.getSequenceId());
     Assert.assertEquals(proto.getState(), info.getState());
+    // If replicaIndex is not in the proto, then -1 should be returned
+    Assert.assertEquals(-1, info.getReplicaIndex());
+  }
+
+  @Test
+  public void testObjectCreatedFromProtoWithReplicaIndedx() {
+    HddsProtos.SCMContainerReplicaProto proto =
+        HddsProtos.SCMContainerReplicaProto.newBuilder()
+            .setKeyCount(10)
+            .setBytesUsed(12345)
+            .setContainerID(567)
+            .setPlaceOfBirth(UUID.randomUUID().toString())
+            .setSequenceID(5)
+            .setDatanodeDetails(MockDatanodeDetails.randomDatanodeDetails()
+                .getProtoBufMessage())
+            .setState("OPEN")
+            .setReplicaIndex(4)
+            .build();
+
+    ContainerReplicaInfo info = ContainerReplicaInfo.fromProto(proto);
+
+    Assert.assertEquals(proto.getContainerID(), info.getContainerID());
+    Assert.assertEquals(proto.getBytesUsed(), info.getBytesUsed());
+    Assert.assertEquals(proto.getKeyCount(), info.getKeyCount());
+    Assert.assertEquals(proto.getPlaceOfBirth(),
+        info.getPlaceOfBirth().toString());
+    Assert.assertEquals(DatanodeDetails.getFromProtoBuf(
+        proto.getDatanodeDetails()), info.getDatanodeDetails());
+    Assert.assertEquals(proto.getSequenceID(), info.getSequenceId());
+    Assert.assertEquals(proto.getState(), info.getState());
+    Assert.assertEquals(4, info.getReplicaIndex());
   }
 }

--- a/hadoop-hdds/interface-client/src/main/proto/hdds.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/hdds.proto
@@ -406,6 +406,7 @@ message SCMContainerReplicaProto {
     required int64 sequenceID = 5;
     required int64 keyCount = 6;
     required int64 bytesUsed = 7;
+    optional int64 replicaIndex = 8;
 }
 
 message KeyContainerIDList {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -29,7 +29,6 @@ import com.google.protobuf.ProtocolMessageEnum;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -258,8 +258,7 @@ public class SCMClientProtocolServer implements
 
     if (pipeline == null) {
       pipeline = scm.getPipelineManager().createPipeline(
-          new StandaloneReplicationConfig(ReplicationConfig
-              .getLegacyFactor(container.getReplicationConfig())),
+          container.getReplicationConfig(),
           scm.getContainerManager()
               .getContainerReplicas(cid).stream()
               .map(ContainerReplica::getDatanodeDetails)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -306,7 +306,8 @@ public class SCMClientProtocolServer implements
               .setBytesUsed(r.getBytesUsed())
               .setPlaceOfBirth(r.getOriginDatanodeId().toString())
               .setKeyCount(r.getKeyCount())
-              .setSequenceID(r.getSequenceId()).build()
+              .setSequenceID(r.getSequenceId())
+              .setReplicaIndex(r.getReplicaIndex()).build()
       );
     }
     return results;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -119,6 +119,9 @@ public class InfoSubcommand extends ScmSubcommand {
   private static String buildReplicaDetails(ContainerReplicaInfo replica) {
     StringBuilder sb = new StringBuilder();
     sb.append("State: " + replica.getState() + ";");
+    if (replica.getReplicaIndex() != -1) {
+      sb.append(" ReplicaIndex: " + replica.getReplicaIndex() + ";");
+    }
     sb.append(" Origin: " + replica.getPlaceOfBirth().toString() + ";");
     sb.append(" Location: "
         + buildDatanodeDetails(replica.getDatanodeDetails()));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -206,10 +206,11 @@ public class TestInfoSubCommand {
   }
 
 
-    private List<ContainerReplicaInfo> getReplicas(boolean includeIndex) {
+  private List<ContainerReplicaInfo> getReplicas(boolean includeIndex) {
     List<ContainerReplicaInfo> replicas = new ArrayList<>();
     for (DatanodeDetails dn : datanodes) {
-      ContainerReplicaInfo.Builder container =  new ContainerReplicaInfo.Builder()
+      ContainerReplicaInfo.Builder container
+          = new ContainerReplicaInfo.Builder()
           .setContainerID(1)
           .setBytesUsed(1234)
           .setState("CLOSED")


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-6177](https://issues.apache.org/jira/browse/HDDS-6177) added replica details to the container info command on the master branch. On the EC branch, we need to extend it to add the new replica index field.

The new output includes the replica index in both Json and the human readable format, eg:

```
bash-4.2$ ozone admin container info 2
Container id: 2
Pipeline id: 8a62f588-0fff-497d-9589-aa14ef43c86b
Container State: QUASI_CLOSED
Datanodes: [aef6aa64-1251-4707-aaaa-141c9d03b6b1/ozone_datanode_2.ozone_default,
9b650b01-a361-471a-98a8-2aa4daff5fee/ozone_datanode_5.ozone_default,
d4d57905-08c8-4f4f-8a5f-cf04b066b82c/ozone_datanode_3.ozone_default]
Replicas: [State: QUASI_CLOSED; ReplicaIndex: 5; Origin: aef6aa64-1251-4707-aaaa-141c9d03b6b1; Location: aef6aa64-1251-4707-aaaa-141c9d03b6b1/ozone_datanode_2.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 4; Origin: 9b650b01-a361-471a-98a8-2aa4daff5fee; Location: 9b650b01-a361-471a-98a8-2aa4daff5fee/ozone_datanode_5.ozone_default,
State: QUASI_CLOSED; ReplicaIndex: 1; Origin: d4d57905-08c8-4f4f-8a5f-cf04b066b82c; Location: d4d57905-08c8-4f4f-8a5f-cf04b066b82c/ozone_datanode_3.ozone_default]
```

Note the "ReplicaIndex" field in the Replicas output. This is the newly added field.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6250

## How was this patch tested?

New unit tests and manual testing in docker compose
