### PR TITLE
HDDS-6522. Fix TestOzoneManagerHAWithData#testTwoOMNodesDown

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHA.java
@@ -288,14 +288,18 @@ public abstract class TestOzoneManagerHA {
         // Verify that the request failed
         fail("There is no quorum. Request should have failed");
       }
-    } catch (ConnectException | RemoteException e) {
+    } catch (IOException e) {
       if (!checkSuccess) {
         // If the last OM to be tried by the RetryProxy is down, we would get
         // ConnectException. Otherwise, we would get a RemoteException from the
         // last running OM as it would fail to get a quorum.
         if (e instanceof RemoteException) {
+          GenericTestUtils.assertExceptionContains("OMNotLeaderException", e);
+        } else if (e instanceof ConnectException) {
+          GenericTestUtils.assertExceptionContains("Connection refused", e);
+        } else {
           GenericTestUtils.assertExceptionContains(
-              "OMNotLeaderException", e);
+              "Could not determine or connect to OM Leader", e);
         }
       } else {
         throw e;
@@ -382,14 +386,18 @@ public abstract class TestOzoneManagerHA {
       ozoneInputStream.read(fileContent);
       Assert.assertEquals(value, new String(fileContent, UTF_8));
 
-    } catch (ConnectException | RemoteException e) {
+    } catch (IOException e) {
       if (!checkSuccess) {
         // If the last OM to be tried by the RetryProxy is down, we would get
         // ConnectException. Otherwise, we would get a RemoteException from the
         // last running OM as it would fail to get a quorum.
         if (e instanceof RemoteException) {
+          GenericTestUtils.assertExceptionContains("OMNotLeaderException", e);
+        } else if (e instanceof ConnectException) {
+          GenericTestUtils.assertExceptionContains("Connection refused", e);
+        } else {
           GenericTestUtils.assertExceptionContains(
-              "OMNotLeaderException", e);
+              "Could not determine or connect to OM Leader", e);
         }
       } else {
         throw e;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAWithData.java
@@ -78,7 +78,6 @@ public class TestOzoneManagerHAWithData extends TestOzoneManagerHA {
   /**
    * Test client request fails when 2 OMs are down.
    */
-  @Flaky("This test is failing randomly. It will be enabled after fixing it.")
   @Test
   public void testTwoOMNodesDown() throws Exception {
     getCluster().stopOzoneManager(1);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix integration test `TestOzoneManagerHAWithData#testTwoOMNodesDown()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6522

## How was this patch tested?

100x testTwoOMNodesDown (before): https://github.com/kaijchen/ozone/actions/runs/2215651435
100x testTwoOMNodesDown (after): https://github.com/kaijchen/ozone/actions/runs/2215651878
Regular CI: https://github.com/kaijchen/ozone/actions/runs/2215934619