### PR TITLE
HDDS-6471. Only repeat flaky tests

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -293,7 +293,10 @@ jobs:
             maven-repo-
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
-        continue-on-error: ${{ matrix.profile == 'flaky' }}
+        if: matrix.profile != 'flaky'
+      - name: Execute flaky tests
+        run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }} -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600
+        if: matrix.profile == 'flaky'
       - name: Summary of failures
         run: cat target/${{ github.job }}/summary.txt
         if: always()

--- a/hadoop-ozone/dev-support/checks/integration.sh
+++ b/hadoop-ozone/dev-support/checks/integration.sh
@@ -16,4 +16,4 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CHECK=integration
-source "${DIR}/junit.sh" -pl :ozone-integration-test,:mini-chaos-tests -Dsurefire.rerunFailingTestsCount=5 -Dsurefire.fork.timeout=3600 "$@"
+source "${DIR}/junit.sh" -pl :ozone-integration-test,:mini-chaos-tests "$@"

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -49,6 +49,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
@@ -288,6 +290,8 @@ public class TestContainerStateManagerIntegration {
             SCMTestUtils.getReplicationFactor(conf), OzoneConsts.OZONE);
     Map<Long, Long> container2MatchedCount = new ConcurrentHashMap<>();
 
+    Executor executor = Executors.newFixedThreadPool(4);
+
     // allocate blocks using multiple threads
     int numBlockAllocates = 100000;
     for (int i = 0; i < numBlockAllocates; i++) {
@@ -298,7 +302,7 @@ public class TestContainerStateManagerIntegration {
         container2MatchedCount
             .compute(info.getContainerID(), (k, v) -> v == null ? 1L : v + 1);
         return null;
-      });
+      }, executor);
     }
 
     // make sure pipeline has has numContainerPerOwnerInPipeline number of

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManagerIntegration.java
@@ -51,10 +51,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_PIPELINE_LIMIT;
+
 /**
  * Tests for ContainerStateManager.
  */
-@Flaky("HDDS-1159")
 public class TestContainerStateManagerIntegration {
 
   private static final Logger LOG =
@@ -72,6 +73,7 @@ public class TestContainerStateManagerIntegration {
   @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
+    conf.setInt(OZONE_DATANODE_PIPELINE_LIMIT, 1);
     numContainerPerOwnerInPipeline =
         conf.getInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT,
             ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT_DEFAULT);
@@ -278,7 +280,7 @@ public class TestContainerStateManagerIntegration {
   }
 
   @Test
-  @Flaky("TODO:HDDS-1159")
+  @Flaky("HDDS-1159")
   public void testGetMatchingContainerMultipleThreads()
       throws IOException, InterruptedException {
     ContainerWithPipeline container1 = scm.getClientProtocolServer().
@@ -397,9 +399,9 @@ public class TestContainerStateManagerIntegration {
 
     // Test 1: no replica's exist
     ContainerID containerID = ContainerID.valueOf(RandomUtils.nextLong());
-    Set<ContainerReplica> replicaSet;
-    containerStateManager.getContainerReplicas(containerID);
-    Assert.fail();
+    Set<ContainerReplica> replicaSet =
+        containerStateManager.getContainerReplicas(containerID);
+    Assert.assertNull(replicaSet);
 
     ContainerWithPipeline container = scm.getClientProtocolServer()
         .allocateContainer(


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-6095 included a change to re-run failing integration tests a few times.  It was intended to only repeat flaky tests, but currently applies to all integration tests.  This may hide real problems.

The change in this PR was already included in #3148 (7e4578c), but then reverted (22f4964) for some reason, and it seems I forgot to re-add it.

https://issues.apache.org/jira/browse/HDDS-6471

## How was this patch tested?

Regular CI (on top of #3234):
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2043639817