### PR TITLE
HDDS-6428. [Merge rocksdb in datanode] Add prefix iterator support to RDBTable.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -350,7 +350,9 @@ public class KeyValueContainerData extends ContainerData {
   }
 
   public KeyPrefixFilter getUnprefixedKeyFilter() {
-    return new KeyPrefixFilter().addFilter(containerPrefix() + "#", true);
+    String schemaPrefix = containerPrefix();
+    return new KeyPrefixFilter().addFilter(
+        schemaPrefix == null ? "#" : schemaPrefix + "#", true);
   }
 
   public KeyPrefixFilter getDeletingBlockKeyFilter() {
@@ -368,11 +370,11 @@ public class KeyValueContainerData extends ContainerData {
 
   /**
    * Schema v3 use containerID as key prefix,
-   * for other schemas just return empty.
+   * for other schemas just return null.
    * @return
    */
   public String containerPrefix() {
-    return "";
+    return null;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -217,7 +217,8 @@ public final class KeyValueContainerUtil {
                 kvContainerData.getDeletingBlockKeyFilter();
         int numPendingDeletionBlocks =
             store.getBlockDataTable()
-            .getSequentialRangeKVs(null, Integer.MAX_VALUE, filter)
+            .getSequentialRangeKVs(kvContainerData.startKeyEmpty(),
+                Integer.MAX_VALUE, kvContainerData.containerPrefix(), filter)
             .size();
         kvContainerData.incrPendingDeletionBlocks(numPendingDeletionBlocks);
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -331,7 +331,7 @@ public class BlockManagerImpl implements BlockManager {
         List<? extends Table.KeyValue<String, BlockData>> range =
             db.getStore().getBlockDataTable()
                 .getSequentialRangeKVs(startKey, count,
-                    cData.getUnprefixedKeyFilter());
+                    cData.containerPrefix(), cData.getUnprefixedKeyFilter());
         for (Table.KeyValue<String, BlockData> entry : range) {
           BlockData data = new BlockData(entry.getValue().getBlockID());
           result.add(data);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -317,7 +317,9 @@ public class BlockDeletingService extends BackgroundService {
         KeyPrefixFilter filter = containerData.getDeletingBlockKeyFilter();
         List<? extends Table.KeyValue<String, BlockData>> toDeleteBlocks =
             blockDataTable
-                .getSequentialRangeKVs(null, (int) blocksToDelete, filter);
+                .getSequentialRangeKVs(containerData.startKeyEmpty(),
+                    (int) blocksToDelete, containerData.containerPrefix(),
+                    filter);
         if (toDeleteBlocks.isEmpty()) {
           LOG.debug("No under deletion block found in container : {}",
               containerData.getContainerID());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -86,11 +86,6 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public void setFixedPrefixLength(int length) {
-    table.setFixedPrefixLength(length);
-  }
-
-  @Override
   public String getName() throws IOException {
     return table.getName();
   }
@@ -122,18 +117,18 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   @Override
   public List<? extends KeyValue<KEY, VALUE>> getRangeKVs(
-          KEY startKey, int count,
+          KEY startKey, int count, KEY prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
-    return table.getRangeKVs(startKey, count, filters);
+    return table.getRangeKVs(startKey, count, prefix, filters);
   }
 
   @Override
   public List<? extends KeyValue<KEY, VALUE>> getSequentialRangeKVs(
-          KEY startKey, int count,
+          KEY startKey, int count, KEY prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
-    return table.getSequentialRangeKVs(startKey, count, filters);
+    return table.getSequentialRangeKVs(startKey, count, prefix, filters);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/DatanodeTable.java
@@ -78,6 +78,19 @@ public class DatanodeTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public final TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator(
+      KEY prefix) {
+    throw new UnsupportedOperationException("Iterating tables directly is not" +
+        " supported for datanode containers due to differing schema " +
+        "version.");
+  }
+
+  @Override
+  public void setFixedPrefixLength(int length) {
+    table.setFixedPrefixLength(length);
+  }
+
+  @Override
   public String getName() throws IOException {
     return table.getName();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneDeletedBlocksTable.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/SchemaOneDeletedBlocksTable.java
@@ -97,7 +97,7 @@ public class SchemaOneDeletedBlocksTable extends DatanodeTable<String,
 
   @Override
   public List<? extends KeyValue<String, ChunkInfoList>> getRangeKVs(
-          String startKey, int count,
+          String startKey, int count, String prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
 
@@ -105,12 +105,12 @@ public class SchemaOneDeletedBlocksTable extends DatanodeTable<String,
     // else in this schema version. Ignore any user passed prefixes that could
     // collide with this and return results that are not deleted blocks.
     return unprefix(super.getRangeKVs(prefix(startKey), count,
-            getDeletedFilter()));
+        prefix, getDeletedFilter()));
   }
 
   @Override
   public List<? extends KeyValue<String, ChunkInfoList>> getSequentialRangeKVs(
-          String startKey, int count,
+          String startKey, int count, String prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
 
@@ -118,7 +118,7 @@ public class SchemaOneDeletedBlocksTable extends DatanodeTable<String,
     // else in this schema version. Ignore any user passed prefixes that could
     // collide with this and return results that are not deleted blocks.
     return unprefix(super.getSequentialRangeKVs(prefix(startKey), count,
-            getDeletedFilter()));
+        prefix, getDeletedFilter()));
   }
 
   private static String prefix(String key) {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestBlockDeletingService.java
@@ -376,7 +376,8 @@ public class TestBlockDeletingService {
       KeyValueContainerData data) throws IOException {
     if (data.getSchemaVersion().equals(SCHEMA_V1)) {
       return meta.getStore().getBlockDataTable()
-          .getRangeKVs(null, 100, data.getDeletingBlockKeyFilter())
+          .getRangeKVs(null, 100, data.containerPrefix(),
+              data.getDeletingBlockKeyFilter())
           .size();
     } else if (data.getSchemaVersion().equals(SCHEMA_V2)) {
       int pendingBlocks = 0;

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestSchemaOneBackwardsCompatibility.java
@@ -177,7 +177,8 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // Test rangeKVs.
       List<? extends Table.KeyValue<String, ChunkInfoList>> deletedBlocks =
-              deletedBlocksTable.getRangeKVs(cData.startKeyEmpty(), 100);
+              deletedBlocksTable.getRangeKVs(cData.startKeyEmpty(), 100,
+                  cData.containerPrefix());
 
       for (Table.KeyValue<String, ChunkInfoList> kv: deletedBlocks) {
         assertFalse(kv.getKey().contains(prefix));
@@ -185,7 +186,7 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // Test sequentialRangeKVs.
       deletedBlocks = deletedBlocksTable.getRangeKVs(cData.startKeyEmpty(),
-          100);
+          100, cData.containerPrefix());
 
       for (Table.KeyValue<String, ChunkInfoList> kv: deletedBlocks) {
         assertFalse(kv.getKey().contains(prefix));
@@ -330,7 +331,8 @@ public class TestSchemaOneBackwardsCompatibility {
       // Read blocks that were already deleted before the upgrade.
       List<? extends Table.KeyValue<String, ChunkInfoList>> deletedBlocks =
               refCountedDB.getStore().getDeletedBlocksTable()
-                  .getRangeKVs(cData.startKeyEmpty(), 100);
+                  .getRangeKVs(cData.startKeyEmpty(), 100,
+                      cData.containerPrefix());
 
       Set<String> preUpgradeBlocks = new HashSet<>();
 
@@ -391,7 +393,7 @@ public class TestSchemaOneBackwardsCompatibility {
       // Test decoding keys from the database.
       List<? extends Table.KeyValue<String, BlockData>> blockKeyValues =
           blockDataTable.getRangeKVs(cData.startKeyEmpty(), 100,
-              cData.getUnprefixedKeyFilter());
+              cData.containerPrefix(), cData.getUnprefixedKeyFilter());
 
       List<String> decodedKeys = new ArrayList<>();
 
@@ -434,7 +436,7 @@ public class TestSchemaOneBackwardsCompatibility {
       // Test decoding keys from the database.
       List<? extends Table.KeyValue<String, BlockData>> blockKeyValues =
           blockDataTable.getRangeKVs(cData.startKeyEmpty(), 100,
-              cData.getDeletingBlockKeyFilter());
+              cData.containerPrefix(), cData.getDeletingBlockKeyFilter());
 
       List<String> decodedKeys = new ArrayList<>();
 
@@ -502,7 +504,8 @@ public class TestSchemaOneBackwardsCompatibility {
 
       // Test decoding keys from the database.
       List<? extends Table.KeyValue<String, ChunkInfoList>> chunkInfoKeyValues =
-          deletedBlocksTable.getRangeKVs(cData.startKeyEmpty(), 100);
+          deletedBlocksTable.getRangeKVs(cData.startKeyEmpty(), 100,
+              cData.containerPrefix());
 
       List<String> decodedKeys = new ArrayList<>();
 
@@ -600,7 +603,8 @@ public class TestSchemaOneBackwardsCompatibility {
           throws IOException {
     return refCountedDB.getStore().getDeletedBlocksTable()
             .getRangeKVs(cData.startKeyEmpty(), 100,
-                    cData.getUnprefixedKeyFilter()).size();
+                cData.containerPrefix(),
+                cData.getUnprefixedKeyFilter()).size();
   }
 
   private int countDeletingBlocks(DBHandle refCountedDB,
@@ -608,7 +612,8 @@ public class TestSchemaOneBackwardsCompatibility {
           throws IOException {
     return refCountedDB.getStore().getBlockDataTable()
             .getRangeKVs(cData.startKeyEmpty(), 100,
-                    cData.getDeletingBlockKeyFilter()).size();
+                cData.containerPrefix(),
+                cData.getDeletingBlockKeyFilter()).size();
   }
 
   private int countUnprefixedBlocks(DBHandle refCountedDB,
@@ -616,7 +621,8 @@ public class TestSchemaOneBackwardsCompatibility {
           throws IOException {
     return refCountedDB.getStore().getBlockDataTable()
             .getRangeKVs(cData.startKeyEmpty(), 100,
-                    cData.getUnprefixedKeyFilter()).size();
+                cData.containerPrefix(),
+                cData.getUnprefixedKeyFilter()).size();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueBlockIterator.java
@@ -285,9 +285,11 @@ public class TestKeyValueBlockIterator {
             blockIDs.get(OzoneConsts.DELETING_KEY_PREFIX));
 
     // Test arbitrary filter.
+    String schemaPrefix = containerData.containerPrefix();
     MetadataKeyFilters.KeyPrefixFilter secondFilter =
             new MetadataKeyFilters.KeyPrefixFilter()
-            .addFilter(containerData.containerPrefix() + secondPrefix);
+            .addFilter(schemaPrefix == null ?
+                secondPrefix : schemaPrefix + secondPrefix);
     testWithFilter(secondFilter, blockIDs.get(secondPrefix));
   }
 
@@ -383,6 +385,7 @@ public class TestKeyValueBlockIterator {
       // prefix.
       Table<String, BlockData> blockDataTable =
               metadataStore.getStore().getBlockDataTable();
+      String schemaPrefix = containerData.containerPrefix();
 
       for (Map.Entry<String, Integer> entry: prefixCounts.entrySet()) {
         String prefix = entry.getKey();
@@ -394,8 +397,8 @@ public class TestKeyValueBlockIterator {
           blockIndex++;
           BlockData blockData = new BlockData(blockID);
           blockData.setChunks(chunkList);
-          String blockKey = containerData.containerPrefix() + prefix +
-              blockID.getLocalID();
+          String blockKey = (schemaPrefix == null ? "" : schemaPrefix) +
+              prefix + blockID.getLocalID();
           blockDataTable.put(blockKey, blockData);
           blockIDs.get(prefix).add(blockID.getLocalID());
         }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStoreIterator.java
@@ -82,8 +82,7 @@ public class RDBStoreIterator
   @Override
   public boolean hasNext() {
     return rocksDBIterator.isValid() &&
-        (prefix == null || Arrays.equals(
-            Arrays.copyOf(rocksDBIterator.key(), prefix.length), prefix));
+        (prefix == null || startsWith(prefix, rocksDBIterator.key()));
   }
 
   @Override
@@ -138,5 +137,26 @@ public class RDBStoreIterator
   @Override
   public void close() throws IOException {
     rocksDBIterator.close();
+  }
+
+  private static boolean startsWith(byte[] prefix, byte[] value) {
+    if (prefix == null) {
+      return true;
+    }
+    if (value == null) {
+      return false;
+    }
+
+    int length = prefix.length;
+    if (value.length < length) {
+      return false;
+    }
+
+    for (int i = 0; i < length; i++) {
+      if (value[i] != prefix[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -162,12 +162,6 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
       throws IOException;
 
   /**
-   * Set the fixed key prefix length.
-   * @param length
-   */
-  void setFixedPrefixLength(int length);
-
-  /**
    * Returns the Name of this Table.
    * @return - Table Name.
    * @throws IOException on failure.
@@ -242,6 +236,7 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    *
    * @param startKey a start key.
    * @param count max number of entries to return.
+   * @param prefix fixed key schema specific prefix
    * @param filters customized one or more
    * {@link MetadataKeyFilters.MetadataKeyFilter}.
    * @return a list of entries found in the database or an empty list if the
@@ -250,7 +245,8 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    * @throws IllegalArgumentException if count is less than 0.
    */
   List<? extends KeyValue<KEY, VALUE>> getRangeKVs(KEY startKey,
-          int count, MetadataKeyFilters.MetadataKeyFilter... filters)
+          int count, KEY prefix,
+          MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException;
 
   /**
@@ -263,6 +259,7 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    *
    * @param startKey a start key.
    * @param count max number of entries to return.
+   * @param prefix fixed key schema specific prefix
    * @param filters customized one or more
    * {@link MetadataKeyFilters.MetadataKeyFilter}.
    * @return a list of entries found in the database.
@@ -270,7 +267,8 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
    * @throws IllegalArgumentException
    */
   List<? extends KeyValue<KEY, VALUE>> getSequentialRangeKVs(KEY startKey,
-          int count, MetadataKeyFilters.MetadataKeyFilter... filters)
+          int count, KEY prefix,
+          MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException;
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/Table.java
@@ -154,6 +154,20 @@ public interface Table<KEY, VALUE> extends AutoCloseable {
   TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator();
 
   /**
+   * Returns a prefixed iterator for this metadata store.
+   * @param prefix
+   * @return
+   */
+  TableIterator<KEY, ? extends KeyValue<KEY, VALUE>> iterator(KEY prefix)
+      throws IOException;
+
+  /**
+   * Set the fixed key prefix length.
+   * @param length
+   */
+  void setFixedPrefixLength(int length);
+
+  /**
    * Returns the Name of this Table.
    * @return - Table Name.
    * @throws IOException on failure.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -289,11 +289,6 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
-  public void setFixedPrefixLength(int length) {
-    rawTable.setFixedPrefixLength(length);
-  }
-
-  @Override
   public String getName() throws IOException {
     return rawTable.getName();
   }
@@ -328,19 +323,23 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   @Override
   public List<TypedKeyValue> getRangeKVs(
-          KEY startKey, int count,
+          KEY startKey, int count, KEY prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
 
     // A null start key means to start from the beginning of the table.
     // Cannot convert a null key to bytes.
     byte[] startKeyBytes = null;
+    byte[] prefixBytes = null;
     if (startKey != null) {
       startKeyBytes = codecRegistry.asRawData(startKey);
     }
+    if (prefix != null) {
+      prefixBytes = codecRegistry.asRawData(prefix);
+    }
 
     List<? extends KeyValue<byte[], byte[]>> rangeKVBytes =
-            rawTable.getRangeKVs(startKeyBytes, count, filters);
+        rawTable.getRangeKVs(startKeyBytes, count, prefixBytes, filters);
 
     List<TypedKeyValue> rangeKVs = new ArrayList<>();
     rangeKVBytes.forEach(byteKV -> rangeKVs.add(new TypedKeyValue(byteKV)));
@@ -350,19 +349,24 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
 
   @Override
   public List<TypedKeyValue> getSequentialRangeKVs(
-          KEY startKey, int count,
+          KEY startKey, int count, KEY prefix,
           MetadataKeyFilters.MetadataKeyFilter... filters)
           throws IOException, IllegalArgumentException {
 
     // A null start key means to start from the beginning of the table.
     // Cannot convert a null key to bytes.
     byte[] startKeyBytes = null;
+    byte[] prefixBytes = null;
     if (startKey != null) {
       startKeyBytes = codecRegistry.asRawData(startKey);
     }
+    if (prefix != null) {
+      prefixBytes = codecRegistry.asRawData(prefix);
+    }
 
     List<? extends KeyValue<byte[], byte[]>> rangeKVBytes =
-            rawTable.getSequentialRangeKVs(startKeyBytes, count, filters);
+        rawTable.getSequentialRangeKVs(startKeyBytes, count,
+            prefixBytes, filters);
 
     List<TypedKeyValue> rangeKVs = new ArrayList<>();
     rangeKVBytes.forEach(byteKV -> rangeKVs.add(new TypedKeyValue(byteKV)));

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/TypedTable.java
@@ -281,6 +281,19 @@ public class TypedTable<KEY, VALUE> implements Table<KEY, VALUE> {
   }
 
   @Override
+  public TableIterator<KEY, TypedKeyValue> iterator(KEY prefix)
+      throws IOException {
+    TableIterator<byte[], ? extends KeyValue<byte[], byte[]>> iterator =
+        rawTable.iterator(codecRegistry.asRawData(prefix));
+    return new TypedTableIterator(iterator, keyType, valueType);
+  }
+
+  @Override
+  public void setFixedPrefixLength(int length) {
+    rawTable.setFixedPrefixLength(length);
+  }
+
+  @Override
   public String getName() throws IOException {
     return rawTable.getName();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMCertStore.java
@@ -265,7 +265,7 @@ public final class SCMCertStore implements CertificateStore {
     } else {
       List<? extends Table.KeyValue<BigInteger, CertInfo>> certs =
           scmMetadataStore.getRevokedCertsV2Table().getRangeKVs(
-          startSerialID, count);
+          startSerialID, count, null);
 
       for (Table.KeyValue<BigInteger, CertInfo> kv : certs) {
         try {
@@ -290,10 +290,10 @@ public final class SCMCertStore implements CertificateStore {
 
     if (role == SCM) {
       return scmMetadataStore.getValidSCMCertsTable().getRangeKVs(
-          startSerialID, count);
+          startSerialID, count, null);
     } else {
       return scmMetadataStore.getValidCertsTable().getRangeKVs(
-          startSerialID, count);
+          startSerialID, count, null);
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestStorageContainerManagerHelper.java
@@ -107,7 +107,8 @@ public class TestStorageContainerManagerHelper {
 
       List<? extends Table.KeyValue<String, BlockData>> kvs =
           db.getStore().getBlockDataTable()
-              .getRangeKVs(cData.startKeyEmpty(), Integer.MAX_VALUE, filter);
+              .getRangeKVs(cData.startKeyEmpty(), Integer.MAX_VALUE,
+                  cData.containerPrefix(), filter);
 
       for (Table.KeyValue<String, BlockData> entry : kvs) {
         pendingDeletionBlocks
@@ -134,7 +135,7 @@ public class TestStorageContainerManagerHelper {
       List<? extends Table.KeyValue<String, BlockData>> kvs =
           db.getStore().getBlockDataTable()
               .getRangeKVs(cData.startKeyEmpty(), Integer.MAX_VALUE,
-                  cData.getUnprefixedKeyFilter());
+                  cData.containerPrefix(), cData.getUnprefixedKeyFilter());
 
       for (Table.KeyValue<String, BlockData> entry : kvs) {
         allBlocks.add(Long.valueOf(entry.getKey()));

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/PrefixParser.java
@@ -217,7 +217,7 @@ public class PrefixParser implements Callable<Void>, SubcommandWithParent {
 
     List<? extends KeyValue
         <String, ? extends WithParentObjectId>> infoList =
-        table.getRangeKVs(null, 1000, filter);
+        table.getRangeKVs(null, 1000, null, filter);
 
     for (KeyValue<String, ? extends WithParentObjectId> info :infoList) {
       Path key = Paths.get(info.getKey());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add prefix iterator support to RDBTable.

A sample from the `metadata` column family of the current per-container rocksdb instance as follows:

"#BCSID" -> 9
"#BLOCKCOUNT" -> 1
"#BYTESUSED" -> 10240000

After rocksdb-merge, it will be like:

"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004#BCSID" -> 9
"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004#BLOCKCOUNT" -> 1
"\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0004#BYTESUSED" -> 10240000

Those chars as a prefix are the containerID encoded in IOS-8859-1(An extension of the ASCII charset).
After rocksdb-merge, every container on the disk will get all its metadata KV pairs in a per-disk rocksdb instance.
When we want to access the metadata KV of a specific container, we have to do a `seek` operation in the column family to the right postion.
Here we use a fixed-length prefix(an encoded containerID) so as to utilize the `Prefix Seek` feature of rocksdb to speed up the seek operation, FYI: https://github.com/facebook/rocksdb/wiki/Prefix-Seek.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6428

## How was this patch tested?

new ut added.
