### PR TITLE
HDDS-6415 - add Over-Utilized and Under-Utilized DN details in debug log

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -374,6 +374,20 @@ public class ContainerBalancer {
             "Under-Utilized Datanodes that need to be balanced.",
         overUtilizedNodes.size(), underUtilizedNodes.size());
 
+    if (LOG.isDebugEnabled()) {
+      overUtilizedNodes.forEach(entry -> {
+        LOG.debug("Datanode {} {} is Over-Utilized.",
+            entry.getDatanodeDetails().getHostName(),
+            entry.getDatanodeDetails().getUuid());
+      });
+
+      underUtilizedNodes.forEach(entry -> {
+        LOG.debug("Datanode {} {} is Under-Utilized.",
+            entry.getDatanodeDetails().getHostName(),
+            entry.getDatanodeDetails().getUuid());
+      });
+    }
+
     selectionCriteria = new ContainerBalancerSelectionCriteria(config,
         nodeManager, replicationManager, containerManager, findSourceStrategy);
     sourceToTargetMap = new HashMap<>(overUtilizedNodes.size() +


### PR DESCRIPTION
## What changes were proposed in this pull request?
Debug logs added to identify Over-Utilized and Under-Utilized DNs.

## What is the link to the Apache JIRA
[HDDS-6415](https://issues.apache.org/jira/browse/HDDS-6415)

## How was this patch tested?
Jar was build after applying the patch. Jar was replaced in live cluster and tested 

Test output:
```
2022-03-07 12:56:53,064 INFO org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Container Balancer has identified 3 Over-Utilized and 5 Under-Utilized Datanodes that need to be balanced.
2022-03-07 12:56:53,064 DEBUG org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Datanode quasar-usholy-1.quasar-usholy.root.hwx.site 9063cde0-96df-4368-bd57-e5dc60c2fd7d is Over-Utilized.
2022-03-07 12:56:53,064 DEBUG org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Datanode quasar-usholy-2.quasar-usholy.root.hwx.site 69a59a13-75d6-4cde-8cb3-5713ae9de7cd is Over-Utilized.
2022-03-07 12:56:53,064 DEBUG org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Datanode quasar-usholy-3.quasar-usholy.root.hwx.site 74a1037f-3abc-4b44-b3a7-82766b906435 is Over-Utilized.
2022-03-07 12:56:53,064 DEBUG org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Datanode quasar-usholy-8.quasar-usholy.root.hwx.site cade74ba-635b-47d9-868b-f315d70ee4ba is Under-Utilized.
2022-03-07 12:56:53,064 DEBUG org.apache.hadoop.hdds.scm.container.balancer.ContainerBalancer: Datanode quasar-usholy-5.quasar-usholy.root.hwx.site c221dcbd-398c-4e76-ab13-dcde074041ae is Under-Utilized.
```
