### PR TITLE
HDDS-6587. SCM Web UI is not displaying `HEALTHY_READONLY` header in node status

### DIFF
--- a/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
+++ b/hadoop-hdds/server-scm/src/main/resources/webapps/scm/scm-overview.html
@@ -37,6 +37,7 @@
         <th>HEALTHY</th>
         <th>STALE</th>
         <th>DEAD</th>
+        <th>HEALTHY_READONLY</th>
     </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## What changes were proposed in this pull request?

A one-line patch to add the missing header `HEALTHY_READONLY` in SCM Web UI.

<img width="1012" alt="01 before" src="https://user-images.githubusercontent.com/50227127/163491977-b73fe970-1965-410c-bff2-580a1798ac36.png">

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6587

## How was this patch tested?

- [x] The 4th column in SCM Web UI should now have the `HEALTHY_READONLY` header.

<img width="1003" alt="02 after" src="https://user-images.githubusercontent.com/50227127/163491961-3ebb274d-8a24-411b-aaab-db648f2c2213.png">
