### PR TITLE
HDDS-6209. EC: [Forward compatibility issue] New client to older server could fail due to the unavailability for client default replication config

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneManagerVersion.java
@@ -32,6 +32,8 @@ public enum OzoneManagerVersion implements ComponentVersion {
   DEFAULT_VERSION(0, "Initial version"),
   S3G_PERSISTENT_CONNECTIONS(1,
       "New S3G persistent connection support is present in OM."),
+  ERASURE_CODED_STORAGE_SUPPORT(2, "OzoneManager version that supports"
+      + "ECReplicationConfig"),
 
   FUTURE_VERSION(-1, "Used internally in the client when the server side is "
       + " newer and an unknown server version has arrived to the client.");

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/protocolPB/ScmBlockLocationProtocolClientSideTranslatorPB.java
@@ -172,6 +172,9 @@ public final class ScmBlockLocationProtocolClientSideTranslatorPB
           ((RatisReplicationConfig) replicationConfig).getReplicationFactor());
       break;
     case EC:
+      // We do not check for server support here, as this call is used only
+      // from OM which has the same software version as SCM.
+      // TODO: Rolling upgrade support needs to change this.
       requestBuilder.setEcReplicationConfig(
           ((ECReplicationConfig)replicationConfig).toProto());
       break;

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/pipeline/CreatePipelineSubcommand.java
@@ -55,7 +55,14 @@ public class CreatePipelineSubcommand extends ScmSubcommand {
 
   @Override
   public void execute(ScmClient scmClient) throws IOException {
-    if (type == HddsProtos.ReplicationType.CHAINED) {
+    // Once we support creating EC containers/pipelines from the client, the
+    // client should check if SCM is able to fulfil the request, and
+    // understands an EcReplicationConfig. For that we also need to have SCM's
+    // version here from ScmInfo response.
+    // As I see there is no way to specify ECReplicationConfig properly here
+    // so failing the request if type is EC, seems to be safe.
+    if (type == HddsProtos.ReplicationType.CHAINED
+        || type == HddsProtos.ReplicationType.EC) {
       throw new IllegalArgumentException(type.name()
           + " is not supported yet.");
     }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -570,7 +570,8 @@ public class RpcClient implements ClientProtocol {
     verifySpaceQuota(bucketArgs.getQuotaInBytes());
     if (omVersion
         .compareTo(OzoneManagerVersion.ERASURE_CODED_STORAGE_SUPPORT) < 0) {
-      if (bucketArgs.getDefaultReplicationConfig().getType()
+      if (bucketArgs.getDefaultReplicationConfig() != null &&
+          bucketArgs.getDefaultReplicationConfig().getType()
           == ReplicationType.EC) {
         throw new IOException("Can not set the default replication of the"
             + " bucket to Erasure Coded replication, as OzoneManager does"
@@ -933,8 +934,9 @@ public class RpcClient implements ClientProtocol {
     HddsClientUtils.checkNotNull(keyName);
     if (omVersion
         .compareTo(OzoneManagerVersion.ERASURE_CODED_STORAGE_SUPPORT) < 0) {
-      if (replicationConfig.getReplicationType()
-          == HddsProtos.ReplicationType.EC) {
+      if (replicationConfig != null &&
+          replicationConfig.getReplicationType()
+              == HddsProtos.ReplicationType.EC) {
         throw new IOException("Can not set the replication of the key to"
             + " Erasure Coded replication, as OzoneManager does not support"
             + " Erasure Coded replication.");

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -321,12 +321,15 @@ public class RpcClient implements ClientProtocol {
   private OzoneManagerVersion getOmVersion(ServiceInfoEx info) {
     OzoneManagerVersion version = OzoneManagerVersion.CURRENT;
     for (ServiceInfo si : info.getServiceInfoList()) {
-      OzoneManagerVersion current =
-          OzoneManagerVersion.fromProtoValue(si.getProtobuf().getOMVersion());
-      if (version.compareTo(current) > 0) {
-        version = current;
+      if (si.getNodeType() == HddsProtos.NodeType.OM) {
+        OzoneManagerVersion current =
+            OzoneManagerVersion.fromProtoValue(si.getProtobuf().getOMVersion());
+        if (version.compareTo(current) > 0) {
+          version = current;
+        }
       }
     }
+    LOG.trace("Ozone Manager version is {}", version.name());
     return version;
   }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/protocolPB/OzoneManagerProtocolClientSideTranslatorPB.java
@@ -221,7 +221,6 @@ public final class OzoneManagerProtocolClientSideTranslatorPB
    * @param cmdType type of the request
    */
   private OMRequest.Builder createOMRequest(Type cmdType) {
-
     return OMRequest.newBuilder()
         .setCmdType(cmdType)
         .setVersion(ClientVersion.CURRENT_VERSION)


### PR DESCRIPTION
## What changes were proposed in this pull request?

The change adds a new OzoneManagerVersion against which the clients can check whether the OM is supporting EC or not.
Added check for replication config arguments in the relevant requests/commands to ensure we do not send an ECReplicationFactor instance to a cluster that does not have support for it.
The affected mutations: CreateKey, CreateFile, CreateBucket, SetBucketProperty, InitiateMultipartUpload.
These 5 places are enough as later on the replication config supplied in those are used passed and used between the client and the server.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6209

## How was this patch tested?

Current CI should cover some of the new additions here, some tests may be adjusted as part of this PR later on, but posting this so that the additional production code can already be reviewed.
