### PR TITLE
HDDS-6383. SCM Web UI doesn’t show correct leader/follower HA info

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsUtils.java
@@ -614,8 +614,7 @@ public final class HddsUtils {
     for (String node : nodes) {
       String[] x = node.split(":");
       sb.append(String
-          .format("{ HostName : %s, Ratis Port : %s, Role : %s } ", x[0], x[1],
-              x[2]));
+          .format("{ HostName : %s, Ratis Port : %s } ", x[0], x[1]));
     }
     return sb.toString();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMMXBean.java
@@ -74,6 +74,8 @@ public interface SCMMXBean extends ServiceRuntimeInfo {
 
   String getScmRatisRoles() throws IOException;
 
+  boolean isLeader();
+
   /**
    * Primordial node is the node on which scm init operation is performed.
    * @return hostname of primordialNode

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -1951,4 +1951,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     }
     return null;
   }
+
+  /**
+   * For HA only.
+   * @return whether current scm is leader
+   */
+  @Override
+  public boolean isLeader() {
+    return scmContext.isLeader();
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -63,9 +63,19 @@
         <td>{{$ctrl.overview.jmx.InSafeMode}}</td>
     </tr>
     <tr>
-        <td> SCM Roles (HA) </td>
+        <td> SCM HA Ring  </td>
         <td>{{$ctrl.overview.jmx.ScmRatisRoles}}</td>
     </tr>
+    <tr ng-hide="$ctrl.overview.jmx.ScmRatisRoles=='STANDALONE'">
+        <td> SCM Role (HA)  </td>
+        <td ng-if="$ctrl.overview.jmx.Leader">
+            LEADER
+        </td>
+        <td ng-if="!$ctrl.overview.jmx.Leader">
+            FOLLOWER
+        </td>
+    </tr>
+
     <tr ng-hide="!$ctrl.overview.jmx.PrimordialNode">
         <td> Primordial Node (HA) </td>
         <td>{{$ctrl.overview.jmx.PrimordialNode}}</td>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Current code for #getScmRatisRoles calls SCMRatisServer.getRatisRoles() which basically determines the leader based on whether the node is local. 
`peer.getAddress().concat(isLocal ?
    ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
    ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString())) 
`
This logic makes sense for other cases since only leader will process this request, but not for jmx case. The web ui  of a particular scm will show itself as the leader according to this logic which is incorrect. Using scmContext.isLeader() instead to solve this

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6383

## How was this patch tested?
Tested on docker scm ha env
<img width="1008" alt="Screenshot 2022-03-01 at 12 50 29 AM" src="https://user-images.githubusercontent.com/31859223/156045132-406c6f6d-e287-4eff-8afb-19058688670e.png">

<img width="1008" alt="Screenshot 2022-03-01 at 12 56 23 AM" src="https://user-images.githubusercontent.com/31859223/156045962-d8192506-f491-4e26-81b0-30b620810e2c.png">


