### PR TITLE
HDDS-6606. Rat check failure ignored for ozone-annotation-processing

### DIFF
--- a/dev-support/annotations/src/main/java/org/apache/ozone/annotations/package-info.java
+++ b/dev-support/annotations/src/main/java/org/apache/ozone/annotations/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /**
  * Annotation processors used at compile time by the Ozone project to validate
  * internal annotations and related code as needed, if needed.

--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -30,7 +30,7 @@ mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
 
 cd "$DIR/../../.." || exit 1
 
-grep -r --include=rat.txt "!????" hadoop-hdds hadoop-ozone | tee "$REPORT_FILE"
+grep -r --include=rat.txt "!????" dev-support/annotations hadoop-hdds hadoop-ozone | tee "$REPORT_FILE"
 
 wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
 

--- a/hadoop-ozone/dev-support/checks/rat.sh
+++ b/hadoop-ozone/dev-support/checks/rat.sh
@@ -21,16 +21,15 @@ mkdir -p "$REPORT_DIR"
 
 REPORT_FILE="$REPORT_DIR/summary.txt"
 
-cd dev-support/annotations || exit 1
-mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
-cd ../../hadoop-hdds || exit 1
-mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
-cd ../hadoop-ozone || exit 1
-mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
+dirs="dev-support/annotations hadoop-hdds hadoop-ozone"
 
-cd "$DIR/../../.." || exit 1
+for d in $dirs; do
+  pushd "$d"
+  mvn -B -fn org.apache.rat:apache-rat-plugin:0.13:check
+  popd
+done
 
-grep -r --include=rat.txt "!????" dev-support/annotations hadoop-hdds hadoop-ozone | tee "$REPORT_FILE"
+grep -r --include=rat.txt "!????" $dirs | tee "$REPORT_FILE"
 
 wc -l "$REPORT_FILE" | awk '{print $1}'> "$REPORT_DIR/failures"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

 * Collect rat failures from the new `dev-support/annotations` directory, too.
 * Add missing license header.
 * Reduce duplication by looping over the dirs to be checked.

https://issues.apache.org/jira/browse/HDDS-6606

## How was this patch tested?

Verified that the check properly fails due to license violation:

```
$ ./hadoop-ozone/dev-support/checks/rat.sh
...
dev-support/annotations/target/rat.txt: !????? src/main/java/org/apache/ozone/annotations/package-info.java
```

Then added the missing header and re-ran the check:

```
$ ./hadoop-ozone/dev-support/checks/rat.sh
...

$ echo $?
0
```

https://github.com/adoroszlai/hadoop-ozone/runs/6081893903