### PR TITLE
HDDS-6391. ClientVersions and DatanodeVersions class to define an enum with version and description

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
@@ -18,15 +18,9 @@
 package org.apache.hadoop.hdds;
 
 /**
- * Base class for component version enums.
+ * Base type for component version enums.
  */
 public interface ComponentVersion {
-
-  /**
-   * Returns the version number the component version enum value has assigned.
-   * @return the version number the component version enum value has assigned.
-   */
-  int version();
 
   /**
    * Returns the description of the version enum value.
@@ -35,22 +29,9 @@ public interface ComponentVersion {
   String description();
 
   /**
-   * Method to compare the actual component version with the one provided by
-   * the other side of the communication.
-   * @param actual the actual component version of the server runtime
-   *               (NOTE: this is not the server's but the other party's
-   *               version number in the current runtime!)
-   * @param other the provided component version of the other component
-   * @return a negative value if the actual version is greater, 0 if the
-   *         two versions are equal, a positive value if the other version is
-   *         greater.
-   * @throws ClassCastException if the two provided component version instance
-   *                            are not instances of the same class.
+   * Returns the value that represents the enum in a protocol message
+   * transferred over the wire.
+   * @return the version associated with the enum value.
    */
-  default int compare(ComponentVersion actual, ComponentVersion other) {
-    if (actual.getClass() != other.getClass()) {
-      throw new ClassCastException();
-    }
-    return (other.version() & Integer.MAX_VALUE) - actual.version();
-  }
+  int toProtoValue();
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hdds;
 
 public interface ComponentVersion {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
@@ -17,10 +17,21 @@
  */
 package org.apache.hadoop.hdds;
 
+/**
+ * Base class for component version enums.
+ */
 public interface ComponentVersion {
 
+  /**
+   * Returns the version number the component version enum value has assigned.
+   * @return the version number the component version enum value has assigned.
+   */
   int version();
 
+  /**
+   * Returns the description of the version enum value.
+   * @return the description of the version enum value.
+   */
   String description();
 
   /**

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ComponentVersion.java
@@ -1,0 +1,28 @@
+package org.apache.hadoop.hdds;
+
+public interface ComponentVersion {
+
+  int version();
+
+  String description();
+
+  /**
+   * Method to compare the actual component version with the one provided by
+   * the other side of the communication.
+   * @param actual the actual component version of the server runtime
+   *               (NOTE: this is not the server's but the other party's
+   *               version number in the current runtime!)
+   * @param other the provided component version of the other component
+   * @return a negative value if the actual version is greater, 0 if the
+   *         two versions are equal, a positive value if the other version is
+   *         greater.
+   * @throws ClassCastException if the two provided component version instance
+   *                            are not instances of the same class.
+   */
+  default int compare(ComponentVersion actual, ComponentVersion other) {
+    if (actual.getClass() != other.getClass()) {
+      throw new ClassCastException();
+    }
+    return (other.version() & Integer.MAX_VALUE) - actual.version();
+  }
+}

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.hdds;
 /**
  * Versioning for datanode.
  */
-public enum DatanodeVersion {
+public enum DatanodeVersion implements ComponentVersion {
+
+  FUTURE_VERSION(-1, "Used internally in the client when the server side is "
+      + " newer and an unknown server version has arrived to the client."),
 
   DEFAULT_VERSION(0, "Initial version"),
 
@@ -37,10 +40,12 @@ public enum DatanodeVersion {
     this.description = description;
   }
 
+  @Override
   public int version() {
     return version;
   }
 
+  @Override
   public String description() {
     return description;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -26,6 +26,9 @@ public enum DatanodeVersion {
 
   SEPARATE_RATIS_PORTS_AVAILABLE(1, "Version with separated Ratis port.");
 
+  public static final DatanodeVersion CURRENT = latest();
+  public static final int CURRENT_VERSION = CURRENT.version;
+
   private final int version;
   private final String description;
 
@@ -42,7 +45,7 @@ public enum DatanodeVersion {
     return description;
   }
 
-  public static DatanodeVersion latest() {
+  private static DatanodeVersion latest() {
     DatanodeVersion[] versions = DatanodeVersion.values();
     return versions[versions.length - 1];
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -20,16 +20,30 @@ package org.apache.hadoop.hdds;
 /**
  * Versioning for datanode.
  */
-public final class DatanodeVersions {
+public enum DatanodeVersion {
 
-  public static final int DEFAULT_VERSION = 0;
+  DEFAULT_VERSION(0, "Initial version"),
 
-  public static final int SEPARATE_RATIS_PORTS_AVAILABLE = 1;
+  SEPARATE_RATIS_PORTS_AVAILABLE(1, "Version with separated Ratis port.");
 
-  // this should always point to the latest version
-  public static final int CURRENT_VERSION = SEPARATE_RATIS_PORTS_AVAILABLE;
+  private final int version;
+  private final String description;
 
-  private DatanodeVersions() {
-    // no instances
+  DatanodeVersion(int version, String description) {
+    this.version = version;
+    this.description = description;
+  }
+
+  public int version() {
+    return version;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public static DatanodeVersion latest() {
+    DatanodeVersion[] versions = DatanodeVersion.values();
+    return versions[versions.length - 1];
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -22,12 +22,12 @@ package org.apache.hadoop.hdds;
  */
 public enum DatanodeVersion implements ComponentVersion {
 
-  FUTURE_VERSION(-1, "Used internally in the client when the server side is "
-      + " newer and an unknown server version has arrived to the client."),
-
   DEFAULT_VERSION(0, "Initial version"),
 
-  SEPARATE_RATIS_PORTS_AVAILABLE(1, "Version with separated Ratis port.");
+  SEPARATE_RATIS_PORTS_AVAILABLE(1, "Version with separated Ratis port."),
+
+  FUTURE_VERSION(-1, "Used internally in the client when the server side is "
+      + " newer and an unknown server version has arrived to the client.");
 
   public static final DatanodeVersion CURRENT = latest();
   public static final int CURRENT_VERSION = CURRENT.version;
@@ -41,17 +41,25 @@ public enum DatanodeVersion implements ComponentVersion {
   }
 
   @Override
-  public int version() {
-    return version;
-  }
-
-  @Override
   public String description() {
     return description;
   }
 
+  @Override
+  public int toProtoValue() {
+    return version;
+  }
+
+  public static DatanodeVersion fromProtoValue(int value) {
+    DatanodeVersion[] versions = DatanodeVersion.values();
+    if (value >= versions.length || value < 0) {
+      return FUTURE_VERSION;
+    }
+    return versions[value];
+  }
+
   private static DatanodeVersion latest() {
     DatanodeVersion[] versions = DatanodeVersion.values();
-    return versions[versions.length - 1];
+    return versions[versions.length - 2];
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -414,8 +414,8 @@ public class DatanodeDetails extends NodeImpl implements
     }
     builder.setPersistedOpStateExpiry(persistedOpStateExpiryEpochSec);
 
-    final boolean handlesUnknownPorts =
-        clientVersion >= VERSION_HANDLES_UNKNOWN_DN_PORTS.version();
+    final boolean handlesUnknownPorts = VERSION_HANDLES_UNKNOWN_DN_PORTS
+        .compareTo(ClientVersion.fromProtoValue(clientVersion)) >= 0;
     for (Port port : ports) {
       if (handlesUnknownPorts || Name.V0_PORTS.contains(port.getName())) {
         builder.addPorts(port.toProto());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -373,7 +373,7 @@ public class DatanodeDetails extends NodeImpl implements
    */
   @JsonIgnore
   public HddsProtos.DatanodeDetailsProto getProtoBufMessage() {
-    return toProto(ClientVersion.latest().version());
+    return toProto(ClientVersion.CURRENT_VERSION);
   }
 
   public HddsProtos.DatanodeDetailsProto toProto(int clientVersion) {
@@ -545,7 +545,7 @@ public class DatanodeDetails extends NodeImpl implements
     private HddsProtos.NodeOperationalState persistedOpState;
     private long persistedOpStateExpiryEpochSec = 0;
     private int initialVersion;
-    private int currentVersion = DatanodeVersion.latest().version();
+    private int currentVersion = ClientVersion.CURRENT_VERSION;
 
     /**
      * Default private constructor. To create Builder instance use

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -414,7 +414,8 @@ public class DatanodeDetails extends NodeImpl implements
     }
     builder.setPersistedOpStateExpiry(persistedOpStateExpiryEpochSec);
 
-    final boolean handlesUnknownPorts = ClientVersion.fromProtoValue(clientVersion)
+    final boolean handlesUnknownPorts =
+        ClientVersion.fromProtoValue(clientVersion)
         .compareTo(VERSION_HANDLES_UNKNOWN_DN_PORTS) >= 0;
     for (Port port : ports) {
       if (handlesUnknownPorts || Name.V0_PORTS.contains(port.getName())) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -27,7 +27,7 @@ import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.collect.ImmutableSet;
-import org.apache.hadoop.hdds.DatanodeVersions;
+import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name;
@@ -37,11 +37,11 @@ import org.apache.hadoop.hdds.scm.net.NodeImpl;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
-import static org.apache.hadoop.ozone.ClientVersions.VERSION_HANDLES_UNKNOWN_DN_PORTS;
+import static org.apache.hadoop.ozone.ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS;
 
 /**
  * DatanodeDetails class contains details about DataNode like:
@@ -373,7 +373,7 @@ public class DatanodeDetails extends NodeImpl implements
    */
   @JsonIgnore
   public HddsProtos.DatanodeDetailsProto getProtoBufMessage() {
-    return toProto(CURRENT_VERSION);
+    return toProto(ClientVersion.latest().version());
   }
 
   public HddsProtos.DatanodeDetailsProto toProto(int clientVersion) {
@@ -415,7 +415,7 @@ public class DatanodeDetails extends NodeImpl implements
     builder.setPersistedOpStateExpiry(persistedOpStateExpiryEpochSec);
 
     final boolean handlesUnknownPorts =
-        clientVersion >= VERSION_HANDLES_UNKNOWN_DN_PORTS;
+        clientVersion >= VERSION_HANDLES_UNKNOWN_DN_PORTS.version();
     for (Port port : ports) {
       if (handlesUnknownPorts || Name.V0_PORTS.contains(port.getName())) {
         builder.addPorts(port.toProto());
@@ -545,7 +545,7 @@ public class DatanodeDetails extends NodeImpl implements
     private HddsProtos.NodeOperationalState persistedOpState;
     private long persistedOpStateExpiryEpochSec = 0;
     private int initialVersion;
-    private int currentVersion = DatanodeVersions.CURRENT_VERSION;
+    private int currentVersion = DatanodeVersion.latest().version();
 
     /**
      * Default private constructor. To create Builder instance use

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -545,7 +545,7 @@ public class DatanodeDetails extends NodeImpl implements
     private HddsProtos.NodeOperationalState persistedOpState;
     private long persistedOpStateExpiryEpochSec = 0;
     private int initialVersion;
-    private int currentVersion = ClientVersion.CURRENT_VERSION;
+    private int currentVersion = DatanodeVersion.CURRENT_VERSION;
 
     /**
      * Default private constructor. To create Builder instance use

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/protocol/DatanodeDetails.java
@@ -414,8 +414,8 @@ public class DatanodeDetails extends NodeImpl implements
     }
     builder.setPersistedOpStateExpiry(persistedOpStateExpiryEpochSec);
 
-    final boolean handlesUnknownPorts = VERSION_HANDLES_UNKNOWN_DN_PORTS
-        .compareTo(ClientVersion.fromProtoValue(clientVersion)) >= 0;
+    final boolean handlesUnknownPorts = ClientVersion.fromProtoValue(clientVersion)
+        .compareTo(VERSION_HANDLES_UNKNOWN_DN_PORTS) >= 0;
     for (Port port : ports) {
       if (handlesUnknownPorts || Name.V0_PORTS.contains(port.getName())) {
         builder.addPorts(port.toProto());

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -20,19 +20,34 @@ package org.apache.hadoop.ozone;
 /**
  * Versioning for protocol clients.
  */
-public final class ClientVersions {
+public enum ClientVersion {
 
   // old client, doesn't even send version number in requests
-  public static final int DEFAULT_VERSION = 0;
+  DEFAULT_VERSION(0, "Initial version"),
 
   // DatanodeDetails#getFromProtobuf handles unknown types of ports
-  public static final int VERSION_HANDLES_UNKNOWN_DN_PORTS = 1;
+  VERSION_HANDLES_UNKNOWN_DN_PORTS(1,
+      "Client version that handles the REPLICATION port in DatanodeDetails.");
 
-  // this should always point to the latest version
-  public static final int CURRENT_VERSION = VERSION_HANDLES_UNKNOWN_DN_PORTS;
+  private int version;
+  private String description;
 
-  private ClientVersions() {
-    // no instances
+  ClientVersion(int version, String description) {
+    this.version = version;
+    this.description = description;
+  }
+
+  public int version() {
+    return version;
+  }
+
+  public String description() {
+    return description;
+  }
+
+  public static ClientVersion latest() {
+    ClientVersion[] versions = ClientVersion.values();
+    return versions[versions.length - 1];
   }
 
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -29,6 +29,9 @@ public enum ClientVersion {
   VERSION_HANDLES_UNKNOWN_DN_PORTS(1,
       "Client version that handles the REPLICATION port in DatanodeDetails.");
 
+  public static final ClientVersion CURRENT = latest();
+  public static final int CURRENT_VERSION = CURRENT.version;
+
   private final int version;
   private final String description;
 
@@ -45,7 +48,7 @@ public enum ClientVersion {
     return description;
   }
 
-  public static ClientVersion latest() {
+  private static ClientVersion latest() {
     ClientVersion[] versions = ClientVersion.values();
     return versions[versions.length - 1];
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -29,8 +29,8 @@ public enum ClientVersion {
   VERSION_HANDLES_UNKNOWN_DN_PORTS(1,
       "Client version that handles the REPLICATION port in DatanodeDetails.");
 
-  private int version;
-  private String description;
+  private final int version;
+  private final String description;
 
   ClientVersion(int version, String description) {
     this.version = version;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -17,10 +17,15 @@
  */
 package org.apache.hadoop.ozone;
 
+import org.apache.hadoop.hdds.ComponentVersion;
+
 /**
  * Versioning for protocol clients.
  */
-public enum ClientVersion {
+public enum ClientVersion implements ComponentVersion {
+
+  FUTURE_VERSION(-1, "Used internally when the server side is older and an"
+      + " unknown client version has arrived from the client."),
 
   // old client, doesn't even send version number in requests
   DEFAULT_VERSION(0, "Initial version"),
@@ -40,10 +45,12 @@ public enum ClientVersion {
     this.description = description;
   }
 
+  @Override
   public int version() {
     return version;
   }
 
+  @Override
   public String description() {
     return description;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -24,15 +24,13 @@ import org.apache.hadoop.hdds.ComponentVersion;
  */
 public enum ClientVersion implements ComponentVersion {
 
-  FUTURE_VERSION(-1, "Used internally when the server side is older and an"
-      + " unknown client version has arrived from the client."),
-
-  // old client, doesn't even send version number in requests
   DEFAULT_VERSION(0, "Initial version"),
 
-  // DatanodeDetails#getFromProtobuf handles unknown types of ports
   VERSION_HANDLES_UNKNOWN_DN_PORTS(1,
-      "Client version that handles the REPLICATION port in DatanodeDetails.");
+      "Client version that handles the REPLICATION port in DatanodeDetails."),
+
+  FUTURE_VERSION(-1, "Used internally when the server side is older and an"
+      + " unknown client version has arrived from the client.");
 
   public static final ClientVersion CURRENT = latest();
   public static final int CURRENT_VERSION = CURRENT.version;
@@ -46,18 +44,26 @@ public enum ClientVersion implements ComponentVersion {
   }
 
   @Override
-  public int version() {
-    return version;
-  }
-
-  @Override
   public String description() {
     return description;
   }
 
+  @Override
+  public int toProtoValue() {
+    return version;
+  }
+
+  public static ClientVersion fromProtoValue(int value) {
+    ClientVersion[] versions = ClientVersion.values();
+    if (value >= versions.length || value < 0) {
+      return FUTURE_VERSION;
+    }
+    return versions[value];
+  }
+
   private static ClientVersion latest() {
     ClientVersion[] versions = ClientVersion.values();
-    return versions[versions.length - 1];
+    return versions[versions.length - 2];
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
@@ -54,7 +54,8 @@ public class TestComponentVersionInvariants {
 
   public TestComponentVersionInvariants(ComponentVersion[] values,
       ComponentVersion defaultValue, ComponentVersion futureValue) {
-    this.values = values;
+    this.values = new ComponentVersion[values.length];
+    System.arraycopy(values, 0, this.values, 0, values.length);
     this.defaultValue = defaultValue;
     this.futureValue = futureValue;
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds;
+
+import org.apache.hadoop.ozone.ClientVersion;
+import org.assertj.core.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test to ensure Component version instances conform with invariants relied
+ * upon in other parts of the codebase.
+ */
+@RunWith(Parameterized.class)
+public class TestComponentVersionInvariants {
+
+  @Parameterized.Parameters
+  public static Object[][] values() {
+    Object[][] values = new Object[2][];
+    values[0] =
+        Arrays.array(
+            DatanodeVersion.values(),
+            DatanodeVersion.DEFAULT_VERSION,
+            DatanodeVersion.FUTURE_VERSION);
+    values[1] =
+        Arrays.array(
+            ClientVersion.values(),
+            ClientVersion.DEFAULT_VERSION,
+            ClientVersion.FUTURE_VERSION);
+    return values;
+  }
+
+  private final ComponentVersion[] values;
+  private final ComponentVersion defaultValue;
+  private final ComponentVersion futureValue;
+
+  public TestComponentVersionInvariants(ComponentVersion[] values,
+      ComponentVersion defaultValue, ComponentVersion futureValue) {
+    this.values = values;
+    this.defaultValue = defaultValue;
+    this.futureValue = futureValue;
+  }
+
+  // FUTURE_VERSION is the latest
+  @Test
+  public void testFutureVersionHasTheHighestOrdinal() {
+    assertEquals(values[values.length - 1], futureValue);
+  }
+
+  // FUTURE_VERSION's internal version id is -1
+  @Test
+  public void testFuturVersionHasMinusOneAsProtoRepresentation() {
+    assertEquals(-1, futureValue.toProtoValue());
+
+  }
+
+  // DEFAULT_VERSION's internal version id is 0
+  @Test
+  public void testDefaultVersionHasZeroAsProtoRepresentation() {
+    assertEquals(0, defaultValue.toProtoValue());
+  }
+
+  // versions are increasing monotonically by one
+  @Test
+  public void testAssignedProtoRepresentations() {
+    int startValue = defaultValue.toProtoValue();
+    // we skip the future version at the last position
+    for (int i = 0; i < values.length - 1; i++) {
+      assertEquals(values[i].toProtoValue(), startValue++);
+    }
+    assertEquals(values.length, ++startValue);
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -25,8 +25,8 @@ import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS;
-import static org.apache.hadoop.ozone.ClientVersions.DEFAULT_VERSION;
-import static org.apache.hadoop.ozone.ClientVersions.VERSION_HANDLES_UNKNOWN_DN_PORTS;
+import static org.apache.hadoop.ozone.ClientVersion.DEFAULT_VERSION;
+import static org.apache.hadoop.ozone.ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -40,11 +40,12 @@ public class TestDatanodeDetails {
   public void protoIncludesNewPortsOnlyForV1() {
     DatanodeDetails subject = MockDatanodeDetails.randomDatanodeDetails();
 
-    HddsProtos.DatanodeDetailsProto proto = subject.toProto(DEFAULT_VERSION);
+    HddsProtos.DatanodeDetailsProto proto =
+        subject.toProto(DEFAULT_VERSION.version());
     assertPorts(proto, V0_PORTS);
 
-    HddsProtos.DatanodeDetailsProto protoV1 = subject.toProto(
-        VERSION_HANDLES_UNKNOWN_DN_PORTS);
+    HddsProtos.DatanodeDetailsProto protoV1 =
+        subject.toProto(VERSION_HANDLES_UNKNOWN_DN_PORTS.version());
     assertPorts(protoV1, ALL_PORTS);
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -41,11 +41,11 @@ public class TestDatanodeDetails {
     DatanodeDetails subject = MockDatanodeDetails.randomDatanodeDetails();
 
     HddsProtos.DatanodeDetailsProto proto =
-        subject.toProto(DEFAULT_VERSION.version());
+        subject.toProto(DEFAULT_VERSION.toProtoValue());
     assertPorts(proto, V0_PORTS);
 
     HddsProtos.DatanodeDetailsProto protoV1 =
-        subject.toProto(VERSION_HANDLES_UNKNOWN_DN_PORTS.version());
+        subject.toProto(VERSION_HANDLES_UNKNOWN_DN_PORTS.toProtoValue());
     assertPorts(protoV1, ALL_PORTS);
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -38,13 +38,13 @@ public class TestPipeline {
     Pipeline subject = MockPipeline.createPipeline(3);
 
     HddsProtos.Pipeline proto =
-        subject.getProtobufMessage(DEFAULT_VERSION.version());
+        subject.getProtobufMessage(DEFAULT_VERSION.toProtoValue());
     for (HddsProtos.DatanodeDetailsProto dn : proto.getMembersList()) {
       assertPorts(dn, V0_PORTS);
     }
 
-    HddsProtos.Pipeline protoV1 =
-        subject.getProtobufMessage(VERSION_HANDLES_UNKNOWN_DN_PORTS.version());
+    HddsProtos.Pipeline protoV1 = subject.getProtobufMessage(
+        VERSION_HANDLES_UNKNOWN_DN_PORTS.toProtoValue());
     for (HddsProtos.DatanodeDetailsProto dn : protoV1.getMembersList()) {
       assertPorts(dn, ALL_PORTS);
     }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -25,8 +25,8 @@ import java.io.IOException;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORTS;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS;
 import static org.apache.hadoop.hdds.protocol.TestDatanodeDetails.assertPorts;
-import static org.apache.hadoop.ozone.ClientVersions.DEFAULT_VERSION;
-import static org.apache.hadoop.ozone.ClientVersions.VERSION_HANDLES_UNKNOWN_DN_PORTS;
+import static org.apache.hadoop.ozone.ClientVersion.DEFAULT_VERSION;
+import static org.apache.hadoop.ozone.ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS;
 
 /**
  * Test for {@link Pipeline}.
@@ -37,13 +37,14 @@ public class TestPipeline {
   public void protoIncludesNewPortsOnlyForV1() throws IOException {
     Pipeline subject = MockPipeline.createPipeline(3);
 
-    HddsProtos.Pipeline proto = subject.getProtobufMessage(DEFAULT_VERSION);
+    HddsProtos.Pipeline proto =
+        subject.getProtobufMessage(DEFAULT_VERSION.version());
     for (HddsProtos.DatanodeDetailsProto dn : proto.getMembersList()) {
       assertPorts(dn, V0_PORTS);
     }
 
-    HddsProtos.Pipeline protoV1 = subject.getProtobufMessage(
-        VERSION_HANDLES_UNKNOWN_DN_PORTS);
+    HddsProtos.Pipeline protoV1 =
+        subject.getProtobufMessage(VERSION_HANDLES_UNKNOWN_DN_PORTS.version());
     for (HddsProtos.DatanodeDetailsProto dn : protoV1.getMembersList()) {
       assertPorts(dn, ALL_PORTS);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
-import org.apache.hadoop.hdds.DatanodeVersions;
+import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.cli.GenericCli;
@@ -226,7 +226,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       datanodeDetails.setRevision(
           HddsVersionInfo.HDDS_VERSION_INFO.getRevision());
       datanodeDetails.setBuildDate(HddsVersionInfo.HDDS_VERSION_INFO.getDate());
-      datanodeDetails.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+      datanodeDetails.setCurrentVersion(DatanodeVersion.latest().version());
       TracingUtil.initTracing(
           "HddsDatanodeService." + datanodeDetails.getUuidString()
               .substring(0, 8), conf);
@@ -461,8 +461,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       // is started.
       DatanodeDetails details = DatanodeDetails.newBuilder()
           .setUuid(UUID.randomUUID()).build();
-      details.setInitialVersion(DatanodeVersions.CURRENT_VERSION);
-      details.setCurrentVersion(DatanodeVersions.CURRENT_VERSION);
+      details.setInitialVersion(DatanodeVersion.latest().version());
+      details.setCurrentVersion(DatanodeVersion.latest().version());
       return details;
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -226,7 +226,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       datanodeDetails.setRevision(
           HddsVersionInfo.HDDS_VERSION_INFO.getRevision());
       datanodeDetails.setBuildDate(HddsVersionInfo.HDDS_VERSION_INFO.getDate());
-      datanodeDetails.setCurrentVersion(DatanodeVersion.latest().version());
+      datanodeDetails.setCurrentVersion(DatanodeVersion.CURRENT_VERSION);
       TracingUtil.initTracing(
           "HddsDatanodeService." + datanodeDetails.getUuidString()
               .substring(0, 8), conf);
@@ -461,8 +461,8 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
       // is started.
       DatanodeDetails details = DatanodeDetails.newBuilder()
           .setUuid(UUID.randomUUID()).build();
-      details.setInitialVersion(DatanodeVersion.latest().version());
-      details.setCurrentVersion(DatanodeVersion.latest().version());
+      details.setInitialVersion(DatanodeVersion.CURRENT_VERSION);
+      details.setCurrentVersion(DatanodeVersion.CURRENT_VERSION);
       return details;
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -108,7 +108,7 @@ import org.apache.ratis.util.TraditionalBinaryPrefix;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.hdds.DatanodeVersions.SEPARATE_RATIS_PORTS_AVAILABLE;
+import static org.apache.hadoop.hdds.DatanodeVersion.SEPARATE_RATIS_PORTS_AVAILABLE;
 
 /**
  * Creates a ratis server endpoint that acts as the communication layer for
@@ -187,7 +187,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT_DEFAULT);
 
-    if (datanodeDetails.getInitialVersion() >= SEPARATE_RATIS_PORTS_AVAILABLE) {
+    if (datanodeDetails.getInitialVersion()
+        >= SEPARATE_RATIS_PORTS_AVAILABLE.version()) {
       adminPort = determinePort(
           OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT,
           OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT_DEFAULT);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/XceiverServerRatis.java
@@ -42,6 +42,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.hadoop.hdds.DatanodeVersion;
 import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
@@ -187,8 +188,8 @@ public final class XceiverServerRatis implements XceiverServerSpi {
         OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT,
         OzoneConfigKeys.DFS_CONTAINER_RATIS_IPC_PORT_DEFAULT);
 
-    if (datanodeDetails.getInitialVersion()
-        >= SEPARATE_RATIS_PORTS_AVAILABLE.version()) {
+    if (DatanodeVersion.fromProtoValue(datanodeDetails.getInitialVersion())
+        .compareTo(SEPARATE_RATIS_PORTS_AVAILABLE) >= 0) {
       adminPort = determinePort(
           OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT,
           OzoneConfigKeys.DFS_CONTAINER_RATIS_ADMIN_PORT_DEFAULT);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -103,7 +103,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
   private SCMBlockLocationRequest.Builder createSCMBlockRequest(Type cmdType) {
     return SCMBlockLocationRequest.newBuilder()
         .setCmdType(cmdType)
-        .setVersion(ClientVersion.latest().version())
+        .setVersion(ClientVersion.CURRENT_VERSION)
         .setTraceID(TracingUtil.exportCurrentSpan());
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtocolTranslator;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.common.DeleteBlockGroupResult;
 
@@ -62,7 +63,6 @@ import com.google.protobuf.RpcController;
 import com.google.protobuf.ServiceException;
 
 import static org.apache.hadoop.hdds.protocol.proto.ScmBlockLocationProtocolProtos.Status.OK;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * This class is the client-side translator to translate the requests made on
@@ -103,7 +103,7 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
   private SCMBlockLocationRequest.Builder createSCMBlockRequest(Type cmdType) {
     return SCMBlockLocationRequest.newBuilder()
         .setCmdType(cmdType)
-        .setVersion(CURRENT_VERSION)
+        .setVersion(ClientVersion.latest().version())
         .setTraceID(TracingUtil.exportCurrentSpan());
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -99,6 +99,7 @@ import org.apache.hadoop.io.retry.RetryProxy;
 import org.apache.hadoop.ipc.ProtobufHelper;
 import org.apache.hadoop.ipc.ProtocolTranslator;
 import org.apache.hadoop.ipc.RPC;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.apache.hadoop.security.token.Token;
@@ -111,7 +112,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * This class is the client-side translator to translate the requests made on
@@ -155,7 +155,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
     try {
       Builder builder = ScmContainerLocationRequest.newBuilder()
           .setCmdType(type)
-          .setVersion(CURRENT_VERSION)
+          .setVersion(ClientVersion.latest().version())
           .setTraceID(TracingUtil.exportCurrentSpan());
       builderConsumer.accept(builder);
       ScmContainerLocationRequest wrapper = builder.build();

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -155,7 +155,7 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
     try {
       Builder builder = ScmContainerLocationRequest.newBuilder()
           .setCmdType(type)
-          .setVersion(ClientVersion.latest().version())
+          .setVersion(ClientVersion.CURRENT_VERSION)
           .setTraceID(TracingUtil.exportCurrentSpan());
       builderConsumer.accept(builder);
       ScmContainerLocationRequest wrapper = builder.build();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -78,6 +78,7 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.ozone.protocol.commands.CloseContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
@@ -86,7 +87,6 @@ import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.ExitUtil;
 import org.apache.hadoop.hdds.utils.db.Table;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport.HealthState;
 
 import com.google.protobuf.GeneratedMessage;
@@ -893,7 +893,7 @@ public class ReplicationManager implements SCMService {
 
       try {
         moveScheduler.startMove(cid.getProtobuf(),
-            mp.getProtobufMessage(CURRENT_VERSION));
+            mp.getProtobufMessage(ClientVersion.latest().version()));
       } catch (IOException e) {
         LOG.warn("Exception while starting move {}", cid);
         ret.complete(MoveResult.FAIL_CAN_NOT_RECORD_TO_DB);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManager.java
@@ -893,7 +893,7 @@ public class ReplicationManager implements SCMService {
 
       try {
         moveScheduler.startMove(cid.getProtobuf(),
-            mp.getProtobufMessage(ClientVersion.latest().version()));
+            mp.getProtobufMessage(ClientVersion.CURRENT_VERSION));
       } catch (IOException e) {
         LOG.warn("Exception while starting move {}", cid);
         ret.complete(MoveResult.FAIL_CAN_NOT_RECORD_TO_DB);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/MoveDataNodePairCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/MoveDataNodePairCodec.java
@@ -34,7 +34,7 @@ public class MoveDataNodePairCodec implements Codec<MoveDataNodePair> {
   public byte[] toPersistedFormat(MoveDataNodePair mdnp)
       throws IOException {
     return mdnp
-        .getProtobufMessage(ClientVersion.latest().version()).toByteArray();
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION).toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/MoveDataNodePairCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/MoveDataNodePairCodec.java
@@ -21,10 +21,9 @@ package org.apache.hadoop.hdds.scm.metadata;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.MoveDataNodePairProto;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.ozone.ClientVersion;
 
 import java.io.IOException;
-
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * Codec to serialize / deserialize MoveDataNodePair.
@@ -34,7 +33,8 @@ public class MoveDataNodePairCodec implements Codec<MoveDataNodePair> {
   @Override
   public byte[] toPersistedFormat(MoveDataNodePair mdnp)
       throws IOException {
-    return mdnp.getProtobufMessage(CURRENT_VERSION).toByteArray();
+    return mdnp
+        .getProtobufMessage(ClientVersion.latest().version()).toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
@@ -36,7 +36,7 @@ public class PipelineCodec implements Codec<Pipeline> {
   @Override
   public byte[] toPersistedFormat(Pipeline object) throws IOException {
     return object
-        .getProtobufMessage(ClientVersion.latest().version()).toByteArray();
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION).toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/metadata/PipelineCodec.java
@@ -26,8 +26,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.utils.db.Codec;
 
 import com.google.common.base.Preconditions;
-
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
+import org.apache.hadoop.ozone.ClientVersion;
 
 /**
  * Codec to serialize / deserialize Pipeline.
@@ -36,7 +35,8 @@ public class PipelineCodec implements Codec<Pipeline> {
 
   @Override
   public byte[] toPersistedFormat(Pipeline object) throws IOException {
-    return object.getProtobufMessage(CURRENT_VERSION).toByteArray();
+    return object
+        .getProtobufMessage(ClientVersion.latest().version()).toByteArray();
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -169,7 +169,7 @@ public class PipelineManagerImpl implements PipelineManager {
     try {
       Pipeline pipeline = pipelineFactory.create(replicationConfig);
       stateManager.addPipeline(pipeline.getProtobufMessage(
-          ClientVersion.latest().version()));
+          ClientVersion.CURRENT_VERSION));
       recordMetricsForPipeline(pipeline);
       return pipeline;
     } catch (IOException ex) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineManagerImpl.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.metrics2.util.MBeans;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.hadoop.util.Time;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
@@ -169,7 +169,7 @@ public class PipelineManagerImpl implements PipelineManager {
     try {
       Pipeline pipeline = pipelineFactory.create(replicationConfig);
       stateManager.addPipeline(pipeline.getProtobufMessage(
-          ClientVersions.CURRENT_VERSION));
+          ClientVersion.latest().version()));
       recordMetricsForPipeline(pipeline);
       return pipeline;
     } catch (IOException ex) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -68,7 +68,7 @@ public final class MockPipelineManager implements PipelineManager {
         .build();
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
-        ClientVersion.latest().version()));
+        ClientVersion.CURRENT_VERSION));
     return pipeline;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipelineManager.java
@@ -26,7 +26,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 
 import java.io.IOException;
 import java.util.Collection;
@@ -68,7 +68,7 @@ public final class MockPipelineManager implements PipelineManager {
         .build();
 
     stateManager.addPipeline(pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION));
+        ClientVersion.latest().version()));
     return pipeline;
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
@@ -135,7 +135,7 @@ public class TestPipelineDatanodesIntersection {
         Pipeline pipeline = provider.create(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersions.CURRENT_VERSION);
+            ClientVersion.latest().version());
         stateManager.addPipeline(pipelineProto);
         nodeManager.addPipeline(pipeline);
         List<Pipeline> overlapPipelines = RatisPipelineUtils

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
@@ -135,7 +135,7 @@ public class TestPipelineDatanodesIntersection {
         Pipeline pipeline = provider.create(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersion.latest().version());
+            ClientVersion.CURRENT_VERSION);
         stateManager.addPipeline(pipelineProto);
         nodeManager.addPipeline(pipeline);
         List<Pipeline> overlapPipelines = RatisPipelineUtils

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -689,7 +689,7 @@ public class TestPipelinePlacementPolicy {
               .build();
 
           pipelineProto = pipeline.getProtobufMessage(
-              ClientVersions.CURRENT_VERSION);
+              ClientVersion.CURRENT_VERSION);
           nodeManager.addPipeline(pipeline);
           stateManager.addPipeline(pipelineProto);
           pipelineCount++;
@@ -773,7 +773,7 @@ public class TestPipelinePlacementPolicy {
         .build();
 
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.CURRENT_VERSION);
     nodeManager.addPipeline(pipeline);
     stateManager.addPipeline(pipelineProto);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -289,7 +289,7 @@ public class TestPipelinePlacementPolicy {
             .setNodes(nodes)
             .build();
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersion.latest().version());
+            ClientVersion.CURRENT_VERSION);
         nodeManager.addPipeline(pipeline);
         stateManager.addPipeline(pipelineProto);
       } catch (SCMException e) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -55,7 +55,7 @@ import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
@@ -289,7 +289,7 @@ public class TestPipelinePlacementPolicy {
             .setNodes(nodes)
             .build();
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-            ClientVersions.CURRENT_VERSION);
+            ClientVersion.latest().version());
         nodeManager.addPipeline(pipeline);
         stateManager.addPipeline(pipelineProto);
       } catch (SCMException e) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
@@ -116,7 +116,7 @@ public class TestPipelineStateManagerImpl {
   public void testAddAndGetPipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(0);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     try {
       stateManager.addPipeline(pipelineProto);
       Assert.fail("Pipeline should not have been added");
@@ -128,7 +128,7 @@ public class TestPipelineStateManagerImpl {
     // add a pipeline
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
 
     try {
@@ -155,11 +155,11 @@ public class TestPipelineStateManagerImpl {
 
     Set<HddsProtos.Pipeline> pipelines = new HashSet<>();
     HddsProtos.Pipeline pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
     pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
 
@@ -189,19 +189,19 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+                  .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+              .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+              .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
         }
@@ -241,20 +241,20 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+                  .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+              .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in dormant state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+              .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           deactivatePipeline(pipeline);
@@ -262,7 +262,7 @@ public class TestPipelineStateManagerImpl {
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+              .getProtobufMessage(ClientVersion.latest().version());
           stateManager.addPipeline(pipeline);
           finalizePipeline(pipeline);
           pipelines.add(pipeline);
@@ -301,7 +301,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 0;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     pipeline = stateManager.getPipeline(pipeline.getId());
     stateManager.addContainerToPipeline(pipeline.getId(),
@@ -335,7 +335,7 @@ public class TestPipelineStateManagerImpl {
   public void testRemovePipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     // close the pipeline
     openPipeline(pipelineProto);
@@ -361,7 +361,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 1;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     // create an open pipeline in stateMap
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
@@ -397,7 +397,7 @@ public class TestPipelineStateManagerImpl {
   public void testFinalizePipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     // finalize on ALLOCATED pipeline
     finalizePipeline(pipelineProto);
@@ -408,7 +408,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     // finalize on OPEN pipeline
@@ -420,7 +420,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     finalizePipeline(pipelineProto);
@@ -436,7 +436,7 @@ public class TestPipelineStateManagerImpl {
   public void testOpenPipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     // open on ALLOCATED pipeline
     openPipeline(pipelineProto);
@@ -458,7 +458,7 @@ public class TestPipelineStateManagerImpl {
         HddsProtos.ReplicationFactor.THREE, 3);
     // pipeline in allocated state should not be reported
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     Assert.assertEquals(0, stateManager
         .getPipelines(RatisReplicationConfig
@@ -480,7 +480,7 @@ public class TestPipelineStateManagerImpl {
         .setState(Pipeline.PipelineState.OPEN)
         .build();
     HddsProtos.Pipeline pipelineProto2 = pipeline2
-        .getProtobufMessage(ClientVersions.CURRENT_VERSION);
+        .getProtobufMessage(ClientVersion.latest().version());
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
     Assert.assertEquals(2, stateManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -116,7 +116,7 @@ public class TestPipelineStateManagerImpl {
   public void testAddAndGetPipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(0);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     try {
       stateManager.addPipeline(pipelineProto);
       Assert.fail("Pipeline should not have been added");
@@ -127,8 +127,7 @@ public class TestPipelineStateManagerImpl {
 
     // add a pipeline
     pipeline = createDummyPipeline(1);
-    pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+    pipelineProto = pipeline.getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
 
     try {
@@ -155,11 +154,11 @@ public class TestPipelineStateManagerImpl {
 
     Set<HddsProtos.Pipeline> pipelines = new HashSet<>();
     HddsProtos.Pipeline pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
     pipeline = createDummyPipeline(1).getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipeline);
     pipelines.add(pipeline);
 
@@ -189,19 +188,19 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersion.latest().version());
+                  .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.latest().version());
+              .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.latest().version());
+              .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
         }
@@ -241,20 +240,20 @@ public class TestPipelineStateManagerImpl {
           // 5 pipelines in allocated state for each type and factor
           HddsProtos.Pipeline pipeline =
               createDummyPipeline(type, factor, factor.getNumber())
-                  .getProtobufMessage(ClientVersion.latest().version());
+                  .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in open state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.latest().version());
+              .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           pipelines.add(pipeline);
 
           // 5 pipelines in dormant state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.latest().version());
+              .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           openPipeline(pipeline);
           deactivatePipeline(pipeline);
@@ -262,7 +261,7 @@ public class TestPipelineStateManagerImpl {
 
           // 5 pipelines in closed state for each type and factor
           pipeline = createDummyPipeline(type, factor, factor.getNumber())
-              .getProtobufMessage(ClientVersion.latest().version());
+              .getProtobufMessage(ClientVersion.CURRENT_VERSION);
           stateManager.addPipeline(pipeline);
           finalizePipeline(pipeline);
           pipelines.add(pipeline);
@@ -301,7 +300,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 0;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     pipeline = stateManager.getPipeline(pipeline.getId());
     stateManager.addContainerToPipeline(pipeline.getId(),
@@ -335,7 +334,7 @@ public class TestPipelineStateManagerImpl {
   public void testRemovePipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     // close the pipeline
     openPipeline(pipelineProto);
@@ -361,7 +360,7 @@ public class TestPipelineStateManagerImpl {
     long containerID = 1;
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     // create an open pipeline in stateMap
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
@@ -397,7 +396,7 @@ public class TestPipelineStateManagerImpl {
   public void testFinalizePipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     // finalize on ALLOCATED pipeline
     finalizePipeline(pipelineProto);
@@ -408,7 +407,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     // finalize on OPEN pipeline
@@ -420,7 +419,7 @@ public class TestPipelineStateManagerImpl {
 
     pipeline = createDummyPipeline(1);
     pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     openPipeline(pipelineProto);
     finalizePipeline(pipelineProto);
@@ -436,7 +435,7 @@ public class TestPipelineStateManagerImpl {
   public void testOpenPipeline() throws IOException {
     Pipeline pipeline = createDummyPipeline(1);
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     // open on ALLOCATED pipeline
     openPipeline(pipelineProto);
@@ -458,7 +457,7 @@ public class TestPipelineStateManagerImpl {
         HddsProtos.ReplicationFactor.THREE, 3);
     // pipeline in allocated state should not be reported
     HddsProtos.Pipeline pipelineProto = pipeline
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     Assert.assertEquals(0, stateManager
         .getPipelines(RatisReplicationConfig
@@ -480,7 +479,7 @@ public class TestPipelineStateManagerImpl {
         .setState(Pipeline.PipelineState.OPEN)
         .build();
     HddsProtos.Pipeline pipelineProto2 = pipeline2
-        .getProtobufMessage(ClientVersion.latest().version());
+        .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
     Assert.assertEquals(2, stateManager

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -125,14 +125,14 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(pipeline);
 
     Pipeline pipeline1 = provider.create(RatisReplicationConfig
         .getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     // New pipeline should not overlap with the previous created pipeline
@@ -177,7 +177,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
 
     factor = HddsProtos.ReplicationFactor.ONE;
@@ -186,7 +186,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
     // With enough pipeline quote on datanodes, they should not share
     // the same set of datanodes.
@@ -264,7 +264,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     nodeManager.addPipeline(pipeline);
     stateManager.addPipeline(pipelineProto);
 
@@ -326,7 +326,7 @@ public class TestRatisPipelineProvider {
         .setId(PipelineID.randomId())
         .build();
     HddsProtos.Pipeline pipelineProto = openPipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
 
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(openPipeline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -125,14 +125,14 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(pipeline);
 
     Pipeline pipeline1 = provider.create(RatisReplicationConfig
         .getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     // New pipeline should not overlap with the previous created pipeline
@@ -177,7 +177,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
 
     factor = HddsProtos.ReplicationFactor.ONE;
@@ -186,7 +186,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto1);
     // With enough pipeline quote on datanodes, they should not share
     // the same set of datanodes.
@@ -264,7 +264,7 @@ public class TestRatisPipelineProvider {
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     nodeManager.addPipeline(pipeline);
     stateManager.addPipeline(pipelineProto);
 
@@ -326,7 +326,7 @@ public class TestRatisPipelineProvider {
         .setId(PipelineID.randomId())
         .build();
     HddsProtos.Pipeline pipelineProto = openPipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
 
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(openPipeline);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -92,7 +92,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     Assert.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
@@ -106,7 +106,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline1 =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersion.latest().version());
+        ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
     Assert.assertEquals(pipeline1.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.scm.metadata.SCMDBDefinition;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.After;
@@ -92,7 +92,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto);
     Assert.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
@@ -106,7 +106,7 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline1 =
         provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
-        ClientVersions.CURRENT_VERSION);
+        ClientVersion.latest().version());
     stateManager.addPipeline(pipelineProto1);
     Assert.assertEquals(pipeline1.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocolServerSideTranslatorPB;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
 
 import org.junit.After;
@@ -42,7 +43,6 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * Test class for @{@link SCMBlockProtocolServer}.
@@ -125,7 +125,7 @@ public class TestSCMBlockProtocolServer {
             .setClient(client)
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
-        service.sortDatanodes(request, CURRENT_VERSION);
+        service.sortDatanodes(request, ClientVersion.latest().version());
     Assert.assertTrue(resp.getNodeList().size() == NODE_COUNT);
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
@@ -141,7 +141,7 @@ public class TestSCMBlockProtocolServer {
         .addAllNodeNetworkName(nodes)
         .setClient(client)
         .build();
-    resp = service.sortDatanodes(request, CURRENT_VERSION);
+    resp = service.sortDatanodes(request, ClientVersion.latest().version());
     System.out.println("client = " + client);
     Assert.assertTrue(resp.getNodeList().size() == 0);
     resp.getNodeList().stream().forEach(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -125,7 +125,7 @@ public class TestSCMBlockProtocolServer {
             .setClient(client)
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
-        service.sortDatanodes(request, ClientVersion.latest().version());
+        service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
     Assert.assertTrue(resp.getNodeList().size() == NODE_COUNT);
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
@@ -141,7 +141,7 @@ public class TestSCMBlockProtocolServer {
         .addAllNodeNetworkName(nodes)
         .setClient(client)
         .build();
-    resp = service.sortDatanodes(request, ClientVersion.latest().version());
+    resp = service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
     System.out.println("client = " + client);
     Assert.assertTrue(resp.getNodeList().size() == 0);
     resp.getNodeList().stream().forEach(

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.protocol.StorageContainerLocationProtocol;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.hdds.utils.HAUtils;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
 import org.slf4j.Logger;
@@ -56,7 +57,6 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_DEFAULT;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * This class provides the client-facing APIs of container operations.
@@ -276,7 +276,7 @@ public class ContainerOperationClient implements ScmClient {
       HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
     return storageContainerLocationClient.queryNode(opState, nodeState,
-        queryScope, poolName, CURRENT_VERSION);
+        queryScope, poolName, ClientVersion.latest().version());
   }
 
   @Override

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -276,7 +276,7 @@ public class ContainerOperationClient implements ScmClient {
       HddsProtos.QueryScope queryScope, String poolName)
       throws IOException {
     return storageContainerLocationClient.queryNode(opState, nodeState,
-        queryScope, poolName, ClientVersion.latest().version());
+        queryScope, poolName, ClientVersion.CURRENT_VERSION);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos
 import org.apache.hadoop.hdds.scm.container.common.helpers.ExcludeList;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
@@ -158,7 +159,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.protobuf.ByteString;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TOKEN_ERROR_OTHER;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CancelPrepareRequest;
@@ -223,7 +223,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
-        .setVersion(CURRENT_VERSION)
+        .setVersion(ClientVersion.latest().version())
         .setClientId(clientID);
   }
 
@@ -707,7 +707,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(args.getDataSize())
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(CURRENT_VERSION))
+            .map(info -> info.getProtobuf(ClientVersion.latest().version()))
             .collect(Collectors.toList()));
 
     if (args.getReplicationConfig() != null) {
@@ -988,7 +988,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(omKeyArgs.getDataSize())
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(CURRENT_VERSION))
+            .map(info -> info.getProtobuf(ClientVersion.latest().version()))
             .collect(Collectors.toList()));
     multipartCommitUploadPartRequest.setClientID(clientId);
     multipartCommitUploadPartRequest.setKeyArgs(keyArgs.build());

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -223,7 +223,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
 
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
-        .setVersion(ClientVersion.latest().version())
+        .setVersion(ClientVersion.CURRENT_VERSION)
         .setClientId(clientID);
   }
 
@@ -707,7 +707,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(args.getDataSize())
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(ClientVersion.latest().version()))
+            .map(info -> info.getProtobuf(ClientVersion.CURRENT_VERSION))
             .collect(Collectors.toList()));
 
     if (args.getReplicationConfig() != null) {
@@ -988,7 +988,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
         .setDataSize(omKeyArgs.getDataSize())
         .addAllKeyLocations(locationInfoList.stream()
             // TODO use OM version?
-            .map(info -> info.getProtobuf(ClientVersion.latest().version()))
+            .map(info -> info.getProtobuf(ClientVersion.CURRENT_VERSION))
             .collect(Collectors.toList()));
     multipartCommitUploadPartRequest.setClientID(clientId);
     multipartCommitUploadPartRequest.setKeyArgs(keyArgs.build());

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -59,7 +59,7 @@ public class TestOmKeyInfo {
         .build();
 
     OmKeyInfo keyAfterSerialization = OmKeyInfo.getFromProtobuf(
-        key.getProtobuf(ClientVersion.latest().version()));
+        key.getProtobuf(ClientVersion.CURRENT_VERSION));
 
     Assert.assertEquals(key, keyAfterSerialization);
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo.Builder;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
@@ -35,7 +36,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
 
 /**
@@ -58,8 +58,8 @@ public class TestOmKeyInfo {
         .addMetadata("key2", "value2")
         .build();
 
-    OmKeyInfo keyAfterSerialization =
-        OmKeyInfo.getFromProtobuf(key.getProtobuf(CURRENT_VERSION));
+    OmKeyInfo keyAfterSerialization = OmKeyInfo.getFromProtobuf(
+        key.getProtobuf(ClientVersion.latest().version()));
 
     Assert.assertEquals(key, keyAfterSerialization);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -244,7 +244,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
 
     OMRequest writeRequest = OMRequest.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
-        .setVersion(ClientVersion.latest().version())
+        .setVersion(ClientVersion.CURRENT_VERSION)
         .setClientId(UUID.randomUUID().toString())
         .setCreateVolumeRequest(CreateVolumeRequest.newBuilder().
             setVolumeInfo(VolumeInfo.newBuilder().setVolume(volumeName)
@@ -266,7 +266,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     // Read Request
     OMRequest readRequest = OMRequest.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.InfoVolume)
-        .setVersion(ClientVersion.latest().version())
+        .setVersion(ClientVersion.CURRENT_VERSION)
         .setClientId(UUID.randomUUID().toString())
         .setInfoVolumeRequest(InfoVolumeRequest.newBuilder()
             .setVolumeName(volumeName).build())

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.CertificateClientTestImpl;
@@ -70,7 +71,6 @@ import java.util.UUID;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.OZONE_METADATA_DIRS;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * This class is to test all the public facing APIs of Ozone Client.
@@ -244,7 +244,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
 
     OMRequest writeRequest = OMRequest.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateVolume)
-        .setVersion(CURRENT_VERSION)
+        .setVersion(ClientVersion.latest().version())
         .setClientId(UUID.randomUUID().toString())
         .setCreateVolumeRequest(CreateVolumeRequest.newBuilder().
             setVolumeInfo(VolumeInfo.newBuilder().setVolume(volumeName)
@@ -266,7 +266,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     // Read Request
     OMRequest readRequest = OMRequest.newBuilder()
         .setCmdType(OzoneManagerProtocolProtos.Type.InfoVolume)
-        .setVersion(CURRENT_VERSION)
+        .setVersion(ClientVersion.latest().version())
         .setClientId(UUID.randomUUID().toString())
         .setInfoVolumeRequest(InfoVolumeRequest.newBuilder()
             .setVolumeName(volumeName).build())

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
@@ -95,7 +95,7 @@ public class TestOmLDBCli {
       String key = "key" + (i);
       Table<byte[], byte[]> keyTable = dbStore.getTable("keyTable");
       byte[] arr = value
-          .getProtobuf(ClientVersion.latest().version()).toByteArray();
+          .getProtobuf(ClientVersion.CURRENT_VERSION).toByteArray();
       keyTable.put(key.getBytes(UTF_8), arr);
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmLDBCli.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.debug.DBScanner;
 import org.apache.hadoop.ozone.debug.RDBParser;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -43,7 +44,6 @@ import java.util.List;
 import java.util.ArrayList;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 
 /**
@@ -94,7 +94,8 @@ public class TestOmLDBCli {
           HddsProtos.ReplicationFactor.ONE);
       String key = "key" + (i);
       Table<byte[], byte[]> keyTable = dbStore.getTable("keyTable");
-      byte[] arr = value.getProtobuf(CURRENT_VERSION).toByteArray();
+      byte[] arr = value
+          .getProtobuf(ClientVersion.latest().version()).toByteArray();
       keyTable.put(key.getBytes(UTF_8), arr);
     }
     rdbParser.setDbPath(dbStore.getDbLocation().getAbsolutePath());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.MiniOzoneHAClusterImpl;
 import org.apache.ozone.test.GenericTestUtils;
@@ -39,7 +40,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.slf4j.event.Level;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 import java.io.IOException;
 import java.util.Map;
@@ -163,7 +163,8 @@ public class TestFailoverWithSCMHA {
     //inflight move after failover, so no need to create container and datanode,
     //just mock them bypassing all the pre checks.
     scm.getReplicationManager().getMoveScheduler().startMove(id.getProtobuf(),
-        (new MoveDataNodePair(dn1, dn2)).getProtobufMessage(CURRENT_VERSION));
+        (new MoveDataNodePair(dn1, dn2))
+            .getProtobufMessage(ClientVersion.latest().version()));
 
     SCMBlockLocationFailoverProxyProvider failoverProxyProvider =
         new SCMBlockLocationFailoverProxyProvider(conf);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestFailoverWithSCMHA.java
@@ -164,7 +164,7 @@ public class TestFailoverWithSCMHA {
     //just mock them bypassing all the pre checks.
     scm.getReplicationManager().getMoveScheduler().startMove(id.getProtobuf(),
         (new MoveDataNodePair(dn1, dn2))
-            .getProtobufMessage(ClientVersion.latest().version()));
+            .getProtobufMessage(ClientVersion.CURRENT_VERSION));
 
     SCMBlockLocationFailoverProxyProvider failoverProxyProvider =
         new SCMBlockLocationFailoverProxyProvider(conf);

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
@@ -53,8 +53,8 @@ public class OmKeyInfoCodec implements Codec<OmKeyInfo> {
   public byte[] toPersistedFormat(OmKeyInfo object) throws IOException {
     Preconditions
         .checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.getProtobuf(ignorePipeline,
-        ClientVersion.latest().version()).toByteArray();
+    return object.getProtobuf(ignorePipeline, ClientVersion.CURRENT_VERSION)
+        .toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmKeyInfoCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.codec;
 
 import java.io.IOException;
 
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyInfo;
 import org.apache.hadoop.hdds.utils.db.Codec;
@@ -27,8 +28,6 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * Codec to encode OmKeyInfo as byte array.
@@ -54,7 +53,8 @@ public class OmKeyInfoCodec implements Codec<OmKeyInfo> {
   public byte[] toPersistedFormat(OmKeyInfo object) throws IOException {
     Preconditions
         .checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.getProtobuf(ignorePipeline, CURRENT_VERSION).toByteArray();
+    return object.getProtobuf(ignorePipeline,
+        ClientVersion.latest().version()).toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.codec;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.utils.db.Codec;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .RepeatedKeyInfo;
@@ -26,8 +27,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 
 /**
  * Codec to encode RepeatedOmKeyInfo as byte array.
@@ -47,7 +46,8 @@ public class RepeatedOmKeyInfoCodec implements Codec<RepeatedOmKeyInfo> {
       throws IOException {
     Preconditions.checkNotNull(object,
         "Null object can't be converted to byte array.");
-    return object.getProto(ignorePipeline, CURRENT_VERSION).toByteArray();
+    return object.getProto(ignorePipeline,
+        ClientVersion.latest().version()).toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/RepeatedOmKeyInfoCodec.java
@@ -46,8 +46,8 @@ public class RepeatedOmKeyInfoCodec implements Codec<RepeatedOmKeyInfo> {
       throws IOException {
     Preconditions.checkNotNull(object,
         "Null object can't be converted to byte array.");
-    return object.getProto(ignorePipeline,
-        ClientVersion.latest().version()).toByteArray();
+    return object.getProto(ignorePipeline, ClientVersion.CURRENT_VERSION)
+        .toByteArray();
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.BackgroundService;
 import org.apache.hadoop.hdds.utils.BackgroundTask;
 import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
 import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.helpers.OMRatisHelper;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -37,7 +38,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_PATH_DELETING_LIMIT_PER_TASK;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_PATH_DELETING_LIMIT_PER_TASK_DEFAULT;
 
@@ -238,13 +238,14 @@ public class DirectoryDeletingService extends BackgroundService {
     }
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(true, CURRENT_VERSION));
+          purgeFile.getProtobuf(true, ClientVersion.latest().version()));
     }
 
     // Add these directories to deletedDirTable, so that its sub-paths will be
     // traversed in next iteration to ensure cleanup all sub-children.
     for (OmKeyInfo dir : markDirsAsDeleted) {
-      purgePathsRequest.addMarkDeletedSubDirs(dir.getProtobuf(CURRENT_VERSION));
+      purgePathsRequest.addMarkDeletedSubDirs(
+          dir.getProtobuf(ClientVersion.latest().version()));
     }
 
     OzoneManagerProtocolProtos.OMRequest omRequest =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DirectoryDeletingService.java
@@ -238,14 +238,14 @@ public class DirectoryDeletingService extends BackgroundService {
     }
     for (OmKeyInfo purgeFile : purgeDeletedFiles) {
       purgePathsRequest.addDeletedSubFiles(
-          purgeFile.getProtobuf(true, ClientVersion.latest().version()));
+          purgeFile.getProtobuf(true, ClientVersion.CURRENT_VERSION));
     }
 
     // Add these directories to deletedDirTable, so that its sub-paths will be
     // traversed in next iteration to ensure cleanup all sub-children.
     for (OmKeyInfo dir : markDirsAsDeleted) {
       purgePathsRequest.addMarkDeletedSubDirs(
-          dir.getProtobuf(ClientVersion.latest().version()));
+          dir.getProtobuf(ClientVersion.CURRENT_VERSION));
     }
 
     OzoneManagerProtocolProtos.OMRequest omRequest =

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.utils.db.Table;
-import org.apache.hadoop.ozone.ClientVersions;
+import org.apache.hadoop.ozone.ClientVersion;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -164,7 +164,7 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
     acquireWriteLock();
     try {
       getStateManager().addPipeline(
-          pipeline.getProtobufMessage(ClientVersions.CURRENT_VERSION));
+          pipeline.getProtobufMessage(ClientVersion.latest().version()));
     } finally {
       releaseWriteLock();
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconPipelineManager.java
@@ -164,7 +164,7 @@ public final class ReconPipelineManager extends PipelineManagerImpl {
     acquireWriteLock();
     try {
       getStateManager().addPipeline(
-          pipeline.getProtobufMessage(ClientVersion.latest().version()));
+          pipeline.getProtobufMessage(ClientVersion.CURRENT_VERSION));
     } finally {
       releaseWriteLock();
     }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -147,7 +147,7 @@ public class StorageContainerServiceProviderImpl
   @Override
   public List<HddsProtos.Node> getNodes() throws IOException {
     return scmClient.queryNode(null, null, HddsProtos.QueryScope.CLUSTER,
-        "", ClientVersion.latest().version());
+        "", ClientVersion.CURRENT_VERSION);
   }
 
   @Override

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/StorageContainerServiceProviderImpl.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.recon.spi.impl;
 
 import static org.apache.hadoop.hdds.scm.server.SCMHTTPServerConfig.ConfigStrings.HDDS_SCM_HTTP_AUTH_TYPE;
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_HTTP_ENDPOINT;
 import static org.apache.hadoop.ozone.recon.ReconConstants.RECON_SCM_SNAPSHOT_DB;
 import static org.apache.hadoop.ozone.recon.ReconServerConfigKeys.OZONE_RECON_SCM_CONNECTION_REQUEST_TIMEOUT;
@@ -54,6 +53,7 @@ import org.apache.hadoop.hdds.server.http.HttpConfig;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
 import org.apache.hadoop.hdds.utils.db.RocksDBCheckpoint;
 import org.apache.hadoop.hdfs.web.URLConnectionFactory;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.scm.ReconStorageConfig;
 import org.apache.hadoop.ozone.recon.spi.StorageContainerServiceProvider;
@@ -147,7 +147,7 @@ public class StorageContainerServiceProviderImpl
   @Override
   public List<HddsProtos.Node> getNodes() throws IOException {
     return scmClient.queryNode(null, null, HddsProtos.QueryScope.CLUSTER,
-        "", CURRENT_VERSION);
+        "", ClientVersion.latest().version());
   }
 
   @Override

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -96,7 +96,7 @@ public class ContainerMapper {
                 keyValueTableIterator.next();
             OmKeyInfo omKeyInfo = keyValue.getValue();
             byte[] value = omKeyInfo
-                .getProtobuf(true, ClientVersion.latest().version())
+                .getProtobuf(true, ClientVersion.CURRENT_VERSION)
                 .toByteArray();
             OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/fsck/ContainerMapper.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.fsck;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -35,7 +36,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.ozone.ClientVersions.CURRENT_VERSION;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
 
 
@@ -95,7 +95,8 @@ public class ContainerMapper {
             Table.KeyValue<String, OmKeyInfo> keyValue =
                 keyValueTableIterator.next();
             OmKeyInfo omKeyInfo = keyValue.getValue();
-            byte[] value = omKeyInfo.getProtobuf(true, CURRENT_VERSION)
+            byte[] value = omKeyInfo
+                .getProtobuf(true, ClientVersion.latest().version())
                 .toByteArray();
             OmKeyInfo keyInfo = OmKeyInfo.getFromProtobuf(
                 OzoneManagerProtocolProtos.KeyInfo.parseFrom(value));


### PR DESCRIPTION
## What changes were proposed in this pull request?

As discussed in the proposal for HDDS-6390, this PR is to change int constants defined in ClientVersions and DatanodeVersions class to enums, providing the same functionality with an int version number, and a description field.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6391

## How was this patch tested?
Same tests via CI should cover the changes. No new tests were added.
