### PR TITLE
HDDS-6262. ozone insight log stops working after OM DBUpdates message

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/protocolPB/OMPBHelper.java
@@ -24,14 +24,12 @@ import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .BucketEncryptionInfoProto;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CipherSuiteProto;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .CryptoProtocolVersionProto;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
-    .FileEncryptionInfoProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.BucketEncryptionInfoProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CipherSuiteProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CryptoProtocolVersionProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.FileEncryptionInfoProto;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.security.OzoneTokenIdentifier;
 import org.apache.hadoop.ozone.security.proto.SecurityProtos.TokenProto;
 import org.apache.hadoop.security.token.Token;
@@ -40,6 +38,9 @@ import org.apache.hadoop.security.token.Token;
  * Utilities for converting protobuf classes.
  */
 public final class OMPBHelper {
+
+  public static final ByteString REDACTED =
+      ByteString.copyFromUtf8("<redacted>");
 
   private OMPBHelper() {
     /** Hidden constructor */
@@ -192,4 +193,24 @@ public final class OMPBHelper {
   }
 
 
+  public static OMRequest processForDebug(OMRequest msg) {
+    return msg;
+  }
+
+  public static OMResponse processForDebug(OMResponse msg) {
+    if (msg == null) {
+      return null;
+    }
+
+    if (msg.hasDbUpdatesResponse()) {
+      OMResponse.Builder builder = msg.toBuilder();
+
+      builder.getDbUpdatesResponseBuilder()
+          .clearData().addData(REDACTED);
+
+      return builder.build();
+    }
+
+    return msg;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -109,7 +109,7 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
     }
     this.omRatisServer = ratisServer;
     dispatcher = new OzoneProtocolMessageDispatcher<>("OzoneProtocol",
-        metrics, LOG);
+        metrics, LOG, OMPBHelper::processForDebug, OMPBHelper::processForDebug);
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similar to HDDS-4271, we need to filter some binary data in OM proto messages.

https://issues.apache.org/jira/browse/HDDS-6262

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone
$ ./run.sh -d
$ sleep 60
$ docker-compose exec scm ozone freon ockg -n1 -t1 -F ONE
$ docker-compose exec scm ozone insight logs -v om.protocol.client

...

[OM] ... [type=DBUpdates] request is processed. Response:
cmdType: DBUpdates
traceID: ""
success: true
status: OK
dbUpdatesResponse {
  sequenceNumber: 18446744073709551615
  data: "<redacted>"
}
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1796465657