### PR TITLE
HDDS-6636. Revert "HDDS-6579. Add commandline argument for Container Info command. (#3306)"

### DIFF
--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/scm/cli/container/InfoSubcommand.java
@@ -63,11 +63,6 @@ public class InfoSubcommand extends ScmSubcommand {
       description = "Format output as JSON")
   private boolean json;
 
-  @CommandLine.Option(names = { "--replicas" },
-      defaultValue = "false",
-      description = "Adds replica related details")
-  private boolean addReplicaDetails;
-
   @Parameters(description = "Decimal id of the container.")
   private long containerID;
 
@@ -108,7 +103,7 @@ public class InfoSubcommand extends ScmSubcommand {
       LOG.info("Datanodes: [{}]", machinesStr);
 
       // Print the replica details if available
-      if (addReplicaDetails && replicas != null) {
+      if (replicas != null) {
         String replicaStr = replicas.stream().map(
             InfoSubcommand::buildReplicaDetails)
             .collect(Collectors.joining(",\n"));

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -97,7 +97,7 @@ public class TestInfoSubCommand {
         .thenReturn(getReplicas(includeIndex));
     cmd = new InfoSubcommand();
     CommandLine c = new CommandLine(cmd);
-    c.parseArgs("1", "--replicas");
+    c.parseArgs("1");
     cmd.execute(scmClient);
 
     // Ensure we have a line for Replicas:


### PR DESCRIPTION
## What changes were proposed in this pull request?

[HDDS-6579](https://issues.apache.org/jira/browse/HDDS-6579) added a flag to hide newly added information in the `ozone admin container info` command for compatibility reasons. However the flag is not necessary, as the changes are not incompatible. It is also not desirable to have a new command flag for every piece of new information that is to be added to every command. It will result in commands with many flags that have to be passed all the time to get the full set of information.

There is a community discussion about compatibility where the consensus is that we provide compatibility for these admin commands via the JSON output, and that the formatting and output of the "human readable" formats can change over time:

https://lists.apache.org/thread/5gqnbstv1pznwmcvx7txspj1qrksy7gl

For those reasons I am reverting HDDS-6579 / #3306.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6636

## How was this patch tested?

CI run and existing tests, as this is just a revert.
