### PR TITLE
HDDS-6379. Not deducting the STANDALONE pipelines when counting pipelines on each datanode to check the pipeline limit

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -39,8 +39,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
-
 /**
  * Pipeline placement policy that choose datanodes based on load balancing
  * and network topology to supply pipeline creation.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -102,9 +102,8 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
   }
 
   private boolean isNonClosedRatisThreePipeline(Pipeline p) {
-    return p.getType() == RATIS
-        && RatisReplicationConfig.hasFactor(p.getReplicationConfig(),
-                ReplicationFactor.THREE)
+    return p.getReplicationConfig()
+        .equals(RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         && !p.isClosed();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -37,8 +37,9 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.RATIS;
 
 /**
  * Pipeline placement policy that choose datanodes based on load balancing
@@ -84,40 +85,28 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     this.heavyNodeCriteria = dnLimit == null ? 0 : Integer.parseInt(dnLimit);
   }
 
-  int currentPipelineCount(DatanodeDetails datanodeDetails, int nodesRequired) {
-
-    // Datanodes from pipeline in some states can also be considered available
-    // for pipeline allocation. Thus the number of these pipeline shall be
-    // deducted from total heaviness calculation.
-    int pipelineNumDeductable = 0;
-    Set<PipelineID> pipelines = nodeManager.getPipelines(datanodeDetails);
-    for (PipelineID pid : pipelines) {
-      Pipeline pipeline;
-      try {
-        pipeline = stateManager.getPipeline(pid);
-      } catch (PipelineNotFoundException e) {
-        LOG.debug("Pipeline not found in pipeline state manager during" +
-            " pipeline creation. PipelineID: {}", pid, e);
-        continue;
-      }
-      if (pipeline != null &&
-          // single node pipeline are not accounted for while determining
-          // the pipeline limit for dn
-          pipeline.getType() == HddsProtos.ReplicationType.RATIS &&
-          (RatisReplicationConfig
-              .hasFactor(pipeline.getReplicationConfig(), ReplicationFactor.ONE)
-              ||
-              pipeline.getReplicationConfig().getRequiredNodes()
-                  == nodesRequired &&
-                  pipeline.getPipelineState()
-                      == Pipeline.PipelineState.CLOSED)) {
-        pipelineNumDeductable++;
-      }
-    }
-    return pipelines.size() - pipelineNumDeductable;
+  int currentRatisThreePipelineCount(DatanodeDetails datanodeDetails) {
+    // Safe to cast collection's size to int
+    return (int) nodeManager.getPipelines(datanodeDetails).stream()
+        .map(id -> {
+          try {
+            return stateManager.getPipeline(id);
+          } catch (PipelineNotFoundException e) {
+            LOG.debug("Pipeline not found in pipeline state manager during" +
+                " pipeline creation. PipelineID: {}", id, e);
+            return null;
+          }
+        })
+        .filter(this::isNonClosedRatisThreePipeline)
+        .count();
   }
 
-
+  private boolean isNonClosedRatisThreePipeline(Pipeline p) {
+    return p.getType() == RATIS
+        && RatisReplicationConfig.hasFactor(p.getReplicationConfig(),
+                ReplicationFactor.THREE)
+        && !p.isClosed();
+  }
 
   /**
    * Filter out viable nodes based on
@@ -162,7 +151,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
     // TODO check if sorting could cause performance issue: HDDS-3466.
     List<DatanodeDetails> healthyList = healthyNodes.stream()
         .map(d ->
-            new DnWithPipelines(d, currentPipelineCount(d, nodesRequired)))
+            new DnWithPipelines(d, currentRatisThreePipelineCount(d)))
         .filter(d ->
             (d.getPipelines() < nodeManager.pipelineLimit(d.getDn())))
         .sorted(Comparator.comparingInt(DnWithPipelines::getPipelines))

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -700,12 +700,13 @@ public class TestPipelinePlacementPolicy {
   }
 
   @Test
-  public void testCurrentRatisThreePipelineCountWith2RatisThreePipeline()
+  public void testCurrentRatisThreePipelineCount()
       throws IOException {
     List<DatanodeDetails> healthyNodes = nodeManager
         .getNodes(NodeStatus.inServiceHealthy());
     int pipelineCount;
 
+    // Check datanode with one STANDALONE/ONE pipeline
     List<DatanodeDetails> standaloneOneDn = new ArrayList<>();
     standaloneOneDn.add(healthyNodes.get(0));
     createPipelineWithReplicationConfig(standaloneOneDn, STAND_ALONE, ONE);
@@ -714,6 +715,7 @@ public class TestPipelinePlacementPolicy {
         = placementPolicy.currentRatisThreePipelineCount(healthyNodes.get(0));
     assertEquals(pipelineCount, 0);
 
+    // Check datanode with one RATIS/ONE pipeline
     List<DatanodeDetails> ratisOneDn = new ArrayList<>();
     ratisOneDn.add(healthyNodes.get(1));
     createPipelineWithReplicationConfig(ratisOneDn, RATIS, ONE);
@@ -722,6 +724,7 @@ public class TestPipelinePlacementPolicy {
         = placementPolicy.currentRatisThreePipelineCount(healthyNodes.get(1));
     assertEquals(pipelineCount, 0);
 
+    // Check datanode with one RATIS/THREE pipeline
     List<DatanodeDetails> ratisThreeDn = new ArrayList<>();
     ratisThreeDn.add(healthyNodes.get(2));
     ratisThreeDn.add(healthyNodes.get(3));
@@ -732,6 +735,7 @@ public class TestPipelinePlacementPolicy {
         = placementPolicy.currentRatisThreePipelineCount(healthyNodes.get(2));
     assertEquals(pipelineCount, 1);
 
+    // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline
     standaloneOneDn = new ArrayList<>();
     standaloneOneDn.add(healthyNodes.get(1));
     createPipelineWithReplicationConfig(standaloneOneDn, STAND_ALONE, ONE);
@@ -740,6 +744,8 @@ public class TestPipelinePlacementPolicy {
         = placementPolicy.currentRatisThreePipelineCount(healthyNodes.get(1));
     assertEquals(pipelineCount, 0);
 
+    // Check datanode with one RATIS/ONE and one STANDALONE/ONE pipeline and
+    // two RATIS/THREE pipelines
     ratisThreeDn = new ArrayList<>();
     ratisThreeDn.add(healthyNodes.get(1));
     ratisThreeDn.add(healthyNodes.get(3));


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I modified the currentPipelineCount() method. I found that when the method calculated the current pipeline count in a datanode it counted in the STANDALONE pipelines. We shouldn't count the single node pipelines in, only the RATIS/THREE ones. So I renamed the method to currentRatisThreePipelineCount() and changed it to count the datanodes non closed RATIS/THREE pipelines. With this I fixed the problem, when we reached the pipeline limit with STANDALONE/ONE pipelines so it didn't create a RATIS/THREE pipeline. 

With the modified method some tests started failing in the TestPipelinePlacementPolicy. It was because some tests are using the insertHeavyNodesIntoNodeManager method which were only inserting the datanodes and its pipelines into the nodeManager and not into the pipelineStateManager. This wasn't a problem before because when we didn't find a pipeline in the pipelineStateManager we continued with the next pipeline, we didn't deducted that pipeline as a non single node pipeline, so we simply calculated it as a good one. Because of this I changed the insertHeavyNodesIntoNodeManager method to also add the pipelines to the pipelineStateManager. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6379

## How was this patch tested?

Added unit tests to the modified method. 
