### PR TITLE
HDDS-6351. [Docs] Update prefix-based FSO documentation.

### DIFF
--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -64,7 +64,7 @@ Following picture describes the OM metadata changes while performing a rename
 
 ## Configuration
 
-The following configuration can be used to define the default value for bucket layout during bucket creation
+The following configuration can be configured in `ozone-site.xml` to define the default value for bucket layout during bucket creation
 if the client has not specified the bucket layout argument.
 Supported values are `OBJECT_STORE` and `FILE_SYSTEM_OPTIMIZED`.
 

--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -39,9 +39,6 @@ may be rejected or normalized.
 This feature is strongly recommended to be turned ON for Ozone buckets mainly used via Hadoop compatible interfaces,
 especially with high number of files in deep directory hierarchy.
 
-Previous versions of Ozone allowed cluster-wide prefix based
-file system optimization by enabling `ozone.om.enable.filesystem.paths` configuration.
-
 ## OzoneManager Metadata layout format
 OzoneManager supports two metadata bucket layout formats - Object Store and File System Optimized.
 
@@ -78,24 +75,5 @@ By default, the buckets will default to `OBJECT_STORE` behaviour.
 <property>
     <name>ozone.default.bucket.layout</name>
     <value>OBJECT_STORE</value>
-</property>
-```
-
-## Configuring Older Versions (1.2.1)
-
-Older clients which do not support bucket layout features can enable cluster-wide prefix-based file system optimization
-using the following configuration.
-
-By default, the feature is disabled. It can be enabled with the following settings in `ozone-site.xml`:
-
-```XML
-
-<property>
-    <name>ozone.om.enable.filesystem.paths</name>
-    <value>true</value>
-</property>
-<property>
-    <name>ozone.om.metadata.layout</name>
-    <value>PREFIX</value>
 </property>
 ```

--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -1,5 +1,5 @@
 ---
-title: "Prefix based FileSystem Optimization"
+title: "Prefix based File System Optimization"
 weight: 2
 menu:
    main:
@@ -23,29 +23,33 @@ summary: Supports atomic rename and delete operation.
   limitations under the License.
 -->
 
-The prefix based FileSystem optimization feature supports atomic rename and
- delete of any directory at any level in the namespace. Also, it will perform
-  rename and delete of any directory in a deterministic/constant time.
+The prefix-based File System Optimization feature supports atomic rename and delete of any directory at any level in the
+namespace in deterministic/constant time.
 
-Note: This feature works only when `ozone.om.enable.filesystem.paths` is
- enabled which means that Hadoop Compatible File System compatibility is
-  favored instead of S3 compatibility. Some irregular S3 key names may be
-   rejected or normalized.
+This feature can be enabled for each specific bucket that requires it by setting the `--layout` flag
+to `FILE_SYSTEM_OPTIMIZED` at the time of bucket creation.
 
-This feature is strongly recommended to be turned ON when Ozone buckets are
- mainly used via Hadoop compatible interfaces, especially with high number of
-  files in deep directory hierarchy.
+```bash
+ozone sh bucket create /<volume-name>/<bucket-name> --layout FILE_SYSTEM_OPTIMIZED
+```
+
+Note: File System Optimization favors Hadoop Compatible File System over S3 compatibility. Some irregular S3 key names
+may be rejected or normalized.
+
+This feature is strongly recommended to be turned ON for Ozone buckets mainly used via Hadoop compatible interfaces,
+especially with high number of files in deep directory hierarchy.
+
+Previous versions of Ozone allowed cluster-wide prefix based
+file system optimization by enabling `ozone.om.enable.filesystem.paths` configuration.
 
 ## OzoneManager Metadata layout format
-OzoneManager supports two metadata layout formats - simple and prefix.
+OzoneManager supports two metadata bucket layout formats - Object Store and File System Optimized.
 
-Simple is the existing OM metadata format, which stores key entry with full path
- name. In Prefix based optimization, OM metadata format stores intermediate
-  directories into `DirectoryTable` and files into `FileTable` as shown in the
-   below picture. The key to the table is the name of a directory or a file
-    prefixed by the unique identifier of its parent directory, `<parent
-     unique-id>/<filename>`. 
-     
+Object Store (also called LEGACY for older versions) is the existing OM metadata format, which stores key entry with
+full path name. In File System Optimized buckets, OM metadata format stores intermediate directories
+into `DirectoryTable` and files into `FileTable` as shown in the below picture. The key to the table is the name of a
+directory or a file prefixed by the unique identifier of its parent directory, `<parent unique-id>/<filename>`.
+
 {{< image src="PrefixFSO-Format.png">}}
 
 
@@ -62,24 +66,9 @@ Following picture describes the OM metadata changes while performing a rename
 {{< image src="PrefixFSO-Rename.png">}}
 
 ## Configuration
-By default the feature is disabled. It can be enabled with the following
- settings in `ozone-site.xml`:
 
-```XML
-<property>
-   <name>ozone.om.enable.filesystem.paths</name>
-   <value>true</value>
-</property>
-<property>
-   <name>ozone.om.metadata.layout</name>
-   <value>PREFIX</value>
-</property>
-```
-
-In reference to efforts towards supporting protocol aware buckets 
-within an Ozone cluster, the following configuration can be used 
-to define the default value for bucket layout during bucket creation 
-if the client has not specified the bucket layout argument. 
+The following configuration can be used to define the default value for bucket layout during bucket creation
+if the client has not specified the bucket layout argument.
 Supported values are `OBJECT_STORE` and `FILE_SYSTEM_OPTIMIZED`.
 
 By default, the buckets will default to `OBJECT_STORE` behaviour.
@@ -87,7 +76,26 @@ By default, the buckets will default to `OBJECT_STORE` behaviour.
 ```XML
 
 <property>
- <name>ozone.default.bucket.layout</name>
- <value>OBJECT_STORE</value>
+    <name>ozone.default.bucket.layout</name>
+    <value>OBJECT_STORE</value>
+</property>
+```
+
+## Configuring Older Versions (1.2.0)
+
+Older clients which do not support bucket layout features can enable cluster-wide prefix-based file system optimization
+using the following configuration.
+
+By default, the feature is disabled. It can be enabled with the following settings in `ozone-site.xml`:
+
+```XML
+
+<property>
+    <name>ozone.om.enable.filesystem.paths</name>
+    <value>true</value>
+</property>
+<property>
+    <name>ozone.om.metadata.layout</name>
+    <value>PREFIX</value>
 </property>
 ```

--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -81,7 +81,7 @@ By default, the buckets will default to `OBJECT_STORE` behaviour.
 </property>
 ```
 
-## Configuring Older Versions (1.2.0)
+## Configuring Older Versions (1.2.1)
 
 Older clients which do not support bucket layout features can enable cluster-wide prefix-based file system optimization
 using the following configuration.

--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -33,19 +33,19 @@ to `FILE_SYSTEM_OPTIMIZED` at the time of bucket creation.
 ozone sh bucket create /<volume-name>/<bucket-name> --layout FILE_SYSTEM_OPTIMIZED
 ```
 
-Note: File System Optimization favors Hadoop Compatible File System over S3 compatibility. Some irregular S3 key names
-may be rejected or normalized.
+Note: File System Optimization favors Hadoop Compatible File System instead of S3 compatibility. Some irregular S3 key
+names may be rejected or normalized.
 
 This feature is strongly recommended to be turned ON for Ozone buckets mainly used via Hadoop compatible interfaces,
 especially with high number of files in deep directory hierarchy.
 
 ## OzoneManager Metadata layout format
-OzoneManager supports two metadata bucket layout formats - Object Store and File System Optimized.
+OzoneManager supports two metadata bucket layout formats - Object Store (OBS) and File System Optimized (FSO).
 
-Object Store (also called LEGACY for older versions) is the existing OM metadata format, which stores key entry with
-full path name. In File System Optimized buckets, OM metadata format stores intermediate directories
-into `DirectoryTable` and files into `FileTable` as shown in the below picture. The key to the table is the name of a
-directory or a file prefixed by the unique identifier of its parent directory, `<parent unique-id>/<filename>`.
+Object Store (OBS) is the existing OM metadata format, which stores key entry with full path name. In File System
+Optimized (FSO) buckets, OM metadata format stores intermediate directories into `DirectoryTable` and files
+into `FileTable` as shown in the below picture. The key to the table is the name of a directory or a file prefixed by
+the unique identifier of its parent directory, `<parent unique-id>/<filename>`.
 
 {{< image src="PrefixFSO-Format.png">}}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

The documentation lists out of date information about File System Optimization features.

We no longer recommend using `ozone.om.enable.filesystem.paths` configuration for enabling File System Optimization. We now have support for bucket layout features to support bucket-specific metadata formats.

Examples of outdated documentation:

[LINK](https://ozone.apache.org/docs/1.2.1/feature/prefixfso.html)

```
...

Note: This feature works only when ozone.om.enable.filesystem.paths is enabled which means that Hadoop Compatible File System compatibility is favored instead of S3 compatibility. Some irregular S3 key names may be rejected or normalized.

...

By default the feature is disabled. It can be enabled with the following settings in ozone-site.xml:<property>
   <name>ozone.om.enable.filesystem.paths</name>
   <value>true</value>
</property>
<property>
   <name>ozone.om.metadata.layout</name>
   <value>PREFIX</value>
</property>

...
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6351

## How was this patch tested?

NA
