### PR TITLE
HDDS-6341: EC: Fix the race condition in TestECBlockReconstructedStripeInputStream.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -226,19 +226,20 @@ public final class ECStreamTestUtil {
 
     private Pipeline currentPipeline;
 
-    public List<ECStreamTestUtil.TestBlockInputStream> getBlockStreams() {
+    public synchronized
+        List<ECStreamTestUtil.TestBlockInputStream> getBlockStreams() {
       return blockStreams;
     }
 
-    public void setBlockStreamData(List<ByteBuffer> bufs) {
+    public synchronized void setBlockStreamData(List<ByteBuffer> bufs) {
       this.blockStreamData = bufs;
     }
 
-    public void setCurrentPipeline(Pipeline pipeline) {
+    public synchronized void setCurrentPipeline(Pipeline pipeline) {
       this.currentPipeline = pipeline;
     }
 
-    public void setFailIndexes(List<Integer> fail) {
+    public synchronized void setFailIndexes(List<Integer> fail) {
       failIndexes.addAll(fail);
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -242,7 +242,8 @@ public final class ECStreamTestUtil {
       failIndexes.addAll(fail);
     }
 
-    public BlockExtendedInputStream create(ReplicationConfig repConfig,
+    public synchronized BlockExtendedInputStream create(
+        ReplicationConfig repConfig,
         OmKeyLocationInfo blockInfo, Pipeline pipeline,
         Token<OzoneBlockTokenIdentifier> token, boolean verifyChecksum,
         XceiverClientFactory xceiverFactory,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
@@ -416,6 +416,7 @@ public class TestECBlockInputStream {
       return blockStreams;
     }
 
+    // Not a thread safe create.
     public BlockExtendedInputStream create(ReplicationConfig repConfig,
         OmKeyLocationInfo blockInfo, Pipeline pipeline,
         Token<OzoneBlockTokenIdentifier> token, boolean verifyChecksum,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestECBlockInputStream.java
@@ -412,15 +412,14 @@ public class TestECBlockInputStream {
 
     private List<TestBlockInputStream> blockStreams = new ArrayList<>();
 
-    public List<TestBlockInputStream> getBlockStreams() {
+    public synchronized List<TestBlockInputStream> getBlockStreams() {
       return blockStreams;
     }
 
-    // Not a thread safe create.
-    public BlockExtendedInputStream create(ReplicationConfig repConfig,
-        OmKeyLocationInfo blockInfo, Pipeline pipeline,
-        Token<OzoneBlockTokenIdentifier> token, boolean verifyChecksum,
-        XceiverClientFactory xceiverFactory,
+    public synchronized BlockExtendedInputStream create(
+        ReplicationConfig repConfig, OmKeyLocationInfo blockInfo,
+        Pipeline pipeline, Token<OzoneBlockTokenIdentifier> token,
+        boolean verifyChecksum, XceiverClientFactory xceiverFactory,
         Function<BlockID, Pipeline> refreshFunction) {
       TestBlockInputStream stream = new TestBlockInputStream(
           blockInfo.getBlockID(), blockInfo.getLength(),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed a race condition in test. When creating stream we used arraylist in stub class. Using ArrayList add in multithreaded envs tend to be problematic. It could induce null values in array list. Due to NPE, randomly test failing.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6341

## How was this patch tested?

Verified the test by keeping it in tight loop.