### PR TITLE
HDDS-6515. Intermittent failure in TestRootedOzoneFileSystem

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -56,8 +56,10 @@ import org.apache.hadoop.ozone.security.acl.OzoneAclConfig;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -148,6 +150,22 @@ public class TestRootedOzoneFileSystem {
     IOUtils.closeQuietly(fs);
   }
 
+  @Before
+  public void createVolumeAndBucket() throws IOException {
+    // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
+    OzoneBucket bucket =
+        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
+    volumeName = bucket.getVolumeName();
+    volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
+    bucketName = bucket.getName();
+    bucketPath = new Path(volumePath, bucketName);
+  }
+
+  @After
+  public void cleanup() throws IOException {
+    fs.delete(volumePath, true);
+  }
+
   public static FileSystem getFs() {
     return fs;
   }
@@ -218,14 +236,6 @@ public class TestRootedOzoneFileSystem {
         .build();
     cluster.waitForClusterToBeReady();
     objectStore = cluster.getClient().getObjectStore();
-
-    // create a volume and a bucket to be used by RootedOzoneFileSystem (OFS)
-    OzoneBucket bucket =
-        TestDataUtil.createVolumeAndBucket(cluster, bucketLayout);
-    volumeName = bucket.getVolumeName();
-    volumePath = new Path(OZONE_URI_DELIMITER, volumeName);
-    bucketName = bucket.getName();
-    bucketPath = new Path(volumePath, bucketName);
 
     rootPath = String.format("%s://%s/",
         OzoneConsts.OZONE_OFS_URI_SCHEME, conf.get(OZONE_OM_ADDRESS_KEY));


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestRootedOzoneFileSystem fails due to missing cleanup in some tests.
This patch fixed this issue by creating new volume and bucket before each test, and cleaning them after each test.

This problem is hided by HDDS-6095, please check [detailed logs](https://github.com/kaijchen/ozone/runs/6088575259?check_suite_focus=true#step:4:3068) in old CI below.
(P.S. I will revert it next time when repeating CI)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6515

## How was this patch tested?

100x TestRootedOzoneFileSystem (old): https://github.com/kaijchen/ozone/actions/runs/2193371915
100x TestRootedOzoneFileSystem (new): https://github.com/kaijchen/ozone/actions/runs/2193660965