### PR TITLE
HDDS-6429. getContainerReplicas should respect client version

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocol.java
@@ -101,8 +101,8 @@ public interface StorageContainerLocationProtocol extends Closeable {
    * @return List of ReplicaInfo for the container or an empty list if none.
    * @throws IOException
    */
-  List<HddsProtos.SCMContainerReplicaProto>
-      getContainerReplicas(long containerId) throws IOException;
+  List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
+      long containerId, int clientVersion) throws IOException;
 
   /**
    * Ask SCM the location of a batch of containers. SCM responds with a group of

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/StorageContainerLocationProtocolClientSideTranslatorPB.java
@@ -259,8 +259,8 @@ public final class StorageContainerLocationProtocolClientSideTranslatorPB
    * {@inheritDoc}
    */
   @Override
-  public List<HddsProtos.SCMContainerReplicaProto>
-      getContainerReplicas(long containerID) throws IOException {
+  public List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
+      long containerID, int clientVersion) throws IOException {
     Preconditions.checkState(containerID >= 0,
         "Container ID cannot be negative");
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/StorageContainerLocationProtocolServerSideTranslatorPB.java
@@ -422,7 +422,8 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
           .setCmdType(request.getCmdType())
           .setStatus(Status.OK)
           .setGetContainerReplicasResponse(getContainerReplicas(
-              request.getGetContainerReplicasRequest()))
+              request.getGetContainerReplicasRequest(),
+              request.getVersion()))
           .build();
       default:
         throw new IllegalArgumentException(
@@ -436,9 +437,10 @@ public final class StorageContainerLocationProtocolServerSideTranslatorPB
   }
 
   public GetContainerReplicasResponseProto getContainerReplicas(
-      GetContainerReplicasRequestProto request) throws IOException {
+      GetContainerReplicasRequestProto request, int clientVersion)
+      throws IOException {
     List<HddsProtos.SCMContainerReplicaProto> replicas
-        = impl.getContainerReplicas(request.getContainerID());
+        = impl.getContainerReplicas(request.getContainerID(), clientVersion);
     return GetContainerReplicasResponseProto.newBuilder()
         .addAllContainerReplica(replicas).build();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -291,8 +291,8 @@ public class SCMClientProtocolServer implements
   }
 
   @Override
-  public List<HddsProtos.SCMContainerReplicaProto>
-      getContainerReplicas(long containerId) throws IOException {
+  public List<HddsProtos.SCMContainerReplicaProto> getContainerReplicas(
+      long containerId, int clientVersion) throws IOException {
     List<HddsProtos.SCMContainerReplicaProto> results = new ArrayList<>();
 
     Set<ContainerReplica> replicas = getScm().getContainerManager()
@@ -302,7 +302,7 @@ public class SCMClientProtocolServer implements
           HddsProtos.SCMContainerReplicaProto.newBuilder()
               .setContainerID(containerId)
               .setState(r.getState().toString())
-              .setDatanodeDetails(r.getDatanodeDetails().getProtoBufMessage())
+              .setDatanodeDetails(r.getDatanodeDetails().toProto(clientVersion))
               .setBytesUsed(r.getBytesUsed())
               .setPlaceOfBirth(r.getOriginDatanodeId().toString())
               .setKeyCount(r.getKeyCount())

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/ContainerOperationClient.java
@@ -493,8 +493,9 @@ public class ContainerOperationClient implements ScmClient {
   @Override
   public List<ContainerReplicaInfo>
       getContainerReplicas(long containerId) throws IOException {
-    List<HddsProtos.SCMContainerReplicaProto> protos
-        = storageContainerLocationClient.getContainerReplicas(containerId);
+    List<HddsProtos.SCMContainerReplicaProto> protos =
+        storageContainerLocationClient.getContainerReplicas(containerId,
+            ClientVersion.CURRENT_VERSION);
     List<ContainerReplicaInfo> replicas = new ArrayList<>();
     for (HddsProtos.SCMContainerReplicaProto p : protos) {
       replicas.add(ContainerReplicaInfo.fromProto(p));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Pass current version from `ContainerOperationClient` to SCM.  Let SCM use it during datanode details proto conversion, instead of its own current client version.

https://issues.apache.org/jira/browse/HDDS-6429

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/1999677055