### PR TITLE
HDDS-6257. Wrong stack trace for S3 errors

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -67,6 +67,7 @@ import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NOT_IMPLEMENTED;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;
 
 /**
@@ -148,7 +149,7 @@ public class BucketEndpoint extends EndpointBase {
       }
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw ex;
       }
@@ -242,8 +243,7 @@ public class BucketEndpoint extends EndpointBase {
           .build();
     } catch (OMException exception) {
       if (exception.getResult() == ResultCodes.INVALID_BUCKET_NAME) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_BUCKET_NAME,
-            bucketName);
+        throw newError(S3ErrorTable.INVALID_BUCKET_NAME, bucketName, exception);
       }
       LOG.error("Error in Create Bucket Request for bucket: {}", bucketName,
           exception);
@@ -263,8 +263,7 @@ public class BucketEndpoint extends EndpointBase {
       ozoneMultipartUploadList = bucket.listMultipartUploads(prefix);
     } catch (OMException exception) {
       if (exception.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            prefix);
+        throw newError(S3ErrorTable.ACCESS_DENIED, prefix, exception);
       }
       throw exception;
     }
@@ -309,13 +308,11 @@ public class BucketEndpoint extends EndpointBase {
       deleteS3Bucket(bucketName);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.BUCKET_NOT_EMPTY) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .BUCKET_NOT_EMPTY, bucketName);
+        throw newError(S3ErrorTable.BUCKET_NOT_EMPTY, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .NO_SUCH_BUCKET, bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw ex;
       }
@@ -402,14 +399,12 @@ public class BucketEndpoint extends EndpointBase {
       return result;
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .NO_SUCH_BUCKET, bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         LOG.error("Failed to get acl of Bucket " + bucketName, ex);
-        throw S3ErrorTable.newError(S3ErrorTable.INTERNAL_ERROR, bucketName);
+        throw newError(S3ErrorTable.INTERNAL_ERROR, bucketName, ex);
       }
     }
   }
@@ -503,11 +498,9 @@ public class BucketEndpoint extends EndpointBase {
       }
     } catch (OMException exception) {
       if (exception.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET,
-            bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, exception);
       } else if (exception.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, exception);
       }
       LOG.error("Error in set ACL Request for bucket: {}", bucketName,
           exception);
@@ -531,13 +524,13 @@ public class BucketEndpoint extends EndpointBase {
     for (String acl: subValues) {
       String[] part = acl.split("=");
       if (part.length != 2) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, acl);
+        throw newError(S3ErrorTable.INVALID_ARGUMENT, acl);
       }
       S3Acl.ACLIdentityType type =
           S3Acl.ACLIdentityType.getTypeFromHeaderType(part[0]);
       if (type == null || !type.isSupported()) {
         LOG.warn("S3 grantee {} is null or not supported", part[0]);
-        throw S3ErrorTable.newError(NOT_IMPLEMENTED, part[0]);
+        throw newError(NOT_IMPLEMENTED, part[0]);
       }
       // Build ACL on Bucket
       BitSet aclsOnBucket =
@@ -564,13 +557,13 @@ public class BucketEndpoint extends EndpointBase {
     for (String acl: subValues) {
       String[] part = acl.split("=");
       if (part.length != 2) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_ARGUMENT, acl);
+        throw newError(S3ErrorTable.INVALID_ARGUMENT, acl);
       }
       S3Acl.ACLIdentityType type =
           S3Acl.ACLIdentityType.getTypeFromHeaderType(part[0]);
       if (type == null || !type.isSupported()) {
         LOG.warn("S3 grantee {} is null or not supported", part[0]);
-        throw S3ErrorTable.newError(NOT_IMPLEMENTED, part[0]);
+        throw newError(NOT_IMPLEMENTED, part[0]);
       }
       // Build ACL on Volume
       BitSet aclsOnVolume =

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -38,6 +38,8 @@ import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
+
 /**
  * Basic helpers for all the REST endpoints.
  */
@@ -57,7 +59,7 @@ public abstract class EndpointBase {
       bucket = volume.getBucket(bucketName);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else {
         throw ex;
       }
@@ -88,9 +90,9 @@ public abstract class EndpointBase {
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND
           || ex.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw ex;
       }
@@ -117,7 +119,7 @@ public abstract class EndpointBase {
       client.getObjectStore().createS3Bucket(bucketName);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, bucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else if (ex.getResult() != ResultCodes.BUCKET_ALREADY_EXISTS) {
         // S3 does not return error for bucket already exists, it just
         // returns the location.
@@ -138,8 +140,7 @@ public abstract class EndpointBase {
       client.getObjectStore().deleteS3Bucket(s3BucketName);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            s3BucketName);
+        throw newError(S3ErrorTable.ACCESS_DENIED, s3BucketName, ex);
       }
       throw ex;
     }
@@ -182,8 +183,7 @@ public abstract class EndpointBase {
       if (e.getResult() == ResultCodes.VOLUME_NOT_FOUND) {
         return Collections.emptyIterator();
       } else  if (e.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            "listBuckets");
+        throw newError(S3ErrorTable.ACCESS_DENIED, "listBuckets", e);
       } else {
         throw e;
       }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -95,6 +95,7 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_ARGUMENT
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INVALID_REQUEST;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NO_SUCH_UPLOAD;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.PRECOND_FAILED;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.ACCEPT_RANGE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.CONTENT_RANGE_HEADER;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.COPY_SOURCE_HEADER;
@@ -210,8 +211,7 @@ public class ObjectEndpoint extends EndpointBase {
           .build();
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.NOT_A_FILE) {
-        OS3Exception os3Exception = S3ErrorTable.newError(INVALID_REQUEST,
-            keyPath);
+        OS3Exception os3Exception = newError(INVALID_REQUEST, keyPath, ex);
         os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
             "when calling the PutObject/MPU PartUpload operation: " +
             OZONE_OM_ENABLE_FILESYSTEM_PATHS + " is enabled Keys are" +
@@ -219,7 +219,7 @@ public class ObjectEndpoint extends EndpointBase {
             "which caused put operation to fail.");
         throw os3Exception;
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
+        throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       }
       LOG.error("Exception occurred in PutObject", ex);
       throw ex;
@@ -274,8 +274,7 @@ public class ObjectEndpoint extends EndpointBase {
             length);
         LOG.debug("range Header provided: {}", rangeHeader);
         if (rangeHeader.isInValidRange()) {
-          throw S3ErrorTable.newError(
-              S3ErrorTable.INVALID_RANGE, rangeHeaderVal);
+          throw newError(S3ErrorTable.INVALID_RANGE, rangeHeaderVal);
         }
       }
       ResponseBuilder responseBuilder;
@@ -326,10 +325,9 @@ public class ObjectEndpoint extends EndpointBase {
       return responseBuilder.build();
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .NO_SUCH_KEY, keyPath);
+        throw newError(S3ErrorTable.NO_SUCH_KEY, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
+        throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else {
         throw ex;
       }
@@ -368,7 +366,7 @@ public class ObjectEndpoint extends EndpointBase {
         // Just return 404 with no content
         return Response.status(Status.NOT_FOUND).build();
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
+        throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else {
         throw ex;
       }
@@ -398,7 +396,7 @@ public class ObjectEndpoint extends EndpointBase {
       ozoneBucket.abortMultipartUpload(key, uploadId);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_UPLOAD, uploadId);
+        throw newError(S3ErrorTable.NO_SUCH_UPLOAD, uploadId, ex);
       }
       throw ex;
     }
@@ -433,8 +431,7 @@ public class ObjectEndpoint extends EndpointBase {
       bucket.deleteKey(keyPath);
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable
-            .NO_SUCH_BUCKET, bucketName);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
         //NOT_FOUND is not a problem, AWS doesn't throw exception for missing
         // keys. Just return 204
@@ -444,7 +441,7 @@ public class ObjectEndpoint extends EndpointBase {
         // NOT_FOUND is not a problem, AWS doesn't throw exception for missing
         // keys. Just return 204
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, keyPath);
+        throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else {
         throw ex;
       }
@@ -495,7 +492,7 @@ public class ObjectEndpoint extends EndpointBase {
           multipartUploadInitiateResponse).build();
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED, key);
+        throw newError(S3ErrorTable.ACCESS_DENIED, key, ex);
       }
       LOG.error("Error in Initiate Multipart Upload Request for bucket: {}, " +
           "key: {}", bucket, key, ex);
@@ -542,21 +539,21 @@ public class ObjectEndpoint extends EndpointBase {
           .build();
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.INVALID_PART) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_PART, key);
+        throw newError(S3ErrorTable.INVALID_PART, key, ex);
       } else if (ex.getResult() == ResultCodes.INVALID_PART_ORDER) {
-        throw S3ErrorTable.newError(S3ErrorTable.INVALID_PART_ORDER, key);
+        throw newError(S3ErrorTable.INVALID_PART_ORDER, key, ex);
       } else if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
-        throw S3ErrorTable.newError(NO_SUCH_UPLOAD, uploadID);
+        throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (ex.getResult() == ResultCodes.ENTITY_TOO_SMALL) {
-        throw S3ErrorTable.newError(ENTITY_TOO_SMALL, key);
+        throw newError(ENTITY_TOO_SMALL, key, ex);
       } else if(ex.getResult() == ResultCodes.INVALID_REQUEST) {
-        OS3Exception os3Exception = S3ErrorTable.newError(INVALID_REQUEST, key);
+        OS3Exception os3Exception = newError(INVALID_REQUEST, key, ex);
         os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
             "when calling the CompleteMultipartUpload operation: You must " +
             "specify at least one part");
         throw os3Exception;
       } else if(ex.getResult() == ResultCodes.NOT_A_FILE) {
-        OS3Exception os3Exception = S3ErrorTable.newError(INVALID_REQUEST, key);
+        OS3Exception os3Exception = newError(INVALID_REQUEST, key, ex);
         os3Exception.setErrorMessage("An error occurred (InvalidRequest) " +
             "when calling the CompleteMultipartUpload operation: " +
             OZONE_OM_ENABLE_FILESYSTEM_PATHS + " is enabled Keys are " +
@@ -602,8 +599,7 @@ public class ObjectEndpoint extends EndpointBase {
               headers.getHeaderString(COPY_SOURCE_IF_UNMODIFIED_SINCE);
           if (!checkCopySourceModificationTime(sourceKeyModificationTime,
               copySourceIfModifiedSince, copySourceIfUnmodifiedSince)) {
-            throw S3ErrorTable.newError(PRECOND_FAILED,
-                sourceBucket + "/" + sourceKey);
+            throw newError(PRECOND_FAILED, sourceBucket + "/" + sourceKey);
           }
 
           try (OzoneInputStream sourceObject =
@@ -651,11 +647,9 @@ public class ObjectEndpoint extends EndpointBase {
 
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
-        throw S3ErrorTable.newError(NO_SUCH_UPLOAD,
-            uploadID);
+        throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            bucket + "/" + key);
+        throw newError(S3ErrorTable.ACCESS_DENIED, bucket + "/" + key, ex);
       }
       throw ex;
     }
@@ -710,11 +704,10 @@ public class ObjectEndpoint extends EndpointBase {
 
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
-        throw S3ErrorTable.newError(NO_SUCH_UPLOAD,
-            uploadID);
+        throw newError(NO_SUCH_UPLOAD, uploadID, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            bucket + "/" + key + "/" + uploadID);
+        throw newError(S3ErrorTable.ACCESS_DENIED,
+            bucket + "/" + key + "/" + uploadID, ex);
       }
       throw ex;
     }
@@ -750,8 +743,7 @@ public class ObjectEndpoint extends EndpointBase {
         // options like storage type are provided or not when source and
         // dest are given same
         if (storageTypeDefault) {
-          OS3Exception ex = S3ErrorTable.newError(S3ErrorTable
-              .INVALID_REQUEST, copyHeader);
+          OS3Exception ex = newError(S3ErrorTable.INVALID_REQUEST, copyHeader);
           ex.setErrorMessage("This copy request is illegal because it is " +
               "trying to copy an object to it self itself without changing " +
               "the object's metadata, storage class, website redirect " +
@@ -797,12 +789,12 @@ public class ObjectEndpoint extends EndpointBase {
       return copyObjectResponse;
     } catch (OMException ex) {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_KEY, sourceKey);
+        throw newError(S3ErrorTable.NO_SUCH_KEY, sourceKey, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
-        throw S3ErrorTable.newError(S3ErrorTable.NO_SUCH_BUCKET, sourceBucket);
+        throw newError(S3ErrorTable.NO_SUCH_BUCKET, sourceBucket, ex);
       } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
-        throw S3ErrorTable.newError(S3ErrorTable.ACCESS_DENIED,
-            destBucket + "/" + destkey);
+        throw newError(S3ErrorTable.ACCESS_DENIED,
+            destBucket + "/" + destkey, ex);
       }
       throw ex;
     } finally {
@@ -829,7 +821,7 @@ public class ObjectEndpoint extends EndpointBase {
     }
     int pos = header.indexOf('/');
     if (pos == -1) {
-      OS3Exception ex = S3ErrorTable.newError(INVALID_ARGUMENT, header);
+      OS3Exception ex = newError(INVALID_ARGUMENT, header);
       ex.setErrorMessage("Copy Source must mention the source bucket and " +
           "key: sourcebucket/sourcekey");
       throw ex;
@@ -840,7 +832,7 @@ public class ObjectEndpoint extends EndpointBase {
       String key = urlDecode(header.substring(pos + 1));
       return Pair.of(bucket, key);
     } catch (UnsupportedEncodingException e) {
-      OS3Exception ex = S3ErrorTable.newError(INVALID_ARGUMENT, header);
+      OS3Exception ex = newError(INVALID_ARGUMENT, header, e);
       ex.setErrorMessage("Copy Source header could not be url-decoded");
       throw ex;
     }
@@ -851,8 +843,7 @@ public class ObjectEndpoint extends EndpointBase {
     try {
       return S3StorageType.valueOf(storageType);
     } catch (IllegalArgumentException ex) {
-      throw S3ErrorTable.newError(INVALID_ARGUMENT,
-          storageType);
+      throw newError(INVALID_ARGUMENT, storageType, ex);
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -120,20 +120,26 @@ public final class S3ErrorTable {
       "NotImplemented", "This part of feature is not implemented yet.",
       HTTP_NOT_IMPLEMENTED);
 
+  public static OS3Exception newError(OS3Exception e, String resource) {
+    return newError(e, resource, null);
+  }
+
   /**
    * Create a new instance of Error.
    * @param e Error Template
    * @param resource Resource associated with this exception
+   * @param ex the original exception, may be null
    * @return creates a new instance of error based on the template
    */
-  public static OS3Exception newError(OS3Exception e, String resource) {
+  public static OS3Exception newError(OS3Exception e, String resource,
+      Exception ex) {
     OS3Exception err =  new OS3Exception(e.getCode(), e.getErrorMessage(),
         e.getHttpCode());
     err.setResource(resource);
     if (e.getHttpCode() == HTTP_INTERNAL_ERROR) {
-      LOG.error("Internal Error: {}", err.toXml(), e);
+      LOG.error("Internal Error: {}", err.toXml(), ex);
     } else if (LOG.isDebugEnabled()) {
-      LOG.debug(err.toXml(), e);
+      LOG.debug(err.toXml(), ex);
     }
     return err;
   }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/ContinueToken.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/util/ContinueToken.java
@@ -111,7 +111,7 @@ public class ContinueToken {
 
       } catch (DecoderException ex) {
         OS3Exception os3Exception = S3ErrorTable.newError(S3ErrorTable
-            .INVALID_ARGUMENT, key);
+            .INVALID_ARGUMENT, key, ex);
         os3Exception.setErrorMessage("The continuation token provided is " +
             "incorrect");
         throw os3Exception;


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3 Gateway logs exception in `S3ErrorTable.newError`, but the stack trace is wrong.

```
s3g_1       | <Error>
s3g_1       |   <Code>InvalidBucketName</Code>
s3g_1       |   <Message>The specified bucket is not valid.</Message>
s3g_1       |   <Resource>a_b_c</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
s3g_1       |
s3g_1       | org.apache.hadoop.ozone.s3.exception.OS3Exception
s3g_1       |    at org.apache.hadoop.ozone.s3.exception.S3ErrorTable.<clinit>(S3ErrorTable.java:88)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.getBucket(EndpointBase.java:91)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.head(BucketEndpoint.java:294)
```

```
s3g_1       | <Error>
s3g_1       |   <Code>NoSuchBucket</Code>
s3g_1       |   <Message>The specified bucket does not exist</Message>
s3g_1       |   <Resource>dont-exist</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
s3g_1       |
s3g_1       | org.apache.hadoop.ozone.s3.exception.OS3Exception
s3g_1       |    at org.apache.hadoop.ozone.s3.exception.S3ErrorTable.<clinit>(S3ErrorTable.java:51)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.getBucket(EndpointBase.java:91)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.head(BucketEndpoint.java:294)
```

Note that both errors have the same stack trace.  It always points to the operation that first accessed `S3ErrorTable` class (i.e. the one that triggered the first error, in this case a `head-bucket` operation).

This change fixes the stack trace by passing the original exception, if available, to the method which logs, instead of using the predefined `OS3Exception`'s stack trace.

https://issues.apache.org/jira/browse/HDDS-6257

## How was this patch tested?

Set log level to debug:

```
log4j.logger.org.apache.hadoop.ozone.s3.exception.S3ErrorTable=DEBUG
```

Tested with the following commands.  Verified that stack traces are unique.

```
aws s3api --endpoint http://s3g:9878 head-bucket --bucket dont-exist
```

```
s3g_1       | 2022-02-09 14:41:46,981 [qtp690052870-22] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>NoSuchBucket</Code>
s3g_1       |   <Message>The specified bucket does not exist</Message>
s3g_1       |   <Resource>dont-exist</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
s3g_1       |
s3g_1       | BUCKET_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: Bucket not found
s3g_1       |    at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.handleError(OzoneManagerProtocolClientSideTranslatorPB.java:654)
s3g_1       |    at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.getBucketInfo(OzoneManagerProtocolClientSideTranslatorPB.java:503)
s3g_1       |    at org.apache.hadoop.ozone.client.rpc.RpcClient.getBucketDetails(RpcClient.java:771)
s3g_1       |    at org.apache.hadoop.ozone.client.OzoneVolume.getBucket(OzoneVolume.java:406)
s3g_1       |    at org.apache.hadoop.ozone.client.ObjectStore.getS3Bucket(ObjectStore.java:122)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.getBucket(EndpointBase.java:89)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.head(BucketEndpoint.java:293)
```

```
aws s3api --endpoint http://s3g:9878 delete-bucket --bucket dont-exist
```

```
s3g_1       | 2022-02-09 14:42:29,766 [qtp690052870-16] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>NoSuchBucket</Code>
s3g_1       |   <Message>The specified bucket does not exist</Message>
s3g_1       |   <Resource>dont-exist</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
s3g_1       |
s3g_1       | BUCKET_NOT_FOUND org.apache.hadoop.ozone.om.exceptions.OMException: Bucket not exists
s3g_1       |    at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.handleError(OzoneManagerProtocolClientSideTranslatorPB.java:654)
s3g_1       |    at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.deleteBucket(OzoneManagerProtocolClientSideTranslatorPB.java:856)
s3g_1       |    at org.apache.hadoop.ozone.client.rpc.RpcClient.deleteBucket(RpcClient.java:756)
s3g_1       |    at org.apache.hadoop.ozone.client.OzoneVolume.deleteBucket(OzoneVolume.java:444)
s3g_1       |    at org.apache.hadoop.ozone.client.ObjectStore.deleteS3Bucket(ObjectStore.java:133)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.deleteS3Bucket(EndpointBase.java:140)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.delete(BucketEndpoint.java:308)
```

```
aws s3api --endpoint http://s3g:9878 create-bucket --bucket 'a_b_c'
```

```
s3g_1       | 2022-02-09 14:43:02,028 [qtp690052870-17] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>InvalidBucketName</Code>
s3g_1       |   <Message>The specified bucket is not valid.</Message>
s3g_1       |   <Resource>a_b_c</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
s3g_1       |
s3g_1       | INVALID_BUCKET_NAME org.apache.hadoop.ozone.om.exceptions.OMException: Bucket or Volume name has an unsupported character : _
s3g_1       |    at org.apache.hadoop.ozone.client.rpc.RpcClient.verifyBucketName(RpcClient.java:582)
s3g_1       |    at org.apache.hadoop.ozone.client.rpc.RpcClient.createBucket(RpcClient.java:521)
s3g_1       |    at org.apache.hadoop.ozone.client.rpc.RpcClient.createBucket(RpcClient.java:512)
s3g_1       |    at org.apache.hadoop.ozone.client.OzoneVolume.createBucket(OzoneVolume.java:385)
s3g_1       |    at org.apache.hadoop.ozone.client.ObjectStore.createS3Bucket(ObjectStore.java:118)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.createS3Bucket(EndpointBase.java:119)
s3g_1       |    at org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint.put(BucketEndpoint.java:240)
```

```
ozone sh bucket create /s3v/bucket1
ozone sh key put /s3v/bucket1/key1 /etc/passwd
aws s3api --endpoint http://s3g:9878 get-object --bucket bucket1 --key key1 --range bytes=10000-10000 /dev/null
```

```
s3g_1       | 2022-02-09 14:56:33,771 [qtp690052870-22] DEBUG exception.S3ErrorTable: <?xml version="1.0" encoding="UTF-8"?>
s3g_1       | <Error>
s3g_1       |   <Code>InvalidRange</Code>
s3g_1       |   <Message>The requested range is not satisfiable</Message>
s3g_1       |   <Resource>bytes=10000-10000</Resource>
s3g_1       |   <RequestId/>
s3g_1       | </Error>
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1818745426