### PR TITLE
HDDS-6392. Introduce OzoneManagerVersions enum

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone;
+
+import org.apache.hadoop.hdds.ComponentVersion;
+
+/**
+ * Versioning for Ozone Manager.
+ */
+public enum OzoneManagerVersion implements ComponentVersion {
+  DEFAULT_VERSION(0, "Initial version"),
+
+  FUTURE_VERSION(-1, "Used internally in the client when the server side is "
+      + " newer and an unknown server version has arrived to the client.");
+
+  public static final OzoneManagerVersion CURRENT = latest();
+  public static final int CURRENT_VERSION = CURRENT.version;
+
+  private final int version;
+  private final String description;
+
+  OzoneManagerVersion(int version, String description) {
+    this.version = version;
+    this.description = description;
+  }
+
+  @Override
+  public String description() {
+    return description;
+  }
+
+  @Override
+  public int toProtoValue() {
+    return version;
+  }
+
+  public static OzoneManagerVersion fromProtoValue(int value) {
+    OzoneManagerVersion[] versions = OzoneManagerVersion.values();
+    if (value >= versions.length || value < 0) {
+      return FUTURE_VERSION;
+    }
+    return versions[value];
+  }
+
+  private static OzoneManagerVersion latest() {
+    OzoneManagerVersion[] versions = OzoneManagerVersion.values();
+    return versions[versions.length - 2];
+  }
+}

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestComponentVersionInvariants.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds;
 
 import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.assertj.core.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,7 +35,7 @@ public class TestComponentVersionInvariants {
 
   @Parameterized.Parameters
   public static Object[][] values() {
-    Object[][] values = new Object[2][];
+    Object[][] values = new Object[3][];
     values[0] =
         Arrays.array(
             DatanodeVersion.values(),
@@ -45,6 +46,11 @@ public class TestComponentVersionInvariants {
             ClientVersion.values(),
             ClientVersion.DEFAULT_VERSION,
             ClientVersion.FUTURE_VERSION);
+    values[2] =
+        Arrays.array(
+            OzoneManagerVersion.values(),
+            OzoneManagerVersion.DEFAULT_VERSION,
+            OzoneManagerVersion.FUTURE_VERSION);
     return values;
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Similarly to ClientVersion and DatanodeVersion, this PR is to introduce OzoneManagerVersion. This is a pre-requisite for the change proposed in HDDS-6393.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6392

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

The PR is introducing a new enum, without uses. Tests that rely on the new enum to be defined in the follow-up JIRA HDDS-6393.
