### PR TITLE
HDDS-6321. Avoid refresh pipeline for key lookup in checkAcls

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1240,12 +1240,12 @@ public class KeyManagerImpl implements KeyManager {
 
       // if the key is a file then do refresh pipeline info in OM by asking SCM
       if (fileKeyInfo != null) {
+        if (args.getLatestVersionLocation()) {
+          slimLocationVersion(fileKeyInfo);
+        }
         // If operation is head, do not perform any additional steps
         // As head operation does not need any of those details.
         if (!args.isHeadOp()) {
-          if (args.getLatestVersionLocation()) {
-            slimLocationVersion(fileKeyInfo);
-          }
           // refreshPipeline flag check has been removed as part of
           // https://issues.apache.org/jira/browse/HDDS-3658.
           // Please refer this jira for more details.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1295,18 +1295,21 @@ public class KeyManagerImpl implements KeyManager {
 
     if (fileStatus != null) {
       // if the key is a file then do refresh pipeline info in OM by asking SCM
-      if (fileStatus.isFile() && !args.isHeadOp()) {
+      if (fileStatus.isFile()) {
         OmKeyInfo fileKeyInfo = fileStatus.getKeyInfo();
         if (args.getLatestVersionLocation()) {
           slimLocationVersion(fileKeyInfo);
         }
-        // refreshPipeline flag check has been removed as part of
-        // https://issues.apache.org/jira/browse/HDDS-3658.
-        // Please refer this jira for more details.
-        refresh(fileKeyInfo);
 
-        if (args.getSortDatanodes()) {
-          sortDatanodes(clientAddress, fileKeyInfo);
+        if (!args.isHeadOp()) {
+          // refreshPipeline flag check has been removed as part of
+          // https://issues.apache.org/jira/browse/HDDS-3658.
+          // Please refer this jira for more details.
+          refresh(fileKeyInfo);
+
+          if (args.getSortDatanodes()) {
+            sortDatanodes(clientAddress, fileKeyInfo);
+          }
         }
         return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
       } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1005,6 +1005,7 @@ public class KeyManagerImpl implements KeyManager {
         .setVolumeName(volume)
         .setBucketName(bucket)
         .setKeyName(keyName)
+        .setHeadOp(true)
         .build();
 
     BucketLayout bucketLayout = BucketLayout.DEFAULT;
@@ -1189,26 +1190,21 @@ public class KeyManagerImpl implements KeyManager {
     Preconditions.checkNotNull(args, "Key args can not be null");
     String volumeName = args.getVolumeName();
     String bucketName = args.getBucketName();
-    String keyName = args.getKeyName();
 
     if (isBucketFSOptimized(volumeName, bucketName)) {
-      return getOzoneFileStatusFSO(volumeName, bucketName, keyName,
-              args.getSortDatanodes(), clientAddress,
-              args.getLatestVersionLocation(), false);
+      return getOzoneFileStatusFSO(args, clientAddress, false);
     }
-    return getOzoneFileStatus(volumeName, bucketName, keyName,
-        args.getRefreshPipeline(), args.getSortDatanodes(),
-        args.getLatestVersionLocation(), clientAddress);
+    return getOzoneFileStatus(args, clientAddress);
   }
 
-  private OzoneFileStatus getOzoneFileStatus(String volumeName,
-                                             String bucketName,
-                                             String keyName,
-                                             boolean refreshPipeline,
-                                             boolean sortDatanodes,
-                                             boolean latestLocationVersion,
-                                             String clientAddress)
-      throws IOException {
+  private OzoneFileStatus getOzoneFileStatus(OmKeyArgs args,
+      String clientAddress) throws IOException {
+
+    Preconditions.checkNotNull(args, "Key args can not be null");
+    final String volumeName = args.getVolumeName();
+    final String bucketName = args.getBucketName();
+    final String keyName = args.getKeyName();
+
     OmKeyInfo fileKeyInfo = null;
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
         bucketName);
@@ -1244,15 +1240,19 @@ public class KeyManagerImpl implements KeyManager {
 
       // if the key is a file then do refresh pipeline info in OM by asking SCM
       if (fileKeyInfo != null) {
-        if (latestLocationVersion) {
-          slimLocationVersion(fileKeyInfo);
-        }
-        // refreshPipeline flag check has been removed as part of
-        // https://issues.apache.org/jira/browse/HDDS-3658.
-        // Please refer this jira for more details.
-        refresh(fileKeyInfo);
-        if (sortDatanodes) {
-          sortDatanodes(clientAddress, fileKeyInfo);
+        // If operation is head, do not perform any additional steps
+        // As head operation does not need any of those details.
+        if (!args.isHeadOp()) {
+          if (args.getLatestVersionLocation()) {
+            slimLocationVersion(fileKeyInfo);
+          }
+          // refreshPipeline flag check has been removed as part of
+          // https://issues.apache.org/jira/browse/HDDS-3658.
+          // Please refer this jira for more details.
+          refresh(fileKeyInfo);
+          if (args.getSortDatanodes()) {
+            sortDatanodes(clientAddress, fileKeyInfo);
+          }
         }
         return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
       }
@@ -1270,10 +1270,11 @@ public class KeyManagerImpl implements KeyManager {
   }
 
 
-  private OzoneFileStatus getOzoneFileStatusFSO(String volumeName,
-      String bucketName, String keyName, boolean sortDatanodes,
-      String clientAddress, boolean latestLocationVersion,
-      boolean skipFileNotFoundError) throws IOException {
+  private OzoneFileStatus getOzoneFileStatusFSO(OmKeyArgs args,
+      String clientAddress, boolean skipFileNotFoundError) throws IOException {
+    final String volumeName = args.getVolumeName();
+    final String bucketName = args.getBucketName();
+    final String keyName = args.getKeyName();
     OzoneFileStatus fileStatus = null;
     metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
             bucketName);
@@ -1294,9 +1295,9 @@ public class KeyManagerImpl implements KeyManager {
 
     if (fileStatus != null) {
       // if the key is a file then do refresh pipeline info in OM by asking SCM
-      if (fileStatus.isFile()) {
+      if (fileStatus.isFile() && !args.isHeadOp()) {
         OmKeyInfo fileKeyInfo = fileStatus.getKeyInfo();
-        if (latestLocationVersion) {
+        if (args.getLatestVersionLocation()) {
           slimLocationVersion(fileKeyInfo);
         }
         // refreshPipeline flag check has been removed as part of
@@ -1304,7 +1305,7 @@ public class KeyManagerImpl implements KeyManager {
         // Please refer this jira for more details.
         refresh(fileKeyInfo);
 
-        if (sortDatanodes) {
+        if (args.getSortDatanodes()) {
           sortDatanodes(clientAddress, fileKeyInfo);
         }
         return new OzoneFileStatus(fileKeyInfo, scmBlockSize, false);
@@ -1369,18 +1370,16 @@ public class KeyManagerImpl implements KeyManager {
     String keyName = args.getKeyName();
     OzoneFileStatus fileStatus;
     if (isBucketFSOptimized(volumeName, bucketName)) {
-      fileStatus = getOzoneFileStatusFSO(volumeName, bucketName, keyName,
-              args.getSortDatanodes(), clientAddress,
-              args.getLatestVersionLocation(), false);
+      fileStatus = getOzoneFileStatusFSO(args, clientAddress, false);
     } else {
-      fileStatus = getOzoneFileStatus(volumeName, bucketName,
-              keyName, args.getRefreshPipeline(), args.getSortDatanodes(),
-              args.getLatestVersionLocation(), clientAddress);
+      fileStatus = getOzoneFileStatus(args, clientAddress);
     }
     //if key is not of type file or if key is not found we throw an exception
     if (fileStatus.isFile()) {
       // add block token for read.
-      addBlockToken4Read(fileStatus.getKeyInfo());
+      if (!args.isHeadOp()) {
+        addBlockToken4Read(fileStatus.getKeyInfo());
+      }
       return fileStatus.getKeyInfo();
     }
     throw new OMException("Can not write to directory: " + keyName,
@@ -1655,9 +1654,9 @@ public class KeyManagerImpl implements KeyManager {
     TreeMap<String, OzoneFileStatus> cacheFileMap = new TreeMap<>();
     TreeMap<String, OzoneFileStatus> cacheDirMap = new TreeMap<>();
 
-    String volumeName = args.getVolumeName();
-    String bucketName = args.getBucketName();
-    String keyName = args.getKeyName();
+    final String volumeName = args.getVolumeName();
+    final String bucketName = args.getBucketName();
+    final String keyName = args.getKeyName();
     String seekFileInDB;
     String seekDirInDB;
     long prefixKeyInDB;
@@ -1758,9 +1757,12 @@ public class KeyManagerImpl implements KeyManager {
         prefixPath = OzoneFSUtils.getParentDir(startKey);
       }
 
-      OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(volumeName,
-          bucketName, startKey, false, null,
-          args.getLatestVersionLocation(), true);
+      OmKeyArgs startKeyArgs = args.toBuilder()
+          .setKeyName(startKey)
+          .setSortDatanodesInPipeline(false)
+          .build();
+      OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(startKeyArgs,
+          null, true);
 
       if (fileStatusInfo != null) {
         prefixKeyInDB = fileStatusInfo.getKeyInfo().getParentObjectID();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
@@ -55,6 +55,7 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
         .setBucketName(bucketName)
         .setKeyName(keyPrefix)
         .setRefreshPipeline(false)
+        .setHeadOp(true)
         .build();
     try {
       pathStatus = keyManager.getFileStatus(omKeyArgs);
@@ -147,6 +148,7 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
           .setBucketName(bucketName)
           .setKeyName(keyPrefix)
           .setRefreshPipeline(false)
+          .setHeadOp(true)
           .build();
 
       List<OzoneFileStatus> statuses = keyManager.listStatus(omKeyArgs, false,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/TrashOzoneFileSystem.java
@@ -287,6 +287,7 @@ public class TrashOzoneFileSystem extends FileSystem {
         .setVolumeName(volume)
         .setBucketName(bucket)
         .setKeyName(key)
+        .setHeadOp(true)
         .build();
     return keyArgs;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -588,6 +588,7 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         .setKeyName(keyArgs.getKeyName())
         .setRefreshPipeline(true)
         .setLatestVersionLocation(keyArgs.getLatestVersionLocation())
+        .setHeadOp(keyArgs.getHeadOp())
         .build();
     List<OzoneFileStatus> statuses =
         impl.listStatus(omKeyArgs, request.getRecursive(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reduce RPC calls by avoiding content-related operations (refresh pipeline, etc.) for ACL check.  Reuse `isHeadOp` flag for this purpose.

https://issues.apache.org/jira/browse/HDDS-6321

## How was this patch tested?

Reproduced manually on `master` in `ozonesecure` environment.

Added integration test:

```
[ERROR] Tests run: 20, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 16.828 s <<< FAILURE! - in org.apache.hadoop.ozone.om.TestKeyManagerImpl
[ERROR] testCheckAccessForFileKey  Time elapsed: 0.044 s  <<< FAILURE!
org.mockito.exceptions.verification.NeverWantedButInvoked:

storageContainerLocationProtocol.getContainerWithPipelineBatch(
    <any>
);
Never wanted here:
-> at org.apache.hadoop.ozone.om.TestKeyManagerImpl.testCheckAccessForFileKey(TestKeyManagerImpl.java:486)
But invoked here:
-> at org.apache.hadoop.ozone.om.KeyManagerImpl.refreshPipeline(KeyManagerImpl.java:507)
```

and verified the change:

```
[INFO] Tests run: 20, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 15.019 s - in org.apache.hadoop.ozone.om.TestKeyManagerImpl
```

https://github.com/adoroszlai/hadoop-ozone/runs/5220817724#step:4:2886