### PR TITLE
HDDS-6553. Incorrect timeout when checking balancer iteration result.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -44,6 +44,10 @@ public final class ContainerBalancerMetrics {
       "in the latest iteration.")
   private MutableCounterLong numContainerMovesInLatestIteration;
 
+  @Metric(about = "Number of timeout container moves performed by " +
+      "Container Balancer in the latest iteration.")
+  private MutableCounterLong numTimeoutContainerMovesInLatestIteration;
+
   @Metric(about = "Number of iterations that Container Balancer has run for.")
   private MutableCounterLong numIterations;
 
@@ -60,6 +64,10 @@ public final class ContainerBalancerMetrics {
   @Metric(about = "Total number of container moves across all iterations of " +
       "Container Balancer.")
   private MutableCounterLong numContainerMoves;
+
+  @Metric(about = "Total number of timeout container moves across " +
+      "all iterations of Container Balancer.")
+  private MutableCounterLong numTimeoutContainerMoves;
 
   @Metric(about = "Total data size in GB moved across all iterations of " +
       "Container Balancer.")
@@ -115,6 +123,25 @@ public final class ContainerBalancerMetrics {
   public void resetNumContainerMovesInLatestIteration() {
     numContainerMovesInLatestIteration.incr(
         -getNumContainerMovesInLatestIteration());
+  }
+
+  /**
+   * Gets the number of timeout container moves performed by
+   * Container Balancer in the latest iteration.
+   * @return number of timeout container moves
+   */
+  public long getNumTimeoutContainerMovesInLatestIteration() {
+    return numTimeoutContainerMovesInLatestIteration.value();
+  }
+
+  public void incrementNumTimeoutContainerMovesInLatestIteration(
+      long valueToAdd) {
+    this.numTimeoutContainerMovesInLatestIteration.incr(valueToAdd);
+  }
+
+  public void resetNumTimeoutContainerMovesInLatestIteration() {
+    numTimeoutContainerMovesInLatestIteration.incr(
+        -getNumTimeoutContainerMovesInLatestIteration());
   }
 
   /**
@@ -185,6 +212,14 @@ public final class ContainerBalancerMetrics {
 
   public void incrementNumContainerMoves(long valueToAdd) {
     numContainerMoves.incr(valueToAdd);
+  }
+
+  public long getNumTimeoutContainerMoves() {
+    return numTimeoutContainerMoves.value();
+  }
+
+  public void incrementNumTimeoutContainerMoves(long valueToAdd) {
+    numTimeoutContainerMoves.incr(valueToAdd);
   }
 
   public long getDataSizeMovedGB() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -40,13 +40,13 @@ public final class ContainerBalancerMetrics {
       " in the latest iteration.")
   private MutableCounterLong dataSizeMovedGBInLatestIteration;
 
-  @Metric(about = "Number of container moves performed by Container Balancer " +
-      "in the latest iteration.")
-  private MutableCounterLong numContainerMovesInLatestIteration;
+  @Metric(about = "Number of completed container moves performed by " +
+      "Container Balancer in the latest iteration.")
+  private MutableCounterLong numContainerMovesCompletedInLatestIteration;
 
   @Metric(about = "Number of timeout container moves performed by " +
       "Container Balancer in the latest iteration.")
-  private MutableCounterLong numTimeoutContainerMovesInLatestIteration;
+  private MutableCounterLong numContainerMovesTimeoutInLatestIteration;
 
   @Metric(about = "Number of iterations that Container Balancer has run for.")
   private MutableCounterLong numIterations;
@@ -61,13 +61,13 @@ public final class ContainerBalancerMetrics {
   @Metric(about = "Number of unbalanced datanodes.")
   private MutableCounterLong numDatanodesUnbalanced;
 
-  @Metric(about = "Total number of container moves across all iterations of " +
-      "Container Balancer.")
-  private MutableCounterLong numContainerMoves;
+  @Metric(about = "Total number of completed container moves across all " +
+      "iterations of Container Balancer.")
+  private MutableCounterLong numContainerMovesCompleted;
 
   @Metric(about = "Total number of timeout container moves across " +
       "all iterations of Container Balancer.")
-  private MutableCounterLong numTimeoutContainerMoves;
+  private MutableCounterLong numContainerMovesTimeout;
 
   @Metric(about = "Total data size in GB moved across all iterations of " +
       "Container Balancer.")
@@ -112,17 +112,18 @@ public final class ContainerBalancerMetrics {
    * latest iteration.
    * @return number of container moves
    */
-  public long getNumContainerMovesInLatestIteration() {
-    return numContainerMovesInLatestIteration.value();
+  public long getNumContainerMovesCompletedInLatestIteration() {
+    return numContainerMovesCompletedInLatestIteration.value();
   }
 
-  public void incrementNumContainerMovesInLatestIteration(long valueToAdd) {
-    this.numContainerMovesInLatestIteration.incr(valueToAdd);
+  public void incrementNumContainerMovesCompletedInLatestIteration(
+      long valueToAdd) {
+    this.numContainerMovesCompletedInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetNumContainerMovesInLatestIteration() {
-    numContainerMovesInLatestIteration.incr(
-        -getNumContainerMovesInLatestIteration());
+  public void resetNumContainerMovesCompletedInLatestIteration() {
+    numContainerMovesCompletedInLatestIteration.incr(
+        -getNumContainerMovesCompletedInLatestIteration());
   }
 
   /**
@@ -130,18 +131,18 @@ public final class ContainerBalancerMetrics {
    * Container Balancer in the latest iteration.
    * @return number of timeout container moves
    */
-  public long getNumTimeoutContainerMovesInLatestIteration() {
-    return numTimeoutContainerMovesInLatestIteration.value();
+  public long getNumContainerMovesTimeoutInLatestIteration() {
+    return numContainerMovesTimeoutInLatestIteration.value();
   }
 
-  public void incrementNumTimeoutContainerMovesInLatestIteration(
+  public void incrementNumContainerMovesTimeoutInLatestIteration(
       long valueToAdd) {
-    this.numTimeoutContainerMovesInLatestIteration.incr(valueToAdd);
+    this.numContainerMovesTimeoutInLatestIteration.incr(valueToAdd);
   }
 
-  public void resetNumTimeoutContainerMovesInLatestIteration() {
-    numTimeoutContainerMovesInLatestIteration.incr(
-        -getNumTimeoutContainerMovesInLatestIteration());
+  public void resetNumContainerMovesTimeoutInLatestIteration() {
+    numContainerMovesTimeoutInLatestIteration.incr(
+        -getNumContainerMovesTimeoutInLatestIteration());
   }
 
   /**
@@ -206,20 +207,20 @@ public final class ContainerBalancerMetrics {
     numDatanodesUnbalanced.incr(-getNumDatanodesUnbalanced());
   }
 
-  public long getNumContainerMoves() {
-    return numContainerMoves.value();
+  public long getNumContainerMovesCompleted() {
+    return numContainerMovesCompleted.value();
   }
 
-  public void incrementNumContainerMoves(long valueToAdd) {
-    numContainerMoves.incr(valueToAdd);
+  public void incrementNumContainerMovesCompleted(long valueToAdd) {
+    numContainerMovesCompleted.incr(valueToAdd);
   }
 
-  public long getNumTimeoutContainerMoves() {
-    return numTimeoutContainerMoves.value();
+  public long getNumContainerMovesTimeout() {
+    return numContainerMovesTimeout.value();
   }
 
-  public void incrementNumTimeoutContainerMoves(long valueToAdd) {
-    numTimeoutContainerMoves.incr(valueToAdd);
+  public void incrementNumContainerMovesTimeout(long valueToAdd) {
+    numContainerMovesTimeout.incr(valueToAdd);
   }
 
   public long getDataSizeMovedGB() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -668,7 +668,10 @@ public class TestContainerBalancer {
     Assert.assertEquals(ContainerBalancer.IterationResult.ITERATION_COMPLETED,
         containerBalancer.getIterationResult());
     Assert.assertEquals(1,
-        containerBalancer.getMetrics().getNumContainerMovesInLatestIteration());
+        containerBalancer.getMetrics()
+            .getNumContainerMovesCompletedInLatestIteration());
+    Assert.assertTrue(containerBalancer.getMetrics()
+            .getNumContainerMovesTimeoutInLatestIteration() > 1);
     containerBalancer.stop();
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The scenario is as follows:

1. ContainerBalancer trying to move the following containers:
    1. container 1, took 20 minutes
    1. container 2, took 40 minutes
    1. container 3, took 60 minutes
2. When checking if a move finishes, the timeout is set to 30minutes.
3. When ContainerBalancer waited 20 minutes, it records container1 as finished.
4. Then Containerbalancer will wait another 30 minutes for container 2. Although container 2 took 40 minutes, ContainerBalancer will still record container 2 as a finished move.
5. The same issue happens when checking move result for container 3.

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6553

## How was this patch tested?

unit test.
