### PR TITLE
HDDS-6425. OmMetadataManagerImpl#isBucketEmpty does not work on FSO buckets.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneFileSystemMissingParent.java
@@ -18,10 +18,7 @@
 
 package org.apache.hadoop.fs.ozone;
 
-import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.*;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -129,5 +126,8 @@ public class TestOzoneFileSystemMissingParent {
     LambdaTestUtils.intercept(OMException.class,
         "Cannot create file : parent/file " + "as parent "
             + "directory doesn't exist", () -> stream.close());
+
+    // cleanup
+    fs.delete(renamedPath, true);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1459,8 +1459,6 @@ public class TestRootedOzoneFileSystem {
     FileStatus[] fStatus = getFs().listStatus(dirPath);
     assertEquals("Renamed failed", 1, fStatus.length);
 
-    // We cannot delete a non-empty bucket.
-    getFs().delete(dirPath, true);
     getFs().delete(getBucketPath(), true);
   }
 
@@ -1482,11 +1480,6 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed", getFs().rename(file1Destin, abcRootPath));
     assertTrue("Renamed filed: /a/b/c/file1", getFs().exists(new Path(
         abcRootPath, "file1")));
-
-    // We cannot delete a non-empty bucket.
-    getFs().delete(dirPath, true);
-    getFs().delete(new Path(getBucketPath() + "/a/"), true);
-    getFs().delete(file1Destin, true);
     getFs().delete(getBucketPath(), true);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1095,8 +1095,9 @@ public class TestRootedOzoneFileSystem {
     // Create test volume, bucket and key
     fs.mkdirs(dirPath3);
     // Delete volume recursively
-    // Note: We can't delete a bucket that contains files or directories, so
-    // clean up the bucket first.
+
+    // HDDS-6414: We can't delete a bucket that contains files or directories,
+    // so, clean up the bucket first.
     Assert.assertTrue(fs.delete(dirPath3, true));
     Assert.assertTrue(fs.delete(volumePath3, true));
     // Verify the volume is deleted
@@ -1458,7 +1459,9 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed: /dir/file1", getFs().exists(file1Destin));
     FileStatus[] fStatus = getFs().listStatus(dirPath);
     assertEquals("Renamed failed", 1, fStatus.length);
-    getFs().delete(getBucketPath(), true);
+
+    // HDDS-6414: cleanup sub-paths
+    getFs().delete(dirPath, true);
   }
 
 
@@ -1479,7 +1482,10 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed", getFs().rename(file1Destin, abcRootPath));
     assertTrue("Renamed filed: /a/b/c/file1", getFs().exists(new Path(
         abcRootPath, "file1")));
-    getFs().delete(getBucketPath(), true);
+
+    // HDDS-6414: cleanup sub-paths
+    getFs().delete(new Path(getBucketPath() + "/a/"), true);
+    getFs().delete(file1Destin, true);
   }
 
   /**
@@ -1515,7 +1521,9 @@ public class TestRootedOzoneFileSystem {
         new Path(getBucketPath() + root + "/file2");
     assertTrue("Rename failed",
         getFs().exists(expectedFilePathAfterRename));
-    getFs().delete(getBucketPath(), true);
+
+    // HDDS-6414: cleanup sub-paths
+    getFs().delete(destRootPath, true);
   }
 
   /**
@@ -1541,6 +1549,9 @@ public class TestRootedOzoneFileSystem {
     } catch (IllegalArgumentException e) {
       //expected
     }
+
+    // cleanup
+    fs.delete(sourceRoot, true);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1458,7 +1458,6 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed: /dir/file1", getFs().exists(file1Destin));
     FileStatus[] fStatus = getFs().listStatus(dirPath);
     assertEquals("Renamed failed", 1, fStatus.length);
-
     getFs().delete(getBucketPath(), true);
   }
 
@@ -1516,9 +1515,6 @@ public class TestRootedOzoneFileSystem {
         new Path(getBucketPath() + root + "/file2");
     assertTrue("Rename failed",
         getFs().exists(expectedFilePathAfterRename));
-
-    // We cannot delete a non-empty bucket.
-    getFs().delete(destRootPath, true);
     getFs().delete(getBucketPath(), true);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1095,6 +1095,9 @@ public class TestRootedOzoneFileSystem {
     // Create test volume, bucket and key
     fs.mkdirs(dirPath3);
     // Delete volume recursively
+    // Note: We can't delete a bucket that contains files or directories, so
+    // clean up the bucket first.
+    Assert.assertTrue(fs.delete(dirPath3, true));
     Assert.assertTrue(fs.delete(volumePath3, true));
     // Verify the volume is deleted
     Assert.assertFalse(volumeExist(volumeStr3));
@@ -1455,6 +1458,9 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed: /dir/file1", getFs().exists(file1Destin));
     FileStatus[] fStatus = getFs().listStatus(dirPath);
     assertEquals("Renamed failed", 1, fStatus.length);
+
+    // We cannot delete a non-empty bucket.
+    getFs().delete(dirPath, true);
     getFs().delete(getBucketPath(), true);
   }
 
@@ -1476,6 +1482,11 @@ public class TestRootedOzoneFileSystem {
     assertTrue("Renamed failed", getFs().rename(file1Destin, abcRootPath));
     assertTrue("Renamed filed: /a/b/c/file1", getFs().exists(new Path(
         abcRootPath, "file1")));
+
+    // We cannot delete a non-empty bucket.
+    getFs().delete(dirPath, true);
+    getFs().delete(new Path(getBucketPath() + "/a/"), true);
+    getFs().delete(file1Destin, true);
     getFs().delete(getBucketPath(), true);
   }
 
@@ -1512,6 +1523,9 @@ public class TestRootedOzoneFileSystem {
         new Path(getBucketPath() + root + "/file2");
     assertTrue("Rename failed",
         getFs().exists(expectedFilePathAfterRename));
+
+    // We cannot delete a non-empty bucket.
+    getFs().delete(destRootPath, true);
     getFs().delete(getBucketPath(), true);
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -62,6 +63,22 @@ public class TestRootedOzoneFileSystemWithFSO
   public static void init()
       throws IOException, InterruptedException, TimeoutException {
     setIsBucketFSOptimized(true);
+  }
+
+  /**
+   * HDDS-6414: Implementation gap for recursive deletion in FSO buckets.
+   * Please remove this once HDDS-6414 is merged.
+   *
+   * @throws IOException IOException
+   */
+  @After
+  public void cleanup() throws IOException {
+    getFs().delete(new Path(getBucketPath(), "root"), true);
+    getFs().delete(new Path(getBucketPath(), "dir"), true);
+    getFs().delete(new Path(getBucketPath(), "dir1"), true);
+    getFs().delete(new Path(getBucketPath(), "dir2"), true);
+    getFs().delete(new Path(getBucketPath(), "sub_dir1"), true);
+    getFs().delete(new Path(getBucketPath(), "file1"), true);
   }
 
   @Override
@@ -171,6 +188,9 @@ public class TestRootedOzoneFileSystemWithFSO
     LOG.info("Rename op-> source:{} to destin:{}", sourceRoot, subDir1);
     //  rename should fail and return false
     Assert.assertFalse(getFs().rename(sourceRoot, subDir1));
-  }
 
+    // cleanup
+    getFs().delete(subDir1, true);
+    getFs().delete(dir1Path, true);
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractRootDir.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/contract/rooted/ITestRootedOzoneContractRootDir.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.fs.contract.AbstractFSContract;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
 
 /**
  * Ozone contract test for ROOT directory operations.
@@ -58,4 +60,17 @@ public class ITestRootedOzoneContractRootDir extends
     // OFS doesn't support creating files directly under root
   }
 
+  @Override
+  @Test
+  @Ignore("HDDS-6414")
+  public void testRmEmptyRootDirNonRecursive() {
+    // Temporarily ignored test case, please add it back with HDDS-6414.
+  }
+
+  @Override
+  @Test
+  @Ignore("HDDS-6414")
+  public void testListEmptyRootDirectory() {
+    // Temporarily ignored test case, please add it back with HDDS-6414.
+  }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -220,7 +220,7 @@ public class TestObjectStoreWithFSO {
    * @throws Exception
    */
   @Test
-  public void testBucketWithKeyDelete() throws Exception {
+  public void testDeleteBucketWithKeys() throws Exception {
     // Create temporary volume and bucket for this test.
     OzoneBucket testBucket = TestDataUtil
         .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestObjectStoreWithFSO.java
@@ -248,6 +248,8 @@ public class TestObjectStoreWithFSO {
 
     // Create a key.
     ozoneBucket.createKey(key, 10).close();
+    Assert.assertFalse(cluster.getOzoneManager().getMetadataManager()
+        .isBucketEmpty(testVolumeName, testBucketName));
 
     try {
       // Try to delete the bucket while a key is present under it.
@@ -259,6 +261,8 @@ public class TestObjectStoreWithFSO {
 
     // Delete the key (this only deletes the file)
     ozoneBucket.deleteKey(key);
+    Assert.assertFalse(cluster.getOzoneManager().getMetadataManager()
+        .isBucketEmpty(testVolumeName, testBucketName));
     try {
       // Try to delete the bucket while intermediate dirs are present under it.
       ozoneVolume.deleteBucket(testBucketName);
@@ -270,6 +274,8 @@ public class TestObjectStoreWithFSO {
 
     // Delete last level of directories.
     ozoneBucket.deleteDirectory(parent, true);
+    Assert.assertFalse(cluster.getOzoneManager().getMetadataManager()
+        .isBucketEmpty(testVolumeName, testBucketName));
     try {
       // Try to delete the bucket while dirs are present under it.
       ozoneVolume.deleteBucket(testBucketName);
@@ -281,6 +287,8 @@ public class TestObjectStoreWithFSO {
 
     // Delete all the intermediate directories
     ozoneBucket.deleteDirectory("a/", true);
+    Assert.assertTrue(cluster.getOzoneManager().getMetadataManager()
+        .isBucketEmpty(testVolumeName, testBucketName));
     ozoneVolume.deleteBucket(testBucketName);
     // Cleanup the Volume.
     cluster.getClient().getObjectStore().deleteVolume(testVolumeName);


### PR DESCRIPTION
## What changes were proposed in this pull request?

OmMetadataManagerImpl#isBucketEmpty only checks the key table. This means it is possible to delete an FSO bucket that still has data, orphaning the remaining data on the OM.

This patch adds a new code path for File System Optimized buckets. In the case of FSO layout, we check the directory and file tables for any entries that might be present under the said bucket.

In buckets with FSO layout, the metadata entry for a
-  **Top-level directory** would be of the format `<bucket ID>/dirName` inside the `dirTable`.
- **Top-level file** (a file directly placed under the bucket without any sub paths) would be of the format `<bucket ID>/fileName` inside the `fileTable`.

We seek any keys in these tables that begin with the requested bucket's ID - if we find any such entries in the table or the table cache, we return False.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6425

## How was this patch tested?

Added integration test.