### PR TITLE
HDDS-6377.  Redundant loop while doing triggerHeartbeat in DatanodeStateMachine.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -297,8 +297,8 @@ public class DatanodeStateMachine implements Closeable {
           try {
             Thread.sleep(nextHB.get() - now);
           } catch (InterruptedException e) {
-            //triggerHeartbeat is called during the sleep
-            Thread.currentThread().interrupt();
+            // TriggerHeartbeat is called during the sleep. Don't need to set
+            // the interrupted state to true.
           }
         }
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The code related to checking heartbeat is as follows.

```
L1    while (context.getState() != DatanodeStates.SHUTDOWN) {
L2      try {
L3        LOG.debug("Executing cycle Number : {}", context.getExecutionCount());
L4        long heartbeatFrequency = context.getHeartbeatFrequency();
L5        nextHB.set(Time.monotonicNow() + heartbeatFrequency);
L6        context.execute(executorService, heartbeatFrequency,
L7            TimeUnit.MILLISECONDS);
L8      } catch (InterruptedException e) {
L9        // Someone has sent interrupt signal, this could be because
L10      // 1. Trigger heartbeat immediately
L11      // 2. Shutdown has be initiated.
L12      Thread.currentThread().interrupt();
L13    } catch (Exception e) {
L14      LOG.error("Unable to finish the execution.", e);
L15    }      
L16
L17    now = Time.monotonicNow();
L18    if (now < nextHB.get()) {
L19      if (!Thread.interrupted()) {
L20        try {
L21          Thread.sleep(nextHB.get() - now);
L22        } catch (InterruptedException e) {
L23          //triggerHeartbeat is called during the sleep
L24          Thread.currentThread().interrupt();
L25        }
L26      }
L27    }
```
     
The redundant case happens as follows:

1. triggerHeartBeat() called while stateMachineThread sleeping at L21.
2. IterruptedException catched in L22, "interrupted" state reset to false.
3. L24 set "interrupted" state to true.
4. Then back to while loop, in try-catch block of L2, since "interrupted" state was set to true, it will go to L8, then L12 set the "interrupted" state to true.
5. In L19, "Thread.interrupted()" was checked, since the current value is true, it will skip the sleep and go to next loop of while, and "interrupted" state is reset to false here.
6. Then in try-catch block of L2, since the "interrupted" state is false, now the heartbeat is triggered.

The issue is in the above step3, we don't need to set the "interrupted" state back to true, so that the next loop can execute the heartbeat directly.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6377

## How was this patch tested?

not tested yet, could you give some advice on the test part?
