### PR TITLE
HDDS-6285. ozonesecure-mr intermittently failing with timeout downloading packages

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/test.sh
@@ -27,9 +27,6 @@ export SECURITY_ENABLED=true
 
 start_docker_env
 
-execute_command_in_container rm sudo bash -c "sed -i -e 's/^mirrorlist/#&/' -e 's/^#baseurl/baseurl/' -e 's/mirror.centos.org/vault.centos.org/' /etc/yum.repos.d/*.repo"
-execute_command_in_container rm sudo yum install -y krb5-workstation
-
 execute_robot_test om kinit.robot
 
 execute_robot_test om createmrenv.robot


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozonesecure-mr` is now intermittently failing with timeout downloading packages.

Based on the log message:

```
Package krb5-workstation-1.17-18.el8.x86_64 is already installed
```

we can skip installing `krb5-workstation` during `ozonesecure-mr` test.  It seems this was only necessary with older Hadoop image.

https://issues.apache.org/jira/browse/HDDS-6285

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/5110698986#step:5:687