### PR TITLE
HDDS-6322. Fix Recon getting inccorrect sequenceNumber from OM

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -24,6 +24,8 @@ import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_CONNECTION_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_OM_SOCKET_TIMEOUT_DEFAULT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LIMIT;
+import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.RECON_OM_DELTA_UPDATE_LOOP_LIMIT;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmDeltaRequest;
 import static org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl.OmSnapshotTaskName.OmSnapshotRequest;
 
@@ -109,6 +111,9 @@ public class TestReconWithOzoneManager {
             OZONE_RECON_OM_CONNECTION_REQUEST_TIMEOUT_DEFAULT),
         TimeUnit.MILLISECONDS
     );
+    conf.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 2);
+    conf.setLong(RECON_OM_DELTA_UPDATE_LOOP_LIMIT, 10);
+
     RequestConfig config = RequestConfig.custom()
         .setConnectTimeout(socketTimeout)
         .setConnectionRequestTimeout(connectionTimeout)


### PR DESCRIPTION
## What changes were proposed in this pull request?

This bug was imported in [HDDS-6215](https://issues.apache.org/jira/browse/HDDS-6215), the root cause is we used `dbUpdates.getData().size()` to accumulate the sequenceNumber. But these two terms are different, a DBUpdates with data size of 10 could have a difference of sequenceNumber of 30 or more.

 The bug can be reproduced by adding the following configurations and running `TestReconWithOzoneManager`.
```
    conf.setLong(RECON_OM_DELTA_UPDATE_LIMIT, 2);
    conf.setLong(RECON_OM_DELTA_UPDATE_LOOP_LIMIT, 10);
```
## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6322

## How was this patch tested?

unit test.
