### PR TITLE
HDDS-4171. DEFAULT_PIPELIME_LIMIT typo in MiniOzoneCluster.java

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -296,7 +296,7 @@ public interface MiniOzoneCluster {
     protected static final int DEFAULT_HB_PROCESSOR_INTERVAL_MS = 100;
     protected static final int ACTIVE_OMS_NOT_SET = -1;
     protected static final int ACTIVE_SCMS_NOT_SET = -1;
-    protected static final int DEFAULT_PIPELIME_LIMIT = 3;
+    protected static final int DEFAULT_PIPELINE_LIMIT = 3;
     protected static final int DEFAULT_RATIS_RPC_TIMEOUT_SEC = 1;
 
     protected OzoneConfiguration conf;
@@ -339,7 +339,7 @@ public interface MiniOzoneCluster {
     protected int numDataVolumes = 1;
     protected boolean  startDataNodes = true;
     protected CertificateClient certClient;
-    protected int pipelineNumLimit = DEFAULT_PIPELIME_LIMIT;
+    protected int pipelineNumLimit = DEFAULT_PIPELINE_LIMIT;
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;


### PR DESCRIPTION
## What changes were proposed in this pull request?

DEFAULT_PIPELIME_LIMIT was changed to DEFAULT_PIPELINE_LIMIT in MiniOzoneCluster.java

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-4171?jql=project%20in%20(HDDS%2C%20DAFFODIL)%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22)%20AND%20text%20~%20%22typos%22

## How was this patch tested?

N/A since a typo
