### PR TITLE
HDDS-6506. Introduce OmOpenKeyInfo for getExpiredOpenKeys

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOpenKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmOpenKeyInfo.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OpenKey;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+
+/**
+ * A class that encapsulates information of an open key.
+ * Including basic info of the bucket and volume it belongs to.
+ */
+public final class OmOpenKeyInfo {
+
+  private final String volumeName;
+  private final String bucketName;
+  private final String keyName;
+  private final long clientID;
+  private final long parentID;
+  private final BucketLayout bucketLayout;
+
+  private OmOpenKeyInfo(Builder builder) {
+    this.volumeName = builder.volumeName;
+    this.bucketName = builder.bucketName;
+    this.keyName = builder.keyName;
+    this.clientID = builder.clientID;
+    this.parentID = builder.parentID;
+    this.bucketLayout = builder.bucketLayout;
+  }
+
+  public String getVolumeName() {
+    return volumeName;
+  }
+
+  public String getBucketName() {
+    return bucketName;
+  }
+
+  public String getKeyName() {
+    return keyName;
+  }
+
+  public long getClientID() {
+    return clientID;
+  }
+
+  public long getParentID() {
+    return parentID;
+  }
+
+  public BucketLayout getBucketLayout() {
+    return bucketLayout;
+  }
+
+  public String toString() {
+    if (bucketLayout.isFileSystemOptimized()) {
+      return parentID + OM_KEY_PREFIX + keyName + OM_KEY_PREFIX + clientID;
+    } else {
+      return OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName
+          + OM_KEY_PREFIX + keyName + OM_KEY_PREFIX + clientID;
+    }
+  }
+
+  public OpenKey toProto() {
+    OpenKey.Builder builder = OpenKey.newBuilder()
+        .setName(keyName)
+        .setClientID(clientID);
+    /* TODO: change the proto to support FSO keys
+    if (bucketLayout.isFileSystemOptimized()) {
+      builder.setParentID(parentID);
+    }
+    */
+    return builder.build();
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Builder for OmOpenKeyInfo.
+   */
+  public static class Builder {
+    private String volumeName;
+    private String bucketName;
+    private String keyName;
+    private long clientID;
+    private long parentID;
+    private BucketLayout bucketLayout;
+
+    public Builder() {
+      bucketLayout = BucketLayout.DEFAULT;
+    }
+
+    public Builder setVolumeName(String volumeName) {
+      this.volumeName = volumeName;
+      return this;
+    }
+
+    public Builder setBucketName(String bucketName) {
+      this.bucketName = bucketName;
+      return this;
+    }
+
+    public Builder setKeyName(String keyName) {
+      this.keyName = keyName;
+      return this;
+    }
+
+    public Builder setClientID(long clientID) {
+      this.clientID = clientID;
+      return this;
+    }
+
+    public Builder setParentID(long parentID) {
+      this.parentID = parentID;
+      return this;
+    }
+
+    public Builder setBucketLayout(BucketLayout bucketLayout) {
+      this.bucketLayout = bucketLayout;
+      return this;
+    }
+
+    public OmOpenKeyInfo build() {
+      return new OmOpenKeyInfo(this);
+    }
+  }
+}

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmOpenKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPrefixInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
@@ -262,10 +263,10 @@ public interface OMMetadataManager extends DBStoreHAManager {
    *
    * @param count The maximum number of open keys to return.
    * @param expireThreshold The threshold of open key expire age.
-   * @return a list of {@link String} representing names of open expired keys.
+   * @return a {@link List} of {@link OmOpenKeyInfo}, the expired open keys.
    * @throws IOException
    */
-  List<String> getExpiredOpenKeys(Duration expireThreshold, int count)
+  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int count)
       throws IOException;
 
   /**

--- a/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
+++ b/hadoop-ozone/interface-storage/src/main/java/org/apache/hadoop/ozone/om/OMMetadataManager.java
@@ -258,15 +258,15 @@ public interface OMMetadataManager extends DBStoreHAManager {
   List<BlockGroup> getPendingDeletionKeys(int count) throws IOException;
 
   /**
-   * Returns the names of up to {@code count} open keys whose age is
+   * Returns the names of up to {@code limit} open keys whose age is
    * greater than or equal to {@code expireThreshold}.
    *
-   * @param count The maximum number of open keys to return.
+   * @param limit The maximum number of open keys to return.
    * @param expireThreshold The threshold of open key expire age.
    * @return a {@link List} of {@link OmOpenKeyInfo}, the expired open keys.
    * @throws IOException
    */
-  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int count)
+  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int limit)
       throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
 import org.apache.hadoop.ozone.om.fs.OzoneManagerFS;
 import org.apache.hadoop.hdds.utils.BackgroundService;
+import org.apache.hadoop.ozone.om.helpers.OmOpenKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 
 import java.io.IOException;
@@ -123,11 +124,10 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
    *
    * @param count The maximum number of expired open keys to return.
    * @param expireThreshold The threshold of open key expiration age.
-   * @return a list of {@link String} representing the names of expired
-   * open keys.
+   * @return a {@link List} of {@link OmOpenKeyInfo}, the expired open keys.
    * @throws IOException
    */
-  List<String> getExpiredOpenKeys(Duration expireThreshold, int count)
+  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int count)
       throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManager.java
@@ -119,15 +119,15 @@ public interface KeyManager extends OzoneManagerFS, IOzoneAcl {
   List<BlockGroup> getPendingDeletionKeys(int count) throws IOException;
 
   /**
-   * Returns the names of up to {@code count} open keys whose age is
+   * Returns the names of up to {@code limit} open keys whose age is
    * greater than or equal to {@code expireThreshold}.
    *
-   * @param count The maximum number of expired open keys to return.
+   * @param limit The maximum number of expired open keys to return.
    * @param expireThreshold The threshold of open key expiration age.
    * @return a {@link List} of {@link OmOpenKeyInfo}, the expired open keys.
    * @throws IOException
    */
-  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int count)
+  List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold, int limit)
       throws IOException;
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -78,6 +78,7 @@ import org.apache.hadoop.ozone.om.helpers.OmMultipartKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUpload;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadList;
 import org.apache.hadoop.ozone.om.helpers.OmMultipartUploadListParts;
+import org.apache.hadoop.ozone.om.helpers.OmOpenKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmPartInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneAclUtil;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
@@ -579,7 +580,7 @@ public class KeyManagerImpl implements KeyManager {
   }
 
   @Override
-  public List<String> getExpiredOpenKeys(Duration expireThreshold,
+  public List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold,
       int count) throws IOException {
     return metadataManager.getExpiredOpenKeys(expireThreshold, count);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -581,8 +581,8 @@ public class KeyManagerImpl implements KeyManager {
 
   @Override
   public List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold,
-      int count) throws IOException {
-    return metadataManager.getExpiredOpenKeys(expireThreshold, count);
+      int limit) throws IOException {
+    return metadataManager.getExpiredOpenKeys(expireThreshold, limit);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1193,13 +1193,18 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
   @Override
   public List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold,
       int limit) throws IOException {
+    return getExpiredOpenKeys(expireThreshold, limit, BucketLayout.DEFAULT);
+  }
+
+  private List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold,
+      int limit, BucketLayout bucketLayout) throws IOException {
     List<OmOpenKeyInfo> expiredKeys = new ArrayList<>();
 
     // Only check for expired keys in the open key table, not its cache.
     // If a key expires while it is in the cache, it will be cleaned
     // up after the cache is flushed.
     try (TableIterator<String, ? extends KeyValue<String, OmKeyInfo>>
-        keyValueTableIterator = getOpenKeyTable(getBucketLayout()).iterator()) {
+        keyValueTableIterator = getOpenKeyTable(bucketLayout).iterator()) {
 
       final long expiredCreationTimestamp =
           Instant.now().minus(expireThreshold).toEpochMilli();
@@ -1218,7 +1223,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
               .setVolumeName(omKeyInfo.getVolumeName())
               .setClientID(clientID)
               .setParentID(omKeyInfo.getParentObjectID())
-              .setBucketLayout(getBucketLayout())
+              .setBucketLayout(bucketLayout)
               .build());
         }
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1192,7 +1192,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
   @Override
   public List<OmOpenKeyInfo> getExpiredOpenKeys(Duration expireThreshold,
-      int count) throws IOException {
+      int limit) throws IOException {
     List<OmOpenKeyInfo> expiredKeys = new ArrayList<>();
 
     // Only check for expired keys in the open key table, not its cache.
@@ -1204,7 +1204,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       final long expiredCreationTimestamp =
           Instant.now().minus(expireThreshold).toEpochMilli();
 
-      while (keyValueTableIterator.hasNext() && expiredKeys.size() < count) {
+      while (keyValueTableIterator.hasNext() && expiredKeys.size() < limit) {
         KeyValue<String, OmKeyInfo> openKeyValue = keyValueTableIterator.next();
         String openKey = openKeyValue.getKey();
         long clientID = Long.parseLong(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOmMetadataManager.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.OmOpenKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
@@ -43,6 +44,7 @@ import java.util.TreeSet;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD;
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_OPEN_KEY_EXPIRE_THRESHOLD_DEFAULT;
@@ -591,34 +593,28 @@ public class TestOmMetadataManager {
     }
 
     // Test retrieving fewer expired keys than actually exist.
-    List<String> someExpiredKeys =
+    List<OmOpenKeyInfo> someExpiredKeys =
         omMetadataManager.getExpiredOpenKeys(expireThreshold,
             numExpiredOpenKeys - 1);
-
     Assert.assertEquals(numExpiredOpenKeys - 1, someExpiredKeys.size());
-    for (String key: someExpiredKeys) {
-      Assert.assertTrue(expiredKeys.contains(key));
-    }
+    Assert.assertTrue(expiredKeys.containsAll(someExpiredKeys.stream()
+        .map(OmOpenKeyInfo::toString).collect(Collectors.toList())));
 
     // Test attempting to retrieving more expired keys than actually exist.
-    List<String> allExpiredKeys =
+    List<OmOpenKeyInfo> allExpiredKeys =
         omMetadataManager.getExpiredOpenKeys(expireThreshold,
             numExpiredOpenKeys + 1);
-
     Assert.assertEquals(numExpiredOpenKeys, allExpiredKeys.size());
-    for (String key: allExpiredKeys) {
-      Assert.assertTrue(expiredKeys.contains(key));
-    }
+    Assert.assertTrue(expiredKeys.containsAll(allExpiredKeys.stream()
+        .map(OmOpenKeyInfo::toString).collect(Collectors.toList())));
 
     // Test retrieving exact amount of expired keys that exist.
     allExpiredKeys =
         omMetadataManager.getExpiredOpenKeys(expireThreshold,
             numExpiredOpenKeys);
-
     Assert.assertEquals(numExpiredOpenKeys, allExpiredKeys.size());
-    for (String key: allExpiredKeys) {
-      Assert.assertTrue(expiredKeys.contains(key));
-    }
+    Assert.assertTrue(expiredKeys.containsAll(allExpiredKeys.stream()
+        .map(OmOpenKeyInfo::toString).collect(Collectors.toList())));
   }
 
   private void addKeysToOM(String volumeName, String bucketName,


### PR DESCRIPTION
## What changes were proposed in this pull request?

New class `OmOpenKeyInfo` was introduced.

Changed the return value of getExpiredOpenKeys from `List<String>` to `List<OmOpenKeyInfo>`.
So we don't have to construct `OpenKeyBucket` by parsing the open key names.
And it enables returning regular keys with FSO keys in the same call.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6506

## How was this patch tested?

Unit tests
