### PR TITLE
HDDS-6350. Test helpers should observe naming conventions - 2.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/StandardOutputTestBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/StandardOutputTestBase.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Utility class to check standard output.
  */
-public class StandardOutputTestUtil {
+public class StandardOutputTestBase {
   private final ByteArrayOutputStream outContent =
       new ByteArrayOutputStream();
   private final ByteArrayOutputStream errContent =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/StandardOutputTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/StandardOutputTestUtil.java
@@ -28,7 +28,7 @@ import java.nio.charset.StandardCharsets;
 /**
  * Utility class to check standard output.
  */
-public class TestStandardOutputUtil {
+public class StandardOutputTestUtil {
   private final ByteArrayOutputStream outContent =
       new ByteArrayOutputStream();
   private final ByteArrayOutputStream errContent =

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.ozone.shell;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.StandardOutputTestUtil;
+import org.apache.hadoop.ozone.StandardOutputTestBase;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -40,7 +40,7 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_K
 /**
  * Test for Namespace CLI.
  */
-public class TestNSSummaryAdmin extends StandardOutputTestUtil {
+public class TestNSSummaryAdmin extends StandardOutputTestBase {
   private static ObjectStore store;
 
   private static OzoneAdmin ozoneAdmin;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestNSSummaryAdmin.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.ozone.shell;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.TestStandardOutputUtil;
+import org.apache.hadoop.ozone.StandardOutputTestUtil;
 import org.apache.hadoop.ozone.client.BucketArgs;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneVolume;
@@ -40,7 +40,7 @@ import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_K
 /**
  * Test for Namespace CLI.
  */
-public class TestNSSummaryAdmin extends TestStandardOutputUtil {
+public class TestNSSummaryAdmin extends StandardOutputTestUtil {
   private static ObjectStore store;
 
   private static OzoneAdmin ozoneAdmin;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Improvements similar to [HDDS-6227](https://issues.apache.org/jira/browse/HDDS-6227).

Rename some test helper classes to match Ozone's naming conventions for tests (`Test*` class should have tests).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6350

## How was this patch tested?

Related Tests.
