### PR TITLE
HDDS-6382. EC: ListPipelines command should consider EC Containers

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
@@ -46,13 +46,14 @@ public class ListPipelinesSubcommand extends ScmSubcommand {
       defaultValue = "")
   private String replicationType;
 
-  @CommandLine.Option(names = {"-r", "--replication"},
+  @CommandLine.Option(
+      names = {"-r", "--replication", "-ffc", "--filterByFactor"},
       description = "Filter listed pipelines by replication, eg ONE, THREE or "
       + "for EC rs-3-2-1024k",
       defaultValue = "")
   private String replication;
 
-  @CommandLine.Option(names = {"-s", "--state"},
+  @CommandLine.Option(names = {"-s", "--state", "-fst", "--filterByState"},
       description = "Filter listed pipelines by State, eg OPEN, CLOSED",
       defaultValue = "")
   private String state;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/ListPipelinesSubcommand.java
@@ -21,6 +21,8 @@ package org.apache.hadoop.hdds.scm.cli.pipeline;
 import com.google.common.base.Strings;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.cli.ScmSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -39,23 +41,41 @@ import java.util.stream.Stream;
     versionProvider = HddsVersionProvider.class)
 public class ListPipelinesSubcommand extends ScmSubcommand {
 
-  @CommandLine.Option(names = {"-ffc", "--filterByFactor"},
-      description = "Filter listed pipelines by Factor(ONE/one)",
+  @CommandLine.Option(names = {"-t", "--type"},
+      description = "Filter listed pipelines by replication type, RATIS or EC",
       defaultValue = "")
-  private String factor;
+  private String replicationType;
 
-  @CommandLine.Option(names = {"-fst", "--filterByState"},
-      description = "Filter listed pipelines by State(OPEN/CLOSE)",
+  @CommandLine.Option(names = {"-r", "--replication"},
+      description = "Filter listed pipelines by replication, eg ONE, THREE or "
+      + "for EC rs-3-2-1024k",
+      defaultValue = "")
+  private String replication;
+
+  @CommandLine.Option(names = {"-s", "--state"},
+      description = "Filter listed pipelines by State, eg OPEN, CLOSED",
       defaultValue = "")
   private String state;
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
     Stream<Pipeline> stream = scmClient.listPipelines().stream();
-    if (!Strings.isNullOrEmpty(factor)) {
+    if (!Strings.isNullOrEmpty(replication)) {
+      if (Strings.isNullOrEmpty(replicationType)) {
+        throw new IOException(
+            "ReplicationType cannot be null if replication is passed");
+      }
+      ReplicationConfig repConfig =
+          ReplicationConfig.parse(ReplicationType.valueOf(replicationType),
+              replication, new OzoneConfiguration());
       stream = stream.filter(
-          p -> ReplicationConfig.getLegacyFactor(p.getReplicationConfig())
-              .toString().compareToIgnoreCase(factor) == 0);
+          p -> p.getReplicationConfig().equals(repConfig));
+    } else if (!Strings.isNullOrEmpty(replicationType)) {
+      stream = stream.filter(
+          p -> p.getReplicationConfig()
+              .getReplicationType()
+              .toString()
+              .compareToIgnoreCase(replicationType) == 0);
     }
     if (!Strings.isNullOrEmpty(state)) {
       stream = stream.filter(p -> p.getPipelineState().toString()

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.cli.pipeline;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.client.ScmClient;
+import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import picocli.CommandLine;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for the ListPipelineSubCommand class.
+ */
+public class TestListPipelinesSubCommand {
+
+  private ListPipelinesSubcommand cmd;
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+  private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
+  private ScmClient scmClient;
+
+  @Before
+  public void setup() throws IOException {
+    cmd = new ListPipelinesSubcommand();
+    System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
+    System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
+
+    scmClient = mock(ScmClient.class);
+    Mockito.when(scmClient.listPipelines())
+        .thenAnswer(invocation -> createPipelines());
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  public void testAllPipelinesReturnedWithNoFilter() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs();
+    cmd.execute(scmClient);
+    Assert.assertEquals(6, outContent.toString(DEFAULT_ENCODING)
+        .split(System.getProperty("line.separator")).length);
+  }
+
+  @Test
+  public void testOnlyOpenReturned() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("-s", "OPEN");
+    cmd.execute(scmClient);
+    String output = outContent.toString(DEFAULT_ENCODING);
+    Assert.assertEquals(3, output.split(
+        System.getProperty("line.separator")).length);
+    Assert.assertEquals(-1, output.indexOf("CLOSED"));
+  }
+
+  @Test(expected = IOException.class)
+  public void testExceptionIfReplicationWithoutType() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("-r", "THREE");
+    cmd.execute(scmClient);
+  }
+
+  @Test
+  public void testReplicationAndType() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("-r", "THREE", "-t", "RATIS");
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    Assert.assertEquals(2, output.split(
+        System.getProperty("line.separator")).length);
+    Assert.assertEquals(-1, output.indexOf("EC"));
+  }
+
+  @Test
+  public void testReplicationAndTypeEC() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("-r", "rs-6-3-1024k", "-t", "EC");
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    Assert.assertEquals(1, output.split(
+        System.getProperty("line.separator")).length);
+    Assert.assertEquals(-1,
+        output.indexOf("ReplicationConfig: RATIS"));
+  }
+
+  @Test
+  public void testReplicationAndTypeAndState() throws IOException {
+    CommandLine c = new CommandLine(cmd);
+    c.parseArgs("-r", "THREE", "-t", "RATIS", "-s", "OPEN");
+    cmd.execute(scmClient);
+
+    String output = outContent.toString(DEFAULT_ENCODING);
+    Assert.assertEquals(1, output.split(
+        System.getProperty("line.separator")).length);
+    Assert.assertEquals(-1, output.indexOf("CLOSED"));
+    Assert.assertEquals(-1, output.indexOf("EC"));
+  }
+
+  private List<Pipeline> createPipelines() {
+    List<Pipeline> pipelines = new ArrayList<>();
+    pipelines.add(createPipeline(
+        new StandaloneReplicationConfig(ONE), Pipeline.PipelineState.OPEN));
+    pipelines.add(createPipeline(
+        new RatisReplicationConfig(THREE), Pipeline.PipelineState.OPEN));
+    pipelines.add(createPipeline(
+        new RatisReplicationConfig(THREE), Pipeline.PipelineState.CLOSED));
+
+    pipelines.add(createPipeline(
+        new ECReplicationConfig(3, 2), Pipeline.PipelineState.OPEN));
+    pipelines.add(createPipeline(
+        new ECReplicationConfig(3, 2), Pipeline.PipelineState.CLOSED));
+    pipelines.add(createPipeline(
+        new ECReplicationConfig(6, 3), Pipeline.PipelineState.CLOSED));
+
+    return pipelines;
+  }
+
+  private Pipeline createPipeline(ReplicationConfig repConfig,
+      Pipeline.PipelineState state) {
+    return new Pipeline.Builder()
+        .setId(PipelineID.randomId())
+        .setCreateTimestamp(System.currentTimeMillis())
+        .setState(state)
+        .setReplicationConfig(repConfig)
+        .setNodes(createDatanodeDetails(1))
+        .build();
+  }
+
+  private List<DatanodeDetails> createDatanodeDetails(int count) {
+    List<DatanodeDetails> dns = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      HddsProtos.DatanodeDetailsProto dnd =
+          HddsProtos.DatanodeDetailsProto.newBuilder()
+              .setHostName("host" + i)
+              .setIpAddress("1.2.3." + i + 1)
+              .setNetworkLocation("/default")
+              .setNetworkName("host" + i)
+              .addPorts(HddsProtos.Port.newBuilder()
+                  .setName("ratis").setValue(5678).build())
+              .setUuid(UUID.randomUUID().toString())
+              .build();
+      dns.add(DatanodeDetails.getFromProtoBuf(dnd));
+    }
+    return dns;
+  }
+}
+
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

In ListPipeline.java we have:

```
@Override
public void execute(ScmClient scmClient) throws IOException {
  Stream<Pipeline> stream = scmClient.listPipelines().stream();
  if (!Strings.isNullOrEmpty(factor)) {
    stream = stream.filter(
        p -> ReplicationConfig.getLegacyFactor(p.getReplicationConfig())
            .toString().compareToIgnoreCase(factor) == 0);
  }
  if (!Strings.isNullOrEmpty(state)) {
    stream = stream.filter(p -> p.getPipelineState().toString()
        .compareToIgnoreCase(state) == 0);
  }
  stream.forEach(System.out::println);
} 
```

This code will fail if the pipeline is an EC pipeline. We should also allow for filtering on EC pipelines.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6382

## How was this patch tested?

New unit tests and verified in docker cluster
