### PR TITLE
HDDS-6310. Update json-smart to 2.4.7.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1512,7 +1512,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
           -->
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <version>2.3.1</version>
+        <version>2.4.7</version>
       </dependency>
       <dependency>
         <groupId>org.skyscreamer</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update json-smart to the latest version from the current 2.3.1.
Ozone's json-smart comes transitively from Hadoop. Note that Hadoop 3.3.1 is already using json-smart 2.4.2. So we shouldn't have problem updating to the 2.4 line.

Reason for the update: https://nvd.nist.gov/vuln/detail/CVE-2021-27568 and https://nvd.nist.gov/vuln/detail/CVE-2021-31684

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6310

## How was this patch tested?
