### PR TITLE
HDDS-6358. EC: Refactor ECKeyOutputStream#write()

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -599,9 +599,9 @@ public class TestOzoneECClient {
         .size() == clusterSize);
   }
 
-  @Test(expected = IllegalStateException.class)
   // The mocked impl throws IllegalStateException when there are not enough
-  // nodes in allocateBlock request.
+  // nodes in allocateBlock request. But write() converts it to IOException.
+  @Test(expected = IOException.class)
   public void testStripeWriteRetriesOnAllNodeFailures() throws IOException {
     OzoneConfiguration con = new OzoneConfiguration();
     con.setStorageSize(OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE, 2, StorageUnit.KB);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor the code to make it cleaner, here is a summary of the changes.

1. Instead of treating `head/middle/tail` differently, use a general way to write data into buffers.
2. No more `allocateBlockIfNeeded` parameters being passed around.
3. Stream will be closed if any exception happens, and `IOException` will be thrown.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6358

## How was this patch tested?

Unit tests.
