### PR TITLE
HDDS-6488. Intermittent failure in ozone debug read-replicas with one datanode STALE

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/testlib.sh
+++ b/hadoop-ozone/dist/src/main/compose/testlib.sh
@@ -442,12 +442,12 @@ execute_debug_tests() {
   local datafile="$(jq -r '.KeyLocations[0][0].Locations.files[0]' ${chunkinfo})"
   docker exec "${container}" sed -i -e '1s/^/a/' "${datafile}"
 
-  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v CORRUPT_REPLICA:0 debug/ozone-debug-corrupt-block.robot
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "CORRUPT_DATANODE:${host}" debug/ozone-debug-corrupt-block.robot
 
   docker stop "${container}"
 
   wait_for_datanode "${container}" STALE 60
-  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v CORRUPT_REPLICA:0 -v "STALE_DATANODE:${host}" debug/ozone-debug-stale-datanode.robot
+  execute_robot_test ${SCM} -v "PREFIX:${prefix}" -v "STALE_DATANODE:${host}" debug/ozone-debug-stale-datanode.robot
 
   wait_for_datanode "${container}" DEAD 60
   execute_robot_test ${SCM} -v "PREFIX:${prefix}" debug/ozone-debug-dead-datanode.robot

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-corrupt-block.robot
@@ -20,11 +20,11 @@ Resource            ../lib/os.robot
 Resource            ozone-debug.robot
 Test Timeout        5 minute
 *** Variables ***
-${PREFIX}           ${EMPTY}
-${VOLUME}           cli-debug-volume${PREFIX}
-${BUCKET}           cli-debug-bucket
-${TESTFILE}         testfile
-${CORRUPT_REPLICA}  0
+${PREFIX}              ${EMPTY}
+${VOLUME}              cli-debug-volume${PREFIX}
+${BUCKET}              cli-debug-bucket
+${TESTFILE}            testfile
+${CORRUPT_DATANODE}    ozone_datanode_1.ozone_default
 
 *** Test Cases ***
 Test ozone debug read-replicas with corrupt block replica
@@ -38,7 +38,9 @@ Test ozone debug read-replicas with corrupt block replica
     ${md5sum} =                         Execute     md5sum testfile | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    3
-        IF    '${replica}' == '${CORRUPT_REPLICA}'
+        ${datanode} =    Set Variable    ${json}[blocks][0][replicas][${replica}][hostname]
+
+        IF    '${datanode}' == '${CORRUPT_DATANODE}'
             Verify Corrupt Replica   ${json}    ${replica}    ${md5sum}
             Should Contain           ${json}[blocks][0][replicas][${replica}][exception]    Checksum mismatch
         ELSE

--- a/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/debug/ozone-debug-stale-datanode.robot
@@ -24,7 +24,6 @@ ${PREFIX}           ${EMPTY}
 ${VOLUME}           cli-debug-volume${PREFIX}
 ${BUCKET}           cli-debug-bucket
 ${TESTFILE}         testfile
-${CORRUPT_REPLICA}  0
 ${STALE_DATANODE}   ozone_datanode_1.ozone_default
 
 *** Test Cases ***
@@ -39,7 +38,9 @@ Test ozone debug read-replicas with one datanode STALE
     ${md5sum} =                    Execute     md5sum testfile | awk '{print $1}'
 
     FOR    ${replica}    IN RANGE    3
-        IF    '${replica}' == '${CORRUPT_REPLICA}'
+        ${datanode} =    Set Variable    ${json}[blocks][0][replicas][${replica}][hostname]
+
+        IF    '${datanode}' == '${STALE_DATANODE}'
             Verify Stale Replica     ${json}    ${replica}
         ELSE
             Verify Healthy Replica   ${json}    ${replica}    ${md5sum}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Smoketest for `read-replicas` [assumes](https://github.com/apache/ozone/pull/3187#discussion_r825649889) `chunkinfo` and `read-replicas` return datanodes in the same order.  This turned out to be false, causing intermittent failures.

This PR eliminates this assumption, improving the test to not rely on replica order.

https://issues.apache.org/jira/browse/HDDS-6488

## How was this patch tested?

Temporarily changed `execute_debug_tests` to corrupt replica=2 instead of replica=0.

Excerpt from `read-replicas` manifest:

```
"replicas": [
  {
    "hostname": "ozone_datanode_1.ozone_default",
    "uuid": "00fab883-5d74-403c-ad54-2d31da07e445"
  },
  {
    "hostname": "ozone_datanode_5.ozone_default",
    "uuid": "ff218756-b571-41e9-9d4b-65f79dee30f0"
  },
  {
    "hostname": "ozone_datanode_3.ozone_default",
    "uuid": "5025a57f-8178-42d5-b18c-5731b71cc678",
    "exception": "java.util.concurrent.ExecutionException: org.apache.ratis.thirdparty.io.grpc.StatusRuntimeException: UNAVAILABLE: io exception"
  }
]
```

Order of datanodes in `chunkinfo` output:

```
$ cat result/testfile-blocks-10827 | jq -r '.KeyLocations[0][]["Datanode-HostName"]'
ozone_datanode_1.ozone_default
ozone_datanode_5.ozone_default
ozone_datanode_3.ozone_default
```

Test still passed.

CI with only this test:
https://github.com/adoroszlai/hadoop-ozone/runs/5649813090#step:5:127

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/5650040811#step:5:887