### PR TITLE
HDDS-6579. Add commandline argument for Container Info command.

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -63,6 +63,11 @@ public class InfoSubcommand extends ScmSubcommand {
       description = "Format output as JSON")
   private boolean json;
 
+  @CommandLine.Option(names = { "--addReplicaDetails" },
+      defaultValue = "false",
+      description = "Adds replica related details")
+  private boolean addReplicaDetails;
+
   @Parameters(description = "Decimal id of the container.")
   private long containerID;
 
@@ -103,7 +108,7 @@ public class InfoSubcommand extends ScmSubcommand {
       LOG.info("Datanodes: [{}]", machinesStr);
 
       // Print the replica details if available
-      if (replicas != null) {
+      if (addReplicaDetails && replicas != null) {
         String replicaStr = replicas.stream().map(
             InfoSubcommand::buildReplicaDetails)
             .collect(Collectors.joining(",\n"));

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -63,7 +63,7 @@ public class InfoSubcommand extends ScmSubcommand {
       description = "Format output as JSON")
   private boolean json;
 
-  @CommandLine.Option(names = { "--addReplicaDetails" },
+  @CommandLine.Option(names = { "--replicas" },
       defaultValue = "false",
       description = "Adds replica related details")
   private boolean addReplicaDetails;

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -85,7 +85,7 @@ public class TestInfoSubCommand {
         .thenReturn(getReplicas());
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("1");
+    c.parseArgs("1", "--addReplicaDetails");
     cmd.execute(scmClient);
 
     // Ensure we have a line for Replicas:

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -85,7 +85,7 @@ public class TestInfoSubCommand {
         .thenReturn(getReplicas());
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("1", "--addReplicaDetails");
+    c.parseArgs("1", "--replicas");
     cmd.execute(scmClient);
 
     // Ensure we have a line for Replicas:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a command line option called --addReplicaDetails to print replica related information for container info command


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6579

## How was this patch tested?

Fixed an existing test
