### PR TITLE
HDDS-6483. Change delete key on OMKey(s)Delete

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.ozone.om.helpers;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .RepeatedKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -102,5 +104,21 @@ public class RepeatedOmKeyInfo {
 
   public RepeatedOmKeyInfo copyObject() {
     return new RepeatedOmKeyInfo(new ArrayList<>(omKeyInfoList));
+  }
+
+  /**
+   * If this key is in a GDPR enforced bucket, then before moving
+   * KeyInfo to deletedTable, remove the GDPR related metadata and
+   * FileEncryptionInfo from KeyInfo.
+   */
+  public void clearGDPRdata() {
+    for (OmKeyInfo keyInfo : omKeyInfoList) {
+      if (Boolean.valueOf(keyInfo.getMetadata().get(OzoneConsts.GDPR_FLAG))) {
+        keyInfo.getMetadata().remove(OzoneConsts.GDPR_FLAG);
+        keyInfo.getMetadata().remove(OzoneConsts.GDPR_ALGORITHM);
+        keyInfo.getMetadata().remove(OzoneConsts.GDPR_SECRET);
+        keyInfo.clearFileEncryptionInfo();
+      }
+    }
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneAtRestEncryption.java
@@ -47,6 +47,9 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.TypedTable;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.BucketArgs;
@@ -353,26 +356,38 @@ public class TestOzoneAtRestEncryption {
     bucket.deleteKey(key.getName());
 
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
-    String objectKey = omMetadataManager.getOzoneKey(volumeName, bucketName,
-        keyName);
-
     GenericTestUtils.waitFor(() -> {
       try {
-        return omMetadataManager.getDeletedTable().isExist(objectKey);
+        TableIterator<String, ? extends TypedTable.KeyValue<String,
+            RepeatedOmKeyInfo>> it = omMetadataManager.getDeletedTable()
+                .iterator();
+        while (it.hasNext()) {
+          Table.KeyValue<String, RepeatedOmKeyInfo> v = it.next();
+
+          // We have no way to identify the transaction log index. So just
+          // scan all keys in the delete table and find the OmKeyInfo.
+          for (OmKeyInfo omKeyInfo: v.getValue().getOmKeyInfoList()) {
+            if (omKeyInfo.getVolumeName().equals(key.getVolumeName()) &&
+                    omKeyInfo.getBucketName().equals(key.getBucketName()) &&
+                    omKeyInfo.getKeyName().equals(key.getName())) {
+
+              Map<String, String> metadata = omKeyInfo.getMetadata();
+              Assert.assertFalse(metadata.containsKey(OzoneConsts.GDPR_FLAG));
+              Assert.assertFalse(
+                      metadata.containsKey(OzoneConsts.GDPR_SECRET));
+              Assert.assertFalse(
+                      metadata.containsKey(OzoneConsts.GDPR_ALGORITHM));
+              Assert.assertNull(omKeyInfo.getFileEncryptionInfo());
+
+              return true;
+            }
+          }
+        }
+        return false;
       } catch (IOException e) {
         return false;
       }
     }, 500, 100000);
-    RepeatedOmKeyInfo deletedKeys =
-        omMetadataManager.getDeletedTable().get(objectKey);
-    Map<String, String> deletedKeyMetadata =
-        deletedKeys.getOmKeyInfoList().get(0).getMetadata();
-    Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_FLAG));
-    Assert.assertFalse(deletedKeyMetadata.containsKey(OzoneConsts.GDPR_SECRET));
-    Assert.assertFalse(
-        deletedKeyMetadata.containsKey(OzoneConsts.GDPR_ALGORITHM));
-    Assert.assertNull(
-        deletedKeys.getOmKeyInfoList().get(0).getFileEncryptionInfo());
   }
 
   private boolean verifyRatisReplication(String volumeName, String bucketName,

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAKeyDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAKeyDeletion.java
@@ -67,7 +67,8 @@ public class TestOzoneManagerHAKeyDeletion extends TestOzoneManagerHA {
     GenericTestUtils.waitFor(() ->
             keyDeletingService.getDeletedKeyCount().get() == 4, 10000, 120000);
 
-    // Check delete table is empty or not on all OMs.
+    // Check delete table is empty or not on all OMs. Waiting until all keys
+    // purged by deletion service; delete table will eventually become empty.
     getCluster().getOzoneManagersList().forEach((om) -> {
       try {
         GenericTestUtils.waitFor(() -> {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeleteTablePrefix.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DeleteTablePrefix.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.util.Time;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Keys in deletion table are hex-encoded String of Timestamp + UpdateID.
+ * The idea is to guarantee rough ordering of deletion by timestamp, and
+ * to guarantee the uniqueness by UpdateID (transaction index).
+ *
+ * UpdateID is transaction index from Ratis, assuming it is already set
+ * during the OMKeyRequest. The transaction index may not be consistently
+ * increasing across OM restart, or Ratis configuration change.
+ *
+ * To address the ordering inconsistency, it is prefixed with hex-encoded
+ * timestamp obtained by Time.now(). Its precision depends on the system -
+ * mostly around 10 milliseconds. We only need rough ordering of actual
+ * deletion of deleted keys - based on the order of deletion called by
+ * clients. We want older deleted keys being processed earlier by deletion
+ * service, and newer keys being processed later.
+ *
+ * Caveat: the only change where it loses the uniqueness is when the system
+ * clock issues the same two timestamps for JVM across OM restart. Say,
+ * before restart, in time t1 from Time.now() with transaction index 1
+ * "t1-0001" issued on deletion, and OM restart happens, and t2 from
+ * Time.now() with another transaction index 1 "t2-0001" issued on deletion
+ * with transaction index being reset.
+ * Although t1!=t2 is not guaranteed by the system, we can (almost) safely
+ * assume OM restart takes long enough so that t1==t2 almost never happens.
+ **/
+public class DeleteTablePrefix {
+  // Will be zero when Ratis is enabled.
+  private long timestamp;
+  private long transactionLogIndex;
+
+  public DeleteTablePrefix(long transactionLogIndex, boolean isRatisEnabled) {
+    // Rule out default value of protocol buffers
+    if (isRatisEnabled) {
+      this.timestamp = 0;
+    } else {
+      this.timestamp = Time.now();
+    }
+    assert transactionLogIndex >= 0;
+    this.transactionLogIndex = transactionLogIndex;
+  }
+
+  /**
+   * Build the key in delete table as string to put into delete table.
+   *
+   * @param omKeyInfo the key info to get object id from
+   * @return Unique and monotonically increasing String for deletion table
+   */
+  public @Nonnull String buildKey(@Nonnull OmKeyInfo omKeyInfo) {
+    // Log.toHexString() is much faster, but the string is compact. Heading 0s
+    // are all erased. e.g. 15L becomes "F", while we want "00000000000F".
+    if (timestamp == 0) {
+      // object id and update id are both needed to identify different updates.
+      return String.format("%016X-%X-%X", transactionLogIndex,
+              omKeyInfo.getObjectID(), omKeyInfo.getUpdateID());
+    }
+    // When Ratis is enabled, we need timestamp as transaction log may be
+    // reset. It is appended after the transaction log index to keep the
+    // ordering across Ratis turned on and off. Keys deleted during non-HA era
+    // be deleted before keys deleted during HA period, because all systems
+    // will finally be upgraded to HA-enabled configuration even though the
+    // system has single OM.
+    return String.format("%016X-%016X-%X-%X", transactionLogIndex, timestamp,
+            omKeyInfo.getObjectID(), omKeyInfo.getUpdateID());
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -154,10 +154,14 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * | keyTable           | /volumeName/bucketName/keyName->KeyInfo         |
    * |----------------------------------------------------------------------|
-   * | deletedTable       | /volumeName/bucketName/keyName->RepeatedKeyInfo |
+   * | deletedTable(*)    | /volumeName/bucketName/keyName->RepeatedKeyInfo |
+   * |                    | trxnIndex-(ts-)oid-uid -> RepeatedKeyInfo(**)   |
    * |----------------------------------------------------------------------|
    * | openKey            | /volumeName/bucketName/keyName/id->KeyInfo      |
    * |----------------------------------------------------------------------|
+   * (*) Either case exists; see HDDS-5905 for the latest progress.
+   *     oid=objectid, uid=updateid, ts=timestamp
+   * (**) Timestamp inserted for non-HA configuration
    *
    * Prefix Tables:
    * |----------------------------------------------------------------------|

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -19,9 +19,11 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -96,7 +98,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
       long trxnLogIndex, OzoneManagerDoubleBufferHelper omDoubleBufferHelper) {
     return validateAndUpdateCache(ozoneManager, trxnLogIndex,
-        omDoubleBufferHelper, BucketLayout.DEFAULT);
+        omDoubleBufferHelper, getBucketLayout());
   }
 
   public OMClientResponse validateAndUpdateCache(OzoneManager ozoneManager,
@@ -171,10 +173,11 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
       // be used by DeleteKeyService only, not used for any client response
       // validation, so we don't need to add to cache.
       // TODO: Revisit if we need it later.
-
+      DeleteTablePrefix prefix = new DeleteTablePrefix(
+              trxnLogIndex, ozoneManager.isRatisEnabled());
       omClientResponse = new OMKeyDeleteResponse(
           omResponse.setDeleteKeyResponse(DeleteKeyResponse.newBuilder())
-              .build(), omKeyInfo, ozoneManager.isRatisEnabled(),
+              .build(), prefix, Arrays.asList(omKeyInfo),
           omBucketInfo.copyObject());
 
       result = Result.SUCCESS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -164,10 +165,11 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // be used by DeleteKeyService only, not used for any client response
       // validation, so we don't need to add to cache.
       // TODO: Revisit if we need it later.
-
+      DeleteTablePrefix prefix = new DeleteTablePrefix(
+          trxnLogIndex, ozoneManager.isRatisEnabled());
       omClientResponse = new OMKeyDeleteResponseWithFSO(omResponse
           .setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),
-          keyName, omKeyInfo, ozoneManager.isRatisEnabled(),
+          keyName, prefix, omKeyInfo,
           omBucketInfo.copyObject(), keyStatus.isDirectory(), volumeId);
 
       result = Result.SUCCESS;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
@@ -96,8 +97,10 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
             openKeyBucket, deletedOpenKeys);
       }
 
+      DeleteTablePrefix prefix = new DeleteTablePrefix(
+          trxnLogIndex, ozoneManager.isRatisEnabled());
       omClientResponse = new OMOpenKeysDeleteResponse(omResponse.build(),
-          deletedOpenKeys, ozoneManager.isRatisEnabled(), getBucketLayout());
+          prefix, deletedOpenKeys, getBucketLayout());
 
       result = Result.SUCCESS;
     } catch (IOException ex) {
@@ -111,8 +114,8 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
               omDoubleBufferHelper);
     }
 
-    processResults(omMetrics, numSubmittedOpenKeys, deletedOpenKeys.size(),
-        deleteOpenKeysRequest, result);
+    processResults(omMetrics, numSubmittedOpenKeys,
+        deletedOpenKeys.size(), deleteOpenKeysRequest, result);
 
     return omClientResponse;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
@@ -135,11 +135,11 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
 
   @NotNull @Override
   protected OMClientResponse getOmClientResponse(OzoneManager ozoneManager,
-          List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
-          OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-          OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
-          boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId,
-          DeleteTablePrefix deleteTablePrefix) {
+      List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
+      OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
+      OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
+      boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId,
+      DeleteTablePrefix deleteTablePrefix) {
     OMClientResponse omClientResponse;
     omClientResponse = new OMKeysDeleteResponseWithFSO(omResponse
         .setDeleteKeysResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.om.request.key;
 import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -134,17 +135,18 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
 
   @NotNull @Override
   protected OMClientResponse getOmClientResponse(OzoneManager ozoneManager,
-      List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
-      OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-      OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
-      boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId) {
+          List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
+          OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
+          OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
+          boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId,
+          DeleteTablePrefix deleteTablePrefix) {
     OMClientResponse omClientResponse;
     omClientResponse = new OMKeysDeleteResponseWithFSO(omResponse
         .setDeleteKeysResponse(
             OzoneManagerProtocolProtos.DeleteKeysResponse.newBuilder()
                 .setStatus(deleteStatus).setUnDeletedKeys(unDeletedKeys))
         .setStatus(deleteStatus ? OK : PARTIAL_DELETE).setSuccess(deleteStatus)
-        .build(), omKeyInfoList, dirList, ozoneManager.isRatisEnabled(),
+        .build(), deleteTablePrefix, omKeyInfoList, dirList,
         omBucketInfo.copyObject(), volumeId);
     return omClientResponse;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/AbstractOMKeyDeleteResponse.java
@@ -101,6 +101,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
     if (omKeyInfoList.isEmpty()) {
       return;
     }
+    // If Key is not empty add this to delete table.
     Table<String, OmKeyInfo> keyTable =
         omMetadataManager.getKeyTable(getBucketLayout());
     for (OmKeyInfo omKeyInfo : omKeyInfoList) {
@@ -118,6 +119,7 @@ public abstract class AbstractOMKeyDeleteResponse extends OmKeyResponse {
       if (isKeyEmpty(omKeyInfo)) {
         continue;
       }
+      // If Key is not empty add this to delete table.
 
       // Append object ID to the deletion key in the delete table for uniqueness
       String key = deleteTablePrefix.buildKey(omKeyInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponse.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
-import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import java.io.IOException;
+import java.util.List;
 import javax.annotation.Nonnull;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
@@ -41,14 +42,14 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
 @CleanupTableInfo(cleanupTables = {KEY_TABLE, DELETED_TABLE, BUCKET_TABLE})
 public class OMKeyDeleteResponse extends AbstractOMKeyDeleteResponse {
 
-  private OmKeyInfo omKeyInfo;
   private OmBucketInfo omBucketInfo;
 
   public OMKeyDeleteResponse(@Nonnull OMResponse omResponse,
-      @Nonnull OmKeyInfo omKeyInfo, boolean isRatisEnabled,
+      @Nonnull DeleteTablePrefix prefix,
+      @Nonnull List<OmKeyInfo> omKeyInfoList,
       @Nonnull OmBucketInfo omBucketInfo) {
-    super(omResponse, isRatisEnabled, omBucketInfo.getBucketLayout());
-    this.omKeyInfo = omKeyInfo;
+    super(omResponse, prefix, omKeyInfoList,
+        omBucketInfo.getBucketLayout());
     this.omBucketInfo = omBucketInfo;
   }
 
@@ -67,12 +68,8 @@ public class OMKeyDeleteResponse extends AbstractOMKeyDeleteResponse {
 
     // For OmResponse with failure, this should do nothing. This method is
     // not called in failure scenario in OM code.
-    String ozoneKey = omMetadataManager.getOzoneKey(omKeyInfo.getVolumeName(),
-        omKeyInfo.getBucketName(), omKeyInfo.getKeyName());
-    Table<String, OmKeyInfo> keyTable =
-        omMetadataManager.getKeyTable(getBucketLayout());
-    addDeletionToBatch(omMetadataManager, batchOperation, keyTable, ozoneKey,
-        omKeyInfo);
+    deleteFromKeyTable(omMetadataManager, batchOperation);
+    insertToDeleteTable(omMetadataManager, batchOperation);
 
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
@@ -80,8 +77,12 @@ public class OMKeyDeleteResponse extends AbstractOMKeyDeleteResponse {
             omBucketInfo.getBucketName()), omBucketInfo);
   }
 
-  protected OmKeyInfo getOmKeyInfo() {
-    return omKeyInfo;
+  @Override
+  protected String getKeyToDelete(OMMetadataManager omMetadataManager,
+      OmKeyInfo omKeyInfo) throws IOException {
+    return omMetadataManager.getOzoneKey(
+        omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
+        omKeyInfo.getKeyName());
   }
 
   protected OmBucketInfo getOmBucketInfo() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -51,9 +51,9 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
 
   @SuppressWarnings("parameternumber")
   public OMKeyDeleteResponseWithFSO(@Nonnull OMResponse omResponse,
-          @Nonnull String keyName, @Nonnull DeleteTablePrefix prefix,
-          @Nonnull OmKeyInfo omKeyInfo, @Nonnull OmBucketInfo omBucketInfo,
-          @Nonnull boolean isDeleteDirectory, @Nonnull long volumeId) {
+      @Nonnull String keyName, @Nonnull DeleteTablePrefix prefix,
+      @Nonnull OmKeyInfo omKeyInfo, @Nonnull OmBucketInfo omBucketInfo,
+      @Nonnull boolean isDeleteDirectory, @Nonnull long volumeId) {
     super(omResponse, prefix, Arrays.asList(omKeyInfo),
         omBucketInfo);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
@@ -49,10 +49,11 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
 
   public OMKeysDeleteResponseWithFSO(
       @NotNull OzoneManagerProtocolProtos.OMResponse omResponse,
+      @NotNull DeleteTablePrefix deleteTablePrefix,
       @NotNull List<OmKeyInfo> keyDeleteList,
-      @NotNull List<OmKeyInfo> dirDeleteList, boolean isRatisEnabled,
+      @NotNull List<OmKeyInfo> dirDeleteList,
       @NotNull OmBucketInfo omBucketInfo, @Nonnull long volId) {
-    super(omResponse, keyDeleteList, isRatisEnabled, omBucketInfo);
+    super(omResponse, deleteTablePrefix, keyDeleteList, omBucketInfo);
     this.dirsList = dirDeleteList;
     this.volumeId = volId;
   }
@@ -60,8 +61,6 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
   @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
-    Table<String, OmKeyInfo> keyTable =
-        omMetadataManager.getKeyTable(getBucketLayout());
 
     final long bucketId = getOmBucketInfo().getObjectID();
     // remove dirs from DirTable and add to DeletedDirTable
@@ -77,20 +76,22 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
     }
 
     // remove keys from FileTable and add to DeletedTable
-    for (OmKeyInfo omKeyInfo : getOmKeyInfoList()) {
-      String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
-          omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());
-      String deletedKey = omMetadataManager
-          .getOzoneKey(omKeyInfo.getVolumeName(), omKeyInfo.getBucketName(),
-              omKeyInfo.getKeyName());
-      addDeletionToBatch(omMetadataManager, batchOperation, keyTable,
-          ozoneDbKey, deletedKey, omKeyInfo);
-    }
+    deleteFromKeyTable(omMetadataManager, batchOperation);
+    insertToDeleteTable(omMetadataManager, batchOperation);
 
     // update bucket usedBytes.
     omMetadataManager.getBucketTable().putWithBatch(batchOperation,
         omMetadataManager.getBucketKey(getOmBucketInfo().getVolumeName(),
             getOmBucketInfo().getBucketName()), getOmBucketInfo());
+  }
+
+  @Override
+  protected String getKeyToDelete(OMMetadataManager omMetadataManager,
+         OmKeyInfo omKeyInfo1) throws IOException {
+    String ozoneDBKey = omMetadataManager.getOzonePathKey(
+            volumeId, getOmBucketInfo().getObjectID(),
+            omKeyInfo1.getParentObjectID(), omKeyInfo1.getFileName());
+    return ozoneDBKey;
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMOpenKeysDeleteResponse.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
@@ -27,6 +28,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.BUCKET_TABLE;
@@ -44,11 +46,11 @@ public class OMOpenKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
 
   public OMOpenKeysDeleteResponse(
       @Nonnull OMResponse omResponse,
+      @Nonnull DeleteTablePrefix prefix,
       @Nonnull Map<String, OmKeyInfo> keysToDelete,
-      boolean isRatisEnabled,
       @Nonnull BucketLayout bucketLayout) {
 
-    super(omResponse, isRatisEnabled, bucketLayout);
+    super(omResponse, prefix, new ArrayList<>(), bucketLayout);
     this.keysToDelete = keysToDelete;
   }
 
@@ -64,15 +66,28 @@ public class OMOpenKeysDeleteResponse extends AbstractOMKeyDeleteResponse {
   }
 
   @Override
+  protected String getKeyToDelete(OMMetadataManager omMetadataManager,
+      OmKeyInfo omKeyInfo) {
+    // This method will never be used, because addToDBBatch()
+    // is already implemented.
+    throw new IllegalStateException("BUG: key to delete cannot be retrieved");
+  }
+
+  @Override
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     Table<String, OmKeyInfo> openKeyTable =
         omMetadataManager.getOpenKeyTable(getBucketLayout());
 
-    for (Map.Entry<String, OmKeyInfo> keyInfoPair : keysToDelete.entrySet()) {
-      addDeletionToBatch(omMetadataManager, batchOperation, openKeyTable,
-          keyInfoPair.getKey(), keyInfoPair.getValue());
+    for (Map.Entry<String, OmKeyInfo> entry : keysToDelete.entrySet()) {
+      openKeyTable.deleteWithBatch(batchOperation, entry.getKey());
+      if (!isKeyEmpty(entry.getValue())) {
+        addToOmKeyInfoList(entry.getValue());
+      }
+    }
+    if (!getOmKeyInfoList().isEmpty()) {
+      insertToDeleteTable(omMetadataManager, batchOperation);
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/service/KeyDeletingService.java
@@ -307,9 +307,18 @@ public class KeyDeletingService extends BackgroundService {
       String objectKey) {
     // Parse volume and bucket name
     String[] split = objectKey.split(OM_KEY_PREFIX);
-    Preconditions.assertTrue(split.length > 3, "Volume and/or Bucket Name " +
-        "missing from Key Name.");
-    Pair<String, String> volumeBucketPair = Pair.of(split[1], split[2]);
+    Pair<String, String> volumeBucketPair;
+
+    if (split.length > 3) {
+      // Old key formatting in delete table: /volume/bucket/key..
+      // TODO: This path must be removed once HDDS-5905 completed.
+      volumeBucketPair = Pair.of(split[1], split[2]);
+    } else {
+      Preconditions.assertTrue(split.length == 1,
+          "Unknown format of delete key format");
+      // For new key format in delete table, use a pair empty strings
+      volumeBucketPair = Pair.of("", "");
+    }
     if (!map.containsKey(volumeBucketPair)) {
       map.put(volumeBucketPair, new ArrayList<>());
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestDeleteTablePrefix.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestDeleteTablePrefix.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import mockit.Expectations;
+import mockit.integration.junit4.JMockit;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.util.Time;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test delete table prefix is correctly built.
+ */
+@RunWith(JMockit.class)
+public class TestDeleteTablePrefix {
+  @Test
+  public void testKeyForDeleteTable() {
+    OmKeyInfo omKeyInfo = new OmKeyInfo.Builder()
+        .setObjectID(42).build();
+    Assert.assertEquals("0000000000000001-2A-0",
+            new DeleteTablePrefix(1L, true).buildKey(omKeyInfo));
+
+    long current = Time.now();
+    String expectedTimestamp = String.format("%016X-%016X-2A-0", 3L, current);
+
+    new Expectations(Time.class) {
+      {
+        Time.now(); result = current;
+      }
+    };
+    Assert.assertEquals(expectedTimestamp,
+            new DeleteTablePrefix(3L, false).buildKey(omKeyInfo));
+
+    Assert.assertEquals("0000000000000003-2A-0",
+            new DeleteTablePrefix(3L, true).buildKey(omKeyInfo));
+
+    Assert.assertEquals("0000000000000144-2A-0",
+            new DeleteTablePrefix(324L, true).buildKey(omKeyInfo));
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 import com.google.common.base.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -94,6 +95,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
  * Helper class to test OMClientRequest classes.
  */
 public final class OMRequestTestUtils {
+  private static AtomicLong objectCounter = new AtomicLong(2L);
 
   private OMRequestTestUtils() {
     //Do nothing
@@ -195,8 +197,9 @@ public final class OMRequestTestUtils {
       HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor,
       OMMetadataManager omMetadataManager) throws Exception {
+    long index = objectCounter.getAndIncrement();
     addKeyToTable(openKeyTable, false, volumeName, bucketName, keyName,
-        clientID, replicationType, replicationFactor, 0L, omMetadataManager);
+        clientID, replicationType, replicationFactor, index, omMetadataManager);
   }
 
   /**
@@ -356,7 +359,7 @@ public final class OMRequestTestUtils {
       String keyName, HddsProtos.ReplicationType replicationType,
       HddsProtos.ReplicationFactor replicationFactor) {
     return createOmKeyInfo(volumeName, bucketName, keyName, replicationType,
-        replicationFactor, 0L);
+        replicationFactor, objectCounter.getAndIncrement());
   }
 
   /**
@@ -1259,6 +1262,10 @@ public final class OMRequestTestUtils {
             enableFileSystemPaths);
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
             bucketLayout.name());
+  }
+
+  public static long newTrxnLogIndex() {
+    return objectCounter.getAndIncrement();
   }
 
   private static BucketLayout getDefaultBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequestWithFSO.java
@@ -145,8 +145,8 @@ public class TestOMFileCreateRequestWithFSO extends TestOMFileCreateRequest {
             OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, key,
                     HddsProtos.ReplicationType.RATIS,
                     HddsProtos.ReplicationFactor.ONE,
-                    parentId + 1,
-                    parentId, 100, Time.now());
+                    parentId + 1, parentId,
+                    100L, Time.now());
     OMRequestTestUtils.addFileToKeyTable(false, false,
             fileName, omKeyInfo, -1, 50, omMetadataManager);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -33,9 +34,10 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
 
   @Override
   protected OMKeyDeleteResponse getOmKeyDeleteResponse(OmKeyInfo omKeyInfo,
-      OzoneManagerProtocolProtos.OMResponse omResponse) throws Exception {
+      OzoneManagerProtocolProtos.OMResponse omResponse,
+      DeleteTablePrefix deleteTablePrefix) throws Exception {
     return new OMKeyDeleteResponseWithFSO(omResponse, omKeyInfo.getKeyName(),
-        omKeyInfo, true, getOmBucketInfo(), false,
+        deleteTablePrefix, omKeyInfo, getOmBucketInfo(), false,
         omMetadataManager.getVolumeId(volumeName));
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -18,9 +18,9 @@
 
 package org.apache.hadoop.ozone.om.response.key;
 
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
-import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
@@ -81,8 +81,9 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
             .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
                 .setStatus(true)).build();
 
-    OMClientResponse omKeysDeleteResponse =
-        getOmKeysDeleteResponse(omResponse, omBucketInfo);
+    DeleteTablePrefix prefix = new DeleteTablePrefix(360L, true);
+    OMClientResponse omKeysDeleteResponse = getOmKeysDeleteResponse(
+        omResponse, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
@@ -90,20 +91,22 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
     for (String ozKey : ozoneKeys) {
       Assert.assertNull(
           omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
-
-      // ozKey had no block information associated with it, so it should have
-      // been removed from the key table but not added to the delete table.
-      RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(ozKey);
-      Assert.assertNull(repeatedOmKeyInfo);
     }
 
+    // deleteKey had no block information associated with it, so it should have
+    // been removed from the key table but not added to the delete table.
+    for (OmKeyInfo omKeyInfo : omKeyInfoList) {
+      String delKey = prefix.buildKey(omKeyInfo);
+      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(delKey));
+    }
   }
 
   protected OMClientResponse getOmKeysDeleteResponse(OMResponse omResponse,
       OmBucketInfo omBucketInfo) {
-    return new OMKeysDeleteResponse(
-        omResponse, omKeyInfoList, true, omBucketInfo);
+    DeleteTablePrefix prefix = new DeleteTablePrefix(360L, true);
+
+    return new OMKeysDeleteResponse(omResponse, prefix,
+        omKeyInfoList, omBucketInfo);
   }
 
   @Test
@@ -116,20 +119,25 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
             .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
                 .setStatus(false)).build();
 
-    OMClientResponse omKeysDeleteResponse
-        = getOmKeysDeleteResponse(omResponse, omBucketInfo);
+    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
+        .setVolumeName(volumeName).setBucketName(bucketName)
+        .build();
+
+    DeleteTablePrefix prefix = new DeleteTablePrefix(360L, true);
+    OMClientResponse omKeysDeleteResponse = new OMKeysDeleteResponse(
+        omResponse, prefix, omKeyInfoList, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
     for (String ozKey : ozoneKeys) {
       Assert.assertNotNull(
           omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
-
-      RepeatedOmKeyInfo repeatedOmKeyInfo =
-          omMetadataManager.getDeletedTable().get(ozKey);
-      Assert.assertNull(repeatedOmKeyInfo);
-
     }
 
+    // On failure, deletion (insert to delete table) should not be committed.
+    for (OmKeyInfo omKeyInfo : omKeyInfoList) {
+      String delKey = prefix.buildKey(omKeyInfo);
+      Assert.assertFalse(omMetadataManager.getDeletedTable().isExist(delKey));
+    }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -22,6 +22,7 @@ import com.google.common.base.Optional;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.DeleteTablePrefix;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
@@ -108,8 +109,10 @@ public class TestOMKeysDeleteResponseWithFSO
   @Override
   protected OMClientResponse getOmKeysDeleteResponse(OMResponse omResponse,
       OmBucketInfo omBucketInfo) {
+    DeleteTablePrefix prefix = new DeleteTablePrefix(360L, true);
+
     return new OMKeysDeleteResponseWithFSO(
-        omResponse, getOmKeyInfoList(), dirDeleteList, true, omBucketInfo,
+        omResponse, prefix, getOmKeyInfoList(), dirDeleteList, omBucketInfo,
         volId);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This patch changes the key format of delete table from full key to `<transactionIndex-in-hex>-<objectid>-<updateid>`.

While there is no need to change deletion service, this change resolves two existing issues. (1) The race condition of object deletion and deletion service, which may lead to blocks leaking (key infos deleted in OM while blocks remain in SCM), and (2) the order of keys and blocks to be deleted, from being deleted in alphabetical ordering of full keys, to being deleted in numerical ordering of transaction index with which the keys deleted. That said, newly-deleted keys will be always deleted later, regardless of the key name, given that transaction log index is monotonically increasing. But it may or may not be unique in case of multiple keyInfos deletion, so object id and update id are appended afterwards.

In case of non-HA configuration, timestamp is inserted after the transaction index to the key to complement the ordering. This is because it is said that transaction index is reset to 0 in that case (which I'm not sure about).

To apply these changes to all APIs, the amount of work would become huge. So I split HDDS-5905 to several subtasks and this is the very first one, which fixes key format of APIs of deleting objects and files (There are a lot of cases where KeyInfos are inserted into the delete table).  See [my design doc](https://docs.google.com/document/d/1KeyhiE1i5SqRSgLy-pIOGW9X6mUYb8iYEkEoDAEQD9Q/edit#) for further details and updates since last discussion.

One of the caveats of this patch is that `DeleteTablePrefix#buildKey(..)` may not be practically fast, not because of retrieving timestamps, but formatting long values as strings. I do have [benchmark numbers and a code snippet to fix it](https://gist.github.com/kuenishi/75d7a435df20ea69c34013f9ff5515c5), but want to contribute as a separate JIRA ticket because the scope of this patch is already fairly large.

## What is the link to the Apache JIRA

HDDS-6483
(Parent task: HDDS-5905)

## How was this patch tested?

unit tests
