### PR TITLE
HDDS-6362. Add aggregate metrics to ContainerBalancerMetrics

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -479,7 +479,7 @@ public class ContainerBalancer {
             ContainerInfo container =
                 containerManager.getContainer(moveSelection.getContainerID());
             this.sizeMovedPerIteration += container.getUsedBytes();
-            metrics.incrementNumMovedContainersInLatestIteration(1);
+            metrics.incrementNumContainerMovesInLatestIteration(1);
             LOG.info("Move completed for container {} to target {}",
                 container.containerID(),
                 moveSelection.getTargetNode().getUuidString());
@@ -506,10 +506,13 @@ public class ContainerBalancer {
         sourceToTargetMap.size() + selectedTargets.size();
     metrics.incrementNumDatanodesInvolvedInLatestIteration(
         countDatanodesInvolvedPerIteration);
-    metrics.incrementDataSizeMovedGBInLatestIteration(
-        sizeMovedPerIteration / OzoneConsts.GB);
+    sizeMovedPerIteration /= OzoneConsts.GB;
+    metrics.incrementDataSizeMovedGBInLatestIteration(sizeMovedPerIteration);
+    metrics.incrementTotalNumContainerMoves(
+        metrics.getNumContainerMovesInLatestIteration());
+    metrics.incrementTotalSizeMovedGB(sizeMovedPerIteration);
     LOG.info("Number of datanodes involved in this iteration: {}. Size moved " +
-            "in this iteration: {}B.",
+            "in this iteration: {}GB.",
         countDatanodesInvolvedPerIteration, sizeMovedPerIteration);
   }
 
@@ -785,7 +788,7 @@ public class ContainerBalancer {
     this.countDatanodesInvolvedPerIteration = 0;
     this.sizeMovedPerIteration = 0;
     metrics.resetDataSizeMovedGBInLatestIteration();
-    metrics.resetNumMovedContainersInLatestIteration();
+    metrics.resetNumContainerMovesInLatestIteration();
     metrics.resetNumDatanodesInvolvedInLatestIteration();
     metrics.resetDataSizeUnbalancedGB();
     metrics.resetNumDatanodesUnbalanced();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -508,9 +508,9 @@ public class ContainerBalancer {
         countDatanodesInvolvedPerIteration);
     sizeMovedPerIteration /= OzoneConsts.GB;
     metrics.incrementDataSizeMovedGBInLatestIteration(sizeMovedPerIteration);
-    metrics.incrementTotalNumContainerMoves(
+    metrics.incrementNumContainerMoves(
         metrics.getNumContainerMovesInLatestIteration());
-    metrics.incrementTotalSizeMovedGB(sizeMovedPerIteration);
+    metrics.incrementDataSizeMovedGB(sizeMovedPerIteration);
     LOG.info("Number of datanodes involved in this iteration: {}. Size moved " +
             "in this iteration: {}GB.",
         countDatanodesInvolvedPerIteration, sizeMovedPerIteration);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -40,9 +40,9 @@ public final class ContainerBalancerMetrics {
       " in the latest iteration.")
   private MutableCounterLong dataSizeMovedGBInLatestIteration;
 
-  @Metric(about = "Number of containers that Container Balancer moved" +
-      " in the latest iteration.")
-  private MutableCounterLong numMovedContainersInLatestIteration;
+  @Metric(about = "Number of container moves performed by Container Balancer " +
+      "in the latest iteration.")
+  private MutableCounterLong numContainerMovesInLatestIteration;
 
   @Metric(about = "Number of iterations that Container Balancer has run for.")
   private MutableCounterLong numIterations;
@@ -56,6 +56,14 @@ public final class ContainerBalancerMetrics {
 
   @Metric(about = "Number of unbalanced datanodes.")
   private MutableCounterLong numDatanodesUnbalanced;
+
+  @Metric(about = "Total number of container moves across all iterations of " +
+      "Container Balancer.")
+  private MutableCounterLong totalNumContainerMoves;
+
+  @Metric(about = "Total data size in GB moved across all iterations of " +
+      "Container Balancer.")
+  private MutableCounterLong totalSizeMovedGB;
 
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
@@ -92,21 +100,21 @@ public final class ContainerBalancerMetrics {
   }
 
   /**
-   * Gets the number of containers moved by Container Balancer in the latest
-   * iteration.
-   * @return number of containers
+   * Gets the number of container moves performed by Container Balancer in the
+   * latest iteration.
+   * @return number of container moves
    */
-  public long getNumMovedContainersInLatestIteration() {
-    return numMovedContainersInLatestIteration.value();
+  public long getNumContainerMovesInLatestIteration() {
+    return numContainerMovesInLatestIteration.value();
   }
 
-  public void incrementNumMovedContainersInLatestIteration(long valueToAdd) {
-    this.numMovedContainersInLatestIteration.incr(valueToAdd);
+  public void incrementNumContainerMovesInLatestIteration(long valueToAdd) {
+    this.numContainerMovesInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetNumMovedContainersInLatestIteration() {
-    numMovedContainersInLatestIteration.incr(
-        -getNumMovedContainersInLatestIteration());
+  public void resetNumContainerMovesInLatestIteration() {
+    numContainerMovesInLatestIteration.incr(
+        -getNumContainerMovesInLatestIteration());
   }
 
   /**
@@ -169,5 +177,21 @@ public final class ContainerBalancerMetrics {
 
   public void resetNumDatanodesUnbalanced() {
     numDatanodesUnbalanced.incr(-getNumDatanodesUnbalanced());
+  }
+
+  public long getTotalNumContainerMoves() {
+    return totalNumContainerMoves.value();
+  }
+
+  public void incrementTotalNumContainerMoves(long valueToAdd) {
+    totalNumContainerMoves.incr(valueToAdd);
+  }
+
+  public long getTotalSizeMovedGB() {
+    return totalSizeMovedGB.value();
+  }
+
+  public void incrementTotalSizeMovedGB(long valueToAdd) {
+    totalSizeMovedGB.incr(valueToAdd);
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -59,11 +59,11 @@ public final class ContainerBalancerMetrics {
 
   @Metric(about = "Total number of container moves across all iterations of " +
       "Container Balancer.")
-  private MutableCounterLong totalNumContainerMoves;
+  private MutableCounterLong numContainerMoves;
 
   @Metric(about = "Total data size in GB moved across all iterations of " +
       "Container Balancer.")
-  private MutableCounterLong totalSizeMovedGB;
+  private MutableCounterLong dataSizeMovedGB;
 
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
@@ -179,19 +179,19 @@ public final class ContainerBalancerMetrics {
     numDatanodesUnbalanced.incr(-getNumDatanodesUnbalanced());
   }
 
-  public long getTotalNumContainerMoves() {
-    return totalNumContainerMoves.value();
+  public long getNumContainerMoves() {
+    return numContainerMoves.value();
   }
 
-  public void incrementTotalNumContainerMoves(long valueToAdd) {
-    totalNumContainerMoves.incr(valueToAdd);
+  public void incrementNumContainerMoves(long valueToAdd) {
+    numContainerMoves.incr(valueToAdd);
   }
 
-  public long getTotalSizeMovedGB() {
-    return totalSizeMovedGB.value();
+  public long getDataSizeMovedGB() {
+    return dataSizeMovedGB.value();
   }
 
-  public void incrementTotalSizeMovedGB(long valueToAdd) {
-    totalSizeMovedGB.incr(valueToAdd);
+  public void incrementDataSizeMovedGB(long valueToAdd) {
+    dataSizeMovedGB.incr(valueToAdd);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add aggregate metrics such as total number of container moves and total size moved across all the iterations of Container Balancer. Currently, only metrics specific to an iteration are present.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6362

## How was this patch tested?

Existing UTs. An integration test or manual testing will be more comprehensive.