### PR TITLE
HDDS-6439. Minor perf optimization in component version enums

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/DatanodeVersion.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.hdds;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 /**
  * Versioning for datanode.
  */
@@ -31,6 +37,10 @@ public enum DatanodeVersion implements ComponentVersion {
 
   public static final DatanodeVersion CURRENT = latest();
   public static final int CURRENT_VERSION = CURRENT.version;
+
+  private static final Map<Integer, DatanodeVersion> BY_PROTO_VALUE =
+      Arrays.stream(values())
+          .collect(toMap(DatanodeVersion::toProtoValue, identity()));
 
   private final int version;
   private final String description;
@@ -51,11 +61,7 @@ public enum DatanodeVersion implements ComponentVersion {
   }
 
   public static DatanodeVersion fromProtoValue(int value) {
-    DatanodeVersion[] versions = DatanodeVersion.values();
-    if (value >= versions.length || value < 0) {
-      return FUTURE_VERSION;
-    }
-    return versions[value];
+    return BY_PROTO_VALUE.getOrDefault(value, FUTURE_VERSION);
   }
 
   private static DatanodeVersion latest() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/ClientVersion.java
@@ -19,6 +19,12 @@ package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.hdds.ComponentVersion;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 /**
  * Versioning for protocol clients.
  */
@@ -34,6 +40,10 @@ public enum ClientVersion implements ComponentVersion {
 
   public static final ClientVersion CURRENT = latest();
   public static final int CURRENT_VERSION = CURRENT.version;
+
+  private static final Map<Integer, ClientVersion> BY_PROTO_VALUE =
+      Arrays.stream(values())
+          .collect(toMap(ClientVersion::toProtoValue, identity()));
 
   private final int version;
   private final String description;
@@ -54,11 +64,7 @@ public enum ClientVersion implements ComponentVersion {
   }
 
   public static ClientVersion fromProtoValue(int value) {
-    ClientVersion[] versions = ClientVersion.values();
-    if (value >= versions.length || value < 0) {
-      return FUTURE_VERSION;
-    }
-    return versions[value];
+    return BY_PROTO_VALUE.getOrDefault(value, FUTURE_VERSION);
   }
 
   private static ClientVersion latest() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -19,6 +19,12 @@ package org.apache.hadoop.ozone;
 
 import org.apache.hadoop.hdds.ComponentVersion;
 
+import java.util.Arrays;
+import java.util.Map;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toMap;
+
 /**
  * Versioning for Ozone Manager.
  */
@@ -30,6 +36,10 @@ public enum OzoneManagerVersion implements ComponentVersion {
 
   public static final OzoneManagerVersion CURRENT = latest();
   public static final int CURRENT_VERSION = CURRENT.version;
+
+  private static final Map<Integer, OzoneManagerVersion> BY_PROTO_VALUE =
+      Arrays.stream(values())
+          .collect(toMap(OzoneManagerVersion::toProtoValue, identity()));
 
   private final int version;
   private final String description;
@@ -50,11 +60,7 @@ public enum OzoneManagerVersion implements ComponentVersion {
   }
 
   public static OzoneManagerVersion fromProtoValue(int value) {
-    OzoneManagerVersion[] versions = OzoneManagerVersion.values();
-    if (value >= versions.length || value < 0) {
-      return FUTURE_VERSION;
-    }
-    return versions[value];
+    return BY_PROTO_VALUE.getOrDefault(value, FUTURE_VERSION);
   }
 
   private static OzoneManagerVersion latest() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid frequent usage of `values()` in component version enums by implementing `toProtoValue` as a map lookup.

https://issues.apache.org/jira/browse/HDDS-6439

## How was this patch tested?

```
[INFO] Tests run: 12, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.005 s - in org.apache.hadoop.hdds.TestComponentVersionInvariants
```

https://github.com/adoroszlai/hadoop-ozone/runs/5533214782#step:5:3181