### PR TITLE
HDDS-6273. Amend doc SecuringTDE.md

### DIFF
--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -58,10 +58,10 @@ To create an encrypted bucket, client need to:
    * Assign the encryption key to a bucket.
 
   ```bash
-  ozone sh bucket create -k encKey /vol/encryptedBucket
+  ozone sh bucket create -k encKey /vol/encryptedbucket
   ```
 
-After this command, all data written to the _encryptedBucket_ will be encrypted
+After this command, all data written to the _encryptedbucket_ will be encrypted
 via the encKey and while reading the clients will talk to Key Management
 Server and read the key and decrypt it. In other words, the data stored
 inside Ozone is always encrypted. The fact that data is encrypted at rest
@@ -71,19 +71,23 @@ will be completely transparent to the clients and end users.
 
 There are two ways to create an encrypted bucket that can be accessed via S3 Gateway.
 
-####1. Create a bucket using shell under "/s3v" volume
+#### Option 1. Create a bucket using shell under "/s3v" volume
 
   ```bash
-  ozone sh bucket create -k encKey /s3v/encryptedBucket
+  ozone sh bucket create -k encKey --layout=FILE_SYSTEM_OPTIMIZED /s3v/encryptedbucket
   ```
-####2. Create a link to an encrypted bucket under "/s3v" volume
+
+#### Option 2. Create a link to an encrypted bucket under "/s3v" volume
 
   ```bash
-  ozone sh bucket create -k encKey /vol/encryptedBucket
-  ozone sh bucket link  /vol/encryptedBucket /s3v/linkencryptedbucket
+  ozone sh bucket create -k encKey --layout=FILE_SYSTEM_OPTIMIZED /vol/encryptedbucket
+  ozone sh bucket link /vol/encryptedbucket /s3v/linkencryptedbucket
   ```
-Note: An encrypted bucket cannot be created via S3 APIs. It must be done using Ozone shell commands as shown above.
+
+Note 1: An encrypted bucket cannot be created via S3 APIs. It must be done using Ozone shell commands as shown above.
 After creating an encrypted bucket, all the keys added to this bucket using s3g will be encrypted.
+
+Note 2: `--layout=FILE_SYSTEM_OPTIMIZED` is added in the command line above to allow HCFS (o3fs / ofs) access.
 
 In non-secure mode, the user running the S3Gateway daemon process is the proxy user, 
 while in secure mode the S3Gateway Kerberos principal (ozone.s3g.kerberos.principal) is the proxy user. 
@@ -111,12 +115,11 @@ The below two configurations must be added to the kms-site.xml to allow the S3Ga
          This is the host where the S3Gateway is running. Set this to '*' to allow
          requests from any hosts to be proxied.
   </description>
-
 </property>
-
 ```
 
-###KMS Authorization
+### KMS Authorization
+
 If Ranger authorization is enabled for KMS, then decrypt key permission should be given to
 access key id user(currently access key is kerberos principal) to decrypt the encrypted key 
 to read/write a key in the encrypted bucket.

--- a/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
@@ -49,7 +49,7 @@ hadoop.security.key.provider.path  | KMS uri. <br> 比如 kms://http@kms-host:96
    * 将加密密钥分配给桶
 
   ```bash
-  ozone sh bucket create -k encKey /vol/encryptedBucket
+  ozone sh bucket create -k encKey /vol/encryptedbucket
   ```
 
-这条命令执行后，所以写往 _encryptedBucket_ 的数据都会用 encKey 进行加密，当读取里面的数据时，客户端通过 KMS 获取密钥进行解密。换句话说，Ozone 中存储的数据一直是加密的，但用户和客户端对此完全无感知。
+这条命令执行后，所以写往 _encryptedbucket_ 的数据都会用 encKey 进行加密，当读取里面的数据时，客户端通过 KMS 获取密钥进行解密。换句话说，Ozone 中存储的数据一直是加密的，但用户和客户端对此完全无感知。


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing some small issues in the existing document SecuringTDE.md:

1. Added note for `--layout=FILE_SYSTEM_OPTIMIZED` that could provide HCFS access. Otherwise access from ofs/o3fs will be rejected due to bucket layout being `OBJECT_STORE` by default.

2. Bucket names doesn't support upper case letters. The example in the doc won't work.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6273

## How was this patch tested?

- Ran `hugo serve` locally and checked that the page http://localhost:1313/security/securingtde.html rendered as expected:

<img width="756" alt="image" src="https://user-images.githubusercontent.com/50227127/152867358-50bf5e22-c3cb-48cf-80ab-8b7b244c62bc.png">
