### PR TITLE
HDDS-6325. Fix interface ClientProtocol methods typo setThreadLocalS3Auth and clearThreadLocalS3Auth

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -762,7 +762,7 @@ public interface ClientProtocol {
    * of the S3 API implementation within Ozone.
    * @param s3Auth authentication information for each S3 API call.
    */
-  void setTheadLocalS3Auth(S3Auth s3Auth);
+  void setThreadLocalS3Auth(S3Auth s3Auth);
 
   /**
    * Gets the S3 Authentication information that is attached to the thread.
@@ -773,7 +773,7 @@ public interface ClientProtocol {
   /**
    * Clears the S3 Authentication information attached to the thread.
    */
-  void clearTheadLocalS3Auth();
+  void clearThreadLocalS3Auth();
 
   /**
    * Sets the owner of bucket.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -1632,7 +1632,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void setTheadLocalS3Auth(
+  public void setThreadLocalS3Auth(
       S3Auth ozoneSharedSecretAuth) {
     ozoneManagerClient.setThreadLocalS3Auth(ozoneSharedSecretAuth);
   }
@@ -1643,7 +1643,7 @@ public class RpcClient implements ClientProtocol {
   }
 
   @Override
-  public void clearTheadLocalS3Auth() {
+  public void clearThreadLocalS3Auth() {
     ozoneManagerClient.clearThreadLocalS3Auth();
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -77,7 +77,7 @@ public class OzoneClientProducer {
 
   @PreDestroy
   public void destroy() throws IOException {
-    client.getObjectStore().getClientProxy().clearTheadLocalS3Auth();
+    client.getObjectStore().getClientProxy().clearThreadLocalS3Auth();
   }
   @Produces
   public S3Auth getSignature() {

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -74,9 +74,9 @@ public abstract class EndpointBase {
   @PostConstruct
   public void initialization() {
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
-    getClient().getObjectStore().
-        getClientProxy().
-        setTheadLocalS3Auth(s3Auth);
+    getClient().getObjectStore()
+        .getClientProxy()
+        .setThreadLocalS3Auth(s3Auth);
     init();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `ClientProtocol`:

```
setTheadLocalS3Auth -> setThreadLocalS3Auth
clearTheadLocalS3Auth -> clearThreadLocalS3Auth
```

Should just fix this before 1.3.0 is released.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6325

## How was this patch tested?

- All existing tests shall pass.