### PR TITLE
HDDS-6153. Add simple integration test to the read-replicas debug tool.

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -21,6 +21,7 @@ OZONE-SITE.XML_ozone.om.address=om
 OZONE-SITE.XML_ozone.om.http-address=om:9874
 OZONE-SITE.XML_ozone.scm.http-address=scm:9876
 OZONE-SITE.XML_ozone.scm.container.size=1GB
+OZONE-SITE.XML_ozone.scm.block.size=1MB
 OZONE-SITE.XML_ozone.scm.datanode.ratis.volume.free-space.min=10MB
 OZONE-SITE.XML_ozone.scm.pipeline.creation.interval=30s
 OZONE-SITE.XML_ozone.scm.pipeline.owner.container.count=1

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -39,6 +39,10 @@ OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_hdds.container.report.interval=60s
+OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
+OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
+OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
+OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-config
@@ -39,10 +39,9 @@ OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_hdds.container.report.interval=60s
-OZONE-SITE.XML_hdds.scm.replication.thread.interval=5s
-OZONE-SITE.XML_hdds.scm.replication.event.timeout=10s
 OZONE-SITE.XML_ozone.scm.stale.node.interval=30s
 OZONE-SITE.XML_ozone.scm.dead.node.interval=45s
+OZONE-SITE.XML_hdds.heartbeat.interval=5s
 
 OZONE_CONF_DIR=/etc/hadoop
 OZONE_LOG_DIR=/var/log/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -50,6 +50,8 @@ execute_robot_test scm freon
 execute_robot_test scm cli
 execute_robot_test scm admincli
 
+execute_debug_tests
+
 execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-fso-ofs-link ozonefs/ozonefs.robot
 execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-fso-o3fs-bucket ozonefs/ozonefs.robot
 

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -37,4 +37,5 @@ Test ozone debug read-replicas with corrupt block replica
     ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
     ${json} =                           Evaluate        json.loads('''${manifest}''')        json
     Compare JSON                        ${json}
+    Check for all datanodes             ${json}
     Check checksum mismatch error       ${json}         ozone_datanode_2.ozone_default

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test read-replicas in case of a corrupt replica
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Resource            ozone-debug.robot
+Test Timeout        5 minute
+*** Variables ***
+${VOLUME}           vol1
+${BUCKET}           bucket1
+${TESTFILE}         testfile
+
+*** Test Cases ***
+Test ozone debug read-replicas with corrupt block replica
+    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
+    Directory Should Exist              ${directory}
+    File Should Exist                   ${directory}/${TESTFILE}_manifest
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
+    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
+    ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
+    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
+    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
+    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
+    Should Not Be Equal                 ${dn2_md5sum}   ${testfile_md5sum}
+    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
+    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
+    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
+    Compare JSON                        ${json}
+    Check cheksum mismatch error        ${json}         ozone_datanode_2.ozone_default

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -16,22 +16,17 @@
 *** Settings ***
 Documentation       Test read-replicas in case of a corrupt replica
 Library             OperatingSystem
-Resource            ../commonlib.robot
+Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 *** Variables ***
-${VOLUME}           vol1
-${BUCKET}           bucket1
+${VOLUME}           cli-debug-volume
+${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
 
 *** Test Cases ***
 Test ozone debug read-replicas with corrupt block replica
-    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
-    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
-    Directory Should Exist              ${directory}
-    File Should Exist                   ${directory}/${TESTFILE}_manifest
-    ${count_files} =                    Count Files In Directory    ${directory}
-    Should Be Equal As Integers         ${count_files}     7
+    ${directory} =                      Execute read-replicas CLI tool
     ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
     ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
     ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
@@ -42,4 +37,4 @@ Test ozone debug read-replicas with corrupt block replica
     ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
     ${json} =                           Evaluate        json.loads('''${manifest}''')        json
     Compare JSON                        ${json}
-    Check cheksum mismatch error        ${json}         ozone_datanode_2.ozone_default
+    Check checksum mismatch error       ${json}         ozone_datanode_2.ozone_default

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-dead-datanode.robot
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test read-replicas in case of one datanode is unavailable
+Library             OperatingSystem
+Resource            ../lib/os.robot
+Resource            ozone-debug.robot
+Test Timeout        5 minute
+*** Variables ***
+${VOLUME}           cli-debug-volume
+${BUCKET}           cli-debug-bucket
+${TESTFILE}         testfile
+
+*** Test Cases ***
+Test ozone debug read-replicas with one datanode DEAD
+    ${directory} =                      Execute read-replicas CLI tool
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     5
+    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
+    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
+    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
+    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
+    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
+    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
+    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
+    Compare JSON                        ${json}
+    ${datanodes_expected} =             Create List  ozone_datanode_1.ozone_default  ozone_datanode_3.ozone_default
+    ${datanodes_b1} =                   Create List   ${json}[blocks][0][replicas][0][hostname]    ${json}[blocks][0][replicas][1][hostname]
+    Check for datanodes                 ${datanodes_b1}    ${datanodes_expected}
+    ${datanodes_b2} =                   Create List   ${json}[blocks][1][replicas][0][hostname]    ${json}[blocks][1][replicas][1][hostname]
+    Check for datanodes                 ${datanodes_b2}    ${datanodes_expected}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-modified-env.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-modified-env.robot
@@ -16,22 +16,17 @@
 *** Settings ***
 Documentation       Test read-replicas in case of one datanode is unavailable
 Library             OperatingSystem
-Resource            ../commonlib.robot
+Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 *** Variables ***
-${VOLUME}           vol1
-${BUCKET}           bucket1
+${VOLUME}           cli-debug-volume
+${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
 
 *** Test Cases ***
 Test ozone debug read-replicas with one datanode unavailable
-    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
-    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
-    Directory Should Exist              ${directory}
-    File Should Exist                   ${directory}/${TESTFILE}_manifest
-    ${count_files} =                    Count Files In Directory    ${directory}
-    Should Be Equal As Integers         ${count_files}     7
+    ${directory} =                      Execute read-replicas CLI tool
     ${corrupted_block1} =               Get File Size   ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default
     ${corrupted_block2} =               Get File Size   ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default
     Should Be Equal As Integers         ${corrupted_block1}     0

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-modified-env.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-modified-env.robot
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test read-replicas in case of one datanode is unavailable
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Resource            ozone-debug.robot
+Test Timeout        5 minute
+*** Variables ***
+${VOLUME}           vol1
+${BUCKET}           bucket1
+${TESTFILE}         testfile
+
+*** Test Cases ***
+Test ozone debug read-replicas with one datanode unavailable
+    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
+    Directory Should Exist              ${directory}
+    File Should Exist                   ${directory}/${TESTFILE}_manifest
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
+    ${corrupted_block1} =               Get File Size   ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default
+    ${corrupted_block2} =               Get File Size   ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default
+    Should Be Equal As Integers         ${corrupted_block1}     0
+    Should Be Equal As Integers         ${corrupted_block2}     0
+    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
+    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
+    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
+    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
+    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
+    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
+    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
+    Compare JSON                        ${json}
+    Check unavailable datanode error    ${json}         ozone_datanode_2.ozone_default

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
@@ -27,6 +27,8 @@ ${TESTFILE}         testfile
 *** Test Cases ***
 Test ozone debug read-replicas with one datanode STALE
     ${directory} =                      Execute read-replicas CLI tool
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
     ${corrupted_block1} =               Get File Size   ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default
     ${corrupted_block2} =               Get File Size   ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default
     Should Be Equal As Integers         ${corrupted_block1}     0
@@ -40,25 +42,4 @@ Test ozone debug read-replicas with one datanode STALE
     ${json} =                           Evaluate        json.loads('''${manifest}''')        json
     Compare JSON                        ${json}
     Check for all datanodes             ${json}
-    Check unavailable datanode error    ${json}         ozone_datanode_2.ozone_default
-
-Test ozone debug read-replicas with one datanode DEAD
-    ${directory} =                      Execute read-replicas CLI tool
-    ${corrupted_block1} =               Get File Size   ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default
-    ${corrupted_block2} =               Get File Size   ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default
-    Should Be Equal As Integers         ${corrupted_block1}     0
-    Should Be Equal As Integers         ${corrupted_block2}     0
-    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
-    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
-    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
-    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
-    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
-    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
-    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
-    Compare JSON                        ${json}
-    ${datanodes_expected} =             Create List  ozone_datanode_1.ozone_default  ozone_datanode_3.ozone_default
-    ${datanodes_b1} =                   Create List   ${json}[blocks][0][replicas][0][hostname]    ${json}[blocks][0][replicas][1][hostname]
-    Check for datanodes                 ${datanodes_b1}    ${datanodes_expected}
-    ${datanodes_b2} =                   Create List   ${json}[blocks][1][replicas][0][hostname]    ${json}[blocks][1][replicas][1][hostname]
-    Check for datanodes                 ${datanodes_b2}    ${datanodes_expected}
     Check unavailable datanode error    ${json}         ozone_datanode_2.ozone_default

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -16,13 +16,13 @@
 *** Settings ***
 Documentation       Test ozone Debug CLI
 Library             OperatingSystem
-Resource            ../commonlib.robot
+Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 Suite Setup         Write keys
 *** Variables ***
-${VOLUME}           vol1
-${BUCKET}           bucket1
+${VOLUME}           cli-debug-volume
+${BUCKET}           cli-debug-bucket
 ${DEBUGKEY}         debugKey
 ${TESTFILE}         testfile
 
@@ -42,12 +42,7 @@ Test ozone debug chunkinfo
                     File Should Exist   ${result}
 
 Test ozone debug read-replicas
-    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
-    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
-    Directory Should Exist              ${directory}
-    File Should Exist                   ${directory}/${TESTFILE}_manifest
-    ${count_files} =                    Count Files In Directory    ${directory}
-    Should Be Equal As Integers         ${count_files}     7
+    ${directory} =                      Execute read-replicas CLI tool
     ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
     ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
     ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Test ozone Debug CLI
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Resource            ozone-debug.robot
+Test Timeout        5 minute
+Suite Setup         Write keys
+*** Variables ***
+${VOLUME}           vol1
+${BUCKET}           bucket1
+${DEBUGKEY}         debugKey
+${TESTFILE}         testfile
+
+*** Keywords ***
+Write keys
+    Execute             ozone sh volume create o3://om/${VOLUME} --space-quota 100TB --namespace-quota 100
+    Execute             ozone sh bucket create o3://om/${VOLUME}/${BUCKET}
+    Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${DEBUGKEY} /opt/hadoop/NOTICE.txt
+    Execute             dd if=/dev/urandom of=testfile bs=100000 count=15
+    Execute             ozone sh key put o3://om/${VOLUME}/${BUCKET}/${TESTFILE} testfile
+
+*** Test Cases ***
+Test ozone debug chunkinfo
+    ${result} =     Execute             ozone debug chunkinfo o3://om/${VOLUME}/${BUCKET}/${DEBUGKEY} | jq -r '.KeyLocations[0][0].Locations'
+                    Should contain      ${result}       files
+    ${result} =     Execute             ozone debug chunkinfo o3://om/${VOLUME}/${BUCKET}/${DEBUGKEY} | jq -r '.KeyLocations[0][0].Locations.files[0]'
+                    File Should Exist   ${result}
+
+Test ozone debug read-replicas
+    Execute                             ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    ${directory} =                      Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
+    Directory Should Exist              ${directory}
+    File Should Exist                   ${directory}/${TESTFILE}_manifest
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
+    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
+    ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
+    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
+    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
+    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
+    Should Be Equal                     ${dn2_md5sum}   ${testfile_md5sum}
+    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
+    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
+    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
+    Compare JSON                        ${json}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-tests.robot
@@ -43,6 +43,8 @@ Test ozone debug chunkinfo
 
 Test ozone debug read-replicas
     ${directory} =                      Execute read-replicas CLI tool
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
     ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
     ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
     ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
@@ -53,3 +55,4 @@ Test ozone debug read-replicas
     ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
     ${json} =                           Evaluate        json.loads('''${manifest}''')        json
     Compare JSON                        ${json}
+    Check for all datanodes             ${json}

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug.robot
@@ -16,14 +16,18 @@
 *** Settings ***
 Documentation       Test ozone Debug CLI
 Library             Collections
-Resource            ../commonlib.robot
-
-*** Variables ***
-${VOLUME}           vol1
-${BUCKET}           bucket1
-${TESTFILE}         testfile
+Resource            ../lib/os.robot
 
 *** Keywords ***
+Execute read-replicas CLI tool
+    Execute                         ozone debug read-replicas o3://om/${VOLUME}/${BUCKET}/${TESTFILE}
+    ${directory} =                  Execute     find /opt/hadoop -maxdepth 1 -name '${VOLUME}_${BUCKET}_${TESTFILE}_*' | tail -n 1
+    Directory Should Exist          ${directory}
+    File Should Exist               ${directory}/${TESTFILE}_manifest
+    ${count_files} =                Count Files In Directory    ${directory}
+    Should Be Equal As Integers     ${count_files}     7
+    [Return]                        ${directory}
+
 Compare JSON
     [arguments]                     ${json}
     Should Be Equal                 ${json}[filename]                   ${VOLUME}/${BUCKET}/${TESTFILE}
@@ -46,7 +50,7 @@ Compare JSON
     ${datanodes_expected_b2} =      Create List  ozone_datanode_1.ozone_default  ozone_datanode_2.ozone_default  ozone_datanode_3.ozone_default
     Lists Should Be Equal	        ${datanodes_b2}    ${datanodes_expected_b2}   ignore_order=True
 
-Check cheksum mismatch error
+Check checksum mismatch error
     [arguments]                     ${json}     ${datanode}
     ${datanodes} =                  Create List     ${json}[blocks][0][replicas][0][hostname]   ${json}[blocks][0][replicas][1][hostname]   ${json}[blocks][0][replicas][2][hostname]
     ${index} =                      Get Index From List         ${datanodes}        ${datanode}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I added acceptance robot tests to the previously added read-replicas debug CLI tool. There was an already existing ozone-debug.robot test which I made into a resource file with keywords to check the JSON file generated with read-replicas. I made an ozone-debug-tests.robot for the chunkinfo and read-replicas CLI tool related tests in basic environment. I added two test files, one for the case when one of the block replicas became corrupt and one when one of the datanodes is unavailable. I changed the block size in the compose/ozone docker environment, so I can test the read-replicas command with a key with more than one block and it won't take that much to execute it. I am executing the added tests in the compose/ozone’s test.sh via a method in testlib.sh.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6153

## How was this patch tested?

Executed the related robot tests successfully. 
