### PR TITLE
HDDS-6270. Use a dedicated file instead of /etc/passwd for xcompat acceptance test

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/read.robot
@@ -16,18 +16,21 @@
 *** Settings ***
 Documentation       Read Compatibility
 Resource            ../ozone-lib/shell.robot
+Resource            setup.robot
 Test Timeout        5 minutes
+Suite Setup         Create Local Test File
 
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
 
 *** Test Cases ***
 Key Can Be Read
-    Key Should Match Local File    /vol1/bucket1/key-${SUFFIX}    /etc/passwd
+    Key Should Match Local File    /vol1/bucket1/key-${SUFFIX}    ${TESTFILE}
 
 Dir Can Be Listed
     Execute    ozone fs -ls o3fs://bucket1.vol1/dir-${SUFFIX}
 
 File Can Be Get
-    Execute    ozone fs -get o3fs://bucket1.vol1/dir-${SUFFIX}/passwd /tmp/passwd-${SUFFIX}
-    [teardown]    Execute    rm /tmp/passwd-${SUFFIX}
+    Execute    ozone fs -get o3fs://bucket1.vol1/dir-${SUFFIX}/file-${SUFFIX} /tmp/
+    Execute    diff -q ${TESTFILE} /tmp/file-${SUFFIX}
+    [teardown]    Execute    rm /tmp/file-${SUFFIX}

--- a/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/compatibility/setup.robot
@@ -14,22 +14,15 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Write Compatibility
+Documentation       Setup for Compatibility Tests
+Library             OperatingSystem
 Resource            ../ozone-lib/shell.robot
-Resource            setup.robot
-Test Timeout        5 minutes
-Suite Setup         Create Local Test File
 
 *** Variables ***
 ${SUFFIX}    ${EMPTY}
 
 
-*** Test Cases ***
-Key Can Be Written
-    Create Key    /vol1/bucket1/key-${SUFFIX}    ${TESTFILE}
-
-Dir Can Be Created
-    Execute    ozone fs -mkdir o3fs://bucket1.vol1/dir-${SUFFIX}
-
-File Can Be Put
-    Execute    ozone fs -put ${TESTFILE} o3fs://bucket1.vol1/dir-${SUFFIX}/file-${SUFFIX}
+*** Keywords ***
+Create Local Test File
+    Set Suite Variable    ${TESTFILE}    /tmp/test-data-${SUFFIX}.txt
+    Create File    ${TESTFILE}    Compatibility Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

`compatibility` test uses `/etc/passwd` for write/read tests, relying on the assumption that the file does not change.  But if we want to upgrade Ozone runner base image, the assumption may be broken, as @smengcl found, since we use old images for existing Ozone versions.

This PR changes the test to use a dedicated file created during test setup.

https://issues.apache.org/jira/browse/HDDS-6270

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/5098198093?check_suite_focus=true#step:5:4582