### PR TITLE
HDDS-6505. TestContainerStateManagerIntegration consistently fails

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -49,6 +49,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
@@ -288,6 +290,8 @@ public class TestContainerStateManagerIntegration {
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
     Map<Long, Long> container2MatchedCount = new ConcurrentHashMap<>();
 
+    Executor executor = Executors.newFixedThreadPool(4);
+
     // allocate blocks using multiple threads
     int numBlockAllocates = 100000;
     for (int i = 0; i < numBlockAllocates; i++) {
@@ -298,7 +302,7 @@ public class TestContainerStateManagerIntegration {
         container2MatchedCount
             .compute(info.getContainerID(), (k, v) -> v == null ? 1L : v + 1);
         return null;
-      });
+      }, executor);
     }
 
     // make sure pipeline has has numContainerPerOwnerInPipeline number of

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -51,10 +51,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+
 /**
  * Tests for ContainerStateManager.
  */
-@Flaky("HDDS-1159")
 public class TestContainerStateManagerIntegration {
 
   private static final Logger LOG =
@@ -72,6 +73,7 @@ public class TestContainerStateManagerIntegration {
   @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT, 1);
     numContainerPerOwnerInPipeline =
         conf.getInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT,
             ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT_DEFAULT);
@@ -278,7 +280,7 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
-  @Flaky("TODO:HDDS-1159")
+  @Flaky("HDDS-1159")
   public void testGetMatchingContainerMultipleThreads()
       throws IOException, InterruptedException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
@@ -397,9 +399,9 @@ public class TestContainerStateManagerIntegration {
 
     // Test 1: no replica's exist
     ContainerID containerID = ContainerID.valueOf(RandomUtils.nextLong());
-    Set<ContainerReplica> replicaSet;
-    containerStateManager.getContainerReplicas(containerID);
-    Assert.fail();
+    Set<ContainerReplica> replicaSet =
+        containerStateManager.getContainerReplicas(containerID);
+    Assert.assertNull(replicaSet);
 
     ContainerWithPipeline container = scm.getClientProtocolServer()
         .allocateContainer(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix TestContainerStateManagerIntegration:

 * Set pipeline limit, as the test assumes single pipeline per datanode (which used to be the default).
 * `testReplicaMap` had a consistent `fail()` call, which used to be part of a try-catch block where exception was expected before HDDS-5607.
 * Remove two test cases that were testing the same code path as others due to always passing an empty set of excluded container IDs.
 * Use a fixed thread pool for `testGetMatchingContainerMultipleThreads`.  It was failing in CI with `unable to create new native thread`, because [`supplyAsync` launches a new thread for each task when parallelism is 1](https://issues.apache.org/jira/browse/RATIS-1497?focusedCommentId=17480241&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17480241).
    ```
    java.lang.OutOfMemoryError: unable to create new native thread
      at java.lang.Thread.start0(Native Method)
      at java.lang.Thread.start(Thread.java:719)
      at java.util.concurrent.CompletableFuture$ThreadPerTaskExecutor.execute(CompletableFuture.java:405)
      at java.util.concurrent.CompletableFuture.asyncSupplyStage(CompletableFuture.java:1618)
      at java.util.concurrent.CompletableFuture.supplyAsync(CompletableFuture.java:1827)
      at org.apache.hadoop.hdds.scm.container.TestContainerStateManagerIntegration.testGetMatchingContainerMultipleThreads(TestContainerStateManagerIntegration.java:294)
    ```

https://issues.apache.org/jira/browse/HDDS-6505

## How was this patch tested?

Repeated 50x without the flaky `testGetMatchingContainerMultipleThreads`:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2034074566

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2034107910