### PR TITLE
HDDS-6354. EC: Fix allocateBlockIfFull condition in ECKeyOutputStream#write()

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -184,7 +184,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
       pos = handleDataWrite(currentStreamIdx, b, off, ecChunkSize, true);
       off += ecChunkSize;
       iters--;
-      checkAndWriteParityCells(pos, iters > 0 || remLen > 0);
+      checkAndWriteParityCells(pos, iters > 0 || lastCellSize > 0);
     }
 
     if (lastCellSize > 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`remLen > 0` will always be true if this `while` loop ever gets entered.
I think it's intended to be `lastCellSize > 0`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6354

## How was this patch tested?

N/A
