### PR TITLE
HDDS-6593. Bump node to v16.14.2 for Recon

### DIFF
--- a/hadoop-ozone/recon/pom.xml
+++ b/hadoop-ozone/recon/pom.xml
@@ -103,7 +103,7 @@
               <goal>install-node-and-npm</goal>
             </goals>
             <configuration>
-              <nodeVersion>v16.2.0</nodeVersion>
+              <nodeVersion>v16.14.2</nodeVersion>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Recon's node to latest LTS: https://nodejs.org/en/download/

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6593

## How was this patch tested?

- [x] Pass compilation
- [x] Recon boots up fine in docker compose cluster