### PR TITLE
HDDS-6516. Shade Kotlin for Ozone Filesystem

### DIFF
--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -143,6 +143,12 @@
                   </includes>
                 </relocation>
                 <relocation>
+                  <pattern>kotlin</pattern>
+                  <shadedPattern>
+                    ${shaded.prefix}.kotlin
+                  </shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>picocli</pattern>
                   <shadedPattern>
                     ${shaded.prefix}.picocli


### PR DESCRIPTION
## What changes were proposed in this pull request?

Relocate Kotlin in shaded Ozone Filesystem jar, to avoid possible version mismatch in downstream projects.

https://issues.apache.org/jira/browse/HDDS-6516

## How was this patch tested?

```
$ unzip -t hadoop-ozone/dist/target/ozone-*/share/ozone/lib/ozone-filesystem-hadoop3-*.jar | grep kotlin | head
    testing: org/apache/hadoop/ozone/shaded/kotlin/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/ranges/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/experimental/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/comparisons/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/native/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/native/concurrent/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/js/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/contracts/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/reflect/   OK
    testing: org/apache/hadoop/ozone/shaded/kotlin/io/   OK
```

https://github.com/adoroszlai/hadoop-ozone/runs/5697432507