### PR TITLE
HDDS-6393. Change the OzoneManager ServiceInfo message to carry the int version from OzoneManagerVersions.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -470,7 +470,7 @@ public final class OzoneConfigKeys {
       "ozone.client.required.om.version.min";
 
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT =
-      OzoneManagerVersion.NEW_S3G_AUTH_SCHEME.name();
+      OzoneManagerVersion.S3G_PERSISTENT_CONNECTIONS.name();
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -466,11 +466,11 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_TEST_OFS_BUCKET_LAYOUT_DEFAULT =
       "FILE_SYSTEM_OPTIMIZED";
 
-  public static final String OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY =
-      "ozone.om.client.protocol.version";
-  // The version of the protocol for Client (S3G/OFS) to OM Communication.
-  // The protocol starts at 2.0.0 and a null or empty value for older versions.
-  public static final String OZONE_OM_CLIENT_PROTOCOL_VERSION = "2.0.0";
+  public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY =
+      "ozone.client.required.om.version.min";
+
+  public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT =
+      OzoneManagerVersion.NEW_S3G_AUTH_SCHEME.name();
 
   /**
    * There is no need to instantiate this class.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -30,7 +30,8 @@ import static java.util.stream.Collectors.toMap;
  */
 public enum OzoneManagerVersion implements ComponentVersion {
   DEFAULT_VERSION(0, "Initial version"),
-  NEW_S3G_AUTH_SCHEME(1, "New S3G auth scheme support is present in OM."),
+  S3G_PERSISTENT_CONNECTIONS(1,
+      "New S3G persistent connection support is present in OM."),
 
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -30,6 +30,7 @@ import static java.util.stream.Collectors.toMap;
  */
 public enum OzoneManagerVersion implements ComponentVersion {
   DEFAULT_VERSION(0, "Initial version"),
+  NEW_S3G_AUTH_SCHEME(1, "New S3G auth scheme support is present in OM."),
 
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -221,9 +221,10 @@ public class RpcClient implements ClientProtocol {
                   s.getProtobuf().getOMVersion());
             }
           }
-          throw new RuntimeException("OmVersion expected "
-              + minOmVersion
-              + ", not found in ServiceList");
+          throw new RuntimeException(
+              "Minimum OzoneManager version required is: " + minOmVersion
+              + ", in the service list there are not enough Ozone Managers"
+              + " meet the criteria.");
         }
       }
       String caCertPem = null;
@@ -293,16 +294,16 @@ public class RpcClient implements ClientProtocol {
     return xceiverClientManager;
   }
 
