### PR TITLE
HDDS-6497. S3gateway throw exception when checking jmx or prom pages from browser

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -803,7 +803,6 @@ public final class HttpServer2 implements FilterContainer {
     addServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
     addServlet("jmx", "/jmx", JMXJsonServlet.class);
     addServlet("conf", "/conf", ConfServlet.class);
-    addServlet("icon", "/favicon.ico", IconServlet.class);
   }
 
   public void addContext(ServletContextHandler ctxt, boolean isFiltered) {
@@ -1517,18 +1516,6 @@ public final class HttpServer2 implements FilterContainer {
     return adminsAcl != null && adminsAcl.isUserAllowed(remoteUserUGI);
   }
 
-  /**
-   * Do nothing for favicon.ico.
-   */
-  public static class IconServlet extends HttpServlet {
-    private static final long serialVersionUID = -1L;
-
-    @Override
-    public void doGet(HttpServletRequest request, HttpServletResponse response)
-        throws ServletException, IOException {
-      return;
-    }
-  }
 
   /**
    * A very simple servlet to serve up a text representation of the current

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -803,6 +803,7 @@ public final class HttpServer2 implements FilterContainer {
     addServlet("logLevel", "/logLevel", LogLevel.Servlet.class);
     addServlet("jmx", "/jmx", JMXJsonServlet.class);
     addServlet("conf", "/conf", ConfServlet.class);
+    addServlet("icon", "/favicon.ico", IconServlet.class);
   }
 
   public void addContext(ServletContextHandler ctxt, boolean isFiltered) {
@@ -1514,6 +1515,19 @@ public final class HttpServer2 implements FilterContainer {
     UserGroupInformation remoteUserUGI =
         UserGroupInformation.createRemoteUser(remoteUser);
     return adminsAcl != null && adminsAcl.isUserAllowed(remoteUserUGI);
+  }
+
+  /**
+   * Do nothing for favicon.ico
+   */
+  public static class IconServlet extends HttpServlet {
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+      return;
+    }
   }
 
   /**

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -1518,7 +1518,7 @@ public final class HttpServer2 implements FilterContainer {
   }
 
   /**
-   * Do nothing for favicon.ico
+   * Do nothing for favicon.ico.
    */
   public static class IconServlet extends HttpServlet {
     private static final long serialVersionUID = -1L;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayHttpServer.java
@@ -22,6 +22,11 @@ import java.io.IOException;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.server.http.BaseHttpServer;
 
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 /**
  * S3 Gateway specific configuration keys.
  */
@@ -35,6 +40,7 @@ public class S3GatewayHttpServer extends BaseHttpServer {
   public S3GatewayHttpServer(MutableConfigurationSource conf,
       String name) throws IOException {
     super(conf, name);
+    addServlet("icon", "/favicon.ico", IconServlet.class);
   }
 
   @Override
@@ -97,4 +103,17 @@ public class S3GatewayHttpServer extends BaseHttpServer {
     return S3GatewayConfigKeys.OZONE_S3G_HTTP_AUTH_CONFIG_PREFIX;
   }
 
+  /**
+   * Servlet for favicon.ico.
+   */
+  public static class IconServlet extends HttpServlet {
+    private static final long serialVersionUID = -1L;
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+        throws ServletException, IOException {
+      response.setContentType("image/png");
+      response.sendRedirect("/static/images/ozone.ico");
+    }
+  }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When checking the JMX or Prometheus or other pages of S3g from browser, the following error was throw from S3g. (From docker container, might be different from local service)

```
2022-03-23 15:32:57,281 [qtp124888672-18] INFO ozone.OmUtils: ozone.om.internal.service.id is not defined, falling back to ozone.om.service.ids to find serviceID for OzoneManager if it is HA enabled cluster
2022-03-23 15:32:57,282 [qtp124888672-18] INFO ozone.OmUtils: No OzoneManager ServiceID configured.
Mar 23, 2022 3:32:57 PM org.glassfish.jersey.internal.Errors logErrors
WARNING: The following warnings have been detected: WARNING: Unknown HK2 failure detected:
MultiException stack 1 of 1
javax.ws.rs.WebApplicationException: User doesn't have the right to access this resource.
```

The reason for this issue is when trying to send request from browser, the browser will send another request like "http://localhost:9878/favicon.ico", which would be treated as a request to bucket of "favicon.ico", as a result a new OzoneClient was to inject for this request.

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6497

## How was this patch tested?

Manually test: Error logs disappears when calling "http://localhost:9878/jmx".
