### PR TITLE
HDDS-6437. EC: Avoid allocating buffers in EC Reconstruction Streams until first read

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedInputStream.java
@@ -141,9 +141,11 @@ public class ECBlockReconstructedInputStream extends BlockExtendedInputStream {
   @Override
   public synchronized void close() throws IOException {
     stripeReader.close();
-    for (int i = 0; i < bufs.length; i++) {
-      byteBufferPool.putBuffer(bufs[i]);
-      bufs[i] = null;
+    if (bufs != null) {
+      for (int i = 0; i < bufs.length; i++) {
+        byteBufferPool.putBuffer(bufs[i]);
+        bufs[i] = null;
+      }
     }
     closed = true;
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedInputStream.java
@@ -47,8 +47,6 @@ public class ECBlockReconstructedInputStream extends BlockExtendedInputStream {
     this.repConfig = repConfig;
     this.byteBufferPool = byteBufferPool;
     this.stripeReader = stripeReader;
-
-    allocateBuffers();
   }
 
   @Override
@@ -75,6 +73,7 @@ public class ECBlockReconstructedInputStream extends BlockExtendedInputStream {
   @Override
   public synchronized int read(ByteBuffer buf) throws IOException {
     ensureNotClosed();
+    allocateBuffers();
     if (!hasRemaining()) {
       return EOF;
     }
@@ -193,6 +192,9 @@ public class ECBlockReconstructedInputStream extends BlockExtendedInputStream {
   }
 
   private void allocateBuffers() {
+    if (bufs != null) {
+      return;
+    }
     bufs = new ByteBuffer[repConfig.getData()];
     for (int i = 0; i < repConfig.getData(); i++) {
       bufs[i] = byteBufferPool.getBuffer(false, repConfig.getEcChunkSize());

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -156,7 +156,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
 
   protected void init() throws InsufficientLocationsException {
     if (decoder == null) {
-      CodecUtil.createRawDecoderWithFallback(getRepConfig());
+      decoder = CodecUtil.createRawDecoderWithFallback(getRepConfig());
     }
     if (decoderInputBuffers == null) {
       // The EC decoder needs an array data+parity long, with missing or not
@@ -581,12 +581,14 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     // Inside this class, we only allocate buffers to read parity into. Data
     // is reconstructed or read into a set of buffers passed in from the calling
     // class. Therefore we only need to ensure we free the parity buffers here.
-    for (int i = getRepConfig().getData();
-         i < getRepConfig().getRequiredNodes(); i++) {
-      ByteBuffer buf = decoderInputBuffers[i];
-      if (buf != null) {
-        byteBufferPool.putBuffer(buf);
-        decoderInputBuffers[i] = null;
+    if (decoderInputBuffers != null) {
+      for (int i = getRepConfig().getData();
+           i < getRepConfig().getRequiredNodes(); i++) {
+        ByteBuffer buf = decoderInputBuffers[i];
+        if (buf != null) {
+          byteBufferPool.putBuffer(buf);
+          decoderInputBuffers[i] = null;
+        }
       }
     }
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -108,7 +108,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   private Set<Integer> failedDataIndexes = new HashSet<>();
   private ByteBufferPool byteBufferPool;
 
-  private final RawErasureDecoder decoder;
+  private RawErasureDecoder decoder;
 
   private boolean initialized = false;
 
@@ -125,11 +125,6 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
         refreshFunction, streamFactory);
     this.byteBufferPool = byteBufferPool;
     this.executor = ecReconstructExecutor;
-    decoder = CodecUtil.createRawDecoderWithFallback(repConfig);
-
-    // The EC decoder needs an array data+parity long, with missing or not
-    // needed indexes set to null.
-    decoderInputBuffers = new ByteBuffer[getRepConfig().getRequiredNodes()];
   }
 
   /**
@@ -160,6 +155,14 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   protected void init() throws InsufficientLocationsException {
+    if (decoder == null) {
+      CodecUtil.createRawDecoderWithFallback(getRepConfig());
+    }
+    if (decoderInputBuffers == null) {
+      // The EC decoder needs an array data+parity long, with missing or not
+      // needed indexes set to null.
+      decoderInputBuffers = new ByteBuffer[getRepConfig().getRequiredNodes()];
+    }
     if (!hasSufficientLocations()) {
       throw new InsufficientLocationsException("There are insufficient " +
           "datanodes to read the EC block");


### PR DESCRIPTION
## What changes were proposed in this pull request?

Due to the issue described in [HDDS-6424](https://issues.apache.org/jira/browse/HDDS-6424), where KeyInputStream opens all its inputStreams for the entire key upfront, we should avoid allocating buffers in the EC Reconstruction InputStreams until they are actually needed (ie on first read).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6437

## How was this patch tested?

Existing tests
