### PR TITLE
HDDS-6455. Adding a Builder class to Freon ContentGenerator, so as to avoid Constructor Telescoping.

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -79,9 +79,10 @@ public class ContentGenerator {
           outputStream.write(buffer[i]);
           flushOrSync(outputStream);
         }
-      } else {  /**
-       * Write the required bytes to the output stream.
-       */
+      } else {
+        /**
+         * Write the required bytes to the output stream.
+         */
         for (int i = 0; i < curSize; i += copyBufferSize) {
           outputStream.write(buffer, i, Math.min(copyBufferSize, curSize - i));
           flushOrSync(outputStream);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -100,6 +100,9 @@ public class ContentGenerator {
     }
   }
 
+  /**
+   * Builder Class for Content generator.
+   */
   public static class Builder {
 
     private long keySize = 1024;
@@ -113,8 +116,8 @@ public class ContentGenerator {
       return this;
     }
 
-    public Builder bufferSize(int bufferSize) {
-      this.bufferSize = bufferSize;
+    public Builder bufferSize(int buffersize) {
+      this.bufferSize = buffersize;
       return this;
     }
 
@@ -123,12 +126,12 @@ public class ContentGenerator {
       return this;
     }
 
-    public Builder Hsync(boolean hsync) {
+    public Builder hsyncData(boolean hsync) {
       this.hSync = hsync;
       return this;
     }
 
-    public Builder Hflush(boolean hflush) {
+    public Builder hflushData(boolean hflush) {
       this.hFlush = hflush;
       return this;
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -69,9 +69,7 @@ public class ContentGenerator {
         .getBytes(StandardCharsets.UTF_8);
   }
 
-  /**
-   * Write the required bytes to the output stream.
-   */
+
   public void write(OutputStream outputStream) throws IOException {
     for (long nrRemaining = keySize; nrRemaining > 0;
          nrRemaining -= bufferSize) {
@@ -81,7 +79,9 @@ public class ContentGenerator {
           outputStream.write(buffer[i]);
           flushOrSync(outputStream);
         }
-      } else {
+      } else {  /**
+       * Write the required bytes to the output stream.
+       */
         for (int i = 0; i < curSize; i += copyBufferSize) {
           outputStream.write(buffer, i, Math.min(copyBufferSize, curSize - i));
           flushOrSync(outputStream);
@@ -136,7 +136,6 @@ public class ContentGenerator {
     //Return the final constructed builder object
     public ContentGenerator build() {
       ContentGenerator contentgenerator =  new ContentGenerator(this);
-    // validateBuilderObject(contentgenerator); For validating the builder object
       return contentgenerator;
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -116,8 +116,8 @@ public class ContentGenerator {
       return this;
     }
 
-    public Builder setBufferSize(int bufferSize) {
-      this.bufferSize = bufferSize;
+    public Builder setBufferSize(int buffersize) {
+      this.bufferSize = buffersize;
       return this;
     }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -31,13 +31,13 @@ public class ContentGenerator {
   /**
    * Size of the destination object (key or file).
    */
-  private long keySize;
+  private final long keySize;
 
   /**
    * Buffer for the pre-allocated content (will be reused if less than the
    * keySize).
    */
-  private int bufferSize;
+  private final int bufferSize;
 
   /**
    * Number of bytes to write in one call.
@@ -60,6 +60,14 @@ public class ContentGenerator {
         .getBytes(StandardCharsets.UTF_8);
   }
 
+  ContentGenerator(ContentGeneratorBuilder contentgeneratorbuilder) {
+    this.keySize = contentgeneratorbuilder.keySize;
+    this.bufferSize = contentgeneratorbuilder.bufferSize;
+    this.copyBufferSize = contentgeneratorbuilder.copyBufferSize;
+    buffer = RandomStringUtils.randomAscii(bufferSize)
+        .getBytes(StandardCharsets.UTF_8);
+  }
+
   /**
    * Write the required bytes to the output stream.
    */
@@ -77,6 +85,34 @@ public class ContentGenerator {
               Math.min(copyBufferSize, curSize - i));
         }
       }
+    }
+  }
+
+
+  public static class ContentGeneratorBuilder{
+
+    private final long keySize; // Required
+    private final int bufferSize; // Required
+    private int copyBufferSize; // Optional
+
+    ContentGeneratorBuilder(long keysize, int buffersize)
+    {
+      this.keySize = keysize;
+      this.bufferSize = buffersize;
+    }
+
+    // Return an object of ContentGeneratorBuilder which will have optional
+    // parameter copyBufferSize Initialized
+    public ContentGeneratorBuilder copyBufferSize(int copybuffersize){
+      this.copyBufferSize = copybuffersize;
+      return this;
+    }
+
+    //Return the final constructed builder object
+    public ContentGenerator build() {
+      ContentGenerator contentgenerator =  new ContentGenerator(this);
+    // validateBuilderObject(contentgenerator); For validating the builder object
+      return contentgenerator;
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -59,6 +59,15 @@ public class ContentGenerator {
    */
   private final boolean hFlush;
 
+  /**
+   * Type of flags.
+   */
+  public enum Flags {
+    hSync,
+    hFlush,
+    None,
+  }
+
   ContentGenerator(Builder objectBuild) {
     this.keySize = objectBuild.keySize;
     this.bufferSize = objectBuild.bufferSize;
@@ -111,6 +120,7 @@ public class ContentGenerator {
     private int copyBufferSize = 1024;
     private boolean hSync = false;
     private boolean hFlush = false;
+    private String flushMode;
 
     public Builder seyKeySize(long keysize) {
       this.keySize = keysize;
@@ -127,20 +137,34 @@ public class ContentGenerator {
       return this;
     }
 
-    public Builder setHsyncData(boolean hsync) {
-      this.hSync = hsync;
-      return this;
-    }
-
-    public Builder setHflushData(boolean hflush) {
-      this.hFlush = hflush;
+    /**
+     * Type of flags permitted
+     * 1. hSync
+     * 2. hFlush
+     * 3. None.
+     */
+    public Builder setFlushMode(String flushmode) {
+      this.flushMode = flushmode;
+      Flags type = Flags.valueOf(flushmode);
+      switch (type) {
+      case hSync:
+        hSync = true;
+        break;
+      case hFlush:
+        hFlush = true;
+        break;
+      case None:
+        break;
+      default:
+        throw new IllegalArgumentException(
+            flushmode + " is not a valid benchmarkType.");
+      }
       return this;
     }
 
     //Return the final constructed builder object
     public ContentGenerator build() {
-      ContentGenerator contentgenerator = new ContentGenerator(this);
-      return contentgenerator;
+      return new ContentGenerator(this);
     }
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -49,7 +49,7 @@ public class ContentGenerator {
   private final byte[] buffer;
 
 
-  ContentGenerator(ContentGeneratorBuilder contentgeneratorbuilder) {
+  ContentGenerator(Builder contentgeneratorbuilder) {
     this.keySize = contentgeneratorbuilder.keySize;
     this.bufferSize = contentgeneratorbuilder.bufferSize;
     this.copyBufferSize = contentgeneratorbuilder.copyBufferSize;
@@ -78,25 +78,14 @@ public class ContentGenerator {
     System.out.println("Write happened2");
   }
 
-  public long getKeySize() {
-    return keySize;
-  }
 
-  public int getBufferSize() {
-    return bufferSize;
-  }
-
-  public int getCopyBufferSize() {
-    return copyBufferSize;
-  }
-
-  public static class ContentGeneratorBuilder{
+  public static class Builder {
 
     private final long keySize; // Required
     private final int bufferSize; // Required
     private int copyBufferSize = 1024; // Optional Parameter Default Value set
 
-    ContentGeneratorBuilder(long keysize, int buffersize)
+    Builder(long keysize, int buffersize)
     {
       this.keySize = keysize;
       this.bufferSize = buffersize;
@@ -104,7 +93,7 @@ public class ContentGenerator {
 
     // Return an object of ContentGeneratorBuilder which will have optional
     // parameter copyBufferSize Initialized
-    public ContentGeneratorBuilder copyBufferSize(int copybuffersize){
+    public Builder copyBufferSize(int copybuffersize){
       this.copyBufferSize = copybuffersize;
       return this;
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -108,34 +108,34 @@ public class ContentGenerator {
     private boolean hSync = false;
     private boolean hFlush = false;
 
-    public Builder keySize(long keysize){
+    public Builder keySize(long keysize) {
       this.keySize = keysize;
       return this;
     }
 
-    public Builder bufferSize(int bufferSize){
+    public Builder bufferSize(int bufferSize) {
       this.bufferSize = bufferSize;
       return this;
     }
 
-    public Builder copyBufferSize(int copybuffersize){
+    public Builder copyBufferSize(int copybuffersize) {
       this.copyBufferSize = copybuffersize;
       return this;
     }
 
-    public Builder Hsync(boolean hsync){
+    public Builder Hsync(boolean hsync) {
       this.hSync = hsync;
       return this;
     }
 
-    public Builder Hflush(boolean hflush){
+    public Builder Hflush(boolean hflush) {
       this.hFlush = hflush;
       return this;
     }
 
     //Return the final constructed builder object
     public ContentGenerator build() {
-      ContentGenerator contentgenerator =  new ContentGenerator(this);
+      ContentGenerator contentgenerator = new ContentGenerator(this);
       return contentgenerator;
     }
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -48,17 +48,6 @@ public class ContentGenerator {
 
   private final byte[] buffer;
 
-  ContentGenerator(long keySize, int bufferSize) {
-    this(keySize, bufferSize, bufferSize);
-  }
-
-  ContentGenerator(long keySize, int bufferSize, int copyBufferSize) {
-    this.keySize = keySize;
-    this.bufferSize = bufferSize;
-    this.copyBufferSize = copyBufferSize;
-    buffer = RandomStringUtils.randomAscii(bufferSize)
-        .getBytes(StandardCharsets.UTF_8);
-  }
 
   ContentGenerator(ContentGeneratorBuilder contentgeneratorbuilder) {
     this.keySize = contentgeneratorbuilder.keySize;
@@ -105,7 +94,7 @@ public class ContentGenerator {
 
     private final long keySize; // Required
     private final int bufferSize; // Required
-    private int copyBufferSize; // Optional
+    private int copyBufferSize = 1024; // Optional Parameter Default Value set
 
     ContentGeneratorBuilder(long keysize, int buffersize)
     {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -111,27 +111,27 @@ public class ContentGenerator {
     private boolean hSync = false;
     private boolean hFlush = false;
 
-    public Builder keySize(long keysize) {
+    public Builder seyKeySize(long keysize) {
       this.keySize = keysize;
       return this;
     }
 
-    public Builder bufferSize(int buffersize) {
-      this.bufferSize = buffersize;
+    public Builder setBufferSize(int bufferSize) {
+      this.bufferSize = bufferSize;
       return this;
     }
 
-    public Builder copyBufferSize(int copybuffersize) {
+    public Builder setCopyBufferSize(int copybuffersize) {
       this.copyBufferSize = copybuffersize;
       return this;
     }
 
-    public Builder hsyncData(boolean hsync) {
+    public Builder setHsyncData(boolean hsync) {
       this.hSync = hsync;
       return this;
     }
 
-    public Builder hflushData(boolean hflush) {
+    public Builder setHflushData(boolean hflush) {
       this.hFlush = hflush;
       return this;
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/ContentGenerator.java
@@ -86,8 +86,20 @@ public class ContentGenerator {
         }
       }
     }
+    System.out.println("Write happened2");
   }
 
+  public long getKeySize() {
+    return keySize;
+  }
+
+  public int getBufferSize() {
+    return bufferSize;
+  }
+
+  public int getCopyBufferSize() {
+    return copyBufferSize;
+  }
 
   public static class ContentGeneratorBuilder{
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -112,7 +112,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
       contentGenerator =
-          new ContentGenerator.ContentGeneratorBuilder(fileSizeInBytes,
+          new ContentGenerator.Builder(fileSizeInBytes,
               bufferSize).build();
       timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -112,8 +112,8 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
       contentGenerator =
-          new ContentGenerator.Builder(fileSizeInBytes,
-              bufferSize).build();
+          new ContentGenerator.Builder().keySize(fileSizeInBytes)
+              .bufferSize(bufferSize).build();
       timer = getMetrics().timer("file-create");
 
       runTests(this::createDir);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -160,8 +160,8 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
     print(message);
   }
 
-  private void createSubDirRecursively(String parent, int depthIndex, int spanIndex)
-      throws Exception {
+  private void createSubDirRecursively(String parent, int depthIndex,
+                                       int spanIndex) throws Exception {
     if (depthIndex < depth) {
       String depthSubDir = makeDirWithGivenNumberOfFiles(parent);
       ++depthIndex;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
     aliases = "dfs-tree-generator",
     description =
         "Create nested directories and create given number of files in each " +
-            "dir in any dfs compatible file system.",
+        "dir in any dfs compatible file system.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -39,7 +39,7 @@ import java.util.concurrent.atomic.AtomicLong;
     aliases = "dfs-tree-generator",
     description =
         "Create nested directories and create given number of files in each " +
-                "dir in any dfs compatible file system.",
+            "dir in any dfs compatible file system.",
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true,
     showDefaultValues = true)
@@ -73,8 +73,8 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
   private long fileSizeInBytes;
 
   @Option(names = {"-b", "--buffer"},
-          description = "Size of buffer used to generated the file content.",
-          defaultValue = "1024")
+      description = "Size of buffer used to generated the file content.",
+      defaultValue = "1024")
   private int bufferSize;
 
   @Option(names = {"-s", "--span"},
@@ -155,14 +155,14 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       createSubDirRecursively(dir, 1, 1);
     }
     String message = "Successfully created directories & files. Total Dirs " +
-            "Count=" + totalDirsCnt.get() + ", Total Files Count=" +
-            timer.getCount();
+        "Count=" + totalDirsCnt.get() + ", Total Files Count=" +
+        timer.getCount();
     print(message);
   }
 
   private void createSubDirRecursively(String parent, int depthIndex,
                                        int spanIndex)
-          throws Exception {
+      throws Exception {
     if (depthIndex < depth) {
       String depthSubDir = makeDirWithGivenNumberOfFiles(parent);
       ++depthIndex;
@@ -182,7 +182,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
       if (LOG.isDebugEnabled()) {
         LOG.debug("SpanSubDir:{}, depthIndex:{}, spanIndex:{} +", levelSubDir,
-                depthIndex, spanIndex);
+            depthIndex, spanIndex);
       }
       // only non-leaf nodes will be iterated recursively..
       if (depthIndex < depth) {
@@ -192,7 +192,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
   }
 
   private String makeDirWithGivenNumberOfFiles(String parent)
-          throws Exception {
+      throws Exception {
     String dir = RandomStringUtils.randomAlphanumeric(length);
     dir = parent.toString().concat("/").concat(dir);
     fileSystem.mkdirs(new Path(dir));
@@ -204,7 +204,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
   private void createFile(String dir, long counter) throws Exception {
     String fileName = dir.concat("/").concat(RandomStringUtils.
-            randomAlphanumeric(length));
+        randomAlphanumeric(length));
     Path file = new Path(fileName);
     if (LOG.isDebugEnabled()) {
       LOG.debug("FilePath:{}", file);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -111,8 +111,9 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       init();
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
-
-      contentGenerator = new ContentGenerator(fileSizeInBytes, bufferSize);
+      contentGenerator =
+          new ContentGenerator.ContentGeneratorBuilder(fileSizeInBytes,
+              bufferSize).build();
       timer = getMetrics().timer("file-create");
 
       runTests(this::createDir);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -112,8 +112,8 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
       contentGenerator =
-          new ContentGenerator.Builder().keySize(fileSizeInBytes)
-              .bufferSize(bufferSize).build();
+          new ContentGenerator.Builder().seyKeySize(fileSizeInBytes)
+              .setBufferSize(bufferSize).build();
       timer = getMetrics().timer("file-create");
 
       runTests(this::createDir);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -160,8 +160,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
     print(message);
   }
 
-  private void createSubDirRecursively(String parent, int depthIndex,
-                                       int spanIndex)
+  private void createSubDirRecursively(String parent, int depthIndex, int spanIndex)
       throws Exception {
     if (depthIndex < depth) {
       String depthSubDir = makeDirWithGivenNumberOfFiles(parent);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopDirTreeGenerator.java
@@ -112,8 +112,10 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
       OzoneConfiguration configuration = createOzoneConfiguration();
       fileSystem = FileSystem.get(URI.create(rootPath), configuration);
       contentGenerator =
-          new ContentGenerator.Builder().seyKeySize(fileSizeInBytes)
-              .setBufferSize(bufferSize).build();
+          new ContentGenerator.Builder()
+              .seyKeySize(fileSizeInBytes)
+              .setBufferSize(bufferSize)
+              .build();
       timer = getMetrics().timer("file-create");
 
       runTests(this::createDir);
@@ -181,7 +183,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
       if (LOG.isDebugEnabled()) {
         LOG.debug("SpanSubDir:{}, depthIndex:{}, spanIndex:{} +", levelSubDir,
-            depthIndex, spanIndex);
+                depthIndex, spanIndex);
       }
       // only non-leaf nodes will be iterated recursively..
       if (depthIndex < depth) {
@@ -191,7 +193,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
   }
 
   private String makeDirWithGivenNumberOfFiles(String parent)
-      throws Exception {
+          throws Exception {
     String dir = RandomStringUtils.randomAlphanumeric(length);
     dir = parent.toString().concat("/").concat(dir);
     fileSystem.mkdirs(new Path(dir));
@@ -203,7 +205,7 @@ public class HadoopDirTreeGenerator extends BaseFreonGenerator
 
   private void createFile(String dir, long counter) throws Exception {
     String fileName = dir.concat("/").concat(RandomStringUtils.
-        randomAlphanumeric(length));
+            randomAlphanumeric(length));
     Path file = new Path(fileName);
     if (LOG.isDebugEnabled()) {
       LOG.debug("FilePath:{}", file);

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import com.codahale.metrics.Timer;
+import org.apache.hadoop.ozone.freon.ContentGenerator.ContentGeneratorBuilder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -89,7 +90,8 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new ContentGenerator(fileSize, bufferSize, copyBufferSize);
+        new ContentGenerator.ContentGeneratorBuilder(fileSize,
+            bufferSize).copyBufferSize(copyBufferSize).build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -90,8 +90,11 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new Builder().seyKeySize(fileSize).setBufferSize(bufferSize)
-            .setCopyBufferSize(copyBufferSize).build();
+        new Builder()
+            .seyKeySize(fileSize)
+            .setBufferSize(bufferSize)
+            .setCopyBufferSize(copyBufferSize)
+            .build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import com.codahale.metrics.Timer;
-import org.apache.hadoop.ozone.freon.ContentGenerator.Builder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -90,10 +89,11 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new Builder()
+        new ContentGenerator.Builder()
             .seyKeySize(fileSize)
             .setBufferSize(bufferSize)
             .setCopyBufferSize(copyBufferSize)
+            .setFlushMode("hSync")
             .build();
 
     timer = getMetrics().timer("file-create");

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -90,7 +90,8 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new Builder(fileSize, bufferSize).copyBufferSize(copyBufferSize).build();
+        new Builder().keySize(fileSize).bufferSize(bufferSize)
+            .copyBufferSize(copyBufferSize).build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -90,8 +90,8 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new Builder().keySize(fileSize).bufferSize(bufferSize)
-            .copyBufferSize(copyBufferSize).build();
+        new Builder().seyKeySize(fileSize).setBufferSize(bufferSize)
+            .setCopyBufferSize(copyBufferSize).build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import com.codahale.metrics.Timer;
-import org.apache.hadoop.ozone.freon.ContentGenerator.ContentGeneratorBuilder;
+import org.apache.hadoop.ozone.freon.ContentGenerator.Builder;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
@@ -90,7 +90,7 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new ContentGenerator.ContentGeneratorBuilder(fileSize, bufferSize).copyBufferSize(copyBufferSize).build();
+        new Builder(fileSize, bufferSize).copyBufferSize(copyBufferSize).build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/HadoopFsGenerator.java
@@ -90,8 +90,7 @@ public class HadoopFsGenerator extends BaseFreonGenerator
     }
 
     contentGenerator =
-        new ContentGenerator.ContentGeneratorBuilder(fileSize,
-            bufferSize).copyBufferSize(copyBufferSize).build();
+        new ContentGenerator.ContentGeneratorBuilder(fileSize, bufferSize).copyBufferSize(copyBufferSize).build();
 
     timer = getMetrics().timer("file-create");
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -91,7 +91,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-    contentGenerator = new ContentGenerator.ContentGeneratorBuilder(keySize, bufferSize).build();
+    contentGenerator = new ContentGenerator.Builder(keySize, bufferSize).build();
     metadata = new HashMap<>();
 
     try (OzoneClient rpcClient = createOzoneClient(omServiceID,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -92,8 +92,8 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
     contentGenerator =
-        new ContentGenerator.Builder().seyKeySize(keySize).setBufferSize(bufferSize)
-            .build();
+        new ContentGenerator.Builder().seyKeySize(keySize)
+            .setBufferSize(bufferSize).build();
     metadata = new HashMap<>();
 
     try (OzoneClient rpcClient = createOzoneClient(omServiceID,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -92,7 +92,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
     contentGenerator =
-        new ContentGenerator.Builder().keySize(keySize).bufferSize(bufferSize)
+        new ContentGenerator.Builder().seyKeySize(keySize).setBufferSize(bufferSize)
             .build();
     metadata = new HashMap<>();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -92,8 +92,10 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
     contentGenerator =
-        new ContentGenerator.Builder().seyKeySize(keySize)
-            .setBufferSize(bufferSize).build();
+        new ContentGenerator.Builder()
+            .seyKeySize(keySize)
+            .setBufferSize(bufferSize)
+            .build();
     metadata = new HashMap<>();
 
     try (OzoneClient rpcClient = createOzoneClient(omServiceID,
@@ -114,7 +116,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     timer.time(() -> {
       try (OutputStream stream = bucket.createKey(key, keySize,
-          ReplicationType.RATIS, factor, metadata)) {
+              ReplicationType.RATIS, factor, metadata)) {
         contentGenerator.write(stream);
         stream.flush();
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -91,7 +91,9 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-    contentGenerator = new ContentGenerator.Builder(keySize, bufferSize).build();
+    contentGenerator =
+        new ContentGenerator.Builder().keySize(keySize).bufferSize(bufferSize)
+            .build();
     metadata = new HashMap<>();
 
     try (OzoneClient rpcClient = createOzoneClient(omServiceID,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -66,7 +66,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
       defaultValue = "4096")
   private int bufferSize;
 
-  @Option(names = { "-F", "--factor" },
+  @Option(names = {"-F", "--factor"},
       description = "Replication factor (ONE, THREE)",
       defaultValue = "THREE"
   )
@@ -114,7 +114,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     timer.time(() -> {
       try (OutputStream stream = bucket.createKey(key, keySize,
-              ReplicationType.RATIS, factor, metadata)) {
+          ReplicationType.RATIS, factor, metadata)) {
         contentGenerator.write(stream);
         stream.flush();
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -91,7 +91,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
 
     OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
 
-    contentGenerator = new ContentGenerator(keySize, bufferSize);
+    contentGenerator = new ContentGenerator.ContentGeneratorBuilder(keySize, bufferSize).build();
     metadata = new HashMap<>();
 
     try (OzoneClient rpcClient = createOzoneClient(omServiceID,

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -91,8 +91,9 @@ public class StreamingGenerator extends BaseFreonGenerator
       }
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
-      ContentGenerator contentGenerator = new ContentGenerator.Builder(fileSize,
-          1024).build();
+      ContentGenerator contentGenerator =
+          new ContentGenerator.Builder().keySize(fileSize).bufferSize(1024)
+              .build();
 
       for (int i = 0; i < numberOfFiles; i++) {
         try (FileOutputStream out = new FileOutputStream(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -91,7 +91,7 @@ public class StreamingGenerator extends BaseFreonGenerator
       }
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
-      ContentGenerator contentGenerator = new ContentGenerator.ContentGeneratorBuilder(fileSize,
+      ContentGenerator contentGenerator = new ContentGenerator.Builder(fileSize,
           1024).build();
 
       for (int i = 0; i < numberOfFiles; i++) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -91,8 +91,8 @@ public class StreamingGenerator extends BaseFreonGenerator
       }
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
-      ContentGenerator contentGenerator = new ContentGenerator(fileSize,
-          1024);
+      ContentGenerator contentGenerator = new ContentGenerator.ContentGeneratorBuilder(fileSize,
+          1024).build();
 
       for (int i = 0; i < numberOfFiles; i++) {
         try (FileOutputStream out = new FileOutputStream(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -92,8 +92,10 @@ public class StreamingGenerator extends BaseFreonGenerator
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
       ContentGenerator contentGenerator =
-          new ContentGenerator.Builder().seyKeySize(fileSize)
-              .setBufferSize(1024).build();
+          new ContentGenerator.Builder()
+              .seyKeySize(fileSize)
+              .setBufferSize(1024)
+              .build();
 
       for (int i = 0; i < numberOfFiles; i++) {
         try (FileOutputStream out = new FileOutputStream(

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -92,7 +92,7 @@ public class StreamingGenerator extends BaseFreonGenerator
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
       ContentGenerator contentGenerator =
-          new ContentGenerator.Builder().keySize(fileSize).bufferSize(1024)
+          new ContentGenerator.Builder().seyKeySize(fileSize).setBufferSize(1024)
               .build();
 
       for (int i = 0; i < numberOfFiles; i++) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/StreamingGenerator.java
@@ -92,8 +92,8 @@ public class StreamingGenerator extends BaseFreonGenerator
       Path subDir = sourceDir.resolve(SUB_DIR_NAME);
       Files.createDirectories(subDir);
       ContentGenerator contentGenerator =
-          new ContentGenerator.Builder().seyKeySize(fileSize).setBufferSize(1024)
-              .build();
+          new ContentGenerator.Builder().seyKeySize(fileSize)
+              .setBufferSize(1024).build();
 
       for (int i = 0; i < numberOfFiles; i++) {
         try (FileOutputStream out = new FileOutputStream(

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -38,14 +38,13 @@ public class TestContentGenerator {
       System.out.println(generator.getCopyBufferSize());
     }
     generator.write(output);
-    System.out.println("Write happened");
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
   }
 
   @Test
   public void writeWithSmallerBuffers() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+        new ContentGenerator.ContentGeneratorBuilder(10000, 1024).copyBufferSize(
             3).build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -30,13 +30,8 @@ public class TestContentGenerator {
   @Test
   public void writeWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).build();
+        new ContentGenerator.Builder(1024, 1024).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-    if(generator!=null){
-      System.out.println(generator.getKeySize());
-      System.out.println(generator.getBufferSize());
-      System.out.println(generator.getCopyBufferSize());
-    }
     generator.write(output);
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
   }
@@ -44,7 +39,7 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallerBuffers() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(10000, 1024).copyBufferSize(
+        new ContentGenerator.Builder(10000, 1024).copyBufferSize(
             3).build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);
@@ -55,7 +50,7 @@ public class TestContentGenerator {
   @Test
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+        new ContentGenerator.Builder(1024, 1024).copyBufferSize(
             1).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
@@ -66,7 +61,7 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallBuffer() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+        new ContentGenerator.Builder(1024, 1024).copyBufferSize(
             10).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
@@ -77,7 +72,7 @@ public class TestContentGenerator {
   @Test
   public void writeWithDistinctSizes() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.ContentGeneratorBuilder(20, 8).copyBufferSize(3)
+        new ContentGenerator.Builder(20, 8).copyBufferSize(3)
             .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -30,7 +30,7 @@ public class TestContentGenerator {
   @Test
   public void writeWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().keySize(1024).bufferSize(1024).build();
+        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     generator.write(output);
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
@@ -39,8 +39,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallerBuffers() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().keySize(10000).bufferSize(1024)
-            .copyBufferSize(3).build();
+        new ContentGenerator.Builder().seyKeySize(10000).setBufferSize(1024)
+            .setCopyBufferSize(3).build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);
 
@@ -50,8 +50,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().keySize(1024).bufferSize(1024)
-            .copyBufferSize(
+        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
+            .setCopyBufferSize(
                 1).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
@@ -62,8 +62,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallBuffer() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().keySize(1024).bufferSize(1024)
-            .copyBufferSize(
+        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
+            .setCopyBufferSize(
                 10).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
@@ -74,8 +74,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithDistinctSizes() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().keySize(20).bufferSize(8)
-            .copyBufferSize(3)
+        new ContentGenerator.Builder().seyKeySize(20).setBufferSize(8)
+            .setCopyBufferSize(3)
             .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -30,7 +30,7 @@ public class TestContentGenerator {
   @Test
   public void writeWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder(1024, 1024).build();
+        new ContentGenerator.Builder().keySize(1024).bufferSize(1024).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     generator.write(output);
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
@@ -39,8 +39,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallerBuffers() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder(10000, 1024).copyBufferSize(
-            3).build();
+        new ContentGenerator.Builder().keySize(10000).bufferSize(1024)
+            .copyBufferSize(3).build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);
 
@@ -50,8 +50,9 @@ public class TestContentGenerator {
   @Test
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder(1024, 1024).copyBufferSize(
-            1).build();
+        new ContentGenerator.Builder().keySize(1024).bufferSize(1024)
+            .copyBufferSize(
+                1).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -61,8 +62,9 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallBuffer() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder(1024, 1024).copyBufferSize(
-            10).build();
+        new ContentGenerator.Builder().keySize(1024).bufferSize(1024)
+            .copyBufferSize(
+                10).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -72,7 +74,8 @@ public class TestContentGenerator {
   @Test
   public void writeWithDistinctSizes() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder(20, 8).copyBufferSize(3)
+        new ContentGenerator.Builder().keySize(20).bufferSize(8)
+            .copyBufferSize(3)
             .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -30,7 +30,9 @@ public class TestContentGenerator {
   @Test
   public void writeWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
+        new ContentGenerator.Builder()
+            .seyKeySize(1024)
+            .setBufferSize(1024)
             .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     generator.write(output);
@@ -40,8 +42,11 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallerBuffers() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(10000).setBufferSize(1024)
-            .setCopyBufferSize(3).build();
+        new ContentGenerator.Builder()
+            .seyKeySize(10000)
+            .setBufferSize(1024)
+            .setCopyBufferSize(3)
+            .build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);
 
@@ -51,8 +56,11 @@ public class TestContentGenerator {
   @Test
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
-            .setCopyBufferSize(1).build();
+        new ContentGenerator.Builder()
+            .seyKeySize(1024)
+            .setBufferSize(1024)
+            .setCopyBufferSize(1)
+            .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -62,8 +70,11 @@ public class TestContentGenerator {
   @Test
   public void writeWithSmallBuffer() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
-            .setCopyBufferSize(10).build();
+        new ContentGenerator.Builder()
+            .seyKeySize(1024)
+            .setBufferSize(1024)
+            .setCopyBufferSize(10)
+            .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -73,7 +84,9 @@ public class TestContentGenerator {
   @Test
   public void writeWithDistinctSizes() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(20).setBufferSize(8)
+        new ContentGenerator.Builder()
+            .seyKeySize(20)
+            .setBufferSize(8)
             .setCopyBufferSize(3)
             .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -51,8 +51,7 @@ public class TestContentGenerator {
   public void writeWithByteLevelWrite() throws IOException {
     ContentGenerator generator =
         new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
-            .setCopyBufferSize(
-                1).build();
+            .setCopyBufferSize(1).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -32,8 +32,13 @@ public class TestContentGenerator {
     ContentGenerator generator =
         new ContentGenerator.ContentGeneratorBuilder(1024, 1024).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
-
+    if(generator!=null){
+      System.out.println(generator.getKeySize());
+      System.out.println(generator.getBufferSize());
+      System.out.println(generator.getCopyBufferSize());
+    }
     generator.write(output);
+    System.out.println("Write happened");
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());
   }
 

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -29,7 +29,8 @@ public class TestContentGenerator {
 
   @Test
   public void writeWrite() throws IOException {
-    ContentGenerator generator = new ContentGenerator(1024, 1024);
+    ContentGenerator generator =
+        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -38,8 +39,9 @@ public class TestContentGenerator {
 
   @Test
   public void writeWithSmallerBuffers() throws IOException {
-    ContentGenerator generator = new ContentGenerator(10000, 1024, 3);
-
+    ContentGenerator generator =
+        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+            3).build();
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
     generator.write(baos);
 
@@ -48,7 +50,9 @@ public class TestContentGenerator {
 
   @Test
   public void writeWithByteLevelWrite() throws IOException {
-    ContentGenerator generator = new ContentGenerator(1024, 1024, 1);
+    ContentGenerator generator =
+        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+            1).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -57,7 +61,9 @@ public class TestContentGenerator {
 
   @Test
   public void writeWithSmallBuffer() throws IOException {
-    ContentGenerator generator = new ContentGenerator(1024, 1024, 10);
+    ContentGenerator generator =
+        new ContentGenerator.ContentGeneratorBuilder(1024, 1024).copyBufferSize(
+            10).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);
@@ -66,7 +72,9 @@ public class TestContentGenerator {
 
   @Test
   public void writeWithDistinctSizes() throws IOException {
-    ContentGenerator generator = new ContentGenerator(20, 8, 3);
+    ContentGenerator generator =
+        new ContentGenerator.ContentGeneratorBuilder(20, 8).copyBufferSize(3)
+            .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -30,7 +30,8 @@ public class TestContentGenerator {
   @Test
   public void writeWrite() throws IOException {
     ContentGenerator generator =
-        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024).build();
+        new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
+            .build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
     generator.write(output);
     Assert.assertArrayEquals(generator.getBuffer(), output.toByteArray());

--- a/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
+++ b/hadoop-ozone/tools/src/test/java/org/apache/hadoop/ozone/freon/TestContentGenerator.java
@@ -63,8 +63,7 @@ public class TestContentGenerator {
   public void writeWithSmallBuffer() throws IOException {
     ContentGenerator generator =
         new ContentGenerator.Builder().seyKeySize(1024).setBufferSize(1024)
-            .setCopyBufferSize(
-                10).build();
+            .setCopyBufferSize(10).build();
     ByteArrayOutputStream output = new ByteArrayOutputStream();
 
     generator.write(output);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The ContentGenerator class of the freon suite has multiple Parametrised Constructors each having various different arguments that have to be initialised, this affects the readability of the code. One way to solve this is to incorporate a builder class for ContentGenerator class so that any new parameters added in the future can be seamlessly added without the need of creating a new constructor.

When a file was closed or flushed, the file contents were written from the DataNode into the operating system using the normal close() and write() system calls.

The data may not be immediately persisted to the underlying physical storage, but may still reside in-memory in the operating system's file cache. This creates a window of vulnerability where if multiple DataNode machines fail simultaneously (e.g. loss of power to a rack), then previously written data may be lost. To combat this problem, HDFS (as of Hadoop 2.0) has introduced new APIs to provide a way to guarantee that written data will be immediately persisted to the underlying physical storage. These APIs are described in the following table.

> **hflush()** : This Method present inside the FSDataOutputStream.java flushes all outstanding data (i.e. the current unfinished packet) from the client into the OS buffers on all DataNode replicas.
> 
> **hsync()** : This Method present inside the FSDataOutputStream.java flushes the data to the DataNodes, like hflush(), but should also force the data to underlying physical storage via fsync (or equivalent).

Hence I have added a method that would implement Hsync or Hflush after every write if the user wants !

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6455

## How was this patch tested?

Existing UTs for ContentGeneratorClass ran successfully