### PR TITLE
HDDS-6258. EC: Read with stopped but not dead nodes gives IllegalStateException rather than InsufficientNodesException

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -78,9 +78,18 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
     return stripeSize;
   }
 
-  protected int availableDataLocations() {
+  /**
+   * Returns the number of available data locations, taking account of the
+   * expected number of locations. Eg, if the block is less than 1 EC chunk,
+   * we only expect 1 data location. If it is between 1 and 2 chunks, we expect
+   * there to be 2 locations, and so on.
+   * @param expectedLocations The maximum number of allowed data locations,
+   *                          depending on the block size.
+   * @return The number of available data locations.
+   */
+  protected int availableDataLocations(int expectedLocations) {
     int count = 0;
-    for (int i = 0; i < repConfig.getData(); i++) {
+    for (int i = 0; i < repConfig.getData() && i < expectedLocations; i++) {
       if (dataLocations[i] != null) {
         count++;
       }
@@ -127,7 +136,7 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
     // must have all data_num locations.
     // We only consider data locations here.
     int expectedDataBlocks = calculateExpectedDataBlocks(repConfig);
-    return expectedDataBlocks == availableDataLocations();
+    return expectedDataBlocks == availableDataLocations(expectedDataBlocks);
   }
 
   protected int calculateExpectedDataBlocks(ECReplicationConfig rConfig) {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -76,17 +76,19 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   /**
    * From ECReplicationConfig and Pipeline with the block locations and location
    * indexes, determine the number of data locations available.
-   * @param repConfig The EC Replication Config
    * @param pipeline The pipeline for the data block, givings its locations and
    *                 the index of each location.
+   * @param expectedLocs The number of locations we expect for the block to have
+   *                     based on its block length and replication config. The
+   *                     max value should be the repConfig data number.
    * @return The number of locations available
    */
-  public static int availableDataLocations(ECReplicationConfig repConfig,
-      Pipeline pipeline) {
+  public static int availableDataLocations(Pipeline pipeline,
+      int expectedLocs) {
     Set<Integer> locations = new HashSet<>();
     for (DatanodeDetails dn : pipeline.getNodes()) {
       int index = pipeline.getReplicaIndex(dn);
-      if (index > 0 && index <= repConfig.getData()) {
+      if (index > 0 && index <= expectedLocs) {
         locations.add(index);
       }
     }
@@ -110,7 +112,7 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
 
   private synchronized void setReaderType() {
     int expected = expectedDataLocations(repConfig, getLength());
-    int available = availableDataLocations(repConfig, blockInfo.getPipeline());
+    int available = availableDataLocations(blockInfo.getPipeline(), expected);
     reconstructionReader = available < expected;
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -74,8 +74,8 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
   }
 
   /**
-   * From ECReplicationConfig and Pipeline with the block locations and location
-   * indexes, determine the number of data locations available.
+   * From the Pipeline and expected number of locations, determine the number
+   * of data locations available.
    * @param pipeline The pipeline for the data block, givings its locations and
    *                 the index of each location.
    * @param expectedLocs The number of locations we expect for the block to have

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -558,7 +558,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     ECReplicationConfig repConfig = getRepConfig();
     int expectedDataBlocks = calculateExpectedDataBlocks(repConfig);
     int availableLocations =
-        availableDataLocations() + availableParityLocations();
+        availableDataLocations(expectedDataBlocks) + availableParityLocations();
     int paddedLocations = repConfig.getData() - expectedDataBlocks;
     int failedLocations = failedDataIndexes.size();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -221,6 +221,8 @@ public final class ECStreamTestUtil {
 
     private List<TestBlockInputStream> blockStreams = new ArrayList<>();
     private List<ByteBuffer> blockStreamData;
+    // List of EC indexes that should fail immediately on read
+    private List<Integer> failIndexes = new ArrayList<>();
 
     private Pipeline currentPipeline;
 
@@ -236,6 +238,10 @@ public final class ECStreamTestUtil {
       this.currentPipeline = pipeline;
     }
 
+    public void setFailIndexes(List<Integer> fail) {
+      failIndexes.addAll(fail);
+    }
+
     public BlockExtendedInputStream create(ReplicationConfig repConfig,
         OmKeyLocationInfo blockInfo, Pipeline pipeline,
         Token<OzoneBlockTokenIdentifier> token, boolean verifyChecksum,
@@ -246,6 +252,9 @@ public final class ECStreamTestUtil {
       TestBlockInputStream stream = new TestBlockInputStream(
           blockInfo.getBlockID(), blockInfo.getLength(),
           blockStreamData.get(repInd - 1), repInd);
+      if (failIndexes.contains(repInd)) {
+        stream.setShouldError(true);
+      }
       blockStreams.add(stream);
       return stream;
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
@@ -230,6 +230,29 @@ public class TestECBlockInputStream {
     }
   }
 
+  /**
+   * This test is to ensure we can read a small key of 1 chunk or less when only
+   * the first replica index is available.
+   */
+  @Test
+  public void testSimpleReadUnderOneChunk() throws IOException {
+    OmKeyLocationInfo keyInfo =
+        ECStreamTestUtil.createKeyInfo(repConfig, 1, ONEMB);
+    try (ECBlockInputStream ecb = new ECBlockInputStream(repConfig,
+        keyInfo, true, null, null, streamFactory)) {
+
+      ByteBuffer buf = ByteBuffer.allocate(100);
+
+      int read = ecb.read(buf);
+      Assert.assertEquals(100, read);
+      validateBufferContents(buf, 0, 100, (byte) 0);
+      Assert.assertEquals(100, ecb.getPos());
+    }
+    for (TestBlockInputStream s : streamFactory.getBlockStreams()) {
+      Assert.assertTrue(s.isClosed());
+    }
+  }
+
   @Test
   public void testReadPastEOF() throws IOException {
     OmKeyLocationInfo keyInfo =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStreamProxy.java
@@ -92,21 +92,25 @@ public class TestECBlockInputStreamProxy {
   @Test
   public void testAvailableDataLocations() {
     Map<DatanodeDetails, Integer> dnMap =
-        ECStreamTestUtil.createIndexMap(1, 2, 4, 5);
+        ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
     OmKeyLocationInfo blockInfo =
         ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
+    Assert.assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
+        blockInfo.getPipeline(), 1));
     Assert.assertEquals(2, ECBlockInputStreamProxy.availableDataLocations(
-        repConfig, blockInfo.getPipeline()));
+        blockInfo.getPipeline(), 2));
+    Assert.assertEquals(3, ECBlockInputStreamProxy.availableDataLocations(
+        blockInfo.getPipeline(), 3));
 
     dnMap = ECStreamTestUtil.createIndexMap(1, 4, 5);
     blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
     Assert.assertEquals(1, ECBlockInputStreamProxy.availableDataLocations(
-        repConfig, blockInfo.getPipeline()));
+        blockInfo.getPipeline(), 3));
 
-    dnMap = ECStreamTestUtil.createIndexMap(1, 2, 3, 4, 5);
+    dnMap = ECStreamTestUtil.createIndexMap(2, 3, 4, 5);
     blockInfo = ECStreamTestUtil.createKeyInfo(repConfig, 1024, dnMap);
-    Assert.assertEquals(3, ECBlockInputStreamProxy.availableDataLocations(
-        repConfig, blockInfo.getPipeline()));
+    Assert.assertEquals(0, ECBlockInputStreamProxy.availableDataLocations(
+        blockInfo.getPipeline(), 1));
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Attempting to read a key less than 1 chunk, with 3 of the 5 nodes stopped (both when not yet stale or stale), the read hangs for sometime and fails with:

```
$ ozone sh key get /vol1/bucket/ec1 /tmp/3_down
java.lang.IllegalStateException
    at org.apache.ratis.util.Preconditions.assertTrue(Preconditions.java:33)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.selectParityIndexes(ECBlockReconstructedStripeInputStream.java:432)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.init(ECBlockReconstructedStripeInputStream.java:179)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedStripeInputStream.readStripe(ECBlockReconstructedStripeInputStream.java:285)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.readStripe(ECBlockReconstructedInputStream.java:192)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.selectNextBuffer(ECBlockReconstructedInputStream.java:109)
    at org.apache.hadoop.ozone.client.io.ECBlockReconstructedInputStream.read(ECBlockReconstructedInputStream.java:83)
    at org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy.read(ECBlockInputStreamProxy.java:156)
    at org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy.read(ECBlockInputStreamProxy.java:171)
    at org.apache.hadoop.ozone.client.io.ECBlockInputStreamProxy.read(ECBlockInputStreamProxy.java:141)
    at org.apache.hadoop.hdds.scm.storage.ByteArrayReader.readFromBlock(ByteArrayReader.java:57)
    at org.apache.hadoop.ozone.client.io.KeyInputStream.readWithStrategy(KeyInputStream.java:268)
    at org.apache.hadoop.ozone.client.io.KeyInputStream.read(KeyInputStream.java:235)
    at org.apache.hadoop.ozone.client.io.OzoneInputStream.read(OzoneInputStream.java:56)
    at java.base/java.io.InputStream.read(InputStream.java:205)
    at org.apache.hadoop.io.IOUtils.copyBytes(IOUtils.java:94)
    at org.apache.hadoop.ozone.shell.keys.GetKeyHandler.execute(GetKeyHandler.java:88)
    at org.apache.hadoop.ozone.shell.Handler.call(Handler.java:98)
    at org.apache.hadoop.ozone.shell.Handler.call(Handler.java:44)
    at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
    at picocli.CommandLine.access$1300(CommandLine.java:145)
    at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
    at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
    at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2172)
    at picocli.CommandLine.parseWithHandlers(CommandLine.java:2550)
    at picocli.CommandLine.parseWithHandler(CommandLine.java:2485)
    at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:96)
    at org.apache.hadoop.ozone.shell.OzoneShell.lambda$execute$0(OzoneShell.java:55)
    at org.apache.hadoop.hdds.tracing.TracingUtil.executeInNewSpan(TracingUtil.java:159)
    at org.apache.hadoop.ozone.shell.OzoneShell.execute(OzoneShell.java:53)
    at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:87)
    at org.apache.hadoop.ozone.shell.OzoneShell.main(OzoneShell.java:47)
```    

After the nodes are marked dead and the replicas no longer present in SCM, we get the expected error immediately:

```
ozone sh key get /vol1/bucket/ec1 /tmp/3_down_dead
There are insufficient datanodes to read the EC block
```

This issue is caused by a bug in the sufficientLocations check. For a small key in a container (under 1 chunk), there may be many other large keys in the same container. This means that all data locations will be reported for the parity + data blocks. However in the sufficientLocations method, we count the available data blocks and then count the "padding only" blocks, resulting in double counting the padding only blocks, and then the sufficientLocations check passes when it should fail.

This change ensures that when counting the available data blocks for a key, we limit the count based on the number of expected blocks.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6258

## How was this patch tested?

Reproduced via a unit test and then fixed the issue.

Also confirmed on Docker Compose the original error no longer occurs:

```
// The 3 DNs holdin data and parity are stale

Datanode: 9175f19e-184f-4592-9588-d356fd8efb4e (/default-rack/172.19.0.10/ozone_datanode_2.ozone_default/1 pipelines)
Operational State: IN_SERVICE
Health State: STALE
Related pipelines:
be8ae2ce-64c0-4e6c-b007-1527361e7663/EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1048576, codec=rs}/EC/CLOSED/Follower

Datanode: 9bcae82f-6aba-4325-8af1-6d2746af6232 (/default-rack/172.19.0.2/ozone_datanode_4.ozone_default/1 pipelines)
Operational State: IN_SERVICE
Health State: STALE
Related pipelines:
be8ae2ce-64c0-4e6c-b007-1527361e7663/EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1048576, codec=rs}/EC/CLOSED/Follower

Datanode: 61112c1b-78a7-4689-a1d2-8fc7aa324e64 (/default-rack/172.19.0.8/ozone_datanode_1.ozone_default/1 pipelines)
Operational State: IN_SERVICE
Health State: STALE
Related pipelines:
be8ae2ce-64c0-4e6c-b007-1527361e7663/EC/ECReplicationConfig{data=3, parity=2, ecChunkSize=1048576, codec=rs}/EC/CLOSED/Follower


bash-4.2$ ozone admin container info 1
Container id: 1
Pipeline id: be8ae2ce-64c0-4e6c-b007-1527361e7663
Container State: CLOSING
Datanodes: [9bcae82f-6aba-4325-8af1-6d2746af6232/ozone_datanode_4.ozone_default,
79c581c2-0339-481a-82a6-6908d00f0af2/ozone_datanode_3.ozone_default,
75244723-cb13-484b-a256-b0f04411c249/ozone_datanode_5.ozone_default,
61112c1b-78a7-4689-a1d2-8fc7aa324e64/ozone_datanode_1.ozone_default,
9175f19e-184f-4592-9588-d356fd8efb4e/ozone_datanode_2.ozone_default]
Replicas: [State: OPEN; ReplicaIndex: 5; Origin: 9175f19e-184f-4592-9588-d356fd8efb4e; Location: 9175f19e-184f-4592-9588-d356fd8efb4e/ozone_datanode_2.ozone_default,
State: OPEN; ReplicaIndex: 4; Origin: 61112c1b-78a7-4689-a1d2-8fc7aa324e64; Location: 61112c1b-78a7-4689-a1d2-8fc7aa324e64/ozone_datanode_1.ozone_default,
State: OPEN; ReplicaIndex: 1; Origin: 9bcae82f-6aba-4325-8af1-6d2746af6232; Location: 9bcae82f-6aba-4325-8af1-6d2746af6232/ozone_datanode_4.ozone_default]

bash-4.2$ ozone sh key get /vol1/bucket/key1 /tmp/test2
There are insufficient datanodes to read the EC block
```
