### PR TITLE
HDDS-6574. Set owner of buckets created via S3 Gateway to actual user rather than `s3g`; print LinkBucket owner field on the client

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -533,7 +533,7 @@ public class RpcClient implements ClientProtocol {
     verifyCountsQuota(bucketArgs.getQuotaInNamespace());
     verifySpaceQuota(bucketArgs.getQuotaInBytes());
 
-    String owner;
+    final String owner;
     // If S3 auth exists, set owner name to the short user name derived from the
     //  accessId. Similar to RpcClient#getDEK
     if (getThreadLocalS3Auth() != null) {

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure-ha/docker-config
@@ -67,7 +67,7 @@ HDFS-SITE.XML_dfs.datanode.address=0.0.0.0:1019
 HDFS-SITE.XML_dfs.datanode.http.address=0.0.0.0:1012
 CORE-SITE.XML_dfs.data.transfer.protection=authentication
 CORE-SITE.XML_hadoop.security.authentication=kerberos
-CORE-SITE.XML_hadoop.security.auth_to_local=RULE:[2:$1](testuser2.*) RULE:[2:$1@$0](.*)s/.*/root/
+CORE-SITE.XML_hadoop.security.auth_to_local="RULE:[2:$1](testuser2.*) RULE:[2:$1](testuser.*) RULE:[2:$1@$0](.*)s/.*/root/"
 CORE-SITE.XML_hadoop.security.key.provider.path=kms://http@kms:9600/kms
 
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -34,7 +34,7 @@ List buckets
 
 Get bucket info with Ozone Shell to check the owner field
     Pass Execution If   '${SECURITY_ENABLED}' == 'false'    Skipping this check as security is not enabled
-    ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '. | select(.name=="${BUCKET}") | .owner'
+    ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '.owner'
                         Should Be Equal     ${result}       testuser
                         # In ozonesecure(-ha) docker-config, hadoop.security.auth_to_local is set
                         # in the way that getShortUserName() converts the accessId to "testuser".

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -33,6 +33,7 @@ List buckets
                         Should contain          ${result}    ${BUCKET}
 
 Get bucket info with Ozone Shell to check the owner field
+    Pass Execution If   '${SECURITY_ENABLED}' == 'false'    Skipping this check for insecure cluster
     ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '. | select(.name=="${BUCKET}") | .owner'
                         Should Be Equal     ${result}       root
                         # In ozonesecure(-ha) docker-config, hadoop.security.auth_to_local is set

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -32,9 +32,12 @@ List buckets
     ${result} =         Execute AWSS3APICli     list-buckets | jq -r '.Buckets[].Name'
                         Should contain          ${result}    ${BUCKET}
 
-List bucket using Ozone Shell CLI and check the owner
+Get bucket info with Ozone Shell to check the owner field
     ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '. | select(.name=="${BUCKET}") | .owner'
-                        Should Be Equal     ${result}       dlfknslnfslf    # See "Setup dummy credentials for S3" in commonawslib.robot
+                        Should Be Equal     ${result}       root
+                        # In ozonesecure(-ha) docker-config, hadoop.security.auth_to_local is set
+                        # in the way that getShortUserName() converts the accessId to "root".
+                        # Also see "Setup dummy credentials for S3" in commonawslib.robot
 
 List buckets with empty access id
                         Execute                    aws configure set aws_access_key_id ''

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -33,11 +33,11 @@ List buckets
                         Should contain          ${result}    ${BUCKET}
 
 Get bucket info with Ozone Shell to check the owner field
-    Pass Execution If   '${SECURITY_ENABLED}' == 'false'    Skipping this check for insecure cluster
+    Pass Execution If   '${SECURITY_ENABLED}' == 'false'    Skipping this check as security is not enabled
     ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '. | select(.name=="${BUCKET}") | .owner'
-                        Should Be Equal     ${result}       root
+                        Should Be Equal     ${result}       testuser
                         # In ozonesecure(-ha) docker-config, hadoop.security.auth_to_local is set
-                        # in the way that getShortUserName() converts the accessId to "root".
+                        # in the way that getShortUserName() converts the accessId to "testuser".
                         # Also see "Setup dummy credentials for S3" in commonawslib.robot
 
 List buckets with empty access id

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketlist.robot
@@ -32,6 +32,10 @@ List buckets
     ${result} =         Execute AWSS3APICli     list-buckets | jq -r '.Buckets[].Name'
                         Should contain          ${result}    ${BUCKET}
 
+List bucket using Ozone Shell CLI and check the owner
+    ${result} =         Execute             ozone sh bucket info /s3v/${BUCKET} | jq -r '. | select(.name=="${BUCKET}") | .owner'
+                        Should Be Equal     ${result}       dlfknslnfslf    # See "Setup dummy credentials for S3" in commonawslib.robot
+
 List buckets with empty access id
                         Execute                    aws configure set aws_access_key_id ''
     ${result} =         Execute AWSS3APICli and checkrc         list-buckets    255

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/InfoBucketHandler.java
@@ -58,6 +58,7 @@ public class InfoBucketHandler extends BucketHandler {
     private String sourceBucket;
     private Instant creationTime;
     private Instant modificationTime;
+    private String owner;
 
     LinkBucket(OzoneBucket ozoneBucket) {
       this.volumeName = ozoneBucket.getVolumeName();
@@ -66,6 +67,7 @@ public class InfoBucketHandler extends BucketHandler {
       this.sourceBucket = ozoneBucket.getSourceBucket();
       this.creationTime = ozoneBucket.getCreationTime();
       this.modificationTime = ozoneBucket.getModificationTime();
+      this.owner = ozoneBucket.getOwner();
     }
 
     public String getVolumeName() {
@@ -90,6 +92,10 @@ public class InfoBucketHandler extends BucketHandler {
 
     public Instant getModificationTime() {
       return modificationTime;
+    }
+
+    public String getOwner() {
+      return owner;
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently if a bucket is created using S3 API via S3 Gateway, the bucket owner is always set to "s3g" (whoever S3 Gateway authenticated itself as to the Ozone Manager).

```bash
$ ozone sh bucket list /tenant1
[ {
  "metadata" : { },
  "volumeName" : "s3v",
  "name" : "bucket1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-04-07T14:51:49.053Z",
  "modificationTime" : "2022-04-07T14:51:49.053Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "s3g",  <---
  "link" : false
} ]
```

This bucket owner field should be set to the user behind the accessId (short name) as this should be the intended behavior.

```bash
$ ozone sh bucket list /tenant1
[ {
...
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "hive",  <---
  "link" : false
} ]
```

### Bonus

Also added owner field in the client output when the bucket is a link (rather than a regular one) as it wasn't there in the class `LinkBucket`:

```bash
bash-4.2$ id
uid=1000(hadoop) gid=100(users) groups=100(users)
bash-4.2$ ozone sh volume create vol1
bash-4.2$ ozone sh bucket create vol1/buck2
bash-4.2$ ozone sh bucket link vol1/buck2 vol1/linkbuck3
bash-4.2$ ozone sh bucket info vol1/linkbuck3
{
  "volumeName" : "vol1",
  "bucketName" : "linkbuck3",
  "sourceVolume" : "vol1",
  "sourceBucket" : "buck2",
  "creationTime" : "2022-04-14T00:00:25.395Z",
  "modificationTime" : "2022-04-14T00:00:25.395Z",
  "owner" : "hadoop"  <--- NEWLY ADDED
}
```

The above output is from `compose/ozone` (insecure). But this also applies to `compose/ozonesecure` (secure) and others. The only difference would be that secure ones require `kinit` and the `owner` would become the "short name" after UGI conversion according to the `hadoop.security.auth_to_local` rule.

This was causing trouble for the acceptance test addition. Also it makes sense as the linked (symlink) bucket itself also has an owner, it just wasn't printed.

Output of `ozone sh bucket info` on a regular bucket, just for reference:

```bash
bash-4.2$ ozone sh bucket info vol1/buck2
{
  "metadata" : { },
  "volumeName" : "vol1",
  "name" : "buck2",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-04-14T00:00:02.984Z",
  "modificationTime" : "2022-04-14T00:00:02.984Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "OBJECT_STORE",
  "owner" : "hadoop",
  "link" : false
}
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6574

## How was this patch tested?

- [x] Add an acceptance test case
- [x] All existing tests shall pass