### PR TITLE
HDDS-6348: EC: PartialStripe failure handling logic is writing padding bytes also to DNs

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/BlockOutputStreamEntryPool.java
@@ -324,7 +324,8 @@ public class BlockOutputStreamEntryPool {
     if (keyArgs != null) {
       // in test, this could be null
       long length = getKeyLength();
-      Preconditions.checkArgument(offset == length);
+      Preconditions.checkArgument(offset == length,
+          "Epected offset: " + offset + " expected len: " + length);
       keyArgs.setDataSize(length);
       keyArgs.setLocationInfoList(getLocationInfoList());
       // When the key is multipart upload part file upload, we should not


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed the logic to pass the actual determined length instead of using the cellBuffer.limit
CellBuffer would have beed modified by adding padding bytes by the time of retries. So, it's safe to use determined expected len instead of of just using cellBuffer.limit

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6348

## How was this patch tested?

Added a test check the behavior.
