### PR TITLE
HDDS-6472. Errors in TestOzoneContainer integration test

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -100,7 +100,6 @@ public class TestOzoneContainer {
   @Test
   public void testOzoneContainerStart() throws Exception {
     OzoneConfiguration conf = newOzoneConfiguration();
-    MiniOzoneCluster cluster = null;
     OzoneContainer container = null;
 
     try {
@@ -139,9 +138,6 @@ public class TestOzoneContainer {
     } finally {
       if (container != null) {
         container.stop();
-      }
-      if (cluster != null) {
-        cluster.shutdown();
       }
     }
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -75,8 +75,6 @@ public class TestOzoneContainer {
       conf.setInt(OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,
           pipeline.getFirstNode()
               .getPort(DatanodeDetails.Port.Name.STANDALONE).getValue());
-      conf.setBoolean(
-          OzoneConfigKeys.DFS_CONTAINER_IPC_RANDOM_PORT, false);
 
       DatanodeDetails datanodeDetails = randomDatanodeDetails();
       StateContext context = Mockito.mock(StateContext.class);
@@ -109,8 +107,6 @@ public class TestOzoneContainer {
       conf.setInt(OzoneConfigKeys.DFS_CONTAINER_IPC_PORT,
           pipeline.getFirstNode()
               .getPort(DatanodeDetails.Port.Name.STANDALONE).getValue());
-      conf.setBoolean(
-          OzoneConfigKeys.DFS_CONTAINER_IPC_RANDOM_PORT, false);
 
       DatanodeDetails datanodeDetails = randomDatanodeDetails();
       StateContext context = Mockito.mock(StateContext.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Tests using mini cluster tried to start 3 datanodes with the same fixed port.  Only start one datanode.
 * `runTestOzoneContainerViaDataNode` and `testCloseContainer` had leftover assertions after HDDS-5359, which removed delete chunk/block requests
 * Disable `testBothGetandPutSmallFile`, which is failing due to HDDS-6473, not a test bug.

https://issues.apache.org/jira/browse/HDDS-6472

## How was this patch tested?

50x runs of `TestOzoneContainer`:
https://github.com/adoroszlai/hadoop-ozone/runs/5620046984

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2013240882