### PR TITLE
HDDS-5904. Update Recon for files created with FSO Buckets.

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/ReconUtils.java
@@ -31,6 +31,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.List;
 import java.util.zip.GZIPOutputStream;
 
 import com.google.inject.Singleton;
@@ -55,6 +57,7 @@ import static org.jooq.impl.DSL.select;
 import static org.jooq.impl.DSL.using;
 
 import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
@@ -336,6 +339,18 @@ public class ReconUtils {
       index += 1;
     }
     return index;
+  }
+
+  /**
+   * Fetches a list of supported bucket layouts.
+   *
+   * @return List of supported bucket layouts.
+   */
+  public static List<BucketLayout> getBucketLayoutList() {
+    return Arrays.asList(
+        BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        BucketLayout.OBJECT_STORE
+    );
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -165,7 +165,7 @@ public class ContainerEndpoint {
           Table<String, OmKeyInfo> omKeyInfoTable =
               omMetadataManager.getKeyTable(bucketLayout);
 
-          if(omKeyInfoTable == null) {
+          if (omKeyInfoTable == null) {
             // keyTable for current bucketLayout not found, continue.
             continue;
           }
@@ -176,7 +176,7 @@ public class ContainerEndpoint {
           omKeyInfo =
               omKeyInfoTable.getSkipCache(containerKeyPrefix.getKeyPrefix());
 
-          if(omKeyInfo != null) {
+          if (omKeyInfo != null) {
             // we found the key, so break out of the loop.
             break;
           }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/ContainerEndpoint.java
@@ -398,8 +398,4 @@ public class ContainerEndpoint {
     }
     return blockIds;
   }
-
-  private BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
-  }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -85,7 +85,7 @@ public class ContainerKeyMapperTask implements ReconOmTask {
         Table<String, OmKeyInfo> omKeyInfoTable =
             omMetadataManager.getKeyTable(bucketLayout);
 
-        if(omKeyInfoTable == null) {
+        if (omKeyInfoTable == null) {
           continue;
         }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/ContainerKeyMapperTask.java
@@ -261,9 +261,4 @@ public class ContainerKeyMapperTask implements ReconOmTask {
           .incrementContainerCountBy(containerCountToIncrement);
     }
   }
-
-  private BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
-  }
-
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -80,7 +80,7 @@ public class FileSizeCountTask implements ReconOmTask {
       Table<String, OmKeyInfo> omKeyInfoTable =
           omMetadataManager.getKeyTable(bucketLayout);
 
-      if(omKeyInfoTable == null) {
+      if (omKeyInfoTable == null) {
         continue;
       }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -227,10 +227,6 @@ public class FileSizeCountTask implements ReconOmTask {
     fileSizeCountMap.put(key, count);
   }
 
-  private BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
-  }
-
   /**
    * Calculate and update the count of files being tracked by
    * fileSizeCountMap.

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.ozone.recon.api;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getOmKeyLocationInfo;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getRandomPipeline;
 import static org.apache.hadoop.ozone.recon.OMMetadataManagerTestUtils.getTestReconOmMetadataManager;
@@ -194,7 +196,7 @@ public class TestContainerEndpoint {
     //key = key_one, Blocks = [ {CID = 1, LID = 101}, {CID = 2, LID = 102} ]
     writeDataToOm(reconOMMetadataManager,
         "key_one", "bucketOne", "sampleVol",
-        Collections.singletonList(omKeyLocationInfoGroup));
+        Collections.singletonList(omKeyLocationInfoGroup), bucketLayout);
 
     List<OmKeyLocationInfoGroup> infoGroups = new ArrayList<>();
     BlockID blockID3 = new BlockID(1, 103);
@@ -242,8 +244,8 @@ public class TestContainerEndpoint {
     OMMetadataManager omMetadataManagerMock = mock(OMMetadataManager.class);
     Table tableMock = mock(Table.class);
     String tableName =
-        this.bucketLayout == BucketLayout.FILE_SYSTEM_OPTIMIZED ? "fileTable" :
-            "keyTable";
+        this.bucketLayout.isFileSystemOptimized() ? FILE_TABLE :
+            KEY_TABLE;
     when(tableMock.getName()).thenReturn(tableName);
     when(omMetadataManagerMock.getKeyTable(this.bucketLayout))
         .thenReturn(tableMock);

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -51,10 +52,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  * Unit test for Container Key mapper task.
  */
+@RunWith(Parameterized.class)
 public class TestContainerKeyMapperTask {
 
   @Rule
@@ -64,12 +68,24 @@ public class TestContainerKeyMapperTask {
   private OMMetadataManager omMetadataManager;
   private ReconOMMetadataManager reconOMMetadataManager;
   private OzoneManagerServiceProviderImpl ozoneManagerServiceProvider;
+  private final BucketLayout bucketLayout;
+
+  public TestContainerKeyMapperTask(BucketLayout bucketLayout) {
+    this.bucketLayout = bucketLayout;
+  }
+
+  @Parameterized.Parameters
+  public static List<BucketLayout> parameters() {
+    return Arrays.asList(BucketLayout.OBJECT_STORE,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED);
+  }
 
   @Before
   public void setUp() throws Exception {
     omMetadataManager = initializeNewOmMetadataManager(
         temporaryFolder.newFolder());
-    ozoneManagerServiceProvider = getMockOzoneManagerServiceProvider();
+    ozoneManagerServiceProvider =
+        getMockOzoneManagerServiceProvider(getBucketLayout());
     reconOMMetadataManager = getTestReconOmMetadataManager(omMetadataManager,
         temporaryFolder.newFolder());
 
@@ -116,7 +132,7 @@ public class TestContainerKeyMapperTask {
         "key_one",
         "bucketOne",
         "sampleVol",
-        Collections.singletonList(omKeyLocationInfoGroup));
+        Collections.singletonList(omKeyLocationInfoGroup), getBucketLayout());
 
     ContainerKeyMapperTask containerKeyMapperTask =
         new ContainerKeyMapperTask(reconContainerMetadataManager);
@@ -283,6 +299,6 @@ public class TestContainerKeyMapperTask {
   }
 
   private BucketLayout getBucketLayout() {
-    return BucketLayout.DEFAULT;
+    return bucketLayout;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we only iterate keyTable to update Recon for keys/file stats. After the introduction of bucket types (FSO, LEGACY, OBS), Recon will not be updated for the files created with FSO buckets.
Files created with FSO buckets will have intermediate directories. e.g,
```
Key: '/vol/fsobucket/dir1/dir2/file1'
```
So, it will be stored as follows in the directory table and file table:

```
512/dir -> Directory Table
1024/dir2 -> Directory Table
1025/file1 -> File Table
``` 

Hence in this Jira we will iterate over directory and file tables to update the Recon for files/keys created with FSO buckets.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5904

## How was this patch tested?

Related Integration Tests
