### PR TITLE
HDDS-6502. Blocks of old key versions are not deleted on key deletion

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1117,6 +1117,21 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
             keyBlocksList.add(keyBlocks);
             currentCount++;
           }
+          for (OmKeyInfo info : infoList.getOmKeyInfoList()) {
+            // Add all blocks from all versions of the key to the deletion list
+            for (OmKeyLocationInfoGroup keyLocations :
+                info.getKeyLocationVersions()) {
+              List<BlockID> item = keyLocations.getLocationList().stream()
+                  .map(b -> new BlockID(b.getContainerID(), b.getLocalID()))
+                  .collect(Collectors.toList());
+              BlockGroup keyBlocks = BlockGroup.newBuilder()
+                  .setKeyName(kv.getKey())
+                  .addAllBlockIDs(item)
+                  .build();
+              keyBlocksList.add(keyBlocks);
+            }
+            currentCount++;
+          }
         }
       }
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/OmTestManagers.java
@@ -44,6 +44,7 @@ public final class OmTestManagers {
   private VolumeManager volumeManager;
   private BucketManager bucketManager;
   private PrefixManager prefixManager;
+  private ScmBlockLocationProtocol scmBlockClient;
 
   public OzoneManager getOzoneManager() {
     return om;
@@ -66,6 +67,9 @@ public final class OmTestManagers {
   public KeyManager getKeyManager() {
     return keyManager;
   }
+  public ScmBlockLocationProtocol getScmBlockClient() {
+    return scmBlockClient;
+  }
 
   public OmTestManagers(OzoneConfiguration conf)
       throws AuthenticationException, IOException {
@@ -80,10 +84,8 @@ public final class OmTestManagers {
       containerClient =
           Mockito.mock(StorageContainerLocationProtocol.class);
     }
-    if (blockClient == null) {
-      blockClient =
-          new ScmBlockLocationTestingClient(null, null, 0);
-    }
+    scmBlockClient = blockClient != null ? blockClient :
+        new ScmBlockLocationTestingClient(null, null, 0);
 
     conf.set(ScmConfigKeys.OZONE_SCM_CLIENT_ADDRESS_KEY, "127.0.0.1:0");
     DefaultMetricsSystem.setMiniClusterMode(true);
@@ -97,7 +99,7 @@ public final class OmTestManagers {
 
     keyManager = (KeyManagerImpl) HddsWhiteboxTestUtils
         .getInternalState(om, "keyManager");
-    ScmClient scmClient = new ScmClient(blockClient, containerClient);
+    ScmClient scmClient = new ScmClient(scmBlockClient, containerClient);
     HddsWhiteboxTestUtils.setInternalState(om,
         "scmClient", scmClient);
     HddsWhiteboxTestUtils.setInternalState(keyManager,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ScmBlockLocationTestingClient.java
@@ -76,6 +76,9 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
   private final int failCallsFrequency;
   private int currentCall = 0;
 
+  // The number of blocks deleted by this client
+  private int numBlocksDeleted = 0;
+
   /**
    * If ClusterID or SCMID is blank a per instance ID is generated.
    *
@@ -155,6 +158,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
         switch (this.failCallsFrequency) {
         case 0:
           result = success;
+          numBlocksDeleted++;
           break;
         case 1:
           result = unknownFailure;
@@ -164,6 +168,7 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
             result = unknownFailure;
           } else {
             result = success;
+            numBlocksDeleted++;
           }
         }
         blockResultList.add(new DeleteBlockResult(blockKey, result));
@@ -192,6 +197,13 @@ public class ScmBlockLocationTestingClient implements ScmBlockLocationProtocol {
   public List<DatanodeDetails> sortDatanodes(List<String> nodes,
       String clientMachine) throws IOException {
     return null;
+  }
+
+  /**
+   * Return the number of blocks puesdo deleted by this testing client.
+   */
+  public int getNumberOfDeletedBlocks() {
+    return numBlocksDeleted;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

When a key is deleted from OM, only the latest version of blocks are sent to SCM for deletion. 
In OmMetadataManagerImpl#getPendingDeletionKeys(), we gey the latest version location information and return only those blocks for deletion to KeyDeletingService. This leads to older versions of blocks being orphaned.

```
RepeatedOmKeyInfo infoList = kv.getValue();
// Get block keys as a list.
for (OmKeyInfo info : infoList.getOmKeyInfoList()) {
  OmKeyLocationInfoGroup latest = info.getLatestVersionLocations();
  List<BlockID> item = latest.getLocationList().stream()
    .map(b -> new BlockID(b.getContainerID(), b.getLocalID()))
    .collect(Collectors.toList());
  BlockGroup keyBlocks = BlockGroup.newBuilder()
    .setKeyName(kv.getKey())
    .addAllBlockIDs(item)
    .build();
  keyBlocksList.add(keyBlocks);
  currentCount++;
}
```
This PR proposes to return all blocks from all versions of a key to KeyDeletingService when a key is marked for deletion.

## What is the link to the Apache JIRA

Please replace this section with the link to the Apache JIRA)](https://issues.apache.org/jira/browse/HDDS-6502)

## How was this patch tested?

Added unit test
