### PR TITLE
HDDS-6521. Refactor ListBlock handler

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerD
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerType;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.GetSmallFileRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.KeyValue;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ListBlockRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.PutSmallFileRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.Type;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
@@ -566,15 +567,12 @@ public class KeyValueHandler extends Handler {
 
     List<ContainerProtos.BlockData> returnData = new ArrayList<>();
     try {
-      int count = request.getListBlock().getCount();
-      long startLocalId = -1;
-      if (request.getListBlock().hasStartLocalID()) {
-        startLocalId = request.getListBlock().getStartLocalID();
-      }
-      List<BlockData> responseData =
-          blockManager.listBlock(kvContainer, startLocalId, count);
-      for (int i = 0; i < responseData.size(); i++) {
-        returnData.add(responseData.get(i).getProtoBufMessage());
+      final ListBlockRequestProto proto = request.getListBlock();
+      List<BlockData> responseData = blockManager.listBlock(kvContainer,
+          proto.hasStartLocalID() ? proto.getStartLocalID() : 0,
+          proto.getCount());
+      for (BlockData blockData : responseData) {
+        returnData.add(blockData.getProtoBufMessage());
       }
     } catch (StorageContainerException ex) {
       return ContainerUtils.logAndReturnError(LOG, ex, request);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Refactor ListBlock handler, cleanup code and use `startLocalID = 0` to indicate beginning.

``` java
  /**
   * List blocks in a container.
   *
   * @param container - Container from which blocks need to be listed.
   * @param startLocalID  - Key to start from, 0 to begin.
   * @param count    - Number of blocks to return.
   * @return List of Blocks that match the criteria.
   */
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6521

## How was this patch tested?

CI
