### PR TITLE
HDDS-6625. [Multi-Tenant] Follow-up: Set owner of buckets created via S3 Gateway to actual user

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -554,7 +554,7 @@ public class RpcClient implements ClientProtocol {
     // If S3 auth exists, set owner name to the short user name derived from the
     //  accessId. Similar to RpcClient#getDEK
     if (getThreadLocalS3Auth() != null) {
-      UserGroupInformation s3gUGI = UserGroupInformation.createRemoteUser(
+      final UserGroupInformation s3gUGI = UserGroupInformation.createRemoteUser(
           getThreadLocalS3Auth().getUserPrincipal());
       owner = s3gUGI.getShortUserName();
     } else {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -555,7 +555,7 @@ public class RpcClient implements ClientProtocol {
     //  accessId. Similar to RpcClient#getDEK
     if (getThreadLocalS3Auth() != null) {
       UserGroupInformation s3gUGI = UserGroupInformation.createRemoteUser(
-          getThreadLocalS3Auth().getAccessID());
+          getThreadLocalS3Auth().getUserPrincipal());
       owner = s3gUGI.getShortUserName();
     } else {
       owner = bucketArgs.getOwner() == null ?

--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -64,6 +64,10 @@ Secure Tenant Create Bucket 1 Success via S3 API
     ${output} =         Execute          aws s3api --endpoint-url ${S3G_ENDPOINT_URL} list-buckets
                         Should contain   ${output}         bucket-test1
 
+Secure Tenant Verify Bucket 1 Owner
+    ${result} =         Execute          ozone sh bucket info /tenantone/bucket-test1 | jq -r '.owner'
+                        Should Be Equal  ${result}       testuser
+
 Secure Tenant SetSecret Success with Cluster Admin
     ${output} =         Execute          ozone tenant user setsecret 'tenantone$testuser' --secret=somesecret1 --export
                         Should contain   ${output}         export AWS_SECRET_ACCESS_KEY='somesecret1'

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3117,10 +3117,17 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     // to the default S3 volume.
     String s3Volume = HddsClientUtils.getDefaultS3VolumeName(configuration);
     S3Authentication s3Auth = getS3Auth();
+    // This is the default user principal if request does not have S3Auth set
     String userPrincipal = Server.getRemoteUser().getShortUserName();
 
     if (s3Auth != null) {
       String accessId = s3Auth.getAccessId();
+      final UserGroupInformation s3gUGI =
+          UserGroupInformation.createRemoteUser(accessId);
+      // The user principal below would be used when the accessId belongs to the
+      // default s3v (does not belong to any tenant). i.e. when optionalTenantId
+      // is not present.
+      userPrincipal = s3gUGI.getShortUserName();
       Optional<String> optionalTenantId =
           multiTenantManager.getTenantForAccessID(accessId);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This is a follow-up jira to [HDDS-6574](https://issues.apache.org/jira/browse/HDDS-6574) in the multi-tenancy branch.

See https://github.com/apache/ozone/pull/3298#discussion_r848659291 for the context.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6625

## How was this patch tested?

- [x] All existing tests shall pass.
- [x] Add a new acceptance test case for multi-tenancy to verify the bucket owner should still be the actual user.