### PR TITLE
HDDS-6423. Fix typo in TestTools.md

### DIFF
--- a/hadoop-hdds/docs/content/tools/TestTools.md
+++ b/hadoop-hdds/docs/content/tools/TestTools.md
@@ -59,7 +59,7 @@ cd compose/ozone
 Blockade tests are implemented with the help of tests and can be started from the `./blockade` directory of the distribution.
 
 ```
-cd blocakde
+cd blockade
 pip install pytest==2.8.7,blockade
 python -m pytest -s .
 ```

--- a/hadoop-hdds/docs/content/tools/TestTools.zh.md
+++ b/hadoop-hdds/docs/content/tools/TestTools.zh.md
@@ -59,7 +59,7 @@ cd compose/ozone
 Blockade 测试在其它测试的基础上实现，可以在分发包中的 `./blockade` 目录下进行测试。
 
 ```
-cd blocakde
+cd blockade
 pip install pytest==2.8.7,blockade
 python -m pytest -s .
 ```


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix typo in TestTools.md (and TestTools.zh.md)

```
 diff --git a/hadoop-hdds/docs/content/tools/TestTools.md b/hadoop-hdds/docs/content/tools/TestTools.md
 index 83b40cb5f..bde400d84 100644
 --- a/hadoop-hdds/docs/content/tools/TestTools.md
 +++ b/hadoop-hdds/docs/content/tools/TestTools.md
 @@ -59,7 +59,7 @@ cd compose/ozone
  Blockade tests are implemented with the help of tests and can be started from the `./blockade` directory of the distri>
 
 -cd blocakde
 +cd blockade
  pip install pytest==2.8.7,blockade
  python -m pytest -s .
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6423

## How was this patch tested?

No tests, just an improvement on a document.
