### PR TITLE
HDDS-6632. ReplicationManagerReport should handle unknown metric in protobuf

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/container/ReplicationManagerReport.java
@@ -184,7 +184,11 @@ public class ReplicationManagerReport {
   }
 
   protected void setStat(String stat, long value) {
-    LongAdder adder = getStatAndEnsurePresent(stat);
+    LongAdder adder = stats.get(stat);
+    if (adder == null) {
+      // this is an unknown stat, so ignore it.
+      return;
+    }
     if (adder.longValue() != 0) {
       throw new IllegalStateException(stat + " is expected to be zero");
     }
@@ -192,9 +196,11 @@ public class ReplicationManagerReport {
   }
 
   protected void setSample(String stat, List<ContainerID> sample) {
-    // First get the stat, as we should not receive a sample for a stat which
-    // does not exist.
-    getStatAndEnsurePresent(stat);
+    LongAdder adder = stats.get(stat);
+    if (adder == null) {
+      // this is an unknown stat, so ignore it.
+      return;
+    }
     // Now check there is not already a sample for this stat
     List<ContainerID> existingSample = containerSample.get(stat);
     if (existingSample != null) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -146,6 +146,35 @@ public class TestReplicationManagerReport {
     }
   }
 
+  @Test
+  public void testDeSerializeCanHandleUnknownMetric() {
+    HddsProtos.ReplicationManagerReportProto.Builder proto =
+        HddsProtos.ReplicationManagerReportProto.newBuilder();
+    proto.setTimestamp(12345);
+
+    proto.addStat(HddsProtos.KeyIntValue.newBuilder()
+        .setKey("unknownValue")
+        .setValue(15)
+        .build());
+
+    proto.addStat(HddsProtos.KeyIntValue.newBuilder()
+        .setKey(ReplicationManagerReport.HealthState.UNDER_REPLICATED
+            .toString())
+        .setValue(20)
+        .build());
+
+    HddsProtos.KeyContainerIDList.Builder sample
+        = HddsProtos.KeyContainerIDList.newBuilder();
+    sample.setKey("unknownValue");
+    sample.addContainer(ContainerID.valueOf(1).getProtobuf());
+    proto.addStatSample(sample.build());
+    // Ensure no exception is thrown
+    ReplicationManagerReport newReport =
+        ReplicationManagerReport.fromProtobuf(proto.build());
+    Assert.assertEquals(20, newReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
   @Test(expected = IllegalStateException.class)
   public void testStatCannotBeSetTwice() {
     report.setStat(HddsProtos.LifeCycleState.CLOSED.toString(), 10);


### PR DESCRIPTION
## What changes were proposed in this pull request?

If the client attempts to de-serialize a ReplicationManagerReport object from protobuf, and there is a metric passed from the server to the client which the client does not know about (eg the server and client are at different versions), the client will throw in IllegalArgumentException currently. Instead if should just ignore any metrics it does not know about.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6632

## How was this patch tested?

New unit test to reproduce the issue and confirm it is fixed.
