### PR TITLE
HDDS-6580. Introduce KEY_PATH_LOCK under OzoneManagerLock.Resource

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -254,7 +254,8 @@ public class OzoneManagerLock {
 
   }
 
-  private List<String> getCurrentLocks() {
+  @VisibleForTesting
+  List<String> getCurrentLocks() {
     List<String> currentLocks = new ArrayList<>();
     short lockSetVal = lockSet.get();
     for (Resource value : Resource.values()) {

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -238,6 +238,9 @@ public class OzoneManagerLock {
     } else if (resources.length == 2 && resource == Resource.BUCKET_LOCK) {
       return OzoneManagerLockUtil.generateBucketLockName(resources[0],
           resources[1]);
+    } else if (resources.length == 3 && resource == Resource.KEY_PATH_LOCK) {
+      return OzoneManagerLockUtil.generateKeyPathLockName(resources[0],
+          resources[1], resources[2]);
     } else {
       throw new IllegalArgumentException("acquire lock is supported on single" +
           " resource for all locks except for resource bucket");
@@ -600,7 +603,8 @@ public class OzoneManagerLock {
     USER_LOCK((byte) 3, "USER_LOCK"), // 15
 
     S3_SECRET_LOCK((byte) 4, "S3_SECRET_LOCK"), // 31
-    PREFIX_LOCK((byte) 5, "PREFIX_LOCK"); //63
+    KEY_PATH_LOCK((byte) 5, "KEY_PATH_LOCK"), //63
+    PREFIX_LOCK((byte) 6, "PREFIX_LOCK"); //127
 
     // level of the resource
     private byte lockLevel;

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLockUtil.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLockUtil.java
@@ -69,7 +69,18 @@ final class OzoneManagerLockUtil {
   public static String generateBucketLockName(String volumeName,
       String bucketName) {
     return OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName;
-
   }
 
+  /**
+   * Generate key path lock name.
+   * @param volumeName
+   * @param bucketName
+   * @param keyName
+   */
+  public static String generateKeyPathLockName(String volumeName,
+                                               String bucketName,
+                                               String keyName) {
+    return OM_KEY_PREFIX + volumeName + OM_KEY_PREFIX + bucketName +
+        OM_KEY_PREFIX + keyName;
+  }
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -209,6 +209,9 @@ public class TestOzoneManagerLock {
     if (resource == OzoneManagerLock.Resource.BUCKET_LOCK) {
       return new String[]{UUID.randomUUID().toString(),
           UUID.randomUUID().toString()};
+    } else if (resource == OzoneManagerLock.Resource.KEY_PATH_LOCK) {
+      return new String[]{UUID.randomUUID().toString(),
+          UUID.randomUUID().toString(), UUID.randomUUID().toString()};
     } else {
       return new String[]{UUID.randomUUID().toString()};
     }
@@ -224,6 +227,10 @@ public class TestOzoneManagerLock {
         resource == OzoneManagerLock.Resource.BUCKET_LOCK) {
       return OzoneManagerLockUtil.generateBucketLockName(resources[0],
           resources[1]);
+    } else if (resources.length == 3 &&
+        resource == OzoneManagerLock.Resource.KEY_PATH_LOCK) {
+      return OzoneManagerLockUtil.generateKeyPathLockName(resources[0],
+          resources[1], resources[2]);
     } else {
       throw new IllegalArgumentException("acquire lock is supported on single" +
           " resource for all locks except for resource bucket");

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -22,12 +22,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.junit.rules.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -36,6 +42,13 @@ import static org.junit.Assert.fail;
  * Class tests OzoneManagerLock.
  */
 public class TestOzoneManagerLock {
+
+  @Rule
+  public Timeout timeout = Timeout.seconds(300);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOzoneManagerLock.class);
+
   @Test
   public void acquireResourceLock() {
     String[] resourceName;
@@ -574,5 +587,308 @@ public class TestOzoneManagerLock {
         "Expected " + writeThreadCount +
             " samples in writeLockWaitingTimeMsStat" + writeWaitingStat,
         writeWaitingStat.contains("Samples = " + writeThreadCount));
+  }
+
+  @Test
+  public void testKeyPathLockMultiThreading() throws Exception {
+    testSameKeyPathWriteLockMultiThreading(10, 100);
+    testDiffKeyPathWriteLockMultiThreading(10, 100);
+  }
+
+  class Counter {
+
+    private int count = 0;
+
+    public void incrementCount() {
+      count++;
+    }
+
+    public int getCount() {
+      return count;
+    }
+  }
+
+  // "/a/b/c/d/key1 - WLock - 1st iteration"
+  // "/a/b/c/d/key1 - WLock - 2nd iteration"  -- blocked
+  // "/a/b/c/d/key1 - WLock - 3rd iteration"  -- blocked
+  // "/a/b/c/d/key1 - WLock - 4th iteration"  -- blocked
+  // "/a/b/c/d/key1 - WLock - 5th iteration"  -- blocked
+  // (iterations are sequential)
+
+  public void testSameKeyPathWriteLockMultiThreading(int threadCount,
+                                                     int iterations)
+      throws InterruptedException {
+
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    Thread[] threads = new Thread[threadCount];
+    Counter counter = new Counter();
+    CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+    List<Integer> listTokens = new ArrayList<>(threadCount);
+
+    for (int i = 0; i < threads.length; i++) {
+
+      threads[i] = new Thread(() -> {
+        String[] sampleResourceName =
+            new String[]{volumeName, bucketName, keyName};
+
+        testSameKeyPathWriteLockMultiThreadingUtil(iterations, resource, lock,
+            counter, countDownLatch,
+            listTokens,
+            sampleResourceName);
+      });
+
+      threads[i].start();
+    }
+
+    // Waiting for all the threads to finish execution (run method).
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    // For example, threadCount = 10, iterations = 100. The expected counter
+    // value is 10 * 100
+    Assert.assertEquals(threadCount * iterations, counter.getCount());
+    Assert.assertEquals(threadCount, listTokens.size());
+
+    // Thread-1 -> 1 * 100,
+    // Thread-2 -> 2 * 100 and so on.
+    for (int i = 1; i <= listTokens.size(); i++) {
+      Assert.assertEquals((new Integer(i * iterations)), listTokens.get(i - 1));
+    }
+  }
+
+  private void testSameKeyPathWriteLockMultiThreadingUtil(
+      int iterations, OzoneManagerLock.Resource resource, OzoneManagerLock lock,
+      Counter counter, CountDownLatch countDownLatch, List<Integer> listTokens,
+      String[] sampleResourceName) {
+
+    // Waiting for all the threads to be instantiated/to reach acquireWriteLock.
+    countDownLatch.countDown();
+    while (countDownLatch.getCount() > 0) {
+      try {
+        Thread.sleep(500);
+        LOG.info("countDown.getCount() -> " + countDownLatch.getCount());
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    // Now all threads have been instantiated.
+    Assert.assertEquals(0, countDownLatch.getCount());
+
+    lock.acquireWriteLock(resource, sampleResourceName);
+    LOG.info("Write Lock Acquired by " + Thread.currentThread().getName());
+
+    /**
+     * Critical Section. count = count + 1;
+     */
+    for (int idx = 0; idx < iterations; idx++) {
+      counter.incrementCount();
+    }
+
+    //  Sequence of tokens range from 1-100 (if iterations = 100) for each
+    //  thread. For example:
+    //  Thread-1 -> 1 - 100
+    //  Thread-2 -> 101 - 200 and so on.
+    listTokens.add(counter.getCount());
+
+    lock.releaseWriteLock(resource, sampleResourceName);
+    LOG.info("Write Lock Released by " + Thread.currentThread().getName());
+  }
+
+  // "/a/b/c/d/key1 - WLock - 1st iteration"
+  // "/a/b/c/d/key2 - WLock - 2nd iteration"  -- allowed
+  // "/a/b/c/d/key3 - WLock - 3rd iteration"  -- allowed
+  // "/a/b/c/d/key4 - WLock - 4th iteration"  -- allowed
+  // "/a/b/c/d/key5 - WLock - 5th iteration"  -- allowed
+  // (iterations are parallel)
+
+  public void testDiffKeyPathWriteLockMultiThreading(int threadCount,
+                                                     int iterations)
+      throws Exception {
+
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    Thread[] threads = new Thread[threadCount];
+    Counter counter = new Counter();
+    CountDownLatch countDown = new CountDownLatch(threadCount);
+
+    for (int i = 0; i < threads.length; i++) {
+
+      threads[i] = new Thread(() -> {
+        String keyName = UUID.randomUUID().toString();
+        String[] sampleResourceName =
+            new String[]{volumeName, bucketName, keyName};
+
+        testDiffKeyPathWriteLockMultiThreadingUtil(resource, lock, countDown,
+            sampleResourceName);
+      });
+
+      threads[i].start();
+    }
+
+    /**
+     * Waiting for all the threads to count down
+     */
+    GenericTestUtils.waitFor(() -> {
+      if (countDown.getCount() > 0) {
+        LOG.info("Waiting for the threads to count down {} ",
+            countDown.getCount());
+        return false;
+      }
+      return true; // all threads have finished counting down.
+    }, 3000, 120000); // 2 minutes
+
+    Assert.assertEquals(0, countDown.getCount());
+
+    for (Thread t : threads) {
+      t.join();
+    }
+
+    LOG.info("Expected = " + threadCount * iterations + ", Actual = " +
+        counter.getCount());
+  }
+
+  private void testDiffKeyPathWriteLockMultiThreadingUtil(
+      OzoneManagerLock.Resource resource,
+      OzoneManagerLock lock, CountDownLatch countDown,
+      String[] sampleResourceName) {
+
+    lock.acquireWriteLock(resource, sampleResourceName);
+    LOG.info("Write Lock Acquired by " + Thread.currentThread().getName());
+
+    // Waiting for all the threads to be instantiated/to reach acquireWriteLock.
+    countDown.countDown();
+    while (countDown.getCount() > 0) {
+      try {
+        Thread.sleep(500);
+        LOG.info("countDown.getCount() -> " + countDown.getCount());
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+    }
+
+    Assert.assertEquals(1, lock.getCurrentLocks().size());
+
+    lock.releaseWriteLock(resource, sampleResourceName);
+    LOG.info("Write Lock Released by " + Thread.currentThread().getName());
+  }
+
+  @Test
+  public void testAcquireWriteBucketLockWhileAcquiredWriteKeyPathLock() {
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK, higherResource =
+        OzoneManagerLock.Resource.BUCKET_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    String[] resourceName = new String[]{volumeName, bucketName, keyName},
+        higherResourceName = new String[]{volumeName, bucketName};
+
+    lock.acquireWriteLock(resource, resourceName);
+    try {
+      lock.acquireWriteLock(higherResource, higherResourceName);
+      fail("testAcquireWriteBucketLockWhileAcquiredWriteKeyPathLock() failed");
+    } catch (RuntimeException ex) {
+      String message = "cannot acquire " + higherResource.getName() + " lock " +
+          "while holding [" + resource.getName() + "] lock(s).";
+      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+    }
+  }
+
+  @Test
+  public void testAcquireWriteBucketLockWhileAcquiredReadKeyPathLock() {
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK, higherResource =
+        OzoneManagerLock.Resource.BUCKET_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    String[] resourceName = new String[]{volumeName, bucketName, keyName},
+        higherResourceName = new String[]{volumeName, bucketName};
+
+    lock.acquireReadLock(resource, resourceName);
+    try {
+      lock.acquireWriteLock(higherResource, higherResourceName);
+      fail("testAcquireWriteBucketLockWhileAcquiredReadKeyPathLock() failed");
+    } catch (RuntimeException ex) {
+      String message = "cannot acquire " + higherResource.getName() + " lock " +
+          "while holding [" + resource.getName() + "] lock(s).";
+      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+    }
+  }
+
+  @Test
+  public void testAcquireReadBucketLockWhileAcquiredReadKeyPathLock() {
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK, higherResource =
+        OzoneManagerLock.Resource.BUCKET_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    String[] resourceName = new String[]{volumeName, bucketName, keyName},
+        higherResourceName = new String[]{volumeName, bucketName};
+
+    lock.acquireReadLock(resource, resourceName);
+    try {
+      lock.acquireReadLock(higherResource, higherResourceName);
+      fail("testAcquireReadBucketLockWhileAcquiredReadKeyPathLock() failed");
+    } catch (RuntimeException ex) {
+      String message = "cannot acquire " + higherResource.getName() + " lock " +
+          "while holding [" + resource.getName() + "] lock(s).";
+      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+    }
+  }
+
+  @Test
+  public void testAcquireReadBucketLockWhileAcquiredWriteKeyPathLock() {
+    OzoneManagerLock.Resource resource =
+        OzoneManagerLock.Resource.KEY_PATH_LOCK, higherResource =
+        OzoneManagerLock.Resource.BUCKET_LOCK;
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+    String keyName = UUID.randomUUID().toString();
+
+    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+
+    String[] resourceName = new String[]{volumeName, bucketName, keyName},
+        higherResourceName = new String[]{volumeName, bucketName};
+
+    lock.acquireWriteLock(resource, resourceName);
+    try {
+      lock.acquireReadLock(higherResource, higherResourceName);
+      fail("testAcquireReadBucketLockWhileAcquiredWriteKeyPathLock() failed");
+    } catch (RuntimeException ex) {
+      String message = "cannot acquire " + higherResource.getName() + " lock " +
+          "while holding [" + resource.getName() + "] lock(s).";
+      Assert.assertTrue(ex.getMessage(), ex.getMessage().contains(message));
+    }
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To introduce `KEY_PATH_LOCK` under `OzoneManagerLock.Resource` which is a much more fine-grained lock when compared to the current coarse-grained `BUCKET_LOCK` specific to individual key paths.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6580

## How was this patch tested?

Added UTs
