### PR TITLE
HDDS-6518. EC: Add rpc for EC recovery in replication service

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -260,6 +260,7 @@ public class KeyValueContainerData extends ContainerData {
     builder.setContainerID(this.getContainerID());
     builder.setContainerPath(this.getContainerPath());
     builder.setState(this.getState());
+    builder.setBlockCount(this.getBlockCount());
 
     for (Map.Entry<String, String> entry : getMetadata().entrySet()) {
       ContainerProtos.KeyValue.Builder keyValBuilder =

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ozoneimpl/OzoneContainer.java
@@ -181,7 +181,8 @@ public class OzoneContainer {
         controller,
         conf.getObject(ReplicationConfig.class),
         secConf,
-        certClient);
+        certClient,
+        hddsDispatcher);
 
     readChannel = new XceiverServerGrpc(
         datanodeDetails, config, hddsDispatcher, certClient);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -173,8 +173,8 @@ public class GrpcReplicationClient implements AutoCloseable {
 
     return future.thenApply(responses -> responses.stream()
         .filter(r -> r.getCmdType() == Type.ReadContainer)
-        .map(r -> r.getReadContainer().getContainerData())
-        .findFirst());
+        .findFirst()
+        .map(r -> r.getReadContainer().getContainerData()));
   }
 
   public CompletableFuture<List<ByteBuffer>> readChunk(long containerId,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -154,7 +155,7 @@ public class GrpcReplicationClient implements AutoCloseable {
         .collect(Collectors.toList()));
   }
 
-  public CompletableFuture<List<ContainerDataProto>> readContainer(
+  public CompletableFuture<Optional<ContainerDataProto>> readContainer(
       long containerId, String datanodeUUID) {
 
     ContainerCommandRequestProto command =
@@ -173,7 +174,7 @@ public class GrpcReplicationClient implements AutoCloseable {
     return future.thenApply(responses -> responses.stream()
         .filter(r -> r.getCmdType() == Type.ReadContainer)
         .map(r -> r.getReadContainer().getContainerData())
-        .collect(Collectors.toList()));
+        .findFirst());
   }
 
   public CompletableFuture<List<ByteBuffer>> readChunk(long containerId,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationClient.java
@@ -130,13 +130,20 @@ public class GrpcReplicationClient implements AutoCloseable {
   }
 
   public CompletableFuture<List<BlockData>> listBlock(
+      long containerId, String datanodeUUID, int count) {
+    return listBlock(containerId, datanodeUUID, -1, count);
+  }
+
+  public CompletableFuture<List<BlockData>> listBlock(
       long containerId, String datanodeUUID, long start, int count) {
 
-    ListBlockRequestProto request =
+    ListBlockRequestProto.Builder requestBuilder =
         ListBlockRequestProto.newBuilder()
-            .setStartLocalID(start)
-            .setCount(count)
-            .build();
+            .setCount(count);
+    if (start >= 0) {
+      requestBuilder.setStartLocalID(start);
+    }
+    ListBlockRequestProto request = requestBuilder.build();
 
     ContainerCommandRequestProto command =
         ContainerCommandRequestProto.newBuilder()

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/GrpcReplicationService.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.CopyContainerResponseProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkRequestProto;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunkResponseProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.IntraDatanodeProtocolServiceGrpc;
 
 import org.apache.hadoop.ozone.container.common.impl.HddsDispatcher;
@@ -71,6 +73,23 @@ public class GrpcReplicationService extends
   public void send(ContainerCommandRequestProto request,
       StreamObserver<ContainerCommandResponseProto> observer) {
     observer.onNext(dispatcher.dispatch(request, null));
+    observer.onCompleted();
+  }
+
+  @Override
+  public void push(WriteChunkRequestProto request,
+      StreamObserver<WriteChunkResponseProto> observer) {
+    long containerID = request.getBlockID().getContainerID();
+    if (request.hasData()) {
+      String chunkName = request.getChunkData().getChunkName();
+      LOG.debug("Received chunk {} of container {}", chunkName, containerID);
+      // TODO: Store chunk data for reconstruction
+      // ByteBuffer data = request.getData().asReadOnlyByteBuffer();
+    } else {
+      LOG.info("Starting to reconstruct container {}", containerID);
+      // TODO: Start to reconstruct container
+    }
+    observer.onNext(WriteChunkResponseProto.newBuilder().build());
     observer.onCompleted();
   }
 

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -495,5 +495,8 @@ service XceiverClientProtocolService {
 service IntraDatanodeProtocolService {
   // An intradatanode service to copy the raw container data between nodes
   rpc download (CopyContainerRequestProto) returns (stream CopyContainerResponseProto);
+  // Send read only commands to get status and data from CoordinatorDN to HealthyDN.
   rpc send(ContainerCommandRequestProto) returns (stream ContainerCommandResponseProto);
+  // Push recovered chunks from CoordinatorDN to TargetDN.
+  rpc push(WriteChunkRequestProto) returns (stream WriteChunkResponseProto);
 }

--- a/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
+++ b/hadoop-hdds/interface-client/src/main/proto/DatanodeClientProtocol.proto
@@ -495,4 +495,5 @@ service XceiverClientProtocolService {
 service IntraDatanodeProtocolService {
   // An intradatanode service to copy the raw container data between nodes
   rpc download (CopyContainerRequestProto) returns (stream CopyContainerResponseProto);
+  rpc send(ContainerCommandRequestProto) returns (stream ContainerCommandResponseProto);
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolCli
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.container.replication.GrpcReplicationClient;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.recon.ReconServer;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
@@ -185,6 +186,18 @@ public interface MiniOzoneCluster {
    * @throws IOException
    */
   OzoneClient getRpcClient() throws IOException;
+
+  /**
+   * Creates a {@link GrpcReplicationClient} to access the replication
+   * service of datanode i.
+   *
+   * @param datanode the datanode which the replication client will connect to
+   * @return a {@link GrpcReplicationClient} connected to datanode i,
+   *         should call close() after finish.
+   * @throws IOException
+   */
+  GrpcReplicationClient getReplicationClient(DatanodeDetails datanode)
+      throws IOException;
 
   /**
    * Returns StorageContainerLocationClient to communicate with

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdds.scm.safemode.HealthyPipelineSafeModeRule;
 import org.apache.hadoop.hdds.scm.server.OzoneStorageContainerManager;
 import org.apache.hadoop.hdds.scm.server.SCMStorageConfig;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.client.OzoneClient;
@@ -65,6 +66,7 @@ import org.apache.hadoop.ozone.client.OzoneClientFactory;
 import org.apache.hadoop.ozone.common.Storage.StorageState;
 import org.apache.hadoop.ozone.container.common.DatanodeLayoutStorage;
 import org.apache.hadoop.ozone.container.common.utils.ContainerCache;
+import org.apache.hadoop.ozone.container.replication.GrpcReplicationClient;
 import org.apache.hadoop.ozone.container.replication.ReplicationServer.ReplicationConfig;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMStorage;
@@ -327,6 +329,16 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
   @Override
   public OzoneClient getRpcClient() throws IOException {
     return OzoneClientFactory.getRpcClient(conf);
+  }
+
+  @Override
+  public GrpcReplicationClient getReplicationClient(DatanodeDetails datanode)
+      throws IOException {
+    String workdir = conf.get(OzoneConfigKeys.OZONE_CONTAINER_COPY_WORKDIR,
+        System.getProperty("java.io.tmpdir"));
+    return new GrpcReplicationClient(datanode.getIpAddress(),
+        datanode.getPort(DatanodeDetails.Port.Name.REPLICATION).getValue(),
+        Paths.get(workdir), new SecurityConfig(conf), caClient);
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationService.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/replication/TestReplicationService.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.replication;
+
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationFactor;
+import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.BlockData;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerDataProto;
+import org.apache.hadoop.hdds.scm.ScmConfigKeys;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
+import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Tests for {@link GrpcReplicationClient} and {@link GrpcReplicationService}.
+ */
+public class TestReplicationService {
+
+  private static MiniOzoneCluster cluster;
+  private static OzoneManager om;
+  private static StorageContainerManager scm;
+  private static OzoneClient client;
+  private static ObjectStore store;
+  private static StorageContainerLocationProtocolClientSideTranslatorPB
+      storageContainerLocationClient;
+  private static final String SCM_ID = UUID.randomUUID().toString();
+  private static final String CLUSTER_ID = UUID.randomUUID().toString();
+  private static final int NUM_KEYS = 2;
+  private static final byte[] VALUE =
+      UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+  private static long containerID;
+
+  @BeforeAll
+  public static void init() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setInt(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT, 1);
+    conf.setBoolean(OzoneConfigKeys.OZONE_ACL_ENABLED, true);
+    conf.set(OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS,
+        OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
+    startCluster(conf);
+    prepareData(NUM_KEYS);
+  }
+
+  @AfterAll
+  public static void stop() throws IOException {
+    stopCluster();
+  }
+
+  @Test
+  public void testReadContainer() throws Exception {
+    DatanodeDetails dn = cluster.getHddsDatanodes().get(0).getDatanodeDetails();
+    GrpcReplicationClient rc = cluster.getReplicationClient(dn);
+    Optional<ContainerDataProto> maybeProto =
+        rc.readContainer(containerID, dn.getUuidString()).get();
+    Assertions.assertTrue(maybeProto.isPresent());
+    ContainerDataProto proto = maybeProto.get();
+    Assertions.assertEquals(containerID, proto.getContainerID());
+    Assertions.assertEquals(NUM_KEYS * VALUE.length, proto.getBytesUsed());
+    Assertions.assertEquals(NUM_KEYS, proto.getBlockCount());
+    rc.close();
+  }
+
+  @Test
+  public void testListBlock() throws Exception {
+    DatanodeDetails dn = cluster.getHddsDatanodes().get(0).getDatanodeDetails();
+    GrpcReplicationClient rc = cluster.getReplicationClient(dn);
+    List<BlockData> blocks =
+        rc.listBlock(containerID, dn.getUuidString(), NUM_KEYS + 1).get();
+    Assertions.assertEquals(NUM_KEYS, blocks.size());
+    Assertions.assertEquals(VALUE.length, blocks.get(0).getSize());
+    rc.close();
+  }
+
+  @Test
+  public void testReadChunk() throws Exception {
+    DatanodeDetails dn = cluster.getHddsDatanodes().get(0).getDatanodeDetails();
+    GrpcReplicationClient rc = cluster.getReplicationClient(dn);
+    List<BlockData> blocks =
+        rc.listBlock(containerID, dn.getUuidString(), NUM_KEYS).get();
+
+    for (BlockData block : blocks) {
+      Assertions.assertEquals(1, block.getChunksCount());
+      Optional<ByteBuffer> maybeChunk = rc.readChunk(containerID,
+          dn.getUuidString(), block.getBlockID(), block.getChunks(0)).get();
+      Assertions.assertTrue(maybeChunk.isPresent());
+      ByteBuffer chunk = maybeChunk.get();
+      byte[] chunkData = new byte[chunk.remaining()];
+      chunk.get(chunkData);
+      Assertions.assertArrayEquals(VALUE, chunkData);
+    }
+    rc.close();
+  }
+
+  public static void startCluster(OzoneConfiguration conf) throws Exception {
+    // Reduce long wait time in MiniOzoneClusterImpl#waitForHddsDatanodesStop
+    //  for testZReadKeyWithUnhealthyContainerReplica.
+    conf.set("ozone.scm.stale.node.interval", "10s");
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(3)
+        .setTotalPipelineNumLimit(10)
+        .setScmId(SCM_ID)
+        .setClusterId(CLUSTER_ID)
+        .build();
+    cluster.waitForClusterToBeReady();
+    om = cluster.getOzoneManager();
+    scm = cluster.getStorageContainerManager();
+    client = OzoneClientFactory.getRpcClient(conf);
+    store = client.getObjectStore();
+    storageContainerLocationClient =
+        cluster.getStorageContainerLocationClient();
+  }
+
+  public static void prepareData(int numKeys) throws Exception {
+    final String volumeName = UUID.randomUUID().toString();
+    final String bucketName = UUID.randomUUID().toString();
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+    final ReplicationConfig repConfig = ReplicationConfig
+        .fromTypeAndFactor(ReplicationType.RATIS, ReplicationFactor.THREE);
+    for (int i = 0; i < numKeys; i++) {
+      final String keyName = UUID.randomUUID().toString();
+      try (OutputStream out = bucket.createKey(
+          keyName, VALUE.length, repConfig, new HashMap<>())) {
+        out.write(VALUE);
+      }
+    }
+    Optional<Long> maybeContainerID = scm.getContainerManager()
+        .getContainerIDs().stream().findAny().map(ContainerID::getId);
+    Assertions.assertTrue(maybeContainerID.isPresent());
+    containerID = maybeContainerID.get();
+  }
+
+  public static void stopCluster() throws IOException {
+    if (client != null) {
+      client.close();
+    }
+
+    if (storageContainerLocationClient != null) {
+      storageContainerLocationClient.close();
+    }
+
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When replicating EC containers, we need more rpc than copy container.

### CoordinatorDN -> HealthyDN

This patch adds support for `ContainerCommand` in replication service.

Server Side:

1. Added command handler to dispatch container command requests.

Client Side:

1. Added `readContainer()` to get number of total blocks to list.
2. Added `listBlock()` to list blocks in a container.
3. Added `readChunk()` to read the data from healthy datanodes.

### CoordinatorDN -> TargetDN

The CoordinatorDN should push the chunks to the TargetDN after computing missing blocks.
`WriteChunkProto` without `data` means the end of the container.

Push is chosen for following reasons:

1. CoordinatorDN does not need to hold the missing blocks for long. 
2. CoordinatorDN can controll the progress of the recovery.

Server Side:

1. Added dummy command handler for push chunk and start recovery.

Client Side:

1. Added `writeChunk()` to push chunks to target datanodes.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6518

## How was this patch tested?

New integration test: TestReplicationService