### PR TITLE
HDDS-6468. Set correct resource Type for BucketACL and KeyACL

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOmAcls.java
@@ -114,7 +114,7 @@ public class TestOmAcls {
   }
 
   /**
-   * Reset
+   * Reset ACL.
    */
   @Before
   public void resetAcl() {
@@ -140,7 +140,7 @@ public class TestOmAcls {
     OzoneVolume volume =
         cluster.getClient().getObjectStore().getVolume(volumeName);
 
-    TestOmAcls.bucketAclAllow= false;
+    TestOmAcls.bucketAclAllow = false;
     OzoneTestUtils.expectOmException(ResultCodes.PERMISSION_DENIED,
         () -> volume.createBucket(bucketName));
 
@@ -201,16 +201,17 @@ public class TestOmAcls {
     @Override
     public boolean checkAccess(IOzoneObj ozoneObject, RequestContext context) {
       switch (((OzoneObjInfo) ozoneObject).getResourceType()) {
-        case VOLUME:
-          return TestOmAcls.volumeAclAllow;
-        case BUCKET:
-          return TestOmAcls.bucketAclAllow;
-        case KEY:
-          return TestOmAcls.keyAclAllow;
-        case PREFIX:
-          return TestOmAcls.prefixAclAllow;
+      case VOLUME:
+        return TestOmAcls.volumeAclAllow;
+      case BUCKET:
+        return TestOmAcls.bucketAclAllow;
+      case KEY:
+        return TestOmAcls.keyAclAllow;
+      case PREFIX:
+        return TestOmAcls.prefixAclAllow;
+      default:
+        return false;
       }
-      return false;
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -95,9 +95,9 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
 
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.VOLUME,
+        checkAcls(ozoneManager, OzoneObj.ResourceType.BUCKET,
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
-            volume, null, null);
+            volume, bucket, null);
       }
       lockAcquired =
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK, volume,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -88,7 +88,7 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
 
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.VOLUME,
+        checkAcls(ozoneManager, OzoneObj.ResourceType.KEY,
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
             volume, bucket, key);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -81,7 +81,7 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
 
       // check Acl
       if (ozoneManager.getAclsEnabled()) {
-        checkAcls(ozoneManager, OzoneObj.ResourceType.VOLUME,
+        checkAcls(ozoneManager, OzoneObj.ResourceType.KEY,
             OzoneObj.StoreType.OZONE, IAccessAuthorizer.ACLType.WRITE_ACL,
             volume, bucket, key);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The resource type checked in BucketACL and KeyACL are now currently VOLUME, need to change to the correct resource type.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6468

## How was this patch tested?

unit test
