### PR TITLE
HDDS-6292. Ensure immutable ContainerReplica set is returned from ContainerStateManagerImpl

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -215,7 +215,8 @@ public class ContainerStateMap {
   }
 
   private Set<ContainerReplica> createNewReplicaSet(ContainerID containerID) {
-    return new HashSet<>(replicaMap.get(containerID));
+    Set<ContainerReplica> existingSet = replicaMap.get(containerID);
+    return existingSet == null ? new HashSet<>() : new HashSet<>(existingSet);
   }
 
   private void replaceReplicaSet(ContainerID containerID,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/states/ContainerStateMap.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.scm.container.states;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Collections;
 import java.util.Map;
@@ -119,7 +120,7 @@ public class ContainerStateMap {
       ownerMap.insert(info.getOwner(), id);
       repConfigMap.insert(info.getReplicationConfig(), id);
       typeMap.insert(info.getReplicationType(), id);
-      replicaMap.put(id, ConcurrentHashMap.newKeySet());
+      replicaMap.put(id, Collections.emptySet());
 
       // Flush the cache of this container type, will be added later when
       // get container queries are executed.
@@ -173,8 +174,7 @@ public class ContainerStateMap {
   public Set<ContainerReplica> getContainerReplicas(
       final ContainerID containerID) {
     Preconditions.checkNotNull(containerID);
-    final Set<ContainerReplica> replicas = replicaMap.get(containerID);
-    return replicas == null ? null : Collections.unmodifiableSet(replicas);
+    return replicaMap.get(containerID);
   }
 
   /**
@@ -189,9 +189,10 @@ public class ContainerStateMap {
       final ContainerReplica replica) {
     Preconditions.checkNotNull(containerID);
     if (contains(containerID)) {
-      final Set<ContainerReplica> replicas = replicaMap.get(containerID);
-      replicas.remove(replica);
-      replicas.add(replica);
+      final Set<ContainerReplica> newSet = createNewReplicaSet(containerID);
+      newSet.remove(replica);
+      newSet.add(replica);
+      replaceReplicaSet(containerID, newSet);
     }
   }
 
@@ -207,8 +208,19 @@ public class ContainerStateMap {
     Preconditions.checkNotNull(containerID);
     Preconditions.checkNotNull(replica);
     if (contains(containerID)) {
-      replicaMap.get(containerID).remove(replica);
+      final Set<ContainerReplica> newSet = createNewReplicaSet(containerID);
+      newSet.remove(replica);
+      replaceReplicaSet(containerID, newSet);
     }
+  }
+
+  private Set<ContainerReplica> createNewReplicaSet(ContainerID containerID) {
+    return new HashSet<>(replicaMap.get(containerID));
+  }
+
+  private void replaceReplicaSet(ContainerID containerID,
+      Set<ContainerReplica> newSet) {
+    replicaMap.put(containerID, Collections.unmodifiableSet(newSet));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Inside ContainerStateMap, the replicas for a container are stored in a Set backed by a ConcurrentHashMap.

When you ask for the current replicas of a container, this method is used:

```
public Set<ContainerReplica> getContainerReplicas(
      final ContainerID containerID) {
    Preconditions.checkNotNull(containerID);
    final Set<ContainerReplica> replicas = replicaMap.get(containerID);
    return replicas == null ? null : Collections.unmodifiableSet(replicas);
} 
```

Note that it pulls out the Set, wraps it as unmodifiable and returns it.

There is a problem here, in that if the Set is updated by ICR / FCR at the same time as another part of the code has taken a reference to it, the other part of the code can make incorrect decisions. Eg:

```
Set<> replicas = getContainerReplicas(...)
replicaCount = replicas.size()
// continue to do something based on the size
```

ReplicationManger has run into a race condition like this. We also use the Replicas to form pipelines for closed containers, so I worry there could be some strange issues if the set if mutated during the pipeline creation.

I see two possible solutions here. `GetContainerReplicas` should create a copy of the Set and return that, so the copy the other part of the code gets is its own copy and nothing can change it.

Or, we make the Set immutable, so that each new replica details are received, we create the new copy of the set and store that. Then any other parts of the code can get a reference to it, and know it will never change.

Mutations to the replicas for a closed container will only happen with FCR / ICR, which are relatively rare.

However we may ask for read pipelines very frequently, so it would be cheaper overall to use option 2.

This PR implements option 2 for now.

Note access to the replicas is via ContainerStateManagerImpl, which already has a course RW lock protecting access to the container manager. Quite possibly FCR reporting could be improved by a finer grained or striped lock.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6292

## How was this patch tested?

Existing tests cover this area.
