### PR TITLE
HDDS-6244. ContainerBalancer metrics don't show updated values in JMX

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -308,7 +308,7 @@ public class ContainerBalancer {
       }
       if (Double.compare(utilization, upperLimit) > 0) {
         overUtilizedNodes.add(datanodeUsageInfo);
-        metrics.incrementDatanodesNumUnbalanced(1);
+        metrics.incrementNumDatanodesUnbalanced(1);
 
         // amount of bytes greater than upper limit in this node
         Long overUtilizedBytes = ratioToBytes(
@@ -319,7 +319,7 @@ public class ContainerBalancer {
         totalOverUtilizedBytes += overUtilizedBytes;
       } else if (Double.compare(utilization, lowerLimit) < 0) {
         underUtilizedNodes.add(datanodeUsageInfo);
-        metrics.incrementDatanodesNumUnbalanced(1);
+        metrics.incrementNumDatanodesUnbalanced(1);
 
         // amount of bytes lesser than lower limit in this node
         Long underUtilizedBytes = ratioToBytes(
@@ -442,7 +442,7 @@ public class ContainerBalancer {
             ContainerInfo container =
                 containerManager.getContainer(moveSelection.getContainerID());
             this.sizeMovedPerIteration += container.getUsedBytes();
-            metrics.incrementMovedContainersNumInLatestIteration(1);
+            metrics.incrementNumMovedContainersInLatestIteration(1);
             LOG.info("Move completed for container {} to target {}",
                 container.containerID(),
                 moveSelection.getTargetNode().getUuidString());
@@ -467,7 +467,7 @@ public class ContainerBalancer {
     }
     countDatanodesInvolvedPerIteration =
         sourceToTargetMap.size() + selectedTargets.size();
-    metrics.incrementDatanodesNumInvolvedInLatestIteration(
+    metrics.incrementNumDatanodesInvolvedInLatestIteration(
         countDatanodesInvolvedPerIteration);
     metrics.incrementDataSizeMovedGBInLatestIteration(
         sizeMovedPerIteration / OzoneConsts.GB);
@@ -748,10 +748,10 @@ public class ContainerBalancer {
     this.countDatanodesInvolvedPerIteration = 0;
     this.sizeMovedPerIteration = 0;
     metrics.resetDataSizeMovedGBInLatestIteration();
-    metrics.resetMovedContainersNumInLatestIteration();
-    metrics.resetDatanodesNumInvolvedInLatestIteration();
+    metrics.resetNumMovedContainersInLatestIteration();
+    metrics.resetNumDatanodesInvolvedInLatestIteration();
     metrics.resetDataSizeUnbalancedGB();
-    metrics.resetDatanodesNumUnbalanced();
+    metrics.resetNumDatanodesUnbalanced();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -194,7 +194,7 @@ public class ContainerBalancer {
       //if no new move option is generated, it means the cluster can
       //not be balanced any more , so just stop
       IterationResult iR = doIteration();
-      metrics.incrementCountIterations(1);
+      metrics.incrementNumIterations(1);
       LOG.info("Result of this iteration of Container Balancer: {}", iR);
       if (iR == IterationResult.CAN_NOT_BALANCE_ANY_MORE) {
         stop();
@@ -332,7 +332,7 @@ public class ContainerBalancer {
         withinThresholdUtilizedNodes.add(datanodeUsageInfo);
       }
     }
-    metrics.incrementDataSizeCausingUnbalanceGB(
+    metrics.incrementDataSizeUnbalancedGB(
         Math.max(totalOverUtilizedBytes, totalUnderUtilizedBytes) /
             OzoneConsts.GB);
     Collections.reverse(underUtilizedNodes);
@@ -750,7 +750,7 @@ public class ContainerBalancer {
     metrics.resetDataSizeMovedGBInLatestIteration();
     metrics.resetMovedContainersNumInLatestIteration();
     metrics.resetDatanodesNumInvolvedInLatestIteration();
-    metrics.resetDataSizeCausingUnbalanceGB();
+    metrics.resetDataSizeUnbalancedGB();
     metrics.resetDatanodesNumUnbalanced();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -45,14 +45,14 @@ public final class ContainerBalancerMetrics {
   private MutableCounterLong movedContainersNumInLatestIteration;
 
   @Metric(about = "Number of iterations that Container Balancer has run for.")
-  private MutableCounterLong countIterations;
+  private MutableCounterLong numIterations;
 
   @Metric(about = "Number of datanodes that were involved in balancing in the" +
       " latest iteration.")
   private MutableCounterLong datanodesNumInvolvedInLatestIteration;
 
   @Metric(about = "Amount of data in Gigabytes that is causing unbalance.")
-  private MutableCounterLong dataSizeCausingUnbalanceGB;
+  private MutableCounterLong dataSizeUnbalancedGB;
 
   @Metric(about = "Number of unbalanced datanodes.")
   private MutableCounterLong datanodesNumUnbalanced;
@@ -113,12 +113,12 @@ public final class ContainerBalancerMetrics {
    * Gets the number of iterations that Container Balancer has run for.
    * @return number of iterations
    */
-  public long getCountIterations() {
-    return countIterations.value();
+  public long getNumIterations() {
+    return numIterations.value();
   }
 
-  public void incrementCountIterations(long valueToAdd) {
-    countIterations.incr(valueToAdd);
+  public void incrementNumIterations(long valueToAdd) {
+    numIterations.incr(valueToAdd);
   }
 
   /**
@@ -143,16 +143,16 @@ public final class ContainerBalancerMetrics {
    * Gets the amount of data in Gigabytes that is causing unbalance.
    * @return size of data as a long value
    */
-  public long getDataSizeCausingUnbalanceGB() {
-    return dataSizeCausingUnbalanceGB.value();
+  public long getDataSizeUnbalancedGB() {
+    return dataSizeUnbalancedGB.value();
   }
 
-  public void incrementDataSizeCausingUnbalanceGB(long valueToAdd) {
-    dataSizeCausingUnbalanceGB.incr(valueToAdd);
+  public void incrementDataSizeUnbalancedGB(long valueToAdd) {
+    dataSizeUnbalancedGB.incr(valueToAdd);
   }
 
-  public void resetDataSizeCausingUnbalanceGB() {
-    dataSizeCausingUnbalanceGB.incr(-getDataSizeCausingUnbalanceGB());
+  public void resetDataSizeUnbalancedGB() {
+    dataSizeUnbalancedGB.incr(-getDataSizeUnbalancedGB());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -36,16 +36,26 @@ public final class ContainerBalancerMetrics {
 
   private final MetricsSystem ms;
 
-  @Metric(about = "The amount of Gigabytes that Container Balancer moved" +
-      " in the last iteration.")
-  private MutableCounterLong dataSizeMovedGB;
+  @Metric(about = "Amount of Gigabytes that Container Balancer moved" +
+      " in the latest iteration.")
+  private MutableCounterLong dataSizeMovedGBInLatestIteration;
 
   @Metric(about = "Number of containers that Container Balancer moved" +
-      " in the last iteration.")
-  private MutableCounterLong movedContainersNum;
+      " in the latest iteration.")
+  private MutableCounterLong movedContainersNumInLatestIteration;
 
   @Metric(about = "Number of iterations that Container Balancer has run for.")
   private MutableCounterLong countIterations;
+
+  @Metric(about = "Number of datanodes that were involved in balancing in the" +
+      " latest iteration.")
+  private MutableCounterLong datanodesNumInvolvedInLatestIteration;
+
+  @Metric(about = "Amount of data in Gigabytes that is causing unbalance.")
+  private MutableCounterLong dataSizeCausingUnbalanceGB;
+
+  @Metric(about = "Number of unbalanced datanodes.")
+  private MutableCounterLong datanodesNumUnbalanced;
 
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
@@ -64,36 +74,39 @@ public final class ContainerBalancerMetrics {
   }
 
   /**
-   * Gets the amount of data moved by Container Balancer in the last iteration.
+   * Gets the amount of data moved by Container Balancer in the latest
+   * iteration.
    * @return size in GB
    */
-  public long getDataSizeMovedGB() {
-    return dataSizeMovedGB.value();
+  public long getDataSizeMovedGBInLatestIteration() {
+    return dataSizeMovedGBInLatestIteration.value();
   }
 
-  public void incrementDataSizeMovedGB(long valueToAdd) {
-    this.dataSizeMovedGB.incr(valueToAdd);
+  public void incrementDataSizeMovedGBInLatestIteration(long valueToAdd) {
+    this.dataSizeMovedGBInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetDataSizeMovedGB() {
-    dataSizeMovedGB.incr(-getDataSizeMovedGB());
+  public void resetDataSizeMovedGBInLatestIteration() {
+    dataSizeMovedGBInLatestIteration.incr(
+        -getDataSizeMovedGBInLatestIteration());
   }
 
   /**
-   * Gets the number of containers moved by Container Balancer in the last
+   * Gets the number of containers moved by Container Balancer in the latest
    * iteration.
    * @return number of containers
    */
-  public long getMovedContainersNum() {
-    return movedContainersNum.value();
+  public long getMovedContainersNumInLatestIteration() {
+    return movedContainersNumInLatestIteration.value();
   }
 
-  public void incrementMovedContainersNum(long valueToAdd) {
-    this.movedContainersNum.incr(valueToAdd);
+  public void incrementMovedContainersNumInLatestIteration(long valueToAdd) {
+    this.movedContainersNumInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetMovedContainersNum() {
-    movedContainersNum.incr(-getMovedContainersNum());
+  public void resetMovedContainersNumInLatestIteration() {
+    movedContainersNumInLatestIteration.incr(
+        -getMovedContainersNumInLatestIteration());
   }
 
   /**
@@ -106,5 +119,55 @@ public final class ContainerBalancerMetrics {
 
   public void incrementCountIterations(long valueToAdd) {
     countIterations.incr(valueToAdd);
+  }
+
+  /**
+   * Gets number of datanodes that were involved in balancing in the latest
+   * iteration.
+   * @return number of datanodes
+   */
+  public long getDatanodesNumInvolvedInLatestIteration() {
+    return datanodesNumInvolvedInLatestIteration.value();
+  }
+
+  public void incrementDatanodesNumInvolvedInLatestIteration(long valueToAdd) {
+    datanodesNumInvolvedInLatestIteration.incr(valueToAdd);
+  }
+
+  public void resetDatanodesNumInvolvedInLatestIteration() {
+    datanodesNumInvolvedInLatestIteration.incr(
+        -getDatanodesNumInvolvedInLatestIteration());
+  }
+
+  /**
+   * Gets the amount of data in Gigabytes that is causing unbalance.
+   * @return size of data as a long value
+   */
+  public long getDataSizeCausingUnbalanceGB() {
+    return dataSizeCausingUnbalanceGB.value();
+  }
+
+  public void incrementDataSizeCausingUnbalanceGB(long valueToAdd) {
+    dataSizeCausingUnbalanceGB.incr(valueToAdd);
+  }
+
+  public void resetDataSizeCausingUnbalanceGB() {
+    dataSizeCausingUnbalanceGB.incr(-getDataSizeCausingUnbalanceGB());
+  }
+
+  /**
+   * Gets the number of datanodes that are unbalanced.
+   * @return long value
+   */
+  public long getDatanodesNumUnbalanced() {
+    return datanodesNumUnbalanced.value();
+  }
+
+  public void incrementDatanodesNumUnbalanced(long valueToAdd) {
+    datanodesNumUnbalanced.incr(valueToAdd);
+  }
+
+  public void resetDatanodesNumUnbalanced() {
+    datanodesNumUnbalanced.incr(-getDatanodesNumUnbalanced());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -42,20 +42,20 @@ public final class ContainerBalancerMetrics {
 
   @Metric(about = "Number of containers that Container Balancer moved" +
       " in the latest iteration.")
-  private MutableCounterLong movedContainersNumInLatestIteration;
+  private MutableCounterLong numMovedContainersInLatestIteration;
 
   @Metric(about = "Number of iterations that Container Balancer has run for.")
   private MutableCounterLong numIterations;
 
   @Metric(about = "Number of datanodes that were involved in balancing in the" +
       " latest iteration.")
-  private MutableCounterLong datanodesNumInvolvedInLatestIteration;
+  private MutableCounterLong numDatanodesInvolvedInLatestIteration;
 
   @Metric(about = "Amount of data in Gigabytes that is causing unbalance.")
   private MutableCounterLong dataSizeUnbalancedGB;
 
   @Metric(about = "Number of unbalanced datanodes.")
-  private MutableCounterLong datanodesNumUnbalanced;
+  private MutableCounterLong numDatanodesUnbalanced;
 
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
@@ -96,17 +96,17 @@ public final class ContainerBalancerMetrics {
    * iteration.
    * @return number of containers
    */
-  public long getMovedContainersNumInLatestIteration() {
-    return movedContainersNumInLatestIteration.value();
+  public long getNumMovedContainersInLatestIteration() {
+    return numMovedContainersInLatestIteration.value();
   }
 
-  public void incrementMovedContainersNumInLatestIteration(long valueToAdd) {
-    this.movedContainersNumInLatestIteration.incr(valueToAdd);
+  public void incrementNumMovedContainersInLatestIteration(long valueToAdd) {
+    this.numMovedContainersInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetMovedContainersNumInLatestIteration() {
-    movedContainersNumInLatestIteration.incr(
-        -getMovedContainersNumInLatestIteration());
+  public void resetNumMovedContainersInLatestIteration() {
+    numMovedContainersInLatestIteration.incr(
+        -getNumMovedContainersInLatestIteration());
   }
 
   /**
@@ -126,17 +126,17 @@ public final class ContainerBalancerMetrics {
    * iteration.
    * @return number of datanodes
    */
-  public long getDatanodesNumInvolvedInLatestIteration() {
-    return datanodesNumInvolvedInLatestIteration.value();
+  public long getNumDatanodesInvolvedInLatestIteration() {
+    return numDatanodesInvolvedInLatestIteration.value();
   }
 
-  public void incrementDatanodesNumInvolvedInLatestIteration(long valueToAdd) {
-    datanodesNumInvolvedInLatestIteration.incr(valueToAdd);
+  public void incrementNumDatanodesInvolvedInLatestIteration(long valueToAdd) {
+    numDatanodesInvolvedInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetDatanodesNumInvolvedInLatestIteration() {
-    datanodesNumInvolvedInLatestIteration.incr(
-        -getDatanodesNumInvolvedInLatestIteration());
+  public void resetNumDatanodesInvolvedInLatestIteration() {
+    numDatanodesInvolvedInLatestIteration.incr(
+        -getNumDatanodesInvolvedInLatestIteration());
   }
 
   /**
@@ -159,15 +159,15 @@ public final class ContainerBalancerMetrics {
    * Gets the number of datanodes that are unbalanced.
    * @return long value
    */
-  public long getDatanodesNumUnbalanced() {
-    return datanodesNumUnbalanced.value();
+  public long getNumDatanodesUnbalanced() {
+    return numDatanodesUnbalanced.value();
   }
 
-  public void incrementDatanodesNumUnbalanced(long valueToAdd) {
-    datanodesNumUnbalanced.incr(valueToAdd);
+  public void incrementNumDatanodesUnbalanced(long valueToAdd) {
+    numDatanodesUnbalanced.incr(valueToAdd);
   }
 
-  public void resetDatanodesNumUnbalanced() {
-    datanodesNumUnbalanced.incr(-getDatanodesNumUnbalanced());
+  public void resetNumDatanodesUnbalanced() {
+    numDatanodesUnbalanced.incr(-getNumDatanodesUnbalanced());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -23,8 +23,7 @@ import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
-import org.apache.hadoop.metrics2.lib.MutableGaugeInt;
-import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 
 /**
  * Metrics related to Container Balancer running in SCM.
@@ -37,27 +36,16 @@ public final class ContainerBalancerMetrics {
 
   private final MetricsSystem ms;
 
-  @Metric(about = "The total amount of used space in GigaBytes that needs to " +
-      "be balanced.")
-  private MutableGaugeLong dataSizeToBalanceGB;
+  @Metric(about = "The amount of Gigabytes that Container Balancer moved" +
+      " in the last iteration.")
+  private MutableCounterLong dataSizeMovedGB;
 
-  @Metric(about = "The amount of Giga Bytes that have been moved to achieve " +
-      "balance.")
-  private MutableGaugeLong dataSizeMovedGB;
+  @Metric(about = "Number of containers that Container Balancer moved" +
+      " in the last iteration.")
+  private MutableCounterLong movedContainersNum;
 
-  @Metric(about = "Number of containers that Container Balancer has moved" +
-      " until now.")
-  private MutableGaugeLong movedContainersNum;
-
-  @Metric(about = "The total number of datanodes that need to be balanced.")
-  private MutableGaugeLong datanodesNumToBalance;
-
-  @Metric(about = "Number of datanodes that Container Balancer has balanced " +
-      "until now.")
-  private MutableGaugeLong datanodesNumBalanced;
-
-  @Metric(about = "Utilisation value of the current maximum utilised datanode.")
-  private MutableGaugeInt maxDatanodeUtilizedPercentage;
+  @Metric(about = "Number of iterations that Container Balancer has run for.")
+  private MutableCounterLong countIterations;
 
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
@@ -75,82 +63,48 @@ public final class ContainerBalancerMetrics {
     this.ms = ms;
   }
 
-  public long getDataSizeToBalanceGB() {
-    return dataSizeToBalanceGB.value();
-  }
-
-  public void setDataSizeToBalanceGB(long size) {
-    this.dataSizeToBalanceGB.set(size);
-  }
-
+  /**
+   * Gets the amount of data moved by Container Balancer in the last iteration.
+   * @return size in GB
+   */
   public long getDataSizeMovedGB() {
     return dataSizeMovedGB.value();
   }
 
-  public void setDataSizeMovedGB(long dataSizeMovedGB) {
-    this.dataSizeMovedGB.set(dataSizeMovedGB);
-  }
-
-  public long incrementDataSizeMovedGB(long valueToAdd) {
+  public void incrementDataSizeMovedGB(long valueToAdd) {
     this.dataSizeMovedGB.incr(valueToAdd);
-    return this.dataSizeMovedGB.value();
   }
 
+  public void resetDataSizeMovedGB() {
+    dataSizeMovedGB.incr(-getDataSizeMovedGB());
+  }
+
+  /**
+   * Gets the number of containers moved by Container Balancer in the last
+   * iteration.
+   * @return number of containers
+   */
   public long getMovedContainersNum() {
     return movedContainersNum.value();
   }
 
-  public void setMovedContainersNum(long movedContainersNum) {
-    this.movedContainersNum.set(movedContainersNum);
-  }
-
-  public long incrementMovedContainersNum(long valueToAdd) {
+  public void incrementMovedContainersNum(long valueToAdd) {
     this.movedContainersNum.incr(valueToAdd);
-    return this.movedContainersNum.value();
   }
 
-  public long getDatanodesNumToBalance() {
-    return datanodesNumToBalance.value();
-  }
-
-  public void setDatanodesNumToBalance(long datanodesNumToBalance) {
-    this.datanodesNumToBalance.set(datanodesNumToBalance);
+  public void resetMovedContainersNum() {
+    movedContainersNum.incr(-getMovedContainersNum());
   }
 
   /**
-   * Add specified valueToAdd to the number of datanodes that need to be
-   * balanced.
-   *
-   * @param valueToAdd number of datanodes to add
+   * Gets the number of iterations that Container Balancer has run for.
+   * @return number of iterations
    */
-  public void incrementDatanodesNumToBalance(long valueToAdd) {
-    this.datanodesNumToBalance.incr(valueToAdd);
+  public long getCountIterations() {
+    return countIterations.value();
   }
 
-  public long getDatanodesNumBalanced() {
-    return datanodesNumBalanced.value();
-  }
-
-  public void setDatanodesNumBalanced(long datanodesNumBalanced) {
-    this.datanodesNumBalanced.set(datanodesNumBalanced);
-  }
-
-  /**
-   * Add specified valueToAdd to datanodesNumBalanced.
-   *
-   * @param valueToAdd The value to add.
-   * @return The result after addition.
-   */
-  public long incrementDatanodesNumBalanced(long valueToAdd) {
-    datanodesNumBalanced.incr(valueToAdd);
-    return datanodesNumBalanced.value();
-  }
-
-  public int getMaxDatanodeUtilizedPercentage() {
-    return maxDatanodeUtilizedPercentage.value();
-  }
-
-  public void setMaxDatanodeUtilizedPercentage(int percentage) {
-    this.maxDatanodeUtilizedPercentage.set(percentage);
+  public void incrementCountIterations(long valueToAdd) {
+    countIterations.incr(valueToAdd);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -307,9 +307,11 @@ public class TestContainerBalancer {
     // balancer should not have moved more size than the limit
     Assert.assertFalse(containerBalancer.getSizeMovedPerIteration() >
         10 * OzoneConsts.GB);
-    Assert.assertFalse(
-        containerBalancer.getMetrics().getDataSizeMovedGBInLatestIteration() >
-            10);
+
+    long size =
+        containerBalancer.getMetrics().getDataSizeMovedGBInLatestIteration();
+    Assert.assertTrue(size > 0);
+    Assert.assertFalse(size > 10);
     containerBalancer.stop();
   }
 
@@ -512,7 +514,7 @@ public class TestContainerBalancer {
             balancerConfiguration.getThreshold()).size(),
         metrics.getDatanodesNumUnbalanced());
     Assert.assertTrue(metrics.getDataSizeMovedGBInLatestIteration() <= 6);
-    Assert.assertEquals(1, metrics.getCountIterations());
+    Assert.assertEquals(1, metrics.getNumIterations());
     containerBalancer.stop();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -220,7 +220,7 @@ public class TestContainerBalancer {
     containerBalancer.stop();
     ContainerBalancerMetrics metrics = containerBalancer.getMetrics();
     Assert.assertEquals(0, containerBalancer.getUnBalancedNodes().size());
-    Assert.assertEquals(0, metrics.getDatanodesNumUnbalanced());
+    Assert.assertEquals(0, metrics.getNumDatanodesUnbalanced());
   }
 
   /**
@@ -243,9 +243,9 @@ public class TestContainerBalancer {
     ContainerBalancerMetrics metrics = containerBalancer.getMetrics();
     Assert.assertFalse(
         containerBalancer.getCountDatanodesInvolvedPerIteration() > number);
-    Assert.assertTrue(metrics.getDatanodesNumInvolvedInLatestIteration() > 0);
+    Assert.assertTrue(metrics.getNumDatanodesInvolvedInLatestIteration() > 0);
     Assert.assertFalse(
-        metrics.getDatanodesNumInvolvedInLatestIteration() > number);
+        metrics.getNumDatanodesInvolvedInLatestIteration() > number);
     containerBalancer.stop();
   }
 
@@ -512,7 +512,7 @@ public class TestContainerBalancer {
     ContainerBalancerMetrics metrics = containerBalancer.getMetrics();
     Assert.assertEquals(determineExpectedUnBalancedNodes(
             balancerConfiguration.getThreshold()).size(),
-        metrics.getDatanodesNumUnbalanced());
+        metrics.getNumDatanodesUnbalanced());
     Assert.assertTrue(metrics.getDataSizeMovedGBInLatestIteration() <= 6);
     Assert.assertEquals(1, metrics.getNumIterations());
     containerBalancer.stop();


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ContainerBalancerMetrics` class is responsible for recording metrics. These metrics always show 0 when accessed through JMX, while expected values are greater than 0. 

I deleted some metrics of the type `MutableGaugeLong` and instead used the type `MutableCounterLong`. Introduced a new metric `countIterations` that keeps count of the number of iterations that balancer has run for.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6244

## How was this patch tested?

Updated TestContainerBalancer#testMetrics()