### PR TITLE
HDDS-6337. [FSO] Disable recursive access check flag for directories with no children.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
@@ -71,7 +71,7 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
 
     // Check if this key is a directory.
     // NOTE: checkRecursiveAccess is always false for a file keyPrefix.
-    if (pathStatus.isDirectory()) {
+    if (pathStatus != null && pathStatus.isDirectory()) {
       // set recursive access check to true if this directory contains
       // sub-directories or sub-files.
       checkRecursiveAccess = OMFileRequest.hasChildren(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzonePrefixPathImpl.java
@@ -20,6 +20,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.security.acl.OzonePrefixPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,6 +44,7 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
   // TODO: based on need can make batchSize configurable.
   private int batchSize = 1000;
   private OzoneFileStatus pathStatus;
+  private boolean checkRecursiveAccess = false;
 
   public OzonePrefixPathImpl(String volumeName, String bucketName,
       String keyPrefix, KeyManager keyManagerImpl) throws IOException {
@@ -65,6 +67,15 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
         throw new OMException(ome.getMessage(), KEY_NOT_FOUND);
       }
       throw ome;
+    }
+
+    // Check if this key is a directory.
+    // NOTE: checkRecursiveAccess is always false for a file keyPrefix.
+    if (pathStatus.isDirectory()) {
+      // set recursive access check to true if this directory contains
+      // sub-directories or sub-files.
+      checkRecursiveAccess = OMFileRequest.hasChildren(
+          pathStatus.getKeyInfo(), keyManager.getMetadataManager());
     }
   }
 
@@ -160,5 +171,12 @@ public class OzonePrefixPathImpl implements OzonePrefixPath {
       }
       return statuses;
     }
