### PR TITLE
HDDS-6334. Remove ContainerID to Proto to ContainerID conversion in ContainerStateManagerImpl

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerManagerImpl.java
@@ -36,6 +36,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ContainerInfoProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.LifeCycleEvent;
@@ -282,10 +283,11 @@ public class ContainerManagerImpl implements ContainerManager {
   public void updateContainerState(final ContainerID cid,
                                    final LifeCycleEvent event)
       throws IOException, InvalidStateTransitionException {
+    HddsProtos.ContainerID protoId = cid.getProtobuf();
     lock.lock();
     try {
       if (containerExist(cid)) {
-        containerStateManager.updateContainerState(cid.getProtobuf(), event);
+        containerStateManager.updateContainerState(protoId, event);
       } else {
         throwContainerNotFoundException(cid);
       }
@@ -410,10 +412,11 @@ public class ContainerManagerImpl implements ContainerManager {
   @Override
   public void deleteContainer(final ContainerID cid)
       throws IOException {
+    HddsProtos.ContainerID protoId = cid.getProtobuf();
     lock.lock();
     try {
       if (containerExist(cid)) {
-        containerStateManager.removeContainer(cid.getProtobuf());
+        containerStateManager.removeContainer(protoId);
         scmContainerManagerMetrics.incNumSuccessfulDeleteContainers();
       } else {
         scmContainerManagerMetrics.incNumFailureDeleteContainers();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManager.java
@@ -100,7 +100,7 @@ public interface ContainerStateManager {
   /**
    *
    */
-  boolean contains(HddsProtos.ContainerID containerID);
+  boolean contains(ContainerID containerID);
 
   /**
    * Returns the ID of all the managed containers.
@@ -117,23 +117,23 @@ public interface ContainerStateManager {
   /**
    *
    */
-  ContainerInfo getContainer(HddsProtos.ContainerID id);
+  ContainerInfo getContainer(ContainerID id);
 
   /**
    *
    */
-  Set<ContainerReplica> getContainerReplicas(HddsProtos.ContainerID id);
+  Set<ContainerReplica> getContainerReplicas(ContainerID id);
 
   /**
    *
    */
-  void updateContainerReplica(HddsProtos.ContainerID id,
+  void updateContainerReplica(ContainerID id,
                               ContainerReplica replica);
 
   /**
    *
    */
-  void removeContainerReplica(HddsProtos.ContainerID id,
+  void removeContainerReplica(ContainerID id,
                               ContainerReplica replica);
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -277,10 +277,10 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
-  public ContainerInfo getContainer(final HddsProtos.ContainerID id) {
+  public ContainerInfo getContainer(final ContainerID id) {
     lock.readLock().lock();
     try {
-      return containers.getContainerInfo(ContainerID.getFromProtobuf(id));
+      return containers.getContainerInfo(id);
     } finally {
       lock.readLock().unlock();
     }
@@ -326,11 +326,11 @@ public final class ContainerStateManagerImpl
   }
 
   @Override
-  public boolean contains(final HddsProtos.ContainerID id) {
+  public boolean contains(ContainerID id) {
     lock.readLock().lock();
     try {
       // TODO: Remove the protobuf conversion after fixing ContainerStateMap.
-      return containers.contains(ContainerID.getFromProtobuf(id));
+      return containers.contains(id);
     } finally {
       lock.readLock().unlock();
     }
@@ -370,35 +370,32 @@ public final class ContainerStateManagerImpl
 
 
   @Override
-  public Set<ContainerReplica> getContainerReplicas(
-      final HddsProtos.ContainerID id) {
+  public Set<ContainerReplica> getContainerReplicas(final ContainerID id) {
     lock.readLock().lock();
     try {
-      return containers.getContainerReplicas(
-          ContainerID.getFromProtobuf(id));
+      return containers.getContainerReplicas(id);
     } finally {
       lock.readLock().unlock();
     }
   }
 
   @Override
-  public void updateContainerReplica(final HddsProtos.ContainerID id,
+  public void updateContainerReplica(final ContainerID id,
                                      final ContainerReplica replica) {
     lock.writeLock().lock();
     try {
-      containers.updateContainerReplica(ContainerID.getFromProtobuf(id),
-          replica);
+      containers.updateContainerReplica(id, replica);
     } finally {
       lock.writeLock().unlock();
     }
   }
 
   @Override
-  public void removeContainerReplica(final HddsProtos.ContainerID id,
+  public void removeContainerReplica(final ContainerID id,
                                      final ContainerReplica replica) {
     lock.writeLock().lock();
     try {
-      containers.removeContainerReplica(ContainerID.getFromProtobuf(id),
+      containers.removeContainerReplica(id,
           replica);
     } finally {
       lock.writeLock().unlock();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerStateManagerImpl.java
@@ -329,7 +329,6 @@ public final class ContainerStateManagerImpl
   public boolean contains(ContainerID id) {
     lock.readLock().lock();
     try {
-      // TODO: Remove the protobuf conversion after fixing ContainerStateMap.
       return containers.contains(id);
     } finally {
       lock.readLock().unlock();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -103,13 +103,13 @@ public class TestContainerReportHandler {
     Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainer(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     Mockito.when(containerManager.getContainerReplicas(
         Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainerReplicas(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     Mockito.doAnswer(invocation -> {
       containerStateManager
@@ -123,7 +123,7 @@ public class TestContainerReportHandler {
 
     Mockito.doAnswer(invocation -> {
       containerStateManager.updateContainerReplica(
-          ((ContainerID)invocation.getArguments()[0]).getProtobuf(),
+          ((ContainerID)invocation.getArguments()[0]),
           (ContainerReplica) invocation.getArguments()[1]);
       return null;
     }).when(containerManager).updateContainerReplica(
@@ -131,7 +131,7 @@ public class TestContainerReportHandler {
 
     Mockito.doAnswer(invocation -> {
       containerStateManager.removeContainerReplica(
-          ((ContainerID)invocation.getArguments()[0]).getProtobuf(),
+          ((ContainerID)invocation.getArguments()[0]),
           (ContainerReplica) invocation.getArguments()[1]);
       return null;
     }).when(containerManager).removeContainerReplica(
@@ -177,13 +177,13 @@ public class TestContainerReportHandler {
         ContainerReplicaProto.State.CLOSED,
         datanodeOne, datanodeTwo, datanodeThree)
         .forEach(r -> containerStateManager.updateContainerReplica(
-            containerOne.containerID().getProtobuf(), r));
+            containerOne.containerID(), r));
 
     getReplicas(containerTwo.containerID(),
         ContainerReplicaProto.State.CLOSED,
         datanodeOne, datanodeTwo, datanodeThree)
         .forEach(r -> containerStateManager.updateContainerReplica(
-            containerTwo.containerID().getProtobuf(), r));
+            containerTwo.containerID(), r));
 
 
     // SCM expects both containerOne and containerTwo to be in all the three
@@ -236,13 +236,13 @@ public class TestContainerReportHandler {
         ContainerReplicaProto.State.CLOSED,
         datanodeOne, datanodeTwo, datanodeThree)
         .forEach(r -> containerStateManager.updateContainerReplica(
-            containerOne.containerID().getProtobuf(), r));
+            containerOne.containerID(), r));
 
     getReplicas(containerTwo.containerID(),
         ContainerReplicaProto.State.CLOSED,
         datanodeOne, datanodeTwo, datanodeThree)
         .forEach(r -> containerStateManager.updateContainerReplica(
-            containerTwo.containerID().getProtobuf(), r));
+            containerTwo.containerID(), r));
 
 
     // SCM expects both containerOne and containerTwo to be in all the three
@@ -315,11 +315,11 @@ public class TestContainerReportHandler {
 
     containerOneReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
     containerTwoReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
 
     final ContainerReportsProto containerReport = getContainerReportsProto(
@@ -383,11 +383,11 @@ public class TestContainerReportHandler {
 
     containerOneReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
     containerTwoReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
 
     final ContainerReportsProto containerReport = getContainerReportsProto(
@@ -454,11 +454,11 @@ public class TestContainerReportHandler {
 
     containerOneReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
     containerTwoReplicas.forEach(r ->
         containerStateManager.updateContainerReplica(
-        containerTwo.containerID().getProtobuf(), r));
+        containerTwo.containerID(), r));
 
 
     final ContainerReportsProto containerReport = getContainerReportsProto(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -120,7 +120,7 @@ public class TestContainerStateManager {
 
     //WHEN
     Set<ContainerReplica> replicas = containerStateManager
-        .getContainerReplicas(c1.containerID().getProtobuf());
+        .getContainerReplicas(c1.containerID());
 
     //THEN
     Assert.assertEquals(3, replicas.size());
@@ -140,7 +140,7 @@ public class TestContainerStateManager {
 
     //WHEN
     Set<ContainerReplica> replicas = containerStateManager
-        .getContainerReplicas(c1.containerID().getProtobuf());
+        .getContainerReplicas(c1.containerID());
 
     Assert.assertEquals(2, replicas.size());
     Assert.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
@@ -153,7 +153,7 @@ public class TestContainerStateManager {
         .setDatanodeDetails(node)
         .build();
     containerStateManager
-        .updateContainerReplica(cont.containerID().getProtobuf(), replica);
+        .updateContainerReplica(cont.containerID(), replica);
   }
 
   private ContainerInfo allocateContainer() throws IOException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -131,18 +131,18 @@ public class TestIncrementalContainerReportHandler {
     Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainer(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     Mockito.when(containerManager.getContainerReplicas(
         Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainerReplicas(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     Mockito.doAnswer(invocation -> {
       containerStateManager
           .removeContainerReplica(((ContainerID)invocation
-                  .getArguments()[0]).getProtobuf(),
+                  .getArguments()[0]),
               (ContainerReplica)invocation.getArguments()[1]);
       return null;
     }).when(containerManager).removeContainerReplica(
@@ -162,7 +162,7 @@ public class TestIncrementalContainerReportHandler {
     Mockito.doAnswer(invocation -> {
       containerStateManager
           .updateContainerReplica(((ContainerID)invocation
-                  .getArguments()[0]).getProtobuf(),
+                  .getArguments()[0]),
               (ContainerReplica) invocation.getArguments()[1]);
       return null;
     }).when(containerManager).updateContainerReplica(
@@ -201,7 +201,7 @@ public class TestIncrementalContainerReportHandler {
 
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> containerStateManager.updateContainerReplica(
-        container.containerID().getProtobuf(), r));
+        container.containerID(), r));
 
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -234,7 +234,7 @@ public class TestIncrementalContainerReportHandler {
 
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> containerStateManager.updateContainerReplica(
-        container.containerID().getProtobuf(), r));
+        container.containerID(), r));
 
 
     final IncrementalContainerReportProto containerReport =
@@ -272,7 +272,7 @@ public class TestIncrementalContainerReportHandler {
 
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> containerStateManager.updateContainerReplica(
-        container.containerID().getProtobuf(), r));
+        container.containerID(), r));
 
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -305,9 +305,9 @@ public class TestIncrementalContainerReportHandler {
 
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> containerStateManager.updateContainerReplica(
-        container.containerID().getProtobuf(), r));
+        container.containerID(), r));
     Assert.assertEquals(3, containerStateManager
-        .getContainerReplicas(container.containerID().getProtobuf()).size());
+        .getContainerReplicas(container.containerID()).size());
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
             ContainerReplicaProto.State.DELETED,
@@ -317,7 +317,7 @@ public class TestIncrementalContainerReportHandler {
             datanodeOne, containerReport);
     reportHandler.onMessage(icr, publisher);
     Assert.assertEquals(2, containerStateManager
-        .getContainerReplicas(container.containerID().getProtobuf()).size());
+        .getContainerReplicas(container.containerID()).size());
   }
 
   @Test
@@ -376,7 +376,7 @@ public class TestIncrementalContainerReportHandler {
           // If we find "container" in the NM, then we must also have it in
           // Container Manager.
           Assert.assertEquals(1, containerStateManager
-              .getContainerReplicas(container.containerID().getProtobuf())
+              .getContainerReplicas(container.containerID())
               .size());
           Assert.assertEquals(2, nmContainers.size());
         } else {
@@ -385,12 +385,12 @@ public class TestIncrementalContainerReportHandler {
           // NM, but have found something for it in ContainerManager, and that
           // should not happen. It should be in both, or neither.
           Assert.assertEquals(0, containerStateManager
-              .getContainerReplicas(container.containerID().getProtobuf())
+              .getContainerReplicas(container.containerID())
               .size());
           Assert.assertEquals(1, nmContainers.size());
         }
         Assert.assertEquals(1, containerStateManager
-            .getContainerReplicas(containerTwo.containerID().getProtobuf())
+            .getContainerReplicas(containerTwo.containerID())
             .size());
       }
     } finally {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -156,7 +156,7 @@ public class TestReplicationManager {
           List<ContainerInfo> containers = new ArrayList<>();
           for (ContainerID id : ids) {
             containers.add(containerStateManager.getContainer(
-                id.getProtobuf()));
+                id));
           }
           return containers;
         });
@@ -164,13 +164,13 @@ public class TestReplicationManager {
     Mockito.when(containerManager.getContainer(Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainer(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     Mockito.when(containerManager.getContainerReplicas(
         Mockito.any(ContainerID.class)))
         .thenAnswer(invocation -> containerStateManager
             .getContainerReplicas(((ContainerID)invocation
-                .getArguments()[0]).getProtobuf()));
+                .getArguments()[0])));
 
     containerPlacementPolicy = Mockito.mock(PlacementPolicy.class);
 
@@ -289,7 +289,7 @@ public class TestReplicationManager {
     replicas.addAll(getReplicas(id, State.OPEN, datanode));
 
     for (ContainerReplica replica : replicas) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     final int currentCloseCommandCount = datanodeCommandHandler
@@ -302,7 +302,7 @@ public class TestReplicationManager {
 
     // Update the OPEN to CLOSING
     for (ContainerReplica replica : getReplicas(id, State.CLOSING, datanode)) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     replicationManager.processAll();
@@ -333,10 +333,10 @@ public class TestReplicationManager {
         id, State.OPEN, 1000L, datanodeDetails.getUuid(), datanodeDetails);
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
+        id, replicaThree);
 
     final int currentCloseCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand);
@@ -373,10 +373,10 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
+        id, replicaThree);
 
     // All the QUASI_CLOSED replicas have same originNodeId, so the
     // container will not be closed. ReplicationManager should take no action.
@@ -413,10 +413,10 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
+        id, replicaThree);
 
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
@@ -434,7 +434,7 @@ public class TestReplicationManager {
         id, State.UNHEALTHY, 1000L, originNodeId,
         replicaOne.getDatanodeDetails());
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), unhealthyReplica);
+        id, unhealthyReplica);
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
@@ -447,7 +447,7 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumDeletionCmdsSent());
 
     // Now we will delete the unhealthy replica from in-memory.
-    containerStateManager.removeContainerReplica(id.getProtobuf(), replicaOne);
+    containerStateManager.removeContainerReplica(id, replicaOne);
 
     final long currentBytesToReplicate = replicationManager.getMetrics()
         .getNumReplicationBytesTotal();
@@ -482,7 +482,7 @@ public class TestReplicationManager {
     final ContainerReplica replicatedReplicaOne = getReplicas(
         id, State.CLOSED, 1000L, originNodeId, targetDn);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicatedReplicaOne);
+        id, replicatedReplicaOne);
 
     final long currentReplicationCommandCompleted = replicationManager
         .getMetrics().getNumReplicationCmdsCompleted();
@@ -528,11 +528,11 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFour);
+        id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
 
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
@@ -559,16 +559,16 @@ public class TestReplicationManager {
         .get(id).get(0).getDatanode();
     if (targetDn.equals(replicaOne.getDatanodeDetails())) {
       containerStateManager.removeContainerReplica(
-          id.getProtobuf(), replicaOne);
+          id, replicaOne);
     } else if (targetDn.equals(replicaTwo.getDatanodeDetails())) {
       containerStateManager.removeContainerReplica(
-          id.getProtobuf(), replicaTwo);
+          id, replicaTwo);
     } else if (targetDn.equals(replicaThree.getDatanodeDetails())) {
       containerStateManager.removeContainerReplica(
-          id.getProtobuf(), replicaThree);
+          id, replicaThree);
     } else if (targetDn.equals(replicaFour.getDatanodeDetails())) {
       containerStateManager.removeContainerReplica(
-          id.getProtobuf(), replicaFour);
+          id, replicaFour);
     }
 
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
@@ -616,11 +616,11 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFour);
+        id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
 
     final int currentDeleteCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand);
@@ -648,7 +648,7 @@ public class TestReplicationManager {
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
         .getNumDeletionCmdsCompleted();
     // Now we remove the replica to simulate deletion complete
-    containerStateManager.removeContainerReplica(id.getProtobuf(), replicaOne);
+    containerStateManager.removeContainerReplica(id, replicaOne);
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
@@ -683,8 +683,8 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
 
     final int currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
@@ -722,7 +722,7 @@ public class TestReplicationManager {
     final ContainerReplica replicatedReplicaThree = getReplicas(
         id, State.CLOSED, 1000L, originNodeId, targetDn);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicatedReplicaThree);
+        id, replicatedReplicaThree);
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
@@ -776,8 +776,8 @@ public class TestReplicationManager {
         id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
 
     final int currentReplicateCommandCount = datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand);
@@ -804,7 +804,7 @@ public class TestReplicationManager {
         replicateCommand.get().getDatanodeId());
     ContainerReplica newReplica = getReplicas(
         id, State.QUASI_CLOSED, 1000L, originNodeId, newNode);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), newReplica);
+    containerStateManager.updateContainerReplica(id, newReplica);
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
     Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
@@ -836,7 +836,7 @@ public class TestReplicationManager {
     Assert.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
-    containerStateManager.removeContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.removeContainerReplica(id, replicaTwo);
 
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
         .getNumDeletionCmdsCompleted();
@@ -900,7 +900,7 @@ public class TestReplicationManager {
         randomDatanodeDetails());
     containerStateManager.addContainer(container.getProtobuf());
     for (ContainerReplica replica : replicas) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     final int currentCloseCommandCount = datanodeCommandHandler
@@ -935,7 +935,7 @@ public class TestReplicationManager {
 
     containerStateManager.addContainer(container.getProtobuf());
     for (ContainerReplica replica : replicas) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     replicationManager.processAll();
@@ -964,7 +964,7 @@ public class TestReplicationManager {
 
     containerStateManager.addContainer(container.getProtobuf());
     for (ContainerReplica replica : replicas) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     final CloseContainerEventHandler closeContainerHandler =
@@ -996,7 +996,7 @@ public class TestReplicationManager {
 
     containerStateManager.addContainer(container.getProtobuf());
     for (ContainerReplica replica : replicas) {
-      containerStateManager.updateContainerReplica(id.getProtobuf(), replica);
+      containerStateManager.updateContainerReplica(id, replica);
     }
 
     replicationManager.processAll();
@@ -1031,10 +1031,10 @@ public class TestReplicationManager {
         id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
+        id, replicaThree);
 
     // Ensure a mis-replicated status is returned for any containers in this
     // test where there are 3 replicas. When there are 2 or 4 replicas
@@ -1116,12 +1116,12 @@ public class TestReplicationManager {
         id, State.UNHEALTHY, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFour);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFive);
+        id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
+    containerStateManager.updateContainerReplica(id, replicaFive);
 
     // Ensure a mis-replicated status is returned for any containers in this
     // test where there are exactly 3 replicas checked.
@@ -1168,11 +1168,11 @@ public class TestReplicationManager {
         id, State.CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFour);
+        id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
 
     Mockito.when(containerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list.size() == 3),
@@ -1214,12 +1214,12 @@ public class TestReplicationManager {
         id, State.QUASI_CLOSED, 1000L, originNodeId, randomDatanodeDetails());
 
     containerStateManager.addContainer(container.getProtobuf());
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
     containerStateManager.updateContainerReplica(
-        id.getProtobuf(), replicaThree);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFour);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaFive);
+        id, replicaThree);
+    containerStateManager.updateContainerReplica(id, replicaFour);
+    containerStateManager.updateContainerReplica(id, replicaFive);
 
     Mockito.when(containerPlacementPolicy.validateContainerPlacement(
         Mockito.argThat(list -> list != null && list.size() <= 4),
@@ -1431,7 +1431,7 @@ public class TestReplicationManager {
     // for removal
     Set<ContainerReplica> decom =
         containerStateManager.getContainerReplicas(
-            container.containerID().getProtobuf())
+            container.containerID())
         .stream()
         .filter(r -> r.getDatanodeDetails().getPersistedOpState() != IN_SERVICE)
         .collect(Collectors.toSet());
@@ -1496,7 +1496,7 @@ public class TestReplicationManager {
         SCMCommandProto.Type.deleteContainerCommand, dn1.getDatanodeDetails()));
     Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.deleteContainerCommand));
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn1);
+    containerStateManager.removeContainerReplica(id, dn1);
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
@@ -1579,10 +1579,10 @@ public class TestReplicationManager {
     //deleteContainerCommand will be sent again
     Assert.assertEquals(2, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.deleteContainerCommand));
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn1);
+    containerStateManager.removeContainerReplica(id, dn1);
 
     //replica in src datanode is deleted now
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn1);
+    containerStateManager.removeContainerReplica(id, dn1);
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
@@ -1630,7 +1630,7 @@ public class TestReplicationManager {
     //now, replication succeeds, but replica in dn2 lost,
     //and there are only tree replicas totally, so rm should
     //not delete the replica on dn1
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn2);
+    containerStateManager.removeContainerReplica(id, dn2);
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
@@ -1741,7 +1741,7 @@ public class TestReplicationManager {
     containerStateManager.updateContainerState(id.getProtobuf(),
         LifeCycleEvent.FORCE_CLOSE);
     Assert.assertTrue(LifeCycleState.CLOSED ==
-        containerStateManager.getContainer(id.getProtobuf()).getState());
+        containerStateManager.getContainer(id).getState());
 
     //Node is not in healthy state
     for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
@@ -1805,8 +1805,8 @@ public class TestReplicationManager {
 
     //make the replica num be 2 to test the case
     //that container is in inflightReplication
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn5);
-    containerStateManager.removeContainerReplica(id.getProtobuf(), dn4);
+    containerStateManager.removeContainerReplica(id, dn5);
+    containerStateManager.removeContainerReplica(id, dn4);
     //replication manager should generate inflightReplication
     replicationManager.processAll();
     //waiting for inflightReplication generation
@@ -1902,7 +1902,7 @@ public class TestReplicationManager {
     final ContainerReplica replica = getReplicas(
         container.containerID(), replicaState, 1000L, originNodeId, dn);
     containerStateManager
-        .updateContainerReplica(container.containerID().getProtobuf(), replica);
+        .updateContainerReplica(container.containerID(), replica);
     return replica;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -398,7 +398,7 @@ public class TestContainerStateManagerIntegration {
     // Test 1: no replica's exist
     ContainerID containerID = ContainerID.valueOf(RandomUtils.nextLong());
     Set<ContainerReplica> replicaSet;
-    containerStateManager.getContainerReplicas(containerID.getProtobuf());
+    containerStateManager.getContainerReplicas(containerID);
     Assert.fail();
 
     ContainerWithPipeline container = scm.getClientProtocolServer()
@@ -419,44 +419,44 @@ public class TestContainerStateManagerIntegration {
         .setContainerState(ContainerReplicaProto.State.OPEN)
         .setDatanodeDetails(dn2)
         .build();
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    containerStateManager.updateContainerReplica(id, replicaTwo);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(2, replicaSet.size());
     Assert.assertTrue(replicaSet.contains(replicaOne));
     Assert.assertTrue(replicaSet.contains(replicaTwo));
 
     // Test 3: Remove one replica node and then test
-    containerStateManager.removeContainerReplica(id.getProtobuf(), replicaOne);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.removeContainerReplica(id, replicaOne);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(1, replicaSet.size());
     Assert.assertFalse(replicaSet.contains(replicaOne));
     Assert.assertTrue(replicaSet.contains(replicaTwo));
 
     // Test 3: Remove second replica node and then test
-    containerStateManager.removeContainerReplica(id.getProtobuf(), replicaTwo);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.removeContainerReplica(id, replicaTwo);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(0, replicaSet.size());
     Assert.assertFalse(replicaSet.contains(replicaOne));
     Assert.assertFalse(replicaSet.contains(replicaTwo));
 
     // Test 4: Re-insert dn1
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(1, replicaSet.size());
     Assert.assertTrue(replicaSet.contains(replicaOne));
     Assert.assertFalse(replicaSet.contains(replicaTwo));
 
     // Re-insert dn2
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaTwo);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.updateContainerReplica(id, replicaTwo);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(2, replicaSet.size());
     Assert.assertTrue(replicaSet.contains(replicaOne));
     Assert.assertTrue(replicaSet.contains(replicaTwo));
 
     // Re-insert dn1
-    containerStateManager.updateContainerReplica(id.getProtobuf(), replicaOne);
-    replicaSet = containerStateManager.getContainerReplicas(id.getProtobuf());
+    containerStateManager.updateContainerReplica(id, replicaOne);
+    replicaSet = containerStateManager.getContainerReplicas(id);
     Assert.assertEquals(2, replicaSet.size());
     Assert.assertTrue(replicaSet.contains(replicaOne));
     Assert.assertTrue(replicaSet.contains(replicaTwo));


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ContainerManagerImpl, most of the methods accept a ContainerID object. This is then converted into `HddsProtos.ContainerID` to pass to ContainerStateManagerImpl. The data is stored in ContainerStateMap, where it is all keyed on ContainerID, so the `HddsProtos.ContainerID` has to be converted back to ContainerID again, which seems wasteful.

There are some methods in the ContainerStateManager interface that are annotated `@Replicate`, and they need to continue to passed the ContainerID Protobuf, but they are few and can be handled as special cases.

There are also some TODO's in the code suggesting it was always the intention to make this change, but it never happened, eg:

```
  @Override
  public boolean contains(final HddsProtos.ContainerID id) {
    lock.readLock().lock();
    try {
      // TODO: Remove the protobuf conversion after fixing ContainerStateMap.
      return containers.contains(ContainerID.getFromProtobuf(id));
    } finally {
      lock.readLock().unlock();
    }
  }
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6334

## How was this patch tested?

Existing tests cover this.
