### PR TITLE
HDDS-6327. Upgrade acceptance test doesn't collect logs when the test fails

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -94,8 +94,8 @@ run_test() {
     RESULT=1
   fi
 
-  generate_report 'upgrade' "$RESULT_DIR"
   copy_results "$test_subdir" "$ALL_RESULT_DIR"
+  generate_report 'upgrade' "$RESULT_DIR"
 }
 
 ## @description Generates data on the cluster.

--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -95,7 +95,6 @@ run_test() {
   fi
 
   copy_results "$test_subdir" "$ALL_RESULT_DIR"
-  generate_report 'upgrade' "$RESULT_DIR"
 }
 
 ## @description Generates data on the cluster.


### PR DESCRIPTION
## What changes were proposed in this pull request?

It turns out when the upgrade test suite execution failed, the `rebot` command inside `generate_report` will exit the script when it finished generating the HTML reports. That skipped the `copy_results` call immediately following the `generate_report` call. Swapping the position of these two lines should alleviate the issue. See the comments under jira HDDS-6327 for more information.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6327

## How was this patch tested?

- All existing test cases should pass. In the case of upgrade acceptance test failure (in misc), related `docker-*.log` should be collected.
