### PR TITLE
HDDS-6567. Store datanode command queue counts from heartbeat in DatanodeInfo in SCM

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/states/endpoint/HeartbeatEndpointTask.java
@@ -284,7 +284,7 @@ public class HeartbeatEndpointTask
       reportProto.addCommand(entry.getKey())
           .addCount(entry.getValue());
     }
-    requestBuilder.setQueuedCommandReport(reportProto.build());
+    requestBuilder.setCommandQueueReport(reportProto.build());
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -256,8 +256,8 @@ public class TestHeartbeatEndpointTask {
     Assert.assertTrue(heartbeat.hasContainerReport());
     Assert.assertTrue(heartbeat.getCommandStatusReportsCount() != 0);
     Assert.assertTrue(heartbeat.hasContainerActions());
-    Assert.assertTrue(heartbeat.hasQueuedCommandReport());
-    CommandQueueReportProto queueCount = heartbeat.getQueuedCommandReport();
+    Assert.assertTrue(heartbeat.hasCommandQueueReport());
+    CommandQueueReportProto queueCount = heartbeat.getCommandQueueReport();
     Assert.assertEquals(queueCount.getCommandCount(), commands.size());
     Assert.assertEquals(queueCount.getCountCount(), commands.size());
     for (int i = 0; i < commands.size(); i++) {

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -138,7 +138,7 @@ message SCMHeartbeatRequestProto {
   optional PipelineActionsProto pipelineActions = 7;
   optional PipelineReportsProto pipelineReports = 8;
   optional LayoutVersionProto dataNodeLayoutVersion = 9;
-  optional CommandQueueReportProto queuedCommandReport = 10;
+  optional CommandQueueReportProto commandQueueReport = 10;
 }
 
 message CommandQueueReportProto {
@@ -309,6 +309,7 @@ message PipelineAction {
  */
 message SCMCommandProto {
   enum Type {
+    unknownScmCommand = 0;
     reregisterCommand = 1;
     deleteBlocksCommand = 2;
     closeContainerCommand = 3;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/events/SCMEvents.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Incremen
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.NodeReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineActionsFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.PipelineReportFromDatanode;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CommandQueueReportFromDatanode;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeProtocolServer.NodeRegistrationContainerReport;
 import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.TypedEvent;
@@ -48,6 +49,15 @@ public final class SCMEvents {
    */
   public static final TypedEvent<NodeReportFromDatanode> NODE_REPORT =
       new TypedEvent<>(NodeReportFromDatanode.class, "Node_Report");
+
+  /**
+   * Queued Command counts are sent out by Datanodes. This report is received by
+   * SCMDatanodeHeartbeatDispatcher and the COMMAND_QUEUE_REPORT Event is
+   * generated.
+   */
+  public static final TypedEvent<CommandQueueReportFromDatanode>
+      COMMAND_QUEUE_REPORT = new TypedEvent<>(
+          CommandQueueReportFromDatanode.class, "Command_Queue_Report");
 
   /**
    * Event generated on DataNode registration.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/CommandQueueReportHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/CommandQueueReportHandler.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.node;
+
+import com.google.common.base.Preconditions;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.CommandQueueReportFromDatanode;
+import org.apache.hadoop.hdds.server.events.EventHandler;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+
+/**
+ * Handles QueuedCommand Reports from datanode.
+ */
+public class CommandQueueReportHandler implements
+    EventHandler<CommandQueueReportFromDatanode> {
+
+  private final NodeManager nodeManager;
+
+  public CommandQueueReportHandler(NodeManager nodeManager) {
+    Preconditions.checkNotNull(nodeManager);
+    this.nodeManager = nodeManager;
+  }
+
+  @Override
+  public void onMessage(CommandQueueReportFromDatanode queueReportFromDatanode,
+                        EventPublisher publisher) {
+    Preconditions.checkNotNull(queueReportFromDatanode);
+    DatanodeDetails dn = queueReportFromDatanode.getDatanodeDetails();
+    Preconditions.checkNotNull(dn, "QueueReport is "
+        + "missing DatanodeDetails.");
+    nodeManager.processNodeCommandQueueReport(dn,
+        queueReportFromDatanode.getReport());
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/DatanodeInfo.java
@@ -22,6 +22,8 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVer
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -29,9 +31,13 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -41,6 +47,8 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class DatanodeInfo extends DatanodeDetails {
 
+  private static final Logger LOG = LoggerFactory.getLogger(DatanodeInfo.class);
+
   private final ReadWriteLock lock;
 
   private volatile long lastHeartbeatTime;
@@ -49,6 +57,7 @@ public class DatanodeInfo extends DatanodeDetails {
   private List<StorageReportProto> storageReports;
   private List<MetadataStorageReportProto> metadataStorageReports;
   private LayoutVersionProto lastKnownLayoutVersion;
+  private Map<SCMCommandProto.Type, Integer> commandCounts;
 
   private NodeStatus nodeStatus;
 
@@ -69,6 +78,7 @@ public class DatanodeInfo extends DatanodeDetails {
     this.storageReports = Collections.emptyList();
     this.nodeStatus = nodeStatus;
     this.metadataStorageReports = Collections.emptyList();
+    this.commandCounts = new HashMap<>();
   }
 
   /**
@@ -269,6 +279,57 @@ public class DatanodeInfo extends DatanodeDetails {
       this.nodeStatus = newNodeStatus;
     } finally {
       lock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Set the current command counts for this datanode, as reported in the last
+   * heartbeat.
+   * @param cmds Proto message containing a list of command count pairs.
+   */
+  public void setCommandCounts(CommandQueueReportProto cmds) {
+    try {
+      int count = cmds.getCommandCount();
+      lock.writeLock().lock();
+      for (int i = 0; i < count; i++) {
+        SCMCommandProto.Type command = cmds.getCommand(i);
+        if (command == SCMCommandProto.Type.unknownScmCommand) {
+          LOG.warn("Unknown SCM Command received from {} in the "
+              + "heartbeat. SCM and the DN may not be at the same version.",
+              this);
+          continue;
+        }
+        int cmdCount = cmds.getCount(i);
+        if (cmdCount < 0) {
+          LOG.warn("Command count of {} from {} should be greater than zero. " +
+              "Setting it to zero", cmdCount, this);
+          cmdCount = 0;
+        }
+        commandCounts.put(command, cmdCount);
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
+  }
+
+  /**
+   * Retrieve the number of queued commands of the given type, as reported by
+   * the datanode at the last heartbeat.
+   * @param cmd The command for which to receive the queued command count
+   * @return -1 if we have no information about the count, or an integer >= 0
+   *         indicating the command count at the last heartbeat.
+   */
+  public int getCommandCount(SCMCommandProto.Type cmd) {
+    try {
+      lock.readLock().lock();
+      Integer count = commandCounts.get(cmd);
+      if (count == null) {
+        return -1;
+      } else {
+        return count.intValue();
+      }
+    } finally {
+      lock.readLock().unlock();
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -310,7 +310,7 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   /**
    * Get the number of commands of the given type queued on the datanode at the
    * last heartbeat. If the Datanode has not reported information for the given
-   * command type, -1 wil be returned.
+   * command type, -1 will be returned.
    * @param cmdType
    * @return The queued count or -1 if no data has been received from the DN.
    */

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/NodeManager.java
@@ -20,9 +20,11 @@ package org.apache.hadoop.hdds.scm.node;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -296,6 +298,24 @@ public interface NodeManager extends StorageContainerNodeProtocol,
   void processLayoutVersionReport(DatanodeDetails datanodeDetails,
                          LayoutVersionProto layoutReport);
 
+  /**
+   * Process the Command Queue Report sent from datanodes as part of the
+   * heartbeat message.
+   * @param datanodeDetails
+   * @param commandReport
+   */
+  void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
+      CommandQueueReportProto commandReport);
+
+  /**
+   * Get the number of commands of the given type queued on the datanode at the
+   * last heartbeat. If the Datanode has not reported information for the given
+   * command type, -1 wil be returned.
+   * @param cmdType
+   * @return The queued count or -1 if no data has been received from the DN.
+   */
+  int getNodeQueuedCommandCount(DatanodeDetails datanodeDetails,
+      SCMCommandProto.Type cmdType) throws NodeNotFoundException;
 
   /**
    * Get list of SCMCommands in the Command Queue for a particular Datanode.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/node/SCMNodeMetrics.java
@@ -50,6 +50,8 @@ public final class SCMNodeMetrics implements MetricsSource {
   private @Metric MutableCounterLong numHBProcessingFailed;
   private @Metric MutableCounterLong numNodeReportProcessed;
   private @Metric MutableCounterLong numNodeReportProcessingFailed;
+  private @Metric MutableCounterLong numNodeCommandQueueReportProcessed;
+  private @Metric MutableCounterLong numNodeCommandQueueReportProcessingFailed;
   private @Metric String textMetric;
 
   private final MetricsRegistry registry;
@@ -109,6 +111,20 @@ public final class SCMNodeMetrics implements MetricsSource {
    */
   void incNumNodeReportProcessingFailed() {
     numNodeReportProcessingFailed.incr();
+  }
+
+  /**
+   * Increments number of Command Queue reports processed.
+   */
+  void incNumNodeCommandQueueReportProcessed() {
+    numNodeCommandQueueReportProcessed.incr();
+  }
+
+  /**
+   * Increments number of Command Queue reports where processing failed.
+   */
+  void incNumNodeCommandQueueReportProcessingFailed() {
+    numNodeCommandQueueReportProcessingFailed.incr();
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDatanodeHeartbeatDispatcher.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.scm.server;
 
 import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.CRLStatusReport;
 import org.apache.hadoop.hdds.protocol.proto
@@ -58,6 +59,7 @@ import static org.apache.hadoop.hdds.scm.events.SCMEvents.NODE_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CMD_STATUS_REPORT;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.PIPELINE_ACTIONS;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.PIPELINE_REPORT;
+import static org.apache.hadoop.hdds.scm.events.SCMEvents.COMMAND_QUEUE_REPORT;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature.INITIAL_VERSION;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.toLayoutVersionProto;
 
@@ -130,6 +132,13 @@ public final class SCMDatanodeHeartbeatDispatcher {
             new NodeReportFromDatanode(
                 datanodeDetails,
                 heartbeat.getNodeReport()));
+      }
+
+      if (heartbeat.hasCommandQueueReport()) {
+        LOG.debug("Dispatching Queued Command Report");
+        eventPublisher.fireEvent(COMMAND_QUEUE_REPORT,
+            new CommandQueueReportFromDatanode(datanodeDetails,
+                heartbeat.getCommandQueueReport()));
       }
 
       if (heartbeat.hasContainerReport()) {
@@ -229,6 +238,17 @@ public final class SCMDatanodeHeartbeatDispatcher {
 
     public NodeReportFromDatanode(DatanodeDetails datanodeDetails,
         NodeReportProto report) {
+      super(datanodeDetails, report);
+    }
+  }
+
+  /**
+   * Command Queue Report with origin.
+   */
+  public static class CommandQueueReportFromDatanode
+      extends ReportFromDatanode<CommandQueueReportProto> {
+    public CommandQueueReportFromDatanode(DatanodeDetails datanodeDetails,
+                                          CommandQueueReportProto report) {
       super(datanodeDetails, report);
     }
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
 import org.apache.hadoop.hdds.scm.ha.SequenceIdGenerator;
 import org.apache.hadoop.hdds.scm.ScmInfo;
+import org.apache.hadoop.hdds.scm.node.CommandQueueReportHandler;
 import org.apache.hadoop.hdds.scm.server.upgrade.ScmHAUnfinalizedStateValidationAction;
 import org.apache.hadoop.hdds.scm.pipeline.WritableContainerFactory;
 import org.apache.hadoop.hdds.security.token.ContainerTokenGenerator;
@@ -403,6 +404,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
             pipelineManager, containerManager, scmContext);
     NodeReportHandler nodeReportHandler =
         new NodeReportHandler(scmNodeManager);
+    CommandQueueReportHandler commandQueueReportHandler =
+        new CommandQueueReportHandler(scmNodeManager);
     PipelineReportHandler pipelineReportHandler =
         new PipelineReportHandler(
             scmSafeModeManager, pipelineManager, scmContext, configuration);
@@ -440,6 +443,8 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     eventQueue.addHandler(SCMEvents.DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.RETRIABLE_DATANODE_COMMAND, scmNodeManager);
     eventQueue.addHandler(SCMEvents.NODE_REPORT, nodeReportHandler);
+    eventQueue.addHandler(SCMEvents.COMMAND_QUEUE_REPORT,
+        commandQueueReportHandler);
 
     // Use the same executor for both ICR and FCR.
     // The Executor maps the event to a thread for DN.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/MockNodeManager.java
@@ -21,9 +21,11 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.MetadataStorageReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMVersionRequestProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto
@@ -586,6 +588,31 @@ public class MockNodeManager implements NodeManager {
   public void processLayoutVersionReport(DatanodeDetails dnUuid,
                                          LayoutVersionProto layoutReport) {
     // do nothing
+  }
+
+  /**
+   * Process the Command Queue Report sent from datanodes as part of the
+   * heartbeat message.
+   * @param datanodeDetails
+   * @param commandReport
+   */
+  @Override
+  public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
+      CommandQueueReportProto commandReport) {
+    // do nothing.
+  }
+
+  /**
+   * Get the number of commands of the given type queued on the datanode at the
+   * last heartbeat. If the Datanode has not reported information for the given
+   * command type, -1 will be returned.
+   * @param cmdType
+   * @return The queued count or -1 if no data has been received from the DN.
+   */
+  @Override
+  public int getNodeQueuedCommandCount(DatanodeDetails datanodeDetails,
+      SCMCommandProto.Type cmdType) {
+    return -1;
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/SimpleMockNodeManager.java
@@ -21,9 +21,11 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.NodeReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -287,6 +289,24 @@ public class SimpleMockNodeManager implements NodeManager {
   @Override
   public void processLayoutVersionReport(DatanodeDetails datanodeDetails,
                                          LayoutVersionProto layoutReport) {
+  }
+
+  @Override
+  public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
+      CommandQueueReportProto commandReport) {
+  }
+
+  /**
+   * Get the number of commands of the given type queued on the datanode at the
+   * last heartbeat. If the Datanode has not reported information for the given
+   * command type, -1 will be returned.
+   * @param cmdType
+   * @return The queued count or -1 if no data has been received from the DN.
+   */
+  @Override
+  public int getNodeQueuedCommandCount(DatanodeDetails datanodeDetails,
+      SCMCommandProto.Type cmdType) {
+    return -1;
   }
 
   @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.hdds.scm.node;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.net.NetworkTopology;
+import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher;
+import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
+import org.apache.hadoop.hdds.server.events.Event;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.hdds.server.events.EventQueue;
+import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
+
+/**
+ * Tests for the CommandQueueReportHandler class.
+ */
+public class TestCommandQueueReportHandler implements EventPublisher {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(TestCommandQueueReportHandler.class);
+  private CommandQueueReportHandler commandQueueReportHandler;
+  private HDDSLayoutVersionManager versionManager;
+  private SCMNodeManager nodeManager;
+
+
+  @Before
+  public void resetEventCollector() throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
+    Mockito.when(storageConfig.getClusterID()).thenReturn("cluster1");
+    NetworkTopology clusterMap = new NetworkTopologyImpl(conf);
+
+    this.versionManager =
+        Mockito.mock(HDDSLayoutVersionManager.class);
+    Mockito.when(versionManager.getMetadataLayoutVersion())
+        .thenReturn(maxLayoutVersion());
+    Mockito.when(versionManager.getSoftwareLayoutVersion())
+        .thenReturn(maxLayoutVersion());
+    nodeManager =
+        new SCMNodeManager(conf, storageConfig, new EventQueue(), clusterMap,
+            SCMContext.emptyContext(), versionManager);
+    commandQueueReportHandler = new CommandQueueReportHandler(nodeManager);
+  }
+
+  @Test
+  public void testQueueReportProcessed() throws NodeNotFoundException {
+    DatanodeDetails dn = MockDatanodeDetails.randomDatanodeDetails();
+    nodeManager.register(dn, null, null);
+    SCMDatanodeHeartbeatDispatcher.CommandQueueReportFromDatanode
+        commandReport = getQueueReport(dn);
+    commandQueueReportHandler.onMessage(commandReport, this);
+
+    int commandCount = commandReport.getReport().getCommandCount();
+    for (int i = 0; i < commandCount; i++) {
+      int storedCount = nodeManager.getNodeQueuedCommandCount(dn,
+          commandReport.getReport().getCommand(i));
+      Assert.assertEquals(commandReport.getReport().getCount(i), storedCount);
+      Assert.assertTrue(storedCount > 0);
+    }
+  }
+
+  private SCMDatanodeHeartbeatDispatcher.CommandQueueReportFromDatanode
+      getQueueReport(DatanodeDetails dn) {
+    CommandQueueReportProto.Builder builder =
+        CommandQueueReportProto.newBuilder();
+    int i = 10;
+    for (SCMCommandProto.Type cmd : SCMCommandProto.Type.values()) {
+      if (cmd == SCMCommandProto.Type.unknownScmCommand) {
+        // Do not include the unknow command type in the message.
+        continue;
+      }
+      builder.addCommand(cmd);
+      builder.addCount(i++);
+    }
+    return new SCMDatanodeHeartbeatDispatcher.CommandQueueReportFromDatanode(
+        dn, builder.build());
+  }
+
+
+  @Override
+  public <PAYLOAD, EVENT_TYPE extends Event<PAYLOAD>> void fireEvent(
+      EVENT_TYPE event, PAYLOAD payload) {
+    LOG.info("Event is published: {}", payload);
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/testutils/ReplicationNodeManagerMock.java
@@ -18,7 +18,9 @@ package org.apache.hadoop.ozone.container.testutils;
 
 import com.google.common.base.Preconditions;
 
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.LayoutVersionProto;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.PipelineReportsProto;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
@@ -428,6 +430,25 @@ public class ReplicationNodeManagerMock implements NodeManager {
   public void processLayoutVersionReport(DatanodeDetails dnUuid,
                                 LayoutVersionProto layoutVersionReport) {
     // do nothing.
+  }
+
+  @Override
+  public void processNodeCommandQueueReport(DatanodeDetails datanodeDetails,
+      CommandQueueReportProto commandReport) {
+    // Do nothing.
+  }
+
+  /**
+   * Get the number of commands of the given type queued on the datanode at the
+   * last heartbeat. If the Datanode has not reported information for the given
+   * command type, -1 will be returned.
+   * @param cmdType
+   * @return The queued count or -1 if no data has been received from the DN.
+   */
+  @Override
+  public int getNodeQueuedCommandCount(DatanodeDetails datanodeDetails,
+      SCMCommandProto.Type cmdType) {
+    return -1;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-6554](https://issues.apache.org/jira/browse/HDDS-6554) added the current command counts for all commands queued on a Datanode to the datanode heartbeat. This Jira will process that information on SCM and store it inside the DatanodeInfo object so other parts of SCM can reference it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6567

## How was this patch tested?

New Unit Tests
