### PR TITLE
HDDS-5862. Datanode to Recon heartbeat interval independently configurable

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -26,6 +26,10 @@ public final class HddsConfigKeys {
       "hdds.heartbeat.interval";
   public static final String HDDS_HEARTBEAT_INTERVAL_DEFAULT =
       "30s";
+  public static final String HDDS_RECON_HEARTBEAT_INTERVAL =
+      "hdds.recon.heartbeat.interval";
+  public static final String HDDS_RECON_HEARTBEAT_INTERVAL_DEFAULT =
+      "30s";
   public static final String HDDS_NODE_REPORT_INTERVAL =
       "hdds.node.report.interval";
   public static final String HDDS_NODE_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -29,7 +29,7 @@ public final class HddsConfigKeys {
   public static final String HDDS_RECON_HEARTBEAT_INTERVAL =
       "hdds.recon.heartbeat.interval";
   public static final String HDDS_RECON_HEARTBEAT_INTERVAL_DEFAULT =
-      "30s";
+      "60s";
   public static final String HDDS_NODE_REPORT_INTERVAL =
       "hdds.node.report.interval";
   public static final String HDDS_NODE_REPORT_INTERVAL_DEFAULT =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -978,10 +978,10 @@
   </property>
   <property>
     <name>hdds.recon.heartbeat.interval</name>
-    <value>30s</value>
+    <value>60s</value>
     <tag>OZONE, MANAGEMENT, RECON</tag>
     <description>
-      The heartbeat interval from a data node to Recon.
+      The heartbeat interval from a Datanode to Recon.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -977,6 +977,14 @@
     </description>
   </property>
   <property>
+    <name>hdds.recon.heartbeat.interval</name>
+    <value>30s</value>
+    <tag>OZONE, MANAGEMENT, RECON</tag>
+    <description>
+      The heartbeat interval from a data node to Recon.
+    </description>
+  </property>
+  <property>
     <name>ozone.scm.heartbeat.log.warn.interval.count</name>
     <value>10</value>
     <tag>OZONE, MANAGEMENT</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -65,6 +65,7 @@ import com.google.common.base.Preconditions;
 import com.google.protobuf.GeneratedMessage;
 import static java.lang.Math.min;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getLogWarnInterval;
+import static org.apache.hadoop.hdds.utils.HddsServerUtil.getReconHeartbeatInterval;
 import static org.apache.hadoop.hdds.utils.HddsServerUtil.getScmHeartbeatInterval;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -149,6 +150,7 @@ public class StateContext {
    */
   private final AtomicLong heartbeatFrequency = new AtomicLong(2000);
 
+  private final AtomicLong reconHeartbeatFrequency = new AtomicLong(2000);
   /**
    * Constructs a StateContext.
    *
@@ -892,5 +894,16 @@ public class StateContext {
   @VisibleForTesting
   public GeneratedMessage getCRLStatusReport() {
     return crlStatusReport.get();
+  }
+
+  public void configureReconHeartbeatFrequency() {
+    reconHeartbeatFrequency.set(getReconHeartbeatInterval(conf));
+  }
+
+  /**
+   * Return current Datanode to Recon heartbeat frequency in ms.
+   */
+  public long getReconHeartbeatFrequency() {
+    return reconHeartbeatFrequency.get();
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
@@ -44,8 +44,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static org.apache.hadoop.hdds.HddsUtils.getReconAddresses;
-
 /**
  * Class that implements handshake with SCM.
  */
@@ -149,7 +147,7 @@ public class RunningDatanodeState implements DatanodeState {
         // so that it won't affect the communication between datanode and
         // other EndpointStateMachine.
         long heartbeatFrequency;
-        if (endpoint.getAddress().equals(getReconAddresses(conf))) {
+        if (endpoint.isPassive()) {
           heartbeatFrequency = context.getReconHeartbeatFrequency();
         } else {
           heartbeatFrequency = context.getHeartbeatFrequency();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/datanode/RunningDatanodeState.java
@@ -44,6 +44,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import static org.apache.hadoop.hdds.HddsUtils.getReconAddresses;
+
 /**
  * Class that implements handshake with SCM.
  */
@@ -146,9 +148,15 @@ public class RunningDatanodeState implements DatanodeState {
         // the thread in executor from DatanodeStateMachine for a long time,
         // so that it won't affect the communication between datanode and
         // other EndpointStateMachine.
+        long heartbeatFrequency;
+        if (endpoint.getAddress().equals(getReconAddresses(conf))) {
+          heartbeatFrequency = context.getReconHeartbeatFrequency();
+        } else {
+          heartbeatFrequency = context.getHeartbeatFrequency();
+        }
         ecs.submit(() -> endpoint.getExecutorService()
             .submit(endpointTask)
-            .get(context.getHeartbeatFrequency(), TimeUnit.MILLISECONDS));
+            .get(heartbeatFrequency, TimeUnit.MILLISECONDS));
       } else {
         // This can happen if a task is taking more time than the timeOut
         // specified for the task in await, and when it is completed the task

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.container.common.states.endpoint;
 
-import static org.apache.hadoop.hdds.HddsUtils.getReconAddresses;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto.ErrorCode.success;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -177,7 +176,7 @@ public final class RegisterEndpointTask implements
             rpcEndPoint.getState().getNextState();
         rpcEndPoint.setState(nextState);
         rpcEndPoint.zeroMissedCount();
-        if (rpcEndPoint.getAddress().equals(getReconAddresses(conf))) {
+        if (rpcEndPoint.isPassive()) {
           this.stateContext.configureReconHeartbeatFrequency();
         } else {
           this.stateContext.configureHeartbeatFrequency();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/RegisterEndpointTask.java
@@ -16,6 +16,7 @@
  */
 package org.apache.hadoop.ozone.container.common.states.endpoint;
 
+import static org.apache.hadoop.hdds.HddsUtils.getReconAddresses;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMRegisteredResponseProto.ErrorCode.success;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -176,7 +177,11 @@ public final class RegisterEndpointTask implements
             rpcEndPoint.getState().getNextState();
         rpcEndPoint.setState(nextState);
         rpcEndPoint.zeroMissedCount();
-        this.stateContext.configureHeartbeatFrequency();
+        if (rpcEndPoint.getAddress().equals(getReconAddresses(conf))) {
+          this.stateContext.configureReconHeartbeatFrequency();
+        } else {
+          this.stateContext.configureHeartbeatFrequency();
+        }
       }
     } catch (IOException ex) {
       rpcEndPoint.logIfNeeded(ex);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -70,6 +70,8 @@ import org.apache.hadoop.security.UserGroupInformation;
 import static org.apache.hadoop.hdds.DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL_DEFAULT;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_HEARTBEAT_INTERVAL;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_RECON_HEARTBEAT_INTERVAL_DEFAULT;
 import static org.apache.hadoop.hdds.HddsUtils.getHostNameFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.HDDS_DATANODE_DIR_KEY;
@@ -250,6 +252,18 @@ public final class HddsServerUtil {
   public static long getScmHeartbeatInterval(ConfigurationSource conf) {
     return conf.getTimeDuration(HDDS_HEARTBEAT_INTERVAL,
         HDDS_HEARTBEAT_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Heartbeat Interval - Defines the heartbeat frequency from a datanode to
+   * Recon.
+   *
+   * @param conf - Ozone Config
+   * @return - HB interval in milli seconds.
+   */
+  public static long getReconHeartbeatInterval(ConfigurationSource conf) {
+    return conf.getTimeDuration(HDDS_RECON_HEARTBEAT_INTERVAL,
+        HDDS_RECON_HEARTBEAT_INTERVAL_DEFAULT, TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconNodeManager.java
@@ -95,7 +95,7 @@ public class ReconNodeManager extends SCMNodeManager {
     super(conf, scmStorageConfig, eventPublisher, networkTopology,
         SCMContext.emptyContext(), scmLayoutVersionManager);
     this.reconDatanodeOutdatedTime = reconStaleDatanodeMultiplier *
-        HddsServerUtil.getScmHeartbeatInterval(conf);
+        HddsServerUtil.getReconHeartbeatInterval(conf);
     this.nodeDB = nodeDB;
     loadExistingNodes();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently DN-Recon and DN-SCM have same heartbeat interval. The Datanode to Recon heartbeat interval should be independently configurable.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5862

## How was this patch tested?

Tested using CI tests. 
