### PR TITLE
HDDS-6640. Node.isAncestor might return incorrect result

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
@@ -473,8 +473,7 @@ public class InnerNodeImpl extends NodeImpl implements InnerNode {
         continue;
       }
       if (excludedScopes != null && excludedScopes.size() > 0) {
-        if (excludedScopes.stream().anyMatch(scope ->
-            node.getNetworkFullPath().startsWith(scope))) {
+        if (excludedScopes.stream().anyMatch(node::isUnderScope)) {
           continue;
         }
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/InnerNodeImpl.java
@@ -473,7 +473,7 @@ public class InnerNodeImpl extends NodeImpl implements InnerNode {
         continue;
       }
       if (excludedScopes != null && excludedScopes.size() > 0) {
-        if (excludedScopes.stream().anyMatch(node::isUnderScope)) {
+        if (excludedScopes.stream().anyMatch(node::isDescendant)) {
           continue;
         }
       }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -155,22 +155,16 @@ public final class NetUtils {
    * the path.
    * @param path path to add suffix
    * @return the normalised path
-   * If <i>path</i>is empty, then {@link NetConstants#ROOT} is returned
+   * If <i>path</i>is empty, then {@link NetConstants#PATH_SEPARATOR_STR} is
+   * returned
    */
   public static String addSuffix(String path) {
     if (path == null) {
       return null;
     }
-
-    int len = path.length();
-    if (len == 0) {
-      return NetConstants.PATH_SEPARATOR_STR;
-    }
-
-    if (path.charAt(len - 1) != NetConstants.PATH_SEPARATOR) {
+    if (!path.endsWith(NetConstants.PATH_SEPARATOR_STR)) {
       return path + NetConstants.PATH_SEPARATOR_STR;
     }
-
     return path;
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -105,7 +105,7 @@ public final class NetUtils {
       }
       // excludedScope is child of ancestor
       List<String> duplicateList = mutableExcludedScopes.stream()
-          .filter(scope -> scope.startsWith(ancestor.getNetworkFullPath()))
+          .filter(ancestor::isAncestor)
           .collect(Collectors.toList());
       mutableExcludedScopes.removeAll(duplicateList);
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -111,7 +111,7 @@ public final class NetUtils {
 
       // ancestor is covered by excludedScope
       mutableExcludedScopes.stream().forEach(scope -> {
-        if (ancestor.getNetworkFullPath().startsWith(scope)) {
+        if (ancestor.isDescendant(scope)) {
           // remove exclude node if it's covered by excludedScope
           iterator.remove();
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetUtils.java
@@ -149,4 +149,28 @@ public final class NetUtils {
     }
     return ancestorList;
   }
+
+  /**
+   * Ensure {@link NetConstants#PATH_SEPARATOR_STR} is added to the suffix of
+   * the path.
+   * @param path path to add suffix
+   * @return the normalised path
+   * If <i>path</i>is empty, then {@link NetConstants#ROOT} is returned
+   */
+  public static String addSuffix(String path) {
+    if (path == null) {
+      return null;
+    }
+
+    int len = path.length();
+    if (len == 0) {
+      return NetConstants.PATH_SEPARATOR_STR;
+    }
+
+    if (path.charAt(len - 1) != NetConstants.PATH_SEPARATOR) {
+      return path + NetConstants.PATH_SEPARATOR_STR;
+    }
+
+    return path;
+  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -534,7 +534,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
             " generation  " + ancestorGen);
       }
       // affinity ancestor should has overlap with scope
-      if (affinityAncestor.getNetworkFullPath().startsWith(scope)) {
+      if (affinityAncestor.isDescendant(scope)) {
         finalScope = affinityAncestor.getNetworkFullPath();
       } else if (!scope.startsWith(affinityAncestor.getNetworkFullPath())) {
         return null;
@@ -746,8 +746,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
       return 0;
     }
     if (!CollectionUtils.isEmpty(mutableExcludedNodes)) {
-      mutableExcludedNodes.removeIf(
-          next -> !next.getNetworkFullPath().startsWith(scope));
+      mutableExcludedNodes.removeIf(next -> !next.isDescendant(scope));
     }
     List<Node> excludedAncestorList =
         NetUtils.getAncestorList(this, mutableExcludedNodes, ancestorGen);
@@ -780,7 +779,7 @@ public class NetworkTopologyImpl implements NetworkTopology {
         }
       } else {
         for (Node ancestor : excludedAncestorList) {
-          if (ancestor.getNetworkFullPath().startsWith(scope)) {
+          if (ancestor.isDescendant(scope)) {
             excludedCount += ancestor.getNumOfLeaves();
           }
         }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
@@ -98,4 +98,12 @@ public interface Node {
    * @return true if this node is an ancestor of <i>n</i>
    */
   boolean isAncestor(Node n);
+
+  /**
+   * Judge if this node is under a specific scope.
+   *
+   * @param scope the scope
+   * @return true if this node is under a specific scope
+   */
+  boolean isUnderScope(String scope);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
@@ -100,10 +100,12 @@ public interface Node {
   boolean isAncestor(Node n);
 
   /**
-   * Judge if this node is under a specific scope.
+   * Judge if this node is a descendant of the node representing by the
+   * nodePath.
+   * Descendant includes itself and all child generations.
    *
-   * @param scope the scope
+   * @param nodePath the scope
    * @return true if this node is under a specific scope
    */
-  boolean isUnderScope(String scope);
+  boolean isDescendant(String nodePath);
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/Node.java
@@ -100,6 +100,24 @@ public interface Node {
   boolean isAncestor(Node n);
 
   /**
+   * Judge if this node is an ancestor of the node representing by the nodePath.
+   * Ancestor includes itself and parents case.
+   *
+   * @param nodePath the node path
+   * @return true if this node is an ancestor of <i>n</i>
+   */
+  boolean isAncestor(String nodePath);
+
+  /**
+   * Judge if this node is a descendant of node <i>n</i>.
+   * Descendant includes itself and all child generations.
+   *
+   * @param n a node
+   * @return true if this node is an descendant of <i>n</i>
+   */
+  boolean isDescendant(Node n);
+
+  /**
    * Judge if this node is a descendant of the node representing by the
    * nodePath.
    * Descendant includes itself and all child generations.

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -231,14 +231,4 @@ public class NodeImpl implements Node {
         this.location + this.name :
         this.location + PATH_SEPARATOR_STR + this.name;
   }
-
-  public static void main(String[] args) {
-    NodeImpl n1 = new NodeImpl("rc", "/", 1);
-    NodeImpl n2 = new NodeImpl("10.128.131.12", "/rc1/dc", 1);
-    System.out.println("n1 full path: " + n1.getNetworkFullPath());
-    System.out.println("n2 full path: " + n2.getNetworkFullPath());
-
-    System.out.println(n2.isAncestor(n1));
-    System.out.println(n1.isAncestor(n2));
-  }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -196,6 +196,9 @@ public class NodeImpl implements Node {
    */
   @Override
   public boolean isAncestor(Node node) {
+    if (node == null) {
+      return false;
+    }
     return isAncestor(node.getNetworkFullPath());
   }
 
@@ -208,6 +211,9 @@ public class NodeImpl implements Node {
   }
   @Override
   public boolean isDescendant(Node node) {
+    if (node == null) {
+      return false;
+    }
     return isDescendant(node.getNetworkFullPath());
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -197,9 +197,9 @@ public class NodeImpl implements Node {
   @Override
   public boolean isAncestor(Node node) {
     return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
-        node.getNetworkLocation().startsWith(this.getNetworkFullPath()) ||
-            node.getNetworkFullPath().equalsIgnoreCase(
-                this.getNetworkFullPath());
+        NetUtils.addSuffix(node.getNetworkLocation()).startsWith(
+            NetUtils.addSuffix(this.getNetworkFullPath())) ||
+        node.getNetworkFullPath().equalsIgnoreCase(this.getNetworkFullPath());
   }
 
   @Override
@@ -230,5 +230,15 @@ public class NodeImpl implements Node {
     return this.location.equals(PATH_SEPARATOR_STR) ?
         this.location + this.name :
         this.location + PATH_SEPARATOR_STR + this.name;
+  }
+
+  public static void main(String[] args) {
+    NodeImpl n1 = new NodeImpl("rc", "/", 1);
+    NodeImpl n2 = new NodeImpl("10.128.131.12", "/rc1/dc", 1);
+    System.out.println("n1 full path: " + n1.getNetworkFullPath());
+    System.out.println("n2 full path: " + n2.getNetworkFullPath());
+
+    System.out.println(n2.isAncestor(n1));
+    System.out.println(n1.isAncestor(n2));
   }
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -197,14 +197,14 @@ public class NodeImpl implements Node {
   @Override
   public boolean isAncestor(Node node) {
     return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
-        node.isUnderScope(this.getNetworkFullPath()) ||
+        node.isDescendant(this.getNetworkFullPath()) ||
         node.getNetworkFullPath().equalsIgnoreCase(this.getNetworkFullPath());
   }
 
   @Override
-  public boolean isUnderScope(String scope) {
+  public boolean isDescendant(String nodePath) {
     return NetUtils.addSuffix(this.getNetworkFullPath()).startsWith(
-        NetUtils.addSuffix(scope));
+        NetUtils.addSuffix(nodePath));
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -204,6 +204,9 @@ public class NodeImpl implements Node {
 
   @Override
   public boolean isAncestor(String nodePath) {
+    if (nodePath == null) {
+      return false;
+    }
     return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
         nodePath.equalsIgnoreCase(this.getNetworkFullPath()) ||
         NetUtils.addSuffix(nodePath).startsWith(
@@ -219,6 +222,9 @@ public class NodeImpl implements Node {
 
   @Override
   public boolean isDescendant(String nodePath) {
+    if (nodePath == null) {
+      return false;
+    }
     return NetUtils.addSuffix(this.getNetworkFullPath()).startsWith(
         NetUtils.addSuffix(nodePath));
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -203,7 +203,7 @@ public class NodeImpl implements Node {
 
   @Override
   public boolean isUnderScope(String scope) {
-    return NetUtils.addSuffix(this.getNetworkLocation()).startsWith(
+    return NetUtils.addSuffix(this.getNetworkFullPath()).startsWith(
         NetUtils.addSuffix(scope));
   }
 

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -196,9 +196,19 @@ public class NodeImpl implements Node {
    */
   @Override
   public boolean isAncestor(Node node) {
+    return isAncestor(node.getNetworkFullPath());
+  }
+
+  @Override
+  public boolean isAncestor(String nodePath) {
     return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
-        node.isDescendant(this.getNetworkFullPath()) ||
-        node.getNetworkFullPath().equalsIgnoreCase(this.getNetworkFullPath());
+        nodePath.equalsIgnoreCase(this.getNetworkFullPath()) ||
+        NetUtils.addSuffix(nodePath).startsWith(
+            NetUtils.addSuffix(this.getNetworkFullPath()));
+  }
+  @Override
+  public boolean isDescendant(Node node) {
+    return isDescendant(node.getNetworkFullPath());
   }
 
   @Override

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeImpl.java
@@ -197,9 +197,14 @@ public class NodeImpl implements Node {
   @Override
   public boolean isAncestor(Node node) {
     return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
-        NetUtils.addSuffix(node.getNetworkLocation()).startsWith(
-            NetUtils.addSuffix(this.getNetworkFullPath())) ||
+        node.isUnderScope(this.getNetworkFullPath()) ||
         node.getNetworkFullPath().equalsIgnoreCase(this.getNetworkFullPath());
+  }
+
+  @Override
+  public boolean isUnderScope(String scope) {
+    return NetUtils.addSuffix(this.getNetworkLocation()).startsWith(
+        NetUtils.addSuffix(scope));
   }
 
   @Override

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -192,6 +192,13 @@ public class TestNetworkTopologyImpl {
     assertEquals(cluster.getNode(""), cluster.getNode("/"));
     assertEquals(null, cluster.getNode("/switch1/node1"));
     assertEquals(null, cluster.getNode("/switch1"));
+
+    if (cluster.getNode("/d1") != null) {
+      List<String> excludedScope = new ArrayList<>();
+      excludedScope.add("/d");
+      Node n = cluster.getNode(0, "/d1", excludedScope, null, null, 0);
+      assertNotNull(n);
+    }
   }
 
   @Test
@@ -908,9 +915,18 @@ public class TestNetworkTopologyImpl {
 
   @Test
   public void testIsAncestor() {
-    NodeImpl n1 = new NodeImpl("r1", "/", NODE_COST_DEFAULT);
-    NodeImpl n2 = new NodeImpl("dc", "/r12", NODE_COST_DEFAULT);
-    Assert.assertFalse(n1.isAncestor(n2));
+    NodeImpl r1 = new NodeImpl("r1", "/", NODE_COST_DEFAULT);
+    NodeImpl r12 = new NodeImpl("r12", "/", NODE_COST_DEFAULT);
+    NodeImpl dc = new NodeImpl("dc", "/r12", NODE_COST_DEFAULT);
+    Assert.assertFalse(r1.isAncestor(dc));
+    Assert.assertFalse(r1.isAncestor("/r12/dc2"));
+    Assert.assertFalse(dc.isDescendant(r1));
+    Assert.assertFalse(dc.isDescendant("/r1"));
+
+    Assert.assertTrue(r12.isAncestor(dc));
+    Assert.assertTrue(r12.isAncestor("/r12/dc2"));
+    Assert.assertTrue(dc.isDescendant(r12));
+    Assert.assertTrue(dc.isDescendant("/r12"));
   }
 
   @Test
@@ -925,7 +941,6 @@ public class TestNetworkTopologyImpl {
     excludedScope.add("/r1");
     Assert.assertFalse(n1.isDescendant("/r1"));
     Assert.assertEquals(n1, dc.getLeaf(0, excludedScope, null, 0));
-
   }
 
   private static Node createDatanode(String name, String path) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.DATACENTER_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.NODEGROUP_SCHEMA;
+import static org.apache.hadoop.hdds.scm.net.NetConstants.NODE_COST_DEFAULT;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.PATH_SEPARATOR_STR;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.REGION_SCHEMA;
@@ -44,6 +45,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -903,6 +906,13 @@ public class TestNetworkTopologyImpl {
     chosenNode = newCluster.chooseRandom(NetConstants.ROOT,
         Arrays.asList(node.getNetworkFullPath()), Arrays.asList(node), node, 0);
     assertNull(chosenNode);
+  }
+
+  @Test
+  public void testIsAncestor() {
+    NodeImpl n1 = new NodeImpl("r1", "/", NODE_COST_DEFAULT);
+    NodeImpl n2 = new NodeImpl("dc", "/r12", NODE_COST_DEFAULT);
+    Assert.assertFalse(n1.isAncestor(n2));
   }
 
   private static Node createDatanode(String name, String path) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -915,6 +915,21 @@ public class TestNetworkTopologyImpl {
     Assert.assertFalse(n1.isAncestor(n2));
   }
 
+  @Test
+  public void testGetLeafOnLeafParent() {
+    InnerNodeImpl root = new InnerNodeImpl("", "", null, 0, 0);
+    InnerNodeImpl r12 = new InnerNodeImpl("r12", "/", root, 1, 0);
+    InnerNodeImpl dc = new InnerNodeImpl("dc", "/r12", r12, 2, 0);
+    NodeImpl n1 = new NodeImpl("n1", "/r12/dc", dc, 2, 0);
+    dc.add(n1);
+
+    List<String> excludedScope = new ArrayList<>();
+    excludedScope.add("/r1");
+    Assert.assertFalse(n1.isUnderScope("/r1"));
+    Assert.assertEquals(n1, dc.getLeaf(0, excludedScope, null, 0));
+
+  }
+
   private static Node createDatanode(String name, String path) {
     return new NodeImpl(name, path, NetConstants.NODE_COST_DEFAULT);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -413,7 +413,7 @@ public class TestNetworkTopologyImpl {
         scope = "~" + path;
         frequency = pickNodesAtRandom(100, scope, null, 0);
         for (Node key : dataNodes) {
-          if (key.getNetworkFullPath().startsWith(path)) {
+          if (key.isDescendant(path)) {
             assertTrue(frequency.get(key) == 0);
           }
         }
@@ -547,8 +547,7 @@ public class TestNetworkTopologyImpl {
             List<Node> ancestorList = NetUtils.getAncestorList(cluster,
                 excludedList, ancestorGen);
             for (Node key : dataNodes) {
-              if (excludedList.contains(key) ||
-                  key.getNetworkFullPath().startsWith(path) ||
+              if (excludedList.contains(key) || key.isDescendant(path) ||
                   (ancestorList.size() > 0 &&
                       ancestorList.stream()
                           .map(a -> (InnerNode) a)
@@ -653,8 +652,7 @@ public class TestNetworkTopologyImpl {
                       excludedList.contains(key)) {
                     continue;
                   } else if (pathList != null &&
-                      pathList.stream().anyMatch(path ->
-                          key.getNetworkFullPath().startsWith(path))) {
+                      pathList.stream().anyMatch(key::isDescendant)) {
                     continue;
                   } else if (key.getNetworkFullPath().equals(
                       affinityNode.getNetworkFullPath())) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -925,7 +925,7 @@ public class TestNetworkTopologyImpl {
 
     List<String> excludedScope = new ArrayList<>();
     excludedScope.add("/r1");
-    Assert.assertFalse(n1.isUnderScope("/r1"));
+    Assert.assertFalse(n1.isDescendant("/r1"));
     Assert.assertEquals(n1, dc.getLeaf(0, excludedScope, null, 0));
 
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In NodeImpl, the relation of ancestor is decided as follows:
```
@Override
public boolean isAncestor(Node node) {
  return this.getNetworkFullPath().equals(PATH_SEPARATOR_STR) ||
      node.getNetworkLocation().startsWith(this.getNetworkFullPath()) ||
      node.getNetworkFullPath().equalsIgnoreCase(this.getNetworkFullPath()); 
```
The corner case is as follows:
```
Node n1: "/rc"
Node n2: "/rc1/dc/1.1.1.1"
```
The result of n1.isAncestor(n2) is false, while in fact n1 is not n2's ancestor.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6640

## How was this patch tested?

unit test
