### PR TITLE
HDDS-6603. Dynamically refresh debug operations for audit log

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/audit/AuditLogger.java
@@ -37,7 +37,7 @@ import java.util.stream.Collectors;
 /**
  * Class to define Audit Logger for Ozone.
  */
-public class AuditLogger {
+public final class AuditLogger {
 
   private static final Logger LOG = LoggerFactory.getLogger(AuditLogger.class);
 
@@ -53,20 +53,26 @@ public class AuditLogger {
 
   /**
    * Parametrized Constructor to initialize logger.
-   * @param type Audit Logger Type
    */
-  public AuditLogger(AuditLoggerType type) {
-    initializeLogger(type);
+  private AuditLogger() {
   }
 
   /**
    * Initializes the logger with specific type.
    * @param loggerType specified one of the values from enum AuditLoggerType.
    */
-  private void initializeLogger(AuditLoggerType loggerType) {
+  public void initializeLogger(AuditLoggerType loggerType) {
     this.logger = LogManager.getContext(false).getLogger(loggerType.getType());
     this.type = loggerType;
     refreshDebugCmdSet();
+  }
+
+  public static AuditLogger instance() {
+    return AuditLoggerHolder.INSTANCE;
+  }
+
+  private static class AuditLoggerHolder {
+    private static final AuditLogger INSTANCE = new AuditLogger();
   }
 
   @VisibleForTesting

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -21,6 +21,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,8 +58,7 @@ public class TestOzoneAuditLogger {
         "org.apache.logging.log4j.core.async.AsyncLoggerContextSelector");
   }
 
-  private static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.OMLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
 
   private static final Map<String, String> PARAMS =
       new DummyEntity().toAuditMap();
@@ -101,6 +101,12 @@ public class TestOzoneAuditLogger {
           .withParams(PARAMS)
           .withResult(SUCCESS)
           .withException(null).build();
+
+
+  @BeforeClass
+  public static void initLogger() {
+    AUDIT.initializeLogger(AuditLoggerType.OMLOGGER);
+  }
 
   @AfterClass
   public static void tearDown() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/HddsDispatcher.java
@@ -77,8 +77,7 @@ import org.slf4j.LoggerFactory;
 public class HddsDispatcher implements ContainerDispatcher, Auditor {
 
   static final Logger LOG = LoggerFactory.getLogger(HddsDispatcher.class);
-  private static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.DNLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
   private final Map<ContainerType, Handler> handlers;
   private final ConfigurationSource conf;
   private final ContainerSet containerSet;
@@ -100,6 +99,7 @@ public class HddsDispatcher implements ContainerDispatcher, Auditor {
       VolumeSet volumes, Map<ContainerType, Handler> handlers,
       StateContext context, ContainerMetrics metrics,
       TokenVerifier tokenVerifier) {
+    AUDIT.initializeLogger(AuditLoggerType.DNLOGGER);
     this.conf = config;
     this.containerSet = contSet;
     this.volumeSet = volumes;

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/AuditLogServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/AuditLogServlet.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server.http;
+
+import org.apache.hadoop.ozone.audit.AuditLogger;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+/**
+ * Servlet to refresh AuditLog configurations.
+ */
+public class AuditLogServlet extends HttpServlet {
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+      throws ServletException, IOException {
+    AuditLogger auditLogger = AuditLogger.instance();
+    auditLogger.refreshDebugCmdSet();
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -140,6 +140,7 @@ public abstract class BaseHttpServer {
       httpServer.addServlet("conf", "/conf", HddsConfServlet.class);
 
       httpServer.addServlet("logstream", "/logstream", LogStreamServlet.class);
+      httpServer.addServlet("auditlog", "/auditlog", AuditLogServlet.class);
       prometheusSupport =
           conf.getBoolean(HddsConfigKeys.HDDS_PROMETHEUS_ENABLED, true);
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMBlockProtocolServer.java
@@ -81,8 +81,7 @@ public class SCMBlockProtocolServer implements
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMBlockProtocolServer.class);
 
-  private static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.SCMLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
 
   private final StorageContainerManager scm;
   private final OzoneConfiguration conf;
@@ -96,6 +95,7 @@ public class SCMBlockProtocolServer implements
    */
   public SCMBlockProtocolServer(OzoneConfiguration conf,
       StorageContainerManager scm) throws IOException {
+    AUDIT.initializeLogger(AuditLoggerType.SCMLOGGER);
     this.scm = scm;
     this.conf = conf;
     final int handlerCount =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMClientProtocolServer.java
@@ -108,8 +108,7 @@ public class SCMClientProtocolServer implements
     StorageContainerLocationProtocol, Auditor {
   private static final Logger LOG =
       LoggerFactory.getLogger(SCMClientProtocolServer.class);
-  private static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.SCMLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
   private final RPC.Server clientRpcServer;
   private final InetSocketAddress clientRpcAddress;
   private final StorageContainerManager scm;
@@ -117,6 +116,7 @@ public class SCMClientProtocolServer implements
 
   public SCMClientProtocolServer(OzoneConfiguration conf,
       StorageContainerManager scm) throws IOException {
+    AUDIT.initializeLogger(AuditLoggerType.SCMLOGGER);
     this.scm = scm;
     final int handlerCount =
         conf.getInt(OZONE_SCM_HANDLER_COUNT_KEY,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeProtocolServer.java
@@ -113,8 +113,7 @@ public class SCMDatanodeProtocolServer implements
   private static final Logger LOG = LoggerFactory.getLogger(
       SCMDatanodeProtocolServer.class);
 
-  private static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.SCMLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
 
   /**
    * The RPC server that listens to requests from DataNodes.
@@ -136,6 +135,8 @@ public class SCMDatanodeProtocolServer implements
     // passive SCM server can override them.
     Preconditions.checkNotNull(scm, "SCM cannot be null");
     Preconditions.checkNotNull(eventPublisher, "EventPublisher cannot be null");
+
+    AUDIT.initializeLogger(AuditLoggerType.SCMLOGGER);
 
     this.scm = scm;
     this.eventPublisher = eventPublisher;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -268,8 +268,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public static final Logger LOG =
       LoggerFactory.getLogger(OzoneManager.class);
 
-  private static final AuditLogger AUDIT = new AuditLogger(
-      AuditLoggerType.OMLOGGER);
+  private static final AuditLogger AUDIT = AuditLogger.instance();
 
   private static final String OM_DAEMON = "om";
 
@@ -399,6 +398,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   private OzoneManager(OzoneConfiguration conf, StartupOption startupOption)
       throws IOException, AuthenticationException {
     super(OzoneVersionInfo.OZONE_VERSION_INFO);
+    AUDIT.initializeLogger(AuditLoggerType.OMLOGGER);
     Preconditions.checkNotNull(conf);
     setConfiguration(conf);
     // Load HA related configurations

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/security/TestOMGetDelegationTokenRequest.java
@@ -66,8 +66,8 @@ public class TestOMGetDelegationTokenRequest extends
   public void setupGetDelegationToken() throws IOException {
     secretManager = Mockito.mock(OzoneDelegationTokenSecretManager.class);
     when(ozoneManager.getDelegationTokenMgr()).thenReturn(secretManager);
-    when(ozoneManager.getAuditLogger()).thenReturn(new AuditLogger(
-        AuditLoggerType.OMLOGGER));
+    when(ozoneManager.getAuditLogger()).thenReturn(AuditLogger.instance());
+    AuditLogger.instance().initializeLogger(AuditLoggerType.OMLOGGER);
     when(ozoneManager.getVersionManager()).thenReturn(
         new OMLayoutVersionManager());
 

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayAuditLogger.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/S3GatewayAuditLogger.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.s3;
+
+import org.apache.hadoop.ozone.audit.AuditLogger;
+import org.apache.hadoop.ozone.audit.AuditLoggerType;
+
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * This class is for singleton AuditLogger in S3gateway.
+ */
+@ApplicationScoped
+public class S3GatewayAuditLogger {
+
+  public static final AuditLogger AUDIT = AuditLogger.instance();
+
+  public S3GatewayAuditLogger() {
+    AUDIT.initializeLogger(AuditLoggerType.S3GLOGGER);
+  }
+
+  public AuditLogger getAudit() {
+    return AUDIT;
+  }
+}

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -69,6 +69,7 @@ import java.util.Map;
 import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneAcl.AclScope.ACCESS;
+import static org.apache.hadoop.ozone.s3.S3GatewayAuditLogger.AUDIT;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.NOT_IMPLEMENTED;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.newError;
 import static org.apache.hadoop.ozone.s3.util.S3Consts.ENCODING_TYPE;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -66,8 +66,7 @@ public abstract class EndpointBase implements Auditor {
   private static final Logger LOG =
       LoggerFactory.getLogger(EndpointBase.class);
 
-  protected static final AuditLogger AUDIT =
-      new AuditLogger(AuditLoggerType.S3GLOGGER);
+  protected static final AuditLogger AUDIT = AuditLogger.instance();
 
   protected OzoneBucket getBucket(OzoneVolume volume, String bucketName)
       throws OS3Exception, IOException {
@@ -90,6 +89,7 @@ public abstract class EndpointBase implements Auditor {
    */
   @PostConstruct
   public void initialization() {
+    AUDIT.initializeLogger(AuditLoggerType.S3GLOGGER);
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
     getClient().getObjectStore()
         .getClientProxy()

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -30,8 +30,6 @@ import java.util.function.Function;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.ozone.audit.AuditAction;
 import org.apache.hadoop.ozone.audit.AuditEventStatus;
-import org.apache.hadoop.ozone.audit.AuditLogger;
-import org.apache.hadoop.ozone.audit.AuditLoggerType;
 import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.audit.Auditor;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -40,6 +38,7 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes;
 import org.apache.hadoop.ozone.om.protocol.S3Auth;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -60,13 +59,14 @@ public abstract class EndpointBase implements Auditor {
   private OzoneClient client;
   @Inject
   private S3Auth s3Auth;
+  @Inject
+  private S3GatewayAuditLogger s3GatewayAuditLogger;
+
   @Context
   private ContainerRequestContext context;
 
   private static final Logger LOG =
       LoggerFactory.getLogger(EndpointBase.class);
-
-  protected static final AuditLogger AUDIT = AuditLogger.instance();
 
   protected OzoneBucket getBucket(OzoneVolume volume, String bucketName)
       throws OS3Exception, IOException {
@@ -89,7 +89,6 @@ public abstract class EndpointBase implements Auditor {
    */
   @PostConstruct
   public void initialization() {
-    AUDIT.initializeLogger(AuditLoggerType.S3GLOGGER);
     LOG.debug("S3 access id: {}", s3Auth.getAccessID());
     getClient().getObjectStore()
         .getClientProxy()
@@ -249,6 +248,11 @@ public abstract class EndpointBase implements Auditor {
 
   public OzoneClient getClient() {
     return client;
+  }
+
+  @VisibleForTesting
+  public void setS3GatewayAuditLogger(S3GatewayAuditLogger logger) {
+    this.s3GatewayAuditLogger = logger;
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -89,6 +89,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS;
+import static org.apache.hadoop.ozone.s3.S3GatewayAuditLogger.AUDIT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_DEFAULT;
 import static org.apache.hadoop.ozone.s3.S3GatewayConfigKeys.OZONE_S3G_CLIENT_BUFFER_SIZE_KEY;
 import static org.apache.hadoop.ozone.s3.exception.S3ErrorTable.ENTITY_TOO_SMALL;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/RootEndpoint.java
@@ -32,6 +32,8 @@ import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.s3.S3GatewayAuditLogger.AUDIT;
+
 /**
  * Top level rest endpoint.
  */

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/TestS3GatewayAuditLog.java
@@ -70,19 +70,23 @@ public class TestS3GatewayAuditLog {
   @Before
   public void setup() throws Exception {
 
+    S3GatewayAuditLogger auditLogger = new S3GatewayAuditLogger();
     clientStub = new OzoneClientStub();
     clientStub.getObjectStore().createS3Bucket(bucketName);
     bucket = clientStub.getObjectStore().getS3Bucket(bucketName);
 
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setS3GatewayAuditLogger(auditLogger);
 
     rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(clientStub);
+    rootEndpoint.setS3GatewayAuditLogger(auditLogger);
 
     keyEndpoint = new ObjectEndpoint();
     keyEndpoint.setClient(clientStub);
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    keyEndpoint.setS3GatewayAuditLogger(auditLogger);
 
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestAbortMultipartUpload.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.Test;
@@ -59,6 +60,7 @@ public class TestAbortMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
     Response response = rest.initializeMultipartUpload(bucket, key);
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketAcl.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.security.acl.IAccessAuthorizer;
 import org.junit.After;
@@ -72,6 +73,7 @@ public class TestBucketAcl {
 
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   @After

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketDelete.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.ObjectStoreStub;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 
@@ -58,6 +59,7 @@ public class TestBucketDelete {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
 
   }

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketHead.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.Assert;
 
@@ -51,6 +52,7 @@ public class TestBucketHead {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestBucketPut.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -48,6 +49,7 @@ public class TestBucketPut {
 
   @Before
   public void setup() throws Exception {
+    S3GatewayAuditLogger auditLogger = new S3GatewayAuditLogger();
 
     //Create client stub and object store stub.
     clientStub = new OzoneClientStub();
@@ -55,6 +57,7 @@ public class TestBucketPut {
     // Create HeadBucket and setClient to OzoneClientStub
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setS3GatewayAuditLogger(auditLogger);
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestInitiateMultipartUpload.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -57,6 +58,7 @@ public class TestInitiateMultipartUpload {
     rest.setHeaders(headers);
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
     Response response = rest.initializeMultipartUpload(bucket, key);
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestListParts.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.Assert;
@@ -62,6 +63,7 @@ public class TestListParts {
     REST.setHeaders(headers);
     REST.setClient(client);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
     Response response = REST.initializeMultipartUpload(OzoneConsts.S3_BUCKET,
         OzoneConsts.KEY);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadComplete.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.apache.hadoop.ozone.s3.exception.S3ErrorTable;
 import org.junit.BeforeClass;
@@ -70,6 +71,7 @@ public class TestMultipartUploadComplete {
     REST.setHeaders(headers);
     REST.setClient(CLIENT);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   private String initiateMultipartUpload(String key) throws IOException,

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestMultipartUploadWithCopy.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.endpoint.CompleteMultipartUploadRequest.Part;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
@@ -122,6 +123,7 @@ public class TestMultipartUploadWithCopy {
     REST.setHeaders(headers);
     REST.setClient(CLIENT);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectDelete.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.junit.Assert;
@@ -49,6 +50,7 @@ public class TestObjectDelete {
     ObjectEndpoint rest = new ObjectEndpoint();
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
     //WHEN
     rest.delete("b1", "key1", null);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectGet.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.apache.commons.io.IOUtils;
@@ -62,6 +63,7 @@ public class TestObjectGet {
     ObjectEndpoint rest = new ObjectEndpoint();
     rest.setClient(client);
     rest.setOzoneConfiguration(new OzoneConfiguration());
+    rest.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
     HttpHeaders headers = Mockito.mock(HttpHeaders.class);
     rest.setHeaders(headers);
     ByteArrayInputStream body =

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectHead.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
@@ -62,6 +63,7 @@ public class TestObjectHead {
     keyEndpoint = new ObjectEndpoint();
     keyEndpoint.setClient(clientStub);
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    keyEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectMultiDelete.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.endpoint.MultiDeleteRequest.DeleteObject;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
@@ -51,6 +52,7 @@ public class TestObjectMultiDelete {
 
     BucketEndpoint rest = new BucketEndpoint();
     rest.setClient(client);
+    rest.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
     MultiDeleteRequest mdr = new MultiDeleteRequest();
     mdr.getObjects().add(new DeleteObject("key1"));

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestObjectPut.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.OzoneKeyDetails;
 import org.apache.hadoop.ozone.client.io.OzoneInputStream;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 
 import org.apache.commons.io.IOUtils;
@@ -74,6 +75,7 @@ public class TestObjectPut {
     objectEndpoint = new ObjectEndpoint();
     objectEndpoint.setClient(clientStub);
     objectEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    objectEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
   @Test

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPartUpload.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -64,6 +65,7 @@ public class TestPartUpload {
     REST.setHeaders(headers);
     REST.setClient(client);
     REST.setOzoneConfiguration(new OzoneConfiguration());
+    REST.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
   }
 
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestPermissionCheck.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.exception.OS3Exception;
 import org.junit.Assert;
 import org.junit.Before;
@@ -57,6 +58,7 @@ public class TestPermissionCheck {
   private OzoneVolume volume;
   private OMException exception;
   private HttpHeaders headers;
+  private S3GatewayAuditLogger s3GatewayAuditLogger;
 
   @Before
   public void setup() {
@@ -72,6 +74,7 @@ public class TestPermissionCheck {
     Mockito.when(client.getObjectStore()).thenReturn(objectStore);
     Mockito.when(client.getConfiguration()).thenReturn(conf);
     headers = Mockito.mock(HttpHeaders.class);
+    s3GatewayAuditLogger = new S3GatewayAuditLogger();
   }
 
   /**
@@ -82,6 +85,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).getVolume(anyString());
     RootEndpoint rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(client);
+    rootEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       rootEndpoint.get();
@@ -100,6 +104,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).getS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       bucketEndpoint.head("bucketName");
@@ -116,6 +121,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).createS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       bucketEndpoint.put("bucketName", null, null, null);
@@ -131,6 +137,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(objectStore).deleteS3Bucket(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       bucketEndpoint.delete("bucketName");
@@ -146,6 +153,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(bucket).listMultipartUploads(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       bucketEndpoint.listMultipartUploads("bucketName", "prefix");
@@ -163,6 +171,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(bucket).listKeys(anyString());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       bucketEndpoint.get("bucketName", null, null, null, 1000,
@@ -181,6 +190,7 @@ public class TestPermissionCheck {
     doThrow(exception).when(bucket).deleteKey(any());
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
     MultiDeleteRequest request = new MultiDeleteRequest();
     List<MultiDeleteRequest.DeleteObject> objectList = new ArrayList<>();
     objectList.add(new MultiDeleteRequest.DeleteObject("deleteKeyName"));
@@ -209,6 +219,7 @@ public class TestPermissionCheck {
         .thenReturn(S3Acl.ACLIdentityType.USER.getHeaderType() + "=root");
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
     try {
       bucketEndpoint.get("bucketName", null, null, null, 1000,
           null, null, null, null, "acl", null);
@@ -233,6 +244,7 @@ public class TestPermissionCheck {
         .thenReturn(S3Acl.ACLIdentityType.USER.getHeaderType() + "=root");
     BucketEndpoint bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(client);
+    bucketEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
     try {
       bucketEndpoint.put("bucketName", "acl", headers, null);
     } catch (Exception e) {
@@ -252,6 +264,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       objectEndpoint.get("bucketName", "keyPath", null, 1000, "marker",
@@ -273,6 +286,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       objectEndpoint.put("bucketName", "keyPath", 1024, 0, null, null);
@@ -291,6 +305,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       objectEndpoint.delete("bucketName", "keyPath", null);
@@ -310,6 +325,7 @@ public class TestPermissionCheck {
     objectEndpoint.setClient(client);
     objectEndpoint.setHeaders(headers);
     objectEndpoint.setOzoneConfiguration(conf);
+    objectEndpoint.setS3GatewayAuditLogger(s3GatewayAuditLogger);
 
     try {
       objectEndpoint.initializeMultipartUpload("bucketName", "keyPath");

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/endpoint/TestRootList.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 
 import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -44,7 +46,7 @@ public class TestRootList {
     // Create HeadBucket and setClient to OzoneClientStub
     rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(clientStub);
-
+    rootEndpoint.setS3GatewayAuditLogger(new S3GatewayAuditLogger());
 
   }
 

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/metrics/TestS3GatewayMetrics.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneClient;
 import org.apache.hadoop.ozone.client.OzoneClientStub;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.s3.S3GatewayAuditLogger;
 import org.apache.hadoop.ozone.s3.endpoint.BucketEndpoint;
 import org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint;
 import org.apache.hadoop.ozone.s3.endpoint.RootEndpoint;
@@ -67,19 +68,23 @@ public class TestS3GatewayMetrics {
 
   @Before
   public void setup() throws Exception {
+    S3GatewayAuditLogger auditLogger = new S3GatewayAuditLogger();
     clientStub = new OzoneClientStub();
     clientStub.getObjectStore().createS3Bucket(bucketName);
     bucket = clientStub.getObjectStore().getS3Bucket(bucketName);
 
     bucketEndpoint = new BucketEndpoint();
     bucketEndpoint.setClient(clientStub);
+    bucketEndpoint.setS3GatewayAuditLogger(auditLogger);
 
     rootEndpoint = new RootEndpoint();
     rootEndpoint.setClient(clientStub);
+    rootEndpoint.setS3GatewayAuditLogger(auditLogger);
 
     keyEndpoint = new ObjectEndpoint();
     keyEndpoint.setClient(clientStub);
     keyEndpoint.setOzoneConfiguration(new OzoneConfiguration());
+    keyEndpoint.setS3GatewayAuditLogger(auditLogger);
 
     headers = Mockito.mock(HttpHeaders.class);
     metrics = bucketEndpoint.getMetrics();


### PR DESCRIPTION
## What changes were proposed in this pull request?

In [HDDS-6562](https://issues.apache.org/jira/browse/HDDS-6562), we introduced the feature to exclude specific operations for AuditLog.

But the usage in PROD cluster is not convenient, we need to update the config and restart service to enable the new configuration.

This ticket is to add a new servlet to refresh the configuration for AuditLog.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6603

## How was this patch tested?

unit test.
