### PR TITLE
HDDS-6541. [Merge rocksdb in datanode] Per-disk DB location management.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/upgrade/HDDSLayoutFeature.java
@@ -31,7 +31,9 @@ public enum HDDSLayoutFeature implements LayoutFeature {
   INITIAL_VERSION(0, "Initial Layout Version"),
   DATANODE_SCHEMA_V2(1, "Datanode RocksDB Schema Version 2 (with column " +
       "families)"),
-  SCM_HA(2, "Storage Container Manager HA");
+  SCM_HA(2, "Storage Container Manager HA"),
+  DATANODE_SCHEMA_V3(3, "Datanode RocksDB Schema Version 3 (one rocksdb " +
+      "per disk)");
 
   //////////////////////////////  //////////////////////////////
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -328,6 +328,11 @@ public final class OzoneConfigKeys {
   public static final String
       HDDS_DATANODE_METADATA_ROCKSDB_CACHE_SIZE_DEFAULT = "1GB";
 
+  // Specifying the dedicated volumes for per-disk db instances.
+  // For container schema v3 only.
+  public static final String HDDS_DATANODE_CONTAINER_DB_DIR =
+      "hdds.datanode.container.db.dir";
+
   public static final String OZONE_SECURITY_ENABLED_KEY =
       "ozone.security.enabled";
   public static final boolean OZONE_SECURITY_ENABLED_DEFAULT = false;

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -135,6 +135,7 @@ public final class OzoneConsts {
   public static final String SCM_DB_NAME = "scm.db";
   public static final String OM_DB_BACKUP_PREFIX = "om.db.backup.";
   public static final String SCM_DB_BACKUP_PREFIX = "scm.db.backup.";
+  public static final String CONTAINER_DB_NAME = "container.db";
 
   public static final String STORAGE_DIR_CHUNKS = "chunks";
   public static final String OZONE_DB_CHECKPOINT_REQUEST_FLUSH =

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -149,7 +149,7 @@
     <value/>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
     <description>Determines where the per-disk rocksdb instances will be
-      stored. Defaults to empty if not specified, then rocksdb instances
+      stored. This setting is optional. If unspecified, then rocksdb instances
       are stored on the same disk as HDDS data.
       The directories should be tagged with corresponding storage types
       ([SSD]/[DISK]/[ARCHIVE]/[RAM_DISK]) for storage policies. The default

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -145,6 +145,20 @@
     </description>
   </property>
   <property>
+    <name>hdds.datanode.container.db.dir</name>
+    <value/>
+    <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>
+    <description>Determines where the per-disk rocksdb instances will be
+      stored. Defaults to empty if not specified, then rocksdb instances
+      are stored on the same disk as HDDS data.
+      The directories should be tagged with corresponding storage types
+      ([SSD]/[DISK]/[ARCHIVE]/[RAM_DISK]) for storage policies. The default
+      storage type will be DISK if the directory does not have a storage type
+      tagged explicitly. Ideally, this should be mapped to a fast disk
+      like an SSD.
+    </description>
+  </property>
+  <property>
     <name>hdds.datanode.dir.du.reserved</name>
     <value/>
     <tag>OZONE, CONTAINER, STORAGE, MANAGEMENT</tag>

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -57,7 +57,7 @@ import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
-import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
@@ -319,7 +319,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
 
     for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
       HddsVolume hddsVolume = (HddsVolume) entry.getValue();
-      boolean result = HddsVolumeUtil.checkVolume(hddsVolume, clusterId,
+      boolean result = StorageVolumeUtil.checkVolume(hddsVolume, clusterId,
           clusterId, conf, LOG, null);
       if (!result) {
         volumeSet.failVolume(hddsVolume.getHddsRootDir().getPath());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/HddsDatanodeService.java
@@ -320,7 +320,7 @@ public class HddsDatanodeService extends GenericCli implements ServicePlugin {
     for (Map.Entry<String, StorageVolume> entry : volumeMap.entrySet()) {
       HddsVolume hddsVolume = (HddsVolume) entry.getValue();
       boolean result = HddsVolumeUtil.checkVolume(hddsVolume, clusterId,
-          clusterId, conf, LOG);
+          clusterId, conf, LOG, null);
       if (!result) {
         volumeSet.failVolume(hddsVolume.getHddsRootDir().getPath());
       }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -45,6 +45,8 @@ public class DatanodeConfiguration {
       "hdds.datanode.failed.data.volumes.tolerated";
   public static final String FAILED_METADATA_VOLUMES_TOLERATED_KEY =
       "hdds.datanode.failed.metadata.volumes.tolerated";
+  public static final String FAILED_DB_VOLUMES_TOLERATED_KEY =
+      "hdds.datanode.failed.db.volumes.tolerated";
   public static final String DISK_CHECK_MIN_GAP_KEY =
       "hdds.datanode.disk.check.min.gap";
   public static final String DISK_CHECK_TIMEOUT_KEY =
@@ -195,6 +197,17 @@ public class DatanodeConfiguration {
   )
   private int failedMetadataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
 
+  @Config(key = "failed.db.volumes.tolerated",
+      defaultValue = "-1",
+      type = ConfigType.INT,
+      tags = { DATANODE },
+      description = "The number of db volumes that are allowed to fail "
+          + "before a datanode stops offering service. "
+          + "Config this to -1 means unlimited, but we should have "
+          + "at least one good volume left."
+  )
+  private int failedDbVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
+
   @Config(key = "disk.check.min.gap",
       defaultValue = "15m",
       type = ConfigType.TIME,
@@ -277,6 +290,13 @@ public class DatanodeConfiguration {
       failedMetadataVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
     }
 
+    if (failedDbVolumesTolerated < -1) {
+      LOG.warn(FAILED_DB_VOLUMES_TOLERATED_KEY +
+              "must be greater than -1 and was set to {}. Defaulting to {}",
+          failedDbVolumesTolerated, FAILED_VOLUMES_TOLERATED_DEFAULT);
+      failedDbVolumesTolerated = FAILED_VOLUMES_TOLERATED_DEFAULT;
+    }
+
     if (diskCheckMinGap < 0) {
       LOG.warn(DISK_CHECK_MIN_GAP_KEY +
               " must be greater than zero and was set to {}. Defaulting to {}",
@@ -323,6 +343,14 @@ public class DatanodeConfiguration {
 
   public void setFailedMetadataVolumesTolerated(int failedVolumesTolerated) {
     this.failedMetadataVolumesTolerated = failedVolumesTolerated;
+  }
+
+  public int getFailedDbVolumesTolerated() {
+    return failedDbVolumesTolerated;
+  }
+
+  public void setFailedDbVolumesTolerated(int failedVolumesTolerated) {
+    this.failedDbVolumesTolerated = failedVolumesTolerated;
   }
 
   public Duration getDiskCheckMinGap() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeConfiguration.java
@@ -54,6 +54,8 @@ public class DatanodeConfiguration {
 
   public static final String WAIT_ON_ALL_FOLLOWERS =
       "hdds.datanode.wait.on.all.followers";
+  public static final String CONTAINER_SCHEMA_V3_ENABLED =
+      "hdds.datanode.container.schema.v3.enabled";
 
   static final boolean CHUNK_DATA_VALIDATION_CHECK_DEFAULT = false;
 
@@ -68,6 +70,8 @@ public class DatanodeConfiguration {
 
   static final long DISK_CHECK_TIMEOUT_DEFAULT =
       Duration.ofMinutes(10).toMillis();
+
+  static final boolean CONTAINER_SCHEMA_V3_ENABLED_DEFAULT = false;
 
   /**
    * Number of threads per volume that Datanode will use for chunk read.
@@ -258,6 +262,15 @@ public class DatanodeConfiguration {
     this.waitOnAllFollowers = val;
   }
 
+  @Config(key = "container.schema.v3.enabled",
+      defaultValue = "false",
+      type = ConfigType.BOOLEAN,
+      tags = { DATANODE },
+      description = "Enable use of container schema v3(one rocksdb per disk)."
+  )
+  private boolean containerSchemaV3Enabled =
+      CONTAINER_SCHEMA_V3_ENABLED_DEFAULT;
+
   @PostConstruct
   public void validate() {
     if (containerDeleteThreads < 1) {
@@ -399,5 +412,13 @@ public class DatanodeConfiguration {
 
   public int getNumReadThreadPerVolume() {
     return numReadThreadPerVolume;
+  }
+
+  public boolean getContainerSchemaV3Enabled() {
+    return this.containerSchemaV3Enabled;
+  }
+
+  public void setContainerSchemaV3Enabled(boolean containerSchemaV3Enabled) {
+    this.containerSchemaV3Enabled = containerSchemaV3Enabled;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/DatanodeStateMachine.java
@@ -316,8 +316,8 @@ public class DatanodeStateMachine implements Closeable {
   public void handleFatalVolumeFailures() {
     LOG.error("DatanodeStateMachine Shutdown due to too many bad volumes, "
         + "check " + DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY
-        + " and "
-        + DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY);
+        + " and " + DatanodeConfiguration.FAILED_METADATA_VOLUMES_TOLERATED_KEY
+        + " and " + DatanodeConfiguration.FAILED_DB_VOLUMES_TOLERATED_KEY);
     hddsDatanodeStopService.stopService();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -101,7 +101,8 @@ public class VersionEndpointTask implements
                 : volumeMap.entrySet()) {
               StorageVolume volume = entry.getValue();
               boolean result = HddsVolumeUtil.checkVolume((HddsVolume) volume,
-                  scmId, clusterId, configuration, LOG);
+                  scmId, clusterId, configuration, LOG,
+                  ozoneContainer.getDbVolumeSet());
               if (!result) {
                 volumeSet.failVolume(volume.getStorageDir().getPath());
               }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/VersionEndpointTask.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
-import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures.SchemaV3;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
@@ -83,8 +83,7 @@ public class VersionEndpointTask implements
               "Reply from SCM: clusterId cannot be null");
 
           // Check DbVolumes
-          if (!VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
-              .equals(OzoneConsts.SCHEMA_V3)) {
+          if (SchemaV3.isFinalizedAndEnabled(configuration)) {
             checkVolumeSet(ozoneContainer.getDbVolumeSet(), scmId, clusterId);
           }
           // Check HddsVolumes

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
@@ -58,7 +58,17 @@ public final class DatanodeStoreCache {
   }
 
   public void removeDB(String containerDBPath) {
-    datanodeStoreMap.remove(containerDBPath);
+    RawDB db = datanodeStoreMap.remove(containerDBPath);
+    if (db == null) {
+      LOG.debug("DB {} already removed", containerDBPath);
+      return;
+    }
+
+    try {
+      db.getStore().stop();
+    } catch (Exception e) {
+      LOG.warn("Stop DatanodeStore: {} failed", containerDBPath, e);
+    }
   }
 
   public void shutdownCache() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/DatanodeStoreCache.java
@@ -67,7 +67,7 @@ public final class DatanodeStoreCache {
     try {
       db.getStore().stop();
     } catch (Exception e) {
-      LOG.warn("Stop DatanodeStore: {} failed", containerDBPath, e);
+      LOG.error("Stop DatanodeStore: {} failed", containerDBPath, e);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.container.common.utils;
 
+import org.apache.hadoop.ozone.container.common.volume.DbVolume;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -47,5 +48,11 @@ public final class StorageVolumeUtil {
       List<StorageVolume> volumes) {
     return volumes.stream().
         map(v -> (HddsVolume) v).collect(Collectors.toList());
+  }
+
+  public static List<DbVolume> getDbVolumesList(
+      List<StorageVolume> volumes) {
+    return volumes.stream().
+        map(v -> (DbVolume) v).collect(Collectors.toList());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
@@ -18,19 +18,35 @@
 
 package org.apache.hadoop.ozone.container.common.utils;
 
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
+import org.apache.hadoop.ozone.container.common.HDDSVolumeLayoutVersion;
 import org.apache.hadoop.ozone.container.common.volume.DbVolume;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.VolumeSet;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
 
+import java.io.File;
+import java.io.IOException;
 import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
  * A util class for {@link StorageVolume}.
  */
 public final class StorageVolumeUtil {
+
+  private static final String VERSION_FILE   = "VERSION";
+  private static final String STORAGE_ID_PREFIX = "DS-";
 
   private StorageVolumeUtil() {
   }
@@ -54,5 +70,184 @@ public final class StorageVolumeUtil {
       List<StorageVolume> volumes) {
     return volumes.stream().
         map(v -> (DbVolume) v).collect(Collectors.toList());
+  }
+
+  public static File getVersionFile(File rootDir) {
+    return new File(rootDir, VERSION_FILE);
+  }
+
+  public static String generateUuid() {
+    return STORAGE_ID_PREFIX + UUID.randomUUID();
+  }
+
+  /**
+   * Returns storageID if it is valid. Throws an exception otherwise.
+   */
+  @VisibleForTesting
+  public static String getStorageID(Properties props, File versionFile)
+      throws InconsistentStorageStateException {
+    return getProperty(props, OzoneConsts.STORAGE_ID, versionFile);
+  }
+
+  /**
+   * Returns clusterID if it is valid. It should match the clusterID from the
+   * Datanode. Throws an exception otherwise.
+   */
+  @VisibleForTesting
+  public static String getClusterID(Properties props, File versionFile,
+      String clusterID) throws InconsistentStorageStateException {
+    String cid = getProperty(props, OzoneConsts.CLUSTER_ID, versionFile);
+
+    if (clusterID == null) {
+      return cid;
+    }
+    if (!clusterID.equals(cid)) {
+      throw new InconsistentStorageStateException("Mismatched " +
+          "ClusterIDs. Version File : " + versionFile + " has clusterID: " +
+          cid + " and Datanode has clusterID: " + clusterID);
+    }
+    return cid;
+  }
+
+  /**
+   * Returns datanodeUuid if it is valid. It should match the UUID of the
+   * Datanode. Throws an exception otherwise.
+   */
+  @VisibleForTesting
+  public static String getDatanodeUUID(Properties props, File versionFile,
+      String datanodeUuid)
+      throws InconsistentStorageStateException {
+    String datanodeID = getProperty(props, OzoneConsts.DATANODE_UUID,
+        versionFile);
+
+    if (datanodeUuid != null && !datanodeUuid.equals(datanodeID)) {
+      throw new InconsistentStorageStateException("Mismatched " +
+          "DatanodeUUIDs. Version File : " + versionFile + " has datanodeUuid: "
+          + datanodeID + " and Datanode has datanodeUuid: " + datanodeUuid);
+    }
+    return datanodeID;
+  }
+
+  /**
+   * Returns creationTime if it is valid. Throws an exception otherwise.
+   */
+  @VisibleForTesting
+  public static long getCreationTime(Properties props, File versionFile)
+      throws InconsistentStorageStateException {
+    String cTimeStr = getProperty(props, OzoneConsts.CTIME, versionFile);
+
+    long cTime = Long.parseLong(cTimeStr);
+    long currentTime = Time.now();
+    if (cTime > currentTime || cTime < 0) {
+      throw new InconsistentStorageStateException("Invalid Creation time in " +
+          "Version File : " + versionFile + " - " + cTime + ". Current system" +
+          " time is " + currentTime);
+    }
+    return cTime;
+  }
+
+  /**
+   * Returns layOutVersion if it is valid. Throws an exception otherwise.
+   */
+  @VisibleForTesting
+  public static int getLayOutVersion(Properties props, File versionFile) throws
+      InconsistentStorageStateException {
+    String lvStr = getProperty(props, OzoneConsts.LAYOUTVERSION, versionFile);
+
+    int lv = Integer.parseInt(lvStr);
+    if (HDDSVolumeLayoutVersion.getLatestVersion().getVersion() != lv) {
+      throw new InconsistentStorageStateException("Invalid layOutVersion. " +
+          "Version file has layOutVersion as " + lv + " and latest Datanode " +
+          "layOutVersion is " +
+          HDDSVolumeLayoutVersion.getLatestVersion().getVersion());
+    }
+    return lv;
+  }
+
+  public static String getProperty(
+      Properties props, String propName, File
+      versionFile
+  )
+      throws InconsistentStorageStateException {
+    String value = props.getProperty(propName);
+    if (StringUtils.isBlank(value)) {
+      throw new InconsistentStorageStateException("Invalid " + propName +
+          ". Version File : " + versionFile + " has null or empty " + propName);
+    }
+    return value;
+  }
+
+  /**
+   * Check Volume is in consistent state or not.
+   * Prior to SCM HA, volumes used the format {@code <volume>/hdds/<scm-id>}.
+   * Post SCM HA, new volumes will use the format {@code <volume>/hdds/<cluster
+   * -id>}.
+   * Existing volumes using SCM ID would have been reformatted to have {@code
+   * <volume>/hdds/<cluster-id>} as a symlink pointing to {@code <volume
+   * >/hdds/<scm-id>}.
+   *
+   * @param volume
+   * @param scmId
+   * @param clusterId
+   * @param conf
+   * @param logger
+   * @param dbVolumeSet
+   * @return true - if volume is in consistent state, otherwise false.
+   */
+  public static boolean checkVolume(StorageVolume volume, String scmId,
+      String clusterId, ConfigurationSource conf, Logger logger,
+      MutableVolumeSet dbVolumeSet) {
+    File hddsRoot = volume.getStorageDir();
+    String volumeRoot = hddsRoot.getPath();
+    File clusterDir = new File(hddsRoot, clusterId);
+
+    try {
+      volume.format(clusterId);
+    } catch (IOException ex) {
+      logger.error("Error during formatting volume {}.",
+          volumeRoot, ex);
+      return false;
+    }
+
+    File[] hddsFiles = hddsRoot.listFiles();
+
+    if (hddsFiles == null) {
+      // This is the case for IOException, where listFiles returns null.
+      // So, we fail the volume.
+      return false;
+    } else if (hddsFiles.length == 1) {
+      // DN started for first time or this is a newly added volume.
+      // The one file is the version file.
+      // So we create cluster ID directory, or SCM ID directory if
+      // pre-finalized for SCM HA.
+      // Either the SCM ID or cluster ID will be used in naming the
+      // volume's subdirectory, depending on the datanode's layout version.
+      String id = VersionedDatanodeFeatures.ScmHA.chooseContainerPathID(conf,
+          scmId, clusterId);
+      try {
+        volume.createWorkingDir(id, dbVolumeSet);
+      } catch (IOException e) {
+        logger.error("Prepare working dir failed for volume {}.",
+            volumeRoot, e);
+        return false;
+      }
+      return true;
+    } else if (hddsFiles.length == 2) {
+      // If we are finalized for SCM HA and there is no cluster ID directory,
+      // the volume may have been unhealthy during finalization and been
+      // skipped. Create cluster ID symlink now.
+      // Else, We are still pre-finalized.
+      // The existing directory should be left for backwards compatibility.
+      return VersionedDatanodeFeatures.ScmHA.
+          upgradeVolumeIfNeeded(volume, clusterId);
+    } else {
+      if (!clusterDir.exists()) {
+        logger.error("Volume {} is in an inconsistent state. {} files found " +
+            "but cluster ID directory {} does not exist.", volumeRoot,
+            hddsFiles.length, clusterDir);
+        return false;
+      }
+      return true;
+    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/utils/StorageVolumeUtil.java
@@ -197,25 +197,25 @@ public final class StorageVolumeUtil {
   public static boolean checkVolume(StorageVolume volume, String scmId,
       String clusterId, ConfigurationSource conf, Logger logger,
       MutableVolumeSet dbVolumeSet) {
-    File hddsRoot = volume.getStorageDir();
-    String volumeRoot = hddsRoot.getPath();
-    File clusterDir = new File(hddsRoot, clusterId);
+    File volumeRoot = volume.getStorageDir();
+    String volumeRootPath = volumeRoot.getPath();
+    File clusterDir = new File(volumeRoot, clusterId);
 
     try {
       volume.format(clusterId);
     } catch (IOException ex) {
       logger.error("Error during formatting volume {}.",
-          volumeRoot, ex);
+          volumeRootPath, ex);
       return false;
     }
 
-    File[] hddsFiles = hddsRoot.listFiles();
+    File[] rootFiles = volumeRoot.listFiles();
 
-    if (hddsFiles == null) {
+    if (rootFiles == null) {
       // This is the case for IOException, where listFiles returns null.
       // So, we fail the volume.
       return false;
-    } else if (hddsFiles.length == 1) {
+    } else if (rootFiles.length == 1) {
       // DN started for first time or this is a newly added volume.
       // The one file is the version file.
       // So we create cluster ID directory, or SCM ID directory if
@@ -228,11 +228,11 @@ public final class StorageVolumeUtil {
         volume.createWorkingDir(id, dbVolumeSet);
       } catch (IOException e) {
         logger.error("Prepare working dir failed for volume {}.",
-            volumeRoot, e);
+            volumeRootPath, e);
         return false;
       }
       return true;
-    } else if (hddsFiles.length == 2) {
+    } else if (rootFiles.length == 2) {
       // If we are finalized for SCM HA and there is no cluster ID directory,
       // the volume may have been unhealthy during finalization and been
       // skipped. Create cluster ID symlink now.
@@ -243,8 +243,8 @@ public final class StorageVolumeUtil {
     } else {
       if (!clusterDir.exists()) {
         logger.error("Volume {} is in an inconsistent state. {} files found " +
-            "but cluster ID directory {} does not exist.", volumeRoot,
-            hddsFiles.length, clusterDir);
+            "but cluster ID directory {} does not exist.", volumeRootPath,
+            rootFiles.length, clusterDir);
         return false;
       }
       return true;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * DbVolume represents a volume in datanode holding db instances
+ * for multiple HddsVolumes. One HddsVolume will have one subdirectory
+ * for its db instance under a DbVolume.
+ *
+ * For example:
+ *   Say we have an SSD device mounted at /ssd1, then the DbVolume
+ *   root directory is /ssd1/db, and we have a subdirectory
+ *   for db instance like
+ *   /ssd1/db/<clusterID>/<storageID>/container.db.
+ */
+public class DbVolume extends StorageVolume {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DbVolume.class);
+
+  public static final String DB_VOLUME_DIR = "db";
+
+  private String clusterID;
+
+  /**
+   * Records all HddsVolumes that put its db instance under this DbVolume.
+   */
+  private final List<String> hddsVolumeIDs;
+
+  protected DbVolume(Builder b) throws IOException {
+    super(b);
+    this.clusterID = b.getClusterID();
+    this.hddsVolumeIDs = new ArrayList<>();
+    if (!b.getFailedVolume()) {
+      initialize();
+    }
+  }
+
+  public boolean format(String cid) {
+    Preconditions.checkNotNull(cid, "clusterID cannot be null while " +
+        "formatting db volume");
+    this.clusterID = cid;
+
+    // create clusterID dir /ssd1/db/<CID-clusterID>
+    File volumeRootDir = getStorageDir();
+    File clusterIdDir = new File(volumeRootDir, clusterID);
+    if (!clusterIdDir.mkdirs() && !clusterIdDir.exists()) {
+      LOG.error("Unable to create ID directory {} for db volume {}",
+          clusterIdDir, volumeRootDir);
+      return false;
+    }
+    return true;
+  }
+
+  public boolean initialize() {
+    // This should be on a test path, normally we should get
+    // the clusterID from SCM, and it should not be available
+    // while restarting.
+    if (clusterID != null) {
+      return format(clusterID);
+    }
+
+    if (!getStorageDir().exists()) {
+      // Not formatted yet
+      return true;
+    }
+
+    File[] storageDirs = getStorageDir().listFiles(File::isDirectory);
+    if (storageDirs == null) {
+      LOG.error("IO error for the db volume {}, skipped loading",
+          getStorageDir());
+      return false;
+    }
+
+    if (storageDirs.length == 0) {
+      // Not formatted completely
+      return true;
+    }
+
+    if (storageDirs.length > 1) {
+      LOG.error("DB volume {} is in an Inconsistent state", getStorageDir());
+      return false;
+    }
+
+    // scan subdirectories for db instances mapped to HddsVolumes
+    File clusterIdDir = storageDirs[0];
+    File[] subdirs = clusterIdDir.listFiles(File::isDirectory);
+    // Not used yet
+    if (subdirs == null) {
+      return true;
+    }
+
+    for (File subdir : subdirs) {
+      String storageID = subdir.getName();
+      hddsVolumeIDs.add(storageID);
+    }
+
+    return true;
+  }
+
+  public List<String> getHddsVolumeIDs() {
+    return this.hddsVolumeIDs;
+  }
+
+  /**
+   * Builder class for DbVolume.
+   */
+  public static class Builder extends StorageVolume.Builder<Builder> {
+
+    private String clusterID;
+
+    public Builder(String volumeRootStr) {
+      super(volumeRootStr, DB_VOLUME_DIR);
+    }
+
+    @Override
+    public Builder getThis() {
+      return this;
+    }
+
+    public Builder clusterID(String cid) {
+      this.clusterID = cid;
+      return this;
+    }
+
+    public DbVolume build() throws IOException {
+      return new DbVolume(this);
+    }
+
+    public String getClusterID() {
+      return this.clusterID;
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolume.java
@@ -108,7 +108,7 @@ public class DbVolume extends StorageVolume {
 
   private void scanForHddsVolumeIDs() throws IOException {
     // Not formatted yet
-    if (getClusterID() == null) {
+    if (!getStorageState().equals(VolumeState.NORMAL)) {
       return;
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolumeFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+
+import java.io.IOException;
+
+/**
+ * A factory class for DbVolume.
+ */
+public class DbVolumeFactory extends StorageVolumeFactory {
+
+  private String clusterID;
+
+  public DbVolumeFactory(ConfigurationSource conf,
+      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet,
+      String clusterID) {
+    super(conf, usageCheckFactory, volumeSet);
+    this.clusterID = clusterID;
+  }
+
+  @Override
+  StorageVolume createVolume(String locationString, StorageType storageType)
+      throws IOException {
+    DbVolume.Builder volumeBuilder =
+        new DbVolume.Builder(locationString)
+            .conf(getConf())
+            .clusterID(clusterID)
+            .usageCheckFactory(getUsageCheckFactory())
+            .storageType(storageType)
+            .volumeSet(getVolumeSet());
+    return volumeBuilder.build();
+  }
+
+  @Override
+  StorageVolume createFailedVolume(String locationString) throws IOException {
+    DbVolume.Builder volumeBuilder =
+        new DbVolume.Builder(locationString)
+            .failedVolume(true);
+    return volumeBuilder.build();
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/DbVolumeFactory.java
@@ -28,26 +28,27 @@ import java.io.IOException;
  */
 public class DbVolumeFactory extends StorageVolumeFactory {
 
-  private String clusterID;
-
   public DbVolumeFactory(ConfigurationSource conf,
       SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet,
-      String clusterID) {
-    super(conf, usageCheckFactory, volumeSet);
-    this.clusterID = clusterID;
+      String datanodeUuid, String clusterID) {
+    super(conf, usageCheckFactory, volumeSet, datanodeUuid, clusterID);
   }
 
   @Override
   StorageVolume createVolume(String locationString, StorageType storageType)
       throws IOException {
-    DbVolume.Builder volumeBuilder =
-        new DbVolume.Builder(locationString)
-            .conf(getConf())
-            .clusterID(clusterID)
-            .usageCheckFactory(getUsageCheckFactory())
-            .storageType(storageType)
-            .volumeSet(getVolumeSet());
-    return volumeBuilder.build();
+    DbVolume.Builder volumeBuilder = new DbVolume.Builder(locationString)
+        .conf(getConf())
+        .datanodeUuid(getDatanodeUuid())
+        .clusterID(getClusterID())
+        .usageCheckFactory(getUsageCheckFactory())
+        .storageType(storageType)
+        .volumeSet(getVolumeSet());
+    DbVolume volume = volumeBuilder.build();
+
+    checkAndSetClusterID(volume.getClusterID());
+
+    return volume;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -222,7 +222,7 @@ public class HddsVolume extends StorageVolume {
    * Use the HddsVolume directly if no DbVolume found.
    * @param dbVolumeSet
    */
-  private void createDbStore(MutableVolumeSet dbVolumeSet)
+  public void createDbStore(MutableVolumeSet dbVolumeSet)
       throws IOException {
     DbVolume chosenDbVolume = null;
     File clusterIdDir;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -27,10 +27,9 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
-import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures.SchemaV3;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,8 +114,7 @@ public class HddsVolume extends StorageVolume {
       MutableVolumeSet dbVolumeSet) throws IOException {
     super.createWorkingDir(workingDirName, dbVolumeSet);
 
-    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
-        .equals(OzoneConsts.SCHEMA_V3)) {
+    if (SchemaV3.isFinalizedAndEnabled(getConf())) {
       createDbStore(dbVolumeSet);
     }
   }
@@ -135,8 +133,7 @@ public class HddsVolume extends StorageVolume {
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
     }
-    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
-        .equals(OzoneConsts.SCHEMA_V3)) {
+    if (SchemaV3.isFinalizedAndEnabled(getConf())) {
       closeDbStore();
     }
   }
@@ -147,8 +144,7 @@ public class HddsVolume extends StorageVolume {
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
     }
-    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
-        .equals(OzoneConsts.SCHEMA_V3)) {
+    if (SchemaV3.isFinalizedAndEnabled(getConf())) {
       closeDbStore();
     }
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -18,24 +18,24 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import static org.apache.hadoop.ozone.container.common.HDDSVolumeLayoutVersion.getLatestVersion;
-
 import java.io.File;
 import java.io.IOException;
-import java.util.Properties;
-import java.util.UUID;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
-import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
-import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
-import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
-import org.apache.hadoop.util.Time;
 
-import com.google.common.base.Preconditions;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_DB_NAME;
+import static org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil.initPerDiskDBStore;
 
 /**
  * HddsVolume represents volume in a datanode. {@link MutableVolumeSet}
@@ -49,12 +49,6 @@ import org.slf4j.LoggerFactory;
  * <p>{@literal ../hdds/<<clusterUuid>>/current/<<containerDir>>/<<containerID
  * >>/<<dataDir>>}
  * <p>
- * Each hdds volume has its own VERSION file. The hdds volume will have one
- * clusterUuid directory for each SCM it is a part of (currently only one SCM is
- * supported).
- *
- * During DN startup, if the VERSION file exists, we verify that the
- * clusterID in the version file matches the clusterID from SCM.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -65,15 +59,8 @@ public class HddsVolume extends StorageVolume {
 
   public static final String HDDS_VOLUME_DIR = "hdds";
 
-  private VolumeState state;
   private final VolumeIOStats volumeIOStats;
 
-  // VERSION file properties
-  private String storageID;       // id of the file system
-  private String clusterID;       // id of the cluster
-  private String datanodeUuid;    // id of the DataNode
-  private long cTime;             // creation time of the file system state
-  private int layoutVersion;      // layout version of the storage data
   private final AtomicLong committedBytes; // till Open containers become full
 
   // The dedicated DbVolume that the db instance of this HddsVolume resides.
@@ -88,8 +75,6 @@ public class HddsVolume extends StorageVolume {
    * Builder for HddsVolume.
    */
   public static class Builder extends StorageVolume.Builder<Builder> {
-    private String datanodeUuid;
-    private String clusterID;
 
     public Builder(String volumeRootStr) {
       super(volumeRootStr, HDDS_VOLUME_DIR);
@@ -97,16 +82,6 @@ public class HddsVolume extends StorageVolume {
 
     @Override
     public Builder getThis() {
-      return this;
-    }
-
-    public Builder datanodeUuid(String datanodeUUID) {
-      this.datanodeUuid = datanodeUUID;
-      return this;
-    }
-
-    public Builder clusterID(String cid) {
-      this.clusterID = cid;
       return this;
     }
 
@@ -119,9 +94,6 @@ public class HddsVolume extends StorageVolume {
     super(b);
 
     if (!b.getFailedVolume()) {
-      this.state = VolumeState.NOT_INITIALIZED;
-      this.clusterID = b.clusterID;
-      this.datanodeUuid = b.datanodeUuid;
       this.volumeIOStats = new VolumeIOStats(b.getVolumeRootStr());
       this.committedBytes = new AtomicLong(0);
 
@@ -133,191 +105,24 @@ public class HddsVolume extends StorageVolume {
       // Builder is called with failedVolume set, so create a failed volume
       // HddsVolume Object.
       volumeIOStats = null;
-      storageID = UUID.randomUUID().toString();
-      state = VolumeState.FAILED;
       committedBytes = null;
     }
 
   }
 
-  /**
-   * Initializes the volume.
-   * Creates the Version file if not present,
-   * otherwise returns with IOException.
-   * @throws IOException
-   */
-  private void initialize() throws IOException {
-    VolumeState intialVolumeState = analyzeVolumeState();
-    switch (intialVolumeState) {
-    case NON_EXISTENT:
-      // Root directory does not exist. Create it.
-      if (!getStorageDir().mkdirs()) {
-        throw new IOException("Cannot create directory " + getStorageDir());
-      }
-      setState(VolumeState.NOT_FORMATTED);
-      createVersionFile();
-      break;
-    case NOT_FORMATTED:
-      // Version File does not exist. Create it.
-      createVersionFile();
-      break;
-    case NOT_INITIALIZED:
-      // Version File exists. Verify its correctness and update property fields.
-      readVersionFile();
-      setState(VolumeState.NORMAL);
-      break;
-    case INCONSISTENT:
-      // Volume Root is in an inconsistent state. Skip loading this volume.
-      throw new IOException("Volume is in an " + VolumeState.INCONSISTENT +
-          " state. Skipped loading volume: " + getStorageDir().getPath());
-    default:
-      throw new IOException("Unrecognized initial state : " +
-          intialVolumeState + "of volume : " + getStorageDir());
+  @Override
+  public void createWorkingDir(String workingDirName,
+      MutableVolumeSet dbVolumeSet) throws IOException {
+    super.createWorkingDir(workingDirName, dbVolumeSet);
+
+    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
+        .equals(OzoneConsts.SCHEMA_V3)) {
+      createDbStore(dbVolumeSet);
     }
-  }
-
-  private VolumeState analyzeVolumeState() {
-    if (!getStorageDir().exists()) {
-      // Volume Root does not exist.
-      return VolumeState.NON_EXISTENT;
-    }
-    if (!getStorageDir().isDirectory()) {
-      // Volume Root exists but is not a directory.
-      LOG.warn("Volume {} exists but is not a directory,"
-          + " current volume state: {}.",
-          getStorageDir().getPath(), VolumeState.INCONSISTENT);
-      return VolumeState.INCONSISTENT;
-    }
-    File[] files = getStorageDir().listFiles();
-    if (files == null || files.length == 0) {
-      // Volume Root exists and is empty.
-      return VolumeState.NOT_FORMATTED;
-    }
-    if (!getVersionFile().exists()) {
-      // Volume Root is non empty but VERSION file does not exist.
-      LOG.warn("VERSION file does not exist in volume {},"
-          + " current volume state: {}.",
-          getStorageDir().getPath(), VolumeState.INCONSISTENT);
-      return VolumeState.INCONSISTENT;
-    }
-    // Volume Root and VERSION file exist.
-    return VolumeState.NOT_INITIALIZED;
-  }
-
-  public void format(String cid) throws IOException {
-    Preconditions.checkNotNull(cid, "clusterID cannot be null while " +
-        "formatting Volume");
-    this.clusterID = cid;
-    initialize();
-  }
-
-  /**
-   * Create Version File and write property fields into it.
-   * @throws IOException
-   */
-  private void createVersionFile() throws IOException {
-    this.storageID = HddsVolumeUtil.generateUuid();
-    this.cTime = Time.now();
-    this.layoutVersion = getLatestVersion().getVersion();
-
-    if (this.clusterID == null || datanodeUuid == null) {
-      // HddsDatanodeService does not have the cluster information yet. Wait
-      // for registration with SCM.
-      LOG.debug("ClusterID not available. Cannot format the volume {}",
-          getStorageDir().getPath());
-      setState(VolumeState.NOT_FORMATTED);
-    } else {
-      // Write the version file to disk.
-      writeVersionFile();
-      setState(VolumeState.NORMAL);
-    }
-  }
-
-  private void writeVersionFile() throws IOException {
-    Preconditions.checkNotNull(this.storageID,
-        "StorageID cannot be null in Version File");
-    Preconditions.checkNotNull(this.clusterID,
-        "ClusterID cannot be null in Version File");
-    Preconditions.checkNotNull(this.datanodeUuid,
-        "DatanodeUUID cannot be null in Version File");
-    Preconditions.checkArgument(this.cTime > 0,
-        "Creation Time should be positive");
-    Preconditions.checkArgument(this.layoutVersion ==
-            getLatestVersion().getVersion(),
-        "Version File should have the latest LayOutVersion");
-
-    File versionFile = getVersionFile();
-    LOG.debug("Writing Version file to disk, {}", versionFile);
-
-    DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(this.storageID,
-        this.clusterID, this.datanodeUuid, this.cTime, this.layoutVersion);
-    dnVersionFile.createVersionFile(versionFile);
-  }
-
-  /**
-   * Read Version File and update property fields.
-   * Get common storage fields.
-   * Should be overloaded if additional fields need to be read.
-   *
-   * @throws IOException on error
-   */
-  private void readVersionFile() throws IOException {
-    File versionFile = getVersionFile();
-    Properties props = DatanodeVersionFile.readFrom(versionFile);
-    if (props.isEmpty()) {
-      throw new InconsistentStorageStateException(
-          "Version file " + versionFile + " is missing");
-    }
-
-    LOG.debug("Reading Version file from disk, {}", versionFile);
-    this.storageID = HddsVolumeUtil.getStorageID(props, versionFile);
-    this.clusterID = HddsVolumeUtil.getClusterID(props, versionFile,
-        this.clusterID);
-    this.datanodeUuid = HddsVolumeUtil.getDatanodeUUID(props, versionFile,
-        this.datanodeUuid);
-    this.cTime = HddsVolumeUtil.getCreationTime(props, versionFile);
-    this.layoutVersion = HddsVolumeUtil.getLayOutVersion(props, versionFile);
-  }
-
-  private File getVersionFile() {
-    return HddsVolumeUtil.getVersionFile(super.getStorageDir());
   }
 
   public File getHddsRootDir() {
     return super.getStorageDir();
-  }
-
-  @Override
-  public String getStorageID() {
-    return storageID;
-  }
-
-  public String getClusterID() {
-    return clusterID;
-  }
-
-  public String getDatanodeUuid() {
-    return datanodeUuid;
-  }
-
-  public long getCTime() {
-    return cTime;
-  }
-
-  public int getLayoutVersion() {
-    return layoutVersion;
-  }
-
-  public VolumeState getStorageState() {
-    return state;
-  }
-
-  public void setState(VolumeState state) {
-    this.state = state;
-  }
-
-  public boolean isFailed() {
-    return (state == VolumeState.FAILED);
   }
 
   public VolumeIOStats getVolumeIOStats() {
@@ -326,41 +131,26 @@ public class HddsVolume extends StorageVolume {
 
   @Override
   public void failVolume() {
-    setState(VolumeState.FAILED);
     super.failVolume();
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
+    }
+    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
+        .equals(OzoneConsts.SCHEMA_V3)) {
+      closeDbStore();
     }
   }
 
   @Override
   public void shutdown() {
-    this.state = VolumeState.NON_EXISTENT;
     super.shutdown();
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
     }
-  }
-
-  /**
-   * VolumeState represents the different states a HddsVolume can be in.
-   * NORMAL          =&gt; Volume can be used for storage
-   * FAILED          =&gt; Volume has failed due and can no longer be used for
-   *                    storing containers.
-   * NON_EXISTENT    =&gt; Volume Root dir does not exist
-   * INCONSISTENT    =&gt; Volume Root dir is not empty but VERSION file is
-   *                    missing or Volume Root dir is not a directory
-   * NOT_FORMATTED   =&gt; Volume Root exists but not formatted(no VERSION file)
-   * NOT_INITIALIZED =&gt; VERSION file exists but has not been verified for
-   *                    correctness.
-   */
-  public enum VolumeState {
-    NORMAL,
-    FAILED,
-    NON_EXISTENT,
-    INCONSISTENT,
-    NOT_FORMATTED,
-    NOT_INITIALIZED
+    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
+        .equals(OzoneConsts.SCHEMA_V3)) {
+      closeDbStore();
+    }
   }
 
   /**
@@ -388,11 +178,108 @@ public class HddsVolume extends StorageVolume {
     return this.dbVolume;
   }
 
-  public void setDbParentDir(File dbParentDir) {
-    this.dbParentDir = dbParentDir;
-  }
-
   public File getDbParentDir() {
     return this.dbParentDir;
+  }
+
+  public void loadDbStore() throws IOException {
+    String clusterID = getClusterID();
+    // DN startup for the first time, not registered yet,
+    // so the DbVolume is not formatted.
+    if (clusterID == null) {
+      return;
+    }
+
+    File clusterIdDir = new File(dbVolume == null ?
+        getStorageDir() : dbVolume.getStorageDir(),
+        clusterID);
+    if (!clusterIdDir.exists()) {
+      throw new IOException("Working dir " + clusterIdDir.getAbsolutePath() +
+          " not created for HddsVolume: " + getStorageDir().getAbsolutePath());
+    }
+
+    File storageIdDir = new File(clusterIdDir, getStorageID());
+    if (!storageIdDir.exists()) {
+      throw new IOException("Db parent dir " + storageIdDir.getAbsolutePath() +
+          " not found for HddsVolume: " + getStorageDir().getAbsolutePath());
+    }
+
+    File containerDBFile = new File(storageIdDir, CONTAINER_DB_NAME);
+    if (!containerDBFile.exists()) {
+      throw new IOException("Db dir " + storageIdDir.getAbsolutePath() +
+          " not found for HddsVolume: " + getStorageDir().getAbsolutePath());
+    }
+
+    String containerDBPath = containerDBFile.getAbsolutePath();
+    try {
+      initPerDiskDBStore(containerDBPath, getConf());
+    } catch (IOException e) {
+      throw new IOException("Can't init db instance under path "
+          + containerDBPath + " for volume " + getStorageID(), e);
+    }
+
+    dbParentDir = storageIdDir;
+  }
+
+  /**
+   * Pick a DbVolume for HddsVolume and init db instance.
+   * Use the HddsVolume directly if no DbVolume found.
+   * @param dbVolumeSet
+   */
+  private void createDbStore(MutableVolumeSet dbVolumeSet)
+      throws IOException {
+    DbVolume chosenDbVolume = null;
+    File clusterIdDir;
+
+    if (dbVolumeSet == null || dbVolumeSet.getVolumesList().isEmpty()) {
+      // No extra db volumes specified, just create db under the HddsVolume.
+      clusterIdDir = new File(getStorageDir(), getClusterID());
+    } else {
+      // Randomly choose a DbVolume for simplicity.
+      List<DbVolume> dbVolumeList = StorageVolumeUtil.getDbVolumesList(
+          dbVolumeSet.getVolumesList());
+      chosenDbVolume = dbVolumeList.get(
+          ThreadLocalRandom.current().nextInt(dbVolumeList.size()));
+      clusterIdDir = new File(chosenDbVolume.getStorageDir(), getClusterID());
+      chosenDbVolume.addHddsVolumeID(getStorageID());
+    }
+
+    if (!clusterIdDir.exists()) {
+      throw new IOException("The working dir "
+          + clusterIdDir.getAbsolutePath() + " is missing for volume "
+          + getStorageID());
+    }
+
+    // Init subdir with the storageID of HddsVolume.
+    File storageIdDir = new File(clusterIdDir, getStorageID());
+    if (!storageIdDir.mkdirs() && !storageIdDir.exists()) {
+      throw new IOException("Can't make subdir under "
+          + clusterIdDir.getAbsolutePath() + " for volume "
+          + getStorageID());
+    }
+
+    // Init the db instance for HddsVolume under the subdir above.
+    String containerDBPath = new File(storageIdDir, CONTAINER_DB_NAME)
+        .getAbsolutePath();
+    try {
+      initPerDiskDBStore(containerDBPath, getConf());
+    } catch (IOException e) {
+      throw new IOException("Can't init db instance under path "
+          + containerDBPath + " for volume " + getStorageID());
+    }
+
+    // Set the dbVolume and dbParentDir of the HddsVolume for db path lookup.
+    dbVolume = chosenDbVolume;
+    dbParentDir = storageIdDir;
+  }
+
+  private void closeDbStore() {
+    if (dbParentDir == null) {
+      return;
+    }
+
+    String containerDBPath = new File(dbParentDir, CONTAINER_DB_NAME)
+        .getAbsolutePath();
+    DatanodeStoreCache.getInstance().removeDB(containerDBPath);
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -76,6 +76,14 @@ public class HddsVolume extends StorageVolume {
   private int layoutVersion;      // layout version of the storage data
   private final AtomicLong committedBytes; // till Open containers become full
 
+  // The dedicated DbVolume that the db instance of this HddsVolume resides.
+  // This is optional, if null then the db instance resides on this HddsVolume.
+  private DbVolume dbVolume;
+  // The subdirectory with storageID as its name, used to build the
+  // container db path. This is initialized only once together with dbVolume,
+  // and stored as a member to prevent spawning lots of File objects.
+  private File dbParentDir;
+
   /**
    * Builder for HddsVolume.
    */
@@ -370,5 +378,21 @@ public class HddsVolume extends StorageVolume {
    */
   public long getCommittedBytes() {
     return committedBytes.get();
+  }
+
+  public void setDbVolume(DbVolume dbVolume) {
+    this.dbVolume = dbVolume;
+  }
+
+  public DbVolume getDbVolume() {
+    return this.dbVolume;
+  }
+
+  public void setDbParentDir(File dbParentDir) {
+    this.dbParentDir = dbParentDir;
+  }
+
+  public File getDbParentDir() {
+    return this.dbParentDir;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -179,16 +179,15 @@ public class HddsVolume extends StorageVolume {
   }
 
   public void loadDbStore() throws IOException {
-    String clusterID = getClusterID();
     // DN startup for the first time, not registered yet,
     // so the DbVolume is not formatted.
-    if (clusterID == null) {
+    if (!getStorageState().equals(VolumeState.NORMAL)) {
       return;
     }
 
     File clusterIdDir = new File(dbVolume == null ?
         getStorageDir() : dbVolume.getStorageDir(),
-        clusterID);
+        getClusterID());
     if (!clusterIdDir.exists()) {
       throw new IOException("Working dir " + clusterIdDir.getAbsolutePath() +
           " not created for HddsVolume: " + getStorageDir().getAbsolutePath());

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -236,7 +236,6 @@ public class HddsVolume extends StorageVolume {
       chosenDbVolume = dbVolumeList.get(
           ThreadLocalRandom.current().nextInt(dbVolumeList.size()));
       clusterIdDir = new File(chosenDbVolume.getStorageDir(), getClusterID());
-      chosenDbVolume.addHddsVolumeID(getStorageID());
     }
 
     if (!clusterIdDir.exists()) {
@@ -266,6 +265,9 @@ public class HddsVolume extends StorageVolume {
     // Set the dbVolume and dbParentDir of the HddsVolume for db path lookup.
     dbVolume = chosenDbVolume;
     dbParentDir = storageIdDir;
+    if (chosenDbVolume != null) {
+      chosenDbVolume.addHddsDbStorePath(getStorageID(), containerDBPath);
+    }
   }
 
   private void closeDbStore() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolumeFactory.java
@@ -21,7 +21,6 @@ package org.apache.hadoop.ozone.container.common.volume;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
-import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 
 import java.io.IOException;
 
@@ -30,15 +29,10 @@ import java.io.IOException;
  */
 public class HddsVolumeFactory extends StorageVolumeFactory {
 
-  private String datanodeUuid;
-  private String clusterID;
-
   public HddsVolumeFactory(ConfigurationSource conf,
       SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet,
       String datanodeUuid, String clusterID) {
-    super(conf, usageCheckFactory, volumeSet);
-    this.datanodeUuid = datanodeUuid;
-    this.clusterID = clusterID;
+    super(conf, usageCheckFactory, volumeSet, datanodeUuid, clusterID);
   }
 
   @Override
@@ -46,8 +40,8 @@ public class HddsVolumeFactory extends StorageVolumeFactory {
       StorageType storageType) throws IOException {
     HddsVolume.Builder volumeBuilder = new HddsVolume.Builder(locationString)
         .conf(getConf())
-        .datanodeUuid(datanodeUuid)
-        .clusterID(clusterID)
+        .datanodeUuid(getDatanodeUuid())
+        .clusterID(getClusterID())
         .usageCheckFactory(getUsageCheckFactory())
         .storageType(storageType)
         .volumeSet(getVolumeSet());
@@ -64,30 +58,5 @@ public class HddsVolumeFactory extends StorageVolumeFactory {
     HddsVolume.Builder volumeBuilder = new HddsVolume.Builder(locationString)
         .failedVolume(true);
     return volumeBuilder.build();
-  }
-
-  /**
-   * If Version file exists and the {@link #clusterID} is not set yet,
-   * assign it the value from Version file. Otherwise, check that the given
-   * id matches with the id from version file.
-   * @param idFromVersionFile value of the property from Version file
-   * @throws InconsistentStorageStateException
-   */
-  private void checkAndSetClusterID(String idFromVersionFile)
-      throws InconsistentStorageStateException {
-    // If the clusterID is null (not set), assign it the value
-    // from version file.
-    if (this.clusterID == null) {
-      this.clusterID = idFromVersionFile;
-      return;
-    }
-
-    // If the clusterID is already set, it should match with the value from the
-    // version file.
-    if (!idFromVersionFile.equals(this.clusterID)) {
-      throw new InconsistentStorageStateException(
-          "Mismatched ClusterIDs. VolumeSet has: " + this.clusterID +
-              ", and version file has: " + idFromVersionFile);
-    }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolume.java
@@ -49,4 +49,9 @@ public class MetadataVolume extends StorageVolume {
       return new MetadataVolume(this);
     }
   }
+
+  @Override
+  public String getStorageID() {
+    return "";
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MetadataVolumeFactory.java
@@ -31,7 +31,7 @@ public class MetadataVolumeFactory extends StorageVolumeFactory {
 
   public MetadataVolumeFactory(ConfigurationSource conf,
       SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet) {
-    super(conf, usageCheckFactory, volumeSet);
+    super(conf, usageCheckFactory, volumeSet, null, null);
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -123,7 +123,7 @@ public class MutableVolumeSet implements VolumeSet {
       maxVolumeFailuresTolerated = dnConf.getFailedMetadataVolumesTolerated();
     } else if (volumeType == StorageVolume.VolumeType.DB_VOLUME) {
       this.volumeFactory = new DbVolumeFactory(conf, usageCheckFactory,
-          this, clusterID);
+          this, datanodeUuid, clusterID);
       maxVolumeFailuresTolerated = dnConf.getFailedDbVolumesTolerated();
     } else {
       this.volumeFactory = new HddsVolumeFactory(conf, usageCheckFactory,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/MutableVolumeSet.java
@@ -121,6 +121,10 @@ public class MutableVolumeSet implements VolumeSet {
       this.volumeFactory = new MetadataVolumeFactory(conf, usageCheckFactory,
           this);
       maxVolumeFailuresTolerated = dnConf.getFailedMetadataVolumesTolerated();
+    } else if (volumeType == StorageVolume.VolumeType.DB_VOLUME) {
+      this.volumeFactory = new DbVolumeFactory(conf, usageCheckFactory,
+          this, clusterID);
+      maxVolumeFailuresTolerated = dnConf.getFailedDbVolumesTolerated();
     } else {
       this.volumeFactory = new HddsVolumeFactory(conf, usageCheckFactory,
           this, datanodeUuid, clusterID);
@@ -150,6 +154,8 @@ public class MutableVolumeSet implements VolumeSet {
     Collection<String> rawLocations;
     if (volumeType == StorageVolume.VolumeType.META_VOLUME) {
       rawLocations = HddsServerUtil.getOzoneDatanodeRatisDirectory(conf);
+    } else if (volumeType == StorageVolume.VolumeType.DB_VOLUME) {
+      rawLocations = HddsServerUtil.getDatanodeDbDirs(conf);
     } else {
       rawLocations = HddsServerUtil.getDatanodeStorageDirs(conf);
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -35,6 +35,7 @@ import java.util.Objects;
  * StorageVolume represents a generic Volume in datanode, could be
  * 1. HddsVolume for container storage.
  * 2. MetadataVolume for metadata(ratis) storage.
+ * 3. DbVolume for db instance storage.
  */
 public abstract class StorageVolume
     implements Checkable<Boolean, VolumeCheckResult> {
@@ -44,7 +45,8 @@ public abstract class StorageVolume
    */
   public enum VolumeType {
     DATA_VOLUME,
-    META_VOLUME
+    META_VOLUME,
+    DB_VOLUME,
   }
 
   private final File storageDir;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -18,27 +18,49 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
 import org.apache.hadoop.hdfs.server.datanode.StorageLocation;
 import org.apache.hadoop.hdfs.server.datanode.checker.Checkable;
 import org.apache.hadoop.hdfs.server.datanode.checker.VolumeCheckResult;
+import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
+import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.util.DiskChecker;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Objects;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.container.common.HDDSVolumeLayoutVersion.getLatestVersion;
 
 /**
  * StorageVolume represents a generic Volume in datanode, could be
  * 1. HddsVolume for container storage.
  * 2. MetadataVolume for metadata(ratis) storage.
+ *    This is a special type of volume, because it is managed
+ *    by ratis itself, so we don't format or initialize it in Ozone.
  * 3. DbVolume for db instance storage.
+ *
+ * Each hdds volume has its own VERSION file. The hdds volume will have one
+ * clusterUuid directory for each SCM it is a part of.
+ *
+ * During DN startup, if the VERSION file exists, we verify that the
+ * clusterID in the version file matches the clusterID from SCM.
  */
 public abstract class StorageVolume
     implements Checkable<Boolean, VolumeCheckResult> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(StorageVolume.class);
 
   /**
    * Type for StorageVolume.
@@ -48,6 +70,38 @@ public abstract class StorageVolume
     META_VOLUME,
     DB_VOLUME,
   }
+
+  /**
+   * VolumeState represents the different states a StorageVolume can be in.
+   * NORMAL          =&gt; Volume can be used for storage
+   * FAILED          =&gt; Volume has failed due and can no longer be used for
+   *                    storing containers.
+   * NON_EXISTENT    =&gt; Volume Root dir does not exist
+   * INCONSISTENT    =&gt; Volume Root dir is not empty but VERSION file is
+   *                    missing or Volume Root dir is not a directory
+   * NOT_FORMATTED   =&gt; Volume Root exists but not formatted(no VERSION file)
+   * NOT_INITIALIZED =&gt; VERSION file exists but has not been verified for
+   *                    correctness.
+   */
+  public enum VolumeState {
+    NORMAL,
+    FAILED,
+    NON_EXISTENT,
+    INCONSISTENT,
+    NOT_FORMATTED,
+    NOT_INITIALIZED
+  }
+
+  private VolumeState state;
+
+  // VERSION file properties
+  private String storageID;       // id of the file system
+  private String clusterID;       // id of the cluster
+  private String datanodeUuid;    // id of the DataNode
+  private long cTime;             // creation time of the file system state
+  private int layoutVersion;      // layout version of the storage data
+
+  private ConfigurationSource conf;
 
   private final File storageDir;
 
@@ -64,11 +118,176 @@ public abstract class StorageVolume
           .usageCheckFactory(b.usageCheckFactory)
           .build();
       this.volumeSet = b.volumeSet;
+      this.state = VolumeState.NOT_INITIALIZED;
+      this.clusterID = b.clusterID;
+      this.datanodeUuid = b.datanodeUuid;
+      this.conf = b.conf;
     } else {
       storageDir = new File(b.volumeRootStr);
       this.volumeInfo = null;
       this.volumeSet = null;
+      this.storageID = UUID.randomUUID().toString();
+      this.state = VolumeState.FAILED;
     }
+  }
+
+  public void format(String cid) throws IOException {
+    Preconditions.checkNotNull(cid, "clusterID cannot be null while " +
+        "formatting Volume");
+    this.clusterID = cid;
+    initialize();
+  }
+
+  /**
+   * Initializes the volume.
+   * Creates the Version file if not present,
+   * otherwise returns with IOException.
+   * @throws IOException
+   */
+  protected void initialize() throws IOException {
+    VolumeState intialVolumeState = analyzeVolumeState();
+    switch (intialVolumeState) {
+    case NON_EXISTENT:
+      // Root directory does not exist. Create it.
+      if (!getStorageDir().mkdirs()) {
+        throw new IOException("Cannot create directory " + getStorageDir());
+      }
+      setState(VolumeState.NOT_FORMATTED);
+      createVersionFile();
+      break;
+    case NOT_FORMATTED:
+      // Version File does not exist. Create it.
+      createVersionFile();
+      break;
+    case NOT_INITIALIZED:
+      // Version File exists.
+      // Verify its correctness and update property fields.
+      readVersionFile();
+      setState(VolumeState.NORMAL);
+      break;
+    case INCONSISTENT:
+      // Volume Root is in an inconsistent state. Skip loading this volume.
+      throw new IOException("Volume is in an " + VolumeState.INCONSISTENT +
+          " state. Skipped loading volume: " + getStorageDir().getPath());
+    default:
+      throw new IOException("Unrecognized initial state : " +
+          intialVolumeState + "of volume : " + getStorageDir());
+    }
+  }
+
+  /**
+   * Create working directory for cluster io loads.
+   * @param workingDirName scmID or clusterID according to SCM HA config
+   * @param dbVolumeSet optional dbVolumes
+   * @throws IOException
+   */
+  public void createWorkingDir(String workingDirName,
+      MutableVolumeSet dbVolumeSet) throws IOException {
+    File idDir = new File(getStorageDir(), workingDirName);
+    if (!idDir.mkdir()) {
+      throw new IOException("Unable to create ID directory " + idDir +
+          " for datanode.");
+    }
+  }
+
+  private VolumeState analyzeVolumeState() {
+    if (!getStorageDir().exists()) {
+      // Volume Root does not exist.
+      return VolumeState.NON_EXISTENT;
+    }
+    if (!getStorageDir().isDirectory()) {
+      // Volume Root exists but is not a directory.
+      LOG.warn("Volume {} exists but is not a directory,"
+              + " current volume state: {}.",
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
+      return VolumeState.INCONSISTENT;
+    }
+    File[] files = getStorageDir().listFiles();
+    if (files == null || files.length == 0) {
+      // Volume Root exists and is empty.
+      return VolumeState.NOT_FORMATTED;
+    }
+    if (!getVersionFile().exists()) {
+      // Volume Root is non empty but VERSION file does not exist.
+      LOG.warn("VERSION file does not exist in volume {},"
+              + " current volume state: {}.",
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
+      return VolumeState.INCONSISTENT;
+    }
+    // Volume Root and VERSION file exist.
+    return VolumeState.NOT_INITIALIZED;
+  }
+
+  /**
+   * Create Version File and write property fields into it.
+   * @throws IOException
+   */
+  private void createVersionFile() throws IOException {
+    this.storageID = StorageVolumeUtil.generateUuid();
+    this.cTime = Time.now();
+    this.layoutVersion = getLatestVersion().getVersion();
+
+    if (this.clusterID == null || datanodeUuid == null) {
+      // HddsDatanodeService does not have the cluster information yet. Wait
+      // for registration with SCM.
+      LOG.debug("ClusterID not available. Cannot format the volume {}",
+          getStorageDir().getPath());
+      setState(VolumeState.NOT_FORMATTED);
+    } else {
+      // Write the version file to disk.
+      writeVersionFile();
+      setState(VolumeState.NORMAL);
+    }
+  }
+
+  private void writeVersionFile() throws IOException {
+    Preconditions.checkNotNull(this.storageID,
+        "StorageID cannot be null in Version File");
+    Preconditions.checkNotNull(this.clusterID,
+        "ClusterID cannot be null in Version File");
+    Preconditions.checkNotNull(this.datanodeUuid,
+        "DatanodeUUID cannot be null in Version File");
+    Preconditions.checkArgument(this.cTime > 0,
+        "Creation Time should be positive");
+    Preconditions.checkArgument(this.layoutVersion ==
+            getLatestVersion().getVersion(),
+        "Version File should have the latest LayOutVersion");
+
+    File versionFile = getVersionFile();
+    LOG.debug("Writing Version file to disk, {}", versionFile);
+
+    DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(this.storageID,
+        this.clusterID, this.datanodeUuid, this.cTime, this.layoutVersion);
+    dnVersionFile.createVersionFile(versionFile);
+  }
+
+  /**
+   * Read Version File and update property fields.
+   * Get common storage fields.
+   * Should be overloaded if additional fields need to be read.
+   *
+   * @throws IOException on error
+   */
+  private void readVersionFile() throws IOException {
+    File versionFile = getVersionFile();
+    Properties props = DatanodeVersionFile.readFrom(versionFile);
+    if (props.isEmpty()) {
+      throw new InconsistentStorageStateException(
+          "Version file " + versionFile + " is missing");
+    }
+
+    LOG.debug("Reading Version file from disk, {}", versionFile);
+    this.storageID = StorageVolumeUtil.getStorageID(props, versionFile);
+    this.clusterID = StorageVolumeUtil.getClusterID(props, versionFile,
+        this.clusterID);
+    this.datanodeUuid = StorageVolumeUtil.getDatanodeUUID(props, versionFile,
+        this.datanodeUuid);
+    this.cTime = StorageVolumeUtil.getCreationTime(props, versionFile);
+    this.layoutVersion = StorageVolumeUtil.getLayOutVersion(props, versionFile);
+  }
+
+  private File getVersionFile() {
+    return StorageVolumeUtil.getVersionFile(getStorageDir());
   }
 
   /**
@@ -83,6 +302,8 @@ public abstract class StorageVolume
     private SpaceUsageCheckFactory usageCheckFactory;
     private VolumeSet volumeSet;
     private boolean failedVolume = false;
+    private String datanodeUuid;
+    private String clusterID;
 
     public Builder(String volumeRootStr, String storageDirStr) {
       this.volumeRootStr = volumeRootStr;
@@ -116,6 +337,16 @@ public abstract class StorageVolume
     // caused during creating StorageVolume object.
     public T failedVolume(boolean failed) {
       this.failedVolume = failed;
+      return this.getThis();
+    }
+
+    public T datanodeUuid(String datanodeUUID) {
+      this.datanodeUuid = datanodeUUID;
+      return this.getThis();
+    }
+
+    public T clusterID(String cid) {
+      this.clusterID = cid;
       return this.getThis();
     }
 
@@ -170,16 +401,50 @@ public abstract class StorageVolume
   }
 
   public String getStorageID() {
-    return "";
+    return storageID;
+  }
+
+  public String getClusterID() {
+    return clusterID;
+  }
+
+  public String getDatanodeUuid() {
+    return datanodeUuid;
+  }
+
+  public long getCTime() {
+    return cTime;
+  }
+
+  public int getLayoutVersion() {
+    return layoutVersion;
+  }
+
+  public VolumeState getStorageState() {
+    return state;
+  }
+
+  public void setState(VolumeState state) {
+    this.state = state;
+  }
+
+  public boolean isFailed() {
+    return (state == VolumeState.FAILED);
+  }
+
+  public ConfigurationSource getConf() {
+    return conf;
   }
 
   public void failVolume() {
+    setState(VolumeState.FAILED);
     if (volumeInfo != null) {
       volumeInfo.shutdownUsageThread();
     }
   }
 
   public void shutdown() {
+    setState(VolumeState.NON_EXISTENT);
     if (volumeInfo != null) {
       volumeInfo.shutdownUsageThread();
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeFactory.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolumeFactory.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.container.common.volume;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory;
+import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 
 import java.io.IOException;
 
@@ -32,12 +33,17 @@ public abstract class StorageVolumeFactory {
   private ConfigurationSource conf;
   private SpaceUsageCheckFactory usageCheckFactory;
   private MutableVolumeSet volumeSet;
+  private String datanodeUuid;
+  private String clusterID;
 
   public StorageVolumeFactory(ConfigurationSource conf,
-      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet) {
+      SpaceUsageCheckFactory usageCheckFactory, MutableVolumeSet volumeSet,
+      String datanodeUuid, String clusterID) {
     this.conf = conf;
     this.usageCheckFactory = usageCheckFactory;
     this.volumeSet = volumeSet;
+    this.datanodeUuid = datanodeUuid;
+    this.clusterID = clusterID;
   }
 
   public ConfigurationSource getConf() {
@@ -50,6 +56,39 @@ public abstract class StorageVolumeFactory {
 
   public VolumeSet getVolumeSet() {
     return this.volumeSet;
+  }
+
+  public String getDatanodeUuid() {
+    return this.datanodeUuid;
+  }
+
+  public String getClusterID() {
+    return this.clusterID;
+  }
+
+  /**
+   * If Version file exists and the {@link #clusterID} is not set yet,
+   * assign it the value from Version file. Otherwise, check that the given
+   * id matches with the id from version file.
+   * @param idFromVersionFile value of the property from Version file
+   * @throws InconsistentStorageStateException
+   */
+  protected void checkAndSetClusterID(String idFromVersionFile)
+      throws InconsistentStorageStateException {
+    // If the clusterID is null (not set), assign it the value
+    // from version file.
+    if (this.clusterID == null) {
+      this.clusterID = idFromVersionFile;
+      return;
+    }
+
+    // If the clusterID is already set, it should match with the value from the
+    // version file.
+    if (!idFromVersionFile.equals(this.clusterID)) {
+      throw new InconsistentStorageStateException(
+          "Mismatched ClusterIDs. VolumeSet has: " + this.clusterID +
+              ", and version file has: " + idFromVersionFile);
+    }
   }
 
   abstract StorageVolume createVolume(String locationString,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -378,6 +378,9 @@ public class OzoneContainer {
     volumeChecker.shutdownAndWait(0, TimeUnit.SECONDS);
     volumeSet.shutdown();
     metaVolumeSet.shutdown();
+    if (dbVolumeSet != null) {
+      dbVolumeSet.shutdown();
+    }
     blockDeletingService.shutdown();
     ContainerMetrics.remove();
   }
@@ -436,6 +439,14 @@ public class OzoneContainer {
       nrb.addMetadataStorageReport(
           metaReports[i].getMetadataProtoBufMessage());
     }
+
+    if (dbVolumeSet != null) {
+      StorageLocationReport[] dbReports = dbVolumeSet.getStorageReport();
+      for (int i = 0; i < dbReports.length; i++) {
+        nrb.addDbStorageReport(dbReports[i].getProtoBufMessage());
+      }
+    }
+
     return nrb.build();
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -143,8 +143,7 @@ public class OzoneContainer {
       dbVolumeSet = HddsServerUtil.getDatanodeDbDirs(conf).isEmpty() ? null :
           new MutableVolumeSet(datanodeDetails.getUuidString(), conf,
               context, VolumeType.DB_VOLUME, volumeChecker);
-      HddsVolumeUtil.loadAllHddsVolumeDbStore(volumeSet, dbVolumeSet,
-          conf, LOG);
+      HddsVolumeUtil.loadAllHddsVolumeDbStore(volumeSet, dbVolumeSet, LOG);
     } else {
       dbVolumeSet = null;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerGr
 import org.apache.hadoop.ozone.container.common.transport.server.XceiverServerSpi;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.XceiverServerRatis;
 import org.apache.hadoop.ozone.container.common.utils.ContainerInspectorUtil;
+import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
@@ -142,6 +143,8 @@ public class OzoneContainer {
       dbVolumeSet = HddsServerUtil.getDatanodeDbDirs(conf).isEmpty() ? null :
           new MutableVolumeSet(datanodeDetails.getUuidString(), conf,
               context, VolumeType.DB_VOLUME, volumeChecker);
+      HddsVolumeUtil.loadAllHddsVolumeDbStore(volumeSet, dbVolumeSet,
+          conf, LOG);
     } else {
       dbVolumeSet = null;
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.hdds.utils.HAUtils;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
-import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.helpers.ContainerMetrics;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.impl.HddsDispatcher;
@@ -65,7 +64,7 @@ import org.apache.hadoop.ozone.container.common.volume.StorageVolumeChecker;
 import org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
-import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
+import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures.SchemaV3;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -138,8 +137,7 @@ public class OzoneContainer {
     volumeSet.setFailedVolumeListener(this::handleVolumeFailures);
     metaVolumeSet = new MutableVolumeSet(datanodeDetails.getUuidString(), conf,
         context, VolumeType.META_VOLUME, volumeChecker);
-    if (VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion()
-        .equals(OzoneConsts.SCHEMA_V3)) {
+    if (SchemaV3.isFinalizedAndEnabled(conf)) {
       dbVolumeSet = HddsServerUtil.getDatanodeDbDirs(conf).isEmpty() ? null :
           new MutableVolumeSet(datanodeDetails.getUuidString(), conf,
               context, VolumeType.DB_VOLUME, volumeChecker);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/ScmHAFinalizeUpgradeActionDatanode.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/ScmHAFinalizeUpgradeActionDatanode.java
@@ -71,7 +71,7 @@ public class ScmHAFinalizeUpgradeActionDatanode
    * Upgrade the specified volume to be compatible with SCM HA layout feature.
    * @return true if the volume upgrade succeeded, false otherwise.
    */
-  public static boolean upgradeVolume(HddsVolume volume, String clusterID) {
+  public static boolean upgradeVolume(StorageVolume volume, String clusterID) {
     Preconditions.checkNotNull(clusterID, "Cannot upgrade volume with null " +
         "cluster ID");
     File hddsVolumeDir = volume.getStorageDir();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 
 import java.io.File;
@@ -154,6 +155,15 @@ public final class VersionedDatanodeFeatures {
       } else {
         return SchemaV2.chooseSchemaVersion();
       }
+    }
+
+    public static boolean isFinalizedAndEnabled(ConfigurationSource conf) {
+      DatanodeConfiguration dcf = conf.getObject(DatanodeConfiguration.class);
+      if (isFinalized(HDDSLayoutFeature.DATANODE_SCHEMA_V3)
+          && dcf.getContainerSchemaV3Enabled()) {
+        return true;
+      }
+      return false;
     }
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
@@ -149,8 +149,8 @@ public final class VersionedDatanodeFeatures {
    * rocksdb instance instead of a per-container instance.
    */
   public static class SchemaV3 {
-    public static String chooseSchemaVersion() {
-      if (isFinalized(HDDSLayoutFeature.DATANODE_SCHEMA_V3)) {
+    public static String chooseSchemaVersion(ConfigurationSource conf) {
+      if (isFinalizedAndEnabled(conf)) {
         return OzoneConsts.SCHEMA_V3;
       } else {
         return SchemaV2.chooseSchemaVersion();

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.hadoop.ozone.OzoneConsts;
-import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
 
 import java.io.File;
@@ -127,7 +126,7 @@ public final class VersionedDatanodeFeatures {
       }
     }
 
-    public static boolean upgradeVolumeIfNeeded(HddsVolume volume,
+    public static boolean upgradeVolumeIfNeeded(StorageVolume volume,
         String clusterID) {
       File clusterIDDir = new File(volume.getStorageDir(), clusterID);
       boolean needsUpgrade = isFinalized(HDDSLayoutFeature.SCM_HA) &&

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/upgrade/VersionedDatanodeFeatures.java
@@ -142,4 +142,19 @@ public final class VersionedDatanodeFeatures {
       return success;
     }
   }
+
+  /**
+   * Utilities for container Schema V3 layout feature.
+   * This schema put all container metadata info into a per-disk
+   * rocksdb instance instead of a per-container instance.
+   */
+  public static class SchemaV3 {
+    public static String chooseSchemaVersion() {
+      if (isFinalized(HDDSLayoutFeature.DATANODE_SCHEMA_V3)) {
+        return OzoneConsts.SCHEMA_V3;
+      } else {
+        return SchemaV2.chooseSchemaVersion();
+      }
+    }
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
@@ -124,5 +125,17 @@ public final class ContainerTestUtils {
             UUID.randomUUID().toString(), UUID.randomUUID().toString());
     kvData.setState(state);
     return new KeyValueContainer(kvData, new OzoneConfiguration());
+  }
+
+  public static void enableSchemaV3(OzoneConfiguration conf) {
+    DatanodeConfiguration dc = conf.getObject(DatanodeConfiguration.class);
+    dc.setContainerSchemaV3Enabled(true);
+    conf.setFromObject(dc);
+  }
+
+  public static void disableSchemaV3(OzoneConfiguration conf) {
+    DatanodeConfiguration dc = conf.getObject(DatanodeConfiguration.class);
+    dc.setContainerSchemaV3Enabled(false);
+    conf.setFromObject(dc);
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeVersionFile.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/helpers/TestDatanodeVersionFile.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.ozone.container.common.helpers;
 
 import org.apache.hadoop.ozone.common.InconsistentStorageStateException;
 import org.apache.hadoop.ozone.container.common.HDDSVolumeLayoutVersion;
-import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
 import org.junit.Before;
@@ -77,15 +77,15 @@ public class TestDatanodeVersionFile {
     //Check VersionFile exists
     assertTrue(versionFile.exists());
 
-    assertEquals(storageID, HddsVolumeUtil.getStorageID(
+    assertEquals(storageID, StorageVolumeUtil.getStorageID(
         properties, versionFile));
-    assertEquals(clusterID, HddsVolumeUtil.getClusterID(
+    assertEquals(clusterID, StorageVolumeUtil.getClusterID(
         properties, versionFile, clusterID));
-    assertEquals(datanodeUUID, HddsVolumeUtil.getDatanodeUUID(
+    assertEquals(datanodeUUID, StorageVolumeUtil.getDatanodeUUID(
         properties, versionFile, datanodeUUID));
-    assertEquals(cTime, HddsVolumeUtil.getCreationTime(
+    assertEquals(cTime, StorageVolumeUtil.getCreationTime(
         properties, versionFile));
-    assertEquals(lv, HddsVolumeUtil.getLayOutVersion(
+    assertEquals(lv, StorageVolumeUtil.getLayOutVersion(
         properties, versionFile));
   }
 
@@ -93,7 +93,7 @@ public class TestDatanodeVersionFile {
   public void testIncorrectClusterId() throws IOException {
     try {
       String randomClusterID = UUID.randomUUID().toString();
-      HddsVolumeUtil.getClusterID(properties, versionFile,
+      StorageVolumeUtil.getClusterID(properties, versionFile,
           randomClusterID);
       fail("Test failure in testIncorrectClusterId");
     } catch (InconsistentStorageStateException ex) {
@@ -110,7 +110,7 @@ public class TestDatanodeVersionFile {
     properties = dnVersionFile.readFrom(versionFile);
 
     try {
-      HddsVolumeUtil.getCreationTime(properties, versionFile);
+      StorageVolumeUtil.getCreationTime(properties, versionFile);
       fail("Test failure in testVerifyCTime");
     } catch (InconsistentStorageStateException ex) {
       GenericTestUtils.assertExceptionContains("Invalid Creation time in " +
@@ -127,7 +127,7 @@ public class TestDatanodeVersionFile {
     Properties props = dnVersionFile.readFrom(versionFile);
 
     try {
-      HddsVolumeUtil.getLayOutVersion(props, versionFile);
+      StorageVolumeUtil.getLayOutVersion(props, versionFile);
       fail("Test failure in testVerifyLayOut");
     } catch (InconsistentStorageStateException ex) {
       GenericTestUtils.assertExceptionContains("Invalid layOutVersion.", ex);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/TestDatanodeConfiguration.java
@@ -28,6 +28,7 @@ import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConf
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_MIN_GAP_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_TIMEOUT_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.DISK_CHECK_TIMEOUT_KEY;
+import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DB_VOLUMES_TOLERATED_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_KEY;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.PERIODIC_DISK_CHECK_INTERVAL_MINUTES_DEFAULT;
 import static org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration.FAILED_DATA_VOLUMES_TOLERATED_KEY;
@@ -57,6 +58,8 @@ public class TestDatanodeConfiguration {
         validFailedVolumesTolerated);
     conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
         validFailedVolumesTolerated);
+    conf.setInt(FAILED_DB_VOLUMES_TOLERATED_KEY,
+        validFailedVolumesTolerated);
     conf.setTimeDuration(DISK_CHECK_MIN_GAP_KEY,
         validDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
@@ -73,6 +76,8 @@ public class TestDatanodeConfiguration {
         subject.getFailedDataVolumesTolerated());
     assertEquals(validFailedVolumesTolerated,
         subject.getFailedMetadataVolumesTolerated());
+    assertEquals(validFailedVolumesTolerated,
+        subject.getFailedDbVolumesTolerated());
     assertEquals(validDiskCheckMinGap,
         subject.getDiskCheckMinGap().toMinutes());
     assertEquals(validDiskCheckTimeout,
@@ -95,6 +100,8 @@ public class TestDatanodeConfiguration {
         invalidFailedVolumesTolerated);
     conf.setInt(FAILED_METADATA_VOLUMES_TOLERATED_KEY,
         invalidFailedVolumesTolerated);
+    conf.setInt(FAILED_DB_VOLUMES_TOLERATED_KEY,
+        invalidFailedVolumesTolerated);
     conf.setTimeDuration(DISK_CHECK_MIN_GAP_KEY,
         invalidDiskCheckMinGap, TimeUnit.MINUTES);
     conf.setTimeDuration(DISK_CHECK_TIMEOUT_KEY,
@@ -112,6 +119,8 @@ public class TestDatanodeConfiguration {
         subject.getFailedDataVolumesTolerated());
     assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
         subject.getFailedMetadataVolumesTolerated());
+    assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
+        subject.getFailedDbVolumesTolerated());
     assertEquals(DISK_CHECK_MIN_GAP_DEFAULT,
         subject.getDiskCheckMinGap().toMillis());
     assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,
@@ -135,6 +144,8 @@ public class TestDatanodeConfiguration {
         subject.getFailedDataVolumesTolerated());
     assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
         subject.getFailedMetadataVolumesTolerated());
+    assertEquals(FAILED_VOLUMES_TOLERATED_DEFAULT,
+        subject.getFailedDbVolumesTolerated());
     assertEquals(DISK_CHECK_MIN_GAP_DEFAULT,
         subject.getDiskCheckMinGap().toMillis());
     assertEquals(DISK_CHECK_TIMEOUT_DEFAULT,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.container.common.utils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.volume.DbVolume;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -55,6 +56,7 @@ public class TestHddsVolumeUtil {
 
   @Before
   public void setup() throws Exception {
+    ContainerTestUtils.enableSchemaV3(conf);
     // Create hdds volumes for loadAll test.
     File[] hddsVolumeDirs = new File[VOLUMNE_NUM];
     StringBuilder hddsDirs = new StringBuilder();

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test for {@link HddsVolumeUtil}.
@@ -232,6 +233,6 @@ public class TestHddsVolumeUtil {
    */
   private void failVolume(File volumeDir) {
     File versionFile = new File(volumeDir, "VERSION");
-    versionFile.delete();
+    assertTrue(versionFile.delete());
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestHddsVolumeUtil.java
@@ -1,0 +1,207 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.utils;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.container.common.volume.DbVolume;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.OzoneConsts.CONTAINER_DB_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * A util class for {@link HddsVolumeUtil}.
+ */
+public class TestHddsVolumeUtil {
+  @Rule
+  public final TemporaryFolder tempDir = new TemporaryFolder();
+
+  private final String datanodeId = UUID.randomUUID().toString();
+  private final String clusterId = UUID.randomUUID().toString();
+  private final OzoneConfiguration conf = new OzoneConfiguration();
+  private static final int VOLUMNE_NUM = 5;
+  private MutableVolumeSet hddsVolumeSet;
+  private MutableVolumeSet dbVolumeSet;
+  private HddsVolume singleHddsVolume;
+
+  @Before
+  public void setup() throws Exception {
+    // Create a single volume for format test.
+    File hddsVolumeDir = tempDir.newFolder();
+    singleHddsVolume = new HddsVolume.Builder(hddsVolumeDir
+        .getAbsolutePath()).conf(conf).datanodeUuid(datanodeId)
+        .clusterID(clusterId).build();
+
+    // Create hdds volumes for loadAll test.
+    File[] hddsVolumeDirs = new File[VOLUMNE_NUM];
+    StringBuilder hddsDirs = new StringBuilder();
+    for (int i = 0; i < VOLUMNE_NUM; i++) {
+      hddsVolumeDirs[i] = tempDir.newFolder();
+      hddsDirs.append(hddsVolumeDirs[i]).append(",");
+    }
+    conf.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, hddsDirs.toString());
+    hddsVolumeSet = new MutableVolumeSet(datanodeId, clusterId, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
+
+    // Create db volumes for format and loadAll test.
+    File[] dbVolumeDirs = new File[VOLUMNE_NUM];
+    StringBuilder dbDirs = new StringBuilder();
+    for (int i = 0; i < VOLUMNE_NUM; i++) {
+      dbVolumeDirs[i] = tempDir.newFolder();
+      dbDirs.append(dbVolumeDirs[i]).append(",");
+    }
+    conf.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,
+        dbDirs.toString());
+    dbVolumeSet = new MutableVolumeSet(datanodeId, clusterId, conf, null,
+        StorageVolume.VolumeType.DB_VOLUME, null);
+  }
+
+  @Test
+  public void testFormatDbStoreForHddsVolumeWithoutDbVolumes()
+      throws IOException {
+    HddsVolumeUtil.formatDbStoreForHddsVolume(singleHddsVolume,
+        null, clusterId, conf);
+
+    File storageIdDir = new File(new File(singleHddsVolume.getStorageDir(),
+        clusterId), singleHddsVolume.getStorageID());
+
+    // No dbVolumes given, so use the hddsVolume to store db instance.
+    assertNull(singleHddsVolume.getDbVolume());
+    assertEquals(storageIdDir, singleHddsVolume.getDbParentDir());
+
+    // The db directory should exist.
+    File containerDBPath = new File(storageIdDir, CONTAINER_DB_NAME);
+    assertTrue(containerDBPath.exists());
+  }
+
+  @Test
+  public void testFormatDbStoreForHddsVolumeWithDbVolumes()
+      throws IOException {
+    HddsVolumeUtil.formatDbStoreForHddsVolume(singleHddsVolume,
+        dbVolumeSet, clusterId, conf);
+
+    // A dbVolume is picked.
+    assertNotNull(singleHddsVolume.getDbVolume());
+
+    File storageIdDir = new File(new File(singleHddsVolume.getDbVolume()
+        .getStorageDir(), clusterId), singleHddsVolume.getStorageID());
+    // Db parent dir should be set to a subdir under the dbVolume.
+    assertEquals(singleHddsVolume.getDbParentDir(), storageIdDir);
+
+    // The db directory should exist.
+    File containerDBPath = new File(storageIdDir, CONTAINER_DB_NAME);
+    assertTrue(containerDBPath.exists());
+  }
+
+  @Test
+  public void testLoadAllHddsVolumeDbStoreWithoutDbVolumes()
+      throws IOException {
+    // Create storageID subdirs under each hddsVolume manually
+    // instead of format a real db instance.
+    for (HddsVolume hddsVolume : StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList())) {
+      File storageIdDir = new File(new File(hddsVolume.getStorageDir(),
+          clusterId), hddsVolume.getStorageID());
+      if (!storageIdDir.mkdirs()) {
+        throw new IOException("Unexpected mkdir failed");
+      }
+    }
+
+    // Reinitialize all the volumes to simulate a DN restart.
+    reinitVolumes();
+    HddsVolumeUtil.loadAllHddsVolumeDbStore(hddsVolumeSet, null,
+        conf, null);
+
+    for (HddsVolume hddsVolume : StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList())) {
+      File storageIdDir = new File(new File(hddsVolume.getStorageDir(),
+          clusterId), hddsVolume.getStorageID());
+
+      // No dbVolumes given, so use the hddsVolume to store db instance.
+      assertNull(hddsVolume.getDbVolume());
+      assertEquals(storageIdDir, hddsVolume.getDbParentDir());
+    }
+  }
+
+  @Test
+  public void testLoadAllHddsVolumeDbStoreWithDbVolumes()
+      throws IOException {
+    // Create storageID subdirs under dbVolumes manually
+    // instead of format a real db instance.
+    // Map hddsVolume[i] -> dbVolume[i]
+    Iterator<HddsVolume> hddsVolumeIter = StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList()).iterator();
+    Iterator<DbVolume> dbVolumeIter = StorageVolumeUtil.getDbVolumesList(
+        dbVolumeSet.getVolumesList()).iterator();
+    for (int i = 0; i < VOLUMNE_NUM; i++) {
+      HddsVolume hddsVolume = hddsVolumeIter.next();
+      DbVolume dbVolume = dbVolumeIter.next();
+      File storageIdDir = new File(new File(dbVolume.getStorageDir(),
+          clusterId), hddsVolume.getStorageID());
+      if (!storageIdDir.mkdirs()) {
+        throw new IOException("Unexpected mkdir failed");
+      }
+    }
+
+    // Reinitialize all the volumes to simulate a DN restart.
+    reinitVolumes();
+    HddsVolumeUtil.loadAllHddsVolumeDbStore(hddsVolumeSet, dbVolumeSet,
+        conf, null);
+
+    hddsVolumeIter = StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList()).iterator();
+    dbVolumeIter = StorageVolumeUtil.getDbVolumesList(
+        dbVolumeSet.getVolumesList()).iterator();
+    for (int i = 0; i < VOLUMNE_NUM; i++) {
+      HddsVolume hddsVolume = hddsVolumeIter.next();
+      DbVolume dbVolume = dbVolumeIter.next();
+
+      // Check volume mapped correctly.
+      assertEquals(dbVolume, hddsVolume.getDbVolume());
+
+      File storageIdDir = new File(new File(dbVolume.getStorageDir(),
+          clusterId), hddsVolume.getStorageID());
+      // Db parent dir should be set to a subdir under the dbVolume.
+      assertEquals(hddsVolume.getDbParentDir(), storageIdDir);
+    }
+  }
+
+  private void reinitVolumes() throws IOException {
+    // On DN startup the clusterID is null.
+    hddsVolumeSet = new MutableVolumeSet(datanodeId, null, conf, null,
+        StorageVolume.VolumeType.DATA_VOLUME, null);
+    dbVolumeSet = new MutableVolumeSet(datanodeId, null, conf, null,
+        StorageVolume.VolumeType.DB_VOLUME, null);
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestStorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestStorageVolumeUtil.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.utils;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
+import org.apache.hadoop.ozone.container.common.volume.DbVolume;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
+import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+/**
+ * Test for {@link StorageVolumeUtil}.
+ */
+public class TestStorageVolumeUtil {
+  @Rule
+  public final TemporaryFolder folder = new TemporaryFolder();
+
+  private static final String DATANODE_UUID = UUID.randomUUID().toString();
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
+
+  private HddsVolume.Builder hddsVolumeBuilder;
+  private DbVolume.Builder dbVolumeBuilder;
+
+  @Before
+  public void setup() throws Exception {
+    hddsVolumeBuilder = new HddsVolume.Builder(folder.newFolder().getPath())
+        .datanodeUuid(DATANODE_UUID)
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE);
+    dbVolumeBuilder = new DbVolume.Builder(folder.newFolder().getPath())
+        .datanodeUuid(DATANODE_UUID)
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE);
+  }
+
+  @Test
+  public void testCheckVolumeNoDupDbStoreCreated() throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
+    HddsVolume hddsVolume = hddsVolumeBuilder.build();
+    HddsVolume spyHddsVolume = spy(hddsVolume);
+    DbVolume dbVolume = dbVolumeBuilder.build();
+    MutableVolumeSet dbVolumeSet = mock(MutableVolumeSet.class);
+    when(dbVolumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(dbVolume));
+
+    // check the dbVolume first for hddsVolume to use
+    boolean res = StorageVolumeUtil.checkVolume(dbVolume, CLUSTER_ID,
+        CLUSTER_ID, CONF, null, null);
+    assertTrue(res);
+
+    // checkVolume for the 1st time: hddsFiles.length == 1
+    res = StorageVolumeUtil.checkVolume(spyHddsVolume, CLUSTER_ID,
+        CLUSTER_ID, CONF, null, dbVolumeSet);
+    assertTrue(res);
+    // createDbStore called as expected
+    verify(spyHddsVolume, times(1)).createDbStore(dbVolumeSet);
+
+    // checkVolume for the 2nd time: hddsFiles.length == 2
+    res = StorageVolumeUtil.checkVolume(spyHddsVolume, CLUSTER_ID,
+        CLUSTER_ID, CONF, null, dbVolumeSet);
+    assertTrue(res);
+
+    // should only call createDbStore once, so no dup db instance
+    verify(spyHddsVolume, times(1)).createDbStore(dbVolumeSet);
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestStorageVolumeUtil.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/utils/TestStorageVolumeUtil.java
@@ -81,14 +81,14 @@ public class TestStorageVolumeUtil {
         CLUSTER_ID, CONF, null, null);
     assertTrue(res);
 
-    // checkVolume for the 1st time: hddsFiles.length == 1
+    // checkVolume for the 1st time: rootFiles.length == 1
     res = StorageVolumeUtil.checkVolume(spyHddsVolume, CLUSTER_ID,
         CLUSTER_ID, CONF, null, dbVolumeSet);
     assertTrue(res);
     // createDbStore called as expected
     verify(spyHddsVolume, times(1)).createDbStore(dbVolumeSet);
 
-    // checkVolume for the 2nd time: hddsFiles.length == 2
+    // checkVolume for the 2nd time: rootFiles.length == 2
     res = StorageVolumeUtil.checkVolume(spyHddsVolume, CLUSTER_ID,
         CLUSTER_ID, CONF, null, dbVolumeSet);
     assertTrue(res);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.junit.Before;
@@ -128,6 +129,8 @@ public class TestDbVolume {
 
   @Test
   public void testDbStoreClosedOnBadDbVolume() throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
     DbVolume dbVolume = volumeBuilder.build();
     dbVolume.format(CLUSTER_ID);
     dbVolume.createWorkingDir(CLUSTER_ID, null);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
@@ -19,6 +19,9 @@ package org.apache.hadoop.ozone.container.common.volume;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -26,79 +29,141 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Unit tests for {@link DbVolume}.
  */
 public class TestDbVolume {
 
+  private static final String DATANODE_UUID = UUID.randomUUID().toString();
   private static final String CLUSTER_ID = UUID.randomUUID().toString();
   private static final OzoneConfiguration CONF = new OzoneConfiguration();
 
   private DbVolume.Builder volumeBuilder;
+  private File versionFile;
 
   @Rule
   public TemporaryFolder folder = new TemporaryFolder();
 
   @Before
   public void setup() throws Exception {
+    File rootDir = new File(folder.getRoot(), DbVolume.DB_VOLUME_DIR);
     volumeBuilder = new DbVolume.Builder(folder.getRoot().getPath())
-        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE).conf(CONF);
+        .datanodeUuid(DATANODE_UUID)
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE);
+    versionFile = StorageVolumeUtil.getVersionFile(rootDir);
   }
 
   @Test
-  public void testFormat() throws IOException {
+  public void testInitializeEmptyDbVolume() throws IOException {
     DbVolume volume = volumeBuilder.build();
 
+    // The initial state of HddsVolume should be "NOT_FORMATTED" when
+    // clusterID is not specified and the version file should not be written
+    // to disk.
+    assertNull(volume.getClusterID());
     assertEquals(StorageType.DEFAULT, volume.getStorageType());
+    assertEquals(HddsVolume.VolumeState.NOT_FORMATTED,
+        volume.getStorageState());
+    assertFalse("Version file should not be created when clusterID is not " +
+        "known.", versionFile.exists());
 
-    boolean res = volume.format(CLUSTER_ID);
-    assertTrue(res);
+    // Format the volume with clusterID.
+    volume.format(CLUSTER_ID);
 
-    File volumeRootDir = new File(folder.getRoot(), DbVolume.DB_VOLUME_DIR);
-    assertTrue(volumeRootDir.exists());
-
-    File clusterIdDir = new File(volumeRootDir, CLUSTER_ID);
-    assertTrue(clusterIdDir.exists());
-
-    // duplicate format will do nothing and return true
-    res = volume.format(CLUSTER_ID);
-    assertTrue(res);
+    // The state of HddsVolume after formatting with clusterID should be
+    // NORMAL and the version file should exist.
+    assertTrue("Volume format should create Version file",
+        versionFile.exists());
+    assertEquals(CLUSTER_ID, volume.getClusterID());
+    assertEquals(HddsVolume.VolumeState.NORMAL, volume.getStorageState());
+    assertEquals(0, volume.getHddsVolumeIDs().size());
   }
 
   @Test
-  public void testInitialize() throws IOException {
+  public void testInitializeNonEmptyDbVolume() throws IOException {
     DbVolume volume = volumeBuilder.build();
 
-    // Initialize before format without clusterID should just return true
-    // and nothing is created, it happens when we boot up a fresh datanode.
-    boolean res = volume.initialize();
-    assertTrue(res);
+    // The initial state of HddsVolume should be "NOT_FORMATTED" when
+    // clusterID is not specified and the version file should not be written
+    // to disk.
+    assertNull(volume.getClusterID());
+    assertEquals(StorageType.DEFAULT, volume.getStorageType());
+    assertEquals(HddsVolume.VolumeState.NOT_FORMATTED,
+        volume.getStorageState());
+    assertFalse("Version file should not be created when clusterID is not " +
+        "known.", versionFile.exists());
 
-    File volumeRootDir = new File(folder.getRoot(), DbVolume.DB_VOLUME_DIR);
-    File clusterIdDir = new File(volumeRootDir, CLUSTER_ID);
+    // Format the volume with clusterID.
+    volume.format(CLUSTER_ID);
+    volume.createWorkingDir(CLUSTER_ID, null);
 
-    assertFalse(volumeRootDir.exists());
-    assertFalse(clusterIdDir.exists());
-
-    // Initialize with clusterID set should do format
-    // this happens for test cases.
-    volumeBuilder.clusterID(CLUSTER_ID);
-    volume = volumeBuilder.build();
-
-    res = volume.initialize();
-    assertTrue(res);
-
-    assertTrue(volumeRootDir.exists());
+    // The clusterIdDir should be created
+    File clusterIdDir = new File(volume.getStorageDir(), CLUSTER_ID);
     assertTrue(clusterIdDir.exists());
 
-    // duplicate initialize will do nothing and return true
-    res = volume.initialize();
-    assertTrue(res);
+    // Create some subdirectories to mock db instances under this volume.
+    int numSubDirs = 5;
+    File[] subdirs = new File[numSubDirs];
+    for (int i = 0; i < numSubDirs; i++) {
+      subdirs[i] = new File(clusterIdDir, UUID.randomUUID().toString());
+      boolean res = subdirs[i].mkdir();
+      assertTrue(res);
+    }
+
+    // Rebuild the same volume to simulate DN restart.
+    volume = volumeBuilder.build();
+    assertEquals(numSubDirs, volume.getHddsVolumeIDs().size());
+  }
+
+  @Test
+  public void testDbStoreClosedOnBadDbVolume() throws IOException {
+    DbVolume dbVolume = volumeBuilder.build();
+    dbVolume.format(CLUSTER_ID);
+    dbVolume.createWorkingDir(CLUSTER_ID, null);
+
+    MutableVolumeSet dbVolumeSet = mock(MutableVolumeSet.class);
+    when(dbVolumeSet.getVolumesList())
+        .thenReturn(Collections.singletonList(dbVolume));
+
+    MutableVolumeSet hddsVolumeSet = createHddsVolumeSet(3);
+    for (HddsVolume hddsVolume : StorageVolumeUtil.getHddsVolumesList(
+        hddsVolumeSet.getVolumesList())) {
+      hddsVolume.format(CLUSTER_ID);
+      hddsVolume.createWorkingDir(CLUSTER_ID, dbVolumeSet);
+    }
+
+    // The db handlers should be in the cache
+    assertEquals(3, DatanodeStoreCache.getInstance().size());
+
+    // Make the dbVolume a bad volume
+    dbVolume.failVolume();
+
+    // The db handlers should be removed from the cache
+    assertEquals(0, DatanodeStoreCache.getInstance().size());
+  }
+
+  private MutableVolumeSet createHddsVolumeSet(int volumeNum)
+      throws IOException {
+    File[] hddsVolumeDirs = new File[volumeNum];
+    StringBuilder hddsDirs = new StringBuilder();
+    for (int i = 0; i < volumeNum; i++) {
+      hddsVolumeDirs[i] = folder.newFolder();
+      hddsDirs.append(hddsVolumeDirs[i]).append(",");
+    }
+    CONF.set(ScmConfigKeys.HDDS_DATANODE_DIR_KEY, hddsDirs.toString());
+    MutableVolumeSet hddsVolumeSet = new MutableVolumeSet(DATANODE_UUID,
+        CLUSTER_ID, CONF, null, StorageVolume.VolumeType.DATA_VOLUME, null);
+    return hddsVolumeSet;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestDbVolume.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for {@link DbVolume}.
+ */
+public class TestDbVolume {
+
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
+
+  private DbVolume.Builder volumeBuilder;
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Before
+  public void setup() throws Exception {
+    volumeBuilder = new DbVolume.Builder(folder.getRoot().getPath())
+        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE).conf(CONF);
+  }
+
+  @Test
+  public void testFormat() throws IOException {
+    DbVolume volume = volumeBuilder.build();
+
+    assertEquals(StorageType.DEFAULT, volume.getStorageType());
+
+    boolean res = volume.format(CLUSTER_ID);
+    assertTrue(res);
+
+    File volumeRootDir = new File(folder.getRoot(), DbVolume.DB_VOLUME_DIR);
+    assertTrue(volumeRootDir.exists());
+
+    File clusterIdDir = new File(volumeRootDir, CLUSTER_ID);
+    assertTrue(clusterIdDir.exists());
+
+    // duplicate format will do nothing and return true
+    res = volume.format(CLUSTER_ID);
+    assertTrue(res);
+  }
+
+  @Test
+  public void testInitialize() throws IOException {
+    DbVolume volume = volumeBuilder.build();
+
+    // Initialize before format without clusterID should just return true
+    // and nothing is created, it happens when we boot up a fresh datanode.
+    boolean res = volume.initialize();
+    assertTrue(res);
+
+    File volumeRootDir = new File(folder.getRoot(), DbVolume.DB_VOLUME_DIR);
+    File clusterIdDir = new File(volumeRootDir, CLUSTER_ID);
+
+    assertFalse(volumeRootDir.exists());
+    assertFalse(clusterIdDir.exists());
+
+    // Initialize with clusterID set should do format
+    // this happens for test cases.
+    volumeBuilder.clusterID(CLUSTER_ID);
+    volume = volumeBuilder.build();
+
+    res = volume.initialize();
+    assertTrue(res);
+
+    assertTrue(volumeRootDir.exists());
+    assertTrue(clusterIdDir.exists());
+
+    // duplicate initialize will do nothing and return true
+    res = volume.initialize();
+    assertTrue(res);
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestHddsVolume.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.utils.DatanodeStoreCache;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.junit.Before;
@@ -257,6 +258,8 @@ public class TestHddsVolume {
 
   @Test
   public void testDbStoreCreatedWithoutDbVolumes() throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
     HddsVolume volume = volumeBuilder.build();
     volume.format(CLUSTER_ID);
     volume.createWorkingDir(CLUSTER_ID, null);
@@ -278,6 +281,8 @@ public class TestHddsVolume {
 
   @Test
   public void testDbStoreCreatedWithDbVolumes() throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
     // create the DbVolumeSet
     MutableVolumeSet dbVolumeSet = createDbVolumeSet();
 
@@ -304,6 +309,8 @@ public class TestHddsVolume {
   @Test
   public void testDbStoreClosedOnBadVolumeWithoutDbVolumes()
       throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
     HddsVolume volume = volumeBuilder.build();
     volume.format(CLUSTER_ID);
     volume.createWorkingDir(CLUSTER_ID, null);
@@ -332,6 +339,8 @@ public class TestHddsVolume {
 
   @Test
   public void testDbStoreClosedOnBadVolumeWithDbVolumes() throws IOException {
+    ContainerTestUtils.enableSchemaV3(CONF);
+
     // create the DbVolumeSet
     MutableVolumeSet dbVolumeSet = createDbVolumeSet();
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolume.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestStorageVolume.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckFactory;
+import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.util.Properties;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test for StorageVolume.
+ */
+public class TestStorageVolume {
+
+  private static final String DATANODE_UUID = UUID.randomUUID().toString();
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
+  private static final OzoneConfiguration CONF = new OzoneConfiguration();
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  private HddsVolume.Builder volumeBuilder;
+  private File versionFile;
+
+  @Before
+  public void setup() throws Exception {
+    File rootDir = new File(folder.getRoot(), HddsVolume.HDDS_VOLUME_DIR);
+    volumeBuilder = new HddsVolume.Builder(folder.getRoot().getPath())
+        .datanodeUuid(DATANODE_UUID)
+        .conf(CONF)
+        .usageCheckFactory(MockSpaceUsageCheckFactory.NONE);
+    versionFile = StorageVolumeUtil.getVersionFile(rootDir);
+  }
+
+  @Test
+  public void testReadPropertiesFromVersionFile() throws Exception {
+    HddsVolume volume = volumeBuilder.build();
+
+    volume.format(CLUSTER_ID);
+
+    Properties properties = DatanodeVersionFile.readFrom(versionFile);
+
+    String storageID = StorageVolumeUtil.getStorageID(properties, versionFile);
+    String clusterID = StorageVolumeUtil.getClusterID(
+        properties, versionFile, CLUSTER_ID);
+    String datanodeUuid = StorageVolumeUtil.getDatanodeUUID(
+        properties, versionFile, DATANODE_UUID);
+    long cTime = StorageVolumeUtil.getCreationTime(
+        properties, versionFile);
+    int layoutVersion = StorageVolumeUtil.getLayOutVersion(
+        properties, versionFile);
+
+    assertEquals(volume.getStorageID(), storageID);
+    assertEquals(volume.getClusterID(), clusterID);
+    assertEquals(volume.getDatanodeUuid(), datanodeUuid);
+    assertEquals(volume.getCTime(), cTime);
+    assertEquals(volume.getLayoutVersion(), layoutVersion);
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -127,6 +127,10 @@ public class TestVolumeSetDiskChecks {
         UUID.randomUUID().toString(), conf, null,
         StorageVolume.VolumeType.META_VOLUME,
         dummyChecker);
+    final MutableVolumeSet dbVolumeSet = new MutableVolumeSet(
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DB_VOLUME,
+        dummyChecker);
 
     Assert.assertEquals(volumeSet.getFailedVolumesList().size(),
         numBadVolumes);
@@ -136,8 +140,14 @@ public class TestVolumeSetDiskChecks {
         numBadVolumes);
     Assert.assertEquals(metaVolumeSet.getVolumesList().size(),
         numVolumes - numBadVolumes);
+    Assert.assertEquals(dbVolumeSet.getFailedVolumesList().size(),
+        numBadVolumes);
+    Assert.assertEquals(dbVolumeSet.getVolumesList().size(),
+        numVolumes - numBadVolumes);
+
     volumeSet.shutdown();
     metaVolumeSet.shutdown();
+    dbVolumeSet.shutdown();
   }
 
   /**
@@ -159,13 +169,21 @@ public class TestVolumeSetDiskChecks {
         UUID.randomUUID().toString(), conf, null,
         StorageVolume.VolumeType.META_VOLUME,
         dummyChecker);
+    final MutableVolumeSet dbVolumeSet = new MutableVolumeSet(
+        UUID.randomUUID().toString(), conf, null,
+        StorageVolume.VolumeType.DB_VOLUME,
+        dummyChecker);
 
     assertEquals(volumeSet.getFailedVolumesList().size(), numVolumes);
     assertEquals(volumeSet.getVolumesList().size(), 0);
     assertEquals(metaVolumeSet.getFailedVolumesList().size(), numVolumes);
     assertEquals(metaVolumeSet.getVolumesList().size(), 0);
+    assertEquals(dbVolumeSet.getFailedVolumesList().size(), numVolumes);
+    assertEquals(dbVolumeSet.getVolumesList().size(), 0);
+
     volumeSet.shutdown();
     metaVolumeSet.shutdown();
+    dbVolumeSet.shutdown();
   }
 
   /**
@@ -188,10 +206,19 @@ public class TestVolumeSetDiskChecks {
     }
     ozoneConf.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
         String.join(",", metaDirs));
+
+    final List<String> dbDirs = new ArrayList<>();
+    for (int i = 0; i < numDirs; ++i) {
+      dbDirs.add(GenericTestUtils.getRandomizedTestDir().getPath());
+    }
+    ozoneConf.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,
+        String.join(",", dbDirs));
+
     DatanodeConfiguration dnConf =
         ozoneConf.getObject(DatanodeConfiguration.class);
     dnConf.setFailedDataVolumesTolerated(numDirs * 2);
     dnConf.setFailedMetadataVolumesTolerated(numDirs * 2);
+    dnConf.setFailedDbVolumesTolerated(numDirs * 2);
     ozoneConf.setFromObject(dnConf);
     return ozoneConf;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeSetDiskChecks.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.DFSConfigKeysLegacy;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.DiskChecker.DiskErrorException;
@@ -117,6 +118,7 @@ public class TestVolumeSetDiskChecks {
     final int numBadVolumes = 2;
 
     conf = getConfWithDataNodeDirs(numVolumes);
+    ContainerTestUtils.enableSchemaV3(conf);
     StorageVolumeChecker dummyChecker =
         new DummyChecker(conf, new Timer(), numBadVolumes);
     final MutableVolumeSet volumeSet = new MutableVolumeSet(
@@ -158,6 +160,7 @@ public class TestVolumeSetDiskChecks {
     final int numVolumes = 5;
 
     conf = getConfWithDataNodeDirs(numVolumes);
+    ContainerTestUtils.enableSchemaV3(conf);
     StorageVolumeChecker dummyChecker =
         new DummyChecker(conf, new Timer(), numVolumes);
 

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.container.common.ContainerTestUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
@@ -194,6 +195,7 @@ public class TestOzoneContainer {
     }
     conf.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,
         dbDirString.toString());
+    ContainerTestUtils.enableSchemaV3(conf);
 
     DatanodeStateMachine stateMachine = Mockito.mock(
             DatanodeStateMachine.class);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ozoneimpl/TestOzoneContainer.java
@@ -59,6 +59,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.util.Random;
 import java.util.UUID;
 import java.util.HashMap;
@@ -184,6 +185,16 @@ public class TestOzoneContainer {
     conf.set(OzoneConfigKeys.DFS_CONTAINER_RATIS_DATANODE_STORAGE_DIR,
             String.join(",",
             path + "/ratis1", path + "/ratis2", path + "ratis3"));
+
+    File[] dbPaths = new File[3];
+    StringBuilder dbDirString = new StringBuilder();
+    for (int i = 0; i < 3; i++) {
+      dbPaths[i] = folder.newFolder();
+      dbDirString.append(dbPaths[i]).append(",");
+    }
+    conf.set(OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR,
+        dbDirString.toString());
+
     DatanodeStateMachine stateMachine = Mockito.mock(
             DatanodeStateMachine.class);
     StateContext context = Mockito.mock(StateContext.class);
@@ -199,7 +210,8 @@ public class TestOzoneContainer {
     Assert.assertEquals(3,
             ozoneContainer.getNodeReport().getMetadataStorageReportList()
                     .size());
-
+    Assert.assertEquals(3,
+            ozoneContainer.getNodeReport().getDbStorageReportList().size());
   }
 
   @Test

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HddsServerUtil.java
@@ -90,6 +90,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTER
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_INFO_WAIT_DURATION_DEFAULT;
 import static org.apache.hadoop.hdds.server.ServerUtils.sanitizeUserArgs;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.HDDS_DATANODE_CONTAINER_DB_DIR;
 
 import org.rocksdb.RocksDBException;
 import org.slf4j.Logger;
@@ -388,6 +389,12 @@ public final class HddsServerUtil {
           + HDDS_DATANODE_DIR_KEY + " or " + DFS_DATANODE_DATA_DIR_KEY);
     }
     return rawLocations;
+  }
+
+  public static Collection<String> getDatanodeDbDirs(
+      ConfigurationSource conf) {
+    // No fallback here, since this config is optional.
+    return conf.getTrimmedStringCollection(HDDS_DATANODE_CONTAINER_DB_DIR);
   }
 
   /**

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -159,6 +159,7 @@ message SCMNodeAddressList {
 message NodeReportProto {
   repeated StorageReportProto storageReport = 1;
   repeated MetadataStorageReportProto metadataStorageReport = 2;
+  repeated StorageReportProto dbStorageReport = 3;
 }
 
 message StorageReportProto {

--- a/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/1.1.0-1.2.0/callback.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/upgrades/non-rolling-upgrade/1.1.0-1.2.0/callback.sh
@@ -63,7 +63,7 @@ with_old_version_downgraded() {
 }
 
 with_new_version_finalized() {
-  _check_hdds_mlvs 2
+  _check_hdds_mlvs 3
   # OM currently only has one layout version.
   _check_om_mlvs 0
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/container/ContainerCommands.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
 import org.apache.hadoop.ozone.container.common.impl.ContainerData;
 import org.apache.hadoop.ozone.container.common.impl.ContainerSet;
 import org.apache.hadoop.ozone.container.common.interfaces.Handler;
-import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
@@ -191,7 +190,7 @@ public class ContainerCommands implements Callable<Void>, SubcommandWithParent {
           "Version file " + versionFile + " is missing");
     }
 
-    return HddsVolumeUtil
+    return StorageVolumeUtil
         .getProperty(props, OzoneConsts.DATANODE_UUID, versionFile);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/containergenerator/GeneratorDatanode.java
@@ -52,7 +52,7 @@ import org.apache.hadoop.ozone.container.common.helpers.DatanodeVersionFile;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext.WriteChunkStage;
-import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
+import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.MutableVolumeSet;
 import org.apache.hadoop.ozone.container.common.volume.RoundRobinVolumeChoosingPolicy;
 import org.apache.hadoop.ozone.container.common.volume.StorageVolume;
@@ -160,9 +160,9 @@ public class GeneratorDatanode extends BaseGenerator {
           "Version file " + versionFile + " is missing");
     }
 
-    String clusterId =
-        HddsVolumeUtil.getProperty(props, OzoneConsts.CLUSTER_ID, versionFile);
-    datanodeId = HddsVolumeUtil
+    String clusterId = StorageVolumeUtil.getProperty(props,
+        OzoneConsts.CLUSTER_ID, versionFile);
+    datanodeId = StorageVolumeUtil
         .getProperty(props, OzoneConsts.DATANODE_UUID, versionFile);
 
     volumeSet = new MutableVolumeSet(datanodeId, clusterId, config, null,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Per-disk DB location management.
More descriptions about the db location could be found in the JIRA below.
Here are some descriptions of the 3 separated commits:
- Add some LayoutFeature definitions but not the whole non-rolling upgrade related stuff, so we could check if we have to init the per-disk db instances.
- A new `StorageVolume` type `DbVolume` for optional dedicated SSDs for db instances to speed up meta operations.
- Format db instances on DN first register and load db instances on DN startup.

We have one subdirectory for each data volume under a db volume, with the StorageID(UUID) of the data volume as the name of the subdirectory.

When extra SSDs are used

- Should create DbVolume to manage it for bad disk checking
- Should create special directory structure including clusterID to be isolated with other stuff on the disk, e.g. /ssd1/db/CID-<clusterID>
- Should have a configuration item: “hdds.datanode.container.db.dir”
- HddsVolume should be mapped to a dedicated subdir named after the StorageID of it, e.g. DS-b559933f-9de3-4da4-a634-07d3a94f7438/
- Container metafile (e.g. 1.container under metadata) does not have to record the dbPath since now it is bind to the HddsVolume and we already know which HddsVolume the container resides.

<img width="475" alt="Screen Shot 2022-04-14 at 6 55 42 PM" src="https://user-images.githubusercontent.com/22789849/163377667-42550538-6967-4a5e-b83f-100b53ee19e4.png">


When no SSD, use the same disk as data by default

- Create container with the same disk where the block files resides
- No DbVolume created, e.g. hddsVolume.dbVolume = null
- Configuration item not specified
- Could be easily migrated to a newly added SSD, e.g.

             `mv /data1/hdds/CID-<clusterID>/DS-<StorageID>  /ssd1/db/CID-<clusterID>/`

<img width="493" alt="Screen Shot 2022-04-14 at 6 55 53 PM" src="https://user-images.githubusercontent.com/22789849/163377702-db7f2ae9-45b2-42d8-b1cd-c449375cafef.png">


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6541

## How was this patch tested?

New UTs.
