### PR TITLE
HDDS-6413. EC: OzoneManagerRequestHandler needs to handle ECReplicaonConfig

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1276,7 +1276,7 @@ message MultipartUploadListPartsResponse {
     optional uint32 nextPartNumberMarker = 4;
     optional bool isTruncated = 5;
     repeated PartInfo partsList = 6;
-
+    optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 7;
 }
 
 message ListMultipartUploadsRequest {
@@ -1298,7 +1298,7 @@ message MultipartUploadInfo {
     required uint64 creationTime = 5;
     required hadoop.hdds.ReplicationType type = 6;
     required hadoop.hdds.ReplicationFactor factor = 7;
-
+    optional hadoop.hdds.ECReplicationConfig ecReplicationConfig = 8;
 }
 
 message PartInfo {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Address usage of `ReplicationConfig.getLegacyFactor()` in `OzoneManagerRequestHandler` and ensure the ECReplicationConfig is returned when the key is EC.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6413

## How was this patch tested?

Existing tests.
