### PR TITLE
HDDS-6448. EC: Reconstructed Input Streams should free resources after reading to end of block

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -612,7 +612,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
   }
 
   private void freeAllResourcesWithoutClosing() throws IOException {
-    LOG.info("Freeing all resources while leaving the block open");
+    LOG.debug("Freeing all resources while leaving the block open");
     freeBuffers();
     closeStreams();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockReconstructedStripeInputStream.java
@@ -138,7 +138,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
    *
    * @param dns A list of DatanodeDetails that are known to be bad.
    */
-  public void addFailedDatanodes(List<DatanodeDetails> dns) {
+  public synchronized void addFailedDatanodes(List<DatanodeDetails> dns) {
     if (initialized) {
       throw new RuntimeException("Cannot add failed datanodes after the " +
           "reader has been initialized");
@@ -154,7 +154,7 @@ public class ECBlockReconstructedStripeInputStream extends ECBlockInputStream {
     }
   }
 
-  protected void init() throws InsufficientLocationsException {
+  private void init() throws InsufficientLocationsException {
     if (decoder == null) {
       decoder = CodecUtil.createRawDecoderWithFallback(getRepConfig());
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/ECStreamTestUtil.java
@@ -41,10 +41,13 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SplittableRandom;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 
 /**
  * Utility class providing methods useful in EC tests.
@@ -218,7 +221,8 @@ public final class ECStreamTestUtil {
   public static class TestBlockInputStreamFactory implements
       BlockInputStreamFactory {
 
-    private List<TestBlockInputStream> blockStreams = new ArrayList<>();
+    private Map<Integer, TestBlockInputStream> blockStreams =
+        new LinkedHashMap<>();
     private List<ByteBuffer> blockStreamData;
     // List of EC indexes that should fail immediately on read
     private List<Integer> failIndexes = new ArrayList<>();
@@ -227,7 +231,16 @@ public final class ECStreamTestUtil {
 
     public synchronized
         List<ECStreamTestUtil.TestBlockInputStream> getBlockStreams() {
-      return blockStreams;
+      return blockStreams.values().stream().collect(Collectors.toList());
+    }
+
+    public synchronized Set<Integer> getStreamIndexes() {
+      return blockStreams.keySet();
+    }
+
+    public synchronized ECStreamTestUtil.TestBlockInputStream getBlockStream(
+        int ecIndex) {
+      return blockStreams.get(ecIndex);
     }
 
     public synchronized void setBlockStreamData(List<ByteBuffer> bufs) {
@@ -256,7 +269,7 @@ public final class ECStreamTestUtil {
       if (failIndexes.contains(repInd)) {
         stream.setShouldError(true);
       }
-      blockStreams.add(stream);
+      blockStreams.put(repInd, stream);
       return stream;
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a read to ECBlockReconstructedInputStream and ECBlockReconstructedStripeInputStream returns and there are zero bytes remaining in the block, we should free the buffers held due to the issue described in [HDDS-6424](https://issues.apache.org/jira/browse/HDDS-6424), where KeyInputStream opens all its inputStreams upfront and does not close any of them until the entire key is closed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6448

## How was this patch tested?

Some modifications to existing tests
