### PR TITLE
HDDS-6331. Remove toString in debug log parameters within SCMCommonPlacementPolicy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -351,7 +351,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
               dataSizeRequired))) {
         LOG.debug("Datanode {} is chosen. Required metadata size is {} and " +
                 "required data size is {}",
-            datanodeDetails.toString(), metadataSizeRequired, dataSizeRequired);
+            datanodeDetails, metadataSizeRequired, dataSizeRequired);
         return true;
       }
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The debug log has "toString()" called on datanode details, which means it must be evaluated before it gets passed into the debug logger. That means this string will always get created even when the log messages is not emitted.

```
LOG.debug("Datanode {} is chosen. Required metadata size is {} and " +
        "required data size is {}",
    datanodeDetails.toString(), metadataSizeRequired, dataSizeRequired); 
```

We can just drop the toString part to fix this.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6331

## How was this patch tested?

Existing tests