### PR TITLE
HDDS-6311. Fix number of keys displayed in Recon Overview.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ClusterStateEndpoint.java
@@ -44,6 +44,7 @@ import java.util.List;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 
 /**
  * Endpoint to fetch current state of ozone cluster.
@@ -92,17 +93,29 @@ public class ClusterStateEndpoint {
         TableCountTask.getRowKeyFromTable(VOLUME_TABLE));
     GlobalStats bucketRecord = globalStatsDao.findById(
         TableCountTask.getRowKeyFromTable(BUCKET_TABLE));
+    // Keys from OBJECT_STORE buckets.
     GlobalStats keyRecord = globalStatsDao.findById(
         TableCountTask.getRowKeyFromTable(KEY_TABLE));
+    // Keys from FILE_SYSTEM_OPTIMIZED buckets
+    GlobalStats fileRecord = globalStatsDao.findById(
+        TableCountTask.getRowKeyFromTable(FILE_TABLE));
+
     if (volumeRecord != null) {
       builder.setVolumes(volumeRecord.getValue());
     }
     if (bucketRecord != null) {
       builder.setBuckets(bucketRecord.getValue());
     }
+
+    Long totalKeys = 0L;
     if (keyRecord != null) {
-      builder.setKeys(keyRecord.getValue());
+      totalKeys += keyRecord.getValue();
     }
+    if (fileRecord != null) {
+      totalKeys += fileRecord.getValue();
+    }
+    builder.setKeys(totalKeys);
+
     ClusterStateResponse response = builder
         .setStorageReport(storageReport)
         .setPipelines(pipelines)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Overview tab in Recon does not display the correct number of total keys in the cluster. Currently, only the keys present in `OBJECT_STORE` buckets are counted.

This task is to add the keys present in `FILE_SYSYEM_OPTIMIZED` buckets to the count.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6311

## How was this patch tested?

Test Script
```bash
# create volume + buckets
ozone sh volume create /vol1
ozone sh bucket create /vol1/bucket-obs
ozone sh bucket create /vol1/bucket-fso --layout FILE_SYSTEM_OPTIMIZED
ozone sh bucket list /vol1 

# Add keys to OBS Bucket
ozone sh key put /vol1/bucket-obs/key1 README.md 
ozone sh key put /vol1/bucket-obs/not-a-dir/key1 README.md

# Add keys to FSO bucket
ozone sh key put /vol1/bucket-fso/dir1/key1 README.md
ozone sh key put /vol1/bucket-fso/key2 README.md
ozone sh key put /vol1/bucket-fso/dir1/dir3/key3 README.md
```

UI (should display Number of keys = 5)

<img width="1214" alt="Screenshot 2022-02-14 at 12 51 13 PM" src="https://user-images.githubusercontent.com/33001894/153817878-758c4ed0-08bd-4d47-ab3e-49a584bcec0e.png">

