### PR TITLE
HDDS-6562. Exclude specific operations in Audit log

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/HddsConfigKeys.java
@@ -269,4 +269,7 @@ public final class HddsConfigKeys {
           "hdds.container.checksum.verification.enabled";
   public static final boolean
           HDDS_CONTAINER_CHECKSUM_VERIFICATION_ENABLED_DEFAULT = true;
+
+  public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_DNAUDIT =
+      "ozone.audit.log.debug.cmd.list.dnaudit";
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -550,6 +550,8 @@ public final class ScmConfigKeys {
   public static final boolean
       OZONE_SCM_HA_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT = false;
 
+  public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_SCMAUDIT =
+      "ozone.audit.log.debug.cmd.list.scmaudit";
   /**
    * Never constructed.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -455,6 +455,8 @@ public final class OzoneConfigKeys {
   public static final String OZONE_CLIENT_REQUIRED_OM_VERSION_MIN_DEFAULT =
       OzoneManagerVersion.S3G_PERSISTENT_CONNECTIONS.name();
 
+  public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_OMAUDIT =
+      "ozone.audit.log.debug.cmd.list.omaudit";
   /**
    * There is no need to instantiate this class.
    */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -71,7 +71,9 @@ public class AuditLogger {
   }
 
   public void logWriteSuccess(AuditMessage msg) {
-    if (!debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+    if (debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+      this.logger.logIfEnabled(FQCN, Level.DEBUG, WRITE_MARKER, msg, null);
+    } else {
       this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, msg, null);
     }
   }
@@ -82,7 +84,9 @@ public class AuditLogger {
   }
 
   public void logReadSuccess(AuditMessage msg) {
-    if (!debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+    if (debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+      this.logger.logIfEnabled(FQCN, Level.DEBUG, READ_MARKER, msg, null);
+    } else {
       this.logger.logIfEnabled(FQCN, Level.INFO, READ_MARKER, msg, null);
     }
   }
@@ -96,6 +100,9 @@ public class AuditLogger {
     if (auditMessage.getThrowable() == null) {
       if (debugCmdSetRef.get().contains(
           auditMessage.getOp().toLowerCase(Locale.ROOT))) {
+        this.logger.logIfEnabled(FQCN, Level.DEBUG, WRITE_MARKER, auditMessage,
+            auditMessage.getThrowable());
+      } else {
         this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, auditMessage,
             auditMessage.getThrowable());
       }
@@ -110,10 +117,10 @@ public class AuditLogger {
     refreshDebugCmdSet(conf);
   }
 
-  public synchronized void refreshDebugCmdSet(OzoneConfiguration conf) {
+  public void refreshDebugCmdSet(OzoneConfiguration conf) {
     Collection<String> cmds = conf.getTrimmedStringCollection(
         AUDIT_LOG_DEBUG_CMD_PREFIX + type.getType().toLowerCase(Locale.ROOT));
-    debugCmdSetRef = new AtomicReference<>(
+    debugCmdSetRef.set(
         cmds.stream().map(String::toLowerCase).collect(Collectors.toSet()));
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -19,10 +19,13 @@ package org.apache.hadoop.ozone.audit;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -36,6 +39,8 @@ import java.util.stream.Collectors;
  * Class to define Audit Logger for Ozone.
  */
 public class AuditLogger {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AuditLogger.class);
 
   private ExtendedLogger logger;
   private static final String FQCN = AuditLogger.class.getName();
@@ -120,6 +125,7 @@ public class AuditLogger {
   public void refreshDebugCmdSet(OzoneConfiguration conf) {
     Collection<String> cmds = conf.getTrimmedStringCollection(
         AUDIT_LOG_DEBUG_CMD_PREFIX + type.getType().toLowerCase(Locale.ROOT));
+    LOG.info("Refresh DebugCmdSet for {} to {}.", type.getType(), cmds);
     debugCmdSetRef.set(
         cmds.stream().map(String::toLowerCase).collect(Collectors.toSet()));
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -18,10 +18,18 @@
 package org.apache.hadoop.ozone.audit;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Locale;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 
 /**
@@ -33,6 +41,11 @@ public class AuditLogger {
   private static final String FQCN = AuditLogger.class.getName();
   private static final Marker WRITE_MARKER = AuditMarker.WRITE.getMarker();
   private static final Marker READ_MARKER = AuditMarker.READ.getMarker();
+  private AtomicReference<Set<String>> debugCmdSetRef =
+      new AtomicReference<>(new HashSet<>());
+  public static final String AUDIT_LOG_DEBUG_CMD_PREFIX =
+      "ozone.audit.log.debug.cmd.";
+  private AuditLoggerType type;
 
   /**
    * Parametrized Constructor to initialize logger.
@@ -48,6 +61,8 @@ public class AuditLogger {
    */
   private void initializeLogger(AuditLoggerType loggerType) {
     this.logger = LogManager.getContext(false).getLogger(loggerType.getType());
+    this.type = loggerType;
+    refreshDebugCmdSet();
   }
 
   @VisibleForTesting
@@ -56,7 +71,9 @@ public class AuditLogger {
   }
 
   public void logWriteSuccess(AuditMessage msg) {
-    this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, msg, null);
+    if (!debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+      this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, msg, null);
+    }
   }
 
   public void logWriteFailure(AuditMessage msg) {
@@ -65,7 +82,9 @@ public class AuditLogger {
   }
 
   public void logReadSuccess(AuditMessage msg) {
-    this.logger.logIfEnabled(FQCN, Level.INFO, READ_MARKER, msg, null);
+    if (!debugCmdSetRef.get().contains(msg.getOp().toLowerCase(Locale.ROOT))) {
+      this.logger.logIfEnabled(FQCN, Level.INFO, READ_MARKER, msg, null);
+    }
   }
 
   public void logReadFailure(AuditMessage msg) {
@@ -75,12 +94,26 @@ public class AuditLogger {
 
   public void logWrite(AuditMessage auditMessage) {
     if (auditMessage.getThrowable() == null) {
-      this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, auditMessage,
-          auditMessage.getThrowable());
+      if (debugCmdSetRef.get().contains(
+          auditMessage.getOp().toLowerCase(Locale.ROOT))) {
+        this.logger.logIfEnabled(FQCN, Level.INFO, WRITE_MARKER, auditMessage,
+            auditMessage.getThrowable());
+      }
     } else {
       this.logger.logIfEnabled(FQCN, Level.ERROR, WRITE_MARKER, auditMessage,
           auditMessage.getThrowable());
     }
   }
 
+  public void refreshDebugCmdSet() {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    refreshDebugCmdSet(conf);
+  }
+
+  public synchronized void refreshDebugCmdSet(OzoneConfiguration conf) {
+    Collection<String> cmds = conf.getTrimmedStringCollection(
+        AUDIT_LOG_DEBUG_CMD_PREFIX + type.getType().toLowerCase(Locale.ROOT));
+    debugCmdSetRef = new AtomicReference<>(
+        cmds.stream().map(String::toLowerCase).collect(Collectors.toSet()));
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.audit;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.ozone.OzoneSecurityUtil;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -48,8 +48,8 @@ public class AuditLogger {
   private static final Marker READ_MARKER = AuditMarker.READ.getMarker();
   private AtomicReference<Set<String>> debugCmdSetRef =
       new AtomicReference<>(new HashSet<>());
-  public static final String AUDIT_LOG_DEBUG_CMD_PREFIX =
-      "ozone.audit.log.debug.cmd.";
+  public static final String AUDIT_LOG_DEBUG_CMD_LIST_PREFIX =
+      "ozone.audit.log.debug.cmd.list.";
   private AuditLoggerType type;
 
   /**
@@ -124,7 +124,8 @@ public class AuditLogger {
 
   public void refreshDebugCmdSet(OzoneConfiguration conf) {
     Collection<String> cmds = conf.getTrimmedStringCollection(
-        AUDIT_LOG_DEBUG_CMD_PREFIX + type.getType().toLowerCase(Locale.ROOT));
+        AUDIT_LOG_DEBUG_CMD_LIST_PREFIX +
+            type.getType().toLowerCase(Locale.ROOT));
     LOG.info("Refresh DebugCmdSet for {} to {}.", type.getType(), cmds);
     debugCmdSetRef.set(
         cmds.stream().map(String::toLowerCase).collect(Collectors.toSet()));

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditMessage.java
@@ -26,10 +26,21 @@ import java.util.Map;
 public final class AuditMessage implements Message {
 
   private final String message;
+  private final String user;
+  private final String ip;
+  private final String op;
+  private final Map<String, String> params;
+  private final String ret;
   private final Throwable throwable;
 
-  private AuditMessage(String message, Throwable throwable) {
-    this.message = message;
+  private AuditMessage(String user, String ip, String op,
+      Map<String, String> params, String ret, Throwable throwable) {
+    this.user = user;
+    this.ip = ip;
+    this.op = op;
+    this.params = params;
+    this.ret = ret;
+    this.message = formMessage(user, ip, op, params, ret);
     this.throwable = throwable;
   }
 
@@ -51,6 +62,10 @@ public final class AuditMessage implements Message {
   @Override
   public Throwable getThrowable() {
     return throwable;
+  }
+
+  public String getOp() {
+    return op;
   }
 
   /**
@@ -95,9 +110,14 @@ public final class AuditMessage implements Message {
     }
 
     public AuditMessage build() {
-      String message = "user=" + this.user + " | ip=" + this.ip + " | " +
-          "op=" + this.op + " " + this.params + " | " + "ret=" + this.ret;
-      return new AuditMessage(message, throwable);
+      return new AuditMessage(user, ip, op, params, ret, throwable);
     }
+  }
+
+  private String formMessage(String userStr, String ipStr, String opStr,
+      Map<String, String> paramsMap, String retStr) {
+    return "user=" + userStr + " | ip=" + ipStr + " | " + "op=" + opStr
+        + " " + paramsMap + " | " + "ret=" + retStr;
+
   }
 }

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3078,7 +3078,7 @@
     <value></value>
     <tag>SCM</tag>
     <description>
-      A comma separated list of OzoneManager commands that are written to the SCM audit logs only if the audit
+      A comma separated list of SCM commands that are written to the SCM audit logs only if the audit
       log level is debug. Ex: "GET_VERSION,REGISTER,SEND_HEARTBEAT".
     </description>
   </property>
@@ -3088,7 +3088,7 @@
     <value></value>
     <tag>DN</tag>
     <description>
-      A comma separated list of OzoneManager commands that are written to the DN audit logs only if the audit
+      A comma separated list of Datanode commands that are written to the DN audit logs only if the audit
       log level is debug. Ex: "CREATE_CONTAINER,READ_CONTAINER,UPDATE_CONTAINER".
     </description>
   </property>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3062,4 +3062,34 @@
       will create intermediate directories.
     </description>
   </property>
+
+  <property>
+    <name>ozone.audit.log.debug.cmd.list.omaudit</name>
+    <value></value>
+    <tag>OM</tag>
+    <description>
+      A comma separated list of OzoneManager commands that are written to the OzoneManager audit logs only if the audit
+      log level is debug.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.audit.log.debug.cmd.list.scmaudit</name>
+    <value></value>
+    <tag>SCM</tag>
+    <description>
+      A comma separated list of OzoneManager commands that are written to the SCM audit logs only if the audit
+      log level is debug.
+    </description>
+  </property>
+
+  <property>
+    <name>ozone.audit.log.debug.cmd.list.dnaudit</name>
+    <value></value>
+    <tag>DN</tag>
+    <description>
+      A comma separated list of OzoneManager commands that are written to the DN audit logs only if the audit
+      log level is debug.
+    </description>
+  </property>
 </configuration>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3069,7 +3069,7 @@
     <tag>OM</tag>
     <description>
       A comma separated list of OzoneManager commands that are written to the OzoneManager audit logs only if the audit
-      log level is debug.
+      log level is debug. Ex: "ALLOCATE_BLOCK,ALLOCATE_KEY,COMMIT_KEY".
     </description>
   </property>
 
@@ -3079,7 +3079,7 @@
     <tag>SCM</tag>
     <description>
       A comma separated list of OzoneManager commands that are written to the SCM audit logs only if the audit
-      log level is debug.
+      log level is debug. Ex: "GET_VERSION,REGISTER,SEND_HEARTBEAT".
     </description>
   </property>
 
@@ -3089,7 +3089,7 @@
     <tag>DN</tag>
     <description>
       A comma separated list of OzoneManager commands that are written to the DN audit logs only if the audit
-      log level is debug.
+      log level is debug. Ex: "CREATE_CONTAINER,READ_CONTAINER,UPDATE_CONTAINER".
     </description>
   </property>
 </configuration>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -166,7 +166,7 @@ public class TestOzoneAuditLogger {
   @Test
   public void notLogWriteEvents() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
-    conf.set(AuditLogger.AUDIT_LOG_DEBUG_CMD_PREFIX +
+    conf.set(AuditLogger.AUDIT_LOG_DEBUG_CMD_LIST_PREFIX +
             AuditLoggerType.OMLOGGER.getType().toLowerCase(Locale.ROOT),
         "CREATE_VOLUME");
     AUDIT.refreshDebugCmdSet(conf);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.ozone.audit;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -110,6 +113,11 @@ public class TestOzoneAuditLogger {
     }
   }
 
+  @Before
+  public void init() {
+    AUDIT.refreshDebugCmdSet();
+  }
+
   /**
    * Test to verify default log level is INFO when logging success events.
    */
@@ -152,6 +160,19 @@ public class TestOzoneAuditLogger {
     verifyNoLog();
   }
 
+  /**
+   * Test to verify no WRITE event is logged.
+   */
+  @Test
+  public void notLogWriteEvents() throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(AuditLogger.AUDIT_LOG_DEBUG_CMD_PREFIX +
+            AuditLoggerType.OMLOGGER.getType().toLowerCase(Locale.ROOT),
+        "CREATE_VOLUME");
+    AUDIT.refreshDebugCmdSet(conf);
+    AUDIT.logWriteSuccess(WRITE_SUCCESS_MSG);
+    verifyNoLog();
+  }
   /**
    * Test to verify if multiline entries can be checked.
    */

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -164,7 +164,7 @@ public class TestOzoneAuditLogger {
    * Test to verify no WRITE event is logged.
    */
   @Test
-  public void notLogWriteEvents() throws IOException {
+  public void excludedEventNotLogged() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(AuditLogger.AUDIT_LOG_DEBUG_CMD_LIST_PREFIX +
             AuditLoggerType.OMLOGGER.getType().toLowerCase(Locale.ROOT),


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the READ operation are omitted in audit log. This is intentionally configured to avoid the massive logs that could hurt the services' performance.

But in a production cluster, audit logs for both READ and WRITE operations would be valuable when comes to data security and audit. 

This ticket is to add the feature that users can specify the operations that they'd like to exclude in audit log, so that the performance of service and valuable operation logs can both be retained.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6562

## How was this patch tested?

unit test
