### PR TITLE
HDDS-6317: Export ReconTaskStatus as Prometheus metrics

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.ozone.recon.metrics;
 
 import com.google.inject.Inject;

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
@@ -75,7 +75,7 @@ public class ReconTaskStatusMetrics implements MetricsSource {
               rts.getTaskName()));
       builder.addGauge(RECORD_INFO_LAST_UPDATED_TS,
           rts.getLastUpdatedTimestamp());
-      builder.addGauge(RECORD_INFO_LAST_UPDATED_SEQ,
+      builder.addCounter(RECORD_INFO_LAST_UPDATED_SEQ,
           rts.getLastUpdatedSeqNumber());
       builder.endRecord();
     });

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/ReconTaskStatusMetrics.java
@@ -1,0 +1,65 @@
+package org.apache.hadoop.ozone.recon.metrics;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import org.apache.hadoop.metrics2.MetricsCollector;
+import org.apache.hadoop.metrics2.MetricsInfo;
+import org.apache.hadoop.metrics2.MetricsRecordBuilder;
+import org.apache.hadoop.metrics2.MetricsSource;
+import org.apache.hadoop.metrics2.MetricsTag;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.Interns;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.hadoop.ozone.recon.schema.tables.daos.ReconTaskStatusDao;
+import org.hadoop.ozone.recon.schema.tables.pojos.ReconTaskStatus;
+
+import java.util.List;
+
+/**
+ * Ship ReconTaskStatus table on persistent DB as a metrics.
+ */
+@Singleton
+@Metrics(about = "Recon Task Status Metrics", context = OzoneConsts.OZONE)
+public class ReconTaskStatusMetrics implements MetricsSource {
+
+  private static final String SOURCE_NAME =
+      ReconTaskStatusMetrics.class.getSimpleName();
+
+  @Inject
+  private ReconTaskStatusDao reconTaskStatusDao;
+
+  private static final MetricsInfo RECORD_INFO_LAST_UPDATED_TS =
+      Interns.info("lastUpdatedTimestamp",
+          "Last updated timestamp of corresponding Recon Task");
+
+  private static final MetricsInfo RECORD_INFO_LAST_UPDATED_SEQ =
+      Interns.info("lastUpdatedSeqNumber",
+          "Last updated sequence number of corresponding Recon Task");
+
+  public void register() {
+    DefaultMetricsSystem.instance()
+        .register(SOURCE_NAME, "Recon Task Metrics", this);
+  }
+
+  public void unregister() {
+    DefaultMetricsSystem.instance()
+        .unregisterSource(SOURCE_NAME);
+  }
+
+  public void getMetrics(MetricsCollector collector, boolean all) {
+    List<ReconTaskStatus> rows = reconTaskStatusDao.findAll();
+    rows.forEach((rts) -> {
+      MetricsRecordBuilder builder = collector.addRecord(SOURCE_NAME);
+      builder.add(
+          new MetricsTag(
+              Interns.info("type", "Recon Task type"),
+              rts.getTaskName()));
+      builder.addGauge(RECORD_INFO_LAST_UPDATED_TS,
+          rts.getLastUpdatedTimestamp());
+      builder.addGauge(RECORD_INFO_LAST_UPDATED_SEQ,
+          rts.getLastUpdatedSeqNumber());
+      builder.endRecord();
+    });
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add an ability to Recon to export a new metrics about timestamps from `ReconTaskStatus` table in Derby DB. Recon also has OzoneManagerSyncMetrics for OM snapshot related tasks but this metrics focuses entire Recon sub-tasks.
```
# TYPE recon_task_status_metrics_last_updated_seq_number counter
recon_task_status_metrics_last_updated_seq_number{type="ContainerHealthTask",hostname="localhost"} 0
recon_task_status_metrics_last_updated_seq_number{type="ContainerKeyMapperTask",hostname="localhost"} 2
recon_task_status_metrics_last_updated_seq_number{type="FileSizeCountTask",hostname="localhost"} 2
recon_task_status_metrics_last_updated_seq_number{type="NSSummaryTask",hostname="localhost"} 2
recon_task_status_metrics_last_updated_seq_number{type="OmDeltaRequest",hostname="localhost"} 2
recon_task_status_metrics_last_updated_seq_number{type="OmSnapshotRequest",hostname="localhost"} 2
recon_task_status_metrics_last_updated_seq_number{type="PipelineSyncTask",hostname="localhost"} 0
recon_task_status_metrics_last_updated_seq_number{type="TableCountTask",hostname="localhost"} 2
# TYPE recon_task_status_metrics_last_updated_timestamp gauge
recon_task_status_metrics_last_updated_timestamp{type="ContainerHealthTask",hostname="localhost"} 1644991713107
recon_task_status_metrics_last_updated_timestamp{type="ContainerKeyMapperTask",hostname="localhost"} 1644896921928
recon_task_status_metrics_last_updated_timestamp{type="FileSizeCountTask",hostname="localhost"} 1644896921932
recon_task_status_metrics_last_updated_timestamp{type="NSSummaryTask",hostname="localhost"} 1644896921919
recon_task_status_metrics_last_updated_timestamp{type="OmDeltaRequest",hostname="localhost"} 1644991465132
recon_task_status_metrics_last_updated_timestamp{type="OmSnapshotRequest",hostname="localhost"} 1644896920719
recon_task_status_metrics_last_updated_timestamp{type="PipelineSyncTask",hostname="localhost"} 1644991714906
recon_task_status_metrics_last_updated_timestamp{type="TableCountTask",hostname="localhost"} 1644896921923
```

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6317

## How was this patch tested?
Ran on localhost && CI check
