### PR TITLE
HDDS-6295. EC: Fix unaligned stripe write failure due to length overflow.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -496,7 +496,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
     }
     closed = true;
     try {
-      final int lastStripeSize = getCurrentStripeSize();
+      final int lastStripeSize = getCurrentDataStripeSize();
       if (isPartialStripe(lastStripeSize)) {
         ByteBuffer bytesToWrite =
             ecChunkBufferCache.getDataBuffers()[blockOutputStreamEntryPool
@@ -582,7 +582,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
     return stripeSize > 0 && stripeSize < numDataBlks * ecChunkSize;
   }
 
-  private int getCurrentStripeSize() {
+  private int getCurrentDataStripeSize() {
     final ByteBuffer[] dataBuffers = ecChunkBufferCache.getDataBuffers();
     int lastStripeSize = 0;
     for (int i = 0; i < numDataBlks; i++) {


### PR DESCRIPTION
Co-authored-by: Uma Maheswara Rao G <umagangumalla@cloudera.com>

## What changes were proposed in this pull request?

Fix unaligned stripe write failure due to length overflow and
eliminate the unnecessary variable `currentBlockGroupLen`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6295

## How was this patch tested?

existing UT in CI: https://github.com/guihecheng/ozone/actions/runs/1827271876
manual test:
./bin/ozone sh bucket create vol1/bucket1 --layout=FILE_SYSTEM_OPTIMIZED --replication=rs-10-4-1024k --type EC
./bin/ozone sh key put /vol1/bucket1/hosts /etc/hosts

a new ut suggested by Uma, tested before and after apply patch.