### PR TITLE
HDDS-6401. Fix flaky TestFilePerBlockStrategy.testWriteAndReadChunkMultipleTimes

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/impl/CommonChunkManagerTestCases.java
@@ -225,7 +225,8 @@ public abstract class CommonChunkManagerTestCases
 
     // THEN
     checkWriteIOStats(len * count, count);
-    assertTrue(getHddsVolume().getVolumeIOStats().getWriteTime() > 0);
+    assertTrue(getHddsVolume().getVolumeIOStats().getWriteBytes() > 0);
+    assertTrue(getHddsVolume().getVolumeIOStats().getWriteOpCount() > 0);
 
     // WHEN
     for (int i = 0; i < count; i++) {


### PR DESCRIPTION
## What changes were proposed in this pull request?


When ChunkUtils.writeData() finishes too fast, elapsed time for writing data in test case becomes zero because it's resolution is a bit rough, in milliseconds. That leads to the failure of test assertion that checks elapsed time being >0. Here, the check must be on written bytes and ops.

I think this failure does not affect any released version.


## What is the link to the Apache JIRA

HDDS-6401

## How was this patch tested?

This is a test code fix
