### PR TITLE
HDDS-6630. Explicitly remove node after being chosen

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -241,6 +241,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
       if (nodeId != null) {
         removePeers(nodeId, healthyNodes);
         results.add(nodeId);
+        healthyNodes.remove(nodeId);
       }
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.scm.container.MockNodeManager;
+import org.apache.hadoop.hdds.scm.exceptions.SCMException;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Test functions of SCMCommonPlacementPolicy.
+ */
+public class TestSCMCommonPlacementPolicy {
+
+  private NodeManager nodeManager;
+  private OzoneConfiguration conf;
+
+  @Before
+  public void setup() {
+    nodeManager = new MockNodeManager(true, 10);
+    conf = SCMTestUtils.getConf();
+  }
+
+  @Test
+  public void testGetResultSet() throws SCMException {
+    DummyPlacementPolicy dummyPlacementPolicy =
+        new DummyPlacementPolicy(nodeManager, conf);
+    List<DatanodeDetails> list =
+        nodeManager.getNodes(NodeStatus.inServiceHealthy());
+    List<DatanodeDetails> result = dummyPlacementPolicy.getResultSet(3, list);
+    Set<DatanodeDetails> resultSet = new HashSet<>(result);
+    Assert.assertNotEquals(1, resultSet.size());
+  }
+
+  private static class DummyPlacementPolicy extends SCMCommonPlacementPolicy {
+
+    DummyPlacementPolicy(
+        NodeManager nodeManager,
+        ConfigurationSource conf) {
+      super(nodeManager, conf);
+    }
+
+    @Override
+    public DatanodeDetails chooseNode(List<DatanodeDetails> healthyNodes) {
+      return healthyNodes.get(0);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `SCMCommonPlacementPolicy.getResultSet()`, the abstract method of "chooseNode" will be invoked each time to get a valid node, the method declarition is as follows:

```
/**
 * Choose a datanode according to the policy, this function is implemented
 * by the actual policy class.
 *
 * @param healthyNodes - Set of healthy nodes we can choose from.
 * @return DatanodeDetails
 */
public abstract DatanodeDetails chooseNode(
    List<DatanodeDetails> healthyNodes); 
```
For this method, all current implementations of subclasses will remove the chosen node from healthyNodes, but seems this side effect is not explicitly clarified. 

For users trying to implement their own subclasses, they might forget this removal, which might return incorrect values.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/projects/HDDS/issues/HDDS-6630?filter=allopenissues

## How was this patch tested?

unit test.
