### PR TITLE
HDDS-6400. EC: [Refactor] Reuse code to write parity in close and retry

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -264,10 +264,6 @@ public class ECKeyOutputStream extends KeyOutputStream {
     if (handleParityWrites(parityCellSize, shouldClose)
         == StripeWriteStatus.FAILED) {
       handleStripeFailure(dataSize, shouldClose);
-    } else {
-      // At this stage stripe write is successful.
-      currentStreamEntry.updateBlockGroupToAckedPosition(
-          currentStreamEntry.getCurrentPosition());
     }
   }
 
@@ -291,6 +287,8 @@ public class ECKeyOutputStream extends KeyOutputStream {
       handleFailedStreams(true);
       return StripeWriteStatus.FAILED;
     }
+    streamEntry.updateBlockGroupToAckedPosition(
+        streamEntry.getCurrentPosition());
     ecChunkBufferCache.clear();
 
     if (streamEntry.getRemaining() <= 0) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor ECKeyOutputStream to make the code cleaner.
Reuse code when writing the last stripe or rewriting failed stripes.

The changes includes:

1. Remove isFullCell argument in handleDataWrite()
2. Move checkAndWriteParityCells() inside handleDataWrite()
3. Change checkAndWriteParityCells() to encodeAndWriteParityCells()
4. Support partial stripe in encodeAndWriteParityCells()
5. Update acked position in handleParityWrites()
6. Seperate generateParityCells() from handleParityWrites()
7. Reuse handleParityWrites() in rewriteStripeToNewBlockGroup()
8. Remove parityCellSize argument in handleParityWrites()

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6400

## How was this patch tested?

CI