### PR TITLE
HDDS-6436. Add write lock waiting and held time metrics

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/ActiveLock.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/ActiveLock.java
@@ -138,6 +138,27 @@ public final class ActiveLock {
   }
 
   /**
+   * Returns the number of reentrant write holds on this lock by the current
+   * thread.
+   *
+   * @return the number of holds on the write lock by the current thread,
+   *         or zero if the write lock is not held by the current thread
+   */
+  int getWriteHoldCount() {
+    return lock.getWriteHoldCount();
+  }
+
+  /**
+   * Queries if the write lock is held by the current thread.
+   *
+   * @return {@code true} if the current thread holds the write lock and
+   *         {@code false} otherwise
+   */
+  boolean isWriteLockedByCurrentThread() {
+    return lock.isWriteLockedByCurrentThread();
+  }
+
+  /**
    * Resets the active count on the lock.
    */
   void resetCounter() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
@@ -281,5 +281,4 @@ public class LockManager<R> {
     }
     return false;
   }
-
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/lock/LockManager.java
@@ -249,4 +249,37 @@ public class LockManager<R> {
     }
     return 0;
   }
+
+  /**
+   * Returns the number of reentrant write holds on this lock by the current
+   * thread on a given resource.
+   *
+   * @param resource for which the write lock hold count has to be returned
+   * @return the number of holds on the write lock by the current thread,
+   *         or zero if the write lock is not held by the current thread
+   */
+  public int getWriteHoldCount(final R resource) {
+    ActiveLock activeLock = activeLocks.get(resource);
+    if (activeLock != null) {
+      return activeLock.getWriteHoldCount();
+    }
+    return 0;
+  }
+
+  /**
+   * Queries if the write lock is held by the current thread on a given
+   * resource.
+   *
+   * @param resource for which the query has to be returned
+   * @return {@code true} if the current thread holds the write lock and
+   *         {@code false} otherwise
+   */
+  public boolean isWriteLockedByCurrentThread(final R resource) {
+    ActiveLock activeLock = activeLocks.get(resource);
+    if (activeLock != null) {
+      return activeLock.isWriteLockedByCurrentThread();
+    }
+    return false;
+  }
+
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/LockUsageInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/LockUsageInfo.java
@@ -22,23 +22,42 @@ package org.apache.hadoop.ozone.om.lock;
  */
 public class LockUsageInfo {
 
-  private long startHeldTimeNanos = -1;
+  private long startReadHeldTimeNanos = -1;
+  private long startWriteHeldTimeNanos = -1;
 
   /**
-   * Sets the time (ns) when the lock holding period begins.
+   * Sets the time (ns) when the read lock holding period begins.
    *
-   * @param startLockHeldTimeNanos lock held start time (ns)
+   * @param startReadLockHeldTimeNanos read lock held start time (ns)
    */
-  public void setStartHeldTimeNanos(long startLockHeldTimeNanos) {
-    this.startHeldTimeNanos = startLockHeldTimeNanos;
+  public void setStartReadHeldTimeNanos(long startReadLockHeldTimeNanos) {
+    this.startReadHeldTimeNanos = startReadLockHeldTimeNanos;
   }
 
   /**
-   * Returns the time (ns) when the lock holding period began.
+   * Sets the time (ns) when the write lock holding period begins.
    *
-   * @return lock held start time (ns)
+   * @param startWriteLockHeldTimeNanos write lock held start time (ns)
    */
-  public long getStartHeldTimeNanos() {
-    return startHeldTimeNanos;
+  public void setStartWriteHeldTimeNanos(long startWriteLockHeldTimeNanos) {
+    this.startWriteHeldTimeNanos = startWriteLockHeldTimeNanos;
+  }
+
+  /**
+   * Returns the time (ns) when the read lock holding period began.
+   *
+   * @return read lock held start time (ns)
+   */
+  public long getStartReadHeldTimeNanos() {
+    return startReadHeldTimeNanos;
+  }
+
+  /**
+   * Returns the time (ns) when the write lock holding period began.
+   *
+   * @return write lock held start time (ns)
+   */
+  public long getStartWriteHeldTimeNanos() {
+    return startWriteHeldTimeNanos;
   }
 };

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/LockUsageInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/LockUsageInfo.java
@@ -60,4 +60,4 @@ public class LockUsageInfo {
   public long getStartWriteHeldTimeNanos() {
     return startWriteHeldTimeNanos;
   }
-};
+}

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
@@ -40,14 +40,22 @@ public final class OMLockMetrics implements MetricsSource {
   private final MetricsRegistry registry;
   private final MutableStat readLockWaitingTimeMsStat;
   private final MutableStat readLockHeldTimeMsStat;
+  private final MutableStat writeLockWaitingTimeMsStat;
+  private final MutableStat writeLockHeldTimeMsStat;
 
   private OMLockMetrics() {
     registry = new MetricsRegistry(SOURCE_NAME);
-    readLockWaitingTimeMsStat = registry.newStat("ReadLockWaitTime",
-        "Time (in milliseconds) spent waiting for acquiring the lock",
+    readLockWaitingTimeMsStat = registry.newStat("ReadLockWaitingTime",
+        "Time (in milliseconds) spent waiting for acquiring the read lock",
         "Ops", "Time", true);
     readLockHeldTimeMsStat = registry.newStat("ReadLockHeldTime",
-        "Time (in milliseconds) spent holding the lock",
+        "Time (in milliseconds) spent holding the read lock",
+        "Ops", "Time", true);
+    writeLockWaitingTimeMsStat = registry.newStat("WriteLockWaitingTime",
+        "Time (in milliseconds) spent waiting for acquiring the write lock",
+        "Ops", "Time", true);
+    writeLockHeldTimeMsStat = registry.newStat("WriteLockHeldTime",
+        "Time (in milliseconds) spent holding the write lock",
         "Ops", "Time", true);
   }
 
@@ -86,6 +94,24 @@ public final class OMLockMetrics implements MetricsSource {
    */
   public void setReadLockHeldTimeMsStat(long readLockHeldTimeMs) {
     this.readLockHeldTimeMsStat.add(readLockHeldTimeMs);
+  }
+
+  /**
+   * Adds a snapshot to the metric writeLockWaitingTimeMsStat.
+   *
+   * @param writeLockWaitingTimeMs write lock waiting time (ms)
+   */
+  public void setWriteLockWaitingTimeMsStat(long writeLockWaitingTimeMs) {
+    this.writeLockWaitingTimeMsStat.add(writeLockWaitingTimeMs);
+  }
+
+  /**
+   * Adds a snapshot to the metric writeLockHeldTimeMsStat.
+   *
+   * @param writeLockHeldTimeMs write lock held time (ms)
+   */
+  public void setWriteLockHeldTimeMsStat(long writeLockHeldTimeMs) {
+    this.writeLockHeldTimeMsStat.add(writeLockHeldTimeMs);
   }
 
   /**
@@ -128,6 +154,48 @@ public final class OMLockMetrics implements MetricsSource {
    */
   public long getLongestReadLockHeldTimeMs() {
     return (long) readLockHeldTimeMsStat.lastStat().max();
+  }
+
+  /**
+   * Returns a string representation of the object. Provides information on the
+   * total number of samples, minimum value, maximum value, arithmetic mean,
+   * standard deviation of all the samples added.
+   *
+   * @return String representation of object
+   */
+  public String getWriteLockWaitingTimeMsStat() {
+    return writeLockWaitingTimeMsStat.toString();
+  }
+
+  /**
+   * Returns the longest time (ms) a write lock was waiting since the last
+   * measurement.
+   *
+   * @return longest write lock waiting time (ms)
+   */
+  public long getLongestWriteLockWaitingTimeMs() {
+    return (long) writeLockWaitingTimeMsStat.lastStat().max();
+  }
+
+  /**
+   * Returns a string representation of the object. Provides information on the
+   * total number of samples, minimum value, maximum value, arithmetic mean,
+   * standard deviation of all the samples added.
+   *
+   * @return String representation of object
+   */
+  public String getWriteLockHeldTimeMsStat() {
+    return writeLockHeldTimeMsStat.toString();
+  }
+
+  /**
+   * Returns the longest time (ms) a write lock was held since the last
+   * measurement.
+   *
+   * @return longest write lock held time (ms)
+   */
+  public long getLongestWriteLockHeldTimeMs() {
+    return (long) writeLockHeldTimeMsStat.lastStat().max();
   }
 
   @Override

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -654,7 +654,10 @@ public class OzoneManagerLock {
      * @return read lock held start time (ns)
      */
     long getStartReadHeldTimeNanos() {
-      return readLockTimeStampNanos.get().getStartReadHeldTimeNanos();
+      long startReadHeldTimeNanos =
+          readLockTimeStampNanos.get().getStartReadHeldTimeNanos();
+      readLockTimeStampNanos.remove();
+      return startReadHeldTimeNanos;
     }
 
     /**
@@ -664,7 +667,10 @@ public class OzoneManagerLock {
      * @return write lock held start time (ns)
      */
     long getStartWriteHeldTimeNanos() {
-      return writeLockTimeStampNanos.get().getStartWriteHeldTimeNanos();
+      long startWriteHeldTimeNanos =
+          writeLockTimeStampNanos.get().getStartWriteHeldTimeNanos();
+      writeLockTimeStampNanos.remove();
+      return startWriteHeldTimeNanos;
     }
 
     Resource(byte pos, String name) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -402,10 +402,10 @@ public class OzoneManagerLock {
 
   private void unlock(Resource resource, String resourceName,
       Consumer<String> lockFn, String lockType) {
+    boolean isWriteLocked = manager.isWriteLockedByCurrentThread(resourceName);
     // TODO: Not checking release of higher order level lock happened while
     // releasing lower order level lock, as for that we need counter for
     // locks, as some locks support acquiring lock again.
-    boolean isWriteLocked = manager.isWriteLockedByCurrentThread(resourceName);
     lockFn.accept(resourceName);
 
     /**

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -437,7 +437,7 @@ public class TestOzoneManagerLock {
       threads[i] = new Thread(() -> {
         lock.acquireReadLock(resource, resourceName);
         try {
-          Thread.sleep(1000);
+          Thread.sleep(500);
         } catch (InterruptedException e) {
           e.printStackTrace();
         }
@@ -474,7 +474,7 @@ public class TestOzoneManagerLock {
       threads[i] = new Thread(() -> {
         lock.acquireWriteLock(resource, resourceName);
         try {
-          Thread.sleep(500);
+          Thread.sleep(100);
         } catch (InterruptedException e) {
           e.printStackTrace();
         }
@@ -512,7 +512,7 @@ public class TestOzoneManagerLock {
       readThreads[i] = new Thread(() -> {
         lock.acquireReadLock(resource, resourceName);
         try {
-          Thread.sleep(1000);
+          Thread.sleep(500);
         } catch (InterruptedException e) {
           e.printStackTrace();
         }
@@ -525,7 +525,7 @@ public class TestOzoneManagerLock {
       writeThreads[i] = new Thread(() -> {
         lock.acquireWriteLock(resource, resourceName);
         try {
-          Thread.sleep(500);
+          Thread.sleep(100);
         } catch (InterruptedException e) {
           e.printStackTrace();
         }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -518,6 +518,7 @@ public class TestOzoneManagerLock {
         }
         lock.releaseReadLock(resource, resourceName);
       });
+      readThreads[i].setName("ReadLockThread-" + i);
       readThreads[i].start();
     }
 
@@ -531,6 +532,7 @@ public class TestOzoneManagerLock {
         }
         lock.releaseWriteLock(resource, resourceName);
       });
+      writeThreads[i].setName("WriteLockThread-" + i);
       writeThreads[i].start();
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To provide useful information by exposing write lock waiting, held time metrics to understand OzoneManagerLock timestamp

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6436

## How was this patch tested?

Added UTs
