### PR TITLE
HDDS-6540. [Merge rocksdb in datanode] Add a Cache for per-disk DB handles.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Cache for all per-disk DB handles under schema v3.
+ */
+public final class DatanodeStoreCache {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(DatanodeStoreCache.class);
+
+  /**
+   * Use container db absolute path as key.
+   */
+  private final Map<String, RawDB> datanodeStoreMap;
+
+  private static DatanodeStoreCache cache;
+
+  private DatanodeStoreCache() {
+    datanodeStoreMap = new ConcurrentHashMap<>();
+  }
+
+  public static synchronized DatanodeStoreCache getInstance() {
+    if (cache == null) {
+      cache = new DatanodeStoreCache();
+    }
+    return cache;
+  }
+
+  public void addDB(String containerDBPath, RawDB db) {
+    datanodeStoreMap.putIfAbsent(containerDBPath, db);
+  }
+
+  public RawDB getDB(String containerDBPath) {
+    return datanodeStoreMap.get(containerDBPath);
+  }
+
+  public void removeDB(String containerDBPath) {
+    datanodeStoreMap.remove(containerDBPath);
+  }
+
+  public void shutdownCache() {
+    for (Map.Entry<String, RawDB> entry : datanodeStoreMap.entrySet()) {
+      try {
+        entry.getValue().getStore().stop();
+      } catch (Exception e) {
+        LOG.warn("Stop DatanodeStore: {} failed", entry.getKey(), e);
+      }
+    }
+    datanodeStoreMap.clear();
+  }
+
+  public int size() {
+    return datanodeStoreMap.size();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -177,6 +177,8 @@ public class KeyValueHandler extends Handler {
 
   @Override
   public void stop() {
+    chunkManager.shutdown();
+    blockManager.shutdown();
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/KeyValueContainerUtil.java
@@ -115,7 +115,7 @@ public final class KeyValueContainerUtil {
     }
 
     //add db handler into cache
-    BlockUtils.addDB(store, dbFile.getAbsolutePath(), conf);
+    BlockUtils.addDB(store, dbFile.getAbsolutePath(), conf, schemaVersion);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/BlockManagerImpl.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.interfaces.Container;
 import org.apache.hadoop.ozone.container.common.interfaces.DBHandle;
-import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainer;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.keyvalue.helpers.BlockUtils;
@@ -348,7 +347,7 @@ public class BlockManagerImpl implements BlockManager {
    */
   @Override
   public void shutdown() {
-    BlockUtils.shutdownCache(ContainerCache.getInstance(config));
+    BlockUtils.shutdownCache(config);
   }
 
   private BlockData getBlockByID(DBHandle db, BlockID blockID,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestDatanodeStoreCache.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
+import org.apache.hadoop.ozone.container.common.utils.RawDB;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStore;
+import org.apache.hadoop.ozone.container.metadata.DatanodeStoreSchemaThreeImpl;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+
+/**
+ * Test DatanodeStoreCache.
+ */
+public class TestDatanodeStoreCache {
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private OzoneConfiguration conf = new OzoneConfiguration();
+
+  @Test
+  public void testBasicOperations() throws IOException {
+    DatanodeStoreCache cache = DatanodeStoreCache.getInstance();
+    String dbPath1 = folder.newFolder("basic1").getAbsolutePath();
+    String dbPath2 = folder.newFolder("basic2").getAbsolutePath();
+    DatanodeStore store1 = new DatanodeStoreSchemaThreeImpl(conf, dbPath1,
+        false);
+    DatanodeStore store2 = new DatanodeStoreSchemaThreeImpl(conf, dbPath2,
+        false);
+
+    // test normal add
+    cache.addDB(dbPath1, new RawDB(store1, dbPath1));
+    cache.addDB(dbPath2, new RawDB(store2, dbPath2));
+    Assert.assertEquals(2, cache.size());
+
+    // test duplicate add
+    cache.addDB(dbPath1, new RawDB(store1, dbPath1));
+    Assert.assertEquals(2, cache.size());
+
+    // test get, test reference the same object using ==
+    Assert.assertTrue(store1 == cache.getDB(dbPath1).getStore());
+
+    // test remove
+    cache.removeDB(dbPath1);
+    Assert.assertEquals(1, cache.size());
+
+    // test remove non-exist
+    try {
+      cache.removeDB(dbPath1);
+    } catch (Exception e) {
+      Assert.fail("Should not throw " + e);
+    }
+
+    // test shutdown
+    cache.shutdownCache();
+    Assert.assertEquals(0, cache.size());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

A new Cache for per-disk db handles after rocksdb-merge.
Originally we have the ContainerCache for per-container db handles.
And we should have a new DatanodeStoreCache for per-disk db handles which should be relatively small.
 
We could choose whether to use the  DatanodeStoreCache or the ContainerCache according to the schema version in BlockUtils.getDB().

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6540

## How was this patch tested?

A new UT.
