### PR TITLE
HDDS-6432. Smoketest for read-replicas tool expects exactly 3 datanodes

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -26,7 +26,7 @@ export OZONE_REPLICATION_FACTOR=3
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
-start_docker_env
+start_docker_env 5
 
 execute_robot_test scm lib
 execute_robot_test scm ozone-lib

--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -424,33 +424,37 @@ prepare_for_runner_image() {
 
 ## @description Executing the Ozone Debug CLI related robot tests
 execute_debug_tests() {
+  local prefix=${RANDOM}
 
-  OZONE_DEBUG_VOLUME="cli-debug-volume"
-  OZONE_DEBUG_BUCKET="cli-debug-bucket"
-  OZONE_DEBUG_KEY="testfile"
+  local volume="cli-debug-volume${prefix}"
+  local bucket="cli-debug-bucket"
+  local key="testfile"
 
-  execute_robot_test datanode debug/ozone-debug-tests.robot
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-tests.robot
 
-  corrupt_block_on_datanode
-  execute_robot_test datanode debug/ozone-debug-corrupt-block.robot
+  # get block locations for key
+  local chunkinfo="${key}-blocks-${prefix}"
+  docker-compose exec -T ${SCM} bash -c "ozone debug chunkinfo ${volume}/${bucket}/${key}" > "$chunkinfo"
+  local host="$(jq -r '.KeyLocations[0][0]["Datanode-HostName"]' ${chunkinfo})"
+  local container="${host%%.*}"
 
-  docker stop ozone_datanode_2
+  # corrupt the first block of key on one of the datanodes
+  local datafile="$(jq -r '.KeyLocations[0][0].Locations.files[0]' ${chunkinfo})"
+  docker exec "${container}" sed -i -e '1s/^/a/' "${datafile}"
 
-  wait_for_datanode datanode_2 STALE 60
-  execute_robot_test datanode debug/ozone-debug-stale-datanode.robot
-  wait_for_datanode datanode_2 DEAD 60
-  execute_robot_test datanode debug/ozone-debug-dead-datanode.robot
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v CORRUPT_REPLICA:0 debug/ozone-debug-corrupt-block.robot
 
-  docker start ozone_datanode_2
+  docker stop "${container}"
 
-  wait_for_datanode datanode_2 HEALTHY 60
-}
+  wait_for_datanode "${container}" STALE 60
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v CORRUPT_REPLICA:0 -v "STALE_DATANODE:${host}" debug/ozone-debug-stale-datanode.robot
 
-## @description  Corrupt a block on a datanode
-corrupt_block_on_datanode() {
-  docker-compose exec -T ${SCM} bash -c "ozone debug chunkinfo ${OZONE_DEBUG_VOLUME}/${OZONE_DEBUG_BUCKET}/${OZONE_DEBUG_KEY}" > /tmp/blocks
-  block=$(cat /tmp/blocks | jq -r '.KeyLocations[0][0].Locations.files[0]')
-  docker exec ozone_datanode_2 sed -i -e '1s/^/a/' "${block}"
+  wait_for_datanode "${container}" DEAD 60
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-dead-datanode.robot
+
+  docker start "${container}"
+
+  wait_for_datanode "${container}" HEALTHY 60
 }
 
 ## @description  Wait for datanode state

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -20,22 +20,28 @@ Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 *** Variables ***
-${VOLUME}           cli-debug-volume
+${PREFIX}           ${EMPTY}
+${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
+${CORRUPT_REPLICA}  0
 
 *** Test Cases ***
 Test ozone debug read-replicas with corrupt block replica
     ${directory} =                      Execute read-replicas CLI tool
-    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
-    ${dn2_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default | md5sum | awk '{print $1}'
-    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
-    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
-    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
-    Should Not Be Equal                 ${dn2_md5sum}   ${testfile_md5sum}
-    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
-    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
-    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
-    Compare JSON                        ${json}
-    Check for all datanodes             ${json}
-    Check checksum mismatch error       ${json}         ozone_datanode_2.ozone_default
+    Set Test Variable    ${DIR}         ${directory}
+
+    ${count_files} =                    Count Files In Directory    ${directory}
+    Should Be Equal As Integers         ${count_files}     7
+
+    ${json} =                           Read Replicas Manifest
+    ${md5sum} =                         Execute     md5sum testfile | awk '{print $1}'
+
+    FOR    ${replica}    IN RANGE    3
+        IF    '${replica}' == '${CORRUPT_REPLICA}'
+            Verify Corrupt Replica   ${json}    ${replica}    ${md5sum}
+            Should Contain           ${json}[blocks][0][replicas][${replica}][exception]    Checksum mismatch
+        ELSE
+            Verify Healthy Replica   ${json}    ${replica}    ${md5sum}
+        END
+    END

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
@@ -14,32 +14,34 @@
 # limitations under the License.
 
 *** Settings ***
-Documentation       Test read-replicas in case of one datanode is unavailable
+Documentation       Test read-replicas in case of one datanode is stale
 Library             OperatingSystem
 Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 *** Variables ***
-${VOLUME}           cli-debug-volume
+${PREFIX}           ${EMPTY}
+${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
+${CORRUPT_REPLICA}  0
+${STALE_DATANODE}   ozone_datanode_1.ozone_default
 
 *** Test Cases ***
 Test ozone debug read-replicas with one datanode STALE
-    ${directory} =                      Execute read-replicas CLI tool
-    ${count_files} =                    Count Files In Directory    ${directory}
-    Should Be Equal As Integers         ${count_files}     7
-    ${corrupted_block1} =               Get File Size   ${directory}/${TESTFILE}_block1_ozone_datanode_2.ozone_default
-    ${corrupted_block2} =               Get File Size   ${directory}/${TESTFILE}_block2_ozone_datanode_2.ozone_default
-    Should Be Equal As Integers         ${corrupted_block1}     0
-    Should Be Equal As Integers         ${corrupted_block2}     0
-    ${dn1_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_1.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_1.ozone_default | md5sum | awk '{print $1}'
-    ${dn3_md5sum} =                     Execute     cat ${directory}/${TESTFILE}_block1_ozone_datanode_3.ozone_default ${directory}/${TESTFILE}_block2_ozone_datanode_3.ozone_default | md5sum | awk '{print $1}'
-    ${testfile_md5sum} =                Execute     md5sum testfile | awk '{print $1}'
-    Should Be Equal                     ${dn1_md5sum}   ${testfile_md5sum}
-    Should Be Equal                     ${dn3_md5sum}   ${testfile_md5sum}
-    ${manifest} =                       Get File        ${directory}/${TESTFILE}_manifest
-    ${json} =                           Evaluate        json.loads('''${manifest}''')        json
-    Compare JSON                        ${json}
-    Check for all datanodes             ${json}
-    Check unavailable datanode error    ${json}         ozone_datanode_2.ozone_default
+    ${directory} =                 Execute read-replicas CLI tool
+    Set Test Variable    ${DIR}         ${directory}
+
+    ${count_files} =               Count Files In Directory    ${directory}
+    Should Be Equal As Integers    ${count_files}     7
+
+    ${json} =                      Read Replicas Manifest
+    ${md5sum} =                    Execute     md5sum testfile | awk '{print $1}'
+
+    FOR    ${replica}    IN RANGE    3
+        IF    '${replica}' == '${CORRUPT_REPLICA}'
+            Verify Stale Replica     ${json}    ${replica}
+        ELSE
+            Verify Healthy Replica   ${json}    ${replica}    ${md5sum}
+        END
+    END


### PR DESCRIPTION
## What changes were proposed in this pull request?

Increase number of datanodes to 5 for `ozone` environment.  EC requires min. 5 datanodes.  The goal of this change is to prevent any new smoketests being introduced on `master` that would not work with 5 nodes.

Refactor smoketest for `read-replicas` tool to make sure it works with more than 3 datanodes.

Also remove the explicit test case for `chunkinfo` tool, which is also exercised by the `read-replicas` test.  The removed test case required running on a datanode where the key was written.  With 3 datanodes this can be any of them, but with 5, we cannot (simply) guarantee that.

https://issues.apache.org/jira/browse/HDDS-6432

## How was this patch tested?

Ran `execute_debug_tests` locally.

CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1970951824