### PR TITLE
HDDS-6294. EC: Make cluster-wide EC configuration take effect

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneBucket.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.OmUtils;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
@@ -153,7 +152,8 @@ public class OzoneBucket extends WithMetadata {
     this.volumeName = volumeName;
     this.name = bucketName;
 
-    this.defaultReplication = ReplicationConfig.getDefault(conf);
+    // Bucket level replication is not configured by default.
+    this.defaultReplication = null;
 
     this.proxy = proxy;
     this.ozoneObj = OzoneObjInfo.Builder.newBuilder()
@@ -249,14 +249,8 @@ public class OzoneBucket extends WithMetadata {
                   .fromTypeAndFactor(defaultReplicationConfig.getType(),
                       defaultReplicationConfig.getFactor());
     } else {
-      // This can happen when talk to old server. So, using old client side
-      // defaults.
-      this.defaultReplication = ReplicationConfig.parse(
-          ReplicationType.valueOf(
-              conf.get(OzoneConfigKeys.OZONE_REPLICATION_TYPE,
-                  OzoneConfigKeys.OZONE_REPLICATION_TYPE_DEFAULT)),
-          conf.get(OzoneConfigKeys.OZONE_REPLICATION,
-              OzoneConfigKeys.OZONE_REPLICATION_DEFAULT), conf);
+      // Bucket level replication is not configured by default.
+      this.defaultReplication = null;
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1169,7 +1169,7 @@ public class RpcClient implements ClientProtocol {
       throws IOException {
     verifyVolumeName(volumeName);
     verifyBucketName(bucketName);
-    HddsClientUtils.checkNotNull(keyName, replicationConfig);
+    HddsClientUtils.checkNotNull(keyName);
     OmKeyArgs keyArgs = new OmKeyArgs.Builder()
         .setVolumeName(volumeName)
         .setBucketName(bucketName)

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -38,10 +38,12 @@ Prepare For Tests
 Test Bucket Creation
     ${result} =     Execute             ozone sh volume create /${prefix}vol1
                     Should not contain  ${result}       Failed
+    ${result} =     Execute             ozone sh bucket create /${prefix}vol1/${prefix}bucket
+                    Should not contain  ${result}       Failed
+                    Verify Bucket Default Replication Config    /${prefix}vol1/${prefix}bucket
     ${result} =     Execute             ozone sh bucket create --replication 3 --type RATIS /${prefix}vol1/${prefix}ratis
                     Should not contain  ${result}       Failed
-    ${result} =     Execute             ozone sh bucket list /${prefix}vol1 | jq -r '.[] | select(.name | contains("${prefix}ratis")) | .replicationConfig.replicationType'
-                    Should contain      ${result}       RATIS
+                    Verify Bucket Legacy Replication Config     /${prefix}vol1/${prefix}ratis   RATIS   THREE
     ${result} =     Execute             ozone sh bucket create --replication rs-3-2-1024k --type EC /${prefix}vol1/${prefix}ec
                     Should not contain  ${result}       Failed
                     Verify Bucket EC Replication Config    /${prefix}vol1/${prefix}ec    RS    3    2    1048576

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -38,7 +38,7 @@ Prepare For Tests
 Test Bucket Creation
     ${result} =     Execute             ozone sh volume create /${prefix}vol1
                     Should not contain  ${result}       Failed
-    ${result} =     Execute             ozone sh bucket create /${prefix}vol1/${prefix}ratis
+    ${result} =     Execute             ozone sh bucket create --replication 3 --type RATIS /${prefix}vol1/${prefix}ratis
                     Should not contain  ${result}       Failed
     ${result} =     Execute             ozone sh bucket list /${prefix}vol1 | jq -r '.[] | select(.name | contains("${prefix}ratis")) | .replicationConfig.replicationType'
                     Should contain      ${result}       RATIS

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -38,17 +38,17 @@ Prepare For Tests
 Test Bucket Creation
     ${result} =     Execute             ozone sh volume create /${prefix}vol1
                     Should not contain  ${result}       Failed
-    ${result} =     Execute             ozone sh bucket create /${prefix}vol1/${prefix}bucket
+    ${result} =     Execute             ozone sh bucket create /${prefix}vol1/${prefix}default
                     Should not contain  ${result}       Failed
-                    Verify Bucket Default Replication Config    /${prefix}vol1/${prefix}bucket
+                    Verify Bucket Empty Replication Config      /${prefix}vol1/${prefix}default
     ${result} =     Execute             ozone sh bucket create --replication 3 --type RATIS /${prefix}vol1/${prefix}ratis
                     Should not contain  ${result}       Failed
-                    Verify Bucket Legacy Replication Config     /${prefix}vol1/${prefix}ratis   RATIS   THREE
+                    Verify Bucket Replica Replication Config    /${prefix}vol1/${prefix}ratis   RATIS   THREE
     ${result} =     Execute             ozone sh bucket create --replication rs-3-2-1024k --type EC /${prefix}vol1/${prefix}ec
                     Should not contain  ${result}       Failed
                     Verify Bucket EC Replication Config    /${prefix}vol1/${prefix}ec    RS    3    2    1048576
 
-Test key Creation
+Test Key Creation EC Bucket
                     Execute                             ozone sh key put /${prefix}vol1/${prefix}ec/${prefix}1mb /tmp/1mb
                     Execute                             ozone sh key put /${prefix}vol1/${prefix}ec/${prefix}2mb /tmp/2mb
                     Execute                             ozone sh key put /${prefix}vol1/${prefix}ec/${prefix}3mb /tmp/3mb
@@ -61,11 +61,15 @@ Test key Creation
 
                     Verify Key EC Replication Config    /${prefix}vol1/${prefix}ec/${prefix}1mb    RS    3    2    1048576
 
+Test Key Creation Default Bucket
+                    Execute                             ozone sh key put /${prefix}vol1/${prefix}default/${prefix}1mb /tmp/1mb
+                    Key Should Match Local File         /${prefix}vol1/${prefix}default/${prefix}1mb      /tmp/1mb
+                    Verify Key Replica Replication Config   /${prefix}vol1/${prefix}default/${prefix}1mb     RATIS    THREE
+
 Test Ratis Key EC Bucket
                     Execute                       ozone sh key put --replication=THREE --type=RATIS /${prefix}vol1/${prefix}ec/${prefix}1mbRatis /tmp/1mb
                     Key Should Match Local File   /${prefix}vol1/${prefix}ec/${prefix}1mbRatis    /tmp/1mb
-    ${result}       Execute                       ozone sh key info /${prefix}vol1/${prefix}ec/${prefix}1mbRatis | jq -r '.replicationConfig.replicationType'
-                    Should Match Regexp           ${result}       ^(?m)RATIS$
+                    Verify Key Replica Replication Config   /${prefix}vol1/${prefix}ec/${prefix}1mbRatis    RATIS   THREE
 
 Test EC Key Ratis Bucket
                     Execute                             ozone sh key put --replication=rs-3-2-1024k --type=EC /${prefix}vol1/${prefix}ratis/${prefix}1mbEC /tmp/1mb

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
@@ -62,17 +62,32 @@ Create Key
                    Should not contain  ${output}       Failed
     Log            Uploaded ${file} to ${key}
 
+Verify Bucket Default Replication Config
+    [arguments]    ${bucket}
+    ${result} =    Execute                      ozone sh bucket info ${bucket} | jq -r '.replicationConfig'
+                   Should Be Equal          ${result}       null
+
+Verify Bucket Legacy Replication Config
+    [arguments]    ${bucket}    ${type}    ${factor}
+    ${result} =    Execute                      ozone sh bucket info ${bucket} | jq -r '.replicationConfig.replicationType, .replicationConfig.replicationFactor'
+                   Verify Legacy Replication Config     ${result}   ${type}     ${factor}
+
+Verify Legacy Replication Config
+    [arguments]    ${result}    ${type}    ${factor}
+                   Should Match Regexp      ${result}       ^(?m)${type}$
+                   Should Match Regexp      ${result}       ^(?m)${factor}$
+
 Verify Bucket EC Replication Config
     [arguments]    ${bucket}    ${encoding}    ${data}    ${parity}    ${chunksize}
     ${result} =    Execute                      ozone sh bucket info ${bucket} | jq -r '.replicationConfig.replicationType, .replicationConfig.codec, .replicationConfig.data, .replicationConfig.parity, .replicationConfig.ecChunkSize'
-                   Verify Replication Config    ${result}    ${encoding}    ${data}    ${parity}    ${chunksize}
+                   Verify EC Replication Config     ${result}    ${encoding}    ${data}    ${parity}    ${chunksize}
 
 Verify Key EC Replication Config
     [arguments]    ${key}    ${encoding}    ${data}    ${parity}    ${chunksize}
     ${result} =    Execute                      ozone sh key info ${key} | jq -r '.replicationConfig.replicationType, .replicationConfig.codec, .replicationConfig.data, .replicationConfig.parity, .replicationConfig.ecChunkSize'
-                   Verify Replication Config    ${result}    ${encoding}    ${data}    ${parity}    ${chunksize}
+                   Verify EC Replication Config     ${result}    ${encoding}    ${data}    ${parity}    ${chunksize}
 
-Verify Replication Config
+Verify EC Replication Config
     [arguments]    ${result}    ${encoding}    ${data}    ${parity}    ${chunksize}
                    Should Match Regexp      ${result}       ^(?m)EC$
                    Should Match Regexp      ${result}       ^(?m)${encoding}$

--- a/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozone-lib/shell.robot
@@ -62,17 +62,22 @@ Create Key
                    Should not contain  ${output}       Failed
     Log            Uploaded ${file} to ${key}
 
-Verify Bucket Default Replication Config
+Verify Bucket Empty Replication Config
     [arguments]    ${bucket}
     ${result} =    Execute                      ozone sh bucket info ${bucket} | jq -r '.replicationConfig'
                    Should Be Equal          ${result}       null
 
-Verify Bucket Legacy Replication Config
+Verify Bucket Replica Replication Config
     [arguments]    ${bucket}    ${type}    ${factor}
     ${result} =    Execute                      ozone sh bucket info ${bucket} | jq -r '.replicationConfig.replicationType, .replicationConfig.replicationFactor'
-                   Verify Legacy Replication Config     ${result}   ${type}     ${factor}
+                   Verify Replica Replication Config    ${result}   ${type}     ${factor}
 
-Verify Legacy Replication Config
+Verify Key Replica Replication Config
+    [arguments]    ${key}    ${type}    ${factor}
+    ${result} =    Execute                      ozone sh key info ${key} | jq -r '.replicationConfig.replicationType, .replicationConfig.replicationFactor'
+                   Verify Replica Replication Config    ${result}   ${type}     ${factor}
+
+Verify Replica Replication Config
     [arguments]    ${result}    ${type}    ${factor}
                    Should Match Regexp      ${result}       ^(?m)${type}$
                    Should Match Regexp      ${result}       ^(?m)${factor}$

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClient.java
@@ -19,23 +19,13 @@
 package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.IOException;
-import java.util.Iterator;
-import java.util.UUID;
-
-import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
-import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.apache.hadoop.ozone.client.BucketArgs;
-import org.apache.hadoop.ozone.client.OzoneBucket;
-import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.Timeout;
 
 
@@ -73,24 +63,5 @@ public class TestOzoneRpcClient extends TestOzoneRpcClientAbstract {
   @AfterClass
   public static void shutdown() throws IOException {
     shutdownCluster();
-  }
-
-  @Test
-  public void testCreateAndListBucketReturnsCorrectRepConfigf()
-      throws Exception {
-    ECReplicationConfig repConfig = new ECReplicationConfig(3, 2);
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-    getStore().createVolume(volumeName);
-    OzoneVolume volume = getStore().getVolume(volumeName);
-
-    BucketArgs bucketArgs = BucketArgs.newBuilder()
-        .setDefaultReplicationConfig(new DefaultReplicationConfig(repConfig))
-        .build();
-    volume.createBucket(bucketName, bucketArgs);
-
-    Iterator<? extends OzoneBucket> iterator = volume.listBuckets(null);
-    OzoneBucket bucket = iterator.next();
-    Assert.assertEquals(repConfig, bucket.getReplicationConfig());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdds.HddsConfigKeys;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -238,6 +239,10 @@ import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_AL
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_VOLUME_LISTALL_ALLOWED_DEFAULT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_KEY;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT;
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DETECTED_LOOP_IN_BUCKET_LINKS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_AUTH_METHOD;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_REQUEST;
@@ -3677,7 +3682,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public ReplicationConfig getDefaultReplicationConfig() {
-    return ReplicationConfig.getDefault(configuration);
+    final String replication = configuration.get(
+        OZONE_SERVER_DEFAULT_REPLICATION_KEY,
+        OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT
+    );
+    final String type = configuration.get(
+        OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
+        OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT
+    );
+    return ReplicationConfig.parse(ReplicationType.valueOf(type),
+        replication, new OzoneConfiguration());
   }
 
   public String getOMDefaultBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3682,16 +3682,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   public ReplicationConfig getDefaultReplicationConfig() {
-    final String replication = configuration.get(
+    final String replication = configuration.getTrimmed(
         OZONE_SERVER_DEFAULT_REPLICATION_KEY,
-        OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT
-    );
-    final String type = configuration.get(
+        OZONE_SERVER_DEFAULT_REPLICATION_DEFAULT);
+    final String type = configuration.getTrimmed(
         OZONE_SERVER_DEFAULT_REPLICATION_TYPE_KEY,
-        OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT
-    );
+        OZONE_SERVER_DEFAULT_REPLICATION_TYPE_DEFAULT);
     return ReplicationConfig.parse(ReplicationType.valueOf(type),
-        replication, new OzoneConfiguration());
+        replication, configuration);
   }
 
   public String getOMDefaultBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -120,19 +120,8 @@ public class OMFileCreateRequest extends OMKeyRequest {
     final long requestedSize = keyArgs.getDataSize() > 0 ?
         keyArgs.getDataSize() : scmBlockSize;
 
-    boolean useRatis = ozoneManager.shouldUseRatis();
-
     HddsProtos.ReplicationFactor factor = keyArgs.getFactor();
-    if (factor == null) {
-      factor = useRatis ? HddsProtos.ReplicationFactor.THREE :
-          HddsProtos.ReplicationFactor.ONE;
-    }
-
     HddsProtos.ReplicationType type = keyArgs.getType();
-    if (type == null) {
-      type = useRatis ? HddsProtos.ReplicationType.RATIS :
-          HddsProtos.ReplicationType.STAND_ALONE;
-    }
 
     final OmBucketInfo bucketInfo = ozoneManager
         .getBucketInfo(keyArgs.getVolumeName(), keyArgs.getBucketName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -129,19 +129,9 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       final long requestedSize = keyArgs.getDataSize() > 0 ?
           keyArgs.getDataSize() : scmBlockSize;
 
-      boolean useRatis = ozoneManager.shouldUseRatis();
-
       HddsProtos.ReplicationFactor factor = keyArgs.getFactor();
-      if (factor == null) {
-        factor = useRatis ? HddsProtos.ReplicationFactor.THREE :
-            HddsProtos.ReplicationFactor.ONE;
-      }
-
       HddsProtos.ReplicationType type = keyArgs.getType();
-      if (type == null) {
-        type = useRatis ? HddsProtos.ReplicationType.RATIS :
-            HddsProtos.ReplicationType.STAND_ALONE;
-      }
+
       final OmBucketInfo bucketInfo = ozoneManager
           .getBucketInfo(keyArgs.getVolumeName(), keyArgs.getBucketName());
       final ReplicationConfig repConfig = OzoneConfigUtil


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use `ozone.server.default.replication` and `ozone.server.default.replication.type` as cluster level replication configs.
ReplicationConfig will be decided in the following order:

1. Client-passed config
2. Bucket-level config
3. Cluster-level config

When creating new buckets, the default bucket-level config is set to `null`.
When listing buckets, buckets with no bucket-level replicationConfig will not show `replicationConfig`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6294

## How was this patch tested?

integration tests and acceptance tests.
