### PR TITLE
HDDS-6374. Fix incorrect queueTime metrics of ReplicationTask

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/MeasuredReplicator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import java.time.Duration;
 import java.time.Instant;
 
 import org.apache.hadoop.metrics2.annotation.Metric;
@@ -71,7 +72,7 @@ public class MeasuredReplicator implements ContainerReplicator, AutoCloseable {
     long start = Time.monotonicNow();
 
     long msInQueue =
-        (Instant.now().getNano() - task.getQueued().getNano()) / 1_000_000;
+        Duration.between(task.getQueued(), Instant.now()).toMillis();
     queueTime.incr(msInQueue);
     delegate.replicate(task);
     long elapsed = Time.monotonicNow() - start;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.container.replication;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 
 import org.apache.hadoop.ozone.container.replication.ReplicationTask.Status;
@@ -121,12 +123,13 @@ public class TestMeasuredReplicator {
 
   @Test
   public void testReplicationQueueTimeMetrics() {
-    ReplicationTask task = new ReplicationTask(100L, new ArrayList<>());
-    try {
-      Thread.sleep(1000L);
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
+    final Instant queued = Instant.now().minus(1, ChronoUnit.SECONDS);
+    ReplicationTask task = new ReplicationTask(100L, new ArrayList<>()) {
+      @Override
+      public Instant getQueued() {
+        return queued;
+      }
+    };
     measuredReplicator.replicate(task);
     // There might be some deviation, so we use >= 1000 here.
     Assert.assertTrue(measuredReplicator.getQueueTime().value() >= 1000);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/replication/TestMeasuredReplicator.java
@@ -119,4 +119,16 @@ public class TestMeasuredReplicator {
     Assert.assertEquals(0, measuredReplicator.getSuccessTime().value());
   }
 
+  @Test
+  public void testReplicationQueueTimeMetrics() {
+    ReplicationTask task = new ReplicationTask(100L, new ArrayList<>());
+    try {
+      Thread.sleep(1000L);
+    } catch (InterruptedException e) {
+      e.printStackTrace();
+    }
+    measuredReplicator.replicate(task);
+    // There might be some deviation, so we use >= 1000 here.
+    Assert.assertTrue(measuredReplicator.getQueueTime().value() >= 1000);
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current logic to calculate the queue time of a ReplicationTask is as follows:
```
(Instant.now().getNano() - task.getQueued().getNano()) / 1_000_000; 
```
But Instant's nano only records the nanosecond part, it's like operation of mod.

For example, if nano part of getQueued is 500_000_000,  and queue time is 600ms

| item | time|
|---| ---|
|getQueued|500_000_000|
|in Queue|600_000_000|
|getProcessed|1100_000_000|
|call getNano()|100_000_000|

Then the result of the code mentioned above would be (100_000_000 - 500_000_000) / 1_000_000, which is -400.

 This ticket is to solve this bug by using Duration.between to get the correct queueTime.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6374

## How was this patch tested?

unit test.
