### PR TITLE
HDDS-6473. Empty data in response for V0 GetSmallFile request

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ContainerCommandResponseBuilders.java
@@ -232,7 +232,7 @@ public final class ContainerCommandResponseBuilders {
       // V0 has all response data in a single ByteBuffer
       ByteString combinedData = ByteString.EMPTY;
       for (ByteString buffer : dataBuffers) {
-        combinedData.concat(buffer);
+        combinedData = combinedData.concat(buffer);
       }
       readChunk = ReadChunkResponseProto.newBuilder()
           .setChunkData(info)

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachin
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.migrationsupport.rules.EnableRuleMigrationSupport;
@@ -238,7 +237,6 @@ public class TestOzoneContainer {
     }
   }
 
-  @Disabled("HDDS-6473")
   @Test
   public void testBothGetandPutSmallFile() throws Exception {
     MiniOzoneCluster cluster = null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the bug that `GetSmallFile` response always has empty `data` for V0 request (when reading into a single `ByteBuffer` instead of `ByteBuffer[]`).

https://issues.apache.org/jira/browse/HDDS-6473

## How was this patch tested?

```
[INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 159.229 s - in org.apache.hadoop.ozone.container.ozoneimpl.TestOzoneContainer
```