### PR TITLE
HDDS-6512. Install Hugo during build if needed

### DIFF
--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -45,7 +45,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           </execution>
         </executions>
         <configuration>
-          <executable>dev-support/bin/generate-site.sh</executable>
+          <executable>../../hadoop-ozone/dev-support/checks/docs.sh</executable>
         </configuration>
       </plugin>
       <plugin>

--- a/hadoop-hdds/docs/pom.xml
+++ b/hadoop-hdds/docs/pom.xml
@@ -28,9 +28,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <name>Apache Ozone/HDDS Documentation</name>
   <packaging>jar</packaging>
 
-  <dependencies>
+  <properties>
+    <skipDocs>false</skipDocs>
+  </properties>
 
-  </dependencies>
   <build>
     <plugins>
       <plugin>
@@ -42,11 +43,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
               <goal>exec</goal>
             </goals>
             <phase>compile</phase>
+            <configuration>
+              <executable>../../hadoop-ozone/dev-support/checks/docs.sh</executable>
+              <skip>${skipDocs}</skip>
+            </configuration>
           </execution>
         </executions>
-        <configuration>
-          <executable>../../hadoop-ozone/dev-support/checks/docs.sh</executable>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>

--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -17,5 +17,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
-mvn -V -B -Dmaven.javadoc.skip=true -DskipTests clean install "$@"
+mvn -V -B -Dmaven.javadoc.skip=true -DskipTests -PskipDocs clean install "$@"
 exit $?

--- a/hadoop-ozone/dev-support/checks/build.sh
+++ b/hadoop-ozone/dev-support/checks/build.sh
@@ -17,5 +17,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$DIR/../../.." || exit 1
 
 export MAVEN_OPTS="-Xmx4096m $MAVEN_OPTS"
-mvn -V -B -Dmaven.javadoc.skip=true -DskipTests -PskipDocs clean install "$@"
+mvn -V -B -Dmaven.javadoc.skip=true -DskipTests -DskipDocs clean install "$@"
 exit $?


### PR DESCRIPTION
## What changes were proposed in this pull request?

Install Hugo if necessary during build.  Advantages:

 * one fewer dependency to manually install
 * improve stability by using fixed Hugo version, newer ones might break compatibility

Reuse existing `docs.sh` (run in CI by _basic (docs)_ check) for this purpose.

Allow skipping the execution of `docs.sh` via the new `skipDocs` property.  This is set by `build.sh`, so that other checks do not fail in case of doc validation problems, which should be caught by the _basic (docs)_ check.

https://issues.apache.org/jira/browse/HDDS-6512

## How was this patch tested?

### Hugo available

```
$ rm -fr .dev-tools/hugo

$ which hugo
/usr/local/bin/hugo

$ mvn -am -pl :hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.3.1:exec (default) @ hdds-docs ---
Skip installing hugo, as it's already available on PATH.
Start building sites …

                   | EN | ZH
-------------------+----+-----
  Pages            | 86 | 50
  Paginator pages  |  0 |  0
  Non-page files   | 26 | 26
  Static files     | 26 | 26
  Processed images |  0 |  0
  Aliases          |  1 |  0
  Sitemaps         |  2 |  1
  Cleaned          |  0 |  0

...
[INFO] BUILD SUCCESS
```

### Force Ozone-specific tool

```
$ rm -fr .dev-tools/hugo

$ which hugo
/usr/local/bin/hugo

$ OZONE_PREFER_LOCAL_TOOL=false mvn -am -pl :hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.3.1:exec (default) @ hdds-docs ---
Installed hugo in .dev-tools/hugo
Start building sites …

                   | EN | ZH
-------------------+----+-----
  Pages            | 86 | 50
  Paginator pages  |  0 |  0
  Non-page files   | 26 | 26
  Static files     | 26 | 26
  Processed images |  0 |  0
  Aliases          |  1 |  0
  Sitemaps         |  2 |  1
  Cleaned          |  0 |  0

...
[INFO] BUILD SUCCESS
```

### Hugo not available

Verified that docs are built even if Hugo is not installed:

```
$ rm -fr .dev-tools/hugo

$ chmod 600 /usr/local/bin/hugo

$ which hugo
hugo not found

$ mvn -am -pl :hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.3.1:exec (default) @ hdds-docs ---
Installed hugo in .dev-tools/hugo
Start building sites …

                   | EN | ZH
-------------------+----+-----
  Pages            | 86 | 50
  Paginator pages  |  0 |  0
  Non-page files   | 26 | 26
  Static files     | 26 | 26
  Processed images |  0 |  0
  Aliases          |  1 |  0
  Sitemaps         |  2 |  1
  Cleaned          |  0 |  0

...
[INFO] BUILD SUCCESS
```

### Skipping docs build

Verified that Hugo is not installed or executed with `-DskipDocs`:

```
$ rm -fr .dev-tools/hugo

$ which hugo
hugo not found

$ mvn -DskipDocs -am -pl :hdds-docs clean compile
...
[INFO] --- exec-maven-plugin:1.3.1:exec (default) @ hdds-docs ---
[INFO] skipping execute as per configuraion
...
[INFO] BUILD SUCCESS
```

Regular CI: