### PR TITLE
HDDS-6396. [Multi-Tenant] Merge and cleanup tenant group/role/policy tables, refactor protobuf messages and `isTenantAdmin`

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -341,15 +341,14 @@ public final class OzoneConsts {
 
   // For multi-tenancy
   public static final String TENANT_ID_USERNAME_DELIMITER = "$";
-  public static final String TENANT_ID_ROLE_DELIMITER = "-";
   public static final String DEFAULT_TENANT_USER_POLICY_SUFFIX = "-users";
   public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX = "-buckets";
   public static final String DEFAULT_TENANT_POLICY_ID_SUFFIX = "-default";
   // Predefined tenant roles
   // Tenant user role. All tenant users are assigned this role by default
-  public static final String TENANT_ROLE_USER = "user";
+  public static final String TENANT_ROLE_USER_SUFFIX = "-UserRole";
   // Tenant admin role. All tenant admins are assigned this role
-  public static final String TENANT_ROLE_ADMIN = "admin";
+  public static final String TENANT_ROLE_ADMIN_SUFFIX = "-AdminRole";
 
   // For OM metrics saving to a file
   public static final String OM_METRICS_FILE = "omMetrics";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -345,7 +345,9 @@ public final class OzoneConsts {
   public static final String DEFAULT_TENANT_USER_POLICY_SUFFIX = "-users";
   public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX = "-buckets";
   public static final String DEFAULT_TENANT_POLICY_ID_SUFFIX = "-default";
-  public static final String DEFAULT_TENANT_USER_GROUP_SUFFIX = "-users";
+  // Predefined tenant roles
+  public static final String TENANT_ROLE_USER = "user";
+  public static final String TENANT_ROLE_ADMIN = "admin";
 
   // For OM metrics saving to a file
   public static final String OM_METRICS_FILE = "omMetrics";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -343,7 +343,7 @@ public final class OzoneConsts {
   public static final String TENANT_ID_USERNAME_DELIMITER = "$";
   public static final String DEFAULT_TENANT_USER_POLICY_SUFFIX = "-users";
   public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX = "-buckets";
-  public static final String DEFAULT_TENANT_POLICY_ID_SUFFIX = "-default";
+  public static final String DEFAULT_TENANT_POLICY_NAME_SUFFIX = "-default";
   // Predefined tenant roles
   // Tenant user role. All tenant users are assigned this role by default
   public static final String TENANT_ROLE_USER_SUFFIX = "-UserRole";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -346,7 +346,9 @@ public final class OzoneConsts {
   public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX = "-buckets";
   public static final String DEFAULT_TENANT_POLICY_ID_SUFFIX = "-default";
   // Predefined tenant roles
+  // Tenant user role. All tenant users are assigned this role by default
   public static final String TENANT_ROLE_USER = "user";
+  // Tenant admin role. All tenant admins are assigned this role
   public static final String TENANT_ROLE_ADMIN = "admin";
 
   // For OM metrics saving to a file

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -341,14 +341,15 @@ public final class OzoneConsts {
 
   // For multi-tenancy
   public static final String TENANT_ID_USERNAME_DELIMITER = "$";
-  public static final String DEFAULT_TENANT_USER_POLICY_SUFFIX = "-users";
-  public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX = "-buckets";
-  public static final String DEFAULT_TENANT_POLICY_NAME_SUFFIX = "-default";
+  public static final String DEFAULT_TENANT_BUCKET_NAMESPACE_POLICY_SUFFIX =
+      "-VolumeAccess";
+  public static final String DEFAULT_TENANT_BUCKET_POLICY_SUFFIX =
+      "-BucketAccess";
   // Predefined tenant roles
   // Tenant user role. All tenant users are assigned this role by default
-  public static final String TENANT_ROLE_USER_SUFFIX = "-UserRole";
+  public static final String DEFAULT_TENANT_ROLE_USER_SUFFIX = "-UserRole";
   // Tenant admin role. All tenant admins are assigned this role
-  public static final String TENANT_ROLE_ADMIN_SUFFIX = "-AdminRole";
+  public static final String DEFAULT_TENANT_ROLE_ADMIN_SUFFIX = "-AdminRole";
 
   // For OM metrics saving to a file
   public static final String OM_METRICS_FILE = "omMetrics";

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/ObjectStore.java
@@ -33,11 +33,11 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
@@ -235,9 +235,9 @@ public class ObjectStore {
    * Delete a tenant.
    * @param tenantId tenant name.
    * @throws IOException
-   * @return DeleteTenantInfo
+   * @return DeleteTenantState
    */
-  public DeleteTenantInfo deleteTenant(String tenantId) throws IOException {
+  public DeleteTenantState deleteTenant(String tenantId) throws IOException {
     return proxy.deleteTenant(tenantId);
   }
 
@@ -304,10 +304,10 @@ public class ObjectStore {
 
   /**
    * List tenants.
-   * @return TenantInfoList
+   * @return TenantStateList
    * @throws IOException
    */
-  public TenantInfoList listTenant() throws IOException {
+  public TenantStateList listTenant() throws IOException {
     return proxy.listTenant();
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/protocol/ClientProtocol.java
@@ -44,7 +44,7 @@ import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadCompleteInfo;
@@ -53,7 +53,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -615,9 +615,9 @@ public interface ClientProtocol {
    * Delete a tenant.
    * @param tenantId tenant name.
    * @throws IOException
-   * @return DeleteTenantInfo
+   * @return DeleteTenantState
    */
-  DeleteTenantInfo deleteTenant(String tenantId) throws IOException;
+  DeleteTenantState deleteTenant(String tenantId) throws IOException;
 
   /**
    * Assign a user to a tenant.
@@ -675,10 +675,10 @@ public interface ClientProtocol {
 
   /**
    * List tenants.
-   * @return TenantInfoList
+   * @return TenantStateList
    * @throws IOException
    */
-  TenantInfoList listTenant() throws IOException;
+  TenantStateList listTenant() throws IOException;
 
   /**
    * Get KMS client provider.

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -89,7 +89,7 @@ import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
@@ -114,7 +114,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
@@ -776,7 +776,7 @@ public class RpcClient implements ClientProtocol {
    * {@inheritDoc}
    */
   @Override
-  public DeleteTenantInfo deleteTenant(String tenantId) throws IOException {
+  public DeleteTenantState deleteTenant(String tenantId) throws IOException {
     Preconditions.checkArgument(Strings.isNotBlank(tenantId),
         "tenantId cannot be null or empty.");
     return ozoneManagerClient.deleteTenant(tenantId);
@@ -861,11 +861,11 @@ public class RpcClient implements ClientProtocol {
 
   /**
    * List tenants.
-   * @return TenantInfoList
+   * @return TenantStateList
    * @throws IOException
    */
   @Override
-  public TenantInfoList listTenant() throws IOException {
+  public TenantStateList listTenant() throws IOException {
     return ozoneManagerClient.listTenant();
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DeleteTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/DeleteTenantState.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteT
 /**
  * A class that encapsulates DeleteTenantResponse protobuf message.
  */
-public class DeleteTenantInfo {
+public class DeleteTenantState {
 
   /**
    * Volume name associated to the deleted tenant.
@@ -35,7 +35,7 @@ public class DeleteTenantInfo {
    */
   private final long volRefCount;
 
-  public DeleteTenantInfo(String volumeName, long volRefCount) {
+  public DeleteTenantState(String volumeName, long volRefCount) {
     this.volumeName = volumeName;
     this.volRefCount = volRefCount;
   }
@@ -48,8 +48,8 @@ public class DeleteTenantInfo {
     return volRefCount;
   }
 
-  public static DeleteTenantInfo fromProtobuf(DeleteTenantResponse resp) {
-    return new DeleteTenantInfo(resp.getVolumeName(), resp.getVolRefCount());
+  public static DeleteTenantState fromProtobuf(DeleteTenantResponse resp) {
+    return new DeleteTenantState(resp.getVolumeName(), resp.getVolRefCount());
   }
 
   public DeleteTenantResponse getProtobuf() {
@@ -59,8 +59,8 @@ public class DeleteTenantInfo {
         .build();
   }
 
-  public static DeleteTenantInfo.Builder newBuilder() {
-    return new DeleteTenantInfo.Builder();
+  public static DeleteTenantState.Builder newBuilder() {
+    return new DeleteTenantState.Builder();
   }
 
   /**
@@ -84,8 +84,8 @@ public class DeleteTenantInfo {
       return this;
     }
 
-    public DeleteTenantInfo build() {
-      return new DeleteTenantInfo(volumeName, volRefCount);
+    public DeleteTenantState build() {
+      return new DeleteTenantState(volumeName, volRefCount);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -64,8 +64,8 @@ public final class OmDBAccessIdInfo {
   /**
    * Convert OmDBAccessIdInfo to protobuf to be persisted to DB.
    */
-  public OzoneManagerProtocolProtos.OmDBAccessInfo getProtobuf() {
-    return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
+  public OzoneManagerProtocolProtos.ExtendedAccessIdInfo getProtobuf() {
+    return OzoneManagerProtocolProtos.ExtendedAccessIdInfo.newBuilder()
         .setTenantId(tenantId)
         .setUserPrincipal(userPrincipal)
         .setIsAdmin(isAdmin)
@@ -78,7 +78,8 @@ public final class OmDBAccessIdInfo {
    * Convert protobuf to OmDBAccessIdInfo.
    */
   public static OmDBAccessIdInfo getFromProtobuf(
-      OzoneManagerProtocolProtos.OmDBAccessInfo infoProto) throws IOException {
+      OzoneManagerProtocolProtos.ExtendedAccessIdInfo infoProto)
+      throws IOException {
     return new Builder()
         .setTenantId(infoProto.getTenantId())
         .setUserPrincipal(infoProto.getUserPrincipal())

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -43,7 +43,7 @@ public final class OmDBAccessIdInfo {
    */
   private final boolean isDelegatedAdmin;
   /**
-   * Role name of the user (that this access ID points to) in this tenant.
+   * Role name of the user (that this access ID is assigned to) in this tenant.
    * e.g. "user", "admin", "auditor"
    */
   private final String roleId;
@@ -75,7 +75,7 @@ public final class OmDBAccessIdInfo {
   }
 
   /**
-   * Convert byte array to OmDBAccessIdInfo.
+   * Convert protobuf to OmDBAccessIdInfo.
    */
   public static OmDBAccessIdInfo getFromProtobuf(
       OzoneManagerProtocolProtos.OmDBAccessInfo infoProto) throws IOException {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -52,18 +52,18 @@ public final class OmDBAccessIdInfo {
    * e.g. OzoneConsts.TENANT_ROLE_USER, OzoneConsts.TENANT_ROLE_ADMIN,
    *      or other custom role names.
    */
-  private final Set<String> roleIds;
+  private final Set<String> roleNames;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OmDBAccessIdInfo.class);
 
   public OmDBAccessIdInfo(String tenantId, String userPrincipal,
-      boolean isAdmin, boolean isDelegatedAdmin, Set<String> roleId) {
+      boolean isAdmin, boolean isDelegatedAdmin, Set<String> roleName) {
     this.tenantId = tenantId;
     this.userPrincipal = userPrincipal;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
-    this.roleIds = roleId;
+    this.roleNames = roleName;
   }
 
   public String getTenantId() {
@@ -79,7 +79,7 @@ public final class OmDBAccessIdInfo {
         .setUserPrincipal(userPrincipal)
         .setIsAdmin(isAdmin)
         .setIsDelegatedAdmin(isDelegatedAdmin)
-        .addAllRoleIds(roleIds)
+        .addAllRoleNames(roleNames)
         .build();
   }
 
@@ -94,7 +94,7 @@ public final class OmDBAccessIdInfo {
         .setUserPrincipal(infoProto.getUserPrincipal())
         .setIsAdmin(infoProto.getIsAdmin())
         .setIsDelegatedAdmin(infoProto.getIsDelegatedAdmin())
-        .setRoleIds(infoProto.getRoleIdsList())
+        .setRoleNames(infoProto.getRoleNamesList())
         .build();
   }
 
@@ -110,24 +110,26 @@ public final class OmDBAccessIdInfo {
     return isDelegatedAdmin;
   }
 
-  public Set<String> getRoleIdsSet() {
-    return roleIds;
+  public Set<String> getRoleNamesSet() {
+    return roleNames;
   }
 
-  public OmDBAccessIdInfo addRoleId(String roleId) {
-    if (roleIds.contains(roleId)) {
-      LOG.warn("Role ID '" + roleId + "' already exists. Ignored addRoleId");
+  public OmDBAccessIdInfo addRoleName(String roleName) {
+    if (roleNames.contains(roleName)) {
+      LOG.warn("Role name '" + roleName + "' already exists. "
+          + "Ignored addRoleName");
     } else {
-      roleIds.add(roleId);
+      roleNames.add(roleName);
     }
     return this;
   }
 
-  public OmDBAccessIdInfo removeRoleId(String roleId) {
-    if (roleIds.contains(roleId)) {
-      roleIds.remove(roleId);
+  public OmDBAccessIdInfo removeRoleName(String roleName) {
+    if (roleNames.contains(roleName)) {
+      roleNames.remove(roleName);
     } else {
-      LOG.warn("Role ID '" + roleId + "' doesn't exist. Ignored removeRoleId");
+      LOG.warn("Role name '" + roleName + "' doesn't exist. "
+          + "Ignored removeRoleName");
     }
     return this;
   }
@@ -139,7 +141,7 @@ public final class OmDBAccessIdInfo {
   public static final class Builder {
     private String tenantId;
     private String userPrincipal;
-    private Set<String> roleIds;
+    private Set<String> roleNames;
     private boolean isAdmin;
     private boolean isDelegatedAdmin;
 
@@ -163,28 +165,28 @@ public final class OmDBAccessIdInfo {
       return this;
     }
 
-    public Builder setRoleIds(Set<String> roleIds) {
-      this.roleIds = roleIds;
+    public Builder setRoleNames(Set<String> roleNames) {
+      this.roleNames = roleNames;
       return this;
     }
 
-    public Builder setRoleIds(List<String> roleIds) {
+    public Builder setRoleNames(List<String> roleNames) {
       // Convert list to set
-      this.roleIds = new HashSet<>(roleIds);
+      this.roleNames = new HashSet<>(roleNames);
       return this;
     }
 
-    public Builder addRoleId(String roleId) {
-      if (roleIds == null) {
-        roleIds = new HashSet<>();
+    public Builder addRoleName(String roleName) {
+      if (roleNames == null) {
+        roleNames = new HashSet<>();
       }
-      this.roleIds.add(roleId);
+      this.roleNames.add(roleName);
       return this;
     }
 
     public OmDBAccessIdInfo build() {
       return new OmDBAccessIdInfo(
-          tenantId, userPrincipal, isAdmin, isDelegatedAdmin, roleIds);
+          tenantId, userPrincipal, isAdmin, isDelegatedAdmin, roleNames);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -42,16 +42,19 @@ public final class OmDBAccessIdInfo {
    * Only effective if isAdmin is true.
    */
   private final boolean isDelegatedAdmin;
-
-  // This implies above String fields should NOT contain the split key.
-  public static final String SERIALIZATION_SPLIT_KEY = ";";
+  /**
+   * Role name of the user (that this access ID points to) in this tenant.
+   * e.g. "user", "admin", "auditor"
+   */
+  private final String roleId;
 
   public OmDBAccessIdInfo(String tenantId, String userPrincipal,
-                          boolean isAdmin, boolean isDelegatedAdmin) {
+      boolean isAdmin, boolean isDelegatedAdmin, String roleId) {
     this.tenantId = tenantId;
     this.userPrincipal = userPrincipal;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
+    this.roleId = roleId;
   }
 
   public String getTenantId() {
@@ -63,10 +66,11 @@ public final class OmDBAccessIdInfo {
    */
   public OzoneManagerProtocolProtos.OmDBAccessInfo getProtobuf() {
     return OzoneManagerProtocolProtos.OmDBAccessInfo.newBuilder()
+        .setTenantId(tenantId)
         .setUserPrincipal(userPrincipal)
         .setIsAdmin(isAdmin)
         .setIsDelegatedAdmin(isDelegatedAdmin)
-        .setTenantId(tenantId)
+        .setRoleId(roleId)
         .build();
   }
 
@@ -76,10 +80,11 @@ public final class OmDBAccessIdInfo {
   public static OmDBAccessIdInfo getFromProtobuf(
       OzoneManagerProtocolProtos.OmDBAccessInfo infoProto) throws IOException {
     return new Builder()
-        .setKerberosPrincipal(infoProto.getUserPrincipal())
+        .setTenantId(infoProto.getTenantId())
+        .setUserPrincipal(infoProto.getUserPrincipal())
         .setIsAdmin(infoProto.getIsAdmin())
         .setIsDelegatedAdmin(infoProto.getIsDelegatedAdmin())
-        .setTenantId(infoProto.getTenantId())
+        .setRoleId(infoProto.getRoleId())
         .build();
   }
 
@@ -101,7 +106,8 @@ public final class OmDBAccessIdInfo {
   @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
     private String tenantId;
-    private String kerberosPrincipal;
+    private String userPrincipal;
+    private String roleId;
     private boolean isAdmin;
     private boolean isDelegatedAdmin;
 
@@ -110,8 +116,8 @@ public final class OmDBAccessIdInfo {
       return this;
     }
 
-    public Builder setKerberosPrincipal(String kerberosPrincipal) {
-      this.kerberosPrincipal = kerberosPrincipal;
+    public Builder setUserPrincipal(String userPrincipal) {
+      this.userPrincipal = userPrincipal;
       return this;
     }
 
@@ -125,9 +131,14 @@ public final class OmDBAccessIdInfo {
       return this;
     }
 
+    public Builder setRoleId(String roleId) {
+      this.roleId = roleId;
+      return this;
+    }
+
     public OmDBAccessIdInfo build() {
-      return new OmDBAccessIdInfo(tenantId, kerberosPrincipal,
-          isAdmin, isDelegatedAdmin);
+      return new OmDBAccessIdInfo(
+          tenantId, userPrincipal, isAdmin, isDelegatedAdmin, roleId);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBAccessIdInfo.java
@@ -22,9 +22,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 
 /**
  * This class is used for storing Ozone tenant accessId info.
@@ -47,23 +44,16 @@ public final class OmDBAccessIdInfo {
    * Only effective if isAdmin is true.
    */
   private final boolean isDelegatedAdmin;
-  /**
-   * Role names of the user (that this access ID is assigned to) in this tenant.
-   * e.g. OzoneConsts.TENANT_ROLE_USER, OzoneConsts.TENANT_ROLE_ADMIN,
-   *      or other custom role names.
-   */
-  private final Set<String> roleNames;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OmDBAccessIdInfo.class);
 
   public OmDBAccessIdInfo(String tenantId, String userPrincipal,
-      boolean isAdmin, boolean isDelegatedAdmin, Set<String> roleName) {
+                          boolean isAdmin, boolean isDelegatedAdmin) {
     this.tenantId = tenantId;
     this.userPrincipal = userPrincipal;
     this.isAdmin = isAdmin;
     this.isDelegatedAdmin = isDelegatedAdmin;
-    this.roleNames = roleName;
   }
 
   public String getTenantId() {
@@ -73,13 +63,12 @@ public final class OmDBAccessIdInfo {
   /**
    * Convert OmDBAccessIdInfo to protobuf to be persisted to DB.
    */
-  public OzoneManagerProtocolProtos.ExtendedAccessIdInfo getProtobuf() {
-    return OzoneManagerProtocolProtos.ExtendedAccessIdInfo.newBuilder()
+  public OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo getProtobuf() {
+    return OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo.newBuilder()
         .setTenantId(tenantId)
         .setUserPrincipal(userPrincipal)
         .setIsAdmin(isAdmin)
         .setIsDelegatedAdmin(isDelegatedAdmin)
-        .addAllRoleNames(roleNames)
         .build();
   }
 
@@ -87,14 +76,13 @@ public final class OmDBAccessIdInfo {
    * Convert protobuf to OmDBAccessIdInfo.
    */
   public static OmDBAccessIdInfo getFromProtobuf(
-      OzoneManagerProtocolProtos.ExtendedAccessIdInfo infoProto)
+      OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo infoProto)
       throws IOException {
     return new Builder()
         .setTenantId(infoProto.getTenantId())
         .setUserPrincipal(infoProto.getUserPrincipal())
         .setIsAdmin(infoProto.getIsAdmin())
         .setIsDelegatedAdmin(infoProto.getIsDelegatedAdmin())
-        .setRoleNames(infoProto.getRoleNamesList())
         .build();
   }
 
@@ -110,30 +98,6 @@ public final class OmDBAccessIdInfo {
     return isDelegatedAdmin;
   }
 
-  public Set<String> getRoleNamesSet() {
-    return roleNames;
-  }
-
-  public OmDBAccessIdInfo addRoleName(String roleName) {
-    if (roleNames.contains(roleName)) {
-      LOG.warn("Role name '" + roleName + "' already exists. "
-          + "Ignored addRoleName");
-    } else {
-      roleNames.add(roleName);
-    }
-    return this;
-  }
-
-  public OmDBAccessIdInfo removeRoleName(String roleName) {
-    if (roleNames.contains(roleName)) {
-      roleNames.remove(roleName);
-    } else {
-      LOG.warn("Role name '" + roleName + "' doesn't exist. "
-          + "Ignored removeRoleName");
-    }
-    return this;
-  }
-
   /**
    * Builder for OmDBAccessIdInfo.
    */
@@ -141,7 +105,6 @@ public final class OmDBAccessIdInfo {
   public static final class Builder {
     private String tenantId;
     private String userPrincipal;
-    private Set<String> roleNames;
     private boolean isAdmin;
     private boolean isDelegatedAdmin;
 
@@ -165,28 +128,9 @@ public final class OmDBAccessIdInfo {
       return this;
     }
 
-    public Builder setRoleNames(Set<String> roleNames) {
-      this.roleNames = roleNames;
-      return this;
-    }
-
-    public Builder setRoleNames(List<String> roleNames) {
-      // Convert list to set
-      this.roleNames = new HashSet<>(roleNames);
-      return this;
-    }
-
-    public Builder addRoleName(String roleName) {
-      if (roleNames == null) {
-        roleNames = new HashSet<>();
-      }
-      this.roleNames.add(roleName);
-      return this;
-    }
-
     public OmDBAccessIdInfo build() {
       return new OmDBAccessIdInfo(
-          tenantId, userPrincipal, isAdmin, isDelegatedAdmin, roleNames);
+          tenantId, userPrincipal, isAdmin, isDelegatedAdmin);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBKerberosPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBKerberosPrincipalInfo.java
@@ -17,18 +17,16 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.apache.hadoop.hdds.StringUtils;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * This class is used for storing info related to the Kerberos principal.
  *
- * For now this is merely used to store a list of accessIds associates with the
- * principal, but can be extended to store more fields later.
+ * For now this only stores a list of accessIds associates with the user
+ * principal.
  */
 public final class OmDBKerberosPrincipalInfo {
 
@@ -37,18 +35,8 @@ public final class OmDBKerberosPrincipalInfo {
    */
   private final Set<String> accessIds;
 
-  // This implies above String fields should NOT contain the split key.
-  // TODO: Reject user input accessId if it contains the split key.
-  public static final String SERIALIZATION_SPLIT_KEY = ";";
-
   public OmDBKerberosPrincipalInfo(Set<String> accessIds) {
     this.accessIds = new HashSet<>(accessIds);
-  }
-
-  private OmDBKerberosPrincipalInfo(String serialized) {
-    accessIds = Arrays.stream(serialized.split(SERIALIZATION_SPLIT_KEY))
-        // Remove any empty accessId strings when deserializing
-        .filter(e -> !e.isEmpty()).collect(Collectors.toSet());
   }
 
   public Set<String> getAccessIds() {
@@ -67,24 +55,23 @@ public final class OmDBKerberosPrincipalInfo {
     return accessIds.contains(accessId);
   }
 
-  private String serialize() {
-    return String.join(SERIALIZATION_SPLIT_KEY, accessIds);
+  /**
+   * Convert OmDBKerberosPrincipalInfo to protobuf to be persisted to DB.
+   */
+  public OzoneManagerProtocolProtos.TenantUserPrincipalInfo getProtobuf() {
+    return OzoneManagerProtocolProtos.TenantUserPrincipalInfo.newBuilder()
+        .addAllAccessIds(accessIds)
+        .build();
   }
 
   /**
-   * Convert OmDBKerberosPrincipalInfo to byteArray to be persisted to DB.
-   * @return byte[]
+   * Convert protobuf to OmDBKerberosPrincipalInfo.
    */
-  public byte[] convertToByteArray() {
-    return StringUtils.string2Bytes(serialize());
-  }
-
-  /**
-   * Convert byte array to OmDBKerberosPrincipalInfo.
-   */
-  public static OmDBKerberosPrincipalInfo getFromByteArray(byte[] bytes) {
-    String tInfo = StringUtils.bytes2String(bytes);
-    return new OmDBKerberosPrincipalInfo(tInfo);
+  public static OmDBKerberosPrincipalInfo getFromProtobuf(
+      OzoneManagerProtocolProtos.TenantUserPrincipalInfo proto) {
+    return new Builder()
+        .setAccessIds(new HashSet<>(proto.getAccessIdsList()))
+        .build();
   }
 
   /**

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
@@ -30,30 +31,19 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
    */
   private final String tenantId;
   /**
-   * Name of the bucket namespace (volume name).
+   * Name of the bucket namespace (volume).
    */
   private final String bucketNamespaceName;
   /**
-   * Name of the account namespace.
+   * Name of the bucket policies.
    */
-  private final String accountNamespaceName;
-  /**
-   * Name of the user policy group.
-   */
-  private final String userPolicyGroupName;
-  /**
-   * Name of the bucket policy group.
-   */
-  private final String bucketPolicyGroupName;
+  private final List<String> policyIds;
 
   public OmDBTenantInfo(String tenantId,
-      String bucketNamespaceName, String accountNamespaceName,
-      String userPolicyGroupName, String bucketPolicyGroupName) {
+      String bucketNamespaceName, List<String> policyIds) {
     this.tenantId = tenantId;
     this.bucketNamespaceName = bucketNamespaceName;
-    this.accountNamespaceName = accountNamespaceName;
-    this.userPolicyGroupName = userPolicyGroupName;
-    this.bucketPolicyGroupName = bucketPolicyGroupName;
+    this.policyIds = policyIds;
   }
 
   @Override
@@ -67,15 +57,12 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
     OmDBTenantInfo that = (OmDBTenantInfo) o;
     return Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bucketNamespaceName, that.bucketNamespaceName)
-        && Objects.equals(accountNamespaceName, that.accountNamespaceName)
-        && Objects.equals(userPolicyGroupName, that.userPolicyGroupName)
-        && Objects.equals(bucketPolicyGroupName, that.bucketPolicyGroupName);
+        && Objects.equals(policyIds, that.policyIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, bucketNamespaceName, accountNamespaceName,
-        userPolicyGroupName, bucketPolicyGroupName);
+    return Objects.hash(tenantId, bucketNamespaceName, policyIds);
   }
 
   @Override
@@ -97,16 +84,8 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
     return bucketNamespaceName;
   }
 
-  public String getAccountNamespaceName() {
-    return accountNamespaceName;
-  }
-
-  public String getUserPolicyGroupName() {
-    return userPolicyGroupName;
-  }
-
-  public String getBucketPolicyGroupName() {
-    return bucketPolicyGroupName;
+  public List<String> getPolicyIds() {
+    return policyIds;
   }
 
   /**
@@ -116,9 +95,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
     return OzoneManagerProtocolProtos.TenantInfo.newBuilder()
         .setTenantId(tenantId)
         .setBucketNamespaceName(bucketNamespaceName)
-        .setAccountNamespaceName(accountNamespaceName)
-        .setUserPolicyGroupName(userPolicyGroupName)
-        .setBucketPolicyGroupName(bucketPolicyGroupName)
+        .addAllPolicyIds(policyIds)
         .build();
   }
 
@@ -130,9 +107,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
     return new Builder()
         .setTenantId(proto.getTenantId())
         .setBucketNamespaceName(proto.getBucketNamespaceName())
-        .setAccountNamespaceName(proto.getAccountNamespaceName())
-        .setUserPolicyGroupName(proto.getUserPolicyGroupName())
-        .setBucketPolicyGroupName(proto.getBucketPolicyGroupName())
+        .setPolicyIdsList(proto.getPolicyIdsList())
         .build();
   }
 
@@ -143,9 +118,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
   public static final class Builder {
     private String tenantId;
     private String bucketNamespaceName;
-    private String accountNamespaceName;
-    private String userPolicyGroupName;
-    private String bucketPolicyGroupName;
+    private List<String> policyIds;
 
     private Builder() {
     }
@@ -160,24 +133,13 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
       return this;
     }
 
-    public Builder setAccountNamespaceName(String accountNamespaceName) {
-      this.accountNamespaceName = accountNamespaceName;
-      return this;
-    }
-
-    public Builder setUserPolicyGroupName(String userPolicyGroupName) {
-      this.userPolicyGroupName = userPolicyGroupName;
-      return this;
-    }
-
-    public Builder setBucketPolicyGroupName(String bucketPolicyGroupName) {
-      this.bucketPolicyGroupName = bucketPolicyGroupName;
+    public Builder setPolicyIdsList(List<String> policyIds) {
+      this.policyIds = policyIds;
       return this;
     }
 
     public OmDBTenantInfo build() {
-      return new OmDBTenantInfo(tenantId, bucketNamespaceName,
-          accountNamespaceName, userPolicyGroupName, bucketPolicyGroupName);
+      return new OmDBTenantInfo(tenantId, bucketNamespaceName, policyIds);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantInfo.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import com.google.common.base.Preconditions;
-import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
 import java.util.Objects;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -35,15 +34,31 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
    */
   private final String bucketNamespaceName;
   /**
-   * Bucket policy names stored as Strings.
+   * Name of the user role of this tenant.
    */
-  private final List<String> policyNames;
+  private final String userRoleName;
+  /**
+   * Name of the admin role of this tenant.
+   */
+  private final String adminRoleName;
+  /**
+   * Name of the volume access policy of this tenant.
+   */
+  private final String bucketNamespacePolicyName;
+  /**
+   * Name of the bucket access policy of this tenant.
+   */
+  private final String bucketPolicyName;
 
-  public OmDBTenantState(String tenantId,
-      String bucketNamespaceName, List<String> policyNames) {
+  public OmDBTenantState(String tenantId, String bucketNamespaceName,
+      String userRoleName, String adminRoleName,
+      String bucketNamespacePolicyName, String bucketPolicyName) {
     this.tenantId = tenantId;
     this.bucketNamespaceName = bucketNamespaceName;
-    this.policyNames = policyNames;
+    this.userRoleName = userRoleName;
+    this.adminRoleName = adminRoleName;
+    this.bucketNamespacePolicyName = bucketNamespacePolicyName;
+    this.bucketPolicyName = bucketPolicyName;
   }
 
   @Override
@@ -57,12 +72,18 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     OmDBTenantState that = (OmDBTenantState) o;
     return Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bucketNamespaceName, that.bucketNamespaceName)
-        && Objects.equals(policyNames, that.policyNames);
+        && Objects.equals(userRoleName, that.userRoleName)
+        && Objects.equals(adminRoleName, that.adminRoleName)
+        && Objects.equals(
+            bucketNamespacePolicyName, that.bucketNamespacePolicyName)
+        && Objects.equals(bucketPolicyName, that.bucketPolicyName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, bucketNamespaceName, policyNames);
+    return Objects.hash(tenantId, bucketNamespaceName,
+        userRoleName, adminRoleName,
+        bucketNamespacePolicyName, bucketPolicyName);
   }
 
   @Override
@@ -84,8 +105,20 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return bucketNamespaceName;
   }
 
-  public List<String> getPolicyNames() {
-    return policyNames;
+  public String getUserRoleName() {
+    return userRoleName;
+  }
+
+  public String getAdminRoleName() {
+    return adminRoleName;
+  }
+
+  public String getBucketNamespacePolicyName() {
+    return bucketNamespacePolicyName;
+  }
+
+  public String getBucketPolicyName() {
+    return bucketPolicyName;
   }
 
   /**
@@ -95,7 +128,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return OzoneManagerProtocolProtos.TenantState.newBuilder()
         .setTenantId(tenantId)
         .setBucketNamespaceName(bucketNamespaceName)
-        .addAllPolicyNames(policyNames)
+        .setUserRoleName(userRoleName)
+        .setAdminRoleName(adminRoleName)
+        .setBucketNamespacePolicyName(bucketNamespacePolicyName)
+        .setBucketPolicyName(bucketPolicyName)
         .build();
   }
 
@@ -107,7 +143,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return new Builder()
         .setTenantId(proto.getTenantId())
         .setBucketNamespaceName(proto.getBucketNamespaceName())
-        .setPolicyNamesList(proto.getPolicyNamesList())
+        .setUserRoleName(proto.getUserRoleName())
+        .setAdminRoleName(proto.getAdminRoleName())
+        .setBucketNamespacePolicyName(proto.getBucketNamespacePolicyName())
+        .setBucketPolicyName(proto.getBucketPolicyName())
         .build();
   }
 
@@ -118,7 +157,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   public static final class Builder {
     private String tenantId;
     private String bucketNamespaceName;
-    private List<String> policyNames;
+    private String userRoleName;
+    private String adminRoleName;
+    private String bucketNamespacePolicyName;
+    private String bucketPolicyName;
 
     private Builder() {
     }
@@ -133,13 +175,31 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
       return this;
     }
 
-    public Builder setPolicyNamesList(List<String> policyNames) {
-      this.policyNames = policyNames;
+    public Builder setUserRoleName(String userRoleName) {
+      this.userRoleName = userRoleName;
+      return this;
+    }
+
+    public Builder setAdminRoleName(String adminRoleName) {
+      this.adminRoleName = adminRoleName;
+      return this;
+    }
+
+    public Builder setBucketNamespacePolicyName(
+        String bucketNamespacePolicyName) {
+      this.bucketNamespacePolicyName = bucketNamespacePolicyName;
+      return this;
+    }
+
+    public Builder setBucketPolicyName(String bucketPolicyName) {
+      this.bucketPolicyName = bucketPolicyName;
       return this;
     }
 
     public OmDBTenantState build() {
-      return new OmDBTenantState(tenantId, bucketNamespaceName, policyNames);
+      return new OmDBTenantState(tenantId, bucketNamespaceName,
+          userRoleName, adminRoleName,
+          bucketNamespacePolicyName, bucketPolicyName);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * This class is used for storing Ozone tenant info.
+ * This class is used for storing Ozone tenant state info.
  */
-public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
+public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   /**
    * Name of the tenant.
    */
@@ -39,7 +39,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
    */
   private final List<String> policyIds;
 
-  public OmDBTenantInfo(String tenantId,
+  public OmDBTenantState(String tenantId,
       String bucketNamespaceName, List<String> policyIds) {
     this.tenantId = tenantId;
     this.bucketNamespaceName = bucketNamespaceName;
@@ -54,7 +54,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    OmDBTenantInfo that = (OmDBTenantInfo) o;
+    OmDBTenantState that = (OmDBTenantState) o;
     return Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bucketNamespaceName, that.bucketNamespaceName)
         && Objects.equals(policyIds, that.policyIds);
@@ -66,7 +66,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
   }
 
   @Override
-  public int compareTo(OmDBTenantInfo o) {
+  public int compareTo(OmDBTenantState o) {
     return this.getTenantId().compareTo(o.getTenantId());
   }
 
@@ -102,7 +102,7 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
   /**
    * Convert protobuf to OmDBTenantInfo.
    */
-  public static OmDBTenantInfo getFromProtobuf(
+  public static OmDBTenantState getFromProtobuf(
       OzoneManagerProtocolProtos.TenantInfo proto) {
     return new Builder()
         .setTenantId(proto.getTenantId())
@@ -138,8 +138,8 @@ public final class OmDBTenantInfo implements Comparable<OmDBTenantInfo> {
       return this;
     }
 
-    public OmDBTenantInfo build() {
-      return new OmDBTenantInfo(tenantId, bucketNamespaceName, policyIds);
+    public OmDBTenantState build() {
+      return new OmDBTenantState(tenantId, bucketNamespaceName, policyIds);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -35,15 +35,15 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
    */
   private final String bucketNamespaceName;
   /**
-   * Bucket policy IDs stored as Strings.
+   * Bucket policy names stored as Strings.
    */
-  private final List<String> policyIds;
+  private final List<String> policyNames;
 
   public OmDBTenantState(String tenantId,
-      String bucketNamespaceName, List<String> policyIds) {
+      String bucketNamespaceName, List<String> policyNames) {
     this.tenantId = tenantId;
     this.bucketNamespaceName = bucketNamespaceName;
-    this.policyIds = policyIds;
+    this.policyNames = policyNames;
   }
 
   @Override
@@ -57,12 +57,12 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     OmDBTenantState that = (OmDBTenantState) o;
     return Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bucketNamespaceName, that.bucketNamespaceName)
-        && Objects.equals(policyIds, that.policyIds);
+        && Objects.equals(policyNames, that.policyNames);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, bucketNamespaceName, policyIds);
+    return Objects.hash(tenantId, bucketNamespaceName, policyNames);
   }
 
   @Override
@@ -84,8 +84,8 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return bucketNamespaceName;
   }
 
-  public List<String> getPolicyIds() {
-    return policyIds;
+  public List<String> getPolicyNames() {
+    return policyNames;
   }
 
   /**
@@ -95,7 +95,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return OzoneManagerProtocolProtos.TenantInfo.newBuilder()
         .setTenantId(tenantId)
         .setBucketNamespaceName(bucketNamespaceName)
-        .addAllPolicyIds(policyIds)
+        .addAllPolicyNames(policyNames)
         .build();
   }
 
@@ -107,7 +107,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
     return new Builder()
         .setTenantId(proto.getTenantId())
         .setBucketNamespaceName(proto.getBucketNamespaceName())
-        .setPolicyIdsList(proto.getPolicyIdsList())
+        .setPolicyNamesList(proto.getPolicyNamesList())
         .build();
   }
 
@@ -118,7 +118,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   public static final class Builder {
     private String tenantId;
     private String bucketNamespaceName;
-    private List<String> policyIds;
+    private List<String> policyNames;
 
     private Builder() {
     }
@@ -133,13 +133,13 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
       return this;
     }
 
-    public Builder setPolicyIdsList(List<String> policyIds) {
-      this.policyIds = policyIds;
+    public Builder setPolicyNamesList(List<String> policyNames) {
+      this.policyNames = policyNames;
       return this;
     }
 
     public OmDBTenantState build() {
-      return new OmDBTenantState(tenantId, bucketNamespaceName, policyIds);
+      return new OmDBTenantState(tenantId, bucketNamespaceName, policyNames);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -35,7 +35,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
    */
   private final String bucketNamespaceName;
   /**
-   * Name of the bucket policies.
+   * Bucket policy IDs stored as Strings.
    */
   private final List<String> policyIds;
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBTenantState.java
@@ -89,10 +89,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   }
 
   /**
-   * Convert OmDBTenantInfo to protobuf to be persisted to DB.
+   * Convert OmDBTenantState to protobuf to be persisted to DB.
    */
-  public OzoneManagerProtocolProtos.TenantInfo getProtobuf() {
-    return OzoneManagerProtocolProtos.TenantInfo.newBuilder()
+  public OzoneManagerProtocolProtos.TenantState getProtobuf() {
+    return OzoneManagerProtocolProtos.TenantState.newBuilder()
         .setTenantId(tenantId)
         .setBucketNamespaceName(bucketNamespaceName)
         .addAllPolicyNames(policyNames)
@@ -100,10 +100,10 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   }
 
   /**
-   * Convert protobuf to OmDBTenantInfo.
+   * Convert protobuf to OmDBTenantState.
    */
   public static OmDBTenantState getFromProtobuf(
-      OzoneManagerProtocolProtos.TenantInfo proto) {
+      OzoneManagerProtocolProtos.TenantState proto) {
     return new Builder()
         .setTenantId(proto.getTenantId())
         .setBucketNamespaceName(proto.getBucketNamespaceName())
@@ -112,7 +112,7 @@ public final class OmDBTenantState implements Comparable<OmDBTenantState> {
   }
 
   /**
-   * Builder for OmDBTenantInfo.
+   * Builder for OmDBTenantState.
    */
   @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmDBUserPrincipalInfo.java
@@ -28,14 +28,14 @@ import java.util.Set;
  * For now this only stores a list of accessIds associates with the user
  * principal.
  */
-public final class OmDBKerberosPrincipalInfo {
+public final class OmDBUserPrincipalInfo {
 
   /**
    * A set of accessIds.
    */
   private final Set<String> accessIds;
 
-  public OmDBKerberosPrincipalInfo(Set<String> accessIds) {
+  public OmDBUserPrincipalInfo(Set<String> accessIds) {
     this.accessIds = new HashSet<>(accessIds);
   }
 
@@ -56,7 +56,7 @@ public final class OmDBKerberosPrincipalInfo {
   }
 
   /**
-   * Convert OmDBKerberosPrincipalInfo to protobuf to be persisted to DB.
+   * Convert OmDBUserPrincipalInfo to protobuf to be persisted to DB.
    */
   public OzoneManagerProtocolProtos.TenantUserPrincipalInfo getProtobuf() {
     return OzoneManagerProtocolProtos.TenantUserPrincipalInfo.newBuilder()
@@ -65,9 +65,9 @@ public final class OmDBKerberosPrincipalInfo {
   }
 
   /**
-   * Convert protobuf to OmDBKerberosPrincipalInfo.
+   * Convert protobuf to OmDBUserPrincipalInfo.
    */
-  public static OmDBKerberosPrincipalInfo getFromProtobuf(
+  public static OmDBUserPrincipalInfo getFromProtobuf(
       OzoneManagerProtocolProtos.TenantUserPrincipalInfo proto) {
     return new Builder()
         .setAccessIds(new HashSet<>(proto.getAccessIdsList()))
@@ -75,7 +75,7 @@ public final class OmDBKerberosPrincipalInfo {
   }
 
   /**
-   * Builder for OmDBKerberosPrincipalInfo.
+   * Builder for OmDBUserPrincipalInfo.
    */
   @SuppressWarnings("checkstyle:hiddenfield")
   public static final class Builder {
@@ -86,8 +86,8 @@ public final class OmDBKerberosPrincipalInfo {
       return this;
     }
 
-    public OmDBKerberosPrincipalInfo build() {
-      return new OmDBKerberosPrincipalInfo(accessIds);
+    public OmDBUserPrincipalInfo build() {
+      return new OmDBUserPrincipalInfo(accessIds);
     }
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantStateList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantStateList.java
@@ -18,38 +18,39 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantState;
 
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Utility class to handle protobuf message TenantInfo conversion.
+ * Utility class to handle protobuf message TenantState conversion.
  */
-public class TenantInfoList {
+public class TenantStateList {
 
   // A list of TenantAccessIdInfo from protobuf.
-  private final List<TenantInfo> tenantInfoList;
+  private final List<TenantState> tenantStateList;
 
-  public List<TenantInfo> getTenantInfoList() {
-    return tenantInfoList;
+  public List<TenantState> getTenantStateList() {
+    return tenantStateList;
   }
 
-  public TenantInfoList(List<TenantInfo> tenantInfoList) {
-    this.tenantInfoList = tenantInfoList;
+  public TenantStateList(List<TenantState> tenantStateList) {
+    this.tenantStateList = tenantStateList;
   }
 
-  public static TenantInfoList fromProtobuf(List<TenantInfo> tenantInfoList) {
-    return new TenantInfoList(tenantInfoList);
+  public static TenantStateList fromProtobuf(
+      List<TenantState> tenantStateList) {
+    return new TenantStateList(tenantStateList);
   }
 
-  public TenantInfo getProtobuf() {
+  public TenantState getProtobuf() {
     throw new NotImplementedException("getProtobuf() not implemented");
   }
 
   @Override
   public String toString() {
-    return "tenantInfoList=" + tenantInfoList;
+    return "tenantStateList=" + tenantStateList;
   }
 
   @Override
@@ -60,12 +61,12 @@ public class TenantInfoList {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    TenantInfoList that = (TenantInfoList) o;
-    return tenantInfoList.equals(that.tenantInfoList);
+    TenantStateList that = (TenantStateList) o;
+    return tenantStateList.equals(that.tenantStateList);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantInfoList);
+    return Objects.hash(tenantStateList);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantStateList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantStateList.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 public class TenantStateList {
 
-  // A list of TenantAccessIdInfo from protobuf.
+  // A list of TenantState from protobuf.
   private final List<TenantState> tenantStateList;
 
   public List<TenantState> getTenantStateList() {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.om.helpers;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAccessIdInfo;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoResponse;
 
 import java.util.List;
 import java.util.Objects;
@@ -49,13 +49,14 @@ public class TenantUserInfoValue {
   }
 
   public static TenantUserInfoValue fromProtobuf(
-      TenantUserInfo tenantUserInfo) {
+      TenantGetUserInfoResponse tenantUserInfo) {
     return new TenantUserInfoValue(tenantUserInfo.getUserPrincipal(),
         tenantUserInfo.getAccessIdInfoList());
   }
 
-  public TenantUserInfo getProtobuf() {
-    final TenantUserInfo.Builder builder = TenantUserInfo.newBuilder();
+  public TenantGetUserInfoResponse getProtobuf() {
+    final TenantGetUserInfoResponse.Builder builder =
+        TenantGetUserInfoResponse.newBuilder();
     builder.setUserPrincipal(this.userPrincipal);
     accessIdInfoList.forEach(builder::addAccessIdInfo);
     return builder.build();

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoResponse;
 
 import java.util.List;
@@ -31,19 +31,19 @@ public class TenantUserInfoValue {
   // Usually this is the Kerberos principal of a user.
   private final String userPrincipal;
 
-  // A list of TenantAccessIdInfo from protobuf.
-  private final List<TenantAccessIdInfo> accessIdInfoList;
+  // A list of ExtendedAccessIdInfo from protobuf.
+  private final List<ExtendedAccessIdInfo> accessIdInfoList;
 
   public String getUserPrincipal() {
     return userPrincipal;
   }
 
-  public List<TenantAccessIdInfo> getAccessIdInfoList() {
+  public List<ExtendedAccessIdInfo> getAccessIdInfoList() {
     return accessIdInfoList;
   }
 
   public TenantUserInfoValue(String kerberosID,
-      List<TenantAccessIdInfo> accessIdInfoList) {
+      List<ExtendedAccessIdInfo> accessIdInfoList) {
     this.userPrincipal = kerberosID;
     this.accessIdInfoList = accessIdInfoList;
   }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserInfoValue.java
@@ -17,55 +17,43 @@
  */
 package org.apache.hadoop.ozone.om.helpers;
 
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantGetUserInfoResponse;
 
 import java.util.List;
 import java.util.Objects;
 
 /**
- * Utility class to handle protobuf message TenantUserInfo conversion.
+ * Utility class to handle TenantGetUserInfoResponse protobuf message.
  */
 public class TenantUserInfoValue {
 
-  // Usually this is the Kerberos principal of a user.
-  private final String userPrincipal;
+  // A list of ExtendedUserAccessIdInfo from protobuf.
+  private final List<ExtendedUserAccessIdInfo> accessIdInfoList;
 
-  // A list of ExtendedAccessIdInfo from protobuf.
-  private final List<ExtendedAccessIdInfo> accessIdInfoList;
-
-  public String getUserPrincipal() {
-    return userPrincipal;
-  }
-
-  public List<ExtendedAccessIdInfo> getAccessIdInfoList() {
+  public List<ExtendedUserAccessIdInfo> getAccessIdInfoList() {
     return accessIdInfoList;
   }
 
-  public TenantUserInfoValue(String kerberosID,
-      List<ExtendedAccessIdInfo> accessIdInfoList) {
-    this.userPrincipal = kerberosID;
+  public TenantUserInfoValue(List<ExtendedUserAccessIdInfo> accessIdInfoList) {
     this.accessIdInfoList = accessIdInfoList;
   }
 
   public static TenantUserInfoValue fromProtobuf(
       TenantGetUserInfoResponse tenantUserInfo) {
-    return new TenantUserInfoValue(tenantUserInfo.getUserPrincipal(),
-        tenantUserInfo.getAccessIdInfoList());
+    return new TenantUserInfoValue(tenantUserInfo.getAccessIdInfoList());
   }
 
   public TenantGetUserInfoResponse getProtobuf() {
     final TenantGetUserInfoResponse.Builder builder =
         TenantGetUserInfoResponse.newBuilder();
-    builder.setUserPrincipal(this.userPrincipal);
     accessIdInfoList.forEach(builder::addAccessIdInfo);
     return builder.build();
   }
 
   @Override
   public String toString() {
-    return "userPrincipal=" + userPrincipal +
-        "\naccessIdInfoList=" + accessIdInfoList;
+    return "accessIdInfoList=" + accessIdInfoList;
   }
 
   @Override
@@ -77,12 +65,11 @@ public class TenantUserInfoValue {
       return false;
     }
     TenantUserInfoValue that = (TenantUserInfoValue) o;
-    return userPrincipal.equals(that.userPrincipal) &&
-        accessIdInfoList.equals(that.accessIdInfoList);
+    return accessIdInfoList.equals(that.accessIdInfoList);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(userPrincipal, accessIdInfoList);
+    return Objects.hash(accessIdInfoList);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantListUserResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 
 /**
  * Class to encapsulate the list of users and corresponding accessIds
@@ -32,10 +32,10 @@ public class TenantUserList {
 
   private final String tenantId;
 
-  private final List<TenantUserAccessId> userAccessIds;
+  private final List<ExtendedAccessIdInfo> userAccessIds;
   
   public TenantUserList(String tenantId,
-                        List<TenantUserAccessId> userAccessIds) {
+                        List<ExtendedAccessIdInfo> userAccessIds) {
     this.tenantId = tenantId;
     this.userAccessIds = userAccessIds;
   }
@@ -44,7 +44,7 @@ public class TenantUserList {
     return tenantId;
   }
 
-  public List<TenantUserAccessId> getUserAccessIds() {
+  public List<ExtendedAccessIdInfo> getUserAccessIds() {
     return userAccessIds;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/TenantUserList.java
@@ -22,41 +22,33 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantListUserResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserAccessIdInfo;
 
 /**
  * Class to encapsulate the list of users and corresponding accessIds
  * associated with a tenant.
  */
 public class TenantUserList {
+  /**
+   * List of user principal -> access ID pairs.
+   */
+  private final List<UserAccessIdInfo> userAccessIds;
 
-  private final String tenantId;
-
-  private final List<ExtendedAccessIdInfo> userAccessIds;
-  
-  public TenantUserList(String tenantId,
-                        List<ExtendedAccessIdInfo> userAccessIds) {
-    this.tenantId = tenantId;
+  public TenantUserList(List<UserAccessIdInfo> userAccessIds) {
     this.userAccessIds = userAccessIds;
   }
 
-  public String getTenantId() {
-    return tenantId;
-  }
-
-  public List<ExtendedAccessIdInfo> getUserAccessIds() {
+  public List<UserAccessIdInfo> getUserAccessIds() {
     return userAccessIds;
   }
 
   public static TenantUserList fromProtobuf(TenantListUserResponse response) {
-    return new TenantUserList(response.getTenantId(),
-        response.getUserAccessIdInfoList());
+    return new TenantUserList(response.getUserAccessIdInfoList());
   }
 
   @Override
   public String toString() {
-    return "tenantId=" + tenantId +
-        "\nuserAccessIds=" + userAccessIds;
+    return "userAccessIds=" + userAccessIds;
   }
 
   @Override
@@ -68,12 +60,11 @@ public class TenantUserList {
       return false;
     }
     TenantUserList that = (TenantUserList) o;
-    return tenantId.equals(that.tenantId) &&
-        userAccessIds.equals(that.userAccessIds);
+    return userAccessIds.equals(that.userAccessIds);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(tenantId, userAccessIds);
+    return Objects.hash(userAccessIds);
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerDummyPlugin.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerDummyPlugin.java
@@ -47,7 +47,7 @@ public class MultiTenantAccessAuthorizerDummyPlugin implements
   @Override
   public String assignUser(BasicUserPrincipal principal, String existingRole,
       boolean isAdmin) throws IOException {
-    return "assignUser-roleId-returned";
+    return "assignUser-roleName-returned";
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerRangerPlugin.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerRangerPlugin.java
@@ -347,6 +347,7 @@ public class MultiTenantAccessAuthorizerRangerPlugin implements
     String policyID;
     try {
       JsonObject jObject = new JsonParser().parse(policyInfo).getAsJsonObject();
+      // TODO: Use policy name instead of id
       policyID = jObject.get("id").getAsString();
       LOG.debug("policyID is: {}", policyID);
     } catch (JsonParseException e) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenant.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenant.java
@@ -27,23 +27,23 @@ import org.apache.hadoop.ozone.om.multitenant.impl.SingleVolumeTenantNamespace;
  * In-memory tenant info. For DB state, see OmDBTenantInfo.
  */
 public class OzoneTenant implements Tenant {
-  private final String tenantID;
-  private List<String> tenantRoleIds;
+  private final String tenantId;
+  private List<String> tenantRoleNames;
   private List<AccessPolicy> accessPolicies;
   private final AccountNameSpace accountNameSpace;
   private final BucketNameSpace bucketNameSpace;
 
   public OzoneTenant(String id) {
-    tenantID = id;
+    tenantId = id;
     accessPolicies = new ArrayList<>();
-    tenantRoleIds = new ArrayList<>();
+    tenantRoleNames = new ArrayList<>();
     accountNameSpace = new AccountNameSpaceImpl(id);
     bucketNameSpace = new SingleVolumeTenantNamespace(id);
   }
 
   @Override
   public String getTenantId() {
-    return tenantID;
+    return tenantId;
   }
 
   @Override
@@ -72,17 +72,17 @@ public class OzoneTenant implements Tenant {
   }
 
   @Override
-  public void addTenantAccessRole(String roleId) {
-    tenantRoleIds.add(roleId);
+  public void addTenantAccessRole(String roleName) {
+    tenantRoleNames.add(roleName);
   }
 
   @Override
-  public void removeTenantAccessRole(String roleId) {
-    tenantRoleIds.remove(roleId);
+  public void removeTenantAccessRole(String roleName) {
+    tenantRoleNames.remove(roleName);
   }
 
   @Override
   public List<String> getTenantRoles() {
-    return tenantRoleIds;
+    return tenantRoleNames;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenant.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenant.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.ozone.om.multitenant.impl.AccountNameSpaceImpl;
 import org.apache.hadoop.ozone.om.multitenant.impl.SingleVolumeTenantNamespace;
 
 /**
- * In-memory tenant info. For DB state, see OmDBTenantInfo.
+ * In-memory tenant info. For DB state, see OmDBTenantState.
  */
 public class OzoneTenant implements Tenant {
   private final String tenantId;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenantRolePrincipal.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenantRolePrincipal.java
@@ -29,12 +29,12 @@ public final class OzoneTenantRolePrincipal implements Principal {
 
   public static OzoneTenantRolePrincipal getUserRole(String tenantId) {
     return new OzoneTenantRolePrincipal(
-        tenantId, OzoneConsts.TENANT_ROLE_USER_SUFFIX);
+        tenantId, OzoneConsts.DEFAULT_TENANT_ROLE_USER_SUFFIX);
   }
 
   public static OzoneTenantRolePrincipal getAdminRole(String tenantId) {
     return new OzoneTenantRolePrincipal(
-        tenantId, OzoneConsts.TENANT_ROLE_ADMIN_SUFFIX);
+        tenantId, OzoneConsts.DEFAULT_TENANT_ROLE_ADMIN_SUFFIX);
   }
 
   private OzoneTenantRolePrincipal(String tenantId, String roleNameSuffix) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenantRolePrincipal.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/multitenant/OzoneTenantRolePrincipal.java
@@ -24,24 +24,26 @@ import java.security.Principal;
  * Used to identify a tenant's role in Ranger.
  */
 public final class OzoneTenantRolePrincipal implements Principal {
-  private final String tenantID;
-  private final String roleName;
+  private final String tenantId;
+  private final String roleNameSuffix;
 
-  public static OzoneTenantRolePrincipal getUserRole(String tenantID) {
-    return new OzoneTenantRolePrincipal(tenantID, "UserRole");
+  public static OzoneTenantRolePrincipal getUserRole(String tenantId) {
+    return new OzoneTenantRolePrincipal(
+        tenantId, OzoneConsts.TENANT_ROLE_USER_SUFFIX);
   }
 
-  public static OzoneTenantRolePrincipal getAdminRole(String tenantID) {
-    return new OzoneTenantRolePrincipal(tenantID, "AdminRole");
+  public static OzoneTenantRolePrincipal getAdminRole(String tenantId) {
+    return new OzoneTenantRolePrincipal(
+        tenantId, OzoneConsts.TENANT_ROLE_ADMIN_SUFFIX);
   }
 
-  private OzoneTenantRolePrincipal(String tenantID, String roleName) {
-    this.tenantID = tenantID;
-    this.roleName = roleName;
+  private OzoneTenantRolePrincipal(String tenantId, String roleNameSuffix) {
+    this.tenantId = tenantId;
+    this.roleNameSuffix = roleNameSuffix;
   }
 
-  public String getTenantID() {
-    return tenantID;
+  public String getTenantId() {
+    return tenantId;
   }
 
   @Override
@@ -51,6 +53,6 @@ public final class OzoneTenantRolePrincipal implements Principal {
 
   @Override
   public String getName() {
-    return tenantID + OzoneConsts.TENANT_ID_ROLE_DELIMITER + roleName;
+    return tenantId + roleNameSuffix;
   }
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocol/OzoneManagerProtocol.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDeleteKeys;
@@ -50,7 +50,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -596,7 +596,7 @@ public interface OzoneManagerProtocol
    * @return DeleteTenantResponse
    * @throws IOException
    */
-  default DeleteTenantInfo deleteTenant(String tenantId)
+  default DeleteTenantState deleteTenant(String tenantId)
       throws IOException {
     throw new UnsupportedOperationException("OzoneManager does not require " +
         "this to be implemented, as write requests use a new approach");
@@ -671,10 +671,10 @@ public interface OzoneManagerProtocol
 
   /**
    * List tenants.
-   * @return TenantInfoList
+   * @return TenantStateList
    * @throws IOException
    */
-  TenantInfoList listTenant() throws IOException;
+  TenantStateList listTenant() throws IOException;
 
   /**
    * OzoneFS api to get file status for an entry.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -1105,7 +1105,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final TenantGetUserInfoResponse resp = handleError(omResponse)
         .getTenantGetUserInfoResponse();
 
-    return TenantUserInfoValue.fromProtobuf(resp.getTenantUserInfo());
+    return TenantUserInfoValue.fromProtobuf(resp);
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.io.Text;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.KeyValueUtil;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -59,7 +59,7 @@ import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.helpers.S3VolumeContext;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
@@ -988,7 +988,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
   }
 
   @Override
-  public DeleteTenantInfo deleteTenant(String tenantId) throws IOException {
+  public DeleteTenantState deleteTenant(String tenantId) throws IOException {
     final DeleteTenantRequest request = DeleteTenantRequest.newBuilder()
         .setTenantId(tenantId)
         .build();
@@ -998,7 +998,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final OMResponse omResponse = submitRequest(omRequest);
     final DeleteTenantResponse resp =
         handleError(omResponse).getDeleteTenantResponse();
-    return DeleteTenantInfo.fromProtobuf(resp);
+    return DeleteTenantState.fromProtobuf(resp);
   }
 
   /**
@@ -1144,7 +1144,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * {@inheritDoc}
    */
   @Override
-  public TenantInfoList listTenant() throws IOException {
+  public TenantStateList listTenant() throws IOException {
 
     final ListTenantRequest request = ListTenantRequest.newBuilder()
         .build();
@@ -1155,7 +1155,7 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
     final ListTenantResponse resp = handleError(omResponse)
         .getListTenantResponse();
 
-    return TenantInfoList.fromProtobuf(resp.getTenantInfoList());
+    return TenantStateList.fromProtobuf(resp.getTenantStateList());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -508,18 +508,6 @@ public class TestOzoneTenantShell {
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
     checkOutput(err, "", true);
 
-    // Get user info with role names
-    executeHA(tenantShell, new String[] {
-        "user", "info", "bob", "--print-roles"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
-        + "- Tenant 'research' with accessId 'research$bob', "
-        + "roles: [research-UserRole]\n"
-        + "- Tenant 'finance' with accessId 'finance$bob', "
-        + "roles: [finance-UserRole]\n"
-        + "- Tenant 'dev' with accessId 'dev$bob', roles: [dev-UserRole]\n",
-        true);
-    checkOutput(err, "", true);
-
     // Assign admin
     executeHA(tenantShell, new String[] {
         "user", "assign-admin", "dev$bob", "--tenant=dev"});
@@ -722,7 +710,6 @@ public class TestOzoneTenantShell {
   }
 
   @Test
-  @SuppressWarnings("methodlength")
   public void testTenantSetSecret() throws IOException, InterruptedException {
 
     final String tenantName = "tenant-test-set-secret";
@@ -818,17 +805,6 @@ public class TestOzoneTenantShell {
     checkOutput(out, "", true);
     checkOutput(err, "Assigned admin", false);
 
-    // Get user info should print AdminRoles
-    executeHA(tenantShell, new String[] {
-        "user", "info", "bob", "--print-roles"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
-            + "- Tenant 'tenant-test-set-secret' delegated admin "
-            + "with accessId 'tenant-test-set-secret$bob', "
-            + "roles: [tenant-test-set-secret-UserRole, "
-            + "tenant-test-set-secret-AdminRole]\n",
-        true);
-    checkOutput(err, "", true);
-
     // Set secret should succeed now
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
@@ -845,16 +821,6 @@ public class TestOzoneTenantShell {
         tenantName + "$" + ugiBob.getShortUserName()});
     checkOutput(out, "", true);
     checkOutput(err, "Revoked admin", false);
-
-    // Get user info should no longer print AdminRoles
-    executeHA(tenantShell, new String[] {
-        "user", "info", "bob", "--print-roles"});
-    checkOutput(out, "User 'bob' is assigned to:\n"
-            + "- Tenant 'tenant-test-set-secret' "
-            + "with accessId 'tenant-test-set-secret$bob', "
-            + "roles: [tenant-test-set-secret-UserRole]\n",
-        true);
-    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$bob"});

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneTenantShell.java
@@ -508,6 +508,18 @@ public class TestOzoneTenantShell {
         + "- Tenant 'dev' with accessId 'dev$bob'\n", true);
     checkOutput(err, "", true);
 
+    // Get user info with role names
+    executeHA(tenantShell, new String[] {
+        "user", "info", "bob", "--print-roles"});
+    checkOutput(out, "User 'bob' is assigned to:\n"
+        + "- Tenant 'research' with accessId 'research$bob', "
+        + "roles: [research-UserRole]\n"
+        + "- Tenant 'finance' with accessId 'finance$bob', "
+        + "roles: [finance-UserRole]\n"
+        + "- Tenant 'dev' with accessId 'dev$bob', roles: [dev-UserRole]\n",
+        true);
+    checkOutput(err, "", true);
+
     // Assign admin
     executeHA(tenantShell, new String[] {
         "user", "assign-admin", "dev$bob", "--tenant=dev"});
@@ -710,6 +722,7 @@ public class TestOzoneTenantShell {
   }
 
   @Test
+  @SuppressWarnings("methodlength")
   public void testTenantSetSecret() throws IOException, InterruptedException {
 
     final String tenantName = "tenant-test-set-secret";
@@ -805,6 +818,18 @@ public class TestOzoneTenantShell {
     checkOutput(out, "", true);
     checkOutput(err, "Assigned admin", false);
 
+    // Get user info should print AdminRoles
+    executeHA(tenantShell, new String[] {
+        "user", "info", "bob", "--print-roles"});
+    checkOutput(out, "User 'bob' is assigned to:\n"
+            + "- Tenant 'tenant-test-set-secret' delegated admin "
+            + "with accessId 'tenant-test-set-secret$bob', "
+            + "roles: [tenant-test-set-secret-UserRole, "
+            + "tenant-test-set-secret-AdminRole]\n",
+        true);
+    checkOutput(err, "", true);
+
+    // Set secret should succeed now
     ugiBob.doAs((PrivilegedExceptionAction<Void>) () -> {
       executeHA(tenantShell, new String[] {
           "user", "setsecret", tenantName + "$alice",
@@ -820,6 +845,16 @@ public class TestOzoneTenantShell {
         tenantName + "$" + ugiBob.getShortUserName()});
     checkOutput(out, "", true);
     checkOutput(err, "Revoked admin", false);
+
+    // Get user info should no longer print AdminRoles
+    executeHA(tenantShell, new String[] {
+        "user", "info", "bob", "--print-roles"});
+    checkOutput(out, "User 'bob' is assigned to:\n"
+            + "- Tenant 'tenant-test-set-secret' "
+            + "with accessId 'tenant-test-set-secret$bob', "
+            + "roles: [tenant-test-set-secret-UserRole]\n",
+        true);
+    checkOutput(err, "", true);
 
     executeHA(tenantShell, new String[] {
         "user", "revoke", tenantName + "$bob"});

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1416,30 +1416,36 @@ message TenantUserPrincipalInfo {
     repeated string accessIds = 1;
 }
 
-// For storing extended access ID information (related to a tenant) to OM DB
-// Does not include the access ID value itself
+// Multi-purpose message for storing or transferring extra access ID information
+//
+// This is an extension to the S3Secret protobuf message, carrying supplementary
+//   information to the existing accessId (kerberosID) field.
+//
+// For now, all fields are related to multi-tenancy. New fields can be added
+//   when necessary in the future. e.g. when implementing new features.
+//
+// Usage 1: Stored as value in OmDBTenantState table.
+//   See OmDBAccessIdInfo.
+//   In this case, accessId field is not set to avoid duplication,
+//   because the key of the OmDBTenantState table is already the accessId.
+//
+// Usage 2: Used when transferring the result of `ozone tenant user list`.
+//   See TenantUserList.
+//   In this case, tenantId field is not set to avoid duplication.
+//   tenantId will be set once and only once in TenantListUserResponse.
+//
+// Usage 3: Used when transferring the result of `ozone tenant user info`
+//   See TenantUserInfoValue.
+//   In this case, userPrincipal field is not set to avoid duplication.
+//   userPrincipal will be set once and only once in TenantGetUserInfoResponse.
+//
 message ExtendedAccessIdInfo {
-    optional string tenantId = 1;
-    optional string userPrincipal = 2;
-    optional bool isAdmin = 3;
-    optional bool isDelegatedAdmin = 4;
-    repeated string roleNames = 5;
-}
-
-// For `tenant user info` to store access ID along with its tenant-related info
-message TenantAccessIdInfo {
-    optional string accessId = 1;
-    optional string tenantId = 2;
-    optional bool isAdmin = 3;
-    optional bool isDelegatedAdmin = 4;
-}
-
-// For `tenant user list` to store all access IDs assigned to the tenant
-message TenantUserAccessId {
-    optional string userPrincipal = 1;
-    optional string accessId = 2;
-    optional bool isAdmin = 3;
-    optional bool isDelegatedAdmin = 4;
+    optional string accessId = 1;        // OmDBTenantState doesn't store this
+    optional string tenantId = 2;        // `tenant user list` doesn't set this
+    optional string userPrincipal = 3;   // `user info` doesn't set this
+    optional bool isAdmin = 4;           // `tenant user list` doesn't set this (yet)
+    optional bool isDelegatedAdmin = 5;  // `tenant user list` doesn't set this (yet)
+    repeated string roleNames = 6;       // `tenant user list` doesn't set this (yet)
 }
 
 message ListTenantRequest {
@@ -1460,13 +1466,13 @@ message TenantListUserRequest {
 }
 
 message TenantGetUserInfoResponse {
-    optional string userPrincipal = 1;
-    repeated TenantAccessIdInfo accessIdInfo = 2;
+    optional string userPrincipal = 1;  // Set only once to avoid duplication
+    repeated ExtendedAccessIdInfo accessIdInfo = 2;
 }
 
 message TenantListUserResponse {
-    optional string tenantId = 1;
-    repeated TenantUserAccessId userAccessIdInfo = 2;
+    optional string tenantId = 1;  // Set only once to avoid duplication
+    repeated ExtendedAccessIdInfo userAccessIdInfo = 2;
 }
 
 message LayoutVersion {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1414,6 +1414,10 @@ message TenantInfo {
     optional string bucketPolicyGroupName = 5;
 }
 
+message TenantUserPrincipalInfo {
+  repeated string accessIds = 1;
+}
+
 // For storing extended access ID information (related to a tenant) to OM DB
 // Does not include the access ID value itself
 message ExtendedAccessIdInfo {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1409,7 +1409,7 @@ message SetS3SecretResponse {
 message TenantInfo {
     optional string tenantId = 1;
     optional string bucketNamespaceName = 2;
-    repeated string policyIds = 3;
+    repeated string policyNames = 3;
 }
 
 message TenantUserPrincipalInfo {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1415,40 +1415,39 @@ message TenantInfo {
 }
 
 message TenantUserPrincipalInfo {
-  repeated string accessIds = 1;
+    repeated string accessIds = 1;
 }
 
 // For storing extended access ID information (related to a tenant) to OM DB
 // Does not include the access ID value itself
 message ExtendedAccessIdInfo {
-  optional string tenantId = 1;
-  optional string userPrincipal = 2;
-  optional bool isAdmin = 3;
-  optional bool isDelegatedAdmin = 4;
-  optional string roleId = 5;
+    optional string tenantId = 1;
+    optional string userPrincipal = 2;
+    optional bool isAdmin = 3;
+    optional bool isDelegatedAdmin = 4;
+    repeated string roleIds = 5;
 }
 
 // For `tenant user info` to store access ID along with its tenant-related info
 message TenantAccessIdInfo {
-  optional string accessId = 1;
-  optional string tenantId = 2;
-  optional bool isAdmin = 3;
-  optional bool isDelegatedAdmin = 4;
+    optional string accessId = 1;
+    optional string tenantId = 2;
+    optional bool isAdmin = 3;
+    optional bool isDelegatedAdmin = 4;
 }
 
 message TenantUserInfo {
-  optional string userPrincipal = 1;
-  repeated TenantAccessIdInfo accessIdInfo = 2;
+    optional string userPrincipal = 1;
+    repeated TenantAccessIdInfo accessIdInfo = 2;
 }
 
 // For `tenant user list` to store all access IDs assigned to the tenant
 message TenantUserAccessId {
-  optional string userPrincipal = 1;
-  optional string accessId = 2;
-  optional bool isAdmin = 3;
-  optional bool isDelegatedAdmin = 4;
+    optional string userPrincipal = 1;
+    optional string accessId = 2;
+    optional bool isAdmin = 3;
+    optional bool isDelegatedAdmin = 4;
 }
-
 
 message ListTenantRequest {
 
@@ -1475,7 +1474,6 @@ message TenantListUserResponse {
     optional string tenantId = 1;
     repeated TenantUserAccessId userAccessIdInfo = 2;
 }
-
 
 message LayoutVersion {
   required uint64 version = 1;

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1414,11 +1414,35 @@ message TenantInfo {
     optional string bucketPolicyGroupName = 5;
 }
 
+// For storing extended access ID information (related to a tenant) to OM DB
+// Does not include the access ID value itself
+message ExtendedAccessIdInfo {
+  optional string tenantId = 1;
+  optional string userPrincipal = 2;
+  optional bool isAdmin = 3;
+  optional bool isDelegatedAdmin = 4;
+  optional string roleId = 5;
+}
+
+// For `tenant user info` to store access ID along with its tenant-related info
+message TenantAccessIdInfo {
+  optional string accessId = 1;
+  optional string tenantId = 2;
+  optional bool isAdmin = 3;
+  optional bool isDelegatedAdmin = 4;
+}
+
+message TenantUserInfo {
+  optional string userPrincipal = 1;
+  repeated TenantAccessIdInfo accessIdInfo = 2;
+}
+
+// For `tenant user list` to store all access IDs assigned to the tenant
 message TenantUserAccessId {
-    optional string userPrincipal = 1;
-    optional string accessId = 2;
-    optional bool isAdmin = 3;
-    optional bool isDelegatedAdmin = 4;
+  optional string userPrincipal = 1;
+  optional string accessId = 2;
+  optional bool isAdmin = 3;
+  optional bool isDelegatedAdmin = 4;
 }
 
 
@@ -1446,18 +1470,6 @@ message TenantGetUserInfoResponse {
 message TenantListUserResponse {
     optional string tenantId = 1;
     repeated TenantUserAccessId userAccessIdInfo = 2;
-}
-
-message TenantUserInfo {
-    optional string userPrincipal = 1;
-    repeated TenantAccessIdInfo accessIdInfo = 2;
-}
-
-message TenantAccessIdInfo {
-    optional string accessId = 1;
-    optional string tenantId = 2;
-    optional bool isAdmin = 3;
-    optional bool isDelegatedAdmin = 4;
 }
 
 
@@ -1528,14 +1540,6 @@ message TenantAssignAdminResponse {
 
 message TenantRevokeAdminResponse {
 
-}
-
-message OmDBAccessInfo {
-  optional string tenantId = 1;
-  optional string userPrincipal = 2;
-  optional bool isAdmin = 3;
-  optional bool isDelegatedAdmin = 4;
-  optional string roleId = 5;
 }
 
 message GetS3VolumeContextResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1406,7 +1406,7 @@ message SetS3SecretResponse {
     optional string secretKey = 2;
 }
 
-message TenantInfo {
+message TenantState {
     optional string tenantId = 1;
     optional string bucketNamespaceName = 2;
     repeated string policyNames = 3;
@@ -1447,7 +1447,7 @@ message ListTenantRequest {
 }
 
 message ListTenantResponse {
-    repeated TenantInfo tenantInfo = 1;
+    repeated TenantState tenantState = 1;
 }
 
 message TenantGetUserInfoRequest {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1535,6 +1535,7 @@ message OmDBAccessInfo {
   optional string userPrincipal = 2;
   optional bool isAdmin = 3;
   optional bool isDelegatedAdmin = 4;
+  optional string roleId = 5;
 }
 
 message GetS3VolumeContextResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1423,7 +1423,7 @@ message ExtendedAccessIdInfo {
     optional string userPrincipal = 2;
     optional bool isAdmin = 3;
     optional bool isDelegatedAdmin = 4;
-    repeated string roleIds = 5;
+    repeated string roleNames = 5;
 }
 
 // For `tenant user info` to store access ID along with its tenant-related info

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1409,9 +1409,7 @@ message SetS3SecretResponse {
 message TenantInfo {
     optional string tenantId = 1;
     optional string bucketNamespaceName = 2;
-    optional string accountNamespaceName = 3;
-    optional string userPolicyGroupName = 4;
-    optional string bucketPolicyGroupName = 5;
+    repeated string policyIds = 3;
 }
 
 message TenantUserPrincipalInfo {
@@ -1434,11 +1432,6 @@ message TenantAccessIdInfo {
     optional string tenantId = 2;
     optional bool isAdmin = 3;
     optional bool isDelegatedAdmin = 4;
-}
-
-message TenantUserInfo {
-    optional string userPrincipal = 1;
-    repeated TenantAccessIdInfo accessIdInfo = 2;
 }
 
 // For `tenant user list` to store all access IDs assigned to the tenant
@@ -1467,7 +1460,8 @@ message TenantListUserRequest {
 }
 
 message TenantGetUserInfoResponse {
-    optional TenantUserInfo tenantUserInfo = 1;
+    optional string userPrincipal = 1;
+    repeated TenantAccessIdInfo accessIdInfo = 2;
 }
 
 message TenantListUserResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1408,44 +1408,43 @@ message SetS3SecretResponse {
 
 message TenantState {
     optional string tenantId = 1;
-    optional string bucketNamespaceName = 2;
-    repeated string policyNames = 3;
+    optional string bucketNamespaceName = 2;        // Volume name
+    optional string userRoleName = 3;
+    optional string adminRoleName = 4;
+    optional string bucketNamespacePolicyName = 5;  // VolumeAccessPolicy name
+    optional string bucketPolicyName = 6;           // BucketAccessPolicy name
 }
 
 message TenantUserPrincipalInfo {
     repeated string accessIds = 1;
 }
 
+// Stores a basic user-accessId pair, used in TenantListUserResponse
+message UserAccessIdInfo {
+    optional string userPrincipal = 1;
+    optional string accessId = 2;
+}
+
 // Multi-purpose message for storing or transferring extra access ID information
 //
 // This is an extension to the S3Secret protobuf message, carrying supplementary
 //   information to the existing accessId (kerberosID) field.
-//
 // For now, all fields are related to multi-tenancy. New fields can be added
 //   when necessary in the future. e.g. when implementing new features.
 //
-// Usage 1: Stored as value in OmDBTenantState table.
-//   See OmDBAccessIdInfo.
+// Usage 1: Stored as value (OmDBAccessIdInfo) in TenantAccessIdTable.
 //   In this case, accessId field is not set to avoid duplication,
-//   because the key of the OmDBTenantState table is already the accessId.
+//   because the key of TenantAccessIdTable is already accessId.
 //
-// Usage 2: Used when transferring the result of `ozone tenant user list`.
-//   See TenantUserList.
-//   In this case, tenantId field is not set to avoid duplication.
-//   tenantId will be set once and only once in TenantListUserResponse.
-//
-// Usage 3: Used when transferring the result of `ozone tenant user info`
+// Usage 2: Used when transferring the result of `ozone tenant user info`
 //   See TenantUserInfoValue.
-//   In this case, userPrincipal field is not set to avoid duplication.
-//   userPrincipal will be set once and only once in TenantGetUserInfoResponse.
 //
-message ExtendedAccessIdInfo {
-    optional string accessId = 1;        // OmDBTenantState doesn't store this
-    optional string tenantId = 2;        // `tenant user list` doesn't set this
-    optional string userPrincipal = 3;   // `user info` doesn't set this
-    optional bool isAdmin = 4;           // `tenant user list` doesn't set this (yet)
-    optional bool isDelegatedAdmin = 5;  // `tenant user list` doesn't set this (yet)
-    repeated string roleNames = 6;       // `tenant user list` doesn't set this (yet)
+message ExtendedUserAccessIdInfo {
+    optional string userPrincipal = 1;
+    optional string accessId = 2;  // OmDBAccessIdInfo doesn't use this field
+    optional string tenantId = 3;
+    optional bool isAdmin = 4;
+    optional bool isDelegatedAdmin = 5;
 }
 
 message ListTenantRequest {
@@ -1456,23 +1455,21 @@ message ListTenantResponse {
     repeated TenantState tenantState = 1;
 }
 
-message TenantGetUserInfoRequest {
-    optional string userPrincipal = 1;
-}
-
 message TenantListUserRequest {
     optional string tenantId = 1;
     optional string prefix = 2;
 }
 
-message TenantGetUserInfoResponse {
-    optional string userPrincipal = 1;  // Set only once to avoid duplication
-    repeated ExtendedAccessIdInfo accessIdInfo = 2;
+message TenantListUserResponse {
+    repeated UserAccessIdInfo userAccessIdInfo = 1;
 }
 
-message TenantListUserResponse {
-    optional string tenantId = 1;  // Set only once to avoid duplication
-    repeated ExtendedAccessIdInfo userAccessIdInfo = 2;
+message TenantGetUserInfoRequest {
+    optional string userPrincipal = 1;
+}
+
+message TenantGetUserInfoResponse {
+    repeated ExtendedUserAccessIdInfo accessIdInfo = 1;
 }
 
 message LayoutVersion {

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -365,8 +365,6 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, OmDBTenantInfo> getTenantStateTable();
 
-  Table<String, String> getTenantPolicyTable();
-
   /**
    * Gets the OM Meta table.
    * @return meta table reference.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
@@ -363,7 +363,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, OmDBUserPrincipalInfo> getPrincipalToAccessIdsTable();
 
-  Table<String, OmDBTenantInfo> getTenantStateTable();
+  Table<String, OmDBTenantState> getTenantStateTable();
 
   /**
    * Gets the OM Meta table.

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -365,8 +365,6 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, OmDBTenantInfo> getTenantStateTable();
 
-  Table<String, String> getTenantGroupTable();
-
   Table<String, String> getTenantRoleTable();
 
   Table<String, String> getTenantPolicyTable();

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -361,7 +361,7 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, OmDBAccessIdInfo> getTenantAccessIdTable();
 
-  Table<String, OmDBKerberosPrincipalInfo> getPrincipalToAccessIdsTable();
+  Table<String, OmDBUserPrincipalInfo> getPrincipalToAccessIdsTable();
 
   Table<String, OmDBTenantInfo> getTenantStateTable();
 

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -365,8 +365,6 @@ public interface OMMetadataManager extends DBStoreHAManager {
 
   Table<String, OmDBTenantInfo> getTenantStateTable();
 
-  Table<String, String> getTenantRoleTable();
-
   Table<String, String> getTenantPolicyTable();
 
   /**

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
@@ -46,7 +46,7 @@ public class OmDBAccessIdInfoCodec implements Codec<OmDBAccessIdInfo> {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
     return OmDBAccessIdInfo.getFromProtobuf(
-        OzoneManagerProtocolProtos.OmDBAccessInfo.parseFrom(rawData));
+        OzoneManagerProtocolProtos.ExtendedAccessIdInfo.parseFrom(rawData));
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
@@ -51,7 +51,7 @@ public class OmDBAccessIdInfoCodec implements Codec<OmDBAccessIdInfo> {
 
   @Override
   public OmDBAccessIdInfo copyObject(OmDBAccessIdInfo object) {
-    // TODO: Not really a "copy". See OMTransactionInfoCodec
+    // Note: Not really a "copy". See OMTransactionInfoCodec
     return object;
   }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBAccessIdInfoCodec.java
@@ -46,7 +46,7 @@ public class OmDBAccessIdInfoCodec implements Codec<OmDBAccessIdInfo> {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
     return OmDBAccessIdInfo.getFromProtobuf(
-        OzoneManagerProtocolProtos.ExtendedAccessIdInfo.parseFrom(rawData));
+        OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo.parseFrom(rawData));
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBKerberosPrincipalInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBKerberosPrincipalInfoCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +39,7 @@ public class OmDBKerberosPrincipalInfoCodec
   public byte[] toPersistedFormat(OmDBKerberosPrincipalInfo object)
       throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.convertToByteArray();
+    return object.getProtobuf().toByteArray();
   }
 
   @Override
@@ -46,13 +47,14 @@ public class OmDBKerberosPrincipalInfoCodec
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OmDBKerberosPrincipalInfo.getFromByteArray(rawData);
+    return OmDBKerberosPrincipalInfo.getFromProtobuf(
+        OzoneManagerProtocolProtos.TenantUserPrincipalInfo.parseFrom(rawData));
   }
 
   @Override
   public OmDBKerberosPrincipalInfo copyObject(
       OmDBKerberosPrincipalInfo object) {
-    // TODO: Not really a "copy". See OMTransactionInfoCodec
+    // Note: Not really a "copy". See OMTransactionInfoCodec
     return object;
   }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,7 +37,7 @@ public class OmDBTenantInfoCodec implements Codec<OmDBTenantInfo> {
   @Override
   public byte[] toPersistedFormat(OmDBTenantInfo object) throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
-    return object.convertToByteArray();
+    return object.getProtobuf().toByteArray();
   }
 
   @Override
@@ -44,7 +45,8 @@ public class OmDBTenantInfoCodec implements Codec<OmDBTenantInfo> {
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OmDBTenantInfo.getFromByteArray(rawData);
+    return OmDBTenantInfo.getFromProtobuf(
+        OzoneManagerProtocolProtos.TenantInfo.parseFrom(rawData));
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,27 +30,27 @@ import static com.google.common.base.Preconditions.checkNotNull;
 /**
  * Codec to encode OmDBTenantInfo as byte array.
  */
-public class OmDBTenantInfoCodec implements Codec<OmDBTenantInfo> {
+public class OmDBTenantInfoCodec implements Codec<OmDBTenantState> {
   private static final Logger LOG =
       LoggerFactory.getLogger(OmDBTenantInfoCodec.class);
 
   @Override
-  public byte[] toPersistedFormat(OmDBTenantInfo object) throws IOException {
+  public byte[] toPersistedFormat(OmDBTenantState object) throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
     return object.getProtobuf().toByteArray();
   }
 
   @Override
-  public OmDBTenantInfo fromPersistedFormat(byte[] rawData)
+  public OmDBTenantState fromPersistedFormat(byte[] rawData)
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OmDBTenantInfo.getFromProtobuf(
+    return OmDBTenantState.getFromProtobuf(
         OzoneManagerProtocolProtos.TenantInfo.parseFrom(rawData));
   }
 
   @Override
-  public OmDBTenantInfo copyObject(OmDBTenantInfo object) {
+  public OmDBTenantState copyObject(OmDBTenantState object) {
     // Note: Not really a "copy". from OMTransactionInfoCodec
     return object;
   }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantInfoCodec.java
@@ -51,7 +51,7 @@ public class OmDBTenantInfoCodec implements Codec<OmDBTenantInfo> {
 
   @Override
   public OmDBTenantInfo copyObject(OmDBTenantInfo object) {
-    // TODO: Not really a "copy". from OMTransactionInfoCodec
+    // Note: Not really a "copy". from OMTransactionInfoCodec
     return object;
   }
 }

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantStateCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBTenantStateCodec.java
@@ -28,11 +28,11 @@ import java.io.IOException;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Codec to encode OmDBTenantInfo as byte array.
+ * Codec to encode OmDBTenantState as byte array.
  */
-public class OmDBTenantInfoCodec implements Codec<OmDBTenantState> {
+public class OmDBTenantStateCodec implements Codec<OmDBTenantState> {
   private static final Logger LOG =
-      LoggerFactory.getLogger(OmDBTenantInfoCodec.class);
+      LoggerFactory.getLogger(OmDBTenantStateCodec.class);
 
   @Override
   public byte[] toPersistedFormat(OmDBTenantState object) throws IOException {
@@ -46,7 +46,7 @@ public class OmDBTenantInfoCodec implements Codec<OmDBTenantState> {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
     return OmDBTenantState.getFromProtobuf(
-        OzoneManagerProtocolProtos.TenantInfo.parseFrom(rawData));
+        OzoneManagerProtocolProtos.TenantState.parseFrom(rawData));
   }
 
   @Override

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBUserPrincipalInfoCodec.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/codec/OmDBUserPrincipalInfoCodec.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.om.codec;
 
 import org.apache.hadoop.hdds.utils.db.Codec;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,32 +28,32 @@ import java.io.IOException;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
- * Codec to encode OmDBKerberosPrincipalInfo as byte array.
+ * Codec to encode OmDBUserPrincipalInfo as byte array.
  */
-public class OmDBKerberosPrincipalInfoCodec
-    implements Codec<OmDBKerberosPrincipalInfo> {
+public class OmDBUserPrincipalInfoCodec
+    implements Codec<OmDBUserPrincipalInfo> {
   private static final Logger LOG =
-      LoggerFactory.getLogger(OmDBKerberosPrincipalInfoCodec.class);
+      LoggerFactory.getLogger(OmDBUserPrincipalInfoCodec.class);
 
   @Override
-  public byte[] toPersistedFormat(OmDBKerberosPrincipalInfo object)
+  public byte[] toPersistedFormat(OmDBUserPrincipalInfo object)
       throws IOException {
     checkNotNull(object, "Null object can't be converted to byte array.");
     return object.getProtobuf().toByteArray();
   }
 
   @Override
-  public OmDBKerberosPrincipalInfo fromPersistedFormat(byte[] rawData)
+  public OmDBUserPrincipalInfo fromPersistedFormat(byte[] rawData)
       throws IOException {
     checkNotNull(rawData, "Null byte array can't be converted to " +
         "real object.");
-    return OmDBKerberosPrincipalInfo.getFromProtobuf(
+    return OmDBUserPrincipalInfo.getFromProtobuf(
         OzoneManagerProtocolProtos.TenantUserPrincipalInfo.parseFrom(rawData));
   }
 
   @Override
-  public OmDBKerberosPrincipalInfo copyObject(
-      OmDBKerberosPrincipalInfo object) {
+  public OmDBUserPrincipalInfo copyObject(
+      OmDBUserPrincipalInfo object) {
     // Note: Not really a "copy". See OMTransactionInfoCodec
     return object;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -222,21 +222,39 @@ public interface OMMultiTenantManager {
   Optional<String> getTenantForAccessID(String accessID) throws IOException;
 
   /**
-   * Get user role name given tenant name.
+   * Get default user role name given tenant name.
    * @param tenantId tenant name
    * @return user role name. e.g. tenant1-UserRole
    */
-  static String getUserRoleName(String tenantId) {
-    return tenantId + OzoneConsts.TENANT_ROLE_USER_SUFFIX;
+  static String getDefaultUserRoleName(String tenantId) {
+    return tenantId + OzoneConsts.DEFAULT_TENANT_ROLE_USER_SUFFIX;
   }
 
   /**
-   * Get admin role name given tenant name.
+   * Get default admin role name given tenant name.
    * @param tenantId tenant name
    * @return admin role name. e.g. tenant1-AdminRole
    */
-  static String getAdminRoleName(String tenantId) {
-    return tenantId + OzoneConsts.TENANT_ROLE_ADMIN_SUFFIX;
+  static String getDefaultAdminRoleName(String tenantId) {
+    return tenantId + OzoneConsts.DEFAULT_TENANT_ROLE_ADMIN_SUFFIX;
+  }
+
+  /**
+   * Get default bucket namespace (volume) policy name given tenant name.
+   * @param tenantId tenant name
+   * @return bucket namespace (volume) policy name. e.g. tenant1-VolumeAccess
+   */
+  static String getDefaultBucketNamespacePolicyName(String tenantId) {
+    return tenantId + OzoneConsts.DEFAULT_TENANT_BUCKET_NAMESPACE_POLICY_SUFFIX;
+  }
+
+  /**
+   * Get default bucket policy name given tenant name.
+   * @param tenantId tenant name
+   * @return bucket policy name. e.g. tenant1-BucketAccess
+   */
+  static String getDefaultBucketPolicyName(String tenantId) {
+    return tenantId + OzoneConsts.DEFAULT_TENANT_BUCKET_POLICY_SUFFIX;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -235,7 +235,7 @@ public interface OMMultiTenantManager {
    * @param tenantId tenant name
    * @return admin role name. e.g. tenant1-AdminRole
    */
-  static String getAdminRoleId(String tenantId) {
+  static String getAdminRoleName(String tenantId) {
     return tenantId + OzoneConsts.TENANT_ROLE_ADMIN_SUFFIX;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -186,7 +186,7 @@ public interface OMMultiTenantManager {
    *                  admin, delegated or not
    */
   boolean isTenantAdmin(UserGroupInformation callerUgi, String tenantId,
-      Boolean delegated);
+      boolean delegated);
 
   /**
    * Check if a tenant exists.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.om.multitenant.AccessPolicy;
 import org.apache.hadoop.ozone.om.multitenant.AccountNameSpace;
 import org.apache.hadoop.ozone.om.multitenant.BucketNameSpace;
 import org.apache.hadoop.ozone.om.multitenant.Tenant;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.http.auth.BasicUserPrincipal;
 
 /**
@@ -177,12 +178,15 @@ public interface OMMultiTenantManager {
   void deactivateUser(String accessID) throws IOException;
 
   /**
-   * Check if a user is a tenant Admin.
-   * @param user user name.
-   * @param tenantId tenant name.
-   * @return
+   * Returns true if user is the tenant's admin or Ozone admin, false otherwise.
+   * @param callerUgi caller's UserGroupInformation
+   * @param tenantId tenant name
+   * @param delegated if set to true, checks if the user is a delegated tenant
+   *                  admin; if set to false, checks if the user is a tenant
+   *                  admin, delegated or not
    */
-  boolean isTenantAdmin(String user, String tenantId);
+  boolean isTenantAdmin(UserGroupInformation callerUgi, String tenantId,
+      Boolean delegated);
 
   /**
    * Check if a tenant exists.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import com.google.common.base.Optional;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.multitenant.AccessPolicy;
 import org.apache.hadoop.ozone.om.multitenant.AccountNameSpace;
@@ -219,6 +220,24 @@ public interface OMMultiTenantManager {
    * @return String tenant name
    */
   Optional<String> getTenantForAccessID(String accessID) throws IOException;
+
+  /**
+   * Get user role name given tenant name.
+   * @param tenantId tenant name
+   * @return user role name. e.g. tenant1-UserRole
+   */
+  static String getUserRoleId(String tenantId) {
+    return tenantId + OzoneConsts.TENANT_ROLE_USER_SUFFIX;
+  }
+
+  /**
+   * Get admin role name given tenant name.
+   * @param tenantId tenant name
+   * @return admin role name. e.g. tenant1-AdminRole
+   */
+  static String getAdminRoleId(String tenantId) {
+    return tenantId + OzoneConsts.TENANT_ROLE_ADMIN_SUFFIX;
+  }
 
   /**
    * Given a user, make him an admin of the corresponding Tenant.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManager.java
@@ -80,7 +80,7 @@ public interface OMMultiTenantManager {
    * @return Tenant interface.
    * @throws IOException
    */
-  Tenant getTenantInfo(String tenantID) throws IOException;
+  Tenant getTenant(String tenantID) throws IOException;
 
   /**
    * Given a TenantID String, deactivate the Tenant. If the Tenant has active
@@ -226,7 +226,7 @@ public interface OMMultiTenantManager {
    * @param tenantId tenant name
    * @return user role name. e.g. tenant1-UserRole
    */
-  static String getUserRoleId(String tenantId) {
+  static String getUserRoleName(String tenantId) {
     return tenantId + OzoneConsts.TENANT_ROLE_USER_SUFFIX;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -65,7 +65,7 @@ import org.apache.hadoop.ozone.om.multitenant.OzoneOwnerPrincipal;
 import org.apache.hadoop.ozone.om.multitenant.OzoneTenantRolePrincipal;
 import org.apache.hadoop.ozone.om.multitenant.RangerAccessPolicy;
 import org.apache.hadoop.ozone.om.multitenant.Tenant;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer.ACLType;
 import org.apache.hadoop.ozone.security.acl.OzoneObj;
 import org.apache.hadoop.ozone.security.acl.OzoneObjInfo;
@@ -455,7 +455,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       throw new IOException("Tenant '" + tenantID + "' not found!");
     }
 
-    List<TenantUserAccessId> userAccessIds = new ArrayList<>();
+    List<ExtendedAccessIdInfo> userAccessIds = new ArrayList<>();
     CachedTenantState cachedTenantState = tenantCache.get(tenantID);
     if (cachedTenantState == null) {
       throw new IOException("Inconsistent in memory Tenant cache '" + tenantID
@@ -467,7 +467,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
             k -> StringUtils.isEmpty(prefix) || k.getKey().startsWith(prefix))
         .forEach(
             k -> userAccessIds.add(
-                TenantUserAccessId.newBuilder()
+                ExtendedAccessIdInfo.newBuilder()
                     .setUserPrincipal(k.getKey())
                     .setAccessId(k.getValue())
                     .build()));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -49,7 +49,6 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
@@ -489,7 +490,6 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       throws IOException {
     return null;
   }
-
 
   @Override
   public void assignTenantAdmin(String accessID, boolean delegated)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -386,7 +386,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
    * {@inheritDoc}
    */
   public boolean isTenantAdmin(UserGroupInformation callerUgi,
-      String tenantId, Boolean delegated) {
+      String tenantId, boolean delegated) {
     if (callerUgi == null) {
       return false;
     } else {
@@ -403,7 +403,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
    * Internal isTenantAdmin method that takes a username String instead of UGI.
    */
   private boolean isTenantAdmin(String username, String tenantId,
-      Boolean delegated) {
+      boolean delegated) {
     if (StringUtils.isEmpty(username) || StringUtils.isEmpty(tenantId)) {
       return false;
     }
@@ -421,6 +421,10 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
       for (final String accessId : principalInfo.getAccessIds()) {
         final OmDBAccessIdInfo accessIdInfo =
             omMetadataManager.getTenantAccessIdTable().get(accessId);
+        // accessIdInfo could be null since we may not have a lock on the tenant
+        if (accessIdInfo == null) {
+          return false;
+        }
         if (tenantId.equals(accessIdInfo.getTenantId())) {
           if (!delegated) {
             return accessIdInfo.getIsAdmin();
@@ -618,7 +622,10 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
     return policy;
   }
 
-  // TODO: Fine-tune this once we have bucket ownership.
+  // TODO: This policy doesn't seem necessary as the bucket-level policy has
+  //  already granted the key-level access.
+  //  Not sure if that is the intended behavior in Ranger though.
+  //  Still, could add this KeyAccess policy as well in Ranger, doesn't hurt.
   private AccessPolicy newDefaultKeyAccessPolicy(String volumeName,
       String bucketName) throws IOException {
     AccessPolicy policy = new RangerAccessPolicy(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -50,7 +50,7 @@ import org.apache.hadoop.ozone.common.BlockGroup;
 import org.apache.hadoop.hdds.utils.TransactionInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmBucketInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmDBAccessIdInfoCodec;
-import org.apache.hadoop.ozone.om.codec.OmDBKerberosPrincipalInfoCodec;
+import org.apache.hadoop.ozone.om.codec.OmDBUserPrincipalInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmDirectoryInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmMultipartKeyInfoCodec;
@@ -65,7 +65,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
@@ -139,7 +139,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | tenantAccessIdTable       | accessId -> OmDBAccessIdInfo             |
    * |----------------------------------------------------------------------|
-   * | principalToAccessIdsTable | Principal -> OmDBKerberosPrincipalInfo   |
+   * | principalToAccessIdsTable | Principal -> OmDBUserPrincipalInfo       |
    * |----------------------------------------------------------------------|
    * | tenantStateTable          | tenantId -> OmDBTenantInfo               |
    * |----------------------------------------------------------------------|
@@ -468,8 +468,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addCodec(OmDirectoryInfo.class, new OmDirectoryInfoCodec())
         .addCodec(OmDBTenantInfo.class, new OmDBTenantInfoCodec())
         .addCodec(OmDBAccessIdInfo.class, new OmDBAccessIdInfoCodec())
-        .addCodec(OmDBKerberosPrincipalInfo.class,
-            new OmDBKerberosPrincipalInfoCodec());
+        .addCodec(OmDBUserPrincipalInfo.class,
+            new OmDBUserPrincipalInfoCodec());
   }
 
   /**
@@ -551,10 +551,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         String.class, OmDBAccessIdInfo.class);
     checkTableStatus(tenantAccessIdTable, TENANT_ACCESS_ID_TABLE);
 
-    // User principal -> OmDBKerberosPrincipalInfo (A list of accessIds)
+    // User principal -> OmDBUserPrincipalInfo (a list of accessIds)
     principalToAccessIdsTable = this.store.getTable(
         PRINCIPAL_TO_ACCESS_IDS_TABLE,
-        String.class, OmDBKerberosPrincipalInfo.class);
+        String.class, OmDBUserPrincipalInfo.class);
     checkTableStatus(principalToAccessIdsTable, PRINCIPAL_TO_ACCESS_IDS_TABLE);
 
     // tenant name -> tenant (tenant states)
@@ -1310,7 +1310,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   @Override
-  public Table<String, OmDBKerberosPrincipalInfo>
+  public Table<String, OmDBUserPrincipalInfo>
       getPrincipalToAccessIdsTable() {
     return principalToAccessIdsTable;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -55,7 +55,7 @@ import org.apache.hadoop.ozone.om.codec.OmDirectoryInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmMultipartKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.OmPrefixInfoCodec;
-import org.apache.hadoop.ozone.om.codec.OmDBTenantInfoCodec;
+import org.apache.hadoop.ozone.om.codec.OmDBTenantStateCodec;
 import org.apache.hadoop.ozone.om.codec.OmVolumeArgsCodec;
 import org.apache.hadoop.ozone.om.codec.RepeatedOmKeyInfoCodec;
 import org.apache.hadoop.ozone.om.codec.S3SecretValueCodec;
@@ -141,7 +141,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | principalToAccessIdsTable | Principal -> OmDBUserPrincipalInfo       |
    * |----------------------------------------------------------------------|
-   * | tenantStateTable          | tenantId -> OmDBTenantInfo               |
+   * | tenantStateTable          | tenantId -> OmDBTenantState              |
    * |----------------------------------------------------------------------|
    *
    * Simple Tables:
@@ -460,7 +460,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addCodec(OmPrefixInfo.class, new OmPrefixInfoCodec())
         .addCodec(TransactionInfo.class, new TransactionInfoCodec())
         .addCodec(OmDirectoryInfo.class, new OmDirectoryInfoCodec())
-        .addCodec(OmDBTenantState.class, new OmDBTenantInfoCodec())
+        .addCodec(OmDBTenantState.class, new OmDBTenantStateCodec())
         .addCodec(OmDBAccessIdInfo.class, new OmDBAccessIdInfoCodec())
         .addCodec(OmDBUserPrincipalInfo.class,
             new OmDBUserPrincipalInfoCodec());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -143,8 +143,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | tenantStateTable          | tenantId -> OmDBTenantInfo               |
    * |----------------------------------------------------------------------|
-   * | tenantPolicyTable         | policyGroup -> [policyId1, policyId2]    |
-   * |----------------------------------------------------------------------|
    *
    * Simple Tables:
    * |----------------------------------------------------------------------|
@@ -194,7 +192,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public static final String PRINCIPAL_TO_ACCESS_IDS_TABLE =
       "principalToAccessIdsTable";
   public static final String TENANT_STATE_TABLE = "tenantStateTable";
-  public static final String TENANT_POLICY_TABLE = "tenantPolicyTable";
 
   static final String[] ALL_TABLES = new String[] {
       USER_TABLE,
@@ -215,8 +212,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       META_TABLE,
       TENANT_ACCESS_ID_TABLE,
       PRINCIPAL_TO_ACCESS_IDS_TABLE,
-      TENANT_STATE_TABLE,
-      TENANT_POLICY_TABLE
+      TENANT_STATE_TABLE
   };
 
   private DBStore store;
@@ -244,7 +240,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private Table tenantAccessIdTable;
   private Table principalToAccessIdsTable;
   private Table tenantStateTable;
-  private Table tenantPolicyTable;
 
   private boolean isRatisEnabled;
   private boolean ignorePipelineinKey;
@@ -453,7 +448,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addTable(TENANT_ACCESS_ID_TABLE)
         .addTable(PRINCIPAL_TO_ACCESS_IDS_TABLE)
         .addTable(TENANT_STATE_TABLE)
-        .addTable(TENANT_POLICY_TABLE)
         .addCodec(OzoneTokenIdentifier.class, new TokenIdentifierCodec())
         .addCodec(OmKeyInfo.class, new OmKeyInfoCodec(true))
         .addCodec(RepeatedOmKeyInfo.class,
@@ -561,11 +555,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
         String.class, OmDBTenantInfo.class);
     checkTableStatus(tenantStateTable, TENANT_STATE_TABLE);
-
-    // tenant policy name -> list of tenant policies
-    tenantPolicyTable = this.store.getTable(TENANT_POLICY_TABLE,
-        String.class, String.class /* TODO: Use custom list */);
-    checkTableStatus(tenantPolicyTable, TENANT_POLICY_TABLE);
   }
 
   /**
@@ -1318,11 +1307,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Table<String, OmDBTenantInfo> getTenantStateTable() {
     return tenantStateTable;
-  }
-
-  @Override
-  public Table<String, String> getTenantPolicyTable() {
-    return tenantPolicyTable;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -143,8 +143,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | tenantStateTable          | tenantId -> OmDBTenantInfo               |
    * |----------------------------------------------------------------------|
-   * | tenantRoleTable           | accessId -> roles [admin, roleB, ...]    |
-   * |----------------------------------------------------------------------|
    * | tenantPolicyTable         | policyGroup -> [policyId1, policyId2]    |
    * |----------------------------------------------------------------------|
    *
@@ -196,7 +194,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public static final String PRINCIPAL_TO_ACCESS_IDS_TABLE =
       "principalToAccessIdsTable";
   public static final String TENANT_STATE_TABLE = "tenantStateTable";
-  public static final String TENANT_ROLE_TABLE = "tenantRoleTable";
   public static final String TENANT_POLICY_TABLE = "tenantPolicyTable";
 
   static final String[] ALL_TABLES = new String[] {
@@ -219,7 +216,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       TENANT_ACCESS_ID_TABLE,
       PRINCIPAL_TO_ACCESS_IDS_TABLE,
       TENANT_STATE_TABLE,
-      TENANT_ROLE_TABLE,
       TENANT_POLICY_TABLE
   };
 
@@ -244,11 +240,10 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private Table transactionInfoTable;
   private Table metaTable;
 
-  // Tables for multi-tenancy
+  // Tables required for multi-tenancy
   private Table tenantAccessIdTable;
   private Table principalToAccessIdsTable;
   private Table tenantStateTable;
-  private Table tenantRoleTable;
   private Table tenantPolicyTable;
 
   private boolean isRatisEnabled;
@@ -458,7 +453,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addTable(TENANT_ACCESS_ID_TABLE)
         .addTable(PRINCIPAL_TO_ACCESS_IDS_TABLE)
         .addTable(TENANT_STATE_TABLE)
-        .addTable(TENANT_ROLE_TABLE)
         .addTable(TENANT_POLICY_TABLE)
         .addCodec(OzoneTokenIdentifier.class, new TokenIdentifierCodec())
         .addCodec(OmKeyInfo.class, new OmKeyInfoCodec(true))
@@ -567,11 +561,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
         String.class, OmDBTenantInfo.class);
     checkTableStatus(tenantStateTable, TENANT_STATE_TABLE);
-
-    // accessId -> list of roles in a tenant. e.g. admin for "finance"
-    tenantRoleTable = this.store.getTable(TENANT_ROLE_TABLE,
-        String.class, String.class /* TODO: Use custom list */);
-    checkTableStatus(tenantRoleTable, TENANT_ROLE_TABLE);
 
     // tenant policy name -> list of tenant policies
     tenantPolicyTable = this.store.getTable(TENANT_POLICY_TABLE,
@@ -1329,11 +1318,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Table<String, OmDBTenantInfo> getTenantStateTable() {
     return tenantStateTable;
-  }
-
-  @Override
-  public Table<String, String> getTenantRoleTable() {
-    return tenantRoleTable;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -137,11 +137,11 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    *
    * Multi-Tenant Tables:
    * |----------------------------------------------------------------------|
+   * | tenantStateTable          | tenantId -> OmDBTenantState              |
+   * |----------------------------------------------------------------------|
    * | tenantAccessIdTable       | accessId -> OmDBAccessIdInfo             |
    * |----------------------------------------------------------------------|
-   * | principalToAccessIdsTable | Principal -> OmDBUserPrincipalInfo       |
-   * |----------------------------------------------------------------------|
-   * | tenantStateTable          | tenantId -> OmDBTenantState              |
+   * | principalToAccessIdsTable | userPrincipal -> OmDBUserPrincipalInfo   |
    * |----------------------------------------------------------------------|
    *
    * Simple Tables:

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -72,7 +72,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfoGroup;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -460,7 +460,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addCodec(OmPrefixInfo.class, new OmPrefixInfoCodec())
         .addCodec(TransactionInfo.class, new TransactionInfoCodec())
         .addCodec(OmDirectoryInfo.class, new OmDirectoryInfoCodec())
-        .addCodec(OmDBTenantInfo.class, new OmDBTenantInfoCodec())
+        .addCodec(OmDBTenantState.class, new OmDBTenantInfoCodec())
         .addCodec(OmDBAccessIdInfo.class, new OmDBAccessIdInfoCodec())
         .addCodec(OmDBUserPrincipalInfo.class,
             new OmDBUserPrincipalInfoCodec());
@@ -553,7 +553,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
     // tenant name -> tenant (tenant states)
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
-        String.class, OmDBTenantInfo.class);
+        String.class, OmDBTenantState.class);
     checkTableStatus(tenantStateTable, TENANT_STATE_TABLE);
   }
 
@@ -1305,7 +1305,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   }
 
   @Override
-  public Table<String, OmDBTenantInfo> getTenantStateTable() {
+  public Table<String, OmDBTenantState> getTenantStateTable() {
     return tenantStateTable;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -143,8 +143,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | tenantStateTable          | tenantId -> OmDBTenantInfo               |
    * |----------------------------------------------------------------------|
-   * | tenantGroupTable          | accessId -> [tenant group A, B, ...]     |
-   * |----------------------------------------------------------------------|
    * | tenantRoleTable           | accessId -> roles [admin, roleB, ...]    |
    * |----------------------------------------------------------------------|
    * | tenantPolicyTable         | policyGroup -> [policyId1, policyId2]    |
@@ -198,7 +196,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   public static final String PRINCIPAL_TO_ACCESS_IDS_TABLE =
       "principalToAccessIdsTable";
   public static final String TENANT_STATE_TABLE = "tenantStateTable";
-  public static final String TENANT_GROUP_TABLE = "tenantGroupTable";
   public static final String TENANT_ROLE_TABLE = "tenantRoleTable";
   public static final String TENANT_POLICY_TABLE = "tenantPolicyTable";
 
@@ -222,7 +219,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       TENANT_ACCESS_ID_TABLE,
       PRINCIPAL_TO_ACCESS_IDS_TABLE,
       TENANT_STATE_TABLE,
-      TENANT_GROUP_TABLE,
       TENANT_ROLE_TABLE,
       TENANT_POLICY_TABLE
   };
@@ -252,7 +248,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   private Table tenantAccessIdTable;
   private Table principalToAccessIdsTable;
   private Table tenantStateTable;
-  private Table tenantGroupTable;
   private Table tenantRoleTable;
   private Table tenantPolicyTable;
 
@@ -463,7 +458,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         .addTable(TENANT_ACCESS_ID_TABLE)
         .addTable(PRINCIPAL_TO_ACCESS_IDS_TABLE)
         .addTable(TENANT_STATE_TABLE)
-        .addTable(TENANT_GROUP_TABLE)
         .addTable(TENANT_ROLE_TABLE)
         .addTable(TENANT_POLICY_TABLE)
         .addCodec(OzoneTokenIdentifier.class, new TokenIdentifierCodec())
@@ -573,11 +567,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
     tenantStateTable = this.store.getTable(TENANT_STATE_TABLE,
         String.class, OmDBTenantInfo.class);
     checkTableStatus(tenantStateTable, TENANT_STATE_TABLE);
-
-    // accessId -> list of tenant groups the user belongs to
-    tenantGroupTable = this.store.getTable(TENANT_GROUP_TABLE,
-        String.class, String.class /* TODO: Use custom list */);
-    checkTableStatus(tenantGroupTable, TENANT_GROUP_TABLE);
 
     // accessId -> list of roles in a tenant. e.g. admin for "finance"
     tenantRoleTable = this.store.getTable(TENANT_ROLE_TABLE,
@@ -1340,11 +1329,6 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public Table<String, OmDBTenantInfo> getTenantStateTable() {
     return tenantStateTable;
-  }
-
-  @Override
-  public Table<String, String> getTenantGroupTable() {
-    return tenantGroupTable;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -117,7 +117,7 @@ import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -3016,7 +3016,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     //  multiple tenants.
 
     // Retrieve the list of accessIds associated to this user principal
-    final OmDBKerberosPrincipalInfo kerberosPrincipalInfo =
+    final OmDBUserPrincipalInfo kerberosPrincipalInfo =
         metadataManager.getPrincipalToAccessIdsTable().get(userPrincipal);
     if (kerberosPrincipalInfo == null) {
       return null;
@@ -3830,7 +3830,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
 
     try {
-      final OmDBKerberosPrincipalInfo principalInfo =
+      final OmDBUserPrincipalInfo principalInfo =
           getMetadataManager().getPrincipalToAccessIdsTable().get(username);
 
       if (principalInfo == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -157,7 +157,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantState;
 import org.apache.hadoop.ozone.protocolPB.OMInterServiceProtocolServerSideImpl;
 import org.apache.hadoop.ozone.protocolPB.OMAdminProtocolServerSideImpl;
@@ -3006,7 +3006,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return null;
     }
 
-    final List<TenantAccessIdInfo> accessIdInfoList = new ArrayList<>();
+    final List<ExtendedAccessIdInfo> accessIdInfoList = new ArrayList<>();
 
     // Won't iterate cache here for a similar reason as in OM#listTenant
     //  tenantGetUserInfo lists all accessIds assigned to a user across
@@ -3036,11 +3036,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           return;
         }
         assert (accessIdInfo.getUserPrincipal().equals(userPrincipal));
-        accessIdInfoList.add(TenantAccessIdInfo.newBuilder()
+        accessIdInfoList.add(ExtendedAccessIdInfo.newBuilder()
             .setAccessId(accessId)
             .setTenantId(accessIdInfo.getTenantId())
             .setIsAdmin(accessIdInfo.getIsAdmin())
             .setIsDelegatedAdmin(accessIdInfo.getIsDelegatedAdmin())
+            .addAllRoleNames(accessIdInfo.getRoleNamesSet())
             .build());
       } catch (IOException e) {
         LOG.error("Potential DB issue. Failed to retrieve OmDBAccessIdInfo "

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -118,7 +118,7 @@ import org.apache.hadoop.ozone.om.helpers.DBUpdates;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
@@ -2963,7 +2963,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       throw omEx;
     }
 
-    final Table<String, OmDBTenantInfo> tenantStateTable =
+    final Table<String, OmDBTenantState> tenantStateTable =
         metadataManager.getTenantStateTable();
 
     // Won't iterate cache here, mainly because we can't acquire a read lock
@@ -2972,16 +2972,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // are flushed to the table. This should be acceptable for a list tenant
     // request.
 
-    final TableIterator<String, ? extends KeyValue<String, OmDBTenantInfo>>
+    final TableIterator<String, ? extends KeyValue<String, OmDBTenantState>>
         iterator = tenantStateTable.iterator();
 
     final List<TenantInfo> tenantInfoList = new ArrayList<>();
 
     // Iterate table
     while (iterator.hasNext()) {
-      final Table.KeyValue<String, OmDBTenantInfo> dbEntry = iterator.next();
+      final Table.KeyValue<String, OmDBTenantState> dbEntry = iterator.next();
       final String tenantId = dbEntry.getKey();
-      final OmDBTenantInfo omDBTenantInfo = dbEntry.getValue();
+      final OmDBTenantState omDBTenantInfo = dbEntry.getValue();
       assert (tenantId.equals(omDBTenantInfo.getTenantId()));
       tenantInfoList.add(TenantInfo.newBuilder()
           .setTenantId(omDBTenantInfo.getTenantId())
@@ -3125,7 +3125,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       if (optionalTenantId.isPresent()) {
         final String tenantId = optionalTenantId.get();
 
-        OmDBTenantInfo tenantInfo =
+        OmDBTenantState tenantInfo =
             metadataManager.getTenantStateTable().get(tenantId);
         if (tenantInfo != null) {
           s3Volume = tenantInfo.getBucketNamespaceName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2986,9 +2986,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       tenantInfoList.add(TenantInfo.newBuilder()
           .setTenantId(omDBTenantInfo.getTenantId())
           .setBucketNamespaceName(omDBTenantInfo.getBucketNamespaceName())
-          .setAccountNamespaceName(omDBTenantInfo.getAccountNamespaceName())
-          .setUserPolicyGroupName(omDBTenantInfo.getUserPolicyGroupName())
-          .setBucketNamespaceName(omDBTenantInfo.getBucketPolicyGroupName())
+          .addAllPolicyIds(omDBTenantInfo.getPolicyIds())
           .build());
     }
 
@@ -3861,10 +3859,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (isAclEnabled) {
       UserGroupInformation ugi = Server.getRemoteUser();
       if (getS3Auth() != null) {
-        ugi = UserGroupInformation
-            .createRemoteUser(
-                OzoneAclUtils.accessIdToUserPrincipal(
-                    getS3Auth().getAccessId()));
+        ugi = UserGroupInformation.createRemoteUser(
+            OzoneAclUtils.accessIdToUserPrincipal(getS3Auth().getAccessId()));
       }
       InetAddress remoteIp = Server.getRemoteIp();
       resolved = resolveBucketLink(requested, new HashSet<>(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -157,7 +157,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.S3Authentication;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantState;
 import org.apache.hadoop.ozone.protocolPB.OMInterServiceProtocolServerSideImpl;
 import org.apache.hadoop.ozone.protocolPB.OMAdminProtocolServerSideImpl;
@@ -2986,7 +2986,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       tenantStateList.add(TenantState.newBuilder()
           .setTenantId(omDBTenantState.getTenantId())
           .setBucketNamespaceName(omDBTenantState.getBucketNamespaceName())
-          .addAllPolicyNames(omDBTenantState.getPolicyNames())
+          .setUserRoleName(omDBTenantState.getUserRoleName())
+          .setAdminRoleName(omDBTenantState.getAdminRoleName())
+          .setBucketNamespacePolicyName(
+              omDBTenantState.getBucketNamespacePolicyName())
+          .setBucketPolicyName(omDBTenantState.getBucketPolicyName())
           .build());
     }
 
@@ -3006,7 +3010,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return null;
     }
 
-    final List<ExtendedAccessIdInfo> accessIdInfoList = new ArrayList<>();
+    final List<ExtendedUserAccessIdInfo> accessIdInfoList = new ArrayList<>();
 
     // Won't iterate cache here for a similar reason as in OM#listTenant
     //  tenantGetUserInfo lists all accessIds assigned to a user across
@@ -3036,12 +3040,12 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
           return;
         }
         assert (accessIdInfo.getUserPrincipal().equals(userPrincipal));
-        accessIdInfoList.add(ExtendedAccessIdInfo.newBuilder()
+        accessIdInfoList.add(ExtendedUserAccessIdInfo.newBuilder()
+            .setUserPrincipal(userPrincipal)
             .setAccessId(accessId)
             .setTenantId(accessIdInfo.getTenantId())
             .setIsAdmin(accessIdInfo.getIsAdmin())
             .setIsDelegatedAdmin(accessIdInfo.getIsDelegatedAdmin())
-            .addAllRoleNames(accessIdInfo.getRoleNamesSet())
             .build());
       } catch (IOException e) {
         LOG.error("Potential DB issue. Failed to retrieve OmDBAccessIdInfo "
@@ -3057,7 +3061,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     AUDIT.logReadSuccess(buildAuditMessageForSuccess(
         OMAction.TENANT_GET_USER_INFO, auditMap));
 
-    return new TenantUserInfoValue(userPrincipal, accessIdInfoList);
+    return new TenantUserInfoValue(accessIdInfoList);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2986,7 +2986,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       tenantInfoList.add(TenantInfo.newBuilder()
           .setTenantId(omDBTenantInfo.getTenantId())
           .setBucketNamespaceName(omDBTenantInfo.getBucketNamespaceName())
-          .addAllPolicyIds(omDBTenantInfo.getPolicyIds())
+          .addAllPolicyNames(omDBTenantInfo.getPolicyNames())
           .build());
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -219,15 +219,6 @@ public class OMDBDefinition implements DBDefinition {
                     new OmDBTenantInfoCodec());
 
   public static final DBColumnFamilyDefinition<String, String>
-            TENANT_ROLE_TABLE =
-            new DBColumnFamilyDefinition<>(
-                    OmMetadataManagerImpl.TENANT_ROLE_TABLE,
-                    String.class,
-                    new StringCodec(),
-                    String.class,
-                    new StringCodec());
-
-  public static final DBColumnFamilyDefinition<String, String>
             TENANT_POLICY_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_POLICY_TABLE,
@@ -257,7 +248,7 @@ public class OMDBDefinition implements DBDefinition {
         FILE_TABLE, OPEN_FILE_TABLE, DELETED_DIR_TABLE, META_TABLE,
         TENANT_ACCESS_ID_TABLE,
         PRINCIPAL_TO_ACCESS_IDS_TABLE, TENANT_STATE_TABLE,
-        TENANT_ROLE_TABLE, TENANT_POLICY_TABLE };
+        TENANT_POLICY_TABLE };
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -215,7 +215,7 @@ public class OMDBDefinition implements DBDefinition {
                     String.class,  // tenantId (tenant name)
                     new StringCodec(),
                     OmDBTenantState.class,
-                    new OmDBTenantInfoCodec());
+                    new OmDBTenantStateCodec());
 
   // End tables for S3 multi-tenancy
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -212,19 +212,10 @@ public class OMDBDefinition implements DBDefinition {
             TENANT_STATE_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_STATE_TABLE,
-                    String.class,
+                    String.class,  // tenantId (tenant name)
                     new StringCodec(),
                     OmDBTenantInfo.class,
                     new OmDBTenantInfoCodec());
-
-  public static final DBColumnFamilyDefinition<String, String>
-            TENANT_POLICY_TABLE =
-            new DBColumnFamilyDefinition<>(
-                    OmMetadataManagerImpl.TENANT_POLICY_TABLE,
-                    String.class,
-                    new StringCodec(),
-                    String.class,
-                    new StringCodec());
 
   // End tables for S3 multi-tenancy
 
@@ -246,8 +237,7 @@ public class OMDBDefinition implements DBDefinition {
         S3_SECRET_TABLE, TRANSACTION_INFO_TABLE, DIRECTORY_TABLE,
         FILE_TABLE, OPEN_FILE_TABLE, DELETED_DIR_TABLE, META_TABLE,
         TENANT_ACCESS_ID_TABLE,
-        PRINCIPAL_TO_ACCESS_IDS_TABLE, TENANT_STATE_TABLE,
-        TENANT_POLICY_TABLE };
+        PRINCIPAL_TO_ACCESS_IDS_TABLE, TENANT_STATE_TABLE};
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
@@ -208,13 +208,13 @@ public class OMDBDefinition implements DBDefinition {
                     OmDBUserPrincipalInfo.class,  // List of accessIds
                     new OmDBUserPrincipalInfoCodec());
 
-  public static final DBColumnFamilyDefinition<String, OmDBTenantInfo>
+  public static final DBColumnFamilyDefinition<String, OmDBTenantState>
             TENANT_STATE_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_STATE_TABLE,
                     String.class,  // tenantId (tenant name)
                     new StringCodec(),
-                    OmDBTenantInfo.class,
+                    OmDBTenantState.class,
                     new OmDBTenantInfoCodec());
 
   // End tables for S3 multi-tenancy

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
@@ -199,15 +199,14 @@ public class OMDBDefinition implements DBDefinition {
                     OmDBAccessIdInfo.class,  // tenantId, secret, principal
                     new OmDBAccessIdInfoCodec());
 
-  public static final DBColumnFamilyDefinition<String,
-            OmDBKerberosPrincipalInfo>
+  public static final DBColumnFamilyDefinition<String, OmDBUserPrincipalInfo>
             PRINCIPAL_TO_ACCESS_IDS_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE,
-                    String.class,  // Kerberos principal
+                    String.class,  // User principal
                     new StringCodec(),
-                    OmDBKerberosPrincipalInfo.class,  // List of accessIds
-                    new OmDBKerberosPrincipalInfoCodec());
+                    OmDBUserPrincipalInfo.class,  // List of accessIds
+                    new OmDBUserPrincipalInfoCodec());
 
   public static final DBColumnFamilyDefinition<String, OmDBTenantInfo>
             TENANT_STATE_TABLE =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/codec/OMDBDefinition.java
@@ -219,15 +219,6 @@ public class OMDBDefinition implements DBDefinition {
                     new OmDBTenantInfoCodec());
 
   public static final DBColumnFamilyDefinition<String, String>
-            TENANT_GROUP_TABLE =
-            new DBColumnFamilyDefinition<>(
-                    OmMetadataManagerImpl.TENANT_GROUP_TABLE,
-                    String.class,
-                    new StringCodec(),
-                    String.class,
-                    new StringCodec());
-
-  public static final DBColumnFamilyDefinition<String, String>
             TENANT_ROLE_TABLE =
             new DBColumnFamilyDefinition<>(
                     OmMetadataManagerImpl.TENANT_ROLE_TABLE,
@@ -265,7 +256,7 @@ public class OMDBDefinition implements DBDefinition {
         S3_SECRET_TABLE, TRANSACTION_INFO_TABLE, DIRECTORY_TABLE,
         FILE_TABLE, OPEN_FILE_TABLE, DELETED_DIR_TABLE, META_TABLE,
         TENANT_ACCESS_ID_TABLE,
-        PRINCIPAL_TO_ACCESS_IDS_TABLE, TENANT_STATE_TABLE, TENANT_GROUP_TABLE,
+        PRINCIPAL_TO_ACCESS_IDS_TABLE, TENANT_STATE_TABLE,
         TENANT_ROLE_TABLE, TENANT_POLICY_TABLE };
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/CachedTenantState.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/CachedTenantState.java
@@ -25,12 +25,12 @@ import org.apache.commons.lang3.tuple.Pair;
 /**
  * A collection of things that we want to maintain about a tenant in memory.
  */
-public class CachedTenantInfo {
+public class CachedTenantState {
 
   private String tenantId;
   private Set<Pair<String, String>> tenantUserAccessIds;
 
-  public CachedTenantInfo(String tenantId) {
+  public CachedTenantState(String tenantId) {
     this.tenantId = tenantId;
     tenantUserAccessIds = new HashSet<>();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -203,12 +203,6 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
           new CacheValue<>(Optional.of(newOmDBAccessIdInfo),
               transactionLogIndex));
 
-      // TODO: Update tenantRoleTable?
-//      final String roleName = "role_admin";
-//      omMetadataManager.getTenantRoleTable().addCacheEntry(
-//          new CacheKey<>(accessId),
-//          new CacheValue<>(Optional.of(roleName), transactionLogIndex));
-
       omResponse.setTenantAssignAdminResponse(
           TenantAssignAdminResponse.newBuilder()
               .build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -191,11 +190,6 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
 
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
-      // Add the admin role to dbAccessIdInfo
-      final String adminRoleName =
-          OMMultiTenantManager.getAdminRoleName(tenantId);
-      dbAccessIdInfo.addRoleName(adminRoleName);
-
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
@@ -203,7 +197,6 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
               .setUserPrincipal(dbAccessIdInfo.getUserPrincipal())
               .setIsAdmin(true)
               .setIsDelegatedAdmin(delegated)
-              .setRoleNames(dbAccessIdInfo.getRoleNamesSet())
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -159,7 +160,8 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
 
     final Map<String, String> auditMap = new HashMap<>();
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    final OMMetadataManager omMetadataManager =
+        ozoneManager.getMetadataManager();
 
     final TenantAssignAdminRequest request =
         getOmRequest().getTenantAssignAdminRequest();
@@ -189,8 +191,9 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
 
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
-      // Add the admin role to OmDBAccessIdInfo we got previously in-place
-      dbAccessIdInfo.addRoleId(OzoneConsts.TENANT_ROLE_ADMIN);
+      // Add the admin role to dbAccessIdInfo
+      final String adminRoleId = OMMultiTenantManager.getAdminRoleId(tenantId);
+      dbAccessIdInfo.addRoleId(adminRoleId);
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -192,8 +192,9 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
       // Add the admin role to dbAccessIdInfo
-      final String adminRoleId = OMMultiTenantManager.getAdminRoleId(tenantId);
-      dbAccessIdInfo.addRoleId(adminRoleId);
+      final String adminRoleName =
+          OMMultiTenantManager.getAdminRoleName(tenantId);
+      dbAccessIdInfo.addRoleName(adminRoleName);
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
@@ -202,7 +203,7 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
               .setUserPrincipal(dbAccessIdInfo.getUserPrincipal())
               .setIsAdmin(true)
               .setIsDelegatedAdmin(delegated)
-              .setRoleIds(dbAccessIdInfo.getRoleIdsSet())
+              .setRoleNames(dbAccessIdInfo.getRoleNamesSet())
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignAdminRequest.java
@@ -192,11 +192,12 @@ public class OMTenantAssignAdminRequest extends OMClientRequest {
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-          .setTenantId(oldAccessIdInfo.getTenantId())
-          .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
-          .setIsAdmin(true)
-          .setIsDelegatedAdmin(delegated)
-          .build();
+              .setTenantId(oldAccessIdInfo.getTenantId())
+              .setUserPrincipal(oldAccessIdInfo.getUserPrincipal())
+              .setIsAdmin(true)
+              .setIsDelegatedAdmin(delegated)
+              .setRoleId(OzoneConsts.TENANT_ROLE_ADMIN)
+              .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.of(newOmDBAccessIdInfo),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -92,7 +92,6 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SC
     - New entry or update existing entry in principalToAccessIdsTable:
       - Key: Kerberos principal of the user.
       - Value: OmDBKerberosPrincipalInfo. Has accessIds.
-    - tenantRoleTable: TBD. No-Op for now.
     - Release VOLUME_LOCK write lock
  */
 
@@ -314,13 +313,6 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           new CacheValue<>(Optional.of(principalInfo),
               transactionLogIndex));
 
-      // Add to tenantRoleTable
-      // TODO: TenantRoleTable is unused for now.
-      final String roleName = "user";
-      omMetadataManager.getTenantRoleTable().addCacheEntry(
-          new CacheKey<>(accessId),
-          new CacheValue<>(Optional.of(roleName), transactionLogIndex));
-
       // Add S3SecretTable cache entry
       acquiredS3SecretLock = omMetadataManager.getLock()
           .acquireWriteLock(S3_SECRET_LOCK, accessId);
@@ -348,7 +340,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
               .build());
       omClientResponse = new OMTenantAssignUserAccessIdResponse(
           omResponse.build(), s3SecretValue, userPrincipal,
-          roleName, accessId, omDBAccessIdInfo, principalInfo);
+          accessId, omDBAccessIdInfo, principalInfo);
     } catch (IOException ex) {
       handleRequestFailure(ozoneManager);
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -54,7 +54,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeSet;
 
-import static org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo.SERIALIZATION_SPLIT_KEY;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.S3_SECRET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
 import static org.apache.hadoop.ozone.om.request.s3.tenant.OMTenantRequestHelper.checkTenantAdmin;
@@ -141,13 +140,6 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
       throw new OMException("Invalid accessId '" + accessId + "'. "
           + "Specifying a custom access ID disallowed. "
           + "Expected accessId to be assigned is '" + expectedAccessId + "'",
-          OMException.ResultCodes.INVALID_ACCESS_ID);
-    }
-
-    // Check accessId validity.
-    if (accessId.contains(SERIALIZATION_SPLIT_KEY)) {
-      throw new OMException("Invalid accessId '" + accessId +
-          "'. accessId should not contain '" + SERIALIZATION_SPLIT_KEY + "'",
           OMException.ResultCodes.INVALID_ACCESS_ID);
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -283,7 +283,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           new S3SecretValue(accessId, awsSecret);
 
       // Add to tenantAccessIdTable
-      final String userRoleId = OMMultiTenantManager.getUserRoleId(tenantId);
+      final String userRoleId = OMMultiTenantManager.getUserRoleName(tenantId);
       final OmDBAccessIdInfo omDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
           .setTenantId(tenantId)
           .setUserPrincipal(userPrincipal)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -286,7 +286,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           .setUserPrincipal(userPrincipal)
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
-          .setRoleId(OzoneConsts.TENANT_ROLE_USER)
+          .addRoleId(OzoneConsts.TENANT_ROLE_USER)
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
@@ -89,8 +89,8 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SC
              Example of accessId: finance$bob@EXAMPLE.COM
       - Value: OmDBAccessIdInfo. Has tenantId, kerberosPrincipal, sharedSecret.
     - New entry or update existing entry in principalToAccessIdsTable:
-      - Key: Kerberos principal of the user.
-      - Value: OmDBKerberosPrincipalInfo. Has accessIds.
+      - Key: User principal. Usually the short name of the Kerberos principal.
+      - Value: OmDBUserPrincipalInfo. Has accessIds.
     - Release VOLUME_LOCK write lock
  */
 
@@ -253,7 +253,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
             OMException.ResultCodes.TENANT_USER_ACCESS_ID_ALREADY_EXISTS);
       }
 
-      OmDBKerberosPrincipalInfo principalInfo = omMetadataManager
+      OmDBUserPrincipalInfo principalInfo = omMetadataManager
           .getPrincipalToAccessIdsTable().getIfExist(userPrincipal);
       // Reject if the user is already assigned to the tenant
       if (principalInfo != null) {
@@ -294,7 +294,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
 
       // Add to principalToAccessIdsTable
       if (principalInfo == null) {
-        principalInfo = new OmDBKerberosPrincipalInfo.Builder()
+        principalInfo = new OmDBUserPrincipalInfo.Builder()
             .setAccessIds(new TreeSet<>(Collections.singleton(accessId)))
             .build();
       } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -219,8 +220,9 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
 
     boolean acquiredVolumeLock = false;
     boolean acquiredS3SecretLock = false;
-    Map<String, String> auditMap = new HashMap<>();
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    final Map<String, String> auditMap = new HashMap<>();
+    final OMMetadataManager omMetadataManager =
+        ozoneManager.getMetadataManager();
 
     final TenantAssignUserAccessIdRequest request =
         getOmRequest().getTenantAssignUserAccessIdRequest();
@@ -281,12 +283,13 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           new S3SecretValue(accessId, awsSecret);
 
       // Add to tenantAccessIdTable
+      final String userRoleId = OMMultiTenantManager.getUserRoleId(tenantId);
       final OmDBAccessIdInfo omDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
           .setTenantId(tenantId)
           .setUserPrincipal(userPrincipal)
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
-          .addRoleId(OzoneConsts.TENANT_ROLE_USER)
+          .addRoleId(userRoleId)
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -289,7 +289,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           .setUserPrincipal(userPrincipal)
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
-          .addRoleId(userRoleId)
+          .addRoleName(userRoleId)
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -92,9 +92,6 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SC
     - New entry or update existing entry in principalToAccessIdsTable:
       - Key: Kerberos principal of the user.
       - Value: OmDBKerberosPrincipalInfo. Has accessIds.
-    - tenantGroupTable: Add this new user to the default tenant group.
-      - Key: finance$bob
-      - Value: finance-users
     - tenantRoleTable: TBD. No-Op for now.
     - Release VOLUME_LOCK write lock
  */
@@ -316,14 +313,6 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           new CacheValue<>(Optional.of(principalInfo),
               transactionLogIndex));
 
-      // Add to tenantGroupTable
-      // TODO: TenantGroupTable is unused for now.
-      final String defaultGroupName =
-          tenantId + OzoneConsts.DEFAULT_TENANT_USER_GROUP_SUFFIX;
-      omMetadataManager.getTenantGroupTable().addCacheEntry(
-          new CacheKey<>(accessId),
-          new CacheValue<>(Optional.of(defaultGroupName), transactionLogIndex));
-
       // Add to tenantRoleTable
       // TODO: TenantRoleTable is unused for now.
       final String roleName = "user";
@@ -357,7 +346,7 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
                   .setAwsSecret(awsSecret).setKerberosID(accessId))
               .build());
       omClientResponse = new OMTenantAssignUserAccessIdResponse(
-          omResponse.build(), s3SecretValue, userPrincipal, defaultGroupName,
+          omResponse.build(), s3SecretValue, userPrincipal,
           roleName, accessId, omDBAccessIdInfo, principalInfo);
     } catch (IOException ex) {
       handleRequestFailure(ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -283,13 +282,11 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
           new S3SecretValue(accessId, awsSecret);
 
       // Add to tenantAccessIdTable
-      final String userRoleId = OMMultiTenantManager.getUserRoleName(tenantId);
       final OmDBAccessIdInfo omDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
           .setTenantId(tenantId)
           .setUserPrincipal(userPrincipal)
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
-          .addRoleName(userRoleId)
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantAssignUserAccessIdRequest.java
@@ -292,9 +292,10 @@ public class OMTenantAssignUserAccessIdRequest extends OMClientRequest {
       // Add to tenantAccessIdTable
       final OmDBAccessIdInfo omDBAccessIdInfo = new OmDBAccessIdInfo.Builder()
           .setTenantId(tenantId)
-          .setKerberosPrincipal(userPrincipal)
+          .setUserPrincipal(userPrincipal)
           .setIsAdmin(false)
           .setIsDelegatedAdmin(false)
+          .setRoleId(OzoneConsts.TENANT_ROLE_USER)
           .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -80,7 +80,7 @@ import static org.apache.hadoop.ozone.om.upgrade.OMLayoutFeature.MULTITENANCY_SC
     - If tenant already exists, throw exception to client; else continue
   - tenantStateTable: New entry
     - Key: tenant name. e.g. finance
-    - Value: new OmDBTenantInfo for the tenant
+    - Value: new OmDBTenantState for the tenant
       - tenantId: finance
       - bucketNamespaceName: finance
       - accountNamespaceName: finance
@@ -302,17 +302,17 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
           bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_NAME_SUFFIX;
       policyNamesList.add(bucketPolicyName);
 
-      final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
+      final OmDBTenantState omDBTenantState = new OmDBTenantState(
           tenantId, bucketNamespaceName, policyNamesList);
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
-          new CacheValue<>(Optional.of(omDBTenantInfo), transactionLogIndex));
+          new CacheValue<>(Optional.of(omDBTenantState), transactionLogIndex));
 
       omResponse.setCreateTenantResponse(
           CreateTenantResponse.newBuilder()
               .build());
       omClientResponse = new OMTenantCreateResponse(omResponse.build(),
-          omVolumeArgs, volumeList, omDBTenantInfo);
+          omVolumeArgs, volumeList, omDBTenantState);
 
     } catch (IOException ex) {
       // Error handling. Clean up Ranger policies when necessary.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
@@ -54,9 +55,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -292,18 +291,18 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       // Create tenant
       // Add to tenantStateTable. Redundant assignment for clarity
       final String bucketNamespaceName = volumeName;
-      final List<String> policyNamesList = new ArrayList<>();
       // Populate policy ID list
-      // TODO: Check if both policies are actually used. Remove if not
-      policyNamesList.add(tenantDefaultPolicies);
-      final String bucketPolicyGroupName =
-          tenantId + OzoneConsts.DEFAULT_TENANT_BUCKET_POLICY_SUFFIX;
+      final String bucketNamespacePolicyName =
+          OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantId);
       final String bucketPolicyName =
-          bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_NAME_SUFFIX;
-      policyNamesList.add(bucketPolicyName);
-
+          OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantId);
+      final String userRoleName =
+          OMMultiTenantManager.getDefaultUserRoleName(tenantId);
+      final String adminRoleName =
+          OMMultiTenantManager.getDefaultAdminRoleName(tenantId);
       final OmDBTenantState omDBTenantState = new OmDBTenantState(
-          tenantId, bucketNamespaceName, policyNamesList);
+          tenantId, bucketNamespaceName, userRoleName, adminRoleName,
+          bucketNamespacePolicyName, bucketPolicyName);
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
           new CacheValue<>(Optional.of(omDBTenantState), transactionLogIndex));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -295,7 +295,7 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       final String bucketNamespacePolicyName =
           OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantId);
       final String bucketPolicyName =
-          OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantId);
+          OMMultiTenantManager.getDefaultBucketPolicyName(tenantId);
       final String userRoleName =
           OMMultiTenantManager.getDefaultUserRoleName(tenantId);
       final String adminRoleName =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -298,9 +298,9 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       policyNamesList.add(tenantDefaultPolicies);
       final String bucketPolicyGroupName =
           tenantId + OzoneConsts.DEFAULT_TENANT_BUCKET_POLICY_SUFFIX;
-      final String bucketPolicyId =
-          bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_ID_SUFFIX;
-      policyNamesList.add(bucketPolicyId);
+      final String bucketPolicyName =
+          bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_NAME_SUFFIX;
+      policyNamesList.add(bucketPolicyName);
 
       final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
           tenantId, bucketNamespaceName, policyNamesList);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.multitenant.AccessPolicy;
 import org.apache.hadoop.ozone.om.multitenant.Tenant;
@@ -302,7 +302,7 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
           bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_ID_SUFFIX;
       policyIdsList.add(bucketPolicyId);
 
-      final OmDBTenantInfo omDBTenantInfo = new OmDBTenantInfo(
+      final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
           tenantId, bucketNamespaceName, policyIdsList);
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -292,18 +292,18 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
       // Create tenant
       // Add to tenantStateTable. Redundant assignment for clarity
       final String bucketNamespaceName = volumeName;
-      final List<String> policyIdsList = new ArrayList<>();
+      final List<String> policyNamesList = new ArrayList<>();
       // Populate policy ID list
       // TODO: Check if both policies are actually used. Remove if not
-      policyIdsList.add(tenantDefaultPolicies);
+      policyNamesList.add(tenantDefaultPolicies);
       final String bucketPolicyGroupName =
           tenantId + OzoneConsts.DEFAULT_TENANT_BUCKET_POLICY_SUFFIX;
       final String bucketPolicyId =
           bucketPolicyGroupName + OzoneConsts.DEFAULT_TENANT_POLICY_ID_SUFFIX;
-      policyIdsList.add(bucketPolicyId);
+      policyNamesList.add(bucketPolicyId);
 
       final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
-          tenantId, bucketNamespaceName, policyIdsList);
+          tenantId, bucketNamespaceName, policyNamesList);
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
           new CacheValue<>(Optional.of(omDBTenantInfo), transactionLogIndex));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -105,11 +105,11 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
       }
 
       // Reading the TenantStateTable without lock as we don't have or need
-      // a TENANT_LOCK. The assumption is that OmDBTenantInfo is read-only
+      // a TENANT_LOCK. The assumption is that OmDBTenantState is read-only
       // once it is set during tenant creation.
-      final OmDBTenantState dbTenantInfo =
+      final OmDBTenantState dbTenantState =
           omMetadataManager.getTenantStateTable().get(tenantId);
-      volumeName = dbTenantInfo.getBucketNamespaceName();
+      volumeName = dbTenantState.getBucketNamespaceName();
       assert (volumeName != null);
 
       LOG.debug("Tenant '{}' has volume '{}'", tenantId, volumeName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -107,7 +107,7 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
       // Reading the TenantStateTable without lock as we don't have or need
       // a TENANT_LOCK. The assumption is that OmDBTenantInfo is read-only
       // once it is set during tenant creation.
-      final OmDBTenantInfo dbTenantInfo =
+      final OmDBTenantState dbTenantInfo =
           omMetadataManager.getTenantStateTable().get(tenantId);
       volumeName = dbTenantInfo.getBucketNamespaceName();
       assert (volumeName != null);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantDeleteRequest.java
@@ -130,20 +130,9 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
             TENANT_NOT_EMPTY);
       }
 
-      // Invalidate cache entries
+      // Invalidate cache entry
       omMetadataManager.getTenantStateTable().addCacheEntry(
           new CacheKey<>(tenantId),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
-
-      final String userPolicyGroupName = dbTenantInfo.getUserPolicyGroupName();
-      omMetadataManager.getTenantPolicyTable().addCacheEntry(
-          new CacheKey<>(userPolicyGroupName),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
-
-      final String bucketPolicyGroupName =
-          dbTenantInfo.getBucketPolicyGroupName();
-      omMetadataManager.getTenantPolicyTable().addCacheEntry(
-          new CacheKey<>(bucketPolicyGroupName),
           new CacheValue<>(Optional.absent(), transactionLogIndex));
 
       // Decrement volume refCount
@@ -182,8 +171,7 @@ public class OMTenantDeleteRequest extends OMVolumeRequest {
 
       omClientResponse = new OMTenantDeleteResponse(
           omResponse.setDeleteTenantResponse(deleteTenantResponse).build(),
-          volumeName, omVolumeArgs, tenantId, userPolicyGroupName,
-          bucketPolicyGroupName);
+          volumeName, omVolumeArgs, tenantId);
 
     } catch (IOException ex) {
       exception = ex;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserAccessIdInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
@@ -241,7 +241,7 @@ public final class OMTenantRequestHelper {
     //  (apart from it being populated on OM startup) right now.
     //  So unless tenantCache is updated on follower nodes later as well,
     //  we can't use listUsersInTenant to check tenant emptiness in followers.
-    final List<ExtendedAccessIdInfo> tenantUserAccessIdsList =
+    final List<UserAccessIdInfo> tenantUserAccessIdsList =
         tenantManager.listUsersInTenant(tenantId, "").getUserAccessIds();
     return tenantUserAccessIdsList.size() == 0;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
 import org.apache.hadoop.security.UserGroupInformation;
 
@@ -108,7 +108,7 @@ public final class OMTenantRequestHelper {
   public static String getTenantVolumeName(OMMetadataManager omMetadataManager,
                                            String tenantId) throws IOException {
 
-    final OmDBTenantInfo tenantInfo =
+    final OmDBTenantState tenantInfo =
         omMetadataManager.getTenantStateTable().get(tenantId);
 
     if (tenantInfo == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -94,7 +94,7 @@ public final class OMTenantRequestHelper {
           throw omEx;
         }
       }
-      throw new OMException("Error while retrieving OmDBTenantInfo for tenant "
+      throw new OMException("Error while retrieving OmDBTenantState for tenant "
           + "'" + tenantId + "': " + ex.getMessage(),
           OMException.ResultCodes.METADATA_ERROR);
     }
@@ -108,16 +108,16 @@ public final class OMTenantRequestHelper {
   public static String getTenantVolumeName(OMMetadataManager omMetadataManager,
                                            String tenantId) throws IOException {
 
-    final OmDBTenantState tenantInfo =
+    final OmDBTenantState tenantState =
         omMetadataManager.getTenantStateTable().get(tenantId);
 
-    if (tenantInfo == null) {
+    if (tenantState == null) {
       throw new OMException("Potential DB error or race condition. "
-          + "OmDBTenantInfo entry is missing for tenant '" + tenantId + "'.",
+          + "OmDBTenantState entry is missing for tenant '" + tenantId + "'.",
           ResultCodes.TENANT_NOT_FOUND);
     }
 
-    final String volumeName = tenantInfo.getBucketNamespaceName();
+    final String volumeName = tenantState.getBucketNamespaceName();
 
     if (volumeName == null) {
       throw new OMException("Potential DB error. volumeName "
@@ -187,7 +187,7 @@ public final class OMTenantRequestHelper {
     // Check if ugi is a tenant admin (or an Ozone cluster admin)
     final OMMultiTenantManager multiTenantManager =
         ozoneManager.getMultiTenantManager();
-    if (multiTenantManager.isTenantAdmin(ugi, tenantId, true)) {
+    if (multiTenantManager.isTenantAdmin(ugi, tenantId, false)) {
       return true;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRequestHelper.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 
 import java.io.IOException;
@@ -241,7 +241,7 @@ public final class OMTenantRequestHelper {
     //  (apart from it being populated on OM startup) right now.
     //  So unless tenantCache is updated on follower nodes later as well,
     //  we can't use listUsersInTenant to check tenant emptiness in followers.
-    final List<TenantUserAccessId> tenantUserAccessIdsList =
+    final List<ExtendedAccessIdInfo> tenantUserAccessIdsList =
         tenantManager.listUsersInTenant(tenantId, "").getUserAccessIds();
     return tenantUserAccessIdsList.size() == 0;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -173,11 +172,6 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
 
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
-      // Remove the admin role from dbAccessIdInfo
-      final String adminRoleId =
-          OMMultiTenantManager.getAdminRoleName(tenantId);
-      dbAccessIdInfo.removeRoleName(adminRoleId);
-
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
@@ -185,7 +179,6 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
               .setUserPrincipal(dbAccessIdInfo.getUserPrincipal())
               .setIsAdmin(false)
               .setIsDelegatedAdmin(false)
-              .setRoleNames(dbAccessIdInfo.getRoleNamesSet())
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.OMAction;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OMMultiTenantManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
@@ -142,7 +143,10 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
         OmResponseUtil.getOMResponseBuilder(getOmRequest());
 
     final Map<String, String> auditMap = new HashMap<>();
-    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+    final OMMetadataManager omMetadataManager =
+        ozoneManager.getMetadataManager();
+    final OMMultiTenantManager omMultiTenantManager =
+        ozoneManager.getMultiTenantManager();
 
     final TenantRevokeAdminRequest request =
         getOmRequest().getTenantRevokeAdminRequest();
@@ -171,8 +175,9 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
 
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
-      // Remove the admin role from OmDBAccessIdInfo we got previously in-place
-      dbAccessIdInfo.removeRoleId(OzoneConsts.TENANT_ROLE_ADMIN);
+      // Remove the admin role from dbAccessIdInfo
+      final String adminRoleId = OMMultiTenantManager.getAdminRoleId(tenantId);
+      dbAccessIdInfo.removeRoleId(adminRoleId);
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -161,24 +161,27 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
       acquiredVolumeLock = omMetadataManager.getLock().acquireWriteLock(
           VOLUME_LOCK, volumeName);
 
-      final OmDBAccessIdInfo oldAccessIdInfo =
+      final OmDBAccessIdInfo dbAccessIdInfo =
           omMetadataManager.getTenantAccessIdTable().get(accessId);
 
-      if (oldAccessIdInfo == null) {
+      if (dbAccessIdInfo == null) {
         throw new OMException("OmDBAccessIdInfo entry is missing for accessId '"
-            + accessId + "'.", OMException.ResultCodes.METADATA_ERROR);
+            + accessId + "'", OMException.ResultCodes.METADATA_ERROR);
       }
 
-      assert (oldAccessIdInfo.getTenantId().equals(tenantId));
+      assert (dbAccessIdInfo.getTenantId().equals(tenantId));
+
+      // Remove the admin role from OmDBAccessIdInfo we got previously in-place
+      dbAccessIdInfo.removeRoleId(OzoneConsts.TENANT_ROLE_ADMIN);
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-              .setTenantId(oldAccessIdInfo.getTenantId())
-              .setUserPrincipal(oldAccessIdInfo.getUserPrincipal())
+              .setTenantId(dbAccessIdInfo.getTenantId())
+              .setUserPrincipal(dbAccessIdInfo.getUserPrincipal())
               .setIsAdmin(false)
               .setIsDelegatedAdmin(false)
-              .setRoleId(OzoneConsts.TENANT_ROLE_USER)
+              .setRoleIds(dbAccessIdInfo.getRoleIdsSet())
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -145,15 +145,13 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
     final Map<String, String> auditMap = new HashMap<>();
     final OMMetadataManager omMetadataManager =
         ozoneManager.getMetadataManager();
-    final OMMultiTenantManager omMultiTenantManager =
-        ozoneManager.getMultiTenantManager();
 
     final TenantRevokeAdminRequest request =
         getOmRequest().getTenantRevokeAdminRequest();
     final String accessId = request.getAccessId();
     final String tenantId = request.getTenantId();
 
-    boolean acquiredVolumeLock = false;  // TODO: use tenant lock instead, maybe
+    boolean acquiredVolumeLock = false;
     IOException exception = null;
 
     String volumeName = null;
@@ -176,8 +174,9 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
       assert (dbAccessIdInfo.getTenantId().equals(tenantId));
 
       // Remove the admin role from dbAccessIdInfo
-      final String adminRoleId = OMMultiTenantManager.getAdminRoleId(tenantId);
-      dbAccessIdInfo.removeRoleId(adminRoleId);
+      final String adminRoleId =
+          OMMultiTenantManager.getAdminRoleName(tenantId);
+      dbAccessIdInfo.removeRoleName(adminRoleId);
 
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
@@ -186,7 +185,7 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
               .setUserPrincipal(dbAccessIdInfo.getUserPrincipal())
               .setIsAdmin(false)
               .setIsDelegatedAdmin(false)
-              .setRoleIds(dbAccessIdInfo.getRoleIdsSet())
+              .setRoleNames(dbAccessIdInfo.getRoleNamesSet())
               .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -174,11 +174,12 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
       // Update tenantAccessIdTable
       final OmDBAccessIdInfo newOmDBAccessIdInfo =
           new OmDBAccessIdInfo.Builder()
-          .setTenantId(oldAccessIdInfo.getTenantId())
-          .setKerberosPrincipal(oldAccessIdInfo.getUserPrincipal())
-          .setIsAdmin(false)
-          .setIsDelegatedAdmin(false)
-          .build();
+              .setTenantId(oldAccessIdInfo.getTenantId())
+              .setUserPrincipal(oldAccessIdInfo.getUserPrincipal())
+              .setIsAdmin(false)
+              .setIsDelegatedAdmin(false)
+              .setRoleId(OzoneConsts.TENANT_ROLE_USER)
+              .build();
       omMetadataManager.getTenantAccessIdTable().addCacheEntry(
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.of(newOmDBAccessIdInfo),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeAdminRequest.java
@@ -185,12 +185,6 @@ public class OMTenantRevokeAdminRequest extends OMClientRequest {
           new CacheValue<>(Optional.of(newOmDBAccessIdInfo),
               transactionLogIndex));
 
-      // Update tenantRoleTable?
-//      final String roleName = "role_admin";
-//      omMetadataManager.getTenantRoleTable().addCacheEntry(
-//          new CacheKey<>(accessId),
-//          new CacheValue<>(Optional.of(roleName), transactionLogIndex));
-
       omResponse.setTenantRevokeAdminResponse(
           TenantRevokeAdminResponse.newBuilder()
               .build());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -177,7 +177,7 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
       assert (omDBAccessIdInfo != null);
       userPrincipal = omDBAccessIdInfo.getUserPrincipal();
       assert (userPrincipal != null);
-      OmDBKerberosPrincipalInfo principalInfo = omMetadataManager
+      OmDBUserPrincipalInfo principalInfo = omMetadataManager
           .getPrincipalToAccessIdsTable().getIfExist(userPrincipal);
       assert (principalInfo != null);
       principalInfo.removeAccessId(accessId);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -193,11 +193,6 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.absent(), transactionLogIndex));
 
-      // Remove from tenantRoleTable
-      omMetadataManager.getTenantRoleTable().addCacheEntry(
-          new CacheKey<>(accessId),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
-
       // Remove from S3SecretTable.
       // Note: S3SecretTable will be deprecated in the future.
       acquiredS3SecretLock = omMetadataManager.getLock()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantRevokeUserAccessIdRequest.java
@@ -193,11 +193,6 @@ public class OMTenantRevokeUserAccessIdRequest extends OMClientRequest {
           new CacheKey<>(accessId),
           new CacheValue<>(Optional.absent(), transactionLogIndex));
 
-      // Remove from tenantGroupTable
-      omMetadataManager.getTenantGroupTable().addCacheEntry(
-          new CacheKey<>(accessId),
-          new CacheValue<>(Optional.absent(), transactionLogIndex));
-
       // Remove from tenantRoleTable
       omMetadataManager.getTenantRoleTable().addCacheEntry(
           new CacheKey<>(accessId),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignAdminResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignAdminResponse.java
@@ -36,7 +36,6 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_
  */
 @CleanupTableInfo(cleanupTables = {
     TENANT_ACCESS_ID_TABLE
-//    TENANT_ROLE_TABLE
 })
 public class OMTenantAssignAdminResponse extends OMClientResponse {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.helpers.S3SecretValue;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -49,7 +49,7 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
   private S3SecretValue s3SecretValue;
   private String principal, accessId;
   private OmDBAccessIdInfo omDBAccessIdInfo;
-  private OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo;
+  private OmDBUserPrincipalInfo omDBUserPrincipalInfo;
 
   @SuppressWarnings("checkstyle:parameternumber")
   public OMTenantAssignUserAccessIdResponse(@Nonnull OMResponse omResponse,
@@ -57,14 +57,14 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
       @Nonnull String principal,
       @Nonnull String accessId,
       @Nonnull OmDBAccessIdInfo omDBAccessIdInfo,
-      @Nonnull OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo
+      @Nonnull OmDBUserPrincipalInfo omDBUserPrincipalInfo
   ) {
     super(omResponse);
     this.s3SecretValue = s3SecretValue;
     this.principal = principal;
     this.accessId = accessId;
     this.omDBAccessIdInfo = omDBAccessIdInfo;
-    this.omDBKerberosPrincipalInfo = omDBKerberosPrincipalInfo;
+    this.omDBUserPrincipalInfo = omDBUserPrincipalInfo;
   }
 
   /**
@@ -90,7 +90,7 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
     omMetadataManager.getTenantAccessIdTable().putWithBatch(
         batchOperation, accessId, omDBAccessIdInfo);
     omMetadataManager.getPrincipalToAccessIdsTable().putWithBatch(
-        batchOperation, principal, omDBKerberosPrincipalInfo);
+        batchOperation, principal, omDBUserPrincipalInfo);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.S3_SECRET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE;
 
 /**
  * Response for OMAssignUserToTenantRequest.
@@ -43,13 +42,12 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE
 @CleanupTableInfo(cleanupTables = {
     S3_SECRET_TABLE,
     TENANT_ACCESS_ID_TABLE,
-    PRINCIPAL_TO_ACCESS_IDS_TABLE,
-    TENANT_ROLE_TABLE
+    PRINCIPAL_TO_ACCESS_IDS_TABLE
 })
 public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
 
   private S3SecretValue s3SecretValue;
-  private String principal, roleName, accessId;
+  private String principal, accessId;
   private OmDBAccessIdInfo omDBAccessIdInfo;
   private OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo;
 
@@ -57,7 +55,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
   public OMTenantAssignUserAccessIdResponse(@Nonnull OMResponse omResponse,
       @Nonnull S3SecretValue s3SecretValue,
       @Nonnull String principal,
-      @Nonnull String roleName,
       @Nonnull String accessId,
       @Nonnull OmDBAccessIdInfo omDBAccessIdInfo,
       @Nonnull OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo
@@ -65,7 +62,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
     super(omResponse);
     this.s3SecretValue = s3SecretValue;
     this.principal = principal;
-    this.roleName = roleName;
     this.accessId = accessId;
     this.omDBAccessIdInfo = omDBAccessIdInfo;
     this.omDBKerberosPrincipalInfo = omDBKerberosPrincipalInfo;
@@ -95,8 +91,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
         batchOperation, accessId, omDBAccessIdInfo);
     omMetadataManager.getPrincipalToAccessIdsTable().putWithBatch(
         batchOperation, principal, omDBKerberosPrincipalInfo);
-    omMetadataManager.getTenantRoleTable().putWithBatch(
-        batchOperation, accessId, roleName);
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantAssignUserAccessIdResponse.java
@@ -35,7 +35,6 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.S3_SECRET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_GROUP_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE;
 
 /**
@@ -45,13 +44,12 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE
     S3_SECRET_TABLE,
     TENANT_ACCESS_ID_TABLE,
     PRINCIPAL_TO_ACCESS_IDS_TABLE,
-    TENANT_GROUP_TABLE,
     TENANT_ROLE_TABLE
 })
 public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
 
   private S3SecretValue s3SecretValue;
-  private String principal, groupName, roleName, accessId;
+  private String principal, roleName, accessId;
   private OmDBAccessIdInfo omDBAccessIdInfo;
   private OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo;
 
@@ -59,7 +57,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
   public OMTenantAssignUserAccessIdResponse(@Nonnull OMResponse omResponse,
       @Nonnull S3SecretValue s3SecretValue,
       @Nonnull String principal,
-      @Nonnull String groupName,
       @Nonnull String roleName,
       @Nonnull String accessId,
       @Nonnull OmDBAccessIdInfo omDBAccessIdInfo,
@@ -68,7 +65,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
     super(omResponse);
     this.s3SecretValue = s3SecretValue;
     this.principal = principal;
-    this.groupName = groupName;
     this.roleName = roleName;
     this.accessId = accessId;
     this.omDBAccessIdInfo = omDBAccessIdInfo;
@@ -99,8 +95,6 @@ public class OMTenantAssignUserAccessIdResponse extends OMClientResponse {
         batchOperation, accessId, omDBAccessIdInfo);
     omMetadataManager.getPrincipalToAccessIdsTable().putWithBatch(
         batchOperation, principal, omDBKerberosPrincipalInfo);
-    omMetadataManager.getTenantGroupTable().putWithBatch(
-        batchOperation, accessId, groupName);
     omMetadataManager.getTenantRoleTable().putWithBatch(
         batchOperation, accessId, roleName);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.ozone.storage.proto.OzoneManagerStorageProtos;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_POLICY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_STATE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
@@ -40,30 +39,23 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
  */
 @CleanupTableInfo(cleanupTables = {
     TENANT_STATE_TABLE,
-    TENANT_POLICY_TABLE,
     VOLUME_TABLE
 })
 public class OMTenantCreateResponse extends OMClientResponse {
 
   private OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo;
   private OmVolumeArgs omVolumeArgs;
-
   private OmDBTenantInfo omTenantInfo;
-  private String userPolicyId, bucketPolicyId;
 
   public OMTenantCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmVolumeArgs omVolumeArgs,
       @Nonnull OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo,
-      @Nonnull OmDBTenantInfo omTenantInfo,
-      @Nonnull String userPolicyId,
-      @Nonnull String bucketPolicyId
+      @Nonnull OmDBTenantInfo omTenantInfo
   ) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
     this.userVolumeInfo = userVolumeInfo;
     this.omTenantInfo = omTenantInfo;
-    this.userPolicyId = userPolicyId;
-    this.bucketPolicyId = bucketPolicyId;
   }
 
   /**
@@ -82,16 +74,6 @@ public class OMTenantCreateResponse extends OMClientResponse {
     final String tenantId = omTenantInfo.getTenantId();
     omMetadataManager.getTenantStateTable().putWithBatch(
         batchOperation, tenantId, omTenantInfo);
-
-    final String userPolicyGroupName =
-        omTenantInfo.getUserPolicyGroupName();
-    omMetadataManager.getTenantPolicyTable().putWithBatch(
-        batchOperation, userPolicyGroupName, userPolicyId);
-
-    final String bucketPolicyGroupName =
-        omTenantInfo.getBucketPolicyGroupName();
-    omMetadataManager.getTenantPolicyTable().putWithBatch(
-        batchOperation, bucketPolicyGroupName, bucketPolicyId);
 
     // From OMVolumeCreateResponse
     String dbVolumeKey =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -45,17 +45,17 @@ public class OMTenantCreateResponse extends OMClientResponse {
 
   private OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo;
   private OmVolumeArgs omVolumeArgs;
-  private OmDBTenantState omTenantInfo;
+  private OmDBTenantState omTenantState;
 
   public OMTenantCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmVolumeArgs omVolumeArgs,
       @Nonnull OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo,
-      @Nonnull OmDBTenantState omTenantInfo
+      @Nonnull OmDBTenantState omTenantState
   ) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
     this.userVolumeInfo = userVolumeInfo;
-    this.omTenantInfo = omTenantInfo;
+    this.omTenantState = omTenantState;
   }
 
   /**
@@ -71,9 +71,9 @@ public class OMTenantCreateResponse extends OMClientResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    final String tenantId = omTenantInfo.getTenantId();
+    final String tenantId = omTenantState.getTenantId();
     omMetadataManager.getTenantStateTable().putWithBatch(
-        batchOperation, tenantId, omTenantInfo);
+        batchOperation, tenantId, omTenantState);
 
     // From OMVolumeCreateResponse
     String dbVolumeKey =
@@ -88,7 +88,7 @@ public class OMTenantCreateResponse extends OMClientResponse {
   }
 
   @VisibleForTesting
-  public OmDBTenantState getOmDBTenantInfo() {
-    return omTenantInfo;
+  public OmDBTenantState getOmDBTenantState() {
+    return omTenantState;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.ozone.om.response.s3.tenant;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
@@ -45,12 +45,12 @@ public class OMTenantCreateResponse extends OMClientResponse {
 
   private OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo;
   private OmVolumeArgs omVolumeArgs;
-  private OmDBTenantInfo omTenantInfo;
+  private OmDBTenantState omTenantInfo;
 
   public OMTenantCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmVolumeArgs omVolumeArgs,
       @Nonnull OzoneManagerStorageProtos.PersistedUserVolumeInfo userVolumeInfo,
-      @Nonnull OmDBTenantInfo omTenantInfo
+      @Nonnull OmDBTenantState omTenantInfo
   ) {
     super(omResponse);
     this.omVolumeArgs = omVolumeArgs;
@@ -88,7 +88,7 @@ public class OMTenantCreateResponse extends OMClientResponse {
   }
 
   @VisibleForTesting
-  public OmDBTenantInfo getOmDBTenantInfo() {
+  public OmDBTenantState getOmDBTenantInfo() {
     return omTenantInfo;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantDeleteResponse.java
@@ -30,7 +30,6 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_POLICY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_STATE_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
@@ -39,7 +38,6 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
  */
 @CleanupTableInfo(cleanupTables = {
     TENANT_STATE_TABLE,
-    TENANT_POLICY_TABLE,
     VOLUME_TABLE
 })
 public class OMTenantDeleteResponse extends OMClientResponse {
@@ -47,21 +45,15 @@ public class OMTenantDeleteResponse extends OMClientResponse {
   private String volumeName;
   private OmVolumeArgs omVolumeArgs;
   private String tenantId;
-  private String userPolicyGroupName;
-  private String bucketPolicyGroupName;
 
   public OMTenantDeleteResponse(@Nonnull OMResponse omResponse,
                                 @Nonnull String volumeName,
                                 @Nullable OmVolumeArgs omVolumeArgs,
-                                @Nonnull String tenantId,
-                                @Nonnull String userPolicyGroupName,
-                                @Nonnull String bucketPolicyGroupName) {
+                                @Nonnull String tenantId) {
     super(omResponse);
     this.volumeName = volumeName;
     this.omVolumeArgs = omVolumeArgs;
     this.tenantId = tenantId;
-    this.userPolicyGroupName = userPolicyGroupName;
-    this.bucketPolicyGroupName = bucketPolicyGroupName;
   }
 
   /**
@@ -79,12 +71,6 @@ public class OMTenantDeleteResponse extends OMClientResponse {
 
     omMetadataManager.getTenantStateTable().deleteWithBatch(
         batchOperation, tenantId);
-
-    omMetadataManager.getTenantPolicyTable().deleteWithBatch(
-        batchOperation, userPolicyGroupName);
-
-    omMetadataManager.getTenantPolicyTable().deleteWithBatch(
-        batchOperation, bucketPolicyGroupName);
 
     if (volumeName.length() > 0) {
       Preconditions.checkNotNull(omVolumeArgs);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeAdminResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeAdminResponse.java
@@ -36,7 +36,6 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_
  */
 @CleanupTableInfo(cleanupTables = {
     TENANT_ACCESS_ID_TABLE
-//    TENANT_ROLE_TABLE
 })
 public class OMTenantRevokeAdminResponse extends OMClientResponse {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.S3_SECRET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_GROUP_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE;
 
 /**
@@ -42,7 +41,6 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE
     S3_SECRET_TABLE,
     TENANT_ACCESS_ID_TABLE,
     PRINCIPAL_TO_ACCESS_IDS_TABLE,
-    TENANT_GROUP_TABLE,
     TENANT_ROLE_TABLE
 })
 public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
@@ -83,8 +81,6 @@ public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
     }
 
     omMetadataManager.getTenantAccessIdTable().deleteWithBatch(
-        batchOperation, accessId);
-    omMetadataManager.getTenantGroupTable().deleteWithBatch(
         batchOperation, accessId);
     omMetadataManager.getTenantRoleTable().deleteWithBatch(
         batchOperation, accessId);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.ozone.om.response.s3.tenant;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.om.helpers.OmDBKerberosPrincipalInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBUserPrincipalInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
@@ -44,18 +44,18 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_
 public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
 
   private String principal, accessId;
-  private OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo;
+  private OmDBUserPrincipalInfo omDBUserPrincipalInfo;
 
   @SuppressWarnings("checkstyle:parameternumber")
   public OMTenantRevokeUserAccessIdResponse(@Nonnull OMResponse omResponse,
       @Nonnull String accessId,
       @Nonnull String principal,
-      @Nonnull OmDBKerberosPrincipalInfo omDBKerberosPrincipalInfo
+      @Nonnull OmDBUserPrincipalInfo omDBUserPrincipalInfo
   ) {
     super(omResponse);
     this.principal = principal;
     this.accessId = accessId;
-    this.omDBKerberosPrincipalInfo = omDBKerberosPrincipalInfo;
+    this.omDBUserPrincipalInfo = omDBUserPrincipalInfo;
   }
 
   /**
@@ -81,9 +81,9 @@ public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
     omMetadataManager.getTenantAccessIdTable().deleteWithBatch(
         batchOperation, accessId);
 
-    if (omDBKerberosPrincipalInfo.getAccessIds().size() > 0) {
+    if (omDBUserPrincipalInfo.getAccessIds().size() > 0) {
       omMetadataManager.getPrincipalToAccessIdsTable().putWithBatch(
-          batchOperation, principal, omDBKerberosPrincipalInfo);
+          batchOperation, principal, omDBUserPrincipalInfo);
     } else {
       // Remove entry from DB if accessId set is empty
       omMetadataManager.getPrincipalToAccessIdsTable().deleteWithBatch(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantRevokeUserAccessIdResponse.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.PRINCIPAL_TO_ACCESS_IDS_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.S3_SECRET_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ACCESS_ID_TABLE;
-import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE;
 
 /**
  * Response for OMTenantRevokeUserAccessIdRequest.
@@ -40,8 +39,7 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_ROLE_TABLE
 @CleanupTableInfo(cleanupTables = {
     S3_SECRET_TABLE,
     TENANT_ACCESS_ID_TABLE,
-    PRINCIPAL_TO_ACCESS_IDS_TABLE,
-    TENANT_ROLE_TABLE
+    PRINCIPAL_TO_ACCESS_IDS_TABLE
 })
 public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
 
@@ -81,8 +79,6 @@ public class OMTenantRevokeUserAccessIdResponse extends OMClientResponse {
     }
 
     omMetadataManager.getTenantAccessIdTable().deleteWithBatch(
-        batchOperation, accessId);
-    omMetadataManager.getTenantRoleTable().deleteWithBatch(
         batchOperation, accessId);
 
     if (omDBKerberosPrincipalInfo.getAccessIds().size() > 0) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -42,7 +42,7 @@ import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.om.helpers.ServiceInfoEx;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer;
@@ -417,8 +417,8 @@ public class OzoneManagerRequestHandler implements RequestHandler {
 
     final ListTenantResponse.Builder resp = ListTenantResponse.newBuilder();
 
-    TenantInfoList ret = impl.listTenant();
-    resp.addAllTenantInfo(ret.getTenantInfoList());
+    TenantStateList ret = impl.listTenant();
+    resp.addAllTenantState(ret.getTenantStateList());
 
     return resp.build();
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatus;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.SequenceNumberNotFoundException;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.UpgradeFinalizationStatus;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.utils.db.SequenceNumberNotFoundException;
@@ -386,7 +387,10 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     TenantUserInfoValue ret = impl.tenantGetUserInfo(userPrincipal);
     // Note impl.tenantGetUserInfo() throws if errs
     if (ret != null) {
-      resp.setTenantUserInfo(ret.getProtobuf());
+      Preconditions.checkState(userPrincipal.equals(ret.getUserPrincipal()),
+          "Result's userPrincipal doesn't match TenantGetUserInfoRequest's");
+      resp.setUserPrincipal(userPrincipal);
+      resp.addAllAccessIdInfo(ret.getAccessIdInfoList());
     }
 
     return resp.build();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerRequestHandler.java
@@ -387,9 +387,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
     TenantUserInfoValue ret = impl.tenantGetUserInfo(userPrincipal);
     // Note impl.tenantGetUserInfo() throws if errs
     if (ret != null) {
-      Preconditions.checkState(userPrincipal.equals(ret.getUserPrincipal()),
-          "Result's userPrincipal doesn't match TenantGetUserInfoRequest's");
-      resp.setUserPrincipal(userPrincipal);
       resp.addAllAccessIdInfo(ret.getAccessIdInfoList());
     }
 
@@ -405,7 +402,6 @@ public class OzoneManagerRequestHandler implements RequestHandler {
         impl.listUsersInTenant(request.getTenantId(), request.getPrefix());
     // Note impl.listUsersInTenant() throws if errs
     if (usersInTenant != null) {
-      builder.setTenantId(request.getTenantId());
       builder.addAllUserAccessIdInfo(usersInTenant.getUserAccessIds());
     }
     return builder.build();

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.http.auth.BasicUserPrincipal;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.junit.Assert;
@@ -96,10 +96,11 @@ public class TestOMMultiTenantManagerImpl {
 
     TenantUserList tenantUserList =
         tenantManager.listUsersInTenant(tenantName, "");
-    List<TenantUserAccessId> userAccessIds = tenantUserList.getUserAccessIds();
+    List<ExtendedAccessIdInfo> userAccessIds =
+        tenantUserList.getUserAccessIds();
     assertEquals(2, userAccessIds.size());
 
-    for (TenantUserAccessId userAccessId : userAccessIds) {
+    for (ExtendedAccessIdInfo userAccessId : userAccessIds) {
       String user = userAccessId.getUserPrincipal();
       if (user.equals("user1")) {
         assertEquals("accessId1", userAccessId.getAccessId());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBAccessIdInfo;
-import org.apache.hadoop.ozone.om.helpers.OmDBTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
 import org.apache.http.auth.BasicUserPrincipal;
@@ -68,7 +68,7 @@ public class TestOMMultiTenantManagerImpl {
 
     // Note: policyIds is initialized with an empty list here.
     //  Expand if needed.
-    final OmDBTenantInfo omDBTenantInfo = new OmDBTenantInfo(
+    final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
         tenantName, bucketNamespaceName, new ArrayList<>());
 
     omMetadataManager.getTenantStateTable().put(tenantName, omDBTenantInfo);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -74,8 +74,8 @@ public class TestOMMultiTenantManagerImpl {
     omMetadataManager.getTenantStateTable().put(tenantName, omDBTenantInfo);
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",
-        new OmDBAccessIdInfo(tenantName, "seed-user1",
-            false, false));
+        new OmDBAccessIdInfo(tenantName, "seed-user1", false, false,
+            OzoneConsts.TENANT_ROLE_USER));
 
     tenantManager = new OMMultiTenantManagerImpl(omMetadataManager, conf);
     assertEquals(1, tenantManager.getTenantCache().size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -75,7 +75,8 @@ public class TestOMMultiTenantManagerImpl {
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",
         new OmDBAccessIdInfo(tenantName, "seed-user1", false, false,
-            new HashSet<String>() {{ add(OzoneConsts.TENANT_ROLE_USER); }}));
+            new HashSet<String>() {{
+              add(tenantName + OzoneConsts.TENANT_ROLE_USER_SUFFIX); }}));
 
     OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
     Mockito.when(ozoneManager.getMetadataManager())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -41,6 +41,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 /**
  * Tests for Multi Tenant Manager APIs.
@@ -77,7 +78,11 @@ public class TestOMMultiTenantManagerImpl {
         new OmDBAccessIdInfo(tenantName, "seed-user1", false, false,
             OzoneConsts.TENANT_ROLE_USER));
 
-    tenantManager = new OMMultiTenantManagerImpl(omMetadataManager, conf);
+    OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
+    Mockito.when(ozoneManager.getMetadataManager())
+        .thenReturn(omMetadataManager);
+
+    tenantManager = new OMMultiTenantManagerImpl(ozoneManager, conf);
     assertEquals(1, tenantManager.getTenantCache().size());
     assertEquals(1,
         tenantManager.getTenantCache().get(tenantName).getTenantUsers().size());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import com.google.common.base.Optional;
@@ -64,15 +65,12 @@ public class TestOMMultiTenantManagerImpl {
     OMMetadataManager omMetadataManager = new OmMetadataManagerImpl(conf);
 
     final String bucketNamespaceName = tenantName;
-    final String accountNamespaceName = tenantName;
-    final String userPolicyGroupName =
-        tenantName + OzoneConsts.DEFAULT_TENANT_USER_POLICY_SUFFIX;
-    final String bucketPolicyGroupName =
-        tenantName + OzoneConsts.DEFAULT_TENANT_BUCKET_POLICY_SUFFIX;
 
+    // Note: policyIds is initialized with an empty list here.
+    //  Expand if needed.
     final OmDBTenantInfo omDBTenantInfo = new OmDBTenantInfo(
-        tenantName, bucketNamespaceName, accountNamespaceName,
-        userPolicyGroupName, bucketPolicyGroupName);
+        tenantName, bucketNamespaceName, new ArrayList<>());
+
     omMetadataManager.getTenantStateTable().put(tenantName, omDBTenantInfo);
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -68,10 +68,10 @@ public class TestOMMultiTenantManagerImpl {
 
     // Note: policyNames is initialized with an empty list here.
     //  Expand if needed.
-    final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
+    final OmDBTenantState omDBTenantState = new OmDBTenantState(
         tenantName, bucketNamespaceName, new ArrayList<>());
 
-    omMetadataManager.getTenantStateTable().put(tenantName, omDBTenantInfo);
+    omMetadataManager.getTenantStateTable().put(tenantName, omDBTenantState);
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",
         new OmDBAccessIdInfo(tenantName, "seed-user1", false, false,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 import com.google.common.base.Optional;
 
@@ -76,7 +77,7 @@ public class TestOMMultiTenantManagerImpl {
 
     omMetadataManager.getTenantAccessIdTable().put("seed-accessId1",
         new OmDBAccessIdInfo(tenantName, "seed-user1", false, false,
-            OzoneConsts.TENANT_ROLE_USER));
+            new HashSet<String>() {{ add(OzoneConsts.TENANT_ROLE_USER); }}));
 
     OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
     Mockito.when(ozoneManager.getMetadataManager())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -66,7 +66,7 @@ public class TestOMMultiTenantManagerImpl {
 
     final String bucketNamespaceName = tenantName;
 
-    // Note: policyIds is initialized with an empty list here.
+    // Note: policyNames is initialized with an empty list here.
     //  Expand if needed.
     final OmDBTenantState omDBTenantInfo = new OmDBTenantState(
         tenantName, bucketNamespaceName, new ArrayList<>());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOMMultiTenantManagerImpl.java
@@ -65,7 +65,7 @@ public class TestOMMultiTenantManagerImpl {
     final String bucketNamespacePolicyName =
         OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantName);
     final String bucketPolicyName =
-        OMMultiTenantManager.getDefaultBucketNamespacePolicyName(tenantName);
+        OMMultiTenantManager.getDefaultBucketPolicyName(tenantName);
     final String userRoleName =
         OMMultiTenantManager.getDefaultUserRoleName(tenantName);
     final String adminRoleName =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -357,7 +357,7 @@ public class TestS3GetSecretRequest {
     // Check response
     Assert.assertTrue(omTenantCreateResponse.getOMResponse().getSuccess());
     Assert.assertEquals(TENANT_ID,
-        omTenantCreateResponse.getOmDBTenantInfo().getTenantId());
+        omTenantCreateResponse.getOmDBTenantState().getTenantId());
 
 
     // 2. AssignUserToTenantRequest: Assign "bob@EXAMPLE.COM" to "finance".

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -329,6 +329,9 @@ public class TestS3GetSecretRequest {
 
     // This effectively makes alice an admin.
     when(ozoneManager.isAdmin(ugiAlice)).thenReturn(true);
+    when(omMultiTenantManager.isTenantAdmin(ugiAlice, TENANT_ID, true))
+        .thenReturn(true);
+
     // Init LayoutVersionManager to prevent NPE in checkLayoutFeature
     final OMLayoutVersionManager lvm =
         new OMLayoutVersionManager(OMLayoutVersionManager.maxLayoutVersion());
@@ -360,7 +363,7 @@ public class TestS3GetSecretRequest {
     // 2. AssignUserToTenantRequest: Assign "bob@EXAMPLE.COM" to "finance".
     ++txLogIndex;
 
-    // Additional mock setup needed for pass accessId check
+    // Additional mock setup needed to pass accessId check
     when(ozoneManager.getMultiTenantManager()).thenReturn(omMultiTenantManager);
     when(omMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB))
         .thenReturn(ACCESS_ID_BOB);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantUserInfoValue;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedUserAccessIdInfo;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
 
@@ -42,10 +42,6 @@ public class GetUserInfoHandler extends TenantHandler {
   @CommandLine.Parameters(description = "List of user principal(s)")
   private List<String> userPrincipals = new ArrayList<>();
 
-  @CommandLine.Option(names = {"--print-roles"},
-      description = "Print role names assigned to the accessIds")
-  private boolean printRoles;
-
   // TODO: HDDS-6340. Add an option to print JSON result
 
   private boolean isEmptyList(List<String> list) {
@@ -65,7 +61,7 @@ public class GetUserInfoHandler extends TenantHandler {
       try {
         final TenantUserInfoValue tenantUserInfo =
             objStore.tenantGetUserInfo(userPrincipal);
-        List<ExtendedAccessIdInfo> accessIdInfoList =
+        List<ExtendedUserAccessIdInfo> accessIdInfoList =
             tenantUserInfo.getAccessIdInfoList();
         if (accessIdInfoList.size() == 0) {
           err().println("User '" + userPrincipal +
@@ -74,7 +70,7 @@ public class GetUserInfoHandler extends TenantHandler {
         }
         out().println("User '" + userPrincipal + "' is assigned to:");
 
-        for (ExtendedAccessIdInfo accessIdInfo : accessIdInfoList) {
+        for (ExtendedUserAccessIdInfo accessIdInfo : accessIdInfoList) {
           // Get admin info
           final String adminInfoString;
           if (accessIdInfo.getIsAdmin()) {
@@ -87,12 +83,6 @@ public class GetUserInfoHandler extends TenantHandler {
               accessIdInfo.getTenantId(),
               adminInfoString,
               accessIdInfo.getAccessId());
-          // Optionally print role names list for each accessId
-          if (printRoles) {
-            out().format(", roles: %s%n", accessIdInfo.getRoleNamesList());
-          } else {
-            out().format("%n");
-          }
         }
 
       } catch (IOException e) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/GetUserInfoHandler.java
@@ -79,7 +79,7 @@ public class GetUserInfoHandler extends TenantHandler {
           } else {
             adminInfoString = "";
           }
-          out().format("- Tenant '%s'%s with accessId '%s'",
+          out().format("- Tenant '%s'%s with accessId '%s'%n",
               accessIdInfo.getTenantId(),
               adminInfoString,
               accessIdInfo.getAccessId());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantDeleteHandler.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.shell.tenant;
 
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.om.helpers.DeleteTenantInfo;
+import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
 
@@ -41,7 +41,7 @@ public class TenantDeleteHandler extends TenantHandler {
   protected void execute(OzoneClient client, OzoneAddress address)
       throws IOException {
     try {
-      final DeleteTenantInfo resp =
+      final DeleteTenantState resp =
           client.getObjectStore().deleteTenant(tenantId);
       out().println("Deleted tenant '" + tenantId + "'.");
       long volumeRefCount = resp.getVolRefCount();

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
@@ -71,11 +71,9 @@ public class TenantListHandler extends TenantHandler {
         out().format(longFormat ? "%-17s" : "%s%n",
             tenantInfo.getTenantId());
         if (longFormat) {
-          out().format("%-17s%-17s%-17s%s%n",
+          out().format("%-17s%-17s%n",
               tenantInfo.getBucketNamespaceName(),
-              tenantInfo.getAccountNamespaceName(),
-              tenantInfo.getUserPolicyGroupName(),
-              tenantInfo.getBucketPolicyGroupName());
+              tenantInfo.getPolicyIdsList());
         }
       });
     } catch (IOException e) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
@@ -55,27 +55,32 @@ public class TenantListHandler extends TenantHandler {
       TenantStateList tenantStateList = objStore.listTenant();
 
       if (printHeader) {
-        // default console width 80 / 5 = 16. +1 for extra room. Change later?
-        out().format(longFormat ? "%-17s" : "%s%n",
+        // Assuming default terminal width 120 / 6 ~= 20. +1 for space
+        out().format(longFormat ? "%-21s" : "%s%n",
             "Tenant");
         if (longFormat) {
-          out().format("%-17s%-17s%-17s%s%n",
+          out().format("%-21s%-21s%-21s%-21s%s%n",
               "BucketNS",
-              "AccountNS",
-              "UserPolicy",
+              "UserRole",
+              "AdminRole",
+              "BucketNSPolicy",
               "BucketPolicy");
         }
       }
 
       tenantStateList.getTenantStateList().forEach(tenantState -> {
-        out().format(longFormat ? "%-17s" : "%s%n",
+        out().format(longFormat ? "%-21s" : "%s%n",
             tenantState.getTenantId());
         if (longFormat) {
-          out().format("%-17s%-17s%n",
+          out().format("%-21s%-21s%-21s%-21s%s%n",
               tenantState.getBucketNamespaceName(),
-              tenantState.getPolicyNamesList());
+              tenantState.getUserRoleName(),
+              tenantState.getAdminRoleName(),
+              tenantState.getBucketNamespacePolicyName(),
+              tenantState.getBucketPolicyName());
         }
       });
+
     } catch (IOException e) {
       LOG.error("Failed to list tenants: {}", e.getMessage());
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.shell.tenant;
 
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
-import org.apache.hadoop.ozone.om.helpers.TenantInfoList;
+import org.apache.hadoop.ozone.om.helpers.TenantStateList;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import picocli.CommandLine;
 
@@ -52,7 +52,7 @@ public class TenantListHandler extends TenantHandler {
   protected void execute(OzoneClient client, OzoneAddress address) {
     final ObjectStore objStore = client.getObjectStore();
     try {
-      TenantInfoList tenantInfoList = objStore.listTenant();
+      TenantStateList tenantStateList = objStore.listTenant();
 
       if (printHeader) {
         // default console width 80 / 5 = 16. +1 for extra room. Change later?
@@ -67,13 +67,13 @@ public class TenantListHandler extends TenantHandler {
         }
       }
 
-      tenantInfoList.getTenantInfoList().forEach(tenantInfo -> {
+      tenantStateList.getTenantStateList().forEach(tenantState -> {
         out().format(longFormat ? "%-17s" : "%s%n",
-            tenantInfo.getTenantId());
+            tenantState.getTenantId());
         if (longFormat) {
           out().format("%-17s%-17s%n",
-              tenantInfo.getBucketNamespaceName(),
-              tenantInfo.getPolicyNamesList());
+              tenantState.getBucketNamespaceName(),
+              tenantState.getPolicyNamesList());
         }
       });
     } catch (IOException e) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListHandler.java
@@ -73,7 +73,7 @@ public class TenantListHandler extends TenantHandler {
         if (longFormat) {
           out().format("%-17s%-17s%n",
               tenantInfo.getBucketNamespaceName(),
-              tenantInfo.getPolicyIdsList());
+              tenantInfo.getPolicyNamesList());
         }
       });
     } catch (IOException e) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.TenantUserAccessId;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.s3.S3Handler;
 
@@ -62,7 +62,8 @@ public class TenantListUsersHandler extends S3Handler {
     try {
       TenantUserList usersInTenant =
           objStore.listUsersInTenant(tenantId, prefix);
-      for (TenantUserAccessId accessIdInfo : usersInTenant.getUserAccessIds()) {
+      for (ExtendedAccessIdInfo accessIdInfo :
+          usersInTenant.getUserAccessIds()) {
         out().println("- User '" + accessIdInfo.getUserPrincipal() +
             "' with accessId '" + accessIdInfo.getAccessId() + "'");
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantListUsersHandler.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.om.helpers.TenantUserList;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ExtendedAccessIdInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserAccessIdInfo;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 import org.apache.hadoop.ozone.shell.s3.S3Handler;
 
@@ -62,8 +62,7 @@ public class TenantListUsersHandler extends S3Handler {
     try {
       TenantUserList usersInTenant =
           objStore.listUsersInTenant(tenantId, prefix);
-      for (ExtendedAccessIdInfo accessIdInfo :
-          usersInTenant.getUserAccessIds()) {
+      for (UserAccessIdInfo accessIdInfo : usersInTenant.getUserAccessIds()) {
         out().println("- User '" + accessIdInfo.getUserPrincipal() +
             "' with accessId '" + accessIdInfo.getAccessId() + "'");
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Remove `TenantGroupTable` (Unused)
- Add new field `roleIds` in `OmDBAccessIdInfo` (`TenantAccessIdTable` value)
- Remove `TenantRoleTable`
- Rename protobuf message `OmDBAccessInfo` to `ExtendedAccessIdInfo`
- Use protobuf in `OmDBTenantInfo` and `OmDBKerberosPrincipalInfo`
- Rename `OmDBKerberosPrincipalInfo` to `OmDBUserPrincipalInfo`
- Move `isTenantAdmin()` from `OzoneManager` to `OMMultiTenantManagerImpl`
  - Fix a bug where `listUsersInTenant` wasn't checking admin permission properly (didn't count the `omAdminUsernames` wildcard case)
- Remove `TenantPolicyTable` (merged into `OmDBTenantInfo` as a new `policyNames` field)
- Rename `OmDBTenantInfo` to `OmDBTenantState`

Some table query changes maybe required for #3131 with this patch.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6396

## How was this patch tested?

- All existing test cases should pass.