### PR TITLE
HDDS-6268. Include audit log in acceptance test bundle

### DIFF
--- a/hadoop-ozone/dev-support/checks/acceptance.sh
+++ b/hadoop-ozone/dev-support/checks/acceptance.sh
@@ -41,6 +41,7 @@ export OZONE_ACCEPTANCE_SUITE
 cd "$DIST_DIR/compose" || exit 1
 ./test-all.sh 2>&1 | tee "${REPORT_DIR}/output.log"
 RES=$?
-cp result/* "$REPORT_DIR/"
+cp -rv result/* "$REPORT_DIR/"
 cp "$REPORT_DIR/log.html" "$REPORT_DIR/summary.html"
+find "$REPORT_DIR" -type f -empty -print0 | xargs -0 rm -v
 exit $RES

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -214,7 +214,7 @@ execute_robot_test(){
 copy_daemon_logs() {
   local c f
   for c in $(docker-compose ps | grep "^${COMPOSE_ENV_NAME}_" | awk '{print $1}'); do
-    for f in $(docker exec "${c}" ls -1 /var/log/hadoop | grep -F '.out'); do
+    for f in $(docker exec "${c}" ls -1 /var/log/hadoop 2> /dev/null | grep -F -e '.out' -e audit); do
       docker cp "${c}:/var/log/hadoop/${f}" "$RESULT_DIR/"
     done
   done
@@ -320,13 +320,12 @@ copy_results() {
   local result_dir="${test_dir}/result"
   local test_dir_name=$(basename ${test_dir})
   if [[ -n "$(find "${result_dir}" -name "*.xml")" ]]; then
-    rebot --nostatusrc -N "${test_dir_name}" -l NONE -r NONE -o "${all_result_dir}/${test_dir_name}.xml" "${result_dir}/*.xml"
+    rebot --nostatusrc -N "${test_dir_name}" -l NONE -r NONE -o "${all_result_dir}/${test_dir_name}.xml" "${result_dir}"/*.xml
+    rm -fv "${result_dir}"/*.xml "${result_dir}"/log.html "${result_dir}"/report.html
   fi
 
-  cp "${result_dir}"/docker-*.log "${all_result_dir}"/
-  if [[ -n "$(find "${result_dir}" -name "*.out")" ]]; then
-    cp "${result_dir}"/*.out* "${all_result_dir}"/
-  fi
+  mkdir -p "${all_result_dir}"/"${test_dir_name}"
+  mv -v "${result_dir}"/* "${all_result_dir}"/"${test_dir_name}"/
 }
 
 run_test_script() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Include audit log files in acceptance test bundle, except empty ones.  For better usability, logs for each environment, including docker logs, are moved to a subdirectory.

https://issues.apache.org/jira/browse/HDDS-6268

## How was this patch tested?

Checked contents of bundles created in CI run:

```
$ unzip -t acceptance-HA.zip
Archive:  acceptance-HA.zip
    testing: jacoco-combined.exec     OK
    testing: log.html                 OK
    testing: output.log               OK
    testing: ozone-ha.xml             OK
    testing: ozone-ha/                OK
    testing: ozonesecure-ha.xml       OK
    testing: ozonesecure-ha/          OK
    testing: report.html              OK
    testing: summary.html             OK
    testing: ozone-ha/docker-ozone-ha-ozone-ha-ozone-shell-single-scm1.log   OK
    testing: ozone-ha/om-audit-om1.log   OK
    testing: ozone-ha/om-audit-om2.log   OK
    testing: ozone-ha/om-audit-om3.log   OK
    testing: ozone-ha/scm-audit-02679c0383b6.log   OK
    testing: ozone-ha/scm-audit-6c7d5a367ba5.log   OK
    testing: ozone-ha/scm-audit-d86efb259536.log   OK
    testing: ozonesecure-ha/dn-audit-15c235b05e53.log   OK
    testing: ozonesecure-ha/dn-audit-82ba3fde5593.log   OK
    testing: ozonesecure-ha/dn-audit-b492ccc66e0a.log   OK
    testing: ozonesecure-ha/docker-ozonesecure-ha-ozonesecure-ha-kinit-scm1.org.log   OK
    testing: ozonesecure-ha/om-audit-om1.log   OK
    testing: ozonesecure-ha/om-audit-om2.log   OK
    testing: ozonesecure-ha/om-audit-om3.log   OK
    testing: ozonesecure-ha/scm-audit-scm1.org.log   OK
    testing: ozonesecure-ha/scm-audit-scm2.org.log   OK
    testing: ozonesecure-ha/scm-audit-scm3.org.log   OK
No errors detected in compressed data of acceptance-HA.zip.

$ unzip -t acceptance-misc.zip
Archive:  acceptance-misc.zip
    testing: compatibility.xml        OK
    testing: compatibility/           OK
    testing: jacoco-combined.exec     OK
    testing: log.html                 OK
    testing: output.log               OK
    testing: ozone-csi.xml            OK
    testing: ozone-csi/               OK
    testing: ozone-om-prepare.xml     OK
    testing: ozone-om-prepare/        OK
    testing: ozone-topology.xml       OK
    testing: ozone-topology/          OK
    testing: ozones3-haproxy.xml      OK
    testing: ozones3-haproxy/         OK
    testing: ozonescripts.xml         OK
    testing: ozonescripts/            OK
    testing: report.html              OK
    testing: restart.xml              OK
    testing: restart/                 OK
    testing: summary.html             OK
    testing: upgrade.xml              OK
    testing: upgrade/                 OK
    testing: xcompat.xml              OK
    testing: xcompat/                 OK
    testing: compatibility/docker-compatibility-compatibility-dn-datanode.log   OK
    testing: compatibility/scm-audit-9b3f71a935d6.log   OK
    testing: ozone-csi/docker-ozone-csi-ozone-csi-csi-csi.log   OK
    testing: ozone-csi/scm-audit-6a81b600d081.log   OK
    testing: ozone-om-prepare/docker-ozone-om-prepare-ozone-om-prepare-om-prepare-scm.log   OK
    testing: ozone-om-prepare/om-audit-1dedecd3b46c.log   OK
    testing: ozone-om-prepare/om-audit-4d7ea5550ba6.log   OK
    testing: ozone-om-prepare/om-audit-798b2a608ea9.log   OK
    testing: ozone-om-prepare/om-audit-7d7a33d7d085.log   OK
    testing: ozone-om-prepare/om-audit-bff81d3547be.log   OK
    testing: ozone-om-prepare/om-audit-f128eba33f7a.log   OK
    testing: ozone-om-prepare/scm-audit-61d7a3b72327.log   OK
    testing: ozone-om-prepare/scm-audit-9a16a4305f12.log   OK
    testing: ozone-om-prepare/scm-audit-e310f86203f2.log   OK
    testing: ozone-topology/docker-ozone-topology-ozone-topology-basic-scm.log   OK
    testing: ozone-topology/om-audit-b4b80a35973d.log   OK
    testing: ozone-topology/scm-audit-7ed3015c6034.log   OK
    testing: ozones3-haproxy/docker-ozones3-haproxy-ozones3-haproxy-basic-scm.log   OK
    testing: ozones3-haproxy/om-audit-9e95dc66574b.log   OK
    testing: ozones3-haproxy/scm-audit-ea9a63db05d6.log   OK
    testing: ozonescripts/docker-ozonescripts-ozonescripts-pipeline-scm.log   OK
    testing: restart/docker-restart-restart-generate-scm.log   OK
    testing: restart/om-audit-2684be950710.log   OK
    testing: restart/om-audit-b17d347b6587.log   OK
    testing: restart/scm-audit-57ad6128c73f.log   OK
    testing: restart/scm-audit-84f489e7e134.log   OK
    testing: upgrade/1.1.0-1.2.0/     OK
    testing: upgrade/1.1.0-1.2.0/docker-1.1.0-downgraded.log   OK
    testing: upgrade/1.1.0-1.2.0/docker-1.1.0.log   OK
    testing: upgrade/1.1.0-1.2.0/docker-1.2.0-finalized.log   OK
    testing: upgrade/1.1.0-1.2.0/docker-1.2.0-pre-finalized.log   OK
    testing: xcompat/docker-xcompat-xcompat-write-new_client.log   OK
    testing: xcompat/om-audit-9ea51e38f258.log   OK
    testing: xcompat/om-audit-dab94608db5e.log   OK
    testing: xcompat/scm-audit-344f02808cb3.log   OK
    testing: xcompat/scm-audit-82c88036f020.log   OK
No errors detected in compressed data of acceptance-misc.zip.

$ unzip -t acceptance-MR.zip
Archive:  acceptance-MR.zip
    testing: jacoco-combined.exec     OK
    testing: log.html                 OK
    testing: output.log               OK
    testing: ozone-mr.xml             OK
    testing: ozone-mr/                OK
    testing: ozonesecure-mr.xml       OK
    testing: ozonesecure-mr/          OK
    testing: report.html              OK
    testing: summary.html             OK
    testing: ozone-mr/hadoop27/       OK
    testing: ozone-mr/hadoop31/       OK
    testing: ozone-mr/hadoop32/       OK
    testing: ozone-mr/hadoop33/       OK
    testing: ozone-mr/hadoop27/docker-hadoop27-hadoop27-createmrenv-scm.log   OK
    testing: ozone-mr/hadoop27/om-audit-om.log   OK
    testing: ozone-mr/hadoop27/scm-audit-scm.log   OK
    testing: ozone-mr/hadoop31/docker-hadoop31-hadoop31-createmrenv-scm.log   OK
    testing: ozone-mr/hadoop31/om-audit-om.log   OK
    testing: ozone-mr/hadoop31/scm-audit-scm.log   OK
    testing: ozone-mr/hadoop32/docker-hadoop32-hadoop32-createmrenv-scm.log   OK
    testing: ozone-mr/hadoop32/om-audit-om.log   OK
    testing: ozone-mr/hadoop32/scm-audit-scm.log   OK
    testing: ozone-mr/hadoop33/docker-hadoop33-hadoop33-createmrenv-scm.log   OK
    testing: ozone-mr/hadoop33/om-audit-om.log   OK
    testing: ozone-mr/hadoop33/scm-audit-scm.log   OK
    testing: ozonesecure-mr/docker-ozonesecure-mr-ozonesecure-mr-kinit-om.log   OK
    testing: ozonesecure-mr/om-audit-om.log   OK
    testing: ozonesecure-mr/scm-audit-scm.log   OK
No errors detected in compressed data of acceptance-MR.zip.
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/1800526379