### PR TITLE
HDDS-6291. Do not let slf4j-log4j12 leak into Ozone FS shaded jar

### DIFF
--- a/hadoop-ozone/client/pom.xml
+++ b/hadoop-ozone/client/pom.xml
@@ -51,6 +51,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/mapreduce.robot
@@ -38,6 +38,7 @@ Execute PI calculation
     ${root} =       Format FS URL    ${SCHEME}    ${volume}    ${bucket}
                     ${output} =      Execute                 yarn jar ${exampleJar} pi -D fs.defaultFS=${root} 3 3
                     Should Contain   ${output}               completed successfully
+                    Should Not Contain   ${output}           multiple SLF4J bindings
 
 Execute WordCount
                     ${exampleJar}    Find example jar

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/hadoopo3fs.robot
@@ -33,6 +33,7 @@ Test hadoop dfs
     ${dir} =          Format FS URL         ${SCHEME}     ${volume}    ${bucket}
     ${random} =        Generate Random String  5  [NUMBERS]
     ${result} =        Execute                    hdfs dfs -put /opt/hadoop/NOTICE.txt ${dir}/${PREFIX}-${random}
+                       Should Not Contain         ${result}           multiple SLF4J bindings
     ${result} =        Execute                    hdfs dfs -ls ${dir}
                        Should contain             ${result}   ${PREFIX}-${random}
     ${result} =        Execute                    hdfs dfs -cat ${dir}/${PREFIX}-${random}

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -57,7 +57,7 @@
         </exclusion>
         <exclusion>
           <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
+          <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

`slf4j-log4j12` was accidentally introduced as compile-time dependency for `ozone-client` in 9644f83c0.  This made it leak into the Ozone FS shaded jars:

```
[INFO] Including org.slf4j:slf4j-log4j12:jar:1.7.30 in the shaded jar.
```
https://github.com/apache/ozone/runs/4756057859#step:6:2442

It also appears in MR test logs:

```
nm_1        | *** Launching "yarn nodemanager"
nm_1        | SLF4J: Class path contains multiple SLF4J bindings.
nm_1        | SLF4J: Found binding in [jar:file:/opt/hadoop/share/hadoop/common/lib/slf4j-log4j12-1.7.30.jar!/org/slf4j/impl/StaticLoggerBinder.class]
nm_1        | SLF4J: Found binding in [jar:file:/opt/ozone/share/ozone/lib/ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar!/org/slf4j/impl/StaticLoggerBinder.class]
nm_1        | SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
nm_1        | SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
nm_1        | 2022-01-31 13:08:02 INFO  NodeManager:51 - STARTUP_MSG: 
```

This PR has the following changes:

 * Exclude all `org.slf4j` artifacts from Ozone FS shaded jar (just in case).
 * Restore scope of dependency on `slf4j-log4j12` to `test` in `ozone-client`.

https://issues.apache.org/jira/browse/HDDS-6291

## How was this patch tested?

Tested the effect of exclusion separately.  Verified that the dependency is excluded from the shaded jar.  Then restored `test` scope.

https://github.com/adoroszlai/hadoop-ozone/runs/5128091580#step:6:7386

Also verified _acceptance (MR)_ logs:

```
nm_1        | *** Launching "yarn nodemanager"
nm_1        | 2022-02-09 16:45:59 INFO  NodeManager:51 - STARTUP_MSG: 
```