### PR TITLE
HDDS-6426. OM keyTable and fileTable use different key formats.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGenerator.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGenerator.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.io.IOException;
+
+/**
+ * Interface used by Request and Response classes to generate DB keys
+ * for looking up files or keys inside fileTable or keyTable respectively.
+ */
+public interface DBKeyGenerator {
+  /**
+   * Generates the DBKey to query key/file Table for a given key's keyArgs.
+   *
+   * @param keyArgs      KeyArgs for which DBKey is to be generated.
+   * @param ozoneManager ozoneManager instance.
+   * @param errMsg       Error message if any.
+   * @return DBKey for the given keyArgs.
+   */
+  String getOzoneDBKey(OmKeyArgs keyArgs, OzoneManager ozoneManager,
+                       String errMsg) throws IOException;
+
+  /**
+   * Generates the DBKey to query key/file Table for a given key's keyArgs.
+   *
+   * @param keyArgs      KeyArgs for which DBKey is to be generated.
+   * @param ozoneManager ozoneManager instance.
+   * @param errMsg       Error message if any.
+   * @return DBKey for the given keyArgs.
+   */
+  String getOzoneDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                       OzoneManager ozoneManager,
+                       String errMsg) throws IOException;
+
+  /**
+   * Generates the DBKey to query Open key/file Table for a given key's keyArgs.
+   *
+   * @param keyArgs      KeyArgs for which DBKey is to be generated.
+   * @param ozoneManager ozoneManager instance.
+   * @param clientId     ClientId for which DBKey is to be generated.
+   * @param errMsg       Error message if any.
+   * @return DBKey for the given keyArgs.
+   */
+  String getOzoneOpenDBKey(OmKeyArgs keyArgs,
+                           OzoneManager ozoneManager, long clientId,
+                           String errMsg) throws IOException;
+
+  /**
+   * Generates the DBKey to query Open key/file Table for a given key's keyArgs.
+   *
+   * @param keyArgs      KeyArgs for which DBKey is to be generated.
+   * @param ozoneManager ozoneManager instance.
+   * @param clientId     ClientId for which DBKey is to be generated.
+   * @param errMsg       Error message if any.
+   * @return DBKey for the given keyArgs.
+   */
+  String getOzoneOpenDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                           OzoneManager ozoneManager, long clientId,
+                           String errMsg) throws IOException;
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGeneratorImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGeneratorImpl.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.eclipse.jetty.util.StringUtil;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+
+/**
+ * DBKeyPathGenerator implementation for Object Store and Legacy buckets.
+ */
+public class DBKeyGeneratorImpl implements DBKeyGenerator {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneDBKey(OmKeyArgs keyArgs, OzoneManager ozoneManager,
+                              String errMsg) {
+    return getOzoneDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                              OzoneManager ozoneManager, String errMsg)
+      throws IOException {
+    return getOzoneDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName());
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneOpenDBKey(OmKeyArgs keyArgs,
+                                  OzoneManager ozoneManager,
+                                  long clientId, String errMsg) {
+
+    return getOzoneOpenDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), clientId);
+  }
+
+  @Override
+  public String getOzoneOpenDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                                  OzoneManager ozoneManager, long clientId,
+                                  String errMsg) throws IOException {
+    return getOzoneOpenDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), clientId);
+  }
+
+  /**
+   * Generate the DB key to query keyTable.
+   * Key format: /volumeName/bucketName/keyName
+   *
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param keyName    key name
+   * @return DB key
+   */
+  private String getOzoneDBKey(String volumeName, String bucketName,
+                               String keyName) {
+    StringBuilder builder = new StringBuilder()
+        .append(OM_KEY_PREFIX)
+        .append(volumeName);
+
+    // TODO : Throw if the Bucket is null?
+    builder.append(OM_KEY_PREFIX).append(bucketName);
+
+    if (StringUtil.isNotBlank(keyName)) {
+      builder.append(OM_KEY_PREFIX);
+      if (!keyName.equals(OM_KEY_PREFIX)) {
+        builder.append(keyName);
+      }
+    }
+    return builder.toString();
+  }
+
+  /**
+   * Generate the DB key to query OpenKeyTable.
+   * Key format: /volumeName/bucketName/keyName/clientId
+   *
+   * @param volumeName volume name
+   * @param bucketName bucket name
+   * @param keyName    key name
+   * @param clientId   request client id
+   * @return DB key
+   */
+  private String getOzoneOpenDBKey(String volumeName, String bucketName,
+                                   String keyName, long clientId) {
+    String openKey = OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName +
+        OM_KEY_PREFIX + keyName + OM_KEY_PREFIX + clientId;
+
+    return openKey;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGeneratorWithFSOImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/DBKeyGeneratorWithFSOImpl.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Iterator;
+
+import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+
+/**
+ * DBKeyPathGenerator implementation for File System Optimized buckets.
+ */
+public class DBKeyGeneratorWithFSOImpl implements DBKeyGenerator {
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneDBKey(OmKeyArgs keyArgs, OzoneManager ozoneManager,
+                              String errMsg) throws IOException {
+    return getOzoneDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), ozoneManager, errMsg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                              OzoneManager ozoneManager, String errMsg)
+      throws IOException {
+    return getOzoneDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), ozoneManager, errMsg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneOpenDBKey(OmKeyArgs keyArgs,
+                                  OzoneManager ozoneManager, long clientId,
+                                  String errMsg)
+      throws IOException {
+    return getOzoneOpenDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), clientId, ozoneManager, errMsg);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public String getOzoneOpenDBKey(OzoneManagerProtocolProtos.KeyArgs keyArgs,
+                                  OzoneManager ozoneManager, long clientId,
+                                  String errMsg) throws IOException {
+    return getOzoneOpenDBKey(keyArgs.getVolumeName(), keyArgs.getBucketName(),
+        keyArgs.getKeyName(), clientId, ozoneManager, errMsg);
+  }
+
+  /**
+   * Generates the DB key for querying the fileTable.
+   * Key is of the format parentID/keyName
+   *
+   * @param volumeName   volume name
+   * @param bucketName   bucket name
+   * @param keyName      key name
+   * @param ozoneManager ozone manager
+   * @param errMsg       error message
+   * @return - DB key
+   * @throws IOException IOException
+   */
+  private String getOzoneDBKey(String volumeName, String bucketName,
+                               String keyName,
+                               OzoneManager ozoneManager, String errMsg)
+      throws IOException {
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+
+    // Get bucket info.
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    CacheValue<OmBucketInfo> value = omMetadataManager.getBucketTable()
+        .getCacheValue(new CacheKey<>(bucketKey));
+
+    OmBucketInfo omBucketInfo = value != null ? value.getCacheValue() :
+        omMetadataManager.getBucketTable().get(bucketKey);
+
+    // In case bucket or volume is not present, throw exception.
+    if (omBucketInfo == null) {
+      // Make sure we throw the correct Exception.
+      if (omMetadataManager.getVolumeTable()
+          .get(omMetadataManager.getVolumeKey(volumeName)) == null) {
+        throw new OMException(OMException.ResultCodes.VOLUME_NOT_FOUND);
+      }
+      throw new OMException(OMException.ResultCodes.BUCKET_NOT_FOUND);
+    }
+
+    // Generate all the components needed to build the ozoneKey.
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+    long bucketId = omBucketInfo.getObjectID();
+    long parentID = OMFileRequest.getParentID(bucketId, pathComponents,
+        keyName, omMetadataManager, errMsg);
+    String fileName = OzoneFSUtils.getFileName(keyName);
+
+    // Generate the DB key.
+    return omMetadataManager.getOzonePathKey(parentID, fileName);
+  }
+
+  /**
+   * Generates the DB key for querying the openFileTable.
+   * Key is of the format <parent ID>/<key name>/<client ID>
+   *
+   * @param volumeName   volume name
+   * @param bucketName   bucket name
+   * @param keyName      key name
+   * @param clientId     request client ID
+   * @param ozoneManager ozone manager instance
+   * @param errMsg       error message
+   * @return - DB key
+   * @throws IOException IOException
+   */
+  private String getOzoneOpenDBKey(String volumeName, String bucketName,
+                                   String keyName, long clientId,
+                                   OzoneManager ozoneManager, String errMsg)
+      throws IOException {
+    OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
+
+    // Get bucket info.
+    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    CacheValue<OmBucketInfo> value = omMetadataManager.getBucketTable()
+        .getCacheValue(new CacheKey<>(bucketKey));
+
+    OmBucketInfo omBucketInfo = value != null ? value.getCacheValue() :
+        omMetadataManager.getBucketTable().get(bucketKey);
+
+    // In case bucket or volume is not present, throw exception.
+    if (omBucketInfo == null) {
+      // Make sure we throw the correct Exception.
+      if (omMetadataManager.getVolumeTable()
+          .get(omMetadataManager.getVolumeKey(volumeName)) == null) {
+        throw new OMException(OMException.ResultCodes.VOLUME_NOT_FOUND);
+      }
+      throw new OMException(OMException.ResultCodes.BUCKET_NOT_FOUND);
+    }
+
+    // Generate all the components needed to build the ozoneKey.
+    Iterator<Path> pathComponents = Paths.get(keyName).iterator();
+    long bucketId = omBucketInfo.getObjectID();
+    long parentID = OMFileRequest.getParentID(bucketId, pathComponents,
+        keyName, omMetadataManager, errMsg);
+    String fileName = OzoneFSUtils.getFileName(keyName);
+
+    // Generate the key.
+    String openKey =
+        parentID + OM_KEY_PREFIX + fileName + OM_KEY_PREFIX + clientId;
+    return openKey;
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -149,10 +149,11 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           commitKeyRequest.getClientID());
 
       String dbOzoneKey =
-          omMetadataManager.getOzoneKey(volumeName, bucketName,
-              keyName);
-      String dbOpenKey = omMetadataManager.getOpenKey(volumeName, bucketName,
-          keyName, commitKeyRequest.getClientID());
+          getDbKeyPathGenerator().getOzoneDBKey(commitKeyArgs, ozoneManager,
+              "");
+      String dbOpenKey =
+          getDbKeyPathGenerator().getOzoneOpenDBKey(commitKeyArgs,
+              ozoneManager, commitKeyRequest.getClientID(), "");
 
       List<OmKeyLocationInfo> locationInfoList = new ArrayList<>();
       for (KeyLocation keyLocation : commitKeyArgs.getKeyLocationsList()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -122,13 +122,14 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       String fileName = OzoneFSUtils.getFileName(keyName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-      long bucketId = omBucketInfo.getObjectID();
-      long parentID = OMFileRequest.getParentID(bucketId, pathComponents,
-          keyName, omMetadataManager, "Cannot create file : " + keyName
-              + " as parent directory doesn't exist");
-      String dbFileKey = omMetadataManager.getOzonePathKey(parentID, fileName);
-      dbOpenFileKey = omMetadataManager.getOpenFileName(parentID, fileName,
-              commitKeyRequest.getClientID());
+      String dbFileKey =
+          getDbKeyPathGenerator().getOzoneDBKey(commitKeyArgs, ozoneManager,
+              "Cannot create file : " + keyName
+                  + " as parent directory doesn't exist");
+
+      dbOpenFileKey =
+          getDbKeyPathGenerator().getOzoneOpenDBKey(commitKeyArgs, ozoneManager,
+              commitKeyRequest.getClientID(), "");
 
       omKeyInfo = OMFileRequest.getOmKeyInfoFromFileTable(true,
               omMetadataManager, dbOpenFileKey, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -134,7 +134,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
           IAccessAuthorizer.ACLType.DELETE, OzoneObj.ResourceType.KEY);
 
       String objectKey =
-          omMetadataManager.getOzoneKey(volumeName, bucketName, keyName);
+          getDbKeyPathGenerator().getOzoneDBKey(keyArgs, ozoneManager, "");
 
       acquiredLock = omMetadataManager.getLock()
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -127,8 +127,8 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
-      String ozonePathKey =
-          getDbKeyPathGenerator().getOzoneDBKey(keyArgs, ozoneManager, "");
+      String ozonePathKey = omMetadataManager.getOzonePathKey(
+          omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());
 
       if (keyStatus.isDirectory()) {
         // Check if there are any sub path exists under the user requested path

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -127,8 +127,8 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
-      String ozonePathKey = omMetadataManager.getOzonePathKey(
-              omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());
+      String ozonePathKey =
+          getDbKeyPathGenerator().getOzoneDBKey(keyArgs, ozoneManager, "");
 
       if (keyStatus.isDirectory()) {
         // Check if there are any sub path exists under the user requested path


### PR DESCRIPTION
## What changes were proposed in this pull request?

[~HDDS-5835~](https://issues.apache.org/jira/browse/HDDS-5835) changed `OMMetadataManager#getKeyTable` to return a different table based on the bucket layout: `fileTable` for FSO buckets, `keyTable` otherwise. The problem is that these two tables have completely different sets of keys and key formats. It is not enough to change existing requests expecting to operate on the key table to now point to the file table if they are invoked on an FSO bucket, because they will query the table with the wrong key format.

This implementation is misleading for developers (you ask for a keyTable and might get a fileTable instead) and caused [HDDS-6414](https://issues.apache.org/jira/browse/HDDS-6414), while possibly masking other similar bugs for existing requests.

This patch introduces a new interface to define methods to build DB Keys to query entries inside the `keyTable` and `fileTable`. We introduce two implementations of this interface - one for FSO, and another for OBS/LEGACY.
This should reduce the effort on developer side to handle key generation logic while writing new Request classes or tests.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6426

## How was this patch tested?

Related unit tests
