### PR TITLE
HDDS-6419. Add detail error message instead of generic INTERNAL SERVER ERROR for S3g

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
@@ -47,7 +47,13 @@ File upload and directory list
                         Should not contain        ${result}         dir1
                         Should contain            ${result}         file
 
+List buckets with empty access id
+                        Execute                    aws configure set aws_access_key_id ''
+    ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255
+                        Should contain            ${result}         The authorization header you provided is invalid
+
 File upload with special chars
+    Run Keyword         Setup s3 tests
                         Execute                   date > /tmp/testfile
     ${result} =         Execute AWSS3Cli          cp /tmp/testfile s3://${BUCKET}/specialchars/a+b
                         Should contain            ${result}         upload

--- a/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/awss3.robot
@@ -47,13 +47,7 @@ File upload and directory list
                         Should not contain        ${result}         dir1
                         Should contain            ${result}         file
 
-List buckets with empty access id
-                        Execute                    aws configure set aws_access_key_id ''
-    ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255
-                        Should contain            ${result}         The authorization header you provided is invalid
-
 File upload with special chars
-    Run Keyword         Setup s3 tests
                         Execute                   date > /tmp/testfile
     ${result} =         Execute AWSS3Cli          cp /tmp/testfile s3://${BUCKET}/specialchars/a+b
                         Should contain            ${result}         upload

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -36,4 +36,3 @@ List buckets with empty access id
                         Execute                    aws configure set aws_access_key_id ''
     ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255
                         Should contain            ${result}         The authorization header you provided is invalid
-    Run Keyword         Setup s3 tests

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -31,3 +31,9 @@ ${BUCKET}             generated
 List buckets
     ${result} =         Execute AWSS3APICli     list-buckets | jq -r '.Buckets[].Name'
                         Should contain          ${result}    ${BUCKET}
+
+List buckets with empty access id
+                        Execute                    aws configure set aws_access_key_id ''
+    ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255
+                        Should contain            ${result}         The authorization header you provided is invalid
+    Run Keyword         Setup s3 tests

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
+import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 
 /**
  * This class creates the OzoneClient for the Rest endpoints.

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -107,7 +107,7 @@ public class OzoneClientProducer {
       // For any other critical errors during object creation throw Internal
       // error.
       LOG.debug("Error during Client Creation: ", e);
-      throw wrapOS3Exception(S3ErrorTable.getInternalError(e));
+      throw wrapOS3Exception(S3ErrorTable.newError(INTERNAL_ERROR, null, e));
     }
   }
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
 import java.io.IOException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -33,6 +34,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
+import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo;
 import org.apache.hadoop.ozone.s3.signature.SignatureInfo.Version;
 import org.apache.hadoop.ozone.s3.signature.SignatureProcessor;
@@ -43,7 +45,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
-import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 
 /**
@@ -92,7 +93,7 @@ public class OzoneClientProducer {
       String awsAccessId = signatureInfo.getAwsAccessId();
       // ONLY validate aws access id when needed.
       if (awsAccessId == null || awsAccessId.equals("")) {
-        LOG.debug("Malformed s3 header. awsAccessID: ", awsAccessId);
+        LOG.debug("Malformed s3 header. awsAccessID: {}", awsAccessId);
         throw ACCESS_DENIED;
       }
 
@@ -106,7 +107,7 @@ public class OzoneClientProducer {
       // For any other critical errors during object creation throw Internal
       // error.
       LOG.debug("Error during Client Creation: ", e);
-      throw wrapOS3Exception(INTERNAL_ERROR);
+      throw wrapOS3Exception(S3ErrorTable.getInternalError(e));
     }
   }
 
@@ -138,7 +139,9 @@ public class OzoneClientProducer {
   }
 
   private WebApplicationException wrapOS3Exception(OS3Exception os3Exception) {
-    return new WebApplicationException(os3Exception,
-        os3Exception.getHttpCode());
+    return new WebApplicationException(os3Exception.getErrorMessage(),
+        os3Exception,
+        Response.status(os3Exception.getHttpCode())
+            .entity(os3Exception.toXml()).build());
   }
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/exception/S3ErrorTable.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.ozone.s3.exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.function.Function;
+
 import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
 import static java.net.HttpURLConnection.HTTP_CONFLICT;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
@@ -142,5 +144,12 @@ public final class S3ErrorTable {
       LOG.debug(err.toXml(), ex);
     }
     return err;
+  }
+
+  private static Function<Exception, OS3Exception> generateInternalError = e ->
+      new OS3Exception("InternalError", e.getMessage(), HTTP_INTERNAL_ERROR);
+
+  public static OS3Exception getInternalError(Exception e) {
+    return generateInternalError.apply(e);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

For many errors, S3g return a fuzzy error log which are not easy for users and maintainers to find the root cause of the error.

The current error is like follows:
```
An error occurred (500) when calling the ListBuckets operation (reached max retries: 4): Internal Server Error 
```
This ticket is to fix this issue and return more detailed messages.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6419

## How was this patch tested?

Test example

1. List bucket with empty auth.
    * Clean the key and secret in ~/.aws/credentials
    * Run the command of `aws s3api --endpoint=http://localhost:9878 list-buckets`
    * Before fix the return error is 
        `An error occurred () when calling the ListBuckets operation:`
    * After fix the return error is
        `An error occurred (AuthorizationHeaderMalformed) when calling the ListBuckets operation: The authorization header you provided is invalid.`
