### PR TITLE
HDDS-6304. Add enforcer to make sure ozone.version equals project.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1977,6 +1977,30 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <artifactId>maven-site-plugin</artifactId>
         <version>${maven-site-plugin.version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireProperty>
+                  <property>ozone.version</property>
+                  <message>You must set a ozone.version to be the same as ${project.version}</message>
+                  <regex>${project.version}</regex>
+                  <regexMessage>The ozone.version property should be set and should be ${project.version}.</regexMessage>
+                </requireProperty>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When updating Ozone's version with "mvn versions:set", the content of "ozone.version" is not updated.

This ticket is to add a maven-enforcer to make sure the ozone.version equals project.version. So that it can notice the inequality for the builder of the project.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6304

## How was this patch tested?

Test by changing the ozone.version in pom.xml. The following error would happen if the ozone.version doesn't equal to project.version.

![Screenshot 2022-02-11 113719](https://user-images.githubusercontent.com/14933944/153534020-c72f23f0-3cda-412e-ab62-4ecf8624d05c.png)


