### PR TITLE
HDDS-6592. [Ozone-Streaming] Fix ContainerStateMachine#applyTransacti…

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -879,7 +879,8 @@ public class ContainerStateMachine extends BaseStateMachine {
         builder.setStage(DispatcherContext.WriteChunkStage.COMMIT_DATA);
       }
       if (cmdType == Type.WriteChunk || cmdType == Type.PutSmallFile
-          || cmdType == Type.PutBlock || cmdType == Type.CreateContainer) {
+          || cmdType == Type.PutBlock || cmdType == Type.CreateContainer
+          || cmdType == Type.StreamInit) {
         builder.setContainer2BCSIDMap(container2BCSIDMap);
       }
       CompletableFuture<Message> applyTransactionFuture =


### PR DESCRIPTION
## What changes were proposed in this pull request?

An assertion error occurs when the datanode is restarted and raft log is played back in ContainerStateMachine#applyTransaction and the streamInit request 'BCSIDMap' is not initialized

![image](https://user-images.githubusercontent.com/5122636/163658824-460b8984-62de-476d-8278-e832a10df18e.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6592


## How was this patch tested?

Use existing UT
