### PR TITLE
HDDS-6557. Execute S3 acceptance tests with EC

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -39,7 +39,7 @@ execute_robot_test scm gdpr
 
 execute_robot_test scm security/ozone-secure-token.robot
 
-for bucket in link generated; do
+for bucket in erasure link generated; do
   execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket} s3
 done
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -105,6 +105,7 @@ Setup s3 tests
                        Set Suite Variable                        ${BUCKET}
                        Run Keyword if                            '${BUCKET}' == 'link'                 Setup links for S3 tests
                        Run Keyword if                            '${BUCKET}' == 'encrypted'            Create encrypted bucket
+                       Run Keyword if                            '${BUCKET}' == 'erasure'              Create EC bucket
 
 Setup links for S3 tests
     ${exists} =        Bucket Exists    o3://${OM_SERVICE_ID}/s3v/link
@@ -123,6 +124,11 @@ Create link
     [arguments]       ${bucket}
     Execute           ozone sh bucket link o3://${OM_SERVICE_ID}/legacy/source-bucket o3://${OM_SERVICE_ID}/s3v/${bucket}
     [return]          ${bucket}
+
+Create EC bucket
+    ${exists} =        Bucket Exists    o3://${OM_SERVICE_ID}/s3v/erasure
+    Return From Keyword If    ${exists}
+    Execute            ozone sh bucket create --replication rs-3-2-1024k --type EC o3://${OM_SERVICE_ID}/s3v/erasure
 
 Generate random prefix
     ${random} =          Generate Ozone String


### PR DESCRIPTION
## What changes were proposed in this pull request?

Create EC bucket and run S3 acceptance tests with it.

https://issues.apache.org/jira/browse/HDDS-6557

## How was this patch tested?

Executed the new test locally, verified keys are stored as EC.

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone
$ KEEP_RUNNING=true ./test.sh
...
s3-erasure                                                            | PASS |
46 tests, 46 passed, 0 failed
...

$ docker-compose exec scm ozone sh key list /s3v/erasure
...
}, {
  "volumeName" : "s3v",
  "bucketName" : "erasure",
  "name" : "ozone-test-5212328738/multipartKey1",
  "dataSize" : 5242886,
  "replicationConfig" : {
    "data" : 3,
    "parity" : 2,
    "ecChunkSize" : 1048576,
    "codec" : "RS",
    "requiredNodes" : 5,
    "replicationType" : "EC"
  }
}, {
...
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/5857406173#step:5:305