### PR TITLE
HDDS-6575. [Multi-Tenant] Clean up unused tenantDefaultPolicyName field in CreateTenantRequest protobuf message

### DIFF
--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -1482,8 +1482,7 @@ message RevokeS3SecretRequest {
 
 message CreateTenantRequest {
     optional string tenantId = 1;  // Tenant name
-    optional string tenantDefaultPolicyName = 2;
-    optional string volumeName = 3;
+    optional string volumeName = 2;
 }
 
 message DeleteTenantRequest {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -170,16 +170,9 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
     tenantInContext = ozoneManager.getMultiTenantManager()
         .createTenantAccessInAuthorizer(tenantId);
 
-    // Get the tenant default policy, pass this along
-    final String tenantDefaultPolicies = tenantInContext
-        .getTenantAccessPolicies()
-        .stream().map(AccessPolicy::getPolicyID)
-        .collect(Collectors.joining(","));
-
     final OMRequest.Builder omRequestBuilder = getOmRequest().toBuilder()
         .setCreateTenantRequest(
             CreateTenantRequest.newBuilder()
-                .setTenantDefaultPolicyName(tenantDefaultPolicies)
                 .setTenantId(tenantId)
                 .setVolumeName(volumeName))
         .setCreateVolumeRequest(
@@ -235,8 +228,6 @@ public class OMTenantCreateRequest extends OMVolumeRequest {
         "CreateTenantRequest's volumeName value should match VolumeInfo's");
     final String dbVolumeKey = omMetadataManager.getVolumeKey(volumeName);
     IOException exception = null;
-
-    final String tenantDefaultPolicies = request.getTenantDefaultPolicyName();
 
     try {
       // Check ACL: requires volume CREATE permission.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/tenant/OMTenantCreateRequest.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OmDBTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
-import org.apache.hadoop.ozone.om.multitenant.AccessPolicy;
 import org.apache.hadoop.ozone.om.multitenant.Tenant;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.util.OmResponseUtil;
@@ -57,7 +56,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.TENANT_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_ALREADY_EXISTS;


### PR DESCRIPTION
## What changes were proposed in this pull request?

This `tenantDefaultPolicyName` field is no longer in-use and didn't get removed in [HDDS-6396](https://issues.apache.org/jira/browse/HDDS-6396).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6575

## How was this patch tested?

- [x] All existing test cases should pass.