### PR TITLE
HDDS-6599. Use a single property to define ozone version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <hadoop.version>3.3.1</hadoop.version>
 
     <!-- version for hdds/ozone components -->
-    <hdds.version>${ozone.version}</hdds.version>
-    <ozone.version>1.3.0-SNAPSHOT</ozone.version>
+    <hdds.version>${project.version}</hdds.version>
+    <ozone.version>${project.version}</ozone.version>
     <ozone.release>Grand Canyon</ozone.release>
     <declared.hdds.version>${hdds.version}</declared.hdds.version>
     <declared.ozone.version>${ozone.version}</declared.ozone.version>
@@ -2024,30 +2024,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
         <version>${maven-site-plugin.version}</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <inherited>false</inherited>
-        <executions>
-          <execution>
-            <id>enforce-property</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireProperty>
-                  <property>ozone.version</property>
-                  <message>You must set a ozone.version to be the same as ${project.version}</message>
-                  <regex>${project.version}</regex>
-                  <regexMessage>The ozone.version property should be set and should be ${project.version}.</regexMessage>
-                </requireProperty>
-              </rules>
-              <fail>true</fail>
-            </configuration>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Setting ozone.version independently makes it hard to automatic version update using 'mvn versions:set' command. This change makes 'project.version' a single source of ozone version. In addition, plugin introduced in HDDS-6304 (which tried to solve the same issue) has been removed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6599

## How was this patch tested?

The following command ended with a success:
mvn versions:set -DnewVersion=1.4.0-SNAPSHOT -DprocessAllModules && mvn clean install 

The above command fails without the proposed changed because 'versions:set' is not applied to ozone-annotation-processing module

