### PR TITLE
HDDS-6648. Add Root in network-topology-default.xml

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NodeSchemaLoader.java
@@ -385,9 +385,6 @@ public final class NodeSchemaLoader {
               + "> is null");
         }
         if (TOPOLOGY_PATH.equals(tagName)) {
-          if (value.startsWith(NetConstants.PATH_SEPARATOR_STR)) {
-            value = value.substring(1);
-          }
           String[] layerIDs = value.split(NetConstants.PATH_SEPARATOR_STR);
           if (layerIDs.length != schemas.size()) {
             throw new IllegalArgumentException("Topology path depth doesn't "

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetworkTopologyImpl.java
@@ -44,6 +44,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
+
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
@@ -227,7 +229,7 @@ public class TestNetworkTopologyImpl {
           "./networkTopologyTestFiles/good.xml").getPath();
       conf.set(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE, filePath);
       NetworkTopology newCluster = new NetworkTopologyImpl(conf);
-      LOG.info("network topology max level = {}", newCluster.getMaxLevel());
+      Assert.assertEquals(5, newCluster.getMaxLevel());
     } catch (Throwable e) {
       fail("should succeed");
     }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNodeSchemaManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNodeSchemaManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm.net;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 
+import static org.apache.hadoop.hdds.scm.net.NetConstants.DEFAULT_DATACENTER;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.DEFAULT_NODEGROUP;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.DEFAULT_RACK;
 import static org.junit.Assert.assertEquals;
@@ -64,7 +65,7 @@ public class TestNodeSchemaManager {
 
   @Test
   public void testPass() {
-    assertEquals(4, manager.getMaxLevel());
+    assertEquals(5, manager.getMaxLevel());
     for (int i  = 1; i <= manager.getMaxLevel(); i++) {
       assertTrue(manager.getCost(i) == 1 || manager.getCost(i) == 0);
     }
@@ -88,14 +89,14 @@ public class TestNodeSchemaManager {
   public void testComplete() {
     // successful complete action
     String path = "/node1";
-    assertEquals(DEFAULT_RACK + DEFAULT_NODEGROUP + path,
+    assertEquals(DEFAULT_DATACENTER + DEFAULT_RACK + DEFAULT_NODEGROUP + path,
         manager.complete(path));
-    assertEquals("/rack" + DEFAULT_NODEGROUP + path,
+    assertEquals(DEFAULT_DATACENTER + "/rack" + DEFAULT_NODEGROUP + path,
         manager.complete("/rack" + path));
-    assertEquals(DEFAULT_RACK + "/nodegroup" + path,
+    assertEquals(DEFAULT_DATACENTER + DEFAULT_RACK + "/nodegroup" + path,
         manager.complete("/nodegroup" + path));
 
     // failed complete action
-    assertEquals(null, manager.complete("/dc" + path));
+    assertEquals(null, manager.complete("/a" + path));
   }
 }

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/enforce-error.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/enforce-error.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/external-entity.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/external-entity.xml
@@ -22,10 +22,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
-      <type>Root</type>
+      <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/good.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/good.xml
@@ -19,10 +19,16 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
-      <type>Root</type>
+      <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
+      <default>/default-datacenter</default>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/invalid-cost.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/invalid-cost.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/invalid-version.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/invalid-version.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>a</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-leaf.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-leaf.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-root.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-root.xml
@@ -19,8 +19,13 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
+      <cost>1</cost>
+      <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
       <cost>1</cost>
       <type>ROOT</type>
     </layer>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-topology.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/multiple-topology.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-leaf.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-leaf.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-root.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-root.xml
@@ -19,8 +19,13 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
       <cost>1</cost>
       <type>InnerNode</type>
     </layer>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-topology.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/no-topology.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/path-layers-size-mismatch.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/path-layers-size-mismatch.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/path-with-id-reference-failure.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/path-with-id-reference-failure.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/unknown-layer-type.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/unknown-layer-type.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/wrong-path-order-1.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/wrong-path-order-1.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>
@@ -37,7 +42,7 @@
     </layer>
   </layers>
   <topology>
-    <path>/rack/datacenter/node</path>
+    <path>rack//datacenter/node</path>
     <enforceprefix>false</enforceprefix>
   </topology>
 </configuration>

--- a/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/wrong-path-order-2.xml
+++ b/hadoop-hdds/common/src/test/resources/networkTopologyTestFiles/wrong-path-order-2.xml
@@ -19,10 +19,15 @@
 <configuration>
   <layoutversion>1</layoutversion>
   <layers>
-    <layer id="datacenter">
+    <layer id="">
       <prefix></prefix>
       <cost>1</cost>
       <type>ROOT</type>
+    </layer>
+    <layer id="datacenter">
+      <prefix>dc</prefix>
+      <cost>1</cost>
+      <type>InnerNode</type>
     </layer>
     <layer id="rack">
       <prefix>rack</prefix>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In `NodeSchemaLoader.init()`, the file of "network-topology-default.xml" is loaded to retrieve the topology schema.

By default the result schema is "/datacenter/rack/nodegroup/node", and the schema size is 4, since datacenter is treated as "ROOT".

The schema size will also be sent to NetworkTopologyImpl to build the topology, the schema size is used as maxLevel.
```
public NetworkTopologyImpl(ConfigurationSource conf) {
  schemaManager = NodeSchemaManager.getInstance();
  schemaManager.init(conf);
  maxLevel = schemaManager.getMaxLevel();
  factory = InnerNodeImpl.FACTORY;
  clusterTree = factory.newInnerNode(ROOT, null, null,
      NetConstants.ROOT_LEVEL,
      schemaManager.getCost(NetConstants.ROOT_LEVEL));
} 
```
But for "/datacenter/rack/nodegroup/node" the maxLevel is in fact 5, the reason of the issue is that "datacenter" is treated as "ROOT" incorrectly. While the yaml file version is correctly treated "datacenter" to a InnerNode.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6648

## How was this patch tested?

unit test.
