### PR TITLE
HDDS-6324. Do not trigger CI by reopening PR

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -15,7 +15,7 @@
 name: build-branch
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened, ready_for_review, synchronize]
   push:
   schedule:
     - cron: 30 0,12 * * *


### PR DESCRIPTION
## What changes were proposed in this pull request?

CI can be retriggered for PRs in three ways:

* pushing new commit
* "re-run all checks" in Github Actions run result view
* closing/reopening PR

New (empty) commit makes CI history visible in the PR, but it triggers two runs: one for the PR and another in the source branch.

Github has recently improved run result view by including UI element for previous runs.  Earlier this was available only via the repository's  _Actions_ view, which lists all action runs, so finding the specific run was not easy.

Closing/reopening to trigger build has two disadvanteges: it produces unnecessary noise (in the PR and email notifications), and CI history is still hard to find.

We should disable build on reopen and prefer "re-run all checks".

https://issues.apache.org/jira/browse/HDDS-6324

## How was this patch tested?

Not tested, trivial change.

Workflow file is validated by CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1846707702