### PR TITLE
HDDS-6590. Get rid of OZONE_IMAGE env variable from upgrade compose cluster config

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/.env
@@ -17,7 +17,6 @@
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
-OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=./data
 OM_SERVICE_ID=omservice

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-compose.yaml
@@ -21,7 +21,7 @@ x-common-config:
   &common-config
   env_file:
     - docker-config
-  image: ${OZONE_IMAGE}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 x-replication:
   &replication

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/.env
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/.env
@@ -17,6 +17,5 @@
 HDDS_VERSION=${hdds.version}
 OZONE_RUNNER_VERSION=${docker.ozone-runner.version}
 OZONE_RUNNER_IMAGE=apache/ozone-runner
-OZONE_IMAGE=apache/ozone-runner:${docker.ozone-runner.version}
 OZONE_DIR=/opt/hadoop
 OZONE_VOLUME=./data

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/non-ha/docker-compose.yaml
@@ -21,7 +21,7 @@ x-common-config:
   &common-config
   env_file:
     - docker-config
-  image: ${OZONE_IMAGE}
+  image: ${OZONE_RUNNER_IMAGE}:${OZONE_RUNNER_VERSION}
 
 x-replication:
   &replication


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change should get upgrade compose cluster config aligned with all other compose cluster configs. e.g. [compose/ozone](https://github.com/apache/ozone/blob/9ce981c1cb2a10d52c7122632d96d0a15ae2000e/hadoop-ozone/dist/src/main/compose/ozone/docker-compose.yaml#L22)

This also solves a hidden "bug" where it disregards user's environment variable OZONE_RUNNER_VERSION. (Possibly because it was missing from [HDDS-6293](https://issues.apache.org/jira/browse/HDDS-6293)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6590

## How was this patch tested?

- [x] Tested that it now respects my local `OZONE_RUNNER_VERSION` now, which I have set to `dev` to use my locally-built arm64 image.

```bash
mvn clean install -Pdist -DskipTests -e -Dmaven.javadoc.skip=true
cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/upgrade/compose/ha
export OZONE_RUNNER_VERSION=dev
docker-compose up -d --scale datanode=3
# Cluster should now boot up with the `dev` tagged image
```