### PR TITLE
HDDS-6349. IncompleteReadError on get MPU key from TDE bucket

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/MultipartCryptoKeyInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/MultipartCryptoKeyInputStream.java
@@ -172,6 +172,10 @@ public class MultipartCryptoKeyInputStream extends OzoneInputStream
             actualNumBytesRead, numBytesRead, readPositionAdjustedBy,
             actualNumBytesRead - readPositionAdjustedBy);
 
+        if (readLengthAdjustedBy > 0) {
+          current.seek(current.getPos() - readLengthAdjustedBy);
+        }
+
         // Reset readPositionAdjustedBy and readLengthAdjustedBy
         readPositionAdjustedBy = 0;
         readLengthAdjustedBy = 0;

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/docker-config
@@ -116,6 +116,10 @@ HADOOP-POLICY.XML_hdds.security.client.scm.certificate.protocol.acl=*
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 
+KMS-SITE.XML_hadoop.kms.proxyuser.root.users=*
+KMS-SITE.XML_hadoop.kms.proxyuser.root.groups=*
+KMS-SITE.XML_hadoop.kms.proxyuser.root.hosts=*
+
 #Enable this variable to print out all hadoop rpc traffic to the stdout. See http://byteman.jboss.org/ to define your own instrumentation.
 #BYTEMAN_SCRIPT_URL=https://raw.githubusercontent.com/apache/hadoop/trunk/dev-support/byteman/hadooprpc.btm
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -43,7 +43,7 @@ for scheme in ofs o3fs; do
   done
 done
 
-for bucket in link generated; do
+for bucket in encrypted link generated; do
   execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
 done
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -27,8 +27,12 @@ Test Setup          Generate random prefix
 *** Keywords ***
 Setup Multipart Tests
     Setup s3 tests
-    Create Random File KB    /tmp/part1    5121 # 5MB + a bit
-    Create Random File KB    /tmp/part2    1023 # 1MB - a bit
+
+    # 5MB + a bit
+    Create Random File KB    /tmp/part1    5121
+
+    # 1MB - a bit
+    Create Random File KB    /tmp/part2    1023
 
 Create Random file
     [arguments]             ${size_in_megabytes}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -32,11 +32,11 @@ Setup Multipart Tests
 
 Create Random file
     [arguments]             ${size_in_megabytes}
-    Execute                 dd if=/dev/urandom of=/tmp/part1 bs=1048576 count=${size_in_megabytes}
+    Execute                 dd if=/dev/urandom of=/tmp/part1 bs=1048576 count=${size_in_megabytes} status=none
 
 Create Random File KB
     [arguments]             ${file}    ${size_in_kilobytes}
-    Execute                 dd if=/dev/urandom of=${file} bs=1024 count=${size_in_kilobytes}
+    Execute                 dd if=/dev/urandom of=${file} bs=1024 count=${size_in_kilobytes} status=none
 
 Wait Til Date Past
     [arguments]         ${date}

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -21,13 +21,22 @@ Library             DateTime
 Resource            ../commonlib.robot
 Resource            commonawslib.robot
 Test Timeout        5 minutes
-Suite Setup         Setup s3 tests
+Suite Setup         Setup Multipart Tests
 Test Setup          Generate random prefix
 
 *** Keywords ***
+Setup Multipart Tests
+    Setup s3 tests
+    Create Random File KB    /tmp/part1    5121 # 5MB + a bit
+    Create Random File KB    /tmp/part2    1023 # 1MB - a bit
+
 Create Random file
     [arguments]             ${size_in_megabytes}
     Execute                 dd if=/dev/urandom of=/tmp/part1 bs=1048576 count=${size_in_megabytes}
+
+Create Random File KB
+    [arguments]             ${file}    ${size_in_kilobytes}
+    Execute                 dd if=/dev/urandom of=${file} bs=1024 count=${size_in_kilobytes}
 
 Wait Til Date Past
     [arguments]         ${date}
@@ -40,6 +49,10 @@ ${ENDPOINT_URL}       http://s3g:9878
 ${BUCKET}             generated
 
 *** Test Cases ***
+
+Test Multipart Upload With Adjusted Length
+    Perform Multipart Upload    ${BUCKET}    multipart/adjusted_length_${PREFIX}    /tmp/part1    /tmp/part2
+    Verify Multipart Upload     ${BUCKET}    multipart/adjusted_length_${PREFIX}    /tmp/part1    /tmp/part2
 
 Test Multipart Upload
     ${result} =         Execute AWSS3APICli     create-multipart-upload --bucket ${BUCKET} --key ${PREFIX}/multipartKey

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -475,8 +475,9 @@ public class TestOzoneAtRestEncryption {
       // Adding a random int with a cap at 8K (the default crypto buffer
       // size) to get parts whose last byte does not coincide with crypto
       // buffer boundary.
-      byte[] data = generateRandomData((MPU_PART_MIN_SIZE * i) +
-          RANDOM.nextInt(DEFAULT_CRYPTO_BUFFER_SIZE));
+      int partSize = (MPU_PART_MIN_SIZE * i) +
+          RANDOM.nextInt(DEFAULT_CRYPTO_BUFFER_SIZE - 1) + 1;
+      byte[] data = generateRandomData(partSize);
       String partName = uploadPart(bucket, keyName, uploadID, i, data);
       partsMap.put(i, partName);
       partsData.add(data);
@@ -495,6 +496,18 @@ public class TestOzoneAtRestEncryption {
     // Complete MPU
     completeMultipartUpload(bucket, keyName, uploadID, partsMap);
 
+    // Create an input stream to read the data
+    OzoneInputStream inputStream = bucket.readKey(keyName);
+    Assert.assertTrue(inputStream instanceof MultipartCryptoKeyInputStream);
+    MultipartCryptoKeyInputStream cryptoInputStream =
+        (MultipartCryptoKeyInputStream) inputStream;
+
+    // Test complete read
+    byte[] completeRead = new byte[keySize];
+    int bytesRead = inputStream.read(completeRead, 0, keySize);
+    Assert.assertEquals(bytesRead, keySize);
+    Assert.assertArrayEquals(inputData, completeRead);
+
     // Read different data lengths and starting from different offsets and
     // verify the data matches.
     Random random = new Random();
@@ -510,12 +523,6 @@ public class TestOzoneAtRestEncryption {
         BLOCK_SIZE - DEFAULT_CRYPTO_BUFFER_SIZE + 1, BLOCK_SIZE, keySize / 3,
         keySize - 1, randomOffset};
 
-    // Create an input stream to read the data
-    OzoneInputStream inputStream = bucket.readKey(keyName);
-    Assert.assertTrue(inputStream instanceof MultipartCryptoKeyInputStream);
-    MultipartCryptoKeyInputStream cryptoInputStream =
-        (MultipartCryptoKeyInputStream) inputStream;
-
     for (int readDataLen : readDataSizes) {
       for (int readFromPosition : readFromPositions) {
         // Check that offset + buffer size does not exceed the key size
@@ -524,10 +531,13 @@ public class TestOzoneAtRestEncryption {
         }
 
         byte[] readData = new byte[readDataLen];
-        cryptoInputStream.seek(readFromPosition);
-        inputStream.read(readData, 0, readDataLen);
+        inputStream.seek(readFromPosition);
+        int actualReadLen = inputStream.read(readData, 0, readDataLen);
 
         assertReadContent(inputData, readData, readFromPosition);
+        Assert.assertEquals(readFromPosition + readDataLen,
+            inputStream.getPos());
+        Assert.assertEquals(readDataLen, actualReadLen);
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -499,8 +499,6 @@ public class TestOzoneAtRestEncryption {
     // Create an input stream to read the data
     OzoneInputStream inputStream = bucket.readKey(keyName);
     Assert.assertTrue(inputStream instanceof MultipartCryptoKeyInputStream);
-    MultipartCryptoKeyInputStream cryptoInputStream =
-        (MultipartCryptoKeyInputStream) inputStream;
 
     // Test complete read
     byte[] completeRead = new byte[keySize];


### PR DESCRIPTION
## What changes were proposed in this pull request?

`MultipartCryptoKeyInputStream` may need to adjust read position and/or length to make sure it reads enough data to fill the crypto buffer.  Position adjustment means read starts at a location before the actual requested position.  Length adjustment means more data is read at the end.  Extra data is discarded in both cases.

This PR fixes a bug in length adjustment: the position of the underlying stream was left at the position after the discarded part, this is where the next read started.  Thus this part was missing from the final data at the client side.

The bug can be reproduced with MPU parts that are not whole multiples of the crypto buffer size, which defaults to 8KB.  Hence test case is added where the first part has 1KB more, to trigger length adjustment in the second part.

The PR also adds the KMS configs necessary to test S3 Gateway with encrypted bucket, and runs all S3 tests with encrypted bucket, too (in non-HA case for now).

https://issues.apache.org/jira/browse/HDDS-6349

## How was this patch tested?

Added Robot test to reproduce the problem:
https://github.com/adoroszlai/hadoop-ozone/runs/5263846303#step:5:528

And verified the fix:
https://github.com/adoroszlai/hadoop-ozone/runs/5265040205#step:5:524