### PR TITLE
HDDS-6556. Check quota while allocate and update usedBytes when commit.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -291,10 +291,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
           bucketName, Optional.absent(), Optional.of(missingParentInfos),
           trxnLogIndex);
 
-      omBucketInfo.incrUsedBytes(preAllocatedSpace);
-      // Update namespace quota
-      omBucketInfo.incrUsedNamespace(1L);
-
       numMissingParents = missingParentInfos.size();
       // Prepare response
       omResponse.setCreateFileResponse(CreateFileResponse.newBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -210,10 +210,6 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
               Optional.absent(), Optional.of(missingParentInfos),
               trxnLogIndex);
 
-      omBucketInfo.incrUsedBytes(preAllocatedSpace);
-      // Update namespace quota
-      omBucketInfo.incrUsedNamespace(1L);
-
       // Prepare response. Sets user given full key name in the 'keyName'
       // attribute in response object.
       int clientVersion = getOmRequest().getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -28,6 +28,7 @@ import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
 import org.apache.hadoop.ozone.om.request.validation.RequestFeatureValidator;
@@ -211,15 +212,16 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
           volumeName, bucketName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
       // check bucket and volume quota
-      long preAllocatedSpace = newLocationList.size()
-          * ozoneManager.getScmBlockSize()
-          * openKeyInfo.getReplicationConfig().getRequiredNodes();
-      long hadAllocatedSpace =
+      long preAllocatedKeySize = newLocationList.size()
+          * ozoneManager.getScmBlockSize();
+      long hadAllocatedKeySize =
           openKeyInfo.getLatestVersionLocations().getLocationList().size()
-              * ozoneManager.getScmBlockSize()
-              * openKeyInfo.getReplicationConfig().getRequiredNodes();
-      checkBucketQuotaInBytes(omBucketInfo,
-          hadAllocatedSpace + preAllocatedSpace);
+              * ozoneManager.getScmBlockSize();
+      ReplicationConfig repConfig = openKeyInfo.getReplicationConfig();
+      long totalAllocatedSpace = QuotaUtil.getReplicatedSize(
+          preAllocatedKeySize, repConfig) + QuotaUtil.getReplicatedSize(
+          hadAllocatedKeySize, repConfig);
+      checkBucketQuotaInBytes(omBucketInfo, totalAllocatedSpace);
       // Append new block
       openKeyInfo.appendNewBlocks(newLocationList, false);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -144,7 +144,12 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
       long preAllocatedSpace = newLocationList.size()
               * ozoneManager.getScmBlockSize()
               * openKeyInfo.getReplicationConfig().getRequiredNodes();
-      checkBucketQuotaInBytes(omBucketInfo, preAllocatedSpace);
+      long hadAllocatedSpace =
+          openKeyInfo.getLatestVersionLocations().getLocationList().size()
+              * ozoneManager.getScmBlockSize()
+              * openKeyInfo.getReplicationConfig().getRequiredNodes();
+      checkBucketQuotaInBytes(omBucketInfo,
+          hadAllocatedSpace + preAllocatedSpace);
       // Append new block
       openKeyInfo.appendNewBlocks(newLocationList, false);
 
@@ -157,7 +162,6 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
       // Add to cache.
       addOpenTableCacheEntry(trxnLogIndex, omMetadataManager, openKeyName,
               openKeyInfo);
-      omBucketInfo.incrUsedBytes(preAllocatedSpace);
 
       omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
               .setKeyLocation(blockLocation).build());
@@ -223,6 +227,6 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
       OMResponse.Builder omResponse, OmKeyInfo openKeyInfo,
       OmBucketInfo omBucketInfo) {
     return new OMAllocateBlockResponseWithFSO(omResponse.build(), openKeyInfo,
-            clientID, omBucketInfo, getBucketLayout());
+            clientID, getBucketLayout());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.om.request.key;
 
 import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.audit.AuditLogger;
 import org.apache.hadoop.ozone.audit.OMAction;
@@ -31,6 +32,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.helpers.OzoneFSUtils;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.QuotaUtil;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -141,15 +143,16 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
               volumeName, bucketName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
       // check bucket and volume quota
-      long preAllocatedSpace = newLocationList.size()
-              * ozoneManager.getScmBlockSize()
-              * openKeyInfo.getReplicationConfig().getRequiredNodes();
-      long hadAllocatedSpace =
+      long preAllocatedKeySize = newLocationList.size()
+          * ozoneManager.getScmBlockSize();
+      long hadAllocatedKeySize =
           openKeyInfo.getLatestVersionLocations().getLocationList().size()
-              * ozoneManager.getScmBlockSize()
-              * openKeyInfo.getReplicationConfig().getRequiredNodes();
-      checkBucketQuotaInBytes(omBucketInfo,
-          hadAllocatedSpace + preAllocatedSpace);
+              * ozoneManager.getScmBlockSize();
+      ReplicationConfig repConfig = openKeyInfo.getReplicationConfig();
+      long totalAllocatedSpace = QuotaUtil.getReplicatedSize(
+          preAllocatedKeySize, repConfig) + QuotaUtil.getReplicatedSize(
+          hadAllocatedKeySize, repConfig);
+      checkBucketQuotaInBytes(omBucketInfo, totalAllocatedSpace);
       // Append new block
       openKeyInfo.appendNewBlocks(newLocationList, false);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -216,21 +216,20 @@ public class OMKeyCommitRequest extends OMKeyRequest {
             "entry is not found in the OpenKey table", KEY_NOT_FOUND);
       }
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-      long correctedSpace = omKeyInfo.getReplicatedSize();
-      // Subtract the size of blocks to be overwritten.
-      if (keyToDelete != null) {
-        correctedSpace -= keyToDelete.getDataSize() *
-            keyToDelete.getReplicationConfig().getRequiredNodes();
-      }
-      checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
-      checkBucketQuotaInNamespace(omBucketInfo, 1L);
-
       omKeyInfo.setDataSize(commitKeyArgs.getDataSize());
       omKeyInfo.setModificationTime(commitKeyArgs.getModificationTime());
       // Update the block length for each block
       omKeyInfo.updateLocationInfoList(locationInfoList, false);
       // Set the UpdateID to current transactionLogIndex
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
+
+      long correctedSpace = omKeyInfo.getReplicatedSize();
+      // Subtract the size of blocks to be overwritten.
+      if (keyToDelete != null) {
+        correctedSpace -= keyToDelete.getReplicatedSize();
+      }
+      checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
+      checkBucketQuotaInNamespace(omBucketInfo, 1L);
 
       // Add to cache of open key table and key table.
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -227,9 +227,11 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       // Subtract the size of blocks to be overwritten.
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getReplicatedSize();
+      } else {
+        // if keyToDelete isn't null, usedNamespace shouldn't increase.
+        checkBucketQuotaInNamespace(omBucketInfo, 1L);
       }
       checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
-      checkBucketQuotaInNamespace(omBucketInfo, 1L);
 
       // Add to cache of open key table and key table.
       omMetadataManager.getOpenKeyTable(getBucketLayout()).addCacheEntry(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -228,8 +228,10 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getReplicatedSize();
       } else {
-        // if keyToDelete isn't null, usedNamespace shouldn't increase.
+        // if keyToDelete isn't null, usedNamespace needn't check and
+        // increase.
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
+        omBucketInfo.incrUsedNamespace(1L);
       }
       checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
 
@@ -248,7 +250,6 @@ public class OMKeyCommitRequest extends OMKeyRequest {
       }
 
       omBucketInfo.incrUsedBytes(correctedSpace);
-      omBucketInfo.incrUsedNamespace(1L);
 
       omClientResponse = new OMKeyCommitResponse(omResponse.build(),
           omKeyInfo, dbOzoneKey, dbOpenKey, omBucketInfo.copyObject(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -161,6 +161,14 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
             trxnLogIndex, ozoneManager.isRatisEnabled());
       }
 
+      long correctedSpace = omKeyInfo.getReplicatedSize();
+      // Subtract the size of blocks to be overwritten.
+      if (keyToDelete != null) {
+        correctedSpace -= keyToDelete.getReplicatedSize();
+      }
+      checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
+      checkBucketQuotaInNamespace(omBucketInfo, 1L);
+
       // Add to cache of open key table and key table.
       OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager, dbFileKey,
               null, fileName, trxnLogIndex);
@@ -172,13 +180,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbFileKey,
                 oldKeyVersionsToDelete, trxnLogIndex);
       }
-      
-      int factor = omKeyInfo.getReplicationConfig().getRequiredNodes();
-      long correctedSpace = omKeyInfo.getReplicatedSize() * factor;
-      // Subtract the size of blocks to be overwritten.
-      if (keyToDelete != null) {
-        correctedSpace -= keyToDelete.getReplicatedSize();
-      }
+
       omBucketInfo.incrUsedBytes(correctedSpace);
       omBucketInfo.incrUsedNamespace(1L);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -172,20 +172,15 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
         OMFileRequest.addDeletedTableCacheEntry(omMetadataManager, dbFileKey,
                 oldKeyVersionsToDelete, trxnLogIndex);
       }
-
-      long scmBlockSize = ozoneManager.getScmBlockSize();
+      
       int factor = omKeyInfo.getReplicationConfig().getRequiredNodes();
-      // Block was pre-requested and UsedBytes updated when createKey and
-      // AllocatedBlock. The space occupied by the Key shall be based on
-      // the actual Key size, and the total Block size applied before should
-      // be subtracted.
-      long correctedSpace = omKeyInfo.getReplicatedSize() -
-          allocatedLocationInfoList.size() * scmBlockSize * factor;
+      long correctedSpace = omKeyInfo.getReplicatedSize() * factor;
       // Subtract the size of blocks to be overwritten.
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getReplicatedSize();
       }
       omBucketInfo.incrUsedBytes(correctedSpace);
+      omBucketInfo.incrUsedNamespace(1L);
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),
               omKeyInfo, dbFileKey, dbOpenFileKey, omBucketInfo.copyObject(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -165,9 +165,11 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       // Subtract the size of blocks to be overwritten.
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getReplicatedSize();
+      } else {
+        // if keyToDelete isn't null, usedNamespace shouldn't increase.
+        checkBucketQuotaInNamespace(omBucketInfo, 1L);
       }
       checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
-      checkBucketQuotaInNamespace(omBucketInfo, 1L);
 
       // Add to cache of open key table and key table.
       OMFileRequest.addOpenFileTableCacheEntry(omMetadataManager, dbFileKey,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -166,8 +166,10 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       if (keyToDelete != null) {
         correctedSpace -= keyToDelete.getReplicatedSize();
       } else {
-        // if keyToDelete isn't null, usedNamespace shouldn't increase.
+        // if keyToDelete isn't null, usedNamespace shouldn't check and
+        // increase.
         checkBucketQuotaInNamespace(omBucketInfo, 1L);
+        omBucketInfo.incrUsedNamespace(1L);
       }
       checkBucketQuotaInBytes(omBucketInfo, correctedSpace);
 
@@ -184,7 +186,6 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
       }
 
       omBucketInfo.incrUsedBytes(correctedSpace);