-  static boolean validateOmVersion(OzoneManagerVersion expectedVersion,
+  static boolean validateOmVersion(OzoneManagerVersion minimumVersion,
                                    List<ServiceInfo> serviceInfoList) {
-    if (expectedVersion == OzoneManagerVersion.FUTURE_VERSION) {
+    if (minimumVersion == OzoneManagerVersion.FUTURE_VERSION) {
       // A FUTURE_VERSION should not be expected ever.
       throw new IllegalArgumentException("Configuration error, expected "
           + "OzoneManager version config evaluates to a future version.");
     }
     // if expected version is unset or is the default, then any OM would do fine
-    if (expectedVersion == null
-        || expectedVersion == OzoneManagerVersion.DEFAULT_VERSION) {
+    if (minimumVersion == null
+        || minimumVersion == OzoneManagerVersion.DEFAULT_VERSION) {
       return true;
     }
 
@@ -312,7 +313,7 @@ public class RpcClient implements ClientProtocol {
         OzoneManagerVersion omv =
             OzoneManagerVersion
                 .fromProtoValue(s.getProtobuf().getOMVersion());
-        if (expectedVersion.compareTo(omv) > 0) {
+        if (minimumVersion.compareTo(omv) > 0) {
           return false;
         } else {
           found = true;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/ServiceInfo.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeType;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRoleInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.ServicePort;
@@ -50,7 +51,7 @@ public final class ServiceInfo {
   /**
    * Protocol version for client.
    */
-  private String omClientProtocolVersion;
+  private OzoneManagerVersion omVersion;
 
   /**
    * List of ports the service listens to.
@@ -73,13 +74,13 @@ public final class ServiceInfo {
   private ServiceInfo(NodeType nodeType,
                       String hostname,
                       List<ServicePort> portList,
-                      String omClientProtocolVersion,
+                      OzoneManagerVersion omVersion,
                       OMRoleInfo omRole) {
     Preconditions.checkNotNull(nodeType);
     Preconditions.checkNotNull(hostname);
     this.nodeType = nodeType;
     this.hostname = hostname;
-    this.omClientProtocolVersion = omClientProtocolVersion;
+    this.omVersion = omVersion;
     this.ports = new HashMap<>();
     for (ServicePort port : portList) {
       ports.put(port.getType(), port.getValue());
@@ -163,8 +164,8 @@ public final class ServiceInfo {
     builder.setNodeType(nodeType)
         .setHostname(hostname)
         .addAllServicePorts(servicePorts);
-    if (omClientProtocolVersion != null) {
-      builder.setOMProtocolVersion(omClientProtocolVersion);
+    if (omVersion != null) {
+      builder.setOMVersion(omVersion.toProtoValue());
     }
     if (nodeType == NodeType.OM && omRoleInfo != null) {
       builder.setOmRole(omRoleInfo);
@@ -183,7 +184,7 @@ public final class ServiceInfo {
     return new ServiceInfo(serviceInfo.getNodeType(),
         serviceInfo.getHostname(),
         serviceInfo.getServicePortsList(),
-        serviceInfo.getOMProtocolVersion(),
+        OzoneManagerVersion.fromProtoValue(serviceInfo.getOMVersion()),
         serviceInfo.hasOmRole() ? serviceInfo.getOmRole() : null);
   }
 
@@ -204,22 +205,22 @@ public final class ServiceInfo {
     private String host;
     private List<ServicePort> portList = new ArrayList<>();
     private OMRoleInfo omRoleInfo;
-    private String omClientProtocolVersion;
+    private OzoneManagerVersion omVersion;
 
     /**
      * Gets the Om Client Protocol Version.
      * @return om client protocol version as a string.
      */
-    public String getOmClientProtocolVersion() {
-      return omClientProtocolVersion;
+    public OzoneManagerVersion getOmVersion() {
+      return omVersion;
     }
 
     /**
      * Sets the Om Client Protocol Version.
      * @param omClientProtocolVer the client protocol version supported.
      */
-    public Builder setOmClientProtocolVersion(String omClientProtocolVer) {
-      this.omClientProtocolVersion = omClientProtocolVer;
+    public Builder setOmVersion(OzoneManagerVersion omClientProtocolVer) {
+      this.omVersion = omClientProtocolVer;
       return this;
     }
 
@@ -266,7 +267,7 @@ public final class ServiceInfo {
       return new ServiceInfo(node,
           host,
           portList,
-          omClientProtocolVersion,
+          omVersion,
           omRoleInfo);
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestOzoneConfigurationFields.java
@@ -68,9 +68,9 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
     configurationPropsToSkipCompare
         .add(ScmConfig.ConfigStrings.HDDS_SCM_INIT_DEFAULT_LAYOUT_VERSION);
     configurationPropsToSkipCompare
-        .add(OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY);
+        .add(OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY);
     configurationPropsToSkipCompare
-        .add(OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION);
+        .add(OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT);
     // This property is tested in TestHttpServer2 instead
     xmlPropsToSkipCompare.add(HttpServer2.HTTP_IDLE_TIMEOUT_MS_KEY);
     addPropertiesNotInXml();
@@ -91,7 +91,7 @@ public class TestOzoneConfigurationFields extends TestConfigurationFieldsBase {
         OMConfigKeys.OZONE_FS_TRASH_CHECKPOINT_INTERVAL_KEY,
         OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE,
         OzoneConfigKeys.OZONE_S3_AUTHINFO_MAX_LIFETIME_KEY,
-        OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
+        OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY,
         ReconConfigKeys.RECON_SCM_CONFIG_PREFIX,
         ReconConfigKeys.OZONE_RECON_ADDRESS_KEY,
         ReconConfigKeys.OZONE_RECON_DATANODE_ADDRESS_KEY,

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1192,7 +1192,7 @@ message ServiceInfo {
     required string hostname = 2;
     repeated ServicePort servicePorts = 3;
     optional OMRoleInfo omRole = 4;
-    optional string OMProtocolVersion = 5;
+    optional int32 OMVersion = 5 [default = 0];
 }
 
 message MultipartInfoInitiateRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCer
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
+import org.apache.hadoop.ozone.OzoneManagerVersion;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.hdds.scm.ha.SCMNodeInfo;
 import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocol;
@@ -209,7 +210,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX_DEFAULT;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SCM_BLOCK_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
@@ -2813,7 +2813,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     ServiceInfo.Builder omServiceInfoBuilder = ServiceInfo.newBuilder()
         .setNodeType(HddsProtos.NodeType.OM)
         .setHostname(omRpcAddress.getHostName())
-        .setOmClientProtocolVersion(OZONE_OM_CLIENT_PROTOCOL_VERSION)
+        .setOmVersion(OzoneManagerVersion.CURRENT)
         .addServicePort(ServicePort.newBuilder()
             .setType(ServicePort.Type.RPC)
             .setValue(omRpcAddress.getPort())
@@ -2857,7 +2857,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
             // For now assume peer is at the same version.
             // This field needs to be fetched from peer when rolling upgrades
             // are implemented.
-            .setOmClientProtocolVersion(OZONE_OM_CLIENT_PROTOCOL_VERSION)
+            .setOmVersion(OzoneManagerVersion.CURRENT)
             .addServicePort(ServicePort.newBuilder()
                 .setType(ServicePort.Type.RPC)
                 .setValue(peerNode.getRpcPort())

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -43,8 +43,8 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ACCESS_DENIED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 
@@ -118,8 +118,8 @@ public class OzoneClientProducer {
     // S3 Gateway should always set the S3 Auth.
     ozoneConfiguration.setBoolean(S3Auth.S3_AUTH_CHECK, true);
     // Set the expected OM version if not set via config.
-    ozoneConfiguration.setIfUnset(OZONE_OM_CLIENT_PROTOCOL_VERSION_KEY,
-        OZONE_OM_CLIENT_PROTOCOL_VERSION);
+    ozoneConfiguration.setIfUnset(OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_KEY,
+        OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT);
     String omServiceID = OmUtils.getOzoneManagerServiceId(ozoneConfiguration);
     if (omServiceID == null) {
       return OzoneClientFactory.getRpcClient(ozoneConfiguration);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change to the new OzoneManagerVersion enum in ServiceInfo message in OM client protocol.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6393

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

JUnit tests changed to conform the new approach.
