### PR TITLE
HDDS-6470. Fix TestOzoneManagerHAWithData#testOMRestart()

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -450,7 +450,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     // the logs corresponding to atleast some of the missed transactions
     // should be purged. This will force the OM to install snapshot when
     // restarted.
-    long minNewTxIndex = followerOM1LastAppliedIndex + getLogPurgeGap() * 3L;
+    long minNewTxIndex = followerOM1LastAppliedIndex + getLogPurgeGap() * 10L;
     while (leaderOM.getOmRatisServer().getLastAppliedTermIndex().getIndex()
         < minNewTxIndex) {
       createKey(ozoneBucket);
@@ -468,7 +468,7 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     // Wait for the follower OM to catch up
     GenericTestUtils.waitFor(() -> followerOM1.getOmRatisServer()
         .getLastAppliedTermIndex().getIndex() >= leaderOMSnaphsotIndex,
-        100, 10000);
+        100, 200000);
 
     // Do more transactions. The restarted OM should receive the
     // new transactions. It's last applied tx index should increase from the

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -431,16 +431,16 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
         .build();
 
     objectStore.createVolume(volumeName, createVolumeArgs);
-    OzoneVolume retVolumeinfo = objectStore.getVolume(volumeName);
+    OzoneVolume ozoneVolume = objectStore.getVolume(volumeName);
 
-    retVolumeinfo.createBucket(bucketName);
-    OzoneBucket ozoneBucket = retVolumeinfo.getBucket(bucketName);
+    ozoneVolume.createBucket(bucketName);
+    OzoneBucket ozoneBucket = ozoneVolume.getBucket(bucketName);
 
     for (int i = 0; i < 10; i++) {
       createKey(ozoneBucket);
     }
 
-    long lastAppliedTxOnFollowerOM =
+    final long followerOM1LastAppliedIndex =
         followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
 
     // Stop one follower OM
@@ -450,38 +450,25 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     // the logs corresponding to atleast some of the missed transactions
     // should be purged. This will force the OM to install snapshot when
     // restarted.
-    long minNewTxIndex = lastAppliedTxOnFollowerOM + (getLogPurgeGap() * 10);
-    long leaderOMappliedLogIndex = leaderOM.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex();
-
-    List<String> missedKeys = new ArrayList<>();
-    while (leaderOMappliedLogIndex < minNewTxIndex) {
-      missedKeys.add(createKey(ozoneBucket));
-      leaderOMappliedLogIndex = leaderOM.getOmRatisServer()
-          .getLastAppliedTermIndex().getIndex();
+    long minNewTxIndex = followerOM1LastAppliedIndex + getLogPurgeGap() * 3L;
+    while (leaderOM.getOmRatisServer().getLastAppliedTermIndex().getIndex()
+        < minNewTxIndex) {
+      createKey(ozoneBucket);
     }
+
+    // Get the latest snapshotIndex from the leader OM.
+    final long leaderOMSnaphsotIndex = leaderOM.getRatisSnapshotIndex();
+
+    // The stopped OM should be lagging behind the leader OM.
+    Assert.assertTrue(followerOM1LastAppliedIndex < leaderOMSnaphsotIndex);
 
     // Restart the stopped OM.
     followerOM1.restart();
 
-    // Get the latest snapshotIndex from the leader OM.
-    long leaderOMSnaphsotIndex = leaderOM.getRatisSnapshotIndex();
-
-    // The recently started OM should be lagging behind the leader OM.
-    long followerOMLastAppliedIndex =
-        followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
-    Assert.assertTrue(
-        followerOMLastAppliedIndex < leaderOMSnaphsotIndex);
-
     // Wait for the follower OM to catch up
-    GenericTestUtils.waitFor(() -> {
-      long lastAppliedIndex =
-          followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
-      if (lastAppliedIndex >= leaderOMSnaphsotIndex) {
-        return true;
-      }
-      return false;
-    }, 100, 200000);
+    GenericTestUtils.waitFor(() -> followerOM1.getOmRatisServer()
+        .getLastAppliedTermIndex().getIndex() >= leaderOMSnaphsotIndex,
+        100, 10000);
 
     // Do more transactions. The restarted OM should receive the
     // new transactions. It's last applied tx index should increase from the
@@ -489,11 +476,10 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
     for (int i = 0; i < 10; i++) {
       createKey(ozoneBucket);
     }
-    long followerOM1lastAppliedIndex = followerOM1.getOmRatisServer()
-        .getLastAppliedTermIndex().getIndex();
-    Assert.assertTrue(followerOM1lastAppliedIndex >
-        leaderOMSnaphsotIndex);
 
+    final long followerOM1LastAppliedIndexNew =
+        followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
+    Assert.assertTrue(followerOM1LastAppliedIndexNew > leaderOMSnaphsotIndex);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This assertion is wrong in TestOzoneManagerHAWithData#testOMRestart().
Because the lagging follower OM may catch up asynchronously.

```java
    // Restart the stopped OM.
    followerOM1.restart();
 
    // Get the latest snapshotIndex from the leader OM.
    long leaderOMSnaphsotIndex = leaderOM.getRatisSnapshotIndex();
 
    // The recently started OM should be lagging behind the leader OM.
    long followerOMLastAppliedIndex =
        followerOM1.getOmRatisServer().getLastAppliedTermIndex().getIndex();
    Assert.assertTrue(
        followerOMLastAppliedIndex < leaderOMSnaphsotIndex);
```

Example of CI failure on master: https://github.com/apache/ozone/runs/5593803014
Result of running this test 100x: https://github.com/kaijchen/ozone/actions/runs/2007487998

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6470

## How was this patch tested?

https://github.com/kaijchen/ozone/actions/runs/2008065589