### PR TITLE
HDDS-6538. Update Spring to 5.2.20 to fix CVE-2022-22965 aka Spring4shell.

### DIFF
--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <spring.version>5.2.18.RELEASE</spring.version>
+    <spring.version>5.2.20</spring.version>
     <jooq.version>3.11.10</jooq.version>
   </properties>
   <modules>

--- a/hadoop-ozone/pom.xml
+++ b/hadoop-ozone/pom.xml
@@ -26,7 +26,7 @@
 
   <properties>
     <docker.image>apache/ozone:${project.version}</docker.image>
-    <spring.version>5.2.20</spring.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
     <jooq.version>3.11.10</jooq.version>
   </properties>
   <modules>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Update Spring to 5.2.20 to fix cve-2022-22965 aka Spring4shell.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6538
