### PR TITLE
HDDS-6626. Exclude Hadoop Thirdparty from shaded Ozone FS jars

### DIFF
--- a/hadoop-ozone/ozonefs-shaded/pom.xml
+++ b/hadoop-ozone/ozonefs-shaded/pom.xml
@@ -53,6 +53,10 @@
           <artifactId>hadoop-annotations</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>org.apache.hadoop.thirdparty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
         </exclusion>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Shaded Ozone FS jars currently include Hadoop Thirdparty libs:

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/share/ozone/lib
$ unzip -t ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar | grep 'org.apache.hadoop.thirdparty.*class' | sort | head
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessage$Builder.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessage$BuilderParent.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessage.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessageLite$Builder$LimitedInputStream.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessageLite$Builder.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractMessageLite.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractParser.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/AbstractProtobufList.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/Android.class   OK
    testing: org/apache/hadoop/thirdparty/protobuf/Any$1.class   OK
```

This can result in version mismatch if the FS jars are used with different Hadoop version than the one we package with (3.3.1 currently).

This PR makes Hadoop Thirdparty libs to be excluded, letting users provide it, similar to regular Hadoop libs (hadoop-common, hadoop-hdfs-client, etc.).

https://issues.apache.org/jira/browse/HDDS-6626

## How was this patch tested?

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/share/ozone/lib
$ unzip -t ozone-filesystem-hadoop3-1.3.0-SNAPSHOT.jar | grep -c 'org.apache.hadoop.thirdparty'
0
```

Functionality is tested by existing acceptance test in `ozone-mr` env.

https://github.com/adoroszlai/hadoop-ozone/runs/6115327106