### PR TITLE
HDDS-6416. EC: Priory of replication config in Ozone FS

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1633,7 +1633,7 @@ public class TestRootedOzoneFileSystem {
     // Bucket has default EC and client has default RATIS.
     // In this case, it should inherit from bucket
     try (OzoneFSOutputStream file = adapter
-        .createFile(vol + "/" + buck + "/test", (short) 3, true, false)) {
+        .createFile(vol + "/" + buck + "/test", (short) 0, true, false)) {
       file.write(new byte[1024]);
     }
     OFSPath ofsPath = new OFSPath(vol + "/" + buck + "/test");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, the priority of replication config in ozone fs is: bucket EC > createFile() parameter > client > bucket others > cluster.
And it also requires polling bucket level replication config from the client.
Because the default createFile() parameter is always valid, so the last 3 configs were just ignored. 
 
It will be nice if we could find a way to make fs replication priority same as key space.
Which is: client > bucket > cluster. And remove the need of polling.

**(This PR is still WIP, it is difficult to identify EC files just from replication parameters)**

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6416

## How was this patch tested?

Unit tests need to be changed.
