### PR TITLE
HDDS-6554. Have the datanode heartbeat include queued command counts

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -18,6 +18,7 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -29,6 +30,7 @@ import org.apache.hadoop.hdds.HddsUtils;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.datanode.metadata.DatanodeCRLStore;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
@@ -509,6 +511,35 @@ public class DatanodeStateMachine implements Closeable {
     if (cmdProcessThread != null) {
       cmdProcessThread.join();
     }
+  }
+
+  /**
+   * Returns a summary of the commands queued in the datanode. Commands are
+   * queued in two places. In the CommandQueue inside the StateContext object.
+   * A single thread picks commands from there and hands the command to the
+   * CommandDispatcher. This finds the handler for the command based on its
+   * command type and either executes the command immediately in the current
+   * (single) thread, or queues it in the handler where a thread pool executor
+   * will process it. The total commands queued in the datanode is therefore
+   * the sum those in the CommandQueue and the dispatcher queues.
+   * @return A map containing a count for each known command.
+   */
+  public Map<SCMCommandProto.Type, Integer> getQueuedCommandCount() {
+    // This is a "sparse map" - there is not guaranteed to be an entry for
+    // every command type
+    Map<SCMCommandProto.Type, Integer> commandQSummary =
+        context.getCommandQueueSummary();
+    // This map will contain an entry for every command type which is registered
+    // with the dispatcher, and that should be all command types the DN knows
+    // about. Any commands with nothing in the queue will return a count of
+    // zero.
+    Map<SCMCommandProto.Type, Integer> dispatcherQSummary =
+        commandDispatcher.getQueuedCommandCount();
+    // Merge the "sparse" map into the fully populated one returning a count
+    // for all known command types.
+    commandQSummary.forEach((k, v)
+        -> dispatcherQSummary.merge(k, v, Integer::sum));
+    return dispatcherQSummary;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/StateContext.java
@@ -784,6 +784,19 @@ public class StateContext {
     this.addCmdStatus(command);
   }
 
+  public Map<SCMCommandProto.Type, Integer> getCommandQueueSummary() {
+    Map<SCMCommandProto.Type, Integer> summary = new HashMap<>();
+    lock.lock();
+    try {
+      for (SCMCommand cmd : commandQueue) {
+        summary.put(cmd.getType(), summary.getOrDefault(cmd.getType(), 0) + 1);
+      }
+    } finally {
+      lock.unlock();
+    }
+    return summary;
+  }
+
   /**
    * Returns the count of the Execution.
    * @return long

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -110,6 +110,22 @@ public final class CommandDispatcher {
     }
   }
 
+  /**
+   * For each registered handler, call its getQueuedCount method to retrieve the
+   * number of queued commands. Any handlers which do not implement an internal
+   * queue will have a count of 0 from the default interface implementation.
+   * The returned map will contain an entry for every registered command in the
+   * dispatcher, with a value of zero if there are no queued commands.
+   * @return A Map of CommandType where the value is the queued command count.
+   */
+  public Map<Type, Integer> getQueuedCommandCount() {
+    Map<Type, Integer> counts = new HashMap<>();
+    for (Map.Entry<Type, CommandHandler> entry : handlerMap.entrySet()) {
+      counts.put(entry.getKey(), entry.getValue().getQueuedCount());
+    }
+    return counts;
+  }
+
   public static Builder newBuilder() {
     return new Builder();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
@@ -80,4 +80,14 @@ public interface CommandHandler {
   default void stop() {
     // Default implementation does nothing
   }
+
+  /**
+   * Returns the queued command count for this handler. Some handlers do not
+   * have an internal queue and hence commands are executed immediately. For
+   * those, the default implementation will return 0.
+   * @return The number of queued commands inside this handler.
+   */
+  default int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteBlocksCommandHandler.java
@@ -125,6 +125,17 @@ public class DeleteBlocksCommandHandler implements CommandHandler {
   }
 
   /**
+   * The count returned here, is the count of queued SCM delete block commands.
+   * We get at most one such command per heartbeat, but the command can contain
+   * many blocks to delete.
+   * @return The number of SCM delete block commands pending in the queue.
+   */
+  @Override
+  public int getQueuedCount() {
+    return deleteCommandQueues.size();
+  }
+
+  /**
    * A delete command info.
    */
   public static final class DeleteCmdInfo {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/DeleteContainerCommandHandler.java
@@ -83,6 +83,11 @@ public class DeleteContainerCommandHandler implements CommandHandler {
   }
 
   @Override
+  public int getQueuedCount() {
+    return ((ThreadPoolExecutor)executor).getQueue().size();
+  }
+
+  @Override
   public SCMCommandProto.Type getCommandType() {
     return SCMCommandProto.Type.deleteContainerCommand;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -75,6 +75,11 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
   }
 
   @Override
+  public int getQueuedCount() {
+    return supervisor.getInFlightReplications();
+  }
+
+  @Override
   public SCMCommandProto.Type getCommandType() {
     return Type.replicateContainerCommand;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -24,7 +24,7 @@ import com.google.protobuf.GeneratedMessage;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -277,15 +277,14 @@ public class HeartbeatEndpointTask
       SCMHeartbeatRequestProto.Builder requestBuilder) {
     Map<SCMCommandProto.Type, Integer> commandCount =
         context.getParent().getQueuedCommandCount();
+    CommandQueueReportProto.Builder reportProto =
+        CommandQueueReportProto.newBuilder();
     for (Map.Entry<SCMCommandProto.Type, Integer> entry
         : commandCount.entrySet()) {
-      requestBuilder.addQueuedCommandCount(
-          StorageContainerDatanodeProtocolProtos.CommandQueueReportProto
-              .newBuilder()
-              .setCommand(entry.getKey())
-              .setCount(entry.getValue())
-              .build());
+      reportProto.addCommand(entry.getKey())
+          .addCount(entry.getValue());
     }
+    requestBuilder.setQueuedCommandReport(reportProto.build());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -24,6 +24,7 @@ import com.google.protobuf.GeneratedMessage;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -65,6 +66,7 @@ import java.io.IOException;
 import java.time.ZonedDateTime;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys
@@ -172,6 +174,7 @@ public class HeartbeatEndpointTask
       addReports(requestBuilder);
       addContainerActions(requestBuilder);
       addPipelineActions(requestBuilder);
+      addQueuedCommandCounts(requestBuilder);
       SCMHeartbeatRequestProto request = requestBuilder.build();
       if (LOG.isDebugEnabled()) {
         LOG.debug("Sending heartbeat message :: {}", request.toString());
@@ -263,6 +266,25 @@ public class HeartbeatEndpointTask
           .addAllPipelineActions(actions)
           .build();
       requestBuilder.setPipelineActions(pap);
+    }
+  }
+
+  /**
+   * Adds the count of all queued commands to the heartbeat.
+   * @param requestBuilder Builder to which the details will be added.
+   */
+  private void addQueuedCommandCounts(
+      SCMHeartbeatRequestProto.Builder requestBuilder) {
+    Map<SCMCommandProto.Type, Integer> commandCount =
+        context.getParent().getQueuedCommandCount();
+    for (Map.Entry<SCMCommandProto.Type, Integer> entry
+        : commandCount.entrySet()) {
+      requestBuilder.addQueuedCommandCount(
+          StorageContainerDatanodeProtocolProtos.CommandQueueReportProto
+              .newBuilder()
+              .setCommand(entry.getKey())
+              .setCount(entry.getValue())
+              .build());
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisor.java
@@ -128,7 +128,7 @@ public class ReplicationSupervisor {
    *
    * @return Count of in-flight replications.
    */
-  int getInFlightReplications() {
+  public int getInFlightReplications() {
     return containersInFlight.size();
   }
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -21,11 +21,16 @@ package org.apache.hadoop.ozone.container.common.states.endpoint;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
 import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerAction;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReportsProto;
@@ -209,8 +214,19 @@ public class TestHeartbeatEndpointTask {
   @Test
   public void testheartbeatWithAllReports() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
+    DatanodeStateMachine datanodeStateMachine =
+        Mockito.mock(DatanodeStateMachine.class);
     StateContext context = new StateContext(conf, DatanodeStates.RUNNING,
-        Mockito.mock(DatanodeStateMachine.class));
+        datanodeStateMachine);
+
+    // Return a Map of command counts when the heartbeat logic requests it
+    final Map<SCMCommandProto.Type, Integer> commands = new HashMap<>();
+    int count = 1;
+    for (SCMCommandProto.Type cmd : SCMCommandProto.Type.values()) {
+      commands.put(cmd, count++);
+    }
+    Mockito.when(datanodeStateMachine.getQueuedCommandCount())
+        .thenReturn(commands);
 
     StorageContainerDatanodeProtocolClientSideTranslatorPB scm =
         Mockito.mock(
@@ -240,6 +256,13 @@ public class TestHeartbeatEndpointTask {
     Assert.assertTrue(heartbeat.hasContainerReport());
     Assert.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
     Assert.assertTrue(heartbeat.hasContainerActions());
+    Assert.assertEquals(heartbeat.getQueuedCommandCountCount(),
+        commands.size());
+    for (CommandQueueReportProto proto :
+        heartbeat.getQueuedCommandCountList()) {
+      Assert.assertEquals(commands.get(proto.getCommand()).intValue(),
+          proto.getCount());
+    }
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -256,12 +256,13 @@ public class TestHeartbeatEndpointTask {
     Assert.assertTrue(heartbeat.hasContainerReport());
     Assert.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
     Assert.assertTrue(heartbeat.hasContainerActions());
-    Assert.assertEquals(heartbeat.getQueuedCommandCountCount(),
-        commands.size());
-    for (CommandQueueReportProto proto :
-        heartbeat.getQueuedCommandCountList()) {
-      Assert.assertEquals(commands.get(proto.getCommand()).intValue(),
-          proto.getCount());
+    Assert.assertTrue(heartbeat.hasQueuedCommandReport());
+    CommandQueueReportProto queueCount = heartbeat.getQueuedCommandReport();
+    Assert.assertEquals(queueCount.getCommandCount(), commands.size());
+    Assert.assertEquals(queueCount.getCountCount(), commands.size());
+    for (int i = 0; i < commands.size(); i++) {
+      Assert.assertEquals(commands.get(queueCount.getCommand(i)).intValue(),
+          queueCount.getCount(i));
     }
   }
 

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -138,12 +138,12 @@ message SCMHeartbeatRequestProto {
   optional PipelineActionsProto pipelineActions = 7;
   optional PipelineReportsProto pipelineReports = 8;
   optional LayoutVersionProto dataNodeLayoutVersion = 9;
-  repeated CommandQueueReportProto queuedCommandCount = 10;
+  optional CommandQueueReportProto queuedCommandReport = 10;
 }
 
 message CommandQueueReportProto {
-  required SCMCommandProto.Type command = 1;
-  required uint32 count = 2;
+  repeated SCMCommandProto.Type command = 1;
+  repeated uint32 count = 2;
 }
 
 /*

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -138,6 +138,12 @@ message SCMHeartbeatRequestProto {
   optional PipelineActionsProto pipelineActions = 7;
   optional PipelineReportsProto pipelineReports = 8;
   optional LayoutVersionProto dataNodeLayoutVersion = 9;
+  repeated CommandQueueReportProto queuedCommandCount = 10;
+}
+
+message CommandQueueReportProto {
+  required SCMCommandProto.Type command = 1;
+  required uint32 count = 2;
 }
 
 /*


### PR DESCRIPTION
## What changes were proposed in this pull request?

To allow SCM to make better decisions about scheduling commands on datanodes, the datanodes should report their current command queue size in the heartbeat. This change adds a section to the heartbeat protobuf message to allow the queued command count for each command type to be reported in each heartbeat.

There will be a count reported for each registered command, with a zero count if the queue is empty.

A follow up change will be needed to use this information on SCM. With this Jira in place, the data will be sent but never used on SCM.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6554

## How was this patch tested?

Some new unit tests and existing tests
