### PR TITLE
HDDS-6261. OM crashes when trying to overwrite a key during upgrade downgrade testing

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -271,8 +271,8 @@ public final class OmKeyInfo extends WithParentObjectId {
    * version to the all version list.
    *
    * @param newLocationList the list of new blocks to be added.
-   * @param updateTime - if true, updates modification time.
-   * @param keepOldVersions - if false, old blocks won't be kept
+   * @param updateTime if true, updates modification time.
+   * @param keepOldVersions if false, old blocks won't be kept
    *                        and the new block versions will always be 0
    * @throws IOException
    */

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java
@@ -272,13 +272,20 @@ public final class OmKeyInfo extends WithParentObjectId {
    *
    * @param newLocationList the list of new blocks to be added.
    * @param updateTime - if true, updates modification time.
-   * @param keepOldVersions - if false, old blocks won't be kept.
+   * @param keepOldVersions - if false, old blocks won't be kept
+   *                        and the new block versions will always be 0
    * @throws IOException
    */
   public synchronized long addNewVersion(
       List<OmKeyLocationInfo> newLocationList, boolean updateTime,
       boolean keepOldVersions) {
     long latestVersionNum;
+
+    if (!keepOldVersions) {
+      // If old versions are cleared, new block version will always start at 0
+      keyLocationVersions.clear();
+    }
+
     if (keyLocationVersions.size() == 0) {
       // no version exist, these blocks are the very first version.
       keyLocationVersions.add(new OmKeyLocationInfoGroup(0, newLocationList));
@@ -293,11 +300,6 @@ public final class OmKeyInfo extends WithParentObjectId {
       // of new version is included.
       OmKeyLocationInfoGroup newVersion =
           currentLatestVersion.generateNextVersion(newLocationList);
-      if (!keepOldVersions) {
-        // Even though old versions are cleared here, they will be
-        // moved to delete table at the time of key commit
-        keyLocationVersions.clear();
-      }
       keyLocationVersions.add(newVersion);
       latestVersionNum = newVersion.getVersion();
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyLocationInfoGroup.java
@@ -151,8 +151,7 @@ public class OmKeyLocationInfoGroup {
    */
   OmKeyLocationInfoGroup generateNextVersion(
       List<OmKeyLocationInfo> newLocationList) {
-    Map<Long, List<OmKeyLocationInfo>> newMap =
-        new HashMap<>();
+    Map<Long, List<OmKeyLocationInfo>> newMap = new HashMap<>();
     newMap.put(version + 1, new ArrayList<>(newLocationList));
     return new OmKeyLocationInfoGroup(version + 1, newMap);
   }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -99,12 +99,16 @@ run_test() {
 
 ## @description Generates data on the cluster.
 ## @param The prefix to use for data generated.
+## @param All parameters after the first one are passed directly to the robot command,
+##        see https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options
 generate() {
     execute_robot_test scm -v PREFIX:"$1" ${@:2} upgrade/generate.robot
 }
 
 ## @description Validates that data exists on the cluster.
 ## @param The prefix of the data to be validated.
+## @param All parameters after the first one are passed directly to the robot command,
+##        see https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#all-command-line-options
 validate() {
     execute_robot_test scm -v PREFIX:"$1" ${@:2} upgrade/validate.robot
 }

--- a/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/testlib.sh
@@ -100,13 +100,13 @@ run_test() {
 ## @description Generates data on the cluster.
 ## @param The prefix to use for data generated.
 generate() {
-    execute_robot_test scm -v PREFIX:"$1" upgrade/generate.robot
+    execute_robot_test scm -v PREFIX:"$1" ${@:2} upgrade/generate.robot
 }
 
 ## @description Validates that data exists on the cluster.
 ## @param The prefix of the data to be validated.
 validate() {
-    execute_robot_test scm -v PREFIX:"$1" upgrade/validate.robot
+    execute_robot_test scm -v PREFIX:"$1" ${@:2} upgrade/validate.robot
 }
 
 ## @description Checks that the metadata layout version of the provided node matches what is expected.

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/1.1.0-1.2.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/1.1.0-1.2.0/callback.sh
@@ -49,6 +49,8 @@ with_new_version_pre_finalized() {
   _check_om_mlvs 0
 
   validate old1
+  # HDDS-6261: overwrite the same keys intentionally
+  generate old1 --exclude create-volume-and-bucket
 
   generate new1
   validate new1
@@ -60,6 +62,10 @@ with_old_version_downgraded() {
 
   generate old2
   validate old2
+
+  # HDDS-6261: overwrite the same keys again to trigger the precondition check
+  # that exists <= 1.1.0 OM
+  generate old1 --exclude create-volume-and-bucket
 }
 
 with_new_version_finalized() {

--- a/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/upgrade/generate.robot
@@ -24,10 +24,13 @@ Test Timeout        5 minutes
 
 
 *** Test Cases ***
-Create a volume, bucket and key
+Create a volume and bucket
+    [Tags]    create-volume-and-bucket
     ${output} =         Execute          ozone sh volume create ${PREFIX}-volume
                         Should not contain  ${output}       Failed
     ${output} =         Execute          ozone sh bucket create /${PREFIX}-volume/${PREFIX}-bucket
                         Should not contain  ${output}       Failed
+
+Create key
     ${output} =         Execute          ozone sh key put /${PREFIX}-volume/${PREFIX}-bucket/${PREFIX}-key /opt/hadoop/NOTICE.txt
                         Should not contain  ${output}       Failed

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmBlockVersioning.java
@@ -198,14 +198,13 @@ public class TestOmBlockVersioning {
     assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
 
-    // this write will create 2nd version, 2nd version will contain block from
-    // version 1, and add a new block
+    // When bucket versioning is disabled, overwriting a key doesn't increment
+    // its version count. Rather it always resets the version to 0
     TestDataUtil.createKey(bucket, keyName, dataString);
-
 
     keyInfo = ozoneManager.lookupKey(omKeyArgs);
     assertEquals(dataString, TestDataUtil.getKey(bucket, keyName));
-    assertEquals(1, keyInfo.getLatestVersionLocations().getVersion());
+    assertEquals(0, keyInfo.getLatestVersionLocations().getVersion());
     assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
 
@@ -214,7 +213,7 @@ public class TestOmBlockVersioning {
 
     keyInfo = ozoneManager.lookupKey(omKeyArgs);
     assertEquals(dataString, TestDataUtil.getKey(bucket, keyName));
-    assertEquals(2, keyInfo.getLatestVersionLocations().getVersion());
+    assertEquals(0, keyInfo.getLatestVersionLocations().getVersion());
     assertEquals(1,
         keyInfo.getLatestVersionLocations().getLocationList().size());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Set new block version to be always 0 when old block versions are cleared (if bucket versioning is disabled), so that OM won't [crash](https://github.com/apache/ozone/blob/ozone-1.1.0/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyInfo.java#L80-L82) when overwriting a key if downgraded from 1.3.0 to 1.1.0 while previously having overwritten the same key with 1.3.0 OM (where the last and only key version becomes larger than 0). For more details, see the jira description.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6261

## How was this patch tested?

- [x] All existing tests shall pass.
- [x] Add a test case that should repro the issue w/o the patch.

## More on the acceptance test addition for future reference

- The existing upgrade test has been slightly modified to repro the issue on my [test branch](https://github.com/smengcl/hadoop-ozone/commits/HDDS-6261-test1) (where this fix is not applied). The repro is [successful](https://github.com/smengcl/hadoop-ozone/runs/5542380890) (in the sense that the test failed as expected). Archive: [acceptance-misc-15f08e7.zip](https://github.com/apache/ozone/files/8248678/acceptance-misc-15f08e7.zip)
- When the issue occurred, the client prints arcane error message `java.lang.IllegalArgumentException` by default with no stacktrace. The full stacktrace can be found in OM log, interleaved in `docker-1.1.0-downgraded.log`:

```
om3_1    | 2022-03-14 18:46:35,295 [IPC Server handler 8 on default port 9862] WARN ipc.Server: IPC Server handler 8 on default port 9862, call Call#3 Retry#0 org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol.submitRequest from 10.9.0.14:40376
om3_1    | java.lang.IllegalArgumentException
om3_1    | 	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:128)
om3_1    | 	at org.apache.hadoop.ozone.om.helpers.OmKeyInfo.<init>(OmKeyInfo.java:81)
om3_1    | 	at org.apache.hadoop.ozone.om.helpers.OmKeyInfo$Builder.build(OmKeyInfo.java:378)
...
```

- OM throws (didn't crash tho, still running) in the first `validate` run in `with_old_version_downgraded()` (at line 60) when getting the key using CLI.
  - I previously had expected it to throw only when overwriting the same key. Hence another `generate old1 --exclude create-volume-and-bucket` addition in `with_old_version_downgraded()`. Regardless, I think I'll keep this addition for robustness.
- Note it would throw the same error everytime the key is accessed, even when listing the bucket:

```
bash-4.2$ ozone sh key get /old1-volume/old1-bucket/old1-key /tmp/key-89923
java.lang.IllegalArgumentException

bash-4.2$ ozone sh key list /old1-volume/old1-bucket/
java.lang.IllegalArgumentException
```