### PR TITLE
HDDS-6445. EC: Fix allocateBlock failure due to inaccurate excludedNodes check.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.SCMCommonPlacementPolicy;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
-import org.apache.hadoop.hdds.scm.net.NetConstants;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
 import org.apache.hadoop.hdds.scm.net.Node;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -99,14 +98,6 @@ public final class SCMContainerPlacementRackScatter
       throws SCMException {
     Preconditions.checkArgument(nodesRequired > 0);
     metrics.incrDatanodeRequestCount(nodesRequired);
-    int datanodeCount = networkTopology.getNumOfLeafNode(NetConstants.ROOT);
-    int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
-    if (datanodeCount < nodesRequired + excludedNodesCount) {
-      throw new SCMException("No enough datanodes to choose. " +
-          "TotalNode = " + datanodeCount +
-          " RequiredNode = " + nodesRequired +
-          " ExcludedNode = " + excludedNodesCount, null);
-    }
 
     List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();
     if (favoredNodes != null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

EC: Fix allocateBlock failure due to inaccurate excludedNodes check.
More details seen in the JIRA below.

Here I just removed the check since I think that the simple calculation is not accurate since ExcludedNodes could contain dead DNs that are not counted in the TotalNode.
And the existing logic follows should be able to correctly pick proper DNs for new pipelines.
Maybe more accurate checks could be done, but I don't think it is necessary just to fix the calculation itself, the purpose is to  choose enough DNs for pipeline creation.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6445

## How was this patch tested?

A new ut.
