### PR TITLE
HDDS-6511. Fix OMDBUpdatesHandler compatibility issue with rocksdbjni >= 6.28.2

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -268,6 +268,15 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
      */
   }
 
+  public void markCommitWithTimestamp(final byte[] xid, final byte[] ts)
+      throws RocksDBException {
+    /**
+     * There are no use cases yet for this method in Recon. These will be
+     * implemented as and when need arises.
+     */
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Get List of events.
    * @return List of events.


### PR DESCRIPTION
## What changes were proposed in this pull request?

See the jira description.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6511

## How was this patch tested?

- All existing tests should pass with (current) rocksdbjni 6.25.3.
- All existing tests should pass with rocksdbjni >= 6.28.2
  - https://github.com/smengcl/hadoop-ozone/commits/HDDS-6511-6.28.2