### PR TITLE
HDDS-6372. EC: Do not throw NotImplementedException in flush()

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -22,7 +22,6 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.FSExceptionMessages;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
@@ -462,7 +461,7 @@ public class ECKeyOutputStream extends KeyOutputStream {
 
   @Override
   public void flush() {
-    throw new NotImplementedException("The flush API is not implemented yet.");
+    LOG.debug("ECKeyOutputStream does not support flush.");
   }
 
   private void closeCurrentStreamEntry()

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.client;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
@@ -908,22 +907,6 @@ public class TestOzoneECClient {
       Assert.assertEquals(-1, is.read(partialChunkToRead));
     }
   }
-
-  @Test(expected = NotImplementedException.class)
-  public void testFlushShouldThrowNotImplementedException() throws IOException {
-    store.createVolume(volumeName);
-    OzoneVolume volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
-
-    try (OzoneOutputStream out = bucket.createKey(keyName, 1024 * 3,
-        new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
-            chunkSize), new HashMap<>())) {
-      out.write(inputChunks[0]); // Just write some content.
-      out.flush();
-    }
-  }
-
 
   private OzoneBucket writeIntoECKey(byte[] data, String key,
       DefaultReplicationConfig defaultReplicationConfig) throws IOException {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.freon;
 
+import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -28,8 +29,6 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
-import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 
 import com.codahale.metrics.Timer;
 import picocli.CommandLine.Command;
@@ -141,13 +140,10 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     final String key = generateObjectName(counter);
 
     timer.time(() -> {
-      try (OzoneOutputStream stream = bucket.createKey(key, keySize,
+      try (OutputStream stream = bucket.createKey(key, keySize,
           replicationConfig, metadata)) {
         contentGenerator.write(stream);
-        if (!(stream.getOutputStream() instanceof ECKeyOutputStream)) {
-          // ECKeyOutputStream#flush() is not implemented yet.
-          stream.flush();
-        }
+        stream.flush();
       }
       return null;
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `NotImplementedException` from `flush()` is causing problems in applications.
Let's replace this exception by log, since we are not going to implement `flush()` API.

(Behave same as HDFS EC.)

https://github.com/apache/hadoop/blob/62c86eaa0e539a4307ca794e0fcd502a77ebceb8/hadoop-hdfs-project/hadoop-hdfs-client/src/main/java/org/apache/hadoop/hdfs/DFSStripedOutputStream.java#L1012-L1024

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6372

## How was this patch tested?

manual tests