### PR TITLE
HDDS-6309. Update ozone-runner version to 20220212-1

### DIFF
--- a/hadoop-ozone/dist/pom.xml
+++ b/hadoop-ozone/dist/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <file.encoding>UTF-8</file.encoding>
     <downloadSources>true</downloadSources>
-    <docker.ozone-runner.version>20211202-1</docker.ozone-runner.version>
+    <docker.ozone-runner.version>20220212-1</docker.ozone-runner.version>
     <docker.ozone-testkr5b.image>apache/ozone-testkrb5:20210419-1</docker.ozone-testkr5b.image>
   </properties>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Ozone to latest `ozone-runner:20220212-1` docker image.

https://issues.apache.org/jira/browse/HDDS-6309

## How was this patch tested?

CI
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1836991719