### PR TITLE
HDDS-6499. Cleanup OMKeyRequest class constructors.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -103,10 +103,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
     FAILURE // The request failed and exception was thrown
   }
 
-  public OMDirectoryCreateRequest(OMRequest omRequest) {
-    super(omRequest);
-  }
-
   public OMDirectoryCreateRequest(OMRequest omRequest,
                                   BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -78,9 +78,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
 
   private static final Logger LOG =
       LoggerFactory.getLogger(OMFileCreateRequest.class);
-  public OMFileCreateRequest(OMRequest omRequest) {
-    super(omRequest);
-  }
 
   public OMFileCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
@@ -400,6 +397,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
     if (bucketLayout.isFileSystemOptimized()) {
       return new OMFileCreateRequestWithFSO(omRequest, bucketLayout);
     }
-    return new OMFileCreateRequest(omRequest);
+    return new OMFileCreateRequest(omRequest, bucketLayout);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -79,10 +79,6 @@ public class OMKeyCreateRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyCreateRequest.class);
 
-  public OMKeyCreateRequest(OMRequest omRequest) {
-    super(omRequest);
-  }
-
   public OMKeyCreateRequest(OMRequest omRequest, BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -70,10 +70,6 @@ public class OMKeyRenameRequest extends OMKeyRequest {
   private static final Logger LOG =
       LoggerFactory.getLogger(OMKeyRenameRequest.class);
 
-  public OMKeyRenameRequest(OMRequest omRequest) {
-    super(omRequest);
-  }
-
   public OMKeyRenameRequest(OMRequest omRequest, BucketLayout bucketLayout) {
     super(omRequest, bucketLayout);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -54,8 +55,9 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
   private static final Logger LOG =
           LoggerFactory.getLogger(OMOpenKeysDeleteRequest.class);
 
-  public OMOpenKeysDeleteRequest(OMRequest omRequest) {
-    super(omRequest);
+  public OMOpenKeysDeleteRequest(OMRequest omRequest,
+                                 BucketLayout bucketLayout) {
+    super(omRequest, bucketLayout);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -114,7 +114,7 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
@@ -138,12 +138,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -166,12 +167,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -195,12 +197,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
 
     OMClientResponse omClientResponse =
@@ -233,12 +236,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -276,12 +280,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -319,12 +324,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -354,12 +360,13 @@ public class TestOMDirectoryCreateRequest {
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
         OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequest omDirectoryCreateRequest =
-        new OMDirectoryCreateRequest(omRequest);
+        new OMDirectoryCreateRequest(omRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omDirectoryCreateRequest.preExecute(ozoneManager);
 
-    omDirectoryCreateRequest = new OMDirectoryCreateRequest(modifiedOmRequest);
+    omDirectoryCreateRequest =
+        new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
 
     Assert.assertEquals(0L, omMetrics.getNumKeys());
     OMClientResponse omClientResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMFileCreateRequest.java
@@ -405,7 +405,7 @@ public class TestOMFileCreateRequest extends TestOMKeyRequest {
    */
   @NotNull
   protected OMFileCreateRequest getOMFileCreateRequest(OMRequest omRequest) {
-    return new OMFileCreateRequest(omRequest);
+    return new OMFileCreateRequest(omRequest, getBucketLayout());
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequest.java
@@ -56,7 +56,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         clientID, replicationType, replicationFactor, omMetadataManager);
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -102,7 +102,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omMetadataManager);
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -119,7 +119,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         doPreExecute(createRenameKeyRequest(toKeyName));
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -139,7 +139,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -163,7 +163,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omMetadataManager);
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -188,7 +188,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
         omMetadataManager);
 
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(modifiedOmRequest);
+        new OMKeyRenameRequest(modifiedOmRequest, getBucketLayout());
 
     OMClientResponse omKeyRenameResponse =
         omKeyRenameRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -207,7 +207,7 @@ public class TestOMKeyRenameRequest extends TestOMKeyRequest {
 
   private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
     OMKeyRenameRequest omKeyRenameRequest =
-        new OMKeyRenameRequest(originalOmRequest);
+        new OMKeyRenameRequest(originalOmRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest = omKeyRenameRequest.preExecute(ozoneManager);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMOpenKeysDeleteRequest.java
@@ -218,7 +218,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
         doPreExecute(createDeleteOpenKeyRequest(openKeys));
 
     OMOpenKeysDeleteRequest openKeyDeleteRequest =
-        new OMOpenKeysDeleteRequest(omRequest);
+        new OMOpenKeysDeleteRequest(omRequest, getBucketLayout());
 
     OMClientResponse omClientResponse =
         openKeyDeleteRequest.validateAndUpdateCache(ozoneManager,
@@ -386,7 +386,7 @@ public class TestOMOpenKeysDeleteRequest extends TestOMKeyRequest {
    */
   private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
     OMOpenKeysDeleteRequest omOpenKeysDeleteRequest =
-        new OMOpenKeysDeleteRequest(originalOmRequest);
+        new OMOpenKeysDeleteRequest(originalOmRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omOpenKeysDeleteRequest.preExecute(ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/upgrade/TestOMCancelPrepareRequest.java
@@ -87,7 +87,7 @@ public class TestOMCancelPrepareRequest extends TestOMKeyRequest {
 
   private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
     OMOpenKeysDeleteRequest omOpenKeysDeleteRequest =
-        new OMOpenKeysDeleteRequest(originalOmRequest);
+        new OMOpenKeysDeleteRequest(originalOmRequest, getBucketLayout());
 
     OMRequest modifiedOmRequest =
         omOpenKeysDeleteRequest.preExecute(ozoneManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -286,7 +286,8 @@ public class TestCleanupTableInfo {
     when(protoRequest.getCreateFileRequest()).thenReturn(aCreateFileRequest());
     when(protoRequest.getCmdType()).thenReturn(Type.CreateFile);
     when(protoRequest.getTraceID()).thenReturn("");
-    return new OMFileCreateRequest(protoRequest);
+    return new OMFileCreateRequest(protoRequest,
+        aBucketInfo().getBucketLayout());
   }
 
   private OMKeyCreateRequest anOMKeyCreateRequest() {
@@ -294,7 +295,8 @@ public class TestCleanupTableInfo {
     when(protoRequest.getCreateKeyRequest()).thenReturn(aKeyCreateRequest());
     when(protoRequest.getCmdType()).thenReturn(Type.CreateKey);
     when(protoRequest.getTraceID()).thenReturn("");
-    return new OMKeyCreateRequest(protoRequest);
+    return new OMKeyCreateRequest(protoRequest,
+        aBucketInfo().getBucketLayout());
   }
 
   private OmBucketInfo aBucketInfo() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should pass the bucket layout to the request constructors extending OMKeyRequest, every time we call them.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6499

## How was this patch tested?

Unit tests.