+  }
+
+  /**
+   * @return true if no sub-directories or sub-files exist, false otherwise
+   */
+  public boolean isCheckRecursiveAccess() {
+    return checkRecursiveAccess;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequest.java
@@ -208,8 +208,9 @@ public abstract class OMClientRequest implements RequestAuditor {
    * @param keyName
    * @throws IOException
    */
-  protected void checkACLs(OzoneManager ozoneManager, String volumeName,
-      String bucketName, String keyName, IAccessAuthorizer.ACLType aclType)
+  protected void checkACLsWithFSO(OzoneManager ozoneManager, String volumeName,
+                                  String bucketName, String keyName,
+                                  IAccessAuthorizer.ACLType aclType)
       throws IOException {
 
     // TODO: Presently not populating sub-paths under a single bucket
@@ -226,11 +227,10 @@ public abstract class OMClientRequest implements RequestAuditor {
         .setKeyName(keyName)
         .setOzonePrefixPath(pathViewer).build();
 
-    boolean isDirectory = pathViewer.getOzoneFileStatus().isDirectory();
-
     RequestContext.Builder contextBuilder = RequestContext.newBuilder()
         .setAclRights(aclType)
-        .setRecursiveAccessCheck(isDirectory); // recursive checks for a dir
+        // recursive checks for a dir with sub-directories or sub-files
+        .setRecursiveAccessCheck(pathViewer.isCheckRecursiveAccess());
 
     // check Acl
     if (ozoneManager.getAclsEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -100,7 +100,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       volumeName = keyArgs.getVolumeName();
       bucketName = keyArgs.getBucketName();
 
-      checkACLs(ozoneManager, volumeName, bucketName, keyName,
+      checkACLsWithFSO(ozoneManager, volumeName, bucketName, keyName,
           IAccessAuthorizer.ACLType.DELETE);
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -113,7 +113,7 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
       // old key and create operation on new key
 
       // check Acl fromKeyName
-      checkACLs(ozoneManager, volumeName, bucketName, fromKeyName,
+      checkACLsWithFSO(ozoneManager, volumeName, bucketName, fromKeyName,
           IAccessAuthorizer.ACLType.DELETE);
 
       // check Acl toKeyName

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -39,10 +39,10 @@ import java.util.NoSuchElementException;
  * Tests OmKeyDelete request with prefix layout.
  */
 public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
-  private final static String partialParentDir = "c/d/";
-  private final static String parentDir = "c/d/e";
-  private final static String fileName = "file1";
-  private final static String fileKey = parentDir + "/" + fileName;
+  private static final String PARTIAL_PARENT_DIR = "c/d/";
+  private static final String PARENT_DIR = "c/d/e";
+  private static final String FILE_NAME = "file1";
+  private static final String FILE_KEY = PARENT_DIR + "/" + FILE_NAME;
 
   @Override
   protected OMKeyDeleteRequest getOmKeyDeleteRequest(
@@ -58,21 +58,21 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
   @Override
   protected String addKeyToTable() throws Exception {
-    keyName = fileKey; // updated key name
+    keyName = FILE_KEY; // updated key name
 
     // Create parent dirs for the path
     long parentId = OMRequestTestUtils.addParentsToDirTable(volumeName,
-            bucketName, parentDir, omMetadataManager);
+            bucketName, PARENT_DIR, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fileKey,
+            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, FILE_KEY,
                     HddsProtos.ReplicationType.RATIS,
                     HddsProtos.ReplicationFactor.ONE,
                     parentId + 1,
                     parentId, 100, Time.now());
-    omKeyInfo.setKeyName(fileName);
+    omKeyInfo.setKeyName(FILE_NAME);
     OMRequestTestUtils.addFileToKeyTable(false, false,
-            fileName, omKeyInfo, -1, 50, omMetadataManager);
+        FILE_NAME, omKeyInfo, -1, 50, omMetadataManager);
     return omKeyInfo.getPath();
   }
 
@@ -191,7 +191,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Instantiate PrefixPath for partial key 'c/d/'.
     pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, partialParentDir, ozoneManager.getKeyManager());
+        bucketName, PARTIAL_PARENT_DIR, ozoneManager.getKeyManager());
 
     // 'c/d' has a sub-directory 'e', hence, we should be performing recursive
     // access check.
@@ -199,7 +199,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Instantiate PrefixPath for complete directory structure (without file).
     pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, parentDir, ozoneManager.getKeyManager());
+        bucketName, PARENT_DIR, ozoneManager.getKeyManager());
 
     // 'c/d/e/' has a 'file1' under it, hence, we should be performing recursive
     // access check.
@@ -207,7 +207,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Instantiate PrefixPath for complete file1.
     pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, fileKey, ozoneManager.getKeyManager());
+        bucketName, FILE_KEY, ozoneManager.getKeyManager());
 
     // Recursive access check is only enabled for directories, hence should be
     // false for file1.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -170,7 +170,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     // should not be enabled for this case.
     Assert.assertFalse(pathViewer.isCheckRecursiveAccess());
 
-    // Instantiate PrefixPath for partial key.
+    // Instantiate PrefixPath for parent key.
     pathViewer = new OzonePrefixPathImpl(volumeName,
         bucketName, parentKey, ozoneManager.getKeyManager());
 
@@ -189,7 +189,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     // As we added manually to key table.
     Assert.assertNotNull(omKeyInfo);
 
-    // Instantiate PrefixPath for partial key 'c/d/'.
+    // Instantiate PrefixPath for parent key 'c/d/'.
     pathViewer = new OzonePrefixPathImpl(volumeName,
         bucketName, INTERMEDIATE_DIR, ozoneManager.getKeyManager());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -39,6 +39,10 @@ import java.util.NoSuchElementException;
  * Tests OmKeyDelete request with prefix layout.
  */
 public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
+  private final String partialParentDir = "c/d/";
+  private final String parentDir = "c/d/e";
+  private final String fileName = "file1";
+  private final String fileKey = parentDir + "/" + fileName;
 
   @Override
   protected OMKeyDeleteRequest getOmKeyDeleteRequest(
@@ -54,17 +58,14 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
   @Override
   protected String addKeyToTable() throws Exception {
-    String parentDir = "c/d/e";
-    String fileName = "file1";
-    String key = parentDir + "/" + fileName;
-    keyName = key; // updated key name
+    keyName = fileKey; // updated key name
 
     // Create parent dirs for the path
     long parentId = OMRequestTestUtils.addParentsToDirTable(volumeName,
             bucketName, parentDir, omMetadataManager);
 
     OmKeyInfo omKeyInfo =
-            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
+            OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, fileKey,
                     HddsProtos.ReplicationType.RATIS,
                     HddsProtos.ReplicationFactor.ONE,
                     parentId + 1,
@@ -72,6 +73,22 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     omKeyInfo.setKeyName(fileName);
     OMRequestTestUtils.addFileToKeyTable(false, false,
             fileName, omKeyInfo, -1, 50, omMetadataManager);
+    return omKeyInfo.getPath();
+  }
+
+  protected String addKeyToDirTable(String volumeName, String bucketName,
+                                    String key) throws Exception {
+    // Create parent dirs for the path
+    long parentId = OMRequestTestUtils.addParentsToDirTable(volumeName,
+        bucketName, key, omMetadataManager);
+
+    OmKeyInfo omKeyInfo =
+        OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
+            HddsProtos.ReplicationType.RATIS,
+            HddsProtos.ReplicationFactor.ONE,
+            parentId + 1,
+            parentId, 100, Time.now());
+    omKeyInfo.setKeyName(key);
     return omKeyInfo.getPath();
   }
 
@@ -131,5 +148,69 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
     } catch (NoSuchElementException nse) {
       // expected
     }
+  }
+
+  @Test
+  public void testRecursiveAccessCheck() throws Exception {
+    // Add volume, bucket and key entries to OM DB.
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, getBucketLayout());
+
+    // Case 1:
+    // We create an empty directory structure.
+    String partialKey = "x/y/";
+    String key = "x/y/z/";
+    addKeyToDirTable(volumeName, bucketName, key);
+
+    // Instantiate PrefixPath for complete key.
+    OzonePrefixPathImpl pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, key, ozoneManager.getKeyManager());
+
+    // 'x/y/z' has no sub-directories or sub files - recursive access check
+    // should not be enabled for this case.
+    Assert.assertFalse(pathViewer.isCheckRecursiveAccess());
+
+    // Instantiate PrefixPath for partial key.
+    pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, partialKey, ozoneManager.getKeyManager());
+
+    // 'x/y/' has a sub-directory 'z', hence, we should be performing recursive
+    // access check.
+    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+
+    // Case 2:
+    // We create a directory structure with a file as the leaf node.
+    // 'c/d/e/file1'.
+    String ozoneKey = addKeyToTable();
+
+    OmKeyInfo omKeyInfo =
+        omMetadataManager.getKeyTable(getBucketLayout()).get(ozoneKey);
+
+    // As we added manually to key table.
+    Assert.assertNotNull(omKeyInfo);
+
+    // Instantiate PrefixPath for partial key 'c/d/'.
+    pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, partialParentDir, ozoneManager.getKeyManager());
+
+    // 'c/d' has a sub-directory 'e', hence, we should be performing recursive
+    // access check.
+    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+
+    // Instantiate PrefixPath for complete directory structure (without file).
+    pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, parentDir, ozoneManager.getKeyManager());
+
+    // 'c/d/e/' has a 'file1' under it, hence, we should be performing recursive
+    // access check.
+    Assert.assertTrue(pathViewer.isCheckRecursiveAccess());
+
+    // Instantiate PrefixPath for complete file1.
+    pathViewer = new OzonePrefixPathImpl(volumeName,
+        bucketName, fileKey, ozoneManager.getKeyManager());
+
+    // Recursive access check is only enabled for directories, hence should be
+    // false for file1.
+    Assert.assertFalse(pathViewer.isCheckRecursiveAccess());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -39,10 +39,10 @@ import java.util.NoSuchElementException;
  * Tests OmKeyDelete request with prefix layout.
  */
 public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
-  private final String partialParentDir = "c/d/";
-  private final String parentDir = "c/d/e";
-  private final String fileName = "file1";
-  private final String fileKey = parentDir + "/" + fileName;
+  private final static String partialParentDir = "c/d/";
+  private final static String parentDir = "c/d/e";
+  private final static String fileName = "file1";
+  private final static String fileKey = parentDir + "/" + fileName;
 
   @Override
   protected OMKeyDeleteRequest getOmKeyDeleteRequest(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyDeleteRequestWithFSO.java
@@ -39,7 +39,7 @@ import java.util.NoSuchElementException;
  * Tests OmKeyDelete request with prefix layout.
  */
 public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
-  private static final String PARTIAL_PARENT_DIR = "c/d/";
+  private static final String INTERMEDIATE_DIR = "c/d/";
   private static final String PARENT_DIR = "c/d/e";
   private static final String FILE_NAME = "file1";
   private static final String FILE_KEY = PARENT_DIR + "/" + FILE_NAME;
@@ -158,7 +158,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Case 1:
     // We create an empty directory structure.
-    String partialKey = "x/y/";
+    String parentKey = "x/y/";
     String key = "x/y/z/";
     addKeyToDirTable(volumeName, bucketName, key);
 
@@ -172,7 +172,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Instantiate PrefixPath for partial key.
     pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, partialKey, ozoneManager.getKeyManager());
+        bucketName, parentKey, ozoneManager.getKeyManager());
 
     // 'x/y/' has a sub-directory 'z', hence, we should be performing recursive
     // access check.
@@ -191,7 +191,7 @@ public class TestOMKeyDeleteRequestWithFSO extends TestOMKeyDeleteRequest {
 
     // Instantiate PrefixPath for partial key 'c/d/'.
     pathViewer = new OzonePrefixPathImpl(volumeName,
-        bucketName, PARTIAL_PARENT_DIR, ozoneManager.getKeyManager());
+        bucketName, INTERMEDIATE_DIR, ozoneManager.getKeyManager());
 
     // 'c/d' has a sub-directory 'e', hence, we should be performing recursive
     // access check.


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a directory under an FSO bucket does not contain any subfiles/directories - set the recursive flag for Ranger#getAcl call to false.

### Scenario:
**Ranger Policy 1:**
Key Resource | Permission | User
-- | -- | --
dir1/dir11, dir1/dir11/ | Read, Write, Delete | user2

**Ranger Policy 2:**
Key Resource | Permission | User
-- | -- | --
dir* | Read, Write, Delete | user1



**Case:**
<p>1) user2 has created a directory dir1/dir11. Since the explicit policy defined for user2, it will successfully create the directories.</p>
<p>2) user1 has recursive permission, he can create any dirs under " dir* ". Say, user1 created a file under directory "dir1/dir11/file".</p>
<p>3) user2 issues recursive delete on "dir1/dir11". <strong>(Recursive flag is sent to Ranger from internal Ozone call)</strong>.</p>
<pre class="code panel" style="border-width: 1px;" data-language="code-java">$ kinit user2
$ ozone fs -rm -R skipTrash o3fs:<span class="code-comment">//fso-buycket.vol1.fso-bucket/dir1/dir11</span></pre>
<p><strong>Expected Result:</strong></p>
<p>Fail to delete directory.</p>
<p><strong>Actual Result:</strong></p>
<p>Permission denied by Ranger.</p>
<p><strong>Comments:</strong></p>
<ul>
<li>Since there is no permission for user2 with policy key resource dir*, Ranger is denying permission for users as access is not determined. Ranger has taken a conservative approach against all the defined policy paths irrespective of the given user who issues the recursive delete operation.</li>
<li>Since there is a file under "dir1/dir11", we shouldn't allow this directory to be deleted, otherwise, this will lead to data loss.</li>
</ul>
<p><strong>Impact:</strong></p>
<p>user2 will never be able to delete "dir1/dir11" since Ozone is always sending the recursive flag to the Ranger plugin - <strong>which is undesirable.</strong></p>
<p><strong>Solution:</strong></p>
<p>If no child exists under "dir1/dir11" then set the recursive flag to False and invoke Ranger#checkAcl.</p>
<p><strong>Cost:</strong></p>
<p>There will be an additional getChildren call on both DirectoryTable and FileTable at the Ozone side. Each of these would be a deterministic time call to RocksDB.</p>

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6337

## How was this patch tested?

Unit Test added.
