### PR TITLE
HDDS-6420. Ratis and Standalone ReplicationConfig should return a static instance

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/BlockInputStream.java
@@ -221,7 +221,7 @@ public class BlockInputStream extends InputStream
     // protocol.
     if (pipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
       pipeline = Pipeline.newBuilder(pipeline)
-          .setReplicationConfig(new StandaloneReplicationConfig(
+          .setReplicationConfig(StandaloneReplicationConfig.getInstance(
               ReplicationConfig
                   .getLegacyFactor(pipeline.getReplicationConfig())))
           .build();

--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/hdds/scm/storage/DummyBlockInputStreamWithRetry.java
@@ -63,7 +63,7 @@ final class DummyBlockInputStreamWithRetry
           return Pipeline.newBuilder()
               .setState(Pipeline.PipelineState.OPEN)
               .setId(PipelineID.randomId())
-              .setReplicationConfig(new StandaloneReplicationConfig(
+              .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                   ReplicationFactor.ONE))
               .setNodes(Collections.emptyList())
               .build();

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -30,7 +30,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 /**
  * Replication configuration for EC replication.
  */
-public class RatisReplicationConfig implements ReplicatedReplicationConfig {
+public final class RatisReplicationConfig
+    implements ReplicatedReplicationConfig {
 
   private final ReplicationFactor replicationFactor;
   private static final ReplicationType REPLICATION_TYPE = ReplicationType.RATIS;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -57,7 +57,11 @@ public class RatisReplicationConfig implements ReplicatedReplicationConfig {
     return new RatisReplicationConfig(factor);
   }
 
-  public RatisReplicationConfig(ReplicationFactor replicationFactor) {
+  /**
+   * Use the static getInstance method rather than the private constructor.
+   * @param replicationFactor
+   */
+  private RatisReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/RatisReplicationConfig.java
@@ -24,6 +24,9 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 
 import java.util.Objects;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+
 /**
  * Replication configuration for EC replication.
  */
@@ -31,6 +34,28 @@ public class RatisReplicationConfig implements ReplicatedReplicationConfig {
 
   private final ReplicationFactor replicationFactor;
   private static final ReplicationType REPLICATION_TYPE = ReplicationType.RATIS;
+
+  private static final RatisReplicationConfig RATIS_ONE_CONFIG =
+      new RatisReplicationConfig(ONE);
+
+  private static final RatisReplicationConfig RATIS_THREE_CONFIG =
+      new RatisReplicationConfig(THREE);
+
+  /**
+   * Get an instance of Ratis Replication Config with the requested factor.
+   * The same static instance will be returned for all requests for the same
+   * factor.
+   * @param factor Replication Factor requested
+   * @return RatisReplicationConfig object of the requested factor
+   */
+  public static RatisReplicationConfig getInstance(ReplicationFactor factor) {
+    if (factor == ONE) {
+      return RATIS_ONE_CONFIG;
+    } else if (factor == THREE) {
+      return RATIS_THREE_CONFIG;
+    }
+    return new RatisReplicationConfig(factor);
+  }
 
   public RatisReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -46,9 +46,9 @@ public interface ReplicationConfig {
   ) {
     switch (type) {
     case RATIS:
-      return new RatisReplicationConfig(factor);
+      return RatisReplicationConfig.getInstance(factor);
     case STAND_ALONE:
-      return new StandaloneReplicationConfig(factor);
+      return StandaloneReplicationConfig.getInstance(factor);
     default:
       throw new UnsupportedOperationException(
           "Not supported replication: " + type);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -30,7 +30,7 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor
 /**
  * Replication configuration for STANDALONE replication.
  */
-public class StandaloneReplicationConfig implements
+public final class StandaloneReplicationConfig implements
     ReplicatedReplicationConfig {
 
   private final ReplicationFactor replicationFactor;
@@ -59,7 +59,11 @@ public class StandaloneReplicationConfig implements
     return new StandaloneReplicationConfig(factor);
   }
 
-  public StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
+  /**
+   * Use the static getInstance method instead of the private constructor.
+   * @param replicationFactor
+   */
+  private StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/StandaloneReplicationConfig.java
@@ -24,6 +24,9 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 
 import java.util.Objects;
 
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+
 /**
  * Replication configuration for STANDALONE replication.
  */
@@ -32,6 +35,29 @@ public class StandaloneReplicationConfig implements
 
   private final ReplicationFactor replicationFactor;
   private static final String REPLICATION_TYPE = "STANDALONE";
+
+  private static final StandaloneReplicationConfig STANDALONE_ONE_CONFIG =
+      new StandaloneReplicationConfig(ONE);
+
+  private static final StandaloneReplicationConfig STANDALONE_THREE_CONFIG =
+      new StandaloneReplicationConfig(THREE);
+
+  /**
+   * Get an instance of Standalone Replication Config with the requested factor.
+   * The same static instance will be returned for all requests for the same
+   * factor.
+   * @param factor Replication Factor requested
+   * @return StandaloneReplicationConfig object of the requested factor
+   */
+  public static StandaloneReplicationConfig getInstance(
+      ReplicationFactor factor) {
+    if (factor == ONE) {
+      return STANDALONE_ONE_CONFIG;
+    } else if (factor == THREE) {
+      return STANDALONE_THREE_CONFIG;
+    }
+    return new StandaloneReplicationConfig(factor);
+  }
 
   public StandaloneReplicationConfig(ReplicationFactor replicationFactor) {
     this.replicationFactor = replicationFactor;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
@@ -38,8 +38,8 @@ public class TestReplicationConfigValidator {
 
     validator.validate(RatisReplicationConfig.getInstance(THREE));
     validator.validate(RatisReplicationConfig.getInstance(ONE));
-    validator.validate(new StandaloneReplicationConfig(THREE));
-    validator.validate(new StandaloneReplicationConfig(ONE));
+    validator.validate(StandaloneReplicationConfig.getInstance(THREE));
+    validator.validate(StandaloneReplicationConfig.getInstance(ONE));
 
   }
 
@@ -52,7 +52,7 @@ public class TestReplicationConfigValidator {
         config.getObject(ReplicationConfigValidator.class);
 
     validator.validate(RatisReplicationConfig.getInstance(THREE));
-    validator.validate(new StandaloneReplicationConfig(ONE));
+    validator.validate(StandaloneReplicationConfig.getInstance(ONE));
 
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
@@ -36,8 +36,8 @@ public class TestReplicationConfigValidator {
     final ReplicationConfigValidator validator =
         config.getObject(ReplicationConfigValidator.class);
 
-    validator.validate(new RatisReplicationConfig(THREE));
-    validator.validate(new RatisReplicationConfig(ONE));
+    validator.validate(RatisReplicationConfig.getInstance(THREE));
+    validator.validate(RatisReplicationConfig.getInstance(ONE));
     validator.validate(new StandaloneReplicationConfig(THREE));
     validator.validate(new StandaloneReplicationConfig(ONE));
 
@@ -51,7 +51,7 @@ public class TestReplicationConfigValidator {
     final ReplicationConfigValidator validator =
         config.getObject(ReplicationConfigValidator.class);
 
-    validator.validate(new RatisReplicationConfig(THREE));
+    validator.validate(RatisReplicationConfig.getInstance(THREE));
     validator.validate(new StandaloneReplicationConfig(ONE));
 
   }
@@ -64,9 +64,9 @@ public class TestReplicationConfigValidator {
     final ReplicationConfigValidator validator =
         config.getObject(ReplicationConfigValidator.class);
 
-    validator.validate(new RatisReplicationConfig(THREE));
+    validator.validate(RatisReplicationConfig.getInstance(THREE));
 
-    validator.validate(new RatisReplicationConfig(ONE));
+    validator.validate(RatisReplicationConfig.getInstance(ONE));
     //exception is expected
 
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -82,7 +82,7 @@ public final class MockPipeline {
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setNodes(nodes)
         .build();
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/MockPipeline.java
@@ -66,7 +66,7 @@ public final class MockPipeline {
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setNodes(dns)
         .build();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineProvider.java
@@ -118,7 +118,8 @@ public class RatisPipelineProvider
           getPipelineStateManager().getPipelines(
               replicationConfig, PipelineState.CLOSED).size()) >
           (pipelineNumberLimit - getPipelineStateManager()
-              .getPipelines(new RatisReplicationConfig(ReplicationFactor.ONE))
+              .getPipelines(RatisReplicationConfig
+                  .getInstance(ReplicationFactor.ONE))
               .size());
     }
 
@@ -163,8 +164,7 @@ public class RatisPipelineProvider
     Pipeline pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setState(PipelineState.ALLOCATED)
-        .setReplicationConfig(new RatisReplicationConfig(
-            factor))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(factor))
         .setNodes(dns)
         .setSuggestedLeaderId(
             suggestedLeader != null ? suggestedLeader.getUuid() : null)

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/RatisPipelineUtils.java
@@ -110,7 +110,8 @@ public final class RatisPipelineUtils {
   static List<Pipeline> checkPipelineContainSameDatanodes(
       PipelineStateManager stateManager, Pipeline pipeline) {
     return stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE))
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE))
         .stream().filter(p -> !p.getId().equals(pipeline.getId()) &&
             (p.getPipelineState() != Pipeline.PipelineState.CLOSED &&
                 p.sameDatanodes(pipeline)))

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/HealthyPipelineSafeModeRule.java
@@ -142,7 +142,7 @@ public class HealthyPipelineSafeModeRule extends SafeModeExitRule<Pipeline> {
 
   private synchronized void initializeRule(boolean refresh) {
     int pipelineCount = pipelineManager.getPipelines(
-        new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE),
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
         Pipeline.PipelineState.OPEN).size();
 
     healthyPipelineThresholdCount = Math.max(minHealthyPipelines,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/safemode/OneReplicaPipelineSafeModeRule.java
@@ -164,7 +164,7 @@ public class OneReplicaPipelineSafeModeRule extends
   private void initializeRule(boolean refresh) {
 
     oldPipelineIDSet = pipelineManager.getPipelines(
-        new RatisReplicationConfig(ReplicationFactor.THREE),
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
         Pipeline.PipelineState.OPEN)
         .stream().map(p -> p.getId()).collect(Collectors.toSet());
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -258,7 +258,7 @@ public class SCMClientProtocolServer implements
 
     if (pipeline == null) {
       pipeline = scm.getPipelineManager().createPipeline(
-          new StandaloneReplicationConfig(ReplicationConfig
+          StandaloneReplicationConfig.getInstance(ReplicationConfig
               .getLegacyFactor(container.getReplicationConfig())),
           scm.getContainerManager()
               .getContainerReplicas(cid).stream()

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/HddsTestUtils.java
@@ -397,7 +397,7 @@ public final class HddsTestUtils {
     for (ReplicationFactor factor : ReplicationFactor.values()) {
       // Trigger the processed pipeline report event
       for (Pipeline pipeline : pipelineManager
-          .getPipelines(new RatisReplicationConfig(factor))) {
+          .getPipelines(RatisReplicationConfig.getInstance(factor))) {
         pipelineManager.openPipeline(pipeline.getId());
       }
     }
@@ -529,7 +529,8 @@ public final class HddsTestUtils {
       allocateContainer(ContainerManager containerManager)
       throws IOException {
     return containerManager
-        .allocateContainer(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .allocateContainer(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE),
             "root");
 
   }
@@ -629,7 +630,8 @@ public final class HddsTestUtils {
     return new ContainerInfo.Builder()
         .setContainerID(RandomUtils.nextLong())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE))
         .setState(state)
         .setSequenceId(10000L)
         .setOwner("TEST");
@@ -692,7 +694,7 @@ public final class HddsTestUtils {
     nodes.add(MockDatanodeDetails.randomDatanodeDetails());
     return Pipeline.newBuilder()
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setId(PipelineID.randomId())
         .setNodes(nodes)
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestBlockManager.java
@@ -182,7 +182,8 @@ public class TestBlockManager {
     CloseContainerEventHandler closeContainerHandler =
         new CloseContainerEventHandler(pipelineManager, mapping, scmContext);
     eventQueue.addHandler(SCMEvents.CLOSE_CONTAINER, closeContainerHandler);
-    replicationConfig = new RatisReplicationConfig(ReplicationFactor.THREE);
+    replicationConfig = RatisReplicationConfig
+        .getInstance(ReplicationFactor.THREE);
 
     scm.getScmContext().updateSafeModeStatus(new SafeModeStatus(false, true));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -482,7 +482,7 @@ public class TestDeletedBlockLog {
     List<DatanodeDetails> dns = Collections.singletonList(dd);
     Pipeline pipeline = Pipeline.newBuilder()
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setState(Pipeline.PipelineState.OPEN)
             .setId(PipelineID.randomId())
             .setNodes(dns)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -164,7 +164,7 @@ public class TestDeletedBlockLog {
     final ContainerInfo container =
         new ContainerInfo.Builder()
             .setContainerID(cid)
-            .setReplicationConfig(new RatisReplicationConfig(THREE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
             .setState(HddsProtos.LifeCycleState.CLOSED)
             .setOwner("TestDeletedBlockLog")
             .setPipelineID(PipelineID.randomId())

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -166,7 +166,7 @@ public class TestCloseContainerEventHandler {
   @Test
   public void testCloseContainerEventWithValidContainers() throws IOException {
     ContainerInfo container = containerManager
-        .allocateContainer(new RatisReplicationConfig(
+        .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE), OzoneConsts.OZONE);
     ContainerID id = container.containerID();
     DatanodeDetails datanode = pipelineManager
@@ -185,7 +185,7 @@ public class TestCloseContainerEventHandler {
     GenericTestUtils.LogCapturer
         .captureLogs(CloseContainerEventHandler.LOG);
     ContainerInfo container = containerManager
-        .allocateContainer(new RatisReplicationConfig(
+        .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), OzoneConsts.OZONE);
     ContainerID id = container.containerID();
     int[] closeCount = new int[3];

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -70,7 +70,7 @@ public class TestContainerManagerImpl {
         conf, scmhaManager, SCMDBDefinition.SEQUENCE_ID.getTable(dbStore));
     final PipelineManager pipelineManager =
         new MockPipelineManager(dbStore, scmhaManager, nodeManager);
-    pipelineManager.createPipeline(new RatisReplicationConfig(
+    pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
         ReplicationFactor.THREE));
     containerManager = new ContainerManagerImpl(conf,
         scmhaManager, sequenceIdGen, pipelineManager,
@@ -95,7 +95,7 @@ public class TestContainerManagerImpl {
     Assert.assertTrue(
         containerManager.getContainers().isEmpty());
     final ContainerInfo container = containerManager.allocateContainer(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
     Assert.assertEquals(1, containerManager.getContainers().size());
     Assert.assertNotNull(containerManager.getContainer(
@@ -105,7 +105,7 @@ public class TestContainerManagerImpl {
   @Test
   public void testUpdateContainerState() throws Exception {
     final ContainerInfo container = containerManager.allocateContainer(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
     final ContainerID cid = container.containerID();
     Assert.assertEquals(HddsProtos.LifeCycleState.OPEN,
@@ -132,7 +132,7 @@ public class TestContainerManagerImpl {
     ContainerID[] cidArray = new ContainerID[10];
     for (int i = 0; i < 10; i++) {
       ContainerInfo container = containerManager.allocateContainer(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE), "admin");
       cidArray[i] = container.containerID();
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -482,7 +482,7 @@ public class TestContainerReportHandler {
         NodeStatus.inServiceHealthy()).iterator();
 
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE));
 
     final DatanodeDetails datanodeOne = nodeIterator.next();
     final DatanodeDetails datanodeTwo = nodeIterator.next();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -76,10 +76,10 @@ public class TestContainerStateManager {
     pipelineManager = Mockito.mock(PipelineManager.class);
     pipeline = Pipeline.newBuilder().setState(Pipeline.PipelineState.CLOSED)
             .setId(PipelineID.randomId())
-            .setReplicationConfig(new StandaloneReplicationConfig(
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                 ReplicationFactor.THREE))
             .setNodes(new ArrayList<>()).build();
-    when(pipelineManager.createPipeline(new StandaloneReplicationConfig(
+    when(pipelineManager.createPipeline(StandaloneReplicationConfig.getInstance(
         ReplicationFactor.THREE))).thenReturn(pipeline);
     when(pipelineManager.containsPipeline(Mockito.any(PipelineID.class)))
         .thenReturn(true);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -733,8 +733,8 @@ public class TestContainerBalancer {
   private ContainerInfo createContainer(long id, int multiple) {
     return new ContainerInfo.Builder()
         .setContainerID(id)
-        .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+        .setReplicationConfig(RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setState(HddsProtos.LifeCycleState.CLOSED)
         .setOwner("TestContainerBalancer")
         .setUsedBytes(OzoneConsts.GB * multiple)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestContainerPlacement.java
@@ -106,7 +106,7 @@ public class TestContainerPlacement {
     nodeManager = new MockNodeManager(true, 10);
     pipelineManager = new MockPipelineManager(dbStore,
         scmhaManager, nodeManager);
-    pipelineManager.createPipeline(new RatisReplicationConfig(
+    pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
         HddsProtos.ReplicationFactor.THREE));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -190,7 +190,8 @@ public class TestDeadNodeHandler {
             Arrays.asList(metaStorageOne)), null);
 
     LambdaTestUtils.await(120000, 1000,
-        () -> pipelineManager.getPipelines(new RatisReplicationConfig(THREE))
+        () -> pipelineManager.getPipelines(RatisReplicationConfig
+                .getInstance(THREE))
             .size() > 3);
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestSCMNodeManager.java
@@ -448,7 +448,8 @@ public class TestSCMNodeManager {
         .map(DatanodeDetails::getUuidString)
         .collect(Collectors.toSet());
 
-    RatisReplicationConfig replConfig = new RatisReplicationConfig(factor);
+    RatisReplicationConfig replConfig = RatisReplicationConfig
+        .getInstance(factor);
 
     // Wait for the expected number of pipelines using allowed DNs.
     GenericTestUtils.waitFor(() -> {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineDatanodesIntersection.java
@@ -132,7 +132,7 @@ public class TestPipelineDatanodesIntersection {
     int createdPipelineCount = 0;
     while (!end && createdPipelineCount <= healthyNodeCount * nodeHeaviness) {
       try {
-        Pipeline pipeline = provider.create(new RatisReplicationConfig(
+        Pipeline pipeline = provider.create(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
         HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
             ClientVersions.CURRENT_VERSION);
@@ -170,7 +170,8 @@ public class TestPipelineDatanodesIntersection {
 
     LOG.info("Among total " +
         stateManager
-            .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE))
+            .getPipelines(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE))
             .size() + " created pipelines" +
         " with " + healthyNodeCount + " healthy datanodes and " +
         nodeHeaviness + " as node heaviness, " +

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -144,12 +144,12 @@ public class TestPipelineManagerImpl {
         createPipelineManager(true, buffer1);
     Assert.assertTrue(pipelineManager.getPipelines().isEmpty());
     Pipeline pipeline1 = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
 
     Pipeline pipeline2 = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.ONE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.ONE));
     Assert.assertEquals(2, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
     buffer1.close();
@@ -163,7 +163,7 @@ public class TestPipelineManagerImpl {
     Assert.assertFalse(pipelineManager2.getPipelines().isEmpty());
     Assert.assertEquals(2, pipelineManager.getPipelines().size());
     Pipeline pipeline3 = pipelineManager2.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     buffer2.close();
     Assert.assertEquals(3, pipelineManager2.getPipelines().size());
     Assert.assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
@@ -177,7 +177,8 @@ public class TestPipelineManagerImpl {
     Assert.assertTrue(pipelineManager.getPipelines().isEmpty());
     try {
       pipelineManager
-          .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+          .createPipeline(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE));
     } catch (NotLeaderException ex) {
       pipelineManager.close();
       return;
@@ -194,7 +195,7 @@ public class TestPipelineManagerImpl {
     Table<PipelineID, Pipeline> pipelineStore =
         SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -206,7 +207,8 @@ public class TestPipelineManagerImpl {
     pipelineManager.openPipeline(pipelineID);
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
     buffer.flush();
     Assert.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
@@ -218,12 +220,14 @@ public class TestPipelineManagerImpl {
     Assert.assertEquals(Pipeline.PipelineState.DORMANT,
         pipelineStore.get(pipeline.getId()).getPipelineState());
     Assert.assertFalse(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
 
     pipelineManager.activatePipeline(pipeline.getId());
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
     buffer.flush();
     Assert.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
@@ -234,7 +238,7 @@ public class TestPipelineManagerImpl {
   public void testOpenPipelineShouldFailOnFollower() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -255,7 +259,7 @@ public class TestPipelineManagerImpl {
   public void testActivatePipelineShouldFailOnFollower() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -276,7 +280,7 @@ public class TestPipelineManagerImpl {
   public void testDeactivatePipelineShouldFailOnFollower() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -299,7 +303,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.setScmContext(scmContext);
     // Create a pipeline
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -316,7 +320,8 @@ public class TestPipelineManagerImpl {
     //Add Container to PipelineStateMap
     pipelineManager.addContainerToPipeline(pipeline.getId(), containerID);
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
 
     try {
@@ -347,7 +352,7 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager.createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE));
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelineManager.getPipelines().size());
     Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
     Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
@@ -372,7 +377,8 @@ public class TestPipelineManagerImpl {
         new SCMSafeModeManager(conf, new ArrayList<>(), null, pipelineManager,
             new EventQueue(), serviceManager, scmContext);
     Pipeline pipeline = pipelineManager
-        .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+        .createPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE));
 
     // pipeline is not healthy until all dns report
     List<DatanodeDetails> nodes = pipeline.getNodes();
@@ -430,7 +436,8 @@ public class TestPipelineManagerImpl {
 
     for (int i = 0; i < maxPipelineCount; i++) {
       Pipeline pipeline = pipelineManager
-          .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+          .createPipeline(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE));
       Assert.assertNotNull(pipeline);
     }
 
@@ -446,7 +453,8 @@ public class TestPipelineManagerImpl {
     //This should fail...
     try {
       pipelineManager
-          .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+          .createPipeline(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE));
       fail();
     } catch (SCMException ioe) {
       // pipeline creation failed this time.
@@ -475,7 +483,8 @@ public class TestPipelineManagerImpl {
         createPipelineManager(true, buffer1);
 
     Pipeline pipeline = pipelineManager
-        .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+        .createPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE));
     // close manager
     buffer1.close();
     pipelineManager.close();
@@ -523,21 +532,25 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager
-        .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+        .createPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE));
     // At this point, pipeline is not at OPEN stage.
     Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipeline.getPipelineState());
 
     // pipeline should be seen in pipelineManager as ALLOCATED.
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(pipeline));
     pipelineManager
-        .scrubPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+        .scrubPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE));
 
     // pipeline should be scrubbed.
     Assert.assertFalse(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(pipeline));
 
     pipelineManager.close();
@@ -553,14 +566,16 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager
-        .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+        .createPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE));
     // At this point, pipeline is not at OPEN stage.
     Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipeline.getPipelineState());
 
     // pipeline should be seen in pipelineManager as ALLOCATED.
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(pipeline));
 
     // Change to follower
@@ -569,7 +584,8 @@ public class TestPipelineManagerImpl {
 
     try {
       pipelineManager
-          .scrubPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+          .scrubPipeline(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE));
     } catch (NotLeaderException ex) {
       pipelineManager.close();
       return;
@@ -591,7 +607,8 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     try {
       pipelineManager
-          .createPipeline(new RatisReplicationConfig(ReplicationFactor.THREE));
+          .createPipeline(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE));
       fail("Pipelines should not have been created");
     } catch (IOException e) {
       // No pipeline is created.
@@ -601,9 +618,11 @@ public class TestPipelineManagerImpl {
     // Ensure a pipeline of factor ONE can be created - no exceptions should be
     // raised.
     Pipeline pipeline = pipelineManager
-        .createPipeline(new RatisReplicationConfig(ReplicationFactor.ONE));
+        .createPipeline(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE));
     Assert.assertTrue(pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.ONE))
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE))
         .contains(pipeline));
 
     // Simulate safemode check exiting.
@@ -657,7 +676,8 @@ public class TestPipelineManagerImpl {
     Table<PipelineID, Pipeline> pipelineStore =
             SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = pipelineManager.createPipeline(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE));
     PipelineID pipelineID = pipeline.getId();
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
     pipelineManager.getStateManager().updatePipelineState(
@@ -678,7 +698,8 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager.createPipeline(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE));
     PipelineID pipelineID = pipeline.getId();
     ContainerManager containerManager = scm.getContainerManager();
     ContainerInfo containerInfo = HddsTestUtils.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelinePlacementPolicy.java
@@ -280,7 +280,7 @@ public class TestPipelinePlacementPolicy {
         Pipeline pipeline = Pipeline.newBuilder()
             .setId(PipelineID.randomId())
             .setState(Pipeline.PipelineState.ALLOCATED)
-            .setReplicationConfig(new RatisReplicationConfig(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                 ReplicationFactor.THREE))
             .setNodes(nodes)
             .build();
@@ -305,7 +305,8 @@ public class TestPipelinePlacementPolicy {
     // Should max out pipeline usage.
     Assert.assertEquals(maxPipelineCount,
         stateManager
-            .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE))
+            .getPipelines(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE))
             .size());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -164,7 +164,8 @@ public class TestPipelineStateManagerImpl {
     pipelines.add(pipeline);
 
     Set<Pipeline> pipelines1 = new HashSet<>(stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.ONE)));
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE)));
     Assert.assertEquals(pipelines1.size(), pipelines.size());
 
     pipelines1 = new HashSet<>(stateManager.getPipelines());
@@ -460,14 +461,16 @@ public class TestPipelineStateManagerImpl {
         .getProtobufMessage(ClientVersions.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
     Assert.assertEquals(0, stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
         .size());
 
     // pipeline in open state should be reported
     openPipeline(pipelineProto);
     Assert.assertEquals(1, stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
         .size());
 
@@ -481,14 +484,16 @@ public class TestPipelineStateManagerImpl {
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
     Assert.assertEquals(2, stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
         .size());
 
     // pipeline in closed state should not be reported
     finalizePipeline(pipelineProto2);
     Assert.assertEquals(1, stateManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+            .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
         .size());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -120,7 +120,8 @@ public class TestRatisPipelineProvider {
 
   private void createPipelineAndAssertions(
       HddsProtos.ReplicationFactor factor) throws IOException {
-    Pipeline pipeline = provider.create(new RatisReplicationConfig(factor));
+    Pipeline pipeline = provider.create(RatisReplicationConfig
+        .getInstance(factor));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
@@ -128,7 +129,8 @@ public class TestRatisPipelineProvider {
     stateManager.addPipeline(pipelineProto);
     nodeManager.addPipeline(pipeline);
 
-    Pipeline pipeline1 = provider.create(new RatisReplicationConfig(factor));
+    Pipeline pipeline1 = provider.create(RatisReplicationConfig
+        .getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersions.CURRENT_VERSION);
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
@@ -170,7 +172,8 @@ public class TestRatisPipelineProvider {
   public void testCreatePipelineWithFactor() throws Exception {
     init(1);
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
-    Pipeline pipeline = provider.create(new RatisReplicationConfig(factor));
+    Pipeline pipeline = provider.create(RatisReplicationConfig
+        .getInstance(factor));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
@@ -178,7 +181,8 @@ public class TestRatisPipelineProvider {
     stateManager.addPipeline(pipelineProto);
 
     factor = HddsProtos.ReplicationFactor.ONE;
-    Pipeline pipeline1 = provider.create(new RatisReplicationConfig(factor));
+    Pipeline pipeline1 = provider.create(RatisReplicationConfig
+        .getInstance(factor));
     assertPipelineProperties(pipeline1, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
@@ -195,13 +199,13 @@ public class TestRatisPipelineProvider {
     init(1);
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
-        provider.create(new RatisReplicationConfig(factor),
+        provider.create(RatisReplicationConfig.getInstance(factor),
             createListOfNodes(factor.getNumber()));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.OPEN);
 
     factor = HddsProtos.ReplicationFactor.ONE;
-    pipeline = provider.create(new RatisReplicationConfig(factor),
+    pipeline = provider.create(RatisReplicationConfig.getInstance(factor),
         createListOfNodes(factor.getNumber()));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.OPEN);
@@ -217,9 +221,11 @@ public class TestRatisPipelineProvider {
         .limit(3).collect(Collectors.toList());
 
     Pipeline pipeline1 = provider.create(
-        new RatisReplicationConfig(ReplicationFactor.THREE), healthyNodes);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+        healthyNodes);
     Pipeline pipeline2 = provider.create(
-        new RatisReplicationConfig(ReplicationFactor.THREE), healthyNodes);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
+        healthyNodes);
 
     Assert.assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
     cleanup();
@@ -242,19 +248,19 @@ public class TestRatisPipelineProvider {
     for (int i = 0; i < maxPipelinePerNode; i++) {
       // Saturate pipeline counts on all the 1st 3 DNs.
       addPipeline(dns, Pipeline.PipelineState.OPEN,
-          new RatisReplicationConfig(factor));
+          RatisReplicationConfig.getInstance(factor));
     }
     Set<DatanodeDetails> membersOfOpenPipelines = new HashSet<>(dns);
 
     // Use up next 3 DNs for a closed pipeline.
     dns = healthyNodes.subList(3, 6);
     addPipeline(dns, Pipeline.PipelineState.CLOSED,
-        new RatisReplicationConfig(factor));
+        RatisReplicationConfig.getInstance(factor));
     Set<DatanodeDetails> membersOfClosedPipelines = new HashSet<>(dns);
 
     // only 2 healthy DNs left that are not part of any pipeline
     Pipeline pipeline = provider.create(
-        new RatisReplicationConfig(factor));
+        RatisReplicationConfig.getInstance(factor));
     assertPipelineProperties(pipeline, factor, REPLICATION_TYPE,
         Pipeline.PipelineState.ALLOCATED);
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
@@ -286,7 +292,7 @@ public class TestRatisPipelineProvider {
     init(1, largeContainerConf);
     for (ReplicationFactor factor: ReplicationFactor.values()) {
       try {
-        provider.create(new RatisReplicationConfig(factor));
+        provider.create(RatisReplicationConfig.getInstance(factor));
         Assert.fail("Expected SCMException for large container size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
@@ -299,7 +305,7 @@ public class TestRatisPipelineProvider {
     init(1, largeMetadataConf);
     for (ReplicationFactor factor: ReplicationFactor.values()) {
       try {
-        provider.create(new RatisReplicationConfig(factor));
+        provider.create(RatisReplicationConfig.getInstance(factor));
         Assert.fail("Expected SCMException for large metadata size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -90,7 +90,7 @@ public class TestSimplePipelineProvider {
   public void testCreatePipelineWithFactor() throws IOException {
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
-        provider.create(new StandaloneReplicationConfig(factor));
+        provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersions.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
@@ -104,7 +104,7 @@ public class TestSimplePipelineProvider {
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
-        provider.create(new StandaloneReplicationConfig(factor));
+        provider.create(StandaloneReplicationConfig.getInstance(factor));
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersions.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
@@ -130,7 +130,7 @@ public class TestSimplePipelineProvider {
   public void testCreatePipelineWithNodes() throws IOException {
     HddsProtos.ReplicationFactor factor = HddsProtos.ReplicationFactor.THREE;
     Pipeline pipeline =
-        provider.create(new StandaloneReplicationConfig(factor),
+        provider.create(StandaloneReplicationConfig.getInstance(factor),
             createListOfNodes(factor.getNumber()));
     Assert.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
@@ -142,7 +142,7 @@ public class TestSimplePipelineProvider {
     Assert.assertEquals(pipeline.getNodes().size(), factor.getNumber());
 
     factor = HddsProtos.ReplicationFactor.ONE;
-    pipeline = provider.create(new StandaloneReplicationConfig(factor),
+    pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
         createListOfNodes(factor.getNumber()));
     Assert.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -149,15 +149,15 @@ public class TestHealthyPipelineSafeModeRule {
 
       // Create 3 pipelines
       Pipeline pipeline1 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
       pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
       pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
       pipelineManager.openPipeline(pipeline3.getId());
 
@@ -247,15 +247,15 @@ public class TestHealthyPipelineSafeModeRule {
 
       // Create 3 pipelines
       Pipeline pipeline1 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.ONE));
       pipelineManager.openPipeline(pipeline1.getId());
       Pipeline pipeline2 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
       pipelineManager.openPipeline(pipeline2.getId());
       Pipeline pipeline3 =
-          pipelineManager.createPipeline(new RatisReplicationConfig(
+          pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
       pipelineManager.openPipeline(pipeline3.getId());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestOneReplicaPipelineSafeModeRule.java
@@ -168,7 +168,7 @@ public class TestOneReplicaPipelineSafeModeRule {
             LoggerFactory.getLogger(SCMSafeModeManager.class));
 
     List<Pipeline> pipelines =
-        pipelineManager.getPipelines(new RatisReplicationConfig(
+        pipelineManager.getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE));
     firePipelineEvent(pipelines);
     GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
@@ -179,7 +179,7 @@ public class TestOneReplicaPipelineSafeModeRule {
 
     pipelines =
         pipelineManager.getPipelines(
-            new RatisReplicationConfig(ReplicationFactor.THREE));
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
 
     firePipelineEvent(pipelines.subList(0, pipelineCountThree - 1));
 
@@ -197,7 +197,7 @@ public class TestOneReplicaPipelineSafeModeRule {
       HddsProtos.ReplicationFactor factor) throws Exception {
     for (int i = 0; i < count; i++) {
       Pipeline pipeline = pipelineManager.createPipeline(
-              new RatisReplicationConfig(factor));
+              RatisReplicationConfig.getInstance(factor));
       pipelineManager.openPipeline(pipeline.getId());
 
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeManager.java
@@ -358,7 +358,7 @@ public class TestSCMSafeModeManager {
     for (int i = 0; i < pipelineCount; i++) {
       // Create pipeline
       Pipeline pipeline = pipelineManager.createPipeline(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
 
       pipelineManager.openPipeline(pipeline.getId());
@@ -610,7 +610,7 @@ public class TestSCMSafeModeManager {
           mockRatisProvider);
 
       Pipeline pipeline = pipelineManager.createPipeline(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
 
       pipeline = pipelineManager.getPipeline(pipeline.getId());
@@ -710,11 +710,11 @@ public class TestSCMSafeModeManager {
     Pipeline pipeline;
     try {
       pipeline = pipelineManager.createPipeline(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE));
     } catch (SCMException ex) {
       pipeline = pipelineManager.getPipelines(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE)).get(0);
     }
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -190,7 +190,7 @@ public class TestInfoSubCommand {
   private ContainerWithPipeline getContainerWithPipeline() {
     Pipeline pipeline = new Pipeline.Builder()
         .setState(Pipeline.PipelineState.CLOSED)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setId(PipelineID.randomId())
         .setNodes(datanodes)
         .build();
@@ -199,7 +199,7 @@ public class TestInfoSubCommand {
         .setSequenceId(1)
         .setPipelineID(pipeline.getId())
         .setUsedBytes(1234)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setNumberOfKeys(1)
         .setState(CLOSED)
         .build();

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -117,7 +117,7 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
     BlockID blockID = keyLocationInfo.getBlockID();
     if (pipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
       pipeline = Pipeline.newBuilder(pipeline)
-          .setReplicationConfig(new StandaloneReplicationConfig(
+          .setReplicationConfig(StandaloneReplicationConfig.getInstance(
               ReplicationConfig
                   .getLegacyFactor(pipeline.getReplicationConfig())))
           .build();

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -131,7 +131,7 @@ public class TestReplicatedFileChecksumHelper {
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setDataSize(0)
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setFileEncryptionInfo(null)
         .setAcls(null)
@@ -172,7 +172,8 @@ public class TestReplicatedFileChecksumHelper {
     pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.CLOSED)
         .setNodes(dns)
         .build();
@@ -213,7 +214,7 @@ public class TestReplicatedFileChecksumHelper {
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setDataSize(0)
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setFileEncryptionInfo(null)
         .setAcls(null)

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -53,7 +53,7 @@ public class TestOmKeyInfo {
         .setModificationTime(123L)
         .setDataSize(123L)
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
         .build();
@@ -83,7 +83,7 @@ public class TestOmKeyInfo {
         .setModificationTime(Time.now())
         .setDataSize(100L)
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .addMetadata("key1", "value1")
         .addMetadata("key2", "value2")
         .setOmKeyLocationInfos(

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyInfo.java
@@ -147,7 +147,7 @@ public class TestOmKeyInfo {
   Pipeline getPipeline() {
     return Pipeline.newBuilder()
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setId(PipelineID.randomId())
         .setNodes(Collections.EMPTY_LIST)
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmMultipartKeyInfo.java
@@ -38,8 +38,8 @@ public class TestOmMultipartKeyInfo {
     OmMultipartKeyInfo omMultipartKeyInfo = new OmMultipartKeyInfo.Builder()
         .setUploadID(UUID.randomUUID().toString())
         .setCreationTime(Time.now())
-        .setReplicationConfig(
-                new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE))
         .build();
 
     OmMultipartKeyInfo cloneMultipartKeyInfo = omMultipartKeyInfo.copyObject();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystem.java
@@ -580,7 +580,7 @@ public class TestOzoneFileSystem {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setAcls(Collections.emptyList())
-        .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setLocationInfoList(new ArrayList<>())
         .build();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -78,7 +78,7 @@ public class TestRatisPipelineLeader {
   @Test(timeout = 120000)
   public void testLeaderIdUsedOnFirstCall() throws Exception {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
-        .getPipelineManager().getPipelines(new RatisReplicationConfig(
+        .getPipelineManager().getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
     Assert.assertFalse(pipelines.isEmpty());
     Pipeline ratisPipeline = pipelines.iterator().next();
@@ -110,7 +110,7 @@ public class TestRatisPipelineLeader {
   @Test(timeout = 120000)
   public void testLeaderIdAfterLeaderChange() throws Exception {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
-        .getPipelineManager().getPipelines(new RatisReplicationConfig(
+        .getPipelineManager().getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
     Assert.assertFalse(pipelines.isEmpty());
     Pipeline ratisPipeline = pipelines.iterator().next();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMInstallSnapshot.java
@@ -90,11 +90,13 @@ public class TestSCMInstallSnapshot {
     PipelineManager pipelineManager = scm.getPipelineManager();
     Pipeline ratisPipeline1 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(THREE), "Owner1").getPipelineID());
+            RatisReplicationConfig.getInstance(THREE), "Owner1")
+            .getPipelineID());
     pipelineManager.openPipeline(ratisPipeline1.getId());
     Pipeline ratisPipeline2 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(ONE), "Owner2").getPipelineID());
+            RatisReplicationConfig.getInstance(ONE), "Owner2")
+            .getPipelineID());
     pipelineManager.openPipeline(ratisPipeline2.getId());
     SCMNodeDetails scmNodeDetails = new SCMNodeDetails.Builder()
         .setRpcAddress(new InetSocketAddress("0.0.0.0", 0))

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -66,11 +66,12 @@ public class TestSCMSnapshot {
     PipelineManager pipelineManager = scm.getPipelineManager();
     Pipeline ratisPipeline1 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(THREE), "Owner1").getPipelineID());
+            RatisReplicationConfig.getInstance(THREE), "Owner1")
+            .getPipelineID());
     pipelineManager.openPipeline(ratisPipeline1.getId());
     Pipeline ratisPipeline2 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(ONE), "Owner2").getPipelineID());
+            RatisReplicationConfig.getInstance(ONE), "Owner2").getPipelineID());
     pipelineManager.openPipeline(ratisPipeline2.getId());
     long snapshotInfo2 = scm.getScmHAManager().asSCMHADBTransactionBuffer()
         .getLatestTrxInfo().getTransactionIndex();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -92,7 +92,7 @@ public class TestSCMContainerManagerMetrics {
         "NumSuccessfulCreateContainers", metrics);
 
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE), OzoneConsts.OZONE);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
@@ -101,7 +101,7 @@ public class TestSCMContainerManagerMetrics {
 
     try {
       containerManager.allocateContainer(
-          new RatisReplicationConfig(
+          RatisReplicationConfig.getInstance(
               HddsProtos.ReplicationFactor.THREE), OzoneConsts.OZONE);
       fail("testContainerOpsMetrics failed");
     } catch (IOException ex) {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestLeaderChoosePolicy.java
@@ -76,7 +76,7 @@ public class TestLeaderChoosePolicy {
   private void checkLeaderBalance(int dnNum, int leaderNumOfEachDn)
       throws Exception {
     List<Pipeline> pipelines = pipelineManager
-        .getPipelines(new RatisReplicationConfig(
+        .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
 
     for (Pipeline pipeline : pipelines) {
@@ -116,7 +116,7 @@ public class TestLeaderChoosePolicy {
     waitForPipelines(pipelineNum);
     // No Factor ONE pipeline is auto created.
     Assert.assertEquals(0,
-        pipelineManager.getPipelines(new RatisReplicationConfig(
+        pipelineManager.getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
     // pipelineNum pipelines in 3 datanodes,
@@ -165,7 +165,7 @@ public class TestLeaderChoosePolicy {
     waitForPipelines(pipelineNum);
     // No Factor ONE pipeline is auto created.
     Assert.assertEquals(0, pipelineManager.getPipelines(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
     // pipelineNum pipelines in 3 datanodes,
@@ -178,7 +178,7 @@ public class TestLeaderChoosePolicy {
       // then check leader balance
 
       List<Pipeline> pipelines = pipelineManager
-          .getPipelines(new RatisReplicationConfig(
+          .getPipelines(RatisReplicationConfig.getInstance(
               ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
 
       int destroyNum = r.nextInt(pipelines.size());
@@ -210,7 +210,7 @@ public class TestLeaderChoosePolicy {
   private void waitForPipelines(int numPipelines)
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> pipelineManager
-        .getPipelines(new RatisReplicationConfig(
+        .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN)
         .size() >= numPipelines, 100, 60000);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -74,7 +74,7 @@ public class TestNode2PipelineMap {
     containerManager = scm.getContainerManager();
     pipelineManager = scm.getPipelineManager();
     ContainerInfo containerInfo = containerManager.allocateContainer(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "testOwner");
     ratisContainer = new ContainerWithPipeline(containerInfo,
         pipelineManager.getPipeline(containerInfo.getPipelineID()));

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
@@ -80,7 +80,7 @@ public class TestNodeFailure {
     final StorageContainerManager scm = cluster.getStorageContainerManager();
     pipelineManager = scm.getPipelineManager();
     ratisPipelines = pipelineManager.getPipelines(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
 
     timeForFailure = (int) ratisServerConfig

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineClose.java
@@ -100,7 +100,7 @@ public class TestPipelineClose {
     containerManager = scm.getContainerManager();
     pipelineManager = scm.getPipelineManager();
     ContainerInfo containerInfo = containerManager
-        .allocateContainer(new RatisReplicationConfig(
+        .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "testOwner");
     ratisContainer = new ContainerWithPipeline(containerInfo,
         pipelineManager.getPipeline(containerInfo.getPipelineID()));
@@ -216,7 +216,7 @@ public class TestPipelineClose {
         ArgumentCaptor.forClass(PipelineActionsFromDatanode.class);
 
     ContainerInfo containerInfo = containerManager
-        .allocateContainer(new RatisReplicationConfig(
+        .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "testOwner");
     ContainerWithPipeline containerWithPipeline =
         new ContainerWithPipeline(containerInfo,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineCreateAndDestroy.java
@@ -83,11 +83,11 @@ public class TestRatisPipelineCreateAndDestroy {
     // make sure two pipelines are created
     waitForPipelines(2);
     Assert.assertEquals(numOfDatanodes, pipelineManager.getPipelines(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
     List<Pipeline> pipelines = pipelineManager
-        .getPipelines(new RatisReplicationConfig(
+        .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
     for (Pipeline pipeline : pipelines) {
       pipelineManager.closePipeline(pipeline, false);
@@ -105,11 +105,11 @@ public class TestRatisPipelineCreateAndDestroy {
     waitForPipelines(2);
     // No Factor ONE pipeline is auto created.
     Assert.assertEquals(0, pipelineManager.getPipelines(
-        new RatisReplicationConfig(
+        RatisReplicationConfig.getInstance(
             ReplicationFactor.ONE)).size());
 
     List<Pipeline> pipelines = pipelineManager
-        .getPipelines(new RatisReplicationConfig(
+        .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN);
     for (Pipeline pipeline : pipelines) {
       pipelineManager.closePipeline(pipeline, false);
@@ -129,7 +129,7 @@ public class TestRatisPipelineCreateAndDestroy {
     List<HddsDatanodeService> dns = new ArrayList<>(cluster.getHddsDatanodes());
 
     List<Pipeline> pipelines =
-        pipelineManager.getPipelines(new RatisReplicationConfig(
+        pipelineManager.getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
     for (HddsDatanodeService dn : dns) {
       cluster.shutdownHddsDatanode(dn.getDatanodeDetails());
@@ -137,7 +137,7 @@ public class TestRatisPipelineCreateAndDestroy {
 
     // try creating another pipeline now
     try {
-      pipelineManager.createPipeline(new RatisReplicationConfig(
+      pipelineManager.createPipeline(RatisReplicationConfig.getInstance(
           ReplicationFactor.THREE));
       Assert.fail("pipeline creation should fail after shutting down pipeline");
     } catch (IOException ioe) {
@@ -173,7 +173,7 @@ public class TestRatisPipelineCreateAndDestroy {
   private void waitForPipelines(int numPipelines)
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> pipelineManager
-        .getPipelines(new RatisReplicationConfig(
+        .getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), Pipeline.PipelineState.OPEN)
         .size() >= numPipelines, 100, 60000);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -82,12 +82,12 @@ public class TestSCMRestart {
     pipelineManager = scm.getPipelineManager();
     ratisPipeline1 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(
+            RatisReplicationConfig.getInstance(
                 ReplicationFactor.THREE), "Owner1").getPipelineID());
     pipelineManager.openPipeline(ratisPipeline1.getId());
     ratisPipeline2 = pipelineManager.getPipeline(
         containerManager.allocateContainer(
-            new RatisReplicationConfig(
+            RatisReplicationConfig.getInstance(
                 ReplicationFactor.ONE), "Owner2").getPipelineID());
     pipelineManager.openPipeline(ratisPipeline2.getId());
     // At this stage, there should be 2 pipeline one with 1 open container
@@ -124,7 +124,7 @@ public class TestSCMRestart {
     // Try creating a new container, it should be from the same pipeline
     // as was before restart
     ContainerInfo containerInfo = newContainerManager
-        .allocateContainer(new RatisReplicationConfig(
+        .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "Owner1");
     Assert.assertEquals(containerInfo.getPipelineID(), ratisPipeline1.getId());
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestSCMSafeModeWithPipelineRules.java
@@ -99,7 +99,7 @@ public class TestSCMSafeModeWithPipelineRules {
 
     pipelineManager = cluster.getStorageContainerManager().getPipelineManager();
     List<Pipeline> pipelineList =
-        pipelineManager.getPipelines(new RatisReplicationConfig(
+        pipelineManager.getPipelines(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE));
 
 
@@ -193,7 +193,8 @@ public class TestSCMSafeModeWithPipelineRules {
   private void waitForRatis3NodePipelines(int numPipelines)
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.THREE),
+        .getPipelines(RatisReplicationConfig
+                .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
         .size() == numPipelines, 100, 60000);
   }
@@ -201,7 +202,7 @@ public class TestSCMSafeModeWithPipelineRules {
   private void waitForRatis1NodePipelines(int numPipelines)
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> pipelineManager
-        .getPipelines(new RatisReplicationConfig(ReplicationFactor.ONE),
+        .getPipelines(RatisReplicationConfig.getInstance(ReplicationFactor.ONE),
             Pipeline.PipelineState.OPEN)
         .size() == numPipelines, 100, 60000);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -238,7 +238,7 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> {
       int openPipelineCount = scm.getPipelineManager().
-          getPipelines(new RatisReplicationConfig(factor),
+          getPipelines(RatisReplicationConfig.getInstance(factor),
               Pipeline.PipelineState.OPEN).size();
       return openPipelineCount >= 1;
     }, 1000, timeoutInMs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -126,7 +126,7 @@ public class TestMiniOzoneCluster {
       Pipeline pipeline = Pipeline.newBuilder()
           .setState(Pipeline.PipelineState.OPEN)
           .setId(PipelineID.randomId())
-          .setReplicationConfig(new StandaloneReplicationConfig(
+          .setReplicationConfig(StandaloneReplicationConfig.getInstance(
               ReplicationFactor.ONE))
           .setNodes(dns)
           .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestBCSID.java
@@ -131,7 +131,8 @@ public class TestBCSID {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName).
         setBucketName(bucketName)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setKeyName("ratis")
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -177,7 +177,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestCloseContainerHandlingByClient.java
@@ -143,7 +143,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(ONE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -212,7 +212,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(ONE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -273,7 +273,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -318,7 +318,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -381,7 +381,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName).
         setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -416,7 +416,7 @@ public class TestCloseContainerHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(ONE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailureOnRead.java
@@ -141,7 +141,7 @@ public class TestContainerStateMachineFailureOnRead {
     // Stop one follower datanode
     List<Pipeline> pipelines =
         cluster.getStorageContainerManager().getPipelineManager()
-            .getPipelines(new RatisReplicationConfig(
+            .getPipelines(RatisReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.THREE));
     Assert.assertEquals(1, pipelines.size());
     Pipeline ratisPipeline = pipelines.iterator().next();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestDeleteWithSlowFollower.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.ratis.conf.RatisClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
@@ -66,6 +65,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_SCM_WATCHER_TIMEOUT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_CREATION_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_DESTROY_TIMEOUT;
@@ -165,7 +165,7 @@ public class TestDeleteWithSlowFollower {
             .setHbInterval(100)
             .build();
     cluster.waitForClusterToBeReady();
-    cluster.waitForPipelineTobeReady(HddsProtos.ReplicationFactor.THREE, 60000);
+    cluster.waitForPipelineTobeReady(THREE, 60000);
     //the easiest way to create an open container is creating a key
     client = OzoneClientFactory.getRpcClient(conf);
     objectStore = client.getObjectStore();
@@ -224,8 +224,7 @@ public class TestDeleteWithSlowFollower {
 
     List<Pipeline> pipelineList =
         cluster.getStorageContainerManager().getPipelineManager()
-            .getPipelines(new RatisReplicationConfig(
-                HddsProtos.ReplicationFactor.THREE));
+            .getPipelines(RatisReplicationConfig.getInstance(THREE));
     Assume.assumeTrue(pipelineList.size() >= FACTOR_THREE_PIPELINE_COUNT);
     Pipeline pipeline = pipelineList.get(0);
     for (HddsDatanodeService dn : cluster.getHddsDatanodes()) {
@@ -261,7 +260,8 @@ public class TestDeleteWithSlowFollower {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName).
         setBucketName(bucketName)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(THREE))
         .setKeyName(keyName)
         .build();
     OmKeyInfo info = cluster.getOzoneManager().lookupKey(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClient.java
@@ -200,7 +200,7 @@ public class TestFailureHandlingByClient {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -343,7 +343,7 @@ public class TestFailureHandlingByClient {
     // will be discarded and write a new block
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -405,7 +405,7 @@ public class TestFailureHandlingByClient {
     key.close();
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -470,7 +470,7 @@ public class TestFailureHandlingByClient {
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -534,7 +534,7 @@ public class TestFailureHandlingByClient {
 
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestFailureHandlingByClientFlushDelay.java
@@ -214,7 +214,8 @@ public class TestFailureHandlingByClientFlushDelay {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestMultiBlockWritesWithDnFailures.java
@@ -178,7 +178,8 @@ public class TestMultiBlockWritesWithDnFailures {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();
@@ -230,7 +231,8 @@ public class TestMultiBlockWritesWithDnFailures {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setKeyName(keyName)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestKeyInputStream.java
@@ -353,7 +353,7 @@ public class TestKeyInputStream extends TestInputStreamBase {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(getVolumeName())
         .setBucketName(getBucketName())
         .setKeyName(keyName)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .build();
     OmKeyInfo keyInfo = getCluster().getOzoneManager().lookupKey(keyArgs);
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -162,7 +162,7 @@ public class TestContainerReplication {
         .setVolumeName(VOLUME)
         .setBucketName(BUCKET)
         .setKeyName(KEY)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .build();
     OmKeyInfo keyInfo = cluster.getOzoneManager().lookupKey(keyArgs);
     OmKeyLocationInfoGroup locations = keyInfo.getLatestVersionLocations();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -199,7 +199,8 @@ public class TestBlockDeletion {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setRefreshPipeline(true)
         .build();
     List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
@@ -311,7 +312,8 @@ public class TestBlockDeletion {
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName).setKeyName(keyName).setDataSize(0)
         .setReplicationConfig(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setRefreshPipeline(true)
         .build();
     List<OmKeyLocationInfoGroup> omKeyLocationInfoGroupList =
@@ -507,7 +509,8 @@ public class TestBlockDeletion {
       OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
           .setBucketName(bucketName).setKeyName(keys.get(j)).setDataSize(0)
           .setReplicationConfig(
-              new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+              RatisReplicationConfig
+                  .getInstance(HddsProtos.ReplicationFactor.THREE))
           .setRefreshPipeline(true)
           .build();
       writeClient.deleteKey(keyArgs);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerByPipeline.java
@@ -117,7 +117,7 @@ public class TestCloseContainerByPipeline {
     //get the name of a valid container
     OmKeyArgs keyArgs =
         new OmKeyArgs.Builder().setVolumeName("test").setBucketName("test")
-            .setReplicationConfig(new RatisReplicationConfig(ONE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName(keyName).setRefreshPipeline(true).build();
     OmKeyLocationInfo omKeyLocationInfo =
@@ -174,7 +174,7 @@ public class TestCloseContainerByPipeline {
     //get the name of a valid container
     OmKeyArgs keyArgs =
         new OmKeyArgs.Builder().setVolumeName("test").setBucketName("test")
-            .setReplicationConfig(new RatisReplicationConfig(ONE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName("standalone")
             .setRefreshPipeline(true)
@@ -233,7 +233,7 @@ public class TestCloseContainerByPipeline {
     //get the name of a valid container
     OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName("test").
         setBucketName("test")
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setDataSize(1024)
         .setKeyName("ratis").setRefreshPipeline(true).build();
 
@@ -297,7 +297,7 @@ public class TestCloseContainerByPipeline {
 
     OmKeyArgs keyArgs =
         new OmKeyArgs.Builder().setVolumeName("test").setBucketName("test")
-            .setReplicationConfig(new RatisReplicationConfig(ONE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName(keyName)
             .setRefreshPipeline(true)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestCloseContainerHandler.java
@@ -106,7 +106,7 @@ public class TestCloseContainerHandler {
     //get the name of a valid container
     OmKeyArgs keyArgs =
         new OmKeyArgs.Builder().setVolumeName("test").setBucketName("test")
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setDataSize(1024)
             .setKeyName("test")
             .setRefreshPipeline(true)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestDeleteContainerHandler.java
@@ -260,7 +260,7 @@ public class TestDeleteContainerHandler {
     OmKeyArgs keyArgs =
         new OmKeyArgs.Builder().setVolumeName(volumeName)
             .setBucketName(bucketName)
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setKeyName(keyName)
             .setRefreshPipeline(true)
             .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestContainerReportWithKeys.java
@@ -120,7 +120,8 @@ public class TestContainerReportWithKeys {
         .setBucketName(bucketName)
         .setKeyName(keyName)
         .setReplicationConfig(
-            new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+            StandaloneReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setDataSize(keySize)
         .setRefreshPipeline(true)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -1514,7 +1514,7 @@ public class TestKeyManagerImpl {
         .setBucketName(bucketName)
         .setDataSize(0)
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ONE))
+            StandaloneReplicationConfig.getInstance(ONE))
         .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
             ALL, ALL))
         .setVolumeName(VOLUME_NAME);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerImpl.java
@@ -322,7 +322,7 @@ public class TestKeyManagerImpl {
     OmKeyArgs keyArgs = createBuilder()
         .setKeyName(KEY_NAME)
         .setDataSize(1000)
-        .setReplicationConfig(new RatisReplicationConfig(THREE))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
         .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),
             ALL, ALL))
         .build();
@@ -791,7 +791,7 @@ public class TestKeyManagerImpl {
     Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
     // create a pipeline using 3 datanodes
     Pipeline pipeline = scm.getPipelineManager().createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE), nodeList);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
@@ -877,7 +877,7 @@ public class TestKeyManagerImpl {
     Assume.assumeFalse(nodeList.get(0).equals(nodeList.get(2)));
     // create a pipeline using 3 datanodes
     Pipeline pipeline = scm.getPipelineManager().createPipeline(
-        new RatisReplicationConfig(ReplicationFactor.THREE), nodeList);
+        RatisReplicationConfig.getInstance(ReplicationFactor.THREE), nodeList);
     List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
     List<OmKeyLocationInfo> locationList =
         keySession.getKeyInfo().getLatestVersionLocations().getLocationList();
@@ -1391,7 +1391,7 @@ public class TestKeyManagerImpl {
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setNodes(new ArrayList<>())
         .build();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -108,7 +108,7 @@ public class TestOmBlockVersioning {
         .setDataSize(1000)
         .setRefreshPipeline(true)
         .setAcls(new ArrayList<>())
-        .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .build();
 
     // 1st update, version 0

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconAsPassiveScm.java
@@ -115,7 +115,7 @@ public class TestReconAsPassiveScm {
     LambdaTestUtils.intercept(UnsupportedOperationException.class,
         "Trying to create pipeline in Recon, which is prohibited!",
         () -> reconPipelineManager
-            .createPipeline(new RatisReplicationConfig(ONE)));
+            .createPipeline(RatisReplicationConfig.getInstance(ONE)));
 
     ContainerManager scmContainerManager = scm.getContainerManager();
     assertTrue(scmContainerManager.getContainers().isEmpty());
@@ -130,7 +130,7 @@ public class TestReconAsPassiveScm {
     ContainerManager reconContainerManager = reconScm.getContainerManager();
     ContainerInfo containerInfo =
         scmContainerManager
-            .allocateContainer(new RatisReplicationConfig(ONE), "test");
+            .allocateContainer(RatisReplicationConfig.getInstance(ONE), "test");
     long containerID = containerInfo.getContainerID();
     Pipeline pipeline =
         scmPipelineManager.getPipeline(containerInfo.getPipelineID());
@@ -171,7 +171,7 @@ public class TestReconAsPassiveScm {
     // Create container in SCM.
     ContainerInfo containerInfo =
         scmContainerManager
-            .allocateContainer(new RatisReplicationConfig(ONE), "test");
+            .allocateContainer(RatisReplicationConfig.getInstance(ONE), "test");
     long containerID = containerInfo.getContainerID();
     PipelineManager scmPipelineManager = scm.getPipelineManager();
     Pipeline pipeline =
@@ -182,7 +182,7 @@ public class TestReconAsPassiveScm {
 
     // Close a pipeline
     Optional<Pipeline> pipelineToClose = scmPipelineManager
-        .getPipelines(new RatisReplicationConfig(ONE))
+        .getPipelines(RatisReplicationConfig.getInstance(ONE))
         .stream()
         .filter(p -> !p.getId().equals(containerInfo.getPipelineID()))
         .findFirst();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconScmSnapshot.java
@@ -92,7 +92,7 @@ public class TestReconScmSnapshot {
         .getContainerManager();
 
     for (int i = 0; i < 10; i++) {
-      containerManager.allocateContainer(new RatisReplicationConfig(
+      containerManager.allocateContainer(RatisReplicationConfig.getInstance(
           HddsProtos.ReplicationFactor.ONE), "testOwner");
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconTasks.java
@@ -107,7 +107,7 @@ public class TestReconTasks {
         (ReconContainerManager) reconScm.getContainerManager();
     ContainerInfo containerInfo =
         scmContainerManager
-            .allocateContainer(new RatisReplicationConfig(ONE), "test");
+            .allocateContainer(RatisReplicationConfig.getInstance(ONE), "test");
     long containerID = containerInfo.getContainerID();
     Pipeline pipeline =
         scmPipelineManager.getPipeline(containerInfo.getPipelineID());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/recon/TestReconWithOzoneManager.java
@@ -405,7 +405,7 @@ public class TestReconWithOzoneManager {
             .setBucketName(bucket)
             .setVolumeName(volume)
             .setKeyName(key)
-            .setReplicationConfig(new StandaloneReplicationConfig(
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE))
             .setOmKeyLocationInfos(omKeyLocationInfoGroupList)
             .build());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMInstallSnapshotWithHA.java
@@ -291,7 +291,7 @@ public class TestSCMInstallSnapshotWithHA {
     while (logIndex <= targetLogIndex) {
       containers.add(scm.getContainerManager()
           .allocateContainer(
-              new RatisReplicationConfig(ReplicationFactor.THREE),
+              RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
               TestSCMInstallSnapshotWithHA.class.getName()));
       Thread.sleep(100);
       logIndex = stateMachine.getLastAppliedTermIndex().getIndex();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
@@ -153,8 +153,8 @@ public class TestSCMMXBean {
     List<ContainerInfo> containerInfoList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       containerInfoList.add(
-          scmContainerManager.allocateContainer(new StandaloneReplicationConfig(
-                  ReplicationFactor.ONE),
+          scmContainerManager.allocateContainer(
+              StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE),
               UUID.randomUUID().toString()));
     }
     long containerID;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -170,7 +170,7 @@ public class TestStorageContainerManagerHA {
     is.close();
     final OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volumeName)
         .setBucketName(bucketName)
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setKeyName(keyName)
         .setRefreshPipeline(true).build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -68,7 +68,7 @@ public class TestXceiverClientGrpc {
     pipeline = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.CLOSED)
         .setNodes(dns)
         .build();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -109,7 +109,7 @@ public class TestSCMPipelineMetrics {
     AllocatedBlock block =
         cluster.getStorageContainerManager().getScmBlockManager()
             .allocateBlock(5,
-                new RatisReplicationConfig(ReplicationFactor.ONE),
+                RatisReplicationConfig.getInstance(ReplicationFactor.ONE),
                 "Test", new ExcludeList());
     MetricsRecordBuilder metrics =
         getMetrics(SCMPipelineMetrics.class.getSimpleName());

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestOmKeyInfoCodec.java
@@ -64,8 +64,8 @@ public class TestOmKeyInfoCodec {
     return new OmKeyInfo.Builder()
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
-        .setReplicationConfig(
-                new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setVolumeName(VOLUME)
         .setBucketName(BUCKET)
         .setKeyName(KEYNAME)

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestOmMultipartKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestOmMultipartKeyInfoCodec.java
@@ -42,7 +42,8 @@ public class TestOmMultipartKeyInfoCodec {
         .setUploadID(UUID.randomUUID().toString())
         .setCreationTime(Time.now())
         .setReplicationConfig(
-                new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+                RatisReplicationConfig.getInstance(
+                    HddsProtos.ReplicationFactor.THREE))
         .build();
 
     byte[] data = new byte[0];

--- a/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestRepeatedOmKeyInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/test/java/org/apache/hadoop/ozone/om/codec/TestRepeatedOmKeyInfoCodec.java
@@ -70,7 +70,8 @@ public class TestRepeatedOmKeyInfoCodec {
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setReplicationConfig(
-                new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE))
+                RatisReplicationConfig
+                    .getInstance(HddsProtos.ReplicationFactor.THREE))
         .setVolumeName(VOLUME)
         .setBucketName(BUCKET)
         .setKeyName(KEYNAME)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1350,7 +1350,8 @@ public class KeyManagerImpl implements KeyManager {
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
         .setDataSize(0)
-        .setReplicationConfig(new RatisReplicationConfig(ReplicationFactor.ONE))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE))
         .setFileEncryptionInfo(encInfo)
         .setAcls(acls)
         .build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -730,8 +730,8 @@ public final class OMFileRequest {
     builder.setObjectID(dirInfo.getObjectID());
     builder.setUpdateID(dirInfo.getUpdateID());
     builder.setFileName(dirInfo.getName());
-    builder.setReplicationConfig(new RatisReplicationConfig(
-            HddsProtos.ReplicationFactor.ONE));
+    builder.setReplicationConfig(RatisReplicationConfig
+        .getInstance(HddsProtos.ReplicationFactor.ONE));
     builder.setOmKeyLocationInfos(Collections.singletonList(
             new OmKeyLocationInfoGroup(0, new ArrayList<>())));
     return builder.build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -137,7 +137,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setNodes(dns)
         .build();
     return pipeline;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestBucketManagerImpl.java
@@ -361,16 +361,16 @@ public class TestBucketManagerImpl {
             .setBucketName("bucketOne")
             .setVolumeName("sampleVol")
             .setKeyName("key_one")
-            .setReplicationConfig(
-                    new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            .setReplicationConfig(StandaloneReplicationConfig
+                .getInstance(ReplicationFactor.ONE))
             .build());
     metaMgr.getKeyTable(getBucketLayout()).put("/sampleVol/bucketOne/key_two",
         new OmKeyInfo.Builder()
             .setBucketName("bucketOne")
             .setVolumeName("sampleVol")
             .setKeyName("key_two")
-            .setReplicationConfig(
-                        new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            .setReplicationConfig(StandaloneReplicationConfig
+                .getInstance(ReplicationFactor.ONE))
             .build());
     try {
       bucketManager.deleteBucket("sampleVol", "bucketOne");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyDeletingService.java
@@ -234,7 +234,7 @@ public class TestKeyDeletingService {
               .setBucketName(bucketName)
               .setKeyName(keyName)
               .setAcls(Collections.emptyList())
-              .setReplicationConfig(new StandaloneReplicationConfig(
+              .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                   HddsProtos.ReplicationFactor.ONE))
               .setLocationInfoList(new ArrayList<>())
               .build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestKeyManagerUnit.java
@@ -303,7 +303,7 @@ public class TestKeyManagerUnit {
         .setBucketName(bucket)
         .setKeyName(key)
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setAcls(new ArrayList<>())
         .build();
     OmMultipartInfo omMultipartInfo = omtest.initiateMultipartUpload(key1);
@@ -319,7 +319,7 @@ public class TestKeyManagerUnit {
         .setUploadID(uploadID)
         .setCreationTime(Time.now())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setPartKeyInfoList(partKeyInfoMap)
         .build();
 
@@ -351,7 +351,7 @@ public class TestKeyManagerUnit {
     final Pipeline pipelineOne = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.OPEN)
         .setLeaderId(dnOne.getUuid())
         .setNodes(Arrays.asList(dnOne, dnTwo, dnThree))
@@ -360,7 +360,7 @@ public class TestKeyManagerUnit {
     final Pipeline pipelineTwo = Pipeline.newBuilder()
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(Pipeline.PipelineState.OPEN)
         .setLeaderId(dnFour.getUuid())
         .setNodes(Arrays.asList(dnFour, dnFive, dnSix))
@@ -408,7 +408,7 @@ public class TestKeyManagerUnit {
         .setModificationTime(Time.now())
         .setDataSize(256000)
         .setReplicationConfig(
-                    new RatisReplicationConfig(ReplicationFactor.THREE))
+                    RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
             .setAcls(Collections.emptyList())
         .build();
     OMRequestTestUtils.addKeyToOM(metadataManager, keyInfo);
@@ -477,8 +477,8 @@ public class TestKeyManagerUnit {
           .setCreationTime(Time.now())
           .setOmKeyLocationInfos(singletonList(
               new OmKeyLocationInfoGroup(0, new ArrayList<>())))
-          .setReplicationConfig(
-                      new RatisReplicationConfig(ReplicationFactor.THREE))
+          .setReplicationConfig(RatisReplicationConfig
+              .getInstance(ReplicationFactor.THREE))
           .setKeyName(keyPrefix + i)
           .setObjectID(i)
           .setUpdateID(i)

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestTrashService.java
@@ -121,8 +121,8 @@ public class TestTrashService {
         .setKeyName(keyName)
         .setAcls(Collections.emptyList())
         .setLocationInfoList(new ArrayList<>())
-        .setReplicationConfig(
-            new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+        .setReplicationConfig(StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.ONE))
         .build();
 
     /* Create and delete key in the Key Manager. */

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -159,7 +159,7 @@ public class TestOMKeyRequest {
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setNodes(new ArrayList<>())
         .build();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -95,7 +95,8 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
     Pipeline pipeline = Pipeline.newBuilder()
         .setState(Pipeline.PipelineState.OPEN)
         .setId(PipelineID.randomId())
-        .setReplicationConfig(new RatisReplicationConfig(replicationFactor))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(replicationFactor))
         .setNodes(new ArrayList<>())
         .build();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -92,7 +92,7 @@ public class TestS3MultipartResponse {
     OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
         .setUploadID(multipartUploadID)
         .setCreationTime(Time.now())
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .build();
 
@@ -102,7 +102,7 @@ public class TestS3MultipartResponse {
         .setKeyName(keyName)
         .setCreationTime(Time.now())
         .setModificationTime(Time.now())
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setOmKeyLocationInfos(Collections.singletonList(
             new OmKeyLocationInfoGroup(0, new ArrayList<>())))
@@ -183,7 +183,7 @@ public class TestS3MultipartResponse {
     OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
             .setUploadID(multipartUploadID)
             .setCreationTime(Time.now())
-            .setReplicationConfig(new RatisReplicationConfig(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                     HddsProtos.ReplicationFactor.ONE))
             .setParentID(parentID)
             .build();
@@ -197,7 +197,7 @@ public class TestS3MultipartResponse {
             .setFileName(fileName)
             .setCreationTime(Time.now())
             .setModificationTime(Time.now())
-            .setReplicationConfig(new RatisReplicationConfig(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                     HddsProtos.ReplicationFactor.ONE))
             .setOmKeyLocationInfos(Collections.singletonList(
                     new OmKeyLocationInfoGroup(0, new ArrayList<>())))
@@ -234,7 +234,7 @@ public class TestS3MultipartResponse {
       multipartKeyInfo = new OmMultipartKeyInfo.Builder()
               .setUploadID(multipartUploadID)
               .setCreationTime(Time.now())
-              .setReplicationConfig(new RatisReplicationConfig(
+              .setReplicationConfig(RatisReplicationConfig.getInstance(
                       HddsProtos.ReplicationFactor.ONE))
               .setParentID(parentID)
               .build();
@@ -257,7 +257,7 @@ public class TestS3MultipartResponse {
             .setFileName(fileName)
             .setCreationTime(Time.now())
             .setModificationTime(Time.now())
-            .setReplicationConfig(new RatisReplicationConfig(
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
                     HddsProtos.ReplicationFactor.ONE))
             .setOmKeyLocationInfos(Collections.singletonList(
                     new OmKeyLocationInfoGroup(0, new ArrayList<>())))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -172,8 +172,8 @@ public class TestOzoneNativeAuthorizer {
         .setVolumeName(volume)
         .setBucketName(bucket)
         .setKeyName(keyName)
-        .setReplicationConfig(
-            new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+        .setReplicationConfig(StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setDataSize(0)
         .setAcls(OzoneAclUtil.getAclList(testUgi.getUserName(),
             testUgi.getGroupNames(), ALL, ALL))

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -386,7 +386,7 @@ public class TestParentAcl {
         .setVolumeName(volume)
         .setBucketName(bucket)
         .setKeyName(keyName)
-        .setReplicationConfig(new StandaloneReplicationConfig(
+        .setReplicationConfig(StandaloneReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.ONE))
         .setDataSize(0)
         // here we give test ugi full access

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -134,7 +134,7 @@ public class TestVolumeOwner {
               .setBucketName(getTestBucketName(j))
               .setKeyName(getTestKeyName(k))
               .setReplicationConfig(
-                  new StandaloneReplicationConfig(
+                  StandaloneReplicationConfig.getInstance(
                       HddsProtos.ReplicationFactor.ONE))
               .setDataSize(0);
           if (k == 0) {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/OMMetadataManagerTestUtils.java
@@ -154,7 +154,7 @@ public final class OMMetadataManagerTestUtils {
             .setBucketName("bucketOne")
             .setVolumeName("sampleVol")
             .setKeyName(key)
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .build());
   }
 
@@ -178,7 +178,7 @@ public final class OMMetadataManagerTestUtils {
             .setBucketName(bucket)
             .setVolumeName(volume)
             .setKeyName(key)
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setOmKeyLocationInfos(omKeyLocationInfoGroupList)
             .build());
   }
@@ -204,7 +204,8 @@ public final class OMMetadataManagerTestUtils {
                     .setBucketName(bucket)
                     .setVolumeName(volume)
                     .setKeyName(key)
-                    .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+                    .setReplicationConfig(
+                        StandaloneReplicationConfig.getInstance(ONE))
                     .setObjectID(objectID)
                     .setParentObjectID(parentObjectId)
                     .setDataSize(dataSize)
@@ -228,7 +229,8 @@ public final class OMMetadataManagerTestUtils {
                     .setVolumeName(volName)
                     .setKeyName(keyName)
                     .setOmKeyLocationInfos(locationVersions)
-                    .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+                    .setReplicationConfig(
+                        StandaloneReplicationConfig.getInstance(ONE))
                     .setObjectID(objectId)
                     .setParentObjectID(parentObjectId)
                     .build());
@@ -299,7 +301,7 @@ public final class OMMetadataManagerTestUtils {
    */
   public static Pipeline getRandomPipeline(DatanodeDetails datanodeDetails) {
     return Pipeline.newBuilder()
-       .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+       .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
         .setId(PipelineID.randomId())
         .setNodes(Collections.singletonList(datanodeDetails))
         .setState(Pipeline.PipelineState.OPEN)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestContainerEndpoint.java
@@ -469,7 +469,7 @@ public class TestContainerEndpoint {
     return new ContainerInfo.Builder()
         .setContainerID(containerId)
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setOwner("owner1")
         .setNumberOfKeys(keyCount)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestEndpoints.java
@@ -167,7 +167,8 @@ public class TestEndpoints extends AbstractReconSqlDBTest {
 
     ContainerInfo containerInfo = new ContainerInfo.Builder()
         .setContainerID(containerId)
-        .setReplicationConfig(new RatisReplicationConfig(ReplicationFactor.ONE))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE))
         .setState(LifeCycleState.OPEN)
         .setOwner("test")
         .setPipelineID(pipeline.getId())

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/TestOpenContainerCount.java
@@ -144,7 +144,7 @@ public class TestOpenContainerCount {
       ContainerInfo containerInfo = new ContainerInfo.Builder()
               .setContainerID(i)
               .setReplicationConfig(
-                      new RatisReplicationConfig(ReplicationFactor.ONE))
+                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
               .setState(LifeCycleState.OPEN)
               .setOwner("test")
               .setPipelineID(pipeline.getId())
@@ -162,7 +162,7 @@ public class TestOpenContainerCount {
       ContainerInfo containerInfo = new ContainerInfo.Builder()
               .setContainerID(i)
               .setReplicationConfig(
-                      new RatisReplicationConfig(ReplicationFactor.ONE))
+                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
               .setState(LifeCycleState.OPEN)
               .setOwner("test")
               .setPipelineID(pipeline2.getId())
@@ -365,7 +365,7 @@ public class TestOpenContainerCount {
       ContainerInfo closedContainer = new ContainerInfo.Builder()
               .setContainerID(containerID)
               .setReplicationConfig(
-                      new RatisReplicationConfig(ReplicationFactor.ONE))
+                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
               .setState(LifeCycleState.CLOSED)
               .setOwner("test")
               .setPipelineID(pipeline.getId())
@@ -379,7 +379,7 @@ public class TestOpenContainerCount {
       ContainerInfo closedContainer = new ContainerInfo.Builder()
               .setContainerID(containerID)
               .setReplicationConfig(
-                      new RatisReplicationConfig(ReplicationFactor.ONE))
+                      RatisReplicationConfig.getInstance(ReplicationFactor.ONE))
               .setState(LifeCycleState.CLOSED)
               .setOwner("test")
               .setPipelineID(pipeline2.getId())

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthStatus.java
@@ -52,8 +52,8 @@ public class TestContainerHealthStatus {
     placementPolicy = mock(PlacementPolicy.class);
     container = mock(ContainerInfo.class);
     when(container.getReplicationConfig())
-        .thenReturn(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+        .thenReturn(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE));
     when(container.containerID()).thenReturn(ContainerID.valueOf(123456));
     when(container.getContainerID()).thenReturn((long)123456);
     when(placementPolicy.validateContainerPlacement(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -317,7 +317,7 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
       ContainerInfo c = mock(ContainerInfo.class);
       when(c.getContainerID()).thenReturn((long)i);
       when(c.getReplicationConfig())
-          .thenReturn(new RatisReplicationConfig(
+          .thenReturn(RatisReplicationConfig.getInstance(
               HddsProtos.ReplicationFactor.THREE));
       when(c.containerID()).thenReturn(ContainerID.valueOf(i));
       containers.add(c);
@@ -329,8 +329,8 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
     ContainerInfo c = mock(ContainerInfo.class);
     when(c.getContainerID()).thenReturn((long)containerID);
     when(c.getReplicationConfig())
-        .thenReturn(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+        .thenReturn(RatisReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.THREE));
     when(c.containerID()).thenReturn(ContainerID.valueOf(containerID));
     when(c.getState()).thenReturn(HddsProtos.LifeCycleState.DELETED);
     return c;

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTaskRecordGenerator.java
@@ -60,7 +60,8 @@ public class TestContainerHealthTaskRecordGenerator {
     container = mock(ContainerInfo.class);
     when(container.getReplicationConfig())
         .thenReturn(
-            new RatisReplicationConfig(HddsProtos.ReplicationFactor.THREE));
+            RatisReplicationConfig
+                .getInstance(HddsProtos.ReplicationFactor.THREE));
     when(container.containerID()).thenReturn(ContainerID.valueOf(123456));
     when(container.getContainerID()).thenReturn((long)123456);
     when(placementPolicy.validateContainerPlacement(

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -172,7 +172,7 @@ public class TestReconOmMetadataManagerImpl {
             .setBucketName("bucketOne")
             .setVolumeName("sampleVol")
             .setKeyName("key_one")
-            .setReplicationConfig(new StandaloneReplicationConfig(
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE))
             .build());
     omMetadataManager.getKeyTable(getBucketLayout()).put(
@@ -180,7 +180,7 @@ public class TestReconOmMetadataManagerImpl {
             .setBucketName("bucketOne")
             .setVolumeName("sampleVol")
             .setKeyName("key_two")
-            .setReplicationConfig(new StandaloneReplicationConfig(
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(
                 HddsProtos.ReplicationFactor.ONE))
             .build());
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/AbstractReconContainerManagerTest.java
@@ -154,7 +154,7 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setOwner("test")
             .setState(OPEN)
             .build();
@@ -174,7 +174,8 @@ public class AbstractReconContainerManagerTest {
               .setContainerID(cID.getId())
               .setNumberOfKeys(10)
               .setPipelineID(pipeline.getId())
-              .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+              .setReplicationConfig(
+                  StandaloneReplicationConfig.getInstance(ONE))
               .setOwner("test")
               //add containers in all kinds of state
               .setState(stateTypes[i % stateTypeCount])
@@ -208,7 +209,7 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setOwner("test")
             .setState(state)
             .build();
@@ -226,7 +227,7 @@ public class AbstractReconContainerManagerTest {
             .setContainerID(containerID.getId())
             .setNumberOfKeys(10)
             .setPipelineID(pipeline.getId())
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE))
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
             .setOwner("test")
             .setState(state)
             .build();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconContainerManager.java
@@ -185,7 +185,7 @@ public class TestReconContainerManager
   ContainerInfo newContainerInfo(long containerId, Pipeline pipeline) {
     return new ContainerInfo.Builder()
         .setContainerID(containerId)
-        .setReplicationConfig(new RatisReplicationConfig(
+        .setReplicationConfig(RatisReplicationConfig.getInstance(
             HddsProtos.ReplicationFactor.THREE))
         .setState(HddsProtos.LifeCycleState.OPEN)
         .setOwner("owner2")

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/scm/TestReconPipelineManager.java
@@ -109,7 +109,7 @@ public class TestReconPipelineManager {
     // Valid pipeline in Allocated state.
     Pipeline validPipeline = Pipeline.newBuilder()
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setId(pipelinesFromScm.get(0).getId())
         .setNodes(pipelinesFromScm.get(0).getNodes())
         .setState(Pipeline.PipelineState.ALLOCATED)
@@ -119,7 +119,7 @@ public class TestReconPipelineManager {
     // Invalid pipeline.
     Pipeline invalidPipeline = Pipeline.newBuilder()
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.ONE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.ONE))
         .setId(PipelineID.randomId())
         .setNodes(Collections.singletonList(randomDatanodeDetails()))
         .setState(Pipeline.PipelineState.CLOSED)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestContainerKeyMapperTask.java
@@ -275,8 +275,8 @@ public class TestContainerKeyMapperTask {
         .setBucketName(bucket)
         .setVolumeName(volume)
         .setKeyName(key)
-        .setReplicationConfig(
-            new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+        .setReplicationConfig(StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setOmKeyLocationInfos(Collections.singletonList(
             omKeyLocationInfoGroup))
         .build();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -417,7 +417,7 @@ public class TestNSSummaryTask {
             .setKeyName(key)
             .setFileName(fileName)
             .setReplicationConfig(
-                    new StandaloneReplicationConfig(
+                    StandaloneReplicationConfig.getInstance(
                             HddsProtos.ReplicationFactor.ONE))
             .setObjectID(objectID)
             .setParentObjectID(parentObjectId)
@@ -447,7 +447,7 @@ public class TestNSSummaryTask {
             .setKeyName(key)
             .setFileName(fileName)
             .setReplicationConfig(
-                    new StandaloneReplicationConfig(
+                    StandaloneReplicationConfig.getInstance(
                             HddsProtos.ReplicationFactor.ONE))
             .setObjectID(objectID)
             .setParentObjectID(parentObjectId)

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -267,8 +267,8 @@ public class TestOMDBUpdatesHandler {
         .setVolumeName(volumeName)
         .setBucketName(bucketName)
         .setKeyName(keyName)
-        .setReplicationConfig(
-            new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE))
+        .setReplicationConfig(StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.ONE))
         .setDataSize(random.nextLong())
         .build();
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -79,7 +79,8 @@ public class OzoneBucketStub extends OzoneBucket {
       long creationTime) {
     super(volumeName,
         bucketName,
-        new StandaloneReplicationConfig(HddsProtos.ReplicationFactor.ONE),
+        StandaloneReplicationConfig
+            .getInstance(HddsProtos.ReplicationFactor.ONE),
         storageType,
         versioning,
         creationTime);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ChunkKeyHandler.java
@@ -120,7 +120,8 @@ public class ChunkKeyHandler extends KeyHandler implements
       Pipeline pipeline = keyLocation.getPipeline();
       if (pipeline.getType() != HddsProtos.ReplicationType.STAND_ALONE) {
         pipeline = Pipeline.newBuilder(pipeline)
-            .setReplicationConfig(new StandaloneReplicationConfig(ONE)).build();
+            .setReplicationConfig(StandaloneReplicationConfig.getInstance(ONE))
+            .build();
       }
       xceiverClient = xceiverClientManager
               .acquireClientForReadData(pipeline);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -192,7 +192,7 @@ public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
         .setId(PipelineID.valueOf(UUID.fromString(pipelineId)))
         .setState(PipelineState.OPEN)
         .setReplicationConfig(
-            new RatisReplicationConfig(ReplicationFactor.THREE))
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
         .setLeaderId(UUID.fromString(serverId))
         .setNodes(datanodes)
         .build();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -107,7 +107,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
     OmKeyArgs keyArgs = new Builder()
         .setBucketName(bucketName)
         .setVolumeName(volumeName)
-        .setReplicationConfig(new RatisReplicationConfig(factor))
+        .setReplicationConfig(RatisReplicationConfig.getInstance(factor))
         .setKeyName(generateObjectName(counter))
         .setLocationInfoList(new ArrayList<>())
         .setAcls(OzoneAclUtil.getAclList(ugi.getUserName(), ugi.getGroupNames(),

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/SCMThroughputBenchmark.java
@@ -501,7 +501,7 @@ public final class SCMThroughputBenchmark implements Callable<Void> {
       public void run() {
         while (totalBlockCounter.getAndIncrement() < totalBlocks) {
           doAllocateBlock(blockSize, 1,
-              new RatisReplicationConfig(ReplicationFactor.THREE));
+              RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
         }
       }
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorOm.java
@@ -206,7 +206,8 @@ public class GeneratorOm extends BaseGenerator implements
         .setDataSize(0)
         .setCreationTime(System.currentTimeMillis())
         .setModificationTime(System.currentTimeMillis())
-        .setReplicationConfig(new RatisReplicationConfig(ReplicationFactor.ONE))
+        .setReplicationConfig(RatisReplicationConfig
+            .getInstance(ReplicationFactor.ONE))
         .build();
     omKeyTable.putWithBatch(omKeyTableBatchOperation,
         "/" + volumeName + "/" + bucketName + "/" + keyName, l3DirInfo);
@@ -263,7 +264,7 @@ public class GeneratorOm extends BaseGenerator implements
         .setCreationTime(System.currentTimeMillis())
         .setModificationTime(System.currentTimeMillis())
         .setReplicationConfig(
-            new StandaloneReplicationConfig(ReplicationFactor.THREE))
+            StandaloneReplicationConfig.getInstance(ReplicationFactor.THREE))
         .addOmKeyLocationInfoGroup(infoGroup)
         .build();
     omKeyTable.putWithBatch(omKeyTableBatchOperation, keyName, keyInfo);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorScm.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorScm.java
@@ -78,8 +78,8 @@ public class GeneratorScm extends BaseGenerator {
           new ContainerInfo.Builder()
               .setContainerID(containerId)
               .setState(LifeCycleState.CLOSED)
-              .setReplicationConfig(
-                  new StandaloneReplicationConfig(ReplicationFactor.THREE))
+              .setReplicationConfig(StandaloneReplicationConfig
+                  .getInstance(ReplicationFactor.THREE))
               .setOwner(getUserId())
               .build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

There is generally a RatisReplicationConfig object stored in each ContainerInfo in SCM, and in each Pipeline too. New instances of the Ratis and Standalone objects are scattered throughout the code and used extensively in the tests. 

Each object is basically identical - it only contains the factor, or ONE or THREE. We can save some memory and object churn if we just return a static value each time someone requests a Standalone/RatisReplicationConfig object.

Unfortunately this PR is quite large. I have split it into 3 commits:

1) Makes the changes in the non-test classes - the changes here are fairly small.

2) Replaces `new RatisReplicationConfig()` across the tests and make the constructor private

3) Replaces `new StandalineReplicationConfig()` across the tests makes the constructor private

The diff is large due to the number of places the replacement happens, but there is no logic change - its just a global replace and then some tidy up for checkstyle line lengths.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6420

## How was this patch tested?

Existing tests - not real functionality changed.
