### PR TITLE
HDDS-6450. [FSO] Fix correctedSpace for usedBytes in commitKey

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -966,32 +966,16 @@ public abstract class TestOzoneRpcClientAbstract {
 
   @Test
   public void testBucketUsedBytes() throws IOException {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-    OzoneVolume volume = null;
-    String value = "sample value";
-    int valueLength = value.getBytes(UTF_8).length;
-    store.createVolume(volumeName);
-    volume = store.getVolume(volumeName);
-    volume.createBucket(bucketName);
-    OzoneBucket bucket = volume.getBucket(bucketName);
-    String keyName = UUID.randomUUID().toString();
-
-    writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
-
-    writeKey(bucket, keyName, ONE, value, valueLength);
-    Assert.assertEquals(valueLength,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
-
-    bucket.deleteKey(keyName);
-    Assert.assertEquals(0L,
-        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+    bucketUsedBytesTestHelper(BucketLayout.OBJECT_STORE);
   }
 
   @Test
   public void testFSOBucketUsedBytes() throws IOException {
+    bucketUsedBytesTestHelper(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+  }
+
+  private void bucketUsedBytesTestHelper(BucketLayout bucketLayout)
+      throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
     int blockSize = (int) ozoneManager.getConfiguration().getStorageSize(
@@ -1001,10 +985,9 @@ public abstract class TestOzoneRpcClientAbstract {
     int valueLength = value.getBytes(UTF_8).length;
     store.createVolume(volumeName);
     volume = store.getVolume(volumeName);
-    BucketArgs bucketArgsFSO = BucketArgs.newBuilder()
-        .setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-        .build();
-    volume.createBucket(bucketName, bucketArgsFSO);
+    BucketArgs bucketArgs = BucketArgs.newBuilder()
+        .setBucketLayout(bucketLayout).build();
+    volume.createBucket(bucketName, bucketArgs);
     OzoneBucket bucket = volume.getBucket(bucketName);
     String keyName = UUID.randomUUID().toString();
 
@@ -1021,7 +1004,6 @@ public abstract class TestOzoneRpcClientAbstract {
     writeKey(bucket, keyName, ONE, value, fakeValueLength);
     Assert.assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
-
 
     bucket.deleteKey(keyName);
     Assert.assertEquals(0L,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -994,6 +994,8 @@ public abstract class TestOzoneRpcClientAbstract {
   public void testFSOBucketUsedBytes() throws IOException {
     String volumeName = UUID.randomUUID().toString();
     String bucketName = UUID.randomUUID().toString();
+    int blockSize = (int) ozoneManager.getConfiguration().getStorageSize(
+        OZONE_SCM_BLOCK_SIZE, OZONE_SCM_BLOCK_SIZE_DEFAULT, StorageUnit.BYTES);
     OzoneVolume volume = null;
     String value = "sample value";
     int valueLength = value.getBytes(UTF_8).length;
@@ -1013,6 +1015,13 @@ public abstract class TestOzoneRpcClientAbstract {
     writeKey(bucket, keyName, ONE, value, valueLength);
     Assert.assertEquals(valueLength,
         store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+
+    // pre-allocate more blocks than needed
+    int fakeValueLength = valueLength + blockSize;
+    writeKey(bucket, keyName, ONE, value, fakeValueLength);
+    Assert.assertEquals(valueLength,
+        store.getVolume(volumeName).getBucket(bucketName).getUsedBytes());
+
 
     bucket.deleteKey(keyName);
     Assert.assertEquals(0L,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -180,7 +180,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // the actual Key size, and the total Block size applied before should
       // be subtracted.
       long correctedSpace = omKeyInfo.getDataSize() * factor -
-              allocatedLocationInfoList.size() * scmBlockSize * factor;
+          allocatedLocationInfoList.size() * scmBlockSize * factor;
       // Subtract the size of blocks to be overwritten.
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getDataSize() *

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -141,6 +141,8 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
 
       // Update the block length for each block
+      List<OmKeyLocationInfo> allocatedLocationInfoList =
+          omKeyInfo.getLatestVersionLocations().getLocationList();
       omKeyInfo.updateLocationInfoList(locationInfoList, false);
 
       // Set the UpdateID to current transactionLogIndex
@@ -178,7 +180,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // the actual Key size, and the total Block size applied before should
       // be subtracted.
       long correctedSpace = omKeyInfo.getDataSize() * factor -
-              locationInfoList.size() * scmBlockSize * factor;
+              allocatedLocationInfoList.size() * scmBlockSize * factor;
       // Subtract the size of blocks to be overwritten.
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getDataSize() *


### PR DESCRIPTION
## What changes were proposed in this pull request?

The incorrect preAllocatedBlocks for EC keys HDDS-6452(#3194) revealed the bug.
The correctedSpace in commitKey should be calculated against preAllocatedBlocks instead of the actual blocks in the final.

~~Steps to reproduce the bug:~~

~~First, cherry-pick f826d124aa1d8063d37a1ef3c1809787401b7b0b from master (already included in this PR).~~

~~`KEYSIZE=$(expr 256 '*' 1024 '*' 1024 '+' 1)`~~
~~`ozone sh volume create vol1`~~
~~`ozone sh bucket create vol1/bucket1 -l FILE_SYSTEM_OPTIMIZED -t EC -r rs-3-2-1024k`~~
~~`ozone freon ockg --volume vol1 --bucket bucket1 -s $KEYSIZE -n 1 -p foobar`~~
~~`ozone freon ockr --volume vol1 --bucket bucket1 -n 1 -p foobar`~~
~~`ozone sh bucket info vol1/bucket1`~~

~~usedBytes should be 0 instead of 1342177280.~~

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6450

## How was this patch tested?

Integration test will be added.
