### PR TITLE
HDDS-5648. Track CI workflow tests temporarily disabled for feature branch

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/docker-config
@@ -38,6 +38,7 @@ OZONE-SITE.XML_ozone.datanode.pipeline.limit=1
 OZONE-SITE.XML_hdds.scmclient.max.retry.timeout=30s
 OZONE-SITE.XML_ozone.scm.primordial.node.id=scm1
 OZONE-SITE.XML_hdds.container.report.interval=60s
+OZONE-SITE.XML_ozone.om.s3.grpc.server_enabled=true
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.address=recon:9891
 OZONE-SITE.XML_ozone.recon.http-address=0.0.0.0:9888

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh
@@ -32,7 +32,7 @@ start_docker_env
 
 execute_robot_test ${SCM} basic/ozone-shell-single.robot
 execute_robot_test ${SCM} basic/links.robot
-#execute_robot_test ${SCM} s3
+execute_robot_test ${SCM} s3
 execute_robot_test ${SCM} freon
 
 stop_docker_env


### PR DESCRIPTION
## What changes were proposed in this pull request?

To _**re-enable**_ an acceptance test that was disabled in the feature branch for incremental development and PR merges.  Test _**re-enabled**_ is to execute s3 acceptance tests in the `ozone-ha` cluster.  

During the development of the s3-performance Grpc feature branch, s3 acceptance tests for the development clusters were temporarily disabled and re-enabled when the feature supported them (HDDS-5648).  The tests were disabled by commenting out the acceptance test call in the test.sh execution script for the development clusters ie.  `hadoop-ozone/dist/src/main/compose/ozonesecure-ha/test.sh (#execute_robot_test ${SCM} s3).`  - see comments in HDDS-5648 for tests disabled then re-enabled as the feature branch supported the tests.

This PR re-enables the last disabled acceptance test for the s3-performance feature branch.  Specifically uncomments,
`#execute_robot_test ${SCM} s3` 
in `hadoop-ozone/dist/src/main/compose/ozone-ha/test.sh`.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-5648

## How was this patch tested?

Running acceptance tests for ozone-ha cluster without error.
ie. 
**set** in _hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-ha/docker-config_ : `OZONE-SITE.XML_ozone.om.transport.class=org.apache.hadoop.ozone.om.protocolPB.GrpcOmTransportFactory`

`$ hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone-ha/test.sh`
