### PR TITLE
HDDS-6290. operational-state and node-state options in datanode list CLI not working correctly

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/datanode/ListInfoSubcommand.java
@@ -71,28 +71,24 @@ public class ListInfoSubcommand extends ScmSubcommand {
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     pipelines = scmClient.listPipelines();
-    if (Strings.isNullOrEmpty(ipaddress) && Strings.isNullOrEmpty(uuid)) {
-      getAllNodes(scmClient).forEach(this::printDatanodeInfo);
-    } else {
-      Stream<DatanodeWithAttributes> allNodes = getAllNodes(scmClient).stream();
-      if (!Strings.isNullOrEmpty(ipaddress)) {
-        allNodes = allNodes.filter(p -> p.getDatanodeDetails().getIpAddress()
-            .compareToIgnoreCase(ipaddress) == 0);
-      }
-      if (!Strings.isNullOrEmpty(uuid)) {
-        allNodes = allNodes.filter(p ->
-            p.getDatanodeDetails().getUuidString().equals(uuid));
-      }
-      if (!Strings.isNullOrEmpty(nodeOperationalState)) {
-        allNodes = allNodes.filter(p -> p.getOpState().toString()
-            .compareToIgnoreCase(nodeOperationalState) == 0);
-      }
-      if (!Strings.isNullOrEmpty(nodeState)) {
-        allNodes = allNodes.filter(p -> p.getHealthState().toString()
-            .compareToIgnoreCase(nodeState) == 0);
-      }
-      allNodes.forEach(this::printDatanodeInfo);
+    Stream<DatanodeWithAttributes> allNodes = getAllNodes(scmClient).stream();
+    if (!Strings.isNullOrEmpty(ipaddress)) {
+      allNodes = allNodes.filter(p -> p.getDatanodeDetails().getIpAddress()
+          .compareToIgnoreCase(ipaddress) == 0);
     }
+    if (!Strings.isNullOrEmpty(uuid)) {
+      allNodes = allNodes.filter(p ->
+          p.getDatanodeDetails().getUuidString().equals(uuid));
+    }
+    if (!Strings.isNullOrEmpty(nodeOperationalState)) {
+      allNodes = allNodes.filter(p -> p.getOpState().toString()
+          .compareToIgnoreCase(nodeOperationalState) == 0);
+    }
+    if (!Strings.isNullOrEmpty(nodeState)) {
+      allNodes = allNodes.filter(p -> p.getHealthState().toString()
+          .compareToIgnoreCase(nodeState) == 0);
+    }
+    allNodes.forEach(this::printDatanodeInfo);
   }
 
   private List<DatanodeWithAttributes> getAllNodes(ScmClient scmClient)


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I fixed the handling of options when using `ozone admin datanode list`. Previously there was a condition check that only let using the --ip and --id options, in other cases it returned all the datanodes without filtering. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6290

## How was this patch tested?

Existing tests (unit and acceptance) and tested in docker environment.
