### PR TITLE
HDDS-6333. Add a metric to record sequence number lag between Recon and OM

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBUpdatesWrapper.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBUpdatesWrapper.java
@@ -29,6 +29,7 @@ public class DBUpdatesWrapper {
 
   private List<byte[]> dataList = new ArrayList<>();
   private long currentSequenceNumber = -1;
+  private long latestSequenceNumber = -1;
 
   public void addWriteBatch(byte[] data, long sequenceNumber) {
     dataList.add(data);
@@ -47,6 +48,14 @@ public class DBUpdatesWrapper {
 
   public long getCurrentSequenceNumber() {
     return currentSequenceNumber;
+  }
+
+  public void setLatestSequenceNumber(long sequenceNumber) {
+    this.latestSequenceNumber = sequenceNumber;
+  }
+
+  public long getLatestSequenceNumber() {
+    return latestSequenceNumber;
   }
 }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -432,6 +432,7 @@ public class RDBStore implements DBStore {
       LOG.error("Unable to get delta updates since sequenceNumber {} ",
           sequenceNumber, e);
     }
+    dbUpdatesWrapper.setLatestSequenceNumber(db.getLatestSequenceNumber());
     return dbUpdatesWrapper;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DBUpdates.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DBUpdates.java
@@ -29,6 +29,8 @@ public class DBUpdates {
 
   private long currentSequenceNumber = -1;
 
+  private long latestSequenceNumber = -1L;
+
   public DBUpdates() {
     this.dataList = new ArrayList<>();
   }
@@ -54,5 +56,13 @@ public class DBUpdates {
 
   public long getCurrentSequenceNumber() {
     return currentSequenceNumber;
+  }
+
+  public void setLatestSequenceNumber(long sequenceNumber) {
+    this.latestSequenceNumber = sequenceNumber;
+  }
+
+  public long getLatestSequenceNumber() {
+    return latestSequenceNumber;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1506,6 +1506,8 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     }
     dbUpdatesWrapper.setCurrentSequenceNumber(
         dbUpdatesResponse.getSequenceNumber());
+    dbUpdatesWrapper.setLatestSequenceNumber(
+        dbUpdatesResponse.getLatestSequenceNumber());
     return dbUpdatesWrapper;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
+import org.apache.hadoop.ozone.recon.metrics.OzoneManagerSyncMetrics;
 import org.apache.hadoop.ozone.recon.spi.impl.OzoneManagerServiceProviderImpl;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
@@ -201,6 +202,7 @@ public class TestReconWithOzoneManager {
     OzoneManagerServiceProviderImpl impl = (OzoneManagerServiceProviderImpl)
         cluster.getReconServer().getOzoneManagerServiceProvider();
     impl.syncDataFromOM();
+    OzoneManagerSyncMetrics metrics = impl.getMetrics();
 
     // HTTP call to /api/containers
     String containerResponse = makeHttpCall(containerKeyServiceURL);
@@ -229,6 +231,7 @@ public class TestReconWithOzoneManager {
 
     // verify sequence number after full snapshot
     Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
 
     //add 4 keys to check for delta updates
     addKeys(1, 5);
@@ -264,6 +267,7 @@ public class TestReconWithOzoneManager {
 
     //verify sequence number after Delta Updates
     Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
 
     long beforeRestartSnapShotTimeStamp = getReconTaskAttributeFromJson(
         taskStatusResponse,
@@ -321,6 +325,7 @@ public class TestReconWithOzoneManager {
 
     //verify sequence number after Delta Updates
     Assert.assertEquals(omLatestSeqNumber, reconLatestSeqNumber);
+    Assert.assertEquals(0, metrics.getSequenceNumberLag().value());
   }
 
   private long getReconTaskAttributeFromJson(String taskStatusResponse,

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1115,6 +1115,7 @@ message ServiceListResponse {
 message DBUpdatesResponse {
     required uint64 sequenceNumber = 1;
     repeated bytes data = 2;
+    optional uint64 latestSequenceNumber = 3;
 }
 
 message FinalizeUpgradeRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3497,6 +3497,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         .getUpdatesSince(dbUpdatesRequest.getSequenceNumber(), limitCount);
     DBUpdates dbUpdates = new DBUpdates(updatesSince.getData());
     dbUpdates.setCurrentSequenceNumber(updatesSince.getCurrentSequenceNumber());
+    dbUpdates.setLatestSequenceNumber(updatesSince.getLatestSequenceNumber());
     return dbUpdates;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -264,6 +264,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
           dbUpdatesWrapper.getData().get(i)));
     }
     builder.setSequenceNumber(dbUpdatesWrapper.getCurrentSequenceNumber());
+    builder.setLatestSequenceNumber(dbUpdatesWrapper.getLatestSequenceNumber());
     return builder.build();
   }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/OzoneManagerSyncMetrics.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/metrics/OzoneManagerSyncMetrics.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
 import org.apache.hadoop.metrics2.lib.MutableRate;
 import org.apache.hadoop.ozone.OzoneConsts;
 
@@ -74,6 +75,9 @@ public final class OzoneManagerSyncMetrics {
 
   @Metric(about = "Average number of updates got per OM delta request")
   private MutableGaugeFloat averageNumUpdatesInDeltaRequest;
+
+  @Metric(about = "The lag of sequence number between Recon and OM")
+  private MutableGaugeLong sequenceNumberLag;
 
   public void incrNumSnapshotRequests() {
     this.numSnapshotRequests.incr();
@@ -129,5 +133,13 @@ public final class OzoneManagerSyncMetrics {
 
   public MutableCounterLong getNumNonZeroDeltaRequests() {
     return numNonZeroDeltaRequests;
+  }
+
+  public void setSequenceNumberLag(long lag) {
+    sequenceNumberLag.set(lag);
+  }
+
+  public MutableGaugeLong getSequenceNumberLag() {
+    return sequenceNumberLag;
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-6312](https://issues.apache.org/jira/browse/HDDS-6312), Recon is regulated to retrieve a limited number of delta updates from OM, which eliminates the possibility of large delta updates causing OM's OOM.

We did this control by setting the configuration of "recon.om.delta.update.limit" and "recon.om.delta.update.loop.limit", the default consume speed would be 2000*10 per 10 minutes, but we are not sure if we are consuming at an optimal speed.

This ticket is to add a metric to record the lag between Recon and OM, which can help to set an appropriate value and prepare for other near real-time works on the Recon side.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6333

## How was this patch tested?

unit test.