### PR TITLE
HDDS-6405. Selective checks: run rat for readme change

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -267,7 +267,7 @@ load bats-assert/load.bash
 @test "other README" {
   run dev-support/ci/selective_ci_checks.sh 5532981a7
 
-  assert_output -p 'basic-checks=[]'
+  assert_output -p 'basic-checks=["rat"]'
   assert_output -p needs-build=false
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -40,7 +40,7 @@ declare -a pattern_array ignore_array
 
 matched_files=""
 ignore_array=(
-    "/README.md" # exclude root README
+    "^[^/]*.md" # exclude root docs
 )
 
 function check_for_full_tests_needed_label() {
@@ -437,6 +437,8 @@ function get_count_misc_files() {
         "^hadoop-ozone/dev-support/checks"
         "^hadoop-ozone/dist/src/main/license"
         "\.bats$"
+        "\.txt$"
+        "\.md$"
         "findbugsExcludeFile.xml"
     )
     local ignore_array=(


### PR DESCRIPTION
## What changes were proposed in this pull request?

_rat_ check may fail if license is missing from non-root README files.  Thus it should be triggered for such changes in PRs.

(found during review of #3132)

https://issues.apache.org/jira/browse/HDDS-6405

## How was this patch tested?

Changed expected outcome in unit test.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1924479431