### PR TITLE
HDDS-5119. Recon file count by size page has incorrect data when keys are deleted

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdateEvent.java
@@ -89,7 +89,7 @@ public final class OMDBUpdateEvent<KEY, VALUE> {
 
   @Override
   public int hashCode() {
-    return Objects.hash(updatedKey, action);
+    return Objects.hash(updatedKey, table, action);
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/OMDBUpdatesHandler.java
@@ -50,7 +50,7 @@ public class OMDBUpdatesHandler extends WriteBatch.Handler {
   private CodecRegistry codecRegistry;
   private OMMetadataManager omMetadataManager;
   private List<OMDBUpdateEvent> omdbUpdateEvents = new ArrayList<>();
-  private HashMap<String, OMDBUpdateEvent> omdbLatestUpdateEvents
+  private Map<String, OMDBUpdateEvent> omdbLatestUpdateEvents
       = new HashMap<>();
   private OMDBDefinition omdbDefinition;
 

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestOMDBUpdatesHandler.java
@@ -140,7 +140,8 @@ public class TestOMDBUpdatesHandler {
   public void testDelete() throws Exception {
     // Write 1 volume, 1 key into source and target OM DBs.
     String volumeKey = omMetadataManager.getVolumeKey("sampleVol");
-    String nonExistVolumeKey = omMetadataManager.getVolumeKey("nonExistingVolume");
+    String nonExistVolumeKey = omMetadataManager
+        .getVolumeKey("nonExistingVolume");
     OmVolumeArgs args =
         OmVolumeArgs.newBuilder()
             .setVolume("sampleVol")
@@ -163,7 +164,8 @@ public class TestOMDBUpdatesHandler {
     // Delete a non-existing volume and key
     omMetadataManager.getKeyTable(getBucketLayout())
         .delete("/sampleVol/bucketOne/key_two");
-    omMetadataManager.getVolumeTable().delete(omMetadataManager.getVolumeKey("nonExistingVolume"));
+    omMetadataManager.getVolumeTable()
+        .delete(omMetadataManager.getVolumeKey("nonExistingVolume"));
 
     List<byte[]> writeBatches = getBytesFromOmMetaManager(3);
     OMDBUpdatesHandler omdbUpdatesHandler = captureEvents(writeBatches);
@@ -243,13 +245,15 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdateEvent keyPutEvent = events.get(1);
     assertEquals(PUT, keyPutEvent.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyPutEvent.getKey());
-    assertEquals("key", ((OmKeyInfo)keyPutEvent.getValue()).getKeyName());
+    assertEquals("key",
+        ((OmKeyInfo)keyPutEvent.getValue()).getKeyName());
     assertNull(keyPutEvent.getOldValue());
 
     OMDBUpdateEvent keyUpdateEvent = events.get(2);
     assertEquals(UPDATE, keyUpdateEvent.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyUpdateEvent.getKey());
-    assertEquals("key_new", ((OmKeyInfo)keyUpdateEvent.getValue()).getKeyName());
+    assertEquals("key_new",
+        ((OmKeyInfo)keyUpdateEvent.getValue()).getKeyName());
     assertNotNull(keyUpdateEvent.getOldValue());
     assertEquals("key",
         ((OmKeyInfo)keyUpdateEvent.getOldValue()).getKeyName());
@@ -257,7 +261,8 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdateEvent keyUpdateEvent2 = events.get(3);
     assertEquals(UPDATE, keyUpdateEvent2.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyUpdateEvent2.getKey());
-    assertEquals("key_new2", ((OmKeyInfo)keyUpdateEvent2.getValue()).getKeyName());
+    assertEquals("key_new2",
+        ((OmKeyInfo)keyUpdateEvent2.getValue()).getKeyName());
     assertNotNull(keyUpdateEvent2.getOldValue());
     assertEquals("key_new",
         ((OmKeyInfo)keyUpdateEvent2.getOldValue()).getKeyName());
@@ -265,17 +270,20 @@ public class TestOMDBUpdatesHandler {
     OMDBUpdateEvent keyDeleteEvent = events.get(4);
     assertEquals(DELETE, keyDeleteEvent.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyDeleteEvent.getKey());
-    assertEquals("key_new2", ((OmKeyInfo)keyDeleteEvent.getValue()).getKeyName());
+    assertEquals("key_new2",
+        ((OmKeyInfo)keyDeleteEvent.getValue()).getKeyName());
 
     OMDBUpdateEvent keyDeleteEvent2 = events.get(5);
     assertEquals(DELETE, keyDeleteEvent2.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyDeleteEvent2.getKey());
-    assertEquals("key_new2", ((OmKeyInfo)keyDeleteEvent2.getValue()).getKeyName());
+    assertEquals("key_new2",
+        ((OmKeyInfo)keyDeleteEvent2.getValue()).getKeyName());
 
     OMDBUpdateEvent keyPut2 = events.get(6);
-    assertEquals(UPDATE, keyPut2.getAction());
+    assertEquals(PUT, keyPut2.getAction());
     assertEquals("/sampleVol/bucketOne/key", keyPut2.getKey());
-    assertEquals("key_new2", ((OmKeyInfo)keyPut2.getValue()).getKeyName());
+    assertEquals("key_new2",
+        ((OmKeyInfo)keyPut2.getValue()).getKeyName());
     assertNotNull(keyPut2.getOldValue());
     assertEquals("key_new2",
         ((OmKeyInfo)keyPut2.getOldValue()).getKeyName());
@@ -300,7 +308,8 @@ public class TestOMDBUpdatesHandler {
   }
 
   @NotNull
-  private List<byte[]> getBytesFromOmMetaManager(int getUpdatesSince) throws RocksDBException {
+  private List<byte[]> getBytesFromOmMetaManager(int getUpdatesSince)
+      throws RocksDBException {
     RDBStore rdbStore = (RDBStore) omMetadataManager.getStore();
     RocksDB rocksDB = rdbStore.getDb();
     // Get all updates from source DB
@@ -320,7 +329,8 @@ public class TestOMDBUpdatesHandler {
   }
 
   @NotNull
-  private OMDBUpdatesHandler captureEvents(List<byte[]> writeBatches) throws RocksDBException {
+  private OMDBUpdatesHandler captureEvents(List<byte[]> writeBatches)
+      throws RocksDBException {
     OMDBUpdatesHandler omdbUpdatesHandler =
         new OMDBUpdatesHandler(reconOmMetadataManager);
     for (byte[] data : writeBatches) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I fixed a bug in Recon. In the OMDBUpdatesHandler class when we process the events, if there were multiple actions on the same key the old value was not correct. The events are iterated upon before the actual Recon's OM copy DB is updated with these set of events. When we set the old value of the event's we set it from the DB, so after the second action the old value wasn't correct. 

I changed it to get the old value from this batch if there were a previous event with the key. I did some refactoring in the TestOMDBUpdatesHandler and added a test case when we operate on the same entry in the same batch. In the OMDBUpdateEvent class I added the table to the hash method, as it was missing from there.  

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-5119

## How was this patch tested?

Added integration tests.
