### PR TITLE
HDDS-6299. Remove Log4J2 from Ozone FS shaded jars

### DIFF
--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -126,12 +126,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>${log4j2.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>log4j</groupId>
@@ -142,11 +136,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.lmax</groupId>
-      <artifactId>disruptor</artifactId>
-      <version>${disruptor.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/hadoop-hdds/common/pom.xml
+++ b/hadoop-hdds/common/pom.xml
@@ -138,6 +138,16 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-pool2</artifactId>
     </dependency>

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -52,6 +52,14 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>hdds-hadoop-dependency-server</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
     </dependency>

--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -60,6 +60,10 @@
           <artifactId>*</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.logging.log4j</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.protobuf</groupId>
           <artifactId>protobuf-java</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1098,6 +1098,21 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.lmax</groupId>
+        <artifactId>disruptor</artifactId>
+        <version>${disruptor.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-core</artifactId>
         <version>${aws-java-sdk.version}</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ozone FS shaded jars started including Log4J2 jars with version 1.0.0:

```
$ unzip -t ozone-0.5.0-beta/share/ozone/lib/hadoop-ozone-filesystem-lib-current-*.jar | grep -c org.apache.logging.log4j
0

$ unzip -t ozone-1.0.0/share/ozone/lib/hadoop-ozone-filesystem-hadoop3-*.jar| grep -c org.apache.logging.log4j
1286

$ unzip -t ozone-1.2.1/share/ozone/lib/ozone-filesystem-hadoop3-*.jar | grep -c org.apache.logging.log4j
1381
```

Since Ozone uses Log4J2 only for audit logging, which is a server-side feature, client does not need this dependency, so I think we can remove it.

This patch:

1. `hdds-common` only needs `log4j-api`, not the implementation (except for unit test).  Move the implementation dependencies to the `hdds-server-framework` module, shared among server-side components.
2. Exclude Log4J2 artifacts (now only `log4j-api`) from Ozone FS shaded jar.

https://issues.apache.org/jira/browse/HDDS-6299

## How was this patch tested?

Built locally, verified shaded Ozone FS jar no longer includes Log4J2:

```
$ mvn -DskipTests clean package > tee mvn.log

$ grep -c 'Including.*log4j' mvn.log
0

$ unzip -t hadoop-ozone/dist/target/ozone*/share/ozone/lib/ozone-filesystem-hadoop3*.jar | grep -c org.apache.logging.log4j
0
```

Verified audit log is still working:

```
$ docker-compose exec om bash -c 'head -2 /var/log/hadoop/*audit*log'
2022-02-10 16:03:47,307 | INFO  | OMAudit | user=hadoop | ip=172.24.0.8 | op=CREATE_VOLUME {admin=hadoop, owner=hadoop, volume=vol1, creationTime=1644509027230, modificationTime=1644509027230, quotaInBytes=-1, quotaInNamespace=-1, usedNamespace=0, objectID=-9223372036854775552, updateID=1} | ret=SUCCESS |
2022-02-10 16:03:47,395 | INFO  | OMAudit | user=hadoop | ip=172.24.0.8 | op=CREATE_BUCKET {volume=vol1, bucket=bucket1, bucketLayout=OBJECT_STORE, gdprEnabled=null, acls=[user:hadoop:a[ACCESS], group:users:a[ACCESS]], isVersionEnabled=false, storageType=DISK, creationTime=1644509027373, bucketEncryptionKey=null, modificationTime=1644509027373, usedBytes=0, usedNamespace=0} | ret=SUCCESS |
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1824839189