### PR TITLE
HDDS-6639. Remove flaky tag for testOMProxyProviderFailoverOnConnectionFailure

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerHAMetadataOnly.java
@@ -46,7 +46,6 @@ import org.apache.ratis.protocol.RaftClientReply;
 import org.apache.ratis.protocol.RaftClientRequest;
 import org.apache.ratis.server.RaftServer;
 import org.junit.Assert;
-import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.Test;
 
 import javax.management.MBeanInfo;
@@ -185,7 +184,6 @@ public class TestOzoneManagerHAMetadataOnly extends TestOzoneManagerHA {
   /**
    * Test OMFailoverProxyProvider failover on connection exception to OM client.
    */
-  @Flaky("This test randomly failing. Let's enable once its fixed.")
   @Test
   public void testOMProxyProviderFailoverOnConnectionFailure()
       throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove flaky tag for TestOzoneManagerHAMetadataOnly#testOMProxyProviderFailoverOnConnectionFailure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6639

## How was this patch tested?

1000x TestOzoneManagerHAMetadataOnly#testOMProxyProviderFailoverOnConnectionFailure:  https://github.com/kaijchen/ozone/actions/runs/2216059091

Regular CI: https://github.com/kaijchen/ozone/actions/runs/2217457986