### PR TITLE
HDDS-6447. Refine SCM handling of unhealthy container replicas

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReportHandler.java
@@ -203,8 +203,10 @@ public class ContainerReportHandler extends AbstractContainerReportHandler
   }
 
   /**
-   * Processes the ContainerReport, unknown container reported
-   * that will be deleted by SCM.
+   * Processes the ContainerReport.
+   * Any unknown container reported by DN and not present in SCM
+   * containerSet will either be logged as an error or deleted based on
+   * unknownContainerHandleAction.
    *
    * @param datanodeDetails Datanode from which this report was received
    * @param container ContainerInfo representing the container


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, containers are marked UNHEALTHY by Container Scrubber for one of the following reasons:

- If an operation fails on an open/ closing container, it is marked unhealthy so that subsequent write transactions also fail.

- If Container Scrubber is enabled and ContainerMetadataScanner detects an error during KeyValueContainerCheck#fastCheck().
  - Metadata path or Chunks path is not accessible as a directory
  - Container checksum verification fails
  - On-disk Container Yaml data does not match in-memory container data (ContainerType, ContainerID, Container DBType, Metadata Path)
- If Container Scrubber is enabled and ContainerDataScanner (runs only on closed and quasi-closed containers) detects any block with missing or corrupted chunks file.

If a container in “open” state in SCM is marked unhealthy (in the container report), SCM asks the DNs to close the container. But for a “closing” container with an “unhealthy” replica, SCM leaves the container replica as is.


Some of the issues with how unhealthy containers are handled:

1. If ReplicationManager does not find a healthy replica for a container, it does not replicate that container. So if there is only one replica of a container and it is unhealthy, SCM will never replicate it and there is potential for data loss if that single replica is lost for any reason (for example: disk failure).
2. If there is a Quasi-Closed replica and an Unhealthy container, SCM will delete the unhealthy container. SCM does not check if the unhealthy replica has higher bcsId. 
3. Let’s say there are 3 quasi-closed replicas of a closed container with all of them having bcsId < container bcsId (closed replica is lost and a quasi-closed replica is replicated). RelicationManager will delete one of these quesi-closed replicas (handleUnstableContainer) and then in the next cycle replicate it again as container would now be under-replicated (handleUnderreplicatedContainer). This will become a loop of replicating and deleting the container replica.

SCM should be more conservative with deleting unhealthy containers as they could possibly be recovered. This Jira proposes to 
1. Let SCM replicate an unhealthy container if there is no other healthy replicas. 
2. If all the replicas are unstable (either unhealthy or quasi-closed with lesser bcsId than container), then no replica should be deleted.
3. An unhealthy replica should be deleted only if it's bcsId is < than all quasi-closed and closed replicas bcsId.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6447

## How was this patch tested?
Add tests in TestReplicationManager