### PR TITLE
HDDS-6380. EC: Key Info command should not display legacy replication fields as they duplicate ReplicationConfig

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ECReplicationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import java.util.EnumSet;
@@ -144,6 +145,7 @@ public class ECReplicationConfig implements ReplicationConfig {
   }
 
   @Override
+  @JsonIgnore
   public String getReplication() {
     return getCodec() + EC_REPLICATION_PARAMS_DELIMITER
         + getData() + EC_REPLICATION_PARAMS_DELIMITER

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
@@ -62,6 +63,7 @@ public class RatisReplicationConfig implements ReplicatedReplicationConfig {
   }
 
   @Override
+  @JsonIgnore
   public String getReplication() {
     return String.valueOf(replicationFactor);
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hdds.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
@@ -48,6 +49,7 @@ public class StandaloneReplicationConfig implements
   }
 
   @Override
+  @JsonIgnore
   public String getReplication() {
     return String.valueOf(this.replicationFactor);
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKey.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
@@ -154,12 +155,14 @@ public class OzoneKey {
    */
 
   @Deprecated
+  @JsonIgnore
   public ReplicationType getReplicationType() {
     return ReplicationType
             .fromProto(replicationConfig.getReplicationType());
   }
 
   @Deprecated
+  @JsonIgnore
   public int getReplicationFactor() {
     return replicationConfig.getRequiredNodes();
   }

--- a/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ozonefs/ozonefs.robot
@@ -45,8 +45,8 @@ Copy from local
                    Execute               ozone fs -copyFromLocal NOTICE.txt ${DEEP_URL}/
     ${result} =    Execute               ozone sh key list ${VOLUME}/${BUCKET} | jq -r '.[].name'
                    Should contain        ${result}         NOTICE.txt
-    ${result} =    Execute               ozone sh key info ${VOLUME}/${BUCKET}/${DEEP_DIR}/NOTICE.txt | jq -r '.replicationFactor'
-                   Should Be Equal       ${result}         3
+    ${result} =    Execute               ozone sh key info ${VOLUME}/${BUCKET}/${DEEP_DIR}/NOTICE.txt | jq -r '.replicationConfig.replicationFactor'
+                   Should Be Equal       ${result}         THREE
 
 Put
                    Execute               ozone fs -put NOTICE.txt ${DEEP_URL}/PUTFILE.txt


### PR DESCRIPTION
## What changes were proposed in this pull request?

Listing they key details looks like the following:

```
$ ozone sh key info /vol1/bucket1/key5
{
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "key5",
  "dataSize" : 174,
  "creationTime" : "2022-02-27T21:38:48.816Z",
  "modificationTime" : "2022-02-27T21:38:49.526Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replication" : "THREE",
    "replicationType" : "RATIS"
  },
  "ozoneKeyLocations" : [ {
    "containerID" : 5,
    "localID" : 109611004723200006,
    "length" : 174,
    "offset" : 0,
    "keyOffset" : 0
  } ],
  "metadata" : { },
  "replicationType" : "RATIS",
  "replicationFactor" : 3
} 
```

ReplicationType and Factor are now contained in ReplicationConfig, so we should not display them in the JSON output. Also note that the replicationFactor is duplicated inside replicationConfig.replication since we added [HDDS-6308](https://issues.apache.org/jira/browse/HDDS-6308), so we should probably also JsonIgnore those new fields to prevent the duplication in the command output.

After this change, the output looks like:

```
$ ozone sh key list /vol1/bucket1
[ {
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "key1",
  "dataSize" : 174,
  "creationTime" : "2022-02-27T23:11:47.227Z",
  "modificationTime" : "2022-02-27T23:11:48.239Z",
  "replicationConfig" : {
    "replicationFactor" : "THREE",
    "requiredNodes" : 3,
    "replicationType" : "RATIS"
  }
}, {
  "volumeName" : "vol1",
  "bucketName" : "bucket1",
  "name" : "key2",
  "dataSize" : 174,
  "creationTime" : "2022-02-27T23:12:53.377Z",
  "modificationTime" : "2022-02-27T23:12:54.308Z",
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "replicationType" : "EC",
    "requiredNodes" : 5
  }
} ]
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6380

## How was this patch tested?

Manually via docker-compose cluster