### PR TITLE
HDDS-6628. Print OMLockMetrics through obrwf freon command

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
@@ -39,7 +39,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import javax.management.*;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.ReflectionException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanException;
+import javax.management.ObjectName;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -25,7 +25,8 @@ import org.apache.hadoop.hdds.server.ServiceRuntimeInfo;
  * This is the JMX management interface for OM information.
  */
 @InterfaceAudience.Private
-public interface OMMXBean extends ServiceRuntimeInfo {
+public interface OMMXBean extends ServiceRuntimeInfo, OzoneManagerLockMXBean {
 
   String getRpcPort();
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2815,6 +2815,30 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     return "" + omRpcAddress.getPort();
   }
 
+  @Override
+  public String getReadLockWaitingTimeMsStat() {
+    return getMetadataManager().getLock().getOMLockMetrics()
+        .getReadLockWaitingTimeMsStat();
+  }
+
+  @Override
+  public String getReadLockHeldTimeMsStat() {
+    return getMetadataManager().getLock().getOMLockMetrics()
+        .getReadLockHeldTimeMsStat();
+  }
+
+  @Override
+  public String getWriteLockWaitingTimeMsStat() {
+    return getMetadataManager().getLock().getOMLockMetrics()
+        .getWriteLockWaitingTimeMsStat();
+  }
+
+  @Override
+  public String getWriteLockHeldTimeMsStat() {
+    return getMetadataManager().getLock().getOMLockMetrics()
+        .getWriteLockHeldTimeMsStat();
+  }
+
   @VisibleForTesting
   public OzoneManagerHttpServer getHttpServer() {
     return httpServer;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerLockMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerLockMXBean.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.annotation.InterfaceAudience;
+
+@InterfaceAudience.Private
+public interface OzoneManagerLockMXBean {
+
+  String getReadLockWaitingTimeMsStat();
+
+  String getReadLockHeldTimeMsStat();
+
+  String getWriteLockWaitingTimeMsStat();
+
+  String getWriteLockHeldTimeMsStat();
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerLockMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManagerLockMXBean.java
@@ -19,6 +19,9 @@ package org.apache.hadoop.ozone.om;
 
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 
+/**
+ * This is the JMX management interface for OzoneManagerLock information.
+ */
 @InterfaceAudience.Private
 public interface OzoneManagerLockMXBean {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Print OMLockMetrics for [HDDS-6457](https://issues.apache.org/jira/browse/HDDS-6457) obrwf freon command by accessing via JMX metrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6628

## How was this patch tested?

Added integration tests.
