### PR TITLE
HDDS-6550. Change log level for exceptions in S3gateway

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -103,7 +103,7 @@ public class OzoneClientProducer {
           signatureInfo.getSignature(),
           awsAccessId);
     } catch (OS3Exception ex) {
-      LOG.error("Error during Client Creation: ", ex);
+      LOG.debug("Error during Client Creation: ", ex);
       throw wrapOS3Exception(ex);
     } catch (Exception e) {
       // For any other critical errors during object creation throw Internal

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/OzoneClientProducer.java
@@ -54,7 +54,8 @@ import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.INTERNAL_ERROR;
 @RequestScoped
 public class OzoneClientProducer {
 
-  private static final Logger LOG =
+  @VisibleForTesting
+  public static final Logger LOG =
       LoggerFactory.getLogger(OzoneClientProducer.class);
 
   private static OzoneClient client;
@@ -102,12 +103,12 @@ public class OzoneClientProducer {
           signatureInfo.getSignature(),
           awsAccessId);
     } catch (OS3Exception ex) {
-      LOG.debug("Error during Client Creation: ", ex);
+      LOG.error("Error during Client Creation: ", ex);
       throw wrapOS3Exception(ex);
     } catch (Exception e) {
       // For any other critical errors during object creation throw Internal
       // error.
-      LOG.debug("Error during Client Creation: ", e);
+      LOG.error("Error during Client Creation: ", e);
       throw wrapOS3Exception(S3ErrorTable.newError(INTERNAL_ERROR, null, e));
     }
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestOzoneClientProducer.java
@@ -43,6 +43,7 @@ import static org.apache.hadoop.ozone.s3.signature.StringToSignProducer.X_AMAZ_D
 import static org.apache.hadoop.ozone.s3.signature.StringToSignProducer.X_AMZ_CONTENT_SHA256;
 import static org.junit.Assert.fail;
 
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -199,6 +200,22 @@ public class TestOzoneClientProducer {
       // the service id check.
       Assert.assertFalse(ex.getMessage().contains(
           "More than 1 OzoneManager ServiceID"));
+    }
+  }
+
+  @Test
+  public void testLogLevelWithGetSignature() {
+    GenericTestUtils.LogCapturer
+        log = GenericTestUtils.LogCapturer.captureLogs(OzoneClientProducer.LOG);
+    try {
+      OzoneConfiguration configuration = new OzoneConfiguration();
+      producer.setOzoneConfiguration(configuration);
+      producer.getSignature();
+    } catch (Exception ex) {
+      Assert.assertTrue(
+          log.getOutput().contains("Error during Client Creation"));
+    } finally {
+      log.stopCapturing();
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a production cluster, the log level is usually not set to DEBUG, due to the log flushing.

In S3gateway, some exceptions are logged at DEBUG level, which causes the exception not being able to be shown at first place, we need to restart the service and reconfigure the log level, and after the fix the exception, we need to restart the service and set back the log level.

This ticket is to change the log level to ERROR instead of DEBUG to easily find the exception.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6550

## How was this patch tested?

uni test.