-      omBucketInfo.incrUsedNamespace(1L);
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),
               omKeyInfo, dbFileKey, dbOpenFileKey, omBucketInfo.copyObject(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -313,10 +313,6 @@ public class OMKeyCreateRequest extends OMKeyRequest {
           new CacheKey<>(dbOpenKeyName),
           new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
 
-      omBucketInfo.incrUsedBytes(preAllocatedSpace);
-      // Update namespace quota
-      omBucketInfo.incrUsedNamespace(1L);
-
       // Prepare response
       omResponse.setCreateKeyResponse(CreateKeyResponse.newBuilder()
           .setKeyInfo(omKeyInfo.getNetworkProtobuf(getOmRequest().getVersion(),

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -194,10 +194,6 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               Optional.absent(), Optional.of(missingParentInfos),
               trxnLogIndex);
 
-      omBucketInfo.incrUsedBytes(preAllocatedSpace);
-      // Update namespace quota
-      omBucketInfo.incrUsedNamespace(1L);
-
       // Prepare response. Sets user given full key name in the 'keyName'
       // attribute in response object.
       int clientVersion = getOmRequest().getVersion();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -229,7 +229,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       int factor = omKeyInfo.getReplicationConfig().getRequiredNodes();
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
-      long correctedSpace = omKeyInfo.getReplicatedSize() * factor;
+      long correctedSpace = omKeyInfo.getReplicatedSize();
       omBucketInfo.incrUsedBytes(correctedSpace);
 
       omResponse.setCommitMultiPartUploadResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -226,15 +226,10 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           new CacheKey<>(openKey),
           new CacheValue<>(Optional.absent(), trxnLogIndex));
 
-      long scmBlockSize = ozoneManager.getScmBlockSize();
       int factor = omKeyInfo.getReplicationConfig().getRequiredNodes();
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-      // Block was pre-requested and UsedBytes updated when createKey and
-      // AllocatedBlock. The space occupied by the Key shall be based on
-      // the actual Key size, and the total Block size applied before should
-      // be subtracted.
-      long correctedSpace = omKeyInfo.getReplicatedSize() -
-          keyArgs.getKeyLocationsList().size() * scmBlockSize * factor;
+
+      long correctedSpace = omKeyInfo.getReplicatedSize() * factor;
       omBucketInfo.incrUsedBytes(correctedSpace);
 
       omResponse.setCommitMultiPartUploadResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -229,6 +229,8 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       long correctedSpace = omKeyInfo.getReplicatedSize();
+      // TODO: S3MultipartUpload did not check quota and did not add nameSpace,
+      //  we need to fix these issues in HDDS-6650.
       omBucketInfo.incrUsedBytes(correctedSpace);
 
       omResponse.setCommitMultiPartUploadResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -226,7 +226,6 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           new CacheKey<>(openKey),
           new CacheValue<>(Optional.absent(), trxnLogIndex));
 
-      int factor = omKeyInfo.getReplicationConfig().getRequiredNodes();
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       long correctedSpace = omKeyInfo.getReplicatedSize();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
@@ -50,7 +50,7 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
                                 @Nonnull OmKeyInfo omKeyInfo,
                                 @Nonnull List<OmDirectoryInfo> parentDirInfos,
                                 long openKeySessionID,
-                                @Nonnull OmBucketInfo omBucketInfo) {
+                                OmBucketInfo omBucketInfo) {
     super(omResponse, omKeyInfo, new ArrayList<>(), openKeySessionID,
         omBucketInfo);
     this.parentDirInfos = parentDirInfos;
@@ -88,11 +88,6 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
 
     OMFileRequest.addToOpenFileTable(omMetadataMgr, batchOp, getOmKeyInfo(),
             getOpenKeySessionID());
-
-    // update bucket usedBytes.
-    omMetadataMgr.getBucketTable().putWithBatch(batchOp,
-            omMetadataMgr.getBucketKey(getOmKeyInfo().getVolumeName(),
-                    getOmKeyInfo().getBucketName()), getOmBucketInfo());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
@@ -50,7 +50,7 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
                                 @Nonnull OmKeyInfo omKeyInfo,
                                 @Nonnull List<OmDirectoryInfo> parentDirInfos,
                                 long openKeySessionID,
-                                OmBucketInfo omBucketInfo) {
+                                @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse, omKeyInfo, new ArrayList<>(), openKeySessionID,
         omBucketInfo);
     this.parentDirInfos = parentDirInfos;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponse.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
@@ -41,15 +40,13 @@ public class OMAllocateBlockResponse extends OmKeyResponse {
 
   private OmKeyInfo omKeyInfo;
   private long clientID;
-  private OmBucketInfo omBucketInfo;
 
   public OMAllocateBlockResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, long clientID,
-      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout) {
+      @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     this.omKeyInfo = omKeyInfo;
     this.clientID = clientID;
-    this.omBucketInfo = omBucketInfo;
   }
 
   /**
@@ -70,19 +67,10 @@ public class OMAllocateBlockResponse extends OmKeyResponse {
         omKeyInfo.getBucketName(), omKeyInfo.getKeyName(), clientID);
     omMetadataManager.getOpenKeyTable(getBucketLayout())
         .putWithBatch(batchOperation, openKey, omKeyInfo);
-
-    // update bucket usedBytes.
-    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-        omMetadataManager.getBucketKey(omKeyInfo.getVolumeName(),
-            omKeyInfo.getBucketName()), omBucketInfo);
   }
 
   protected OmKeyInfo getOmKeyInfo() {
     return omKeyInfo;
-  }
-
-  protected OmBucketInfo getOmBucketInfo() {
-    return omBucketInfo;
   }
 
   protected long getClientID() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.om.response.key;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
 import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
@@ -41,8 +40,8 @@ public class OMAllocateBlockResponseWithFSO extends OMAllocateBlockResponse {
 
   public OMAllocateBlockResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, long clientID,
-      @Nonnull OmBucketInfo omBucketInfo, @Nonnull BucketLayout bucketLayout) {
-    super(omResponse, omKeyInfo, clientID, omBucketInfo, bucketLayout);
+      @Nonnull BucketLayout bucketLayout) {
+    super(omResponse, omKeyInfo, clientID, bucketLayout);
   }
 
   /**
@@ -60,11 +59,6 @@ public class OMAllocateBlockResponseWithFSO extends OMAllocateBlockResponse {
 
     OMFileRequest.addToOpenFileTable(omMetadataManager, batchOperation,
             getOmKeyInfo(), getClientID());
-
-    // update bucket usedBytes.
-    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-            omMetadataManager.getBucketKey(getOmKeyInfo().getVolumeName(),
-                    getOmKeyInfo().getBucketName()), getOmBucketInfo());
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
@@ -52,7 +52,7 @@ public class OMKeyCreateResponse extends OmKeyResponse {
 
   public OMKeyCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, List<OmKeyInfo> parentKeyInfos,
-      long openKeySessionID, OmBucketInfo omBucketInfo) {
+      long openKeySessionID, @Nonnull OmBucketInfo omBucketInfo) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;
     this.openKeySessionID = openKeySessionID;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponse.java
@@ -52,7 +52,7 @@ public class OMKeyCreateResponse extends OmKeyResponse {
 
   public OMKeyCreateResponse(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, List<OmKeyInfo> parentKeyInfos,
-      long openKeySessionID, @Nonnull OmBucketInfo omBucketInfo) {
+      long openKeySessionID, OmBucketInfo omBucketInfo) {
     super(omResponse, omBucketInfo.getBucketLayout());
     this.omKeyInfo = omKeyInfo;
     this.openKeySessionID = openKeySessionID;
@@ -97,11 +97,6 @@ public class OMKeyCreateResponse extends OmKeyResponse {
         omKeyInfo.getBucketName(), omKeyInfo.getKeyName(), openKeySessionID);
     omMetadataManager.getOpenKeyTable(getBucketLayout())
         .putWithBatch(batchOperation, openKey, omKeyInfo);
-
-    // update bucket usedBytes.
-    omMetadataManager.getBucketTable().putWithBatch(batchOperation,
-        omMetadataManager.getBucketKey(omKeyInfo.getVolumeName(),
-            omKeyInfo.getBucketName()), omBucketInfo);
   }
 
   protected long getOpenKeySessionID() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -113,6 +113,6 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
           OmKeyInfo omKeyInfo, OmBucketInfo omBucketInfo,
           OMResponse omResponse) {
     return new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID,
-            omBucketInfo, getBucketLayout());
+        getBucketLayout());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
@@ -67,7 +67,7 @@ public class TestOMAllocateBlockResponseWithFSO
           OmKeyInfo omKeyInfo, OmBucketInfo omBucketInfo,
           OMResponse omResponse) {
     return new OMAllocateBlockResponseWithFSO(omResponse, omKeyInfo, clientID,
-            omBucketInfo, getBucketLayout());
+            getBucketLayout());
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

As we disscussed in https://issues.apache.org/jira/browse/HDDS-5867.
The quota we are currently implementing have a bug. When allocate block, we add usedBytes. If the key fails to write, the Clean Open Key Service subtracts the usedBytes. But the bucket may no longer exist when the open key is being deleted, or may have been deleted and re-created with the same name. This causes usedBytes update error.

We can only update the usedByte when commit key. In this way, failed keys are not counted in the usedByte（we‘ll add service in the background to delete them). This is reasonable for the user. This is garbage data and belongs to the Ozone system. And the Ozone system itself cleans this data.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6556

## How was this patch tested?

existing UT, also add new UT.
