### PR TITLE
HDDS-6189. Intermittent failure in TestDirectoryDeletingServiceWithFSO

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.apache.ozone.test.GenericTestUtils;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.Assert;
@@ -53,6 +52,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.function.LongSupplier;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
@@ -135,7 +135,6 @@ public class TestDirectoryDeletingServiceWithFSO {
     }
   }
 
-  @Flaky("HDDS-6189")
   @Test
   public void testDeleteEmptyDirectory() throws Exception {
     Path root = new Path("/rootDir");
@@ -155,8 +154,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(dirTable, 2);
 
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 0);
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 0);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 0);
 
     // Delete the appRoot, empty dir
     fs.delete(appRoot, true);
@@ -167,8 +166,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(dirTable, 1);
 
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 1);
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 1);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 0);
 
     Assert.assertTrue(dirTable.iterator().hasNext());
     Assert.assertEquals(root.getName(),
@@ -219,8 +218,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(keyTable, 15);
     assertTableRowCount(dirTable, 20);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 0);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 0);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 0);
 
     // Delete the appRoot
     fs.delete(appRoot, true);
@@ -232,8 +231,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(keyTable, 0);
     assertTableRowCount(dirTable, 1);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 15);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 19);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 15);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 19);
 
     Assert.assertTrue(dirDeletingService.getRunCount() > 1);
   }
@@ -266,8 +265,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(dirTable, 5);
     assertTableRowCount(keyTable, 3);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 0);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 0);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 0);
 
     // Delete the rootDir, which should delete all keys.
     fs.delete(root, true);
@@ -279,15 +278,16 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(keyTable, 0);
     assertTableRowCount(dirTable, 0);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 3);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 5);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 3);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 5);
 
     Assert.assertTrue(dirDeletingService.getRunCount() > 1);
   }
 
-  private void assertSubPathsCount(long pathCount, long expectedCount)
+  private void assertSubPathsCount(LongSupplier pathCount, long expectedCount)
       throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() -> pathCount >= expectedCount, 1000, 120000);
+    GenericTestUtils.waitFor(() -> pathCount.getAsLong() >= expectedCount,
+        1000, 120000);
   }
 
   private void assertTableRowCount(Table<String, ?> table, int count)
@@ -374,8 +374,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(deletedKeyTable, 0);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 0);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 0);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 0);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 0);
     // verify whether KeyDeletingService has purged the keys
     long currentDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
     Assert.assertEquals(prevDeletedKeyCount + 3, currentDeletedKeyCount);
@@ -392,8 +392,8 @@ public class TestDirectoryDeletingServiceWithFSO {
     assertTableRowCount(deletedDirTable, 0);
     assertTableRowCount(deletedKeyTable, 0);
 
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(), 2);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(), 1);
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount, 2);
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount, 1);
     // verify whether KeyDeletingService has purged the keys
     currentDeletedKeyCount = keyDeletingService.getDeletedKeyCount().get();
     Assert.assertEquals(prevDeletedKeyCount + 5, currentDeletedKeyCount);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestDirectoryDeletingServiceWithFSO.java
@@ -284,7 +284,7 @@ public class TestDirectoryDeletingServiceWithFSO {
     Assert.assertTrue(dirDeletingService.getRunCount() > 1);
   }
 
-  private void assertSubPathsCount(LongSupplier pathCount, long expectedCount)
+  static void assertSubPathsCount(LongSupplier pathCount, long expectedCount)
       throws TimeoutException, InterruptedException {
     GenericTestUtils.waitFor(() -> pathCount.getAsLong() >= expectedCount,
         1000, 120000);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedDDSWithFSO.java
@@ -51,6 +51,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.apache.hadoop.fs.ozone.TestDirectoryDeletingServiceWithFSO.assertSubPathsCount;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_BLOCK_DELETING_SERVICE_INTERVAL;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
@@ -198,15 +199,10 @@ public class TestRootedDDSWithFSO {
     // There is an immediate file under bucket,
     // which was moved along with bucket delete.
     int movedFilesCount = totalFilesCount - 1;
-    assertSubPathsCount(dirDeletingService.getMovedFilesCount(),
+    assertSubPathsCount(dirDeletingService::getMovedFilesCount,
         movedFilesCount);
-    assertSubPathsCount(dirDeletingService.getDeletedDirsCount(),
+    assertSubPathsCount(dirDeletingService::getDeletedDirsCount,
         totalDirCount);
-  }
-
-  private void assertSubPathsCount(long pathCount, long expectedCount)
-      throws TimeoutException, InterruptedException {
-    GenericTestUtils.waitFor(() -> pathCount >= expectedCount, 1000, 120000);
   }
 
   private void checkPath(Path path) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`TestDirectoryDeletingServiceWithFSO` was intermittently timing out at `assertSubPathsCount`.  This method has a `waitFor`, but the condition cannot change, since it compares two fixed long values.  It can only pass if wait is not necessary and the condition is true at the time of the call.

The fix is to get the actual value for each check during the wait.

https://issues.apache.org/jira/browse/HDDS-6189

## How was this patch tested?

100x passed:
https://github.com/adoroszlai/hadoop-ozone/runs/6107144162

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2200070046