### PR TITLE
HDDS-6293. Allow using custom ozone-runner image

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/compatibility/.env
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/docker-compose.yaml
@@ -19,7 +19,7 @@ version: "3.4"
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config
-  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
   volumes:
     - ../..:/opt/hadoop
   env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/.env
@@ -16,4 +16,5 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-csi/docker-compose.yaml
@@ -18,7 +18,7 @@ version: "3.4"
 
 services:
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:
@@ -30,7 +30,7 @@ services:
       - 9882
     command: ["ozone","datanode"]
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:
@@ -43,7 +43,7 @@ services:
       - 9862:9862
     command: ["ozone","om"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:
@@ -56,7 +56,7 @@ services:
       OZONE_OPTS:
     command: ["ozone","scm"]
   csi:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/.env
@@ -16,4 +16,5 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-compose.yaml
@@ -19,7 +19,7 @@ version: "3.4"
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config
-  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
   volumes:
     - ../..:/opt/hadoop
   env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/.env
@@ -20,3 +20,4 @@ HDDS_VERSION=@hdds.version@
 HADOOP_IMAGE=flokkr/hadoop
 HADOOP_VERSION=2.7.3
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop27/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../../..:/opt/hadoop
     ports:
@@ -27,7 +27,7 @@ services:
       - docker-config
       - ../common-config
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../../..:/opt/hadoop
@@ -42,7 +42,7 @@ services:
       - ../common-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../../..:/opt/hadoop
@@ -53,7 +53,7 @@ services:
       - ../common-config
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/.env
@@ -20,4 +20,5 @@ HDDS_VERSION=@hdds.version@
 HADOOP_IMAGE=flokkr/hadoop
 HADOOP_VERSION=3.1.2
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop31/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../../..:/opt/hadoop
     ports:
@@ -29,7 +29,7 @@ services:
     environment:
       OZONE_OPTS:
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../../..:/opt/hadoop
@@ -45,7 +45,7 @@ services:
       - ../common-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../../..:/opt/hadoop
@@ -58,7 +58,7 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/.env
@@ -18,4 +18,5 @@ HDDS_VERSION=@hdds.version@
 HADOOP_IMAGE=flokkr/hadoop
 HADOOP_VERSION=3.2.2
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop32/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../../..:/opt/hadoop
     ports:
@@ -27,7 +27,7 @@ services:
       - docker-config
       - ../common-config
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../../..:/opt/hadoop
@@ -43,7 +43,7 @@ services:
       - ../common-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../../..:/opt/hadoop
@@ -56,7 +56,7 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/.env
@@ -18,4 +18,5 @@ HDDS_VERSION=@hdds.version@
 HADOOP_IMAGE=flokkr/hadoop
 HADOOP_VERSION=3.3.1
 OZONE_RUNNER_VERSION=@docker.ozone-runner.version@
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-mr/hadoop33/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../../..:/opt/hadoop
     ports:
@@ -27,7 +27,7 @@ services:
       - docker-config
       - ../common-config
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../../..:/opt/hadoop
@@ -43,7 +43,7 @@ services:
       - ../common-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../../..:/opt/hadoop
@@ -56,7 +56,7 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-ha/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-ha/Dockerfile
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG OZONE_RUNNER_IMAGE
 ARG OZONE_RUNNER_VERSION
 
-FROM apache/ozone-runner:${OZONE_RUNNER_VERSION}
+FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 # Install ssh
 RUN sudo yum install -y openssh-clients openssh-server

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/.env
@@ -14,9 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-HDDS_VERSION=1.1.0-SNAPSHOT
-OZONE_RUNNER_VERSION=20200625-1
-OZONE_IMAGE=apache/ozone-runner:20200625-1
+HDDS_VERSION=${hdds.version}
+OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=.
 # Indicates no arguments to the OM.

--- a/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-om-prepare/docker-compose.yaml
@@ -21,7 +21,7 @@ x-common-config:
   &common-config
   env_file:
     - docker-config
-  image: ${OZONE_IMAGE}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 x-replication:
   &replication

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/.env
@@ -16,4 +16,5 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone-topology/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode_1:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -33,7 +33,7 @@ services:
          net:
             ipv4_address: 10.5.0.4
    datanode_2:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -49,7 +49,7 @@ services:
          net:
             ipv4_address: 10.5.0.5
    datanode_3:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -65,7 +65,7 @@ services:
          net:
             ipv4_address: 10.5.0.6
    datanode_4:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
         - ../..:/opt/hadoop
@@ -81,7 +81,7 @@ services:
          net:
             ipv4_address: 10.5.0.7
    datanode_5:
-     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
      privileged: true #required by the profiler
      volumes:
        - ../..:/opt/hadoop
@@ -97,7 +97,7 @@ services:
        net:
          ipv4_address: 10.5.0.8
    datanode_6:
-     image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+     image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
      privileged: true #required by the profiler
      volumes:
        - ../..:/opt/hadoop
@@ -113,7 +113,7 @@ services:
        net:
          ipv4_address: 10.5.0.9
    om:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop
@@ -130,7 +130,7 @@ services:
          net:
             ipv4_address: 10.5.0.70
    scm:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       privileged: true #required by the profiler
       volumes:
          - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozone/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozone/.env
@@ -16,4 +16,5 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml
@@ -19,7 +19,7 @@ version: "3.4"
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-common-config:
   &common-config
-  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
   volumes:
     - ../..:/opt/hadoop
   env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone/freon-ockg.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/freon-ockg.yaml
@@ -17,7 +17,7 @@
 version: "3.4"
 services:
   freon:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozone/freon-rk.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozone/freon-rk.yaml
@@ -17,7 +17,7 @@
 version: "3.4"
 services:
   freon:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
     env_file:

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozoneblockade/docker-compose.yaml
@@ -17,7 +17,7 @@
 version: "3"
 services:
    datanode:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -26,7 +26,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -38,7 +38,7 @@ services:
           - ./docker-config
       command: ["/opt/hadoop/bin/ozone","om"]
    scm:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -50,7 +50,7 @@ services:
           ENSURE_SCM_INITIALIZED: /data/metadata/scm/current/VERSION
       command: ["/opt/hadoop/bin/ozone","scm"]
    ozone_client:
-       image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+       image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
        volumes:
          - ../..:/opt/hadoop
        ports:

--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozones3-haproxy/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       ports:
          - 9878:9878
    datanode:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
         - ../..:/opt/hadoop
       ports:
@@ -33,7 +33,7 @@ services:
       env_file:
         - ./docker-config
    om:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -45,7 +45,7 @@ services:
           - ./docker-config
       command: ["ozone","om"]
    scm:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -58,7 +58,7 @@ services:
           OZONE-SITE.XML_hdds.scm.safemode.min.datanode: "${OZONE_SAFEMODE_MIN_DATANODES:-1}"
       command: ["ozone","scm"]
    s3g1:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -67,7 +67,7 @@ services:
           - ./docker-config
       command: ["ozone","s3g"]
    s3g2:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:
@@ -76,7 +76,7 @@ services:
          - ./docker-config
       command: ["ozone","s3g"]
    s3g3:
-      image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+      image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
       volumes:
          - ../..:/opt/hadoop
       ports:

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/Dockerfile
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG OZONE_RUNNER_IMAGE
 ARG OZONE_RUNNER_VERSION
 
-FROM apache/ozone-runner:${OZONE_RUNNER_VERSION}
+FROM ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 RUN sudo yum install -y openssh-clients openssh-server
 

--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:
@@ -32,6 +33,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:
@@ -45,6 +47,7 @@ services:
       build:
          context: .
          args:
+            - OZONE_RUNNER_IMAGE
             - OZONE_RUNNER_VERSION
       image: ozone-runner-scripts:${OZONE_RUNNER_VERSION}
       volumes:

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/.env
@@ -17,5 +17,6 @@
 HDDS_VERSION=${hdds.version}
 HADOOP_VERSION=3
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.101
   datanode1:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -65,7 +65,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.102
   datanode2:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -87,7 +87,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.103
   datanode3:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -109,7 +109,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.104
   om1:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om1
     volumes:
       - ../..:/opt/hadoop
@@ -134,7 +134,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.111
   om2:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om2
     volumes:
       - ../..:/opt/hadoop
@@ -159,7 +159,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.112
   om3:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om3
     volumes:
       - ../..:/opt/hadoop
@@ -184,7 +184,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.113
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../..:/opt/hadoop
@@ -201,7 +201,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.114
   scm1.org:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm1.org
     volumes:
       - ../..:/opt/hadoop
@@ -228,7 +228,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.116
   scm2.org:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm2.org
     volumes:
       - ../..:/opt/hadoop
@@ -256,7 +256,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.117
   scm3.org:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm3.org
     volumes:
       - ../..:/opt/hadoop
@@ -284,7 +284,7 @@ services:
       ozone_net:
         ipv4_address: 172.25.0.118
   recon:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: recon
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/.env
@@ -18,5 +18,6 @@ HDDS_VERSION=${hdds.version}
 HADOOP_IMAGE=flokkr/hadoop
 HADOOP_VERSION=3.3.1
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-mr/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - ../../libexec/transformation.py:/opt/transformation.py
     command: ["hadoop", "kms"]
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     networks:
       - ozone
     volumes:
@@ -53,7 +53,7 @@ services:
     environment:
       OZONE_OPTS:
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     networks:
       - ozone
@@ -71,7 +71,7 @@ services:
       - docker-config
     command: ["/opt/hadoop/bin/ozone","om"]
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     networks:
       - ozone
@@ -87,7 +87,7 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","s3g"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     networks:
       - ozone

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/.env
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/.env
@@ -17,5 +17,6 @@
 HDDS_VERSION=${hdds.version}
 HADOOP_VERSION=3
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_TESTKRB5_IMAGE=${docker.ozone-testkr5b.image}
 OZONE_OPTS=

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
       - ../../libexec/transformation.py:/opt/transformation.py
     command: ["hadoop", "kms"]
   datanode:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     volumes:
       - ../..:/opt/hadoop
       - ../_keytabs:/etc/security/keytabs
@@ -48,7 +48,7 @@ services:
     environment:
       OZONE_OPTS:
   om:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: om
     volumes:
       - ../..:/opt/hadoop
@@ -65,7 +65,7 @@ services:
     command: ["/opt/hadoop/bin/ozone","om"]
 
   s3g:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: s3g
     volumes:
       - ../..:/opt/hadoop
@@ -79,7 +79,7 @@ services:
     environment:
       OZONE_OPTS:
   recon:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: recon
     volumes:
       - ../..:/opt/hadoop
@@ -93,7 +93,7 @@ services:
       OZONE_OPTS:
     command: ["/opt/hadoop/bin/ozone","recon"]
   scm:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     hostname: scm
     volumes:
       - ../..:/opt/hadoop

--- a/hadoop-ozone/dist/src/main/compose/restart/.env
+++ b/hadoop-ozone/dist/src/main/compose/restart/.env
@@ -16,6 +16,6 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
-OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=.

--- a/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/restart/docker-compose.yaml
@@ -21,7 +21,7 @@ x-common-config:
   &common-config
   env_file:
     - docker-config
-  image: ${OZONE_IMAGE}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 x-replication:
   &replication

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -401,9 +401,10 @@ prepare_for_binary_image() {
 prepare_for_runner_image() {
   local default_version=${docker.ozone-runner.version} # set at build-time from Maven property
   local runner_version=${OZONE_RUNNER_VERSION:-${default_version}} # may be specified by user running the test
+  local runner_image=${OZONE_RUNNER_IMAGE:-apache/ozone-runner} # may be specified by user running the test
   local v=${1:-${runner_version}} # prefer explicit argument
 
   export OZONE_DIR=/opt/hadoop
-  export OZONE_IMAGE="apache/ozone-runner:${v}"
+  export OZONE_IMAGE="${runner_image}:${v}"
 }
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/.env
@@ -16,6 +16,7 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=./data

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/.env
@@ -16,6 +16,7 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner
 OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=./data

--- a/hadoop-ozone/dist/src/main/compose/xcompat/.env
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/.env
@@ -16,3 +16,4 @@
 
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
+OZONE_RUNNER_IMAGE=apache/ozone-runner

--- a/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/clients.yaml
@@ -27,7 +27,7 @@ services:
       HADOOP_OPTS:
     command: ["sleep","1000000"]
   new_client:
-    image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+    image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
     env_file:
       - docker-config
     volumes:

--- a/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/new-cluster.yaml
@@ -19,7 +19,7 @@ version: "3.4"
 # reusable fragments (see https://docs.docker.com/compose/compose-file/#extension-fields)
 x-new-config:
   &new-config
-  image: apache/ozone-runner:${OZONE_RUNNER_VERSION}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
   env_file:
     - docker-config
   volumes:

--- a/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
+++ b/hadoop-ozone/dist/src/main/k8s/examples/testlib.sh
@@ -118,8 +118,9 @@ regenerate_resources() {
 
   local default_version=${docker.ozone-runner.version} # set at build-time from Maven property
   local runner_version=${OZONE_RUNNER_VERSION:-${default_version}} # may be specified by user running the test
+  local runner_image="${OZONE_RUNNER_IMAGE:-apache/ozone-runner}" # may be specified by user running the test
 
-  flekszible generate -t mount:hostPath="$OZONE_ROOT",path=/opt/hadoop -t image:image=apache/ozone-runner:${runner_version} -t ozone/onenode
+  flekszible generate -t mount:hostPath="$OZONE_ROOT",path=/opt/hadoop -t image:image="${runner_image}:${runner_version}" -t ozone/onenode
 }
 
 revert_resources() {

--- a/hadoop-ozone/dist/src/shell/upgrade/1.0.0.sh
+++ b/hadoop-ozone/dist/src/shell/upgrade/1.0.0.sh
@@ -19,5 +19,6 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 : "${SCM_DIR:="${OZONE_VOLUME}/scm"}"
 : "${OZONE_RUNNER_VERSION:="20200625-1"}"
+: "${OZONE_RUNNER_IMAGE:="apache/ozone-runner"}"
 
-docker run --rm -v "${SCM_DIR}":/scm -v "${SCRIPT_DIR}/1.0.0":/upgrade -w /scm/metadata apache/ozone-runner:"${OZONE_RUNNER_VERSION}" /upgrade/01-migrate-scm-db.sh
+docker run --rm -v "${SCM_DIR}":/scm -v "${SCRIPT_DIR}/1.0.0":/upgrade -w /scm/metadata "${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}" /upgrade/01-migrate-scm-db.sh


### PR DESCRIPTION
## What changes were proposed in this pull request?

Acceptance tests currently allow using custom `ozone-runner` version (via `OZONE_RUNNER_VERSION` variable), but the image name is hard-coded.  This changes lets users pass custom image name via `OZONE_RUNNER_IMAGE` variable.  The custom image could come from another Docker Hub user or another container repo.  This would make testing proposed `ozone-runner` changes easier.

https://issues.apache.org/jira/browse/HDDS-6293

## How was this patch tested?

Added an alias tag for existing `apache/ozone-runner` image, then ran tests with it:

```
docker tag apache/ozone-runner:20211202-1 custom-ozone-runner:20211202-1
export OZONE_RUNNER_IMAGE=custom-ozone-runner
cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-csi
KEEP_RUNNING=true ./test.sh
docker ps
```

Output shows custom image is being used:

```
...
Csi :: Smoketest Ozone CSI service                                    | PASS |
...
CONTAINER ID   IMAGE                            COMMAND                  CREATED         STATUS              PORTS                                                                                  NAMES
99dc2ef7f7a5   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute                                                                                          ozone-csi_csi_1
4ae69ba2d461   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute   0.0.0.0:9862->9862/tcp, :::9862->9862/tcp, 0.0.0.0:9874->9874/tcp, :::9874->9874/tcp   ozone-csi_om_1
fd427c815ecf   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute   0.0.0.0:63761->9864/tcp, 0.0.0.0:63762->9882/tcp                                       ozone-csi_datanode_1
e52967d41de1   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute   0.0.0.0:9860->9860/tcp, :::9860->9860/tcp, 0.0.0.0:9876->9876/tcp, :::9876->9876/tcp   ozone-csi_scm_1
248db94f54aa   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute   0.0.0.0:63759->9864/tcp, 0.0.0.0:63760->9882/tcp                                       ozone-csi_datanode_2
a6c08a46e05d   custom-ozone-runner:20211202-1   "/usr/local/bin/dumb…"   2 minutes ago   Up About a minute   0.0.0.0:63757->9864/tcp, 0.0.0.0:63758->9882/tcp                                       ozone-csi_datanode_3
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1823083062