### PR TITLE
HDDS-6509. Checkstyle: Enable setterCanReturnItsClass in HiddenField

### DIFF
--- a/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
+++ b/hadoop-hdds/dev-support/checkstyle/checkstyle.xml
@@ -180,6 +180,7 @@
         <module name="HiddenField">
           <property name="ignoreConstructorParameter" value="true"/>
           <property name="ignoreSetter" value="true"/>
+          <property name="setterCanReturnItsClass" value="true"/>
         </module>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable `setterCanReturnItsClass` in checkstyle `HiddenField` so it will not yield `'fieldName' hides a field` error in Builders.

For example:

```java
public Builder setVolumeName(String volumeName) { // not allowed before
  this.volumeName = volumeName;
  return this;
} 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6509

## How was this patch tested?

Checkstyle
