### PR TITLE
HDDS-6251. Smoketest for ozone admin datanode expects exactly 3 nodes

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/datanode.robot
@@ -36,21 +36,23 @@ Filter list by UUID
 
 Filter list by NodeOperationalState
     ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      ozone admin datanode list | grep -c 'Operational State: IN_SERVICE'
     ${output} =         Execute      ozone admin datanode list --operational-state IN_SERVICE
     Should contain      ${output}    Datanode: ${uuid}
     ${datanodes} =      Get Lines Containing String    ${output}    Datanode:
     @{lines} =          Split To Lines   ${datanodes}
     ${count} =          Get Length   ${lines}
-    Should Be Equal As Integers    ${count}    3
+    Should Be Equal As Integers    ${count}    ${expected}
 
 Filter list by NodeState
     ${uuid} =           Execute      ozone admin datanode list | grep '^Datanode:' | head -1 | awk '{ print \$2 }'
+    ${expected} =       Execute      ozone admin datanode list | grep -c 'Health State: HEALTHY'
     ${output} =         Execute      ozone admin datanode list --node-state HEALTHY
     Should contain      ${output}    Datanode: ${uuid}
     ${datanodes} =      Get Lines Containing String    ${output}    Datanode:
     @{lines} =          Split To Lines   ${datanodes}
     ${count} =          Get Length   ${lines}
-    Should Be Equal As Integers    ${count}    3
+    Should Be Equal As Integers    ${count}    ${expected}
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin datanode


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get expected count of nodes in specific state via unfiltered command, filtering by `grep`.  This allows running the test with any number of datanodes.

(cherry-pick of 8e52561ea from EC branch)

https://issues.apache.org/jira/browse/HDDS-6251

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone
$ docker-compose up -d --scale datanode=5
# wait
$ docker-compose exec scm robot smoketest/admincli/datanode.robot
==============================================================================
Datanode :: Test ozone admin datanode command
==============================================================================
List datanodes                                                        | PASS |
------------------------------------------------------------------------------
Filter list by UUID                                                   | PASS |
------------------------------------------------------------------------------
Filter list by NodeOperationalState                                   | PASS |
------------------------------------------------------------------------------
Filter list by NodeState                                              | PASS |
------------------------------------------------------------------------------
Incomplete command                                                    | PASS |
------------------------------------------------------------------------------
Datanode :: Test ozone admin datanode command                         | PASS |
5 tests, 5 passed, 0 failed
==============================================================================
```

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1968681161