### PR TITLE
HDDS-6188: EC: Adapt java side native coder classes from hadoop.

### DIFF
--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/CodecRegistry.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/CodecRegistry.java
@@ -20,6 +20,8 @@ package org.apache.ozone.erasurecode;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureCoderFactory;
+import org.apache.ozone.erasurecode.rawcoder.NativeRSRawErasureCoderFactory;
+import org.apache.ozone.erasurecode.rawcoder.NativeXORRawErasureCoderFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +89,12 @@ public final class CodecRegistry {
           }
         }
         if (!hasConflit) {
-          coders.add(coderFactory);
+          if (coderFactory instanceof NativeRSRawErasureCoderFactory
+              || coderFactory instanceof NativeXORRawErasureCoderFactory) {
+            coders.add(0, coderFactory);
+          } else {
+            coders.add(coderFactory);
+          }
           LOG.debug("Codec registered: codec = {}, coder = {}",
               coderFactory.getCodecName(), coderFactory.getCoderName());
         }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
@@ -106,4 +106,8 @@ abstract class AbstractNativeRawDecoder extends RawErasureDecoder {
   public boolean preferDirectBuffer() {
     return true;
   }
+
+  protected ReentrantReadWriteLock getDecoderLock() {
+    return decoderLock;
+  }
 }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/AbstractNativeRawDecoder.java
@@ -31,13 +31,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Abstract native raw decoder for all native coders to extend with.
  */
 @InterfaceAudience.Private
+@SuppressWarnings("checkstyle:VisibilityModifier")
 abstract class AbstractNativeRawDecoder extends RawErasureDecoder {
   public static final Logger LOG =
       LoggerFactory.getLogger(AbstractNativeRawDecoder.class);
 
   // Protect ISA-L coder data structure in native layer from being accessed and
   // updated concurrently by the init, release and decode functions.
-  private final ReentrantReadWriteLock decoderLock =
+  protected final ReentrantReadWriteLock decoderLock =
       new ReentrantReadWriteLock();
 
   // To link with the underlying data structure in the native layer.
@@ -105,9 +106,5 @@ abstract class AbstractNativeRawDecoder extends RawErasureDecoder {
   @Override
   public boolean preferDirectBuffer() {
     return true;
-  }
-
-  protected ReentrantReadWriteLock getDecoderLock() {
-    return decoderLock;
   }
 }

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ErasureCodeNative.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/ErasureCodeNative.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Erasure code native libraries (for now, Intel ISA-L) related utilities.
+ *
+ * Note: This class should be modified to check native ozone libs loaded once
+ * ozone native libs started to include native erasure coded bits. For now, we
+ * will just depend on libhadoop lib to check whether native erasure coded libs
+ * available.
+ */
+public final class ErasureCodeNative {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(ErasureCodeNative.class.getName());
+
+  /**
+   * The reason why ISA-L library is not available, or null if it is available.
+   */
+  private static final String LOADING_FAILURE_REASON;
+
+  static {
+    if (!NativeCodeLoader.isNativeCodeLoaded()) {
+      LOADING_FAILURE_REASON = "hadoop native library cannot be loaded.";
+    } else if (!NativeCodeLoader.buildSupportsIsal()) {
+      LOADING_FAILURE_REASON = "libhadoop was built without ISA-L support";
+    } else {
+      String problem = null;
+      try {
+        loadLibrary();
+      } catch (Throwable t) {
+        problem = "Loading ISA-L failed: " + t.getMessage();
+        LOG.warn(problem);
+      }
+      LOADING_FAILURE_REASON = problem;
+    }
+
+    if (LOADING_FAILURE_REASON != null) {
+      LOG.warn("ISA-L support is not available in your platform... " +
+            "using builtin-java codec where applicable");
+    }
+  }
+
+  private ErasureCodeNative() {
+  }
+
+  /**
+   * Are native libraries loaded?
+   */
+  public static boolean isNativeCodeLoaded() {
+    return LOADING_FAILURE_REASON == null;
+  }
+
+  /**
+   * Is the native ISA-L library loaded and initialized? Throw exception if not.
+   */
+  public static void checkNativeCodeLoaded() {
+    if (LOADING_FAILURE_REASON != null) {
+      throw new RuntimeException(LOADING_FAILURE_REASON);
+    }
+  }
+
+  /**
+   * Load native library available or supported.
+   */
+  public static native void loadLibrary();
+
+  /**
+   * Get the native library name that's available or supported.
+   */
+  public static native String getLibraryName();
+
+  public static String getLoadingFailureReason() {
+    return LOADING_FAILURE_REASON;
+  }
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawDecoder.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A Reed-Solomon raw decoder using Intel ISA-L library.
+ */
+@InterfaceAudience.Private
+public class NativeRSRawDecoder extends AbstractNativeRawDecoder {
+
+  static {
+    ErasureCodeNative.checkNativeCodeLoaded();
+  }
+
+  public NativeRSRawDecoder(ECReplicationConfig ecReplicationConfig) {
+    super(ecReplicationConfig);
+    getDecoderLock().writeLock().lock();
+    try {
+      initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
+    } finally {
+      getDecoderLock().writeLock().unlock();
+    }
+  }
+
+  @Override
+  protected void performDecodeImpl(
+      ByteBuffer[] inputs, int[] inputOffsets, int dataLen, int[] erased,
+      ByteBuffer[] outputs, int[] outputOffsets) throws IOException {
+    decodeImpl(inputs, inputOffsets, dataLen, erased, outputs, outputOffsets);
+  }
+
+  @Override
+  public void release() {
+    getDecoderLock().writeLock().lock();
+    try {
+      destroyImpl();
+    } finally {
+      getDecoderLock().writeLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean preferDirectBuffer() {
+    return true;
+  }
+
+  private native void initImpl(int numDataUnits, int numParityUnits);
+
+  private native void decodeImpl(
+          ByteBuffer[] inputs, int[] inputOffsets, int dataLen, int[] erased,
+          ByteBuffer[] outputs, int[] outputOffsets) throws IOException;
+
+  private native void destroyImpl();
+
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawDecoder.java
@@ -35,11 +35,11 @@ public class NativeRSRawDecoder extends AbstractNativeRawDecoder {
 
   public NativeRSRawDecoder(ECReplicationConfig ecReplicationConfig) {
     super(ecReplicationConfig);
-    getDecoderLock().writeLock().lock();
+    decoderLock.writeLock().lock();
     try {
       initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
     } finally {
-      getDecoderLock().writeLock().unlock();
+      decoderLock.writeLock().unlock();
     }
   }
 
@@ -52,11 +52,11 @@ public class NativeRSRawDecoder extends AbstractNativeRawDecoder {
 
   @Override
   public void release() {
-    getDecoderLock().writeLock().lock();
+    decoderLock.writeLock().lock();
     try {
       destroyImpl();
     } finally {
-      getDecoderLock().writeLock().unlock();
+      decoderLock.writeLock().unlock();
     }
   }
 

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawEncoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawEncoder.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A Reed-Solomon raw encoder using Intel ISA-L library.
+ */
+@InterfaceAudience.Private
+public class NativeRSRawEncoder extends AbstractNativeRawEncoder {
+
+  static {
+    ErasureCodeNative.checkNativeCodeLoaded();
+  }
+
+  public NativeRSRawEncoder(ECReplicationConfig ecReplicationConfig) {
+    super(ecReplicationConfig);
+    encoderLock.writeLock().lock();
+    try {
+      initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
+    } finally {
+      encoderLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  protected void performEncodeImpl(
+          ByteBuffer[] inputs, int[] inputOffsets, int dataLen,
+          ByteBuffer[] outputs, int[] outputOffsets) throws IOException {
+    encodeImpl(inputs, inputOffsets, dataLen, outputs, outputOffsets);
+  }
+
+  @Override
+  public void release() {
+    encoderLock.writeLock().lock();
+    try {
+      destroyImpl();
+    } finally {
+      encoderLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean preferDirectBuffer() {
+    return true;
+  }
+
+  private native void initImpl(int numDataUnits, int numParityUnits);
+
+  private native void encodeImpl(ByteBuffer[] inputs, int[] inputOffsets,
+                                 int dataLen, ByteBuffer[] outputs,
+                                 int[] outputOffsets) throws IOException;
+
+  private native void destroyImpl();
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawErasureCoderFactory.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeRSRawErasureCoderFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+/**
+ * A raw coder factory for raw Reed-Solomon coder in native using Intel ISA-L.
+ */
+@InterfaceAudience.Private
+public class NativeRSRawErasureCoderFactory
+    implements RawErasureCoderFactory {
+
+  public static final String CODER_NAME = "rs_native";
+
+  @Override
+  public RawErasureEncoder createEncoder(
+      ECReplicationConfig ecReplicationConfig) {
+    return new NativeRSRawEncoder(ecReplicationConfig);
+  }
+
+  @Override
+  public RawErasureDecoder createDecoder(
+      ECReplicationConfig ecReplicationConfig) {
+    return new NativeRSRawDecoder(ecReplicationConfig);
+  }
+
+  @Override
+  public String getCoderName() {
+    return CODER_NAME;
+  }
+
+  @Override
+  public String getCodecName() {
+    return ECReplicationConfig.EcCodec.RS.name().toLowerCase();
+  }
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawDecoder.java
@@ -35,11 +35,11 @@ public class NativeXORRawDecoder extends AbstractNativeRawDecoder {
 
   public NativeXORRawDecoder(ECReplicationConfig ecReplicationConfig) {
     super(ecReplicationConfig);
-    getDecoderLock().writeLock().lock();
+    decoderLock.writeLock().lock();
     try {
       initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
     } finally {
-      getDecoderLock().writeLock().unlock();
+      decoderLock.writeLock().unlock();
     }
   }
 
@@ -52,11 +52,11 @@ public class NativeXORRawDecoder extends AbstractNativeRawDecoder {
 
   @Override
   public void release() {
-    getDecoderLock().writeLock().lock();
+    decoderLock.writeLock().lock();
     try {
       destroyImpl();
     } finally {
-      getDecoderLock().writeLock().unlock();
+      decoderLock.writeLock().unlock();
     }
   }
 

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawDecoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawDecoder.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A XOR raw decoder using Intel ISA-L library.
+ */
+@InterfaceAudience.Private
+public class NativeXORRawDecoder extends AbstractNativeRawDecoder {
+
+  static {
+    ErasureCodeNative.checkNativeCodeLoaded();
+  }
+
+  public NativeXORRawDecoder(ECReplicationConfig ecReplicationConfig) {
+    super(ecReplicationConfig);
+    getDecoderLock().writeLock().lock();
+    try {
+      initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
+    } finally {
+      getDecoderLock().writeLock().unlock();
+    }
+  }
+
+  @Override
+  protected void performDecodeImpl(
+      ByteBuffer[] inputs, int[] inputOffsets, int dataLen, int[] erased,
+      ByteBuffer[] outputs, int[] outputOffsets) throws IOException {
+    decodeImpl(inputs, inputOffsets, dataLen, erased, outputs, outputOffsets);
+  }
+
+  @Override
+  public void release() {
+    getDecoderLock().writeLock().lock();
+    try {
+      destroyImpl();
+    } finally {
+      getDecoderLock().writeLock().unlock();
+    }
+  }
+
+  private native void initImpl(int numDataUnits, int numParityUnits);
+
+  /**
+   * Native implementation of decoding.
+   * @throws IOException if the decoder is closed.
+   */
+  private native void decodeImpl(
+      ByteBuffer[] inputs, int[] inputOffsets, int dataLen, int[] erased,
+      ByteBuffer[] outputs, int[] outputOffsets) throws IOException;
+
+  private native void destroyImpl();
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawEncoder.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawEncoder.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * A XOR raw encoder using Intel ISA-L library.
+ */
+@InterfaceAudience.Private
+public class NativeXORRawEncoder extends AbstractNativeRawEncoder {
+
+  static {
+    ErasureCodeNative.checkNativeCodeLoaded();
+  }
+
+  public NativeXORRawEncoder(ECReplicationConfig ecReplicationConfig) {
+    super(ecReplicationConfig);
+    encoderLock.writeLock().lock();
+    try {
+      initImpl(ecReplicationConfig.getData(), ecReplicationConfig.getParity());
+    } finally {
+      encoderLock.writeLock().unlock();
+    }
+  }
+
+  @Override
+  protected void performEncodeImpl(
+      ByteBuffer[] inputs, int[] inputOffsets, int dataLen,
+      ByteBuffer[] outputs, int[] outputOffsets) throws IOException {
+    encodeImpl(inputs, inputOffsets, dataLen, outputs, outputOffsets);
+  }
+
+  @Override
+  public void release() {
+    encoderLock.writeLock().lock();
+    try {
+      destroyImpl();
+    } finally {
+      encoderLock.writeLock().unlock();
+    }
+  }
+
+  private native void initImpl(int numDataUnits, int numParityUnits);
+
+  private native void encodeImpl(ByteBuffer[] inputs, int[] inputOffsets,
+                                 int dataLen, ByteBuffer[] outputs,
+                                 int[] outputOffsets) throws IOException;
+
+  private native void destroyImpl();
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawErasureCoderFactory.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/NativeXORRawErasureCoderFactory.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+
+/**
+ * A raw coder factory for xor coder in native using Intel ISA-L library.
+ */
+@InterfaceAudience.Private
+public class NativeXORRawErasureCoderFactory
+    implements RawErasureCoderFactory {
+
+  public static final String CODER_NAME = "xor_native";
+
+  @Override
+  public RawErasureEncoder createEncoder(
+      ECReplicationConfig ecReplicationConfig) {
+    return new NativeXORRawEncoder(ecReplicationConfig);
+  }
+
+  @Override
+  public RawErasureDecoder createDecoder(
+      ECReplicationConfig ecReplicationConfig) {
+    return new NativeXORRawDecoder(ecReplicationConfig);
+  }
+
+  @Override
+  public String getCoderName() {
+    return CODER_NAME;
+  }
+
+  @Override
+  public String getCodecName() {
+    return ECReplicationConfig.EcCodec.XOR.name().toLowerCase();
+  }
+}

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ozone.erasurecode.rawcoder.util;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;

--- a/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
+++ b/hadoop-hdds/erasurecode/src/main/java/org/apache/ozone/erasurecode/rawcoder/util/CodecUtil.java
@@ -1,0 +1,94 @@
+package org.apache.ozone.erasurecode.rawcoder.util;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.ozone.erasurecode.CodecRegistry;
+import org.apache.ozone.erasurecode.rawcoder.RawErasureCoderFactory;
+import org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A codec &amp; coder utility to help create coders conveniently.
+ * <p>
+ * {@link CodecUtil} includes erasure coder configurations key and default
+ * values such as coder class name and erasure codec option values included
+ * by {@link ECReplicationConfig}.{@link RawErasureEncoder} and
+ * {@link RawErasureDecoder} are created by createRawEncoder and
+ * createRawDecoder.
+ */
+@InterfaceAudience.Private
+public final class CodecUtil {
+
+  public static final Logger LOG = LoggerFactory.getLogger(CodecUtil.class);
+
+  private CodecUtil() {
+  }
+
+  private static RawErasureCoderFactory createRawCoderFactory(String coderName,
+      String codecName) {
+    RawErasureCoderFactory fact;
+    fact = CodecRegistry.getInstance().
+        getCoderByName(codecName, coderName);
+
+    return fact;
+  }
+
+  public static RawErasureEncoder createRawEncoderWithFallback(
+      final ECReplicationConfig ecReplicationConfig) {
+    // Note: Coders can be configurable, but for now, we just use whats
+    //  available.
+    String codecName = ecReplicationConfig.getCodec().name().toLowerCase();
+    String[] rawCoderNames =
+        CodecRegistry.getInstance().getCoderNames(codecName);
+    for (String rawCoderName : rawCoderNames) {
+      try {
+        if (rawCoderName != null) {
+          RawErasureCoderFactory fact =
+              createRawCoderFactory(rawCoderName, codecName);
+          return fact.createEncoder(ecReplicationConfig);
+        }
+      } catch (LinkageError | Exception e) {
+        // Fallback to next coder if possible
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Failed to create raw erasure encoder " + rawCoderName
+                  + ", fallback to next codec if possible",
+              e);
+        }
+      }
+    }
+    throw new IllegalArgumentException(
+        "Fail to create raw erasure " + "encoder with given codec: "
+            + codecName);
+  }
+
+  public static RawErasureDecoder createRawDecoderWithFallback(
+      final ECReplicationConfig ecReplicationConfig) {
+    // Note: Coders can be configurable, but for now, we just use whats
+    //  available.
+    String codecName = ecReplicationConfig.getCodec().name().toLowerCase();
+    String[] coders = CodecRegistry.getInstance().getCoderNames(codecName);
+    for (String rawCoderName : coders) {
+      try {
+        if (rawCoderName != null) {
+          RawErasureCoderFactory fact =
+              createRawCoderFactory(rawCoderName, codecName);
+          return fact.createDecoder(ecReplicationConfig);
+        }
+      } catch (LinkageError | Exception e) {
+        // Fallback to next coder if possible
+        if (LOG.isDebugEnabled()) {
+          LOG.debug(
+              "Failed to create raw erasure decoder " + rawCoderName
+                  + ", fallback to next codec if possible",
+              e);
+        }
+      }
+    }
+    throw new IllegalArgumentException(
+        "Fail to create raw erasure " + "decoder with given codec: "
+            + codecName);
+  }
+}

--- a/hadoop-hdds/erasurecode/src/main/resources/META-INF/services/org.apache.ozone.erasurecode.rawcoder.RawErasureCoderFactory
+++ b/hadoop-hdds/erasurecode/src/main/resources/META-INF/services/org.apache.ozone.erasurecode.rawcoder.RawErasureCoderFactory
@@ -13,3 +13,5 @@
 #
 org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory
 org.apache.ozone.erasurecode.rawcoder.XORRawErasureCoderFactory
+org.apache.ozone.erasurecode.rawcoder.NativeRSRawErasureCoderFactory
+org.apache.ozone.erasurecode.rawcoder.NativeXORRawErasureCoderFactory

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCodecRegistry.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/TestCodecRegistry.java
@@ -18,14 +18,13 @@
 package org.apache.ozone.erasurecode;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.ozone.erasurecode.rawcoder.NativeRSRawErasureCoderFactory;
+import org.apache.ozone.erasurecode.rawcoder.NativeXORRawErasureCoderFactory;
 import org.apache.ozone.erasurecode.rawcoder.RSRawErasureCoderFactory;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureCoderFactory;
-import org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder;
-import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
 import org.apache.ozone.erasurecode.rawcoder.XORRawErasureCoderFactory;
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -37,6 +36,12 @@ import static org.junit.Assert.assertTrue;
  * Test CodecRegistry.
  */
 public class TestCodecRegistry {
+  public static final String DUMMY_CODEC_NAME = "dummy";
+  public static final String RS_CODEC_NAME = "rs";
+  public static final String RS_LEGACY_CODEC_NAME = "rs-legacy";
+  public static final String XOR_CODEC_NAME = "xor";
+  public static final String HHXOR_CODEC_NAME = "hhxor";
+
   @Test
   public void testGetCodecs() {
     Set<String> codecs = CodecRegistry.getInstance().getCodecNames();
@@ -51,13 +56,15 @@ public class TestCodecRegistry {
   public void testGetCoders() {
     List<RawErasureCoderFactory> coders = CodecRegistry.getInstance().
         getCoders(ECReplicationConfig.EcCodec.RS.name().toLowerCase());
-    assertEquals(1, coders.size());
-    assertTrue(coders.get(0) instanceof RSRawErasureCoderFactory);
+    assertEquals(2, coders.size());
+    assertTrue(coders.get(0) instanceof NativeRSRawErasureCoderFactory);
+    assertTrue(coders.get(1) instanceof RSRawErasureCoderFactory);
 
     coders = CodecRegistry.getInstance().
         getCoders(ECReplicationConfig.EcCodec.XOR.name().toLowerCase());
-    assertEquals(1, coders.size());
-    assertTrue(coders.get(0) instanceof XORRawErasureCoderFactory);
+    assertEquals(2, coders.size());
+    assertTrue(coders.get(0) instanceof NativeXORRawErasureCoderFactory);
+    assertTrue(coders.get(1) instanceof XORRawErasureCoderFactory);
   }
 
   @Test
@@ -76,39 +83,36 @@ public class TestCodecRegistry {
   }
 
   @Test
-  public void testUpdateCoders() {
-    class RSUserDefinedIncorrectFactory implements RawErasureCoderFactory {
-      public RawErasureEncoder createEncoder(ECReplicationConfig coderOptions) {
-        return null;
-      }
+  public void testGetCoderNames() {
+    String[] coderNames = CodecRegistry.getInstance().
+        getCoderNames(RS_CODEC_NAME);
+    assertEquals(2, coderNames.length);
+    assertEquals(NativeRSRawErasureCoderFactory.CODER_NAME, coderNames[0]);
+    assertEquals(RSRawErasureCoderFactory.CODER_NAME, coderNames[1]);
 
-      public RawErasureDecoder createDecoder(ECReplicationConfig coderOptions) {
-        return null;
-      }
+    coderNames = CodecRegistry.getInstance().
+        getCoderNames(XOR_CODEC_NAME);
+    assertEquals(2, coderNames.length);
+    assertEquals(NativeXORRawErasureCoderFactory.CODER_NAME, coderNames[0]);
+    assertEquals(XORRawErasureCoderFactory.CODER_NAME, coderNames[1]);
+  }
 
-      public String getCoderName() {
-        return "rs_java";
-      }
+  @Test
+  public void testGetCoderByName() {
+    RawErasureCoderFactory coder = CodecRegistry.getInstance().
+        getCoderByName(RS_CODEC_NAME, RSRawErasureCoderFactory.CODER_NAME);
+    assertTrue(coder instanceof RSRawErasureCoderFactory);
 
-      public String getCodecName() {
-        return ECReplicationConfig.EcCodec.RS.name().toLowerCase();
-      }
-    }
+    coder = CodecRegistry.getInstance().getCoderByName(RS_CODEC_NAME,
+        NativeRSRawErasureCoderFactory.CODER_NAME);
+    assertTrue(coder instanceof NativeRSRawErasureCoderFactory);
 
-    List<RawErasureCoderFactory> userDefinedFactories = new ArrayList<>();
-    userDefinedFactories.add(new RSUserDefinedIncorrectFactory());
-    CodecRegistry.getInstance().updateCoders(userDefinedFactories);
+    coder = CodecRegistry.getInstance()
+        .getCoderByName(XOR_CODEC_NAME, XORRawErasureCoderFactory.CODER_NAME);
+    assertTrue(coder instanceof XORRawErasureCoderFactory);
 
-    // check RS coders
-    List<RawErasureCoderFactory> rsCoders = CodecRegistry.getInstance().
-        getCoders(ECReplicationConfig.EcCodec.RS.name().toLowerCase());
-    assertEquals(1, rsCoders.size());
-    assertTrue(rsCoders.get(0) instanceof RSRawErasureCoderFactory);
-
-    // check RS coder names
-    String[] rsCoderNames = CodecRegistry.getInstance().
-        getCoderNames(ECReplicationConfig.EcCodec.RS.name().toLowerCase());
-    assertEquals(1, rsCoderNames.length);
-    assertEquals(RSRawErasureCoderFactory.CODER_NAME, rsCoderNames[0]);
+    coder = CodecRegistry.getInstance().getCoderByName(XOR_CODEC_NAME,
+        NativeXORRawErasureCoderFactory.CODER_NAME);
+    assertTrue(coder instanceof NativeXORRawErasureCoderFactory);
   }
 }

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCodecRawCoderMapping.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCodecRawCoderMapping.java
@@ -1,3 +1,20 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.ozone.erasurecode.rawcoder;
 
 import org.apache.hadoop.hdds.client.ECReplicationConfig;

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCodecRawCoderMapping.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestCodecRawCoderMapping.java
@@ -1,0 +1,51 @@
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test the codec to raw coder mapping.
+ */
+public class TestCodecRawCoderMapping {
+
+  private static final String RS_CODEC_NAME = "rs";
+  private static final String XOR_CODEC_NAME = "xor";
+
+  @Test
+  public void testRSDefaultRawCoder() {
+    ECReplicationConfig coderOptions =
+        new ECReplicationConfig(RS_CODEC_NAME + "-6-3-1024K");
+    // should return default raw coder of rs codec
+    RawErasureEncoder encoder =
+        CodecUtil.createRawEncoderWithFallback(coderOptions);
+    RawErasureDecoder decoder =
+        CodecUtil.createRawDecoderWithFallback(coderOptions);
+    if (ErasureCodeNative.isNativeCodeLoaded()) {
+      Assert.assertTrue(encoder instanceof NativeRSRawEncoder);
+      Assert.assertTrue(decoder instanceof NativeRSRawDecoder);
+    } else {
+      Assert.assertTrue(encoder instanceof RSRawEncoder);
+      Assert.assertTrue(decoder instanceof RSRawDecoder);
+    }
+  }
+
+  @Test
+  public void testXORRawCoder() {
+    ECReplicationConfig coderOptions =
+        new ECReplicationConfig(XOR_CODEC_NAME + "-6-3-1024K");
+    // should return default raw coder of rs codec
+    RawErasureEncoder encoder =
+        CodecUtil.createRawEncoderWithFallback(coderOptions);
+    RawErasureDecoder decoder =
+        CodecUtil.createRawDecoderWithFallback(coderOptions);
+    if (ErasureCodeNative.isNativeCodeLoaded()) {
+      Assert.assertTrue(encoder instanceof NativeXORRawEncoder);
+      Assert.assertTrue(decoder instanceof NativeXORRawDecoder);
+    } else {
+      Assert.assertTrue(encoder instanceof XORRawEncoder);
+      Assert.assertTrue(decoder instanceof XORRawDecoder);
+    }
+  }
+}

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeRSRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeRSRawCoder.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test native raw Reed-solomon encoding and decoding.
+ */
+public class TestNativeRSRawCoder extends TestRSRawCoderBase {
+
+  public TestNativeRSRawCoder() {
+    super(NativeRSRawErasureCoderFactory.class,
+        NativeRSRawErasureCoderFactory.class);
+  }
+
+  @Before
+  public void setup() {
+    Assume.assumeTrue(ErasureCodeNative.isNativeCodeLoaded());
+    setAllowDump(true);
+  }
+
+  @Test
+  public void testCoding6x3ErasingAllD() {
+    prepare(null, 6, 3, new int[]{0, 1, 2}, new int[0], true);
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD0D2() {
+    prepare(null, 6, 3, new int[] {0, 2}, new int[]{});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD0() {
+    prepare(null, 6, 3, new int[]{0}, new int[0]);
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD2() {
+    prepare(null, 6, 3, new int[]{2}, new int[]{});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD0P0() {
+    prepare(null, 6, 3, new int[]{0}, new int[]{0});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingAllP() {
+    prepare(null, 6, 3, new int[0], new int[]{0, 1, 2});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingP0() {
+    prepare(null, 6, 3, new int[0], new int[]{0});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingP2() {
+    prepare(null, 6, 3, new int[0], new int[]{2});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasureP0P2() {
+    prepare(null, 6, 3, new int[0], new int[]{0, 2});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD0P0P1() {
+    prepare(null, 6, 3, new int[]{0}, new int[]{0, 1});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCoding6x3ErasingD0D2P2() {
+    prepare(null, 6, 3, new int[]{0, 2}, new int[]{2});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCodingNegative6x3ErasingD2D4() {
+    prepare(null, 6, 3, new int[]{2, 4}, new int[0]);
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testCodingNegative6x3ErasingTooMany() {
+    prepare(null, 6, 3, new int[]{2, 4}, new int[]{0, 1});
+    testCodingWithErasingTooMany();
+  }
+
+  @Test
+  public void testCoding10x4ErasingD0P0() {
+    prepare(null, 10, 4, new int[] {0}, new int[] {0});
+    testCodingDoMixAndTwice();
+  }
+
+  @Test
+  public void testAfterRelease63() throws Exception {
+    prepare(6, 3, null, null);
+    testAfterRelease();
+  }
+}

--- a/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeXORRawCoder.java
+++ b/hadoop-hdds/erasurecode/src/test/java/org/apache/ozone/erasurecode/rawcoder/TestNativeXORRawCoder.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.ozone.erasurecode.rawcoder;
+
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Test NativeXOR encoding and decoding.
+ */
+public class TestNativeXORRawCoder extends TestXORRawCoderBase {
+
+  public TestNativeXORRawCoder() {
+    super(NativeXORRawErasureCoderFactory.class,
+        NativeXORRawErasureCoderFactory.class);
+  }
+
+  @Before
+  public void setup() {
+    Assume.assumeTrue(ErasureCodeNative.isNativeCodeLoaded());
+    setAllowDump(true);
+  }
+
+  @Test
+  public void testAfterRelease63() throws Exception {
+    prepare(6, 3, null, null);
+    testAfterRelease();
+  }
+}

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -29,8 +29,8 @@ import org.apache.hadoop.hdds.scm.storage.BlockExtendedInputStream;
 import org.apache.hadoop.hdds.scm.storage.ByteReaderStrategy;
 import org.apache.hadoop.io.ByteBufferPool;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
-import org.apache.ozone.erasurecode.CodecRegistry;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureDecoder;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.apache.ratis.util.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,10 +125,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     super(repConfig, blockInfo, verifyChecksum, xceiverClientFactory,
         refreshFunction, streamFactory);
     this.byteBufferPool = byteBufferPool;
-
-    decoder = CodecRegistry.getInstance()
-        .getCodecFactory(repConfig.getCodec().toString())
-        .createDecoder(repConfig);
+    decoder = CodecUtil.createRawDecoderWithFallback(repConfig);
 
     // The EC decoder needs an array data+parity long, with missing or not
     // needed indexes set to null.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -40,8 +40,8 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import org.apache.ozone.erasurecode.CodecRegistry;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -112,9 +112,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
             unsafeByteBufferConversion, xceiverClientManager, handler.getId());
 
     this.writeOffset = 0;
-    this.encoder = CodecRegistry.getInstance()
-        .getCodecFactory(replicationConfig.getCodec().name().toLowerCase())
-        .createEncoder(replicationConfig);
+    this.encoder = CodecUtil.createRawEncoderWithFallback(replicationConfig);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -31,8 +31,8 @@ import org.apache.hadoop.hdds.security.token.OzoneBlockTokenIdentifier;
 import org.apache.hadoop.ozone.client.io.BlockInputStreamFactory;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
-import org.apache.ozone.erasurecode.CodecRegistry;
 import org.apache.ozone.erasurecode.rawcoder.RawErasureEncoder;
+import org.apache.ozone.erasurecode.rawcoder.util.CodecUtil;
 import org.apache.ratis.util.Preconditions;
 import org.junit.Assert;
 
@@ -184,9 +184,8 @@ public final class ECStreamTestUtil {
     for (int i = 0; i < ecConfig.getParity(); i++) {
       parity[i] = ByteBuffer.allocate(cellSize);
     }
-    RawErasureEncoder encoder = CodecRegistry.getInstance()
-        .getCodecFactory(ecConfig.getCodec().toString())
-        .createEncoder(ecConfig);
+    RawErasureEncoder encoder =
+        CodecUtil.createRawEncoderWithFallback(ecConfig);
     encoder.encode(data, parity);
 
     data[0].flip();


### PR DESCRIPTION
## What changes were proposed in this pull request?

Taken the Native Integration of Java side classes with fallback coder support from hadoop. When native coders not available, it will fallback to java.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6188

## How was this patch tested?

There are tests added to verify the behavior and also integrated with Ozone EC IO streams.