### PR TITLE
HDDS-6460. EC: Adjust requested size by EC DataNum in WritableECContainerProvider

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -92,12 +92,16 @@ public class WritableECContainerProvider
   public ContainerInfo getContainer(final long size,
       ECReplicationConfig repConfig, String owner, ExcludeList excludeList)
       throws IOException {
+    // Bound this at a minimum of 1 byte in case a request is made for a very
+    // small size, which when divided by EC DataNum is zero.
+    long requiredSpace = Math.max(1, size / repConfig.getData());
     synchronized (this) {
       int openPipelineCount = pipelineManager.getPipelineCount(repConfig,
           Pipeline.PipelineState.OPEN);
       if (openPipelineCount < providerConfig.getMinimumPipelines()) {
         try {
-          return allocateContainer(repConfig, size, owner, excludeList);
+          return allocateContainer(
+              repConfig, requiredSpace, owner, excludeList);
         } catch (IOException e) {
           LOG.warn("Unable to allocate a container for {} with {} existing "
               + "containers", repConfig, openPipelineCount, e);
@@ -109,7 +113,9 @@ public class WritableECContainerProvider
         excludeList.getDatanodes(), excludeList.getPipelineIds());
 
     PipelineRequestInformation pri =
-        PipelineRequestInformation.Builder.getBuilder().setSize(size).build();
+        PipelineRequestInformation.Builder.getBuilder()
+            .setSize(requiredSpace)
+            .build();
     while (existingPipelines.size() > 0) {
       Pipeline pipeline =
           pipelineChoosePolicy.choosePipeline(existingPipelines, pri);
@@ -121,10 +127,8 @@ public class WritableECContainerProvider
       synchronized (pipeline.getId()) {
         try {
           ContainerInfo containerInfo = getContainerFromPipeline(pipeline);
-          // TODO - For EC, what is the block size? If the client says 128MB,
-          //        is that 128MB / 6 (for EC-6-3?)
           if (containerInfo == null
-              || !containerHasSpace(containerInfo, size)) {
+              || !containerHasSpace(containerInfo, requiredSpace)) {
             // This is O(n), which isn't great if there are a lot of pipelines
             // and we keep finding pipelines without enough space.
             existingPipelines.remove(pipeline);
@@ -148,7 +152,7 @@ public class WritableECContainerProvider
     // allocate a new one and usePipelineManagerV2Impl.java it.
     try {
       synchronized (this) {
-        return allocateContainer(repConfig, size, owner, excludeList);
+        return allocateContainer(repConfig, requiredSpace, owner, excludeList);
       }
     } catch (IOException e) {
       LOG.error("Unable to allocate a container for {} after trying all "

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -296,8 +296,8 @@ public class TestWritableECContainerProvider {
     assertTrue(allocatedContainers.contains(newContainer));
     // Now get a new container where there is not enough space in the existing
     // and ensure a new container gets created.
-     newContainer = provider.getContainer(
-         128 * 1024 * 1024, repConfig, OWNER, new ExcludeList());
+    newContainer = provider.getContainer(
+        128 * 1024 * 1024, repConfig, OWNER, new ExcludeList());
     assertNotNull(newContainer);
     assertFalse(allocatedContainers.contains(newContainer));
     // The original pipelines should all be closed, triggered by the lack of


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-6384](https://issues.apache.org/jira/browse/HDDS-6384) we decided that the size tracked in SCM of an EC container is the usedBytes in the first replica or any parity replica. In WritableECContainerProvider, we currently check if there is enough space in the container by comparing the container UsedBytes against the blockSize requested. However the blockSize needs to be divided by the EC DataNum, as it will be stripped across blocks in the group. There was a TODO left in the code to address this decision later:

```
          ContainerInfo containerInfo = getContainerFromPipeline(pipeline);
          // TODO - For EC, what is the block size? If the client says 128MB,
          //        is that 128MB / 6 (for EC-6-3?)
          if (containerInfo == null
              || !containerHasSpace(containerInfo, size)) {
            // This is O(n), which isn't great if there are a lot of pipelines
            // and we keep finding pipelines without enough space.
            existingPipelines.remove(pipeline);
            pipelineManager.closePipeline(pipeline, true);
```

After the decision in [HDDS-6384](https://issues.apache.org/jira/browse/HDDS-6384), we should remove this TODO and divide the requested size by the dataNum to get the approx space needed in the first replica to hold the new block.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6460

## How was this patch tested?

Modified existing test
