### PR TITLE
HDDS-6289. Upgrade acceptance test log flooded with parse error

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -24,8 +24,8 @@ OZONE-SITE.XML_ozone.om.address.omservice.om1=om1
 OZONE-SITE.XML_ozone.om.address.omservice.om2=om2
 OZONE-SITE.XML_ozone.om.address.omservice.om3=om3
 OZONE-SITE.XML_ozone.om.ratis.enable=true
-// setting ozone.scm.ratis.enable to false for now, as scm ha upgrade is
-// not supported yet. This is supposed to work without SCM HA configuration
+# setting ozone.scm.ratis.enable to false for now, as scm ha upgrade is
+# not supported yet. This is supposed to work without SCM HA configuration
 OZONE-SITE.XML_ozone.scm.ratis.enable=false
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s
 OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use proper comment syntax in `docker-config` to prevent warnings related to parse issues.

Fix is extracted from feature branch PR #3018.

https://issues.apache.org/jira/browse/HDDS-6289

## How was this patch tested?

https://github.com/smengcl/hadoop-ozone/runs/5118089024#step:5:1301