### PR TITLE
HDDS-6658. BackgroundPipelineCreator does not always stop quickly

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineCreator.java
@@ -148,9 +148,7 @@ public class BackgroundPipelineCreator implements SCMService {
     LOG.info("Stopping {}.", THREAD_NAME);
 
     // in case RatisPipelineUtilsThread is sleeping
-    synchronized (monitor) {
-      monitor.notifyAll();
-    }
+    thread.interrupt();
 
     try {
       thread.join();
@@ -175,6 +173,7 @@ public class BackgroundPipelineCreator implements SCMService {
         }
       } catch (InterruptedException e) {
         LOG.warn("{} is interrupted.", THREAD_NAME);
+        running.set(false);
         Thread.currentThread().interrupt();
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineScrubber.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/BackgroundPipelineScrubber.java
@@ -135,7 +135,7 @@ public class BackgroundPipelineScrubber implements SCMService {
         LOG.info("Pipeline Scrubber Service is not running, skip stop.");
         return;
       }
-      notifyAll();
+      scrubThread.interrupt();
     }
     LOG.info("Stopping Pipeline Scrubber Service.");
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

On my laptop, TestSCMSafeModeManager.testSafeModePipelineExitRule() always takes just over 200 seconds. Checking a few PR runs, it does not seem to be slow on PRs, just locally.

Debugging the code, it seems to hang in the BackgroundPipelineCreator.stop() method, where it is waiting for the tread to join:

```
  public void stop() {
    if (!running.compareAndSet(true, false)) {
      LOG.warn("{} is not running, just ignore.", THREAD_NAME);
      return;
    }

    LOG.info("Stopping {}.", THREAD_NAME);

    // in case RatisPipelineUtilsThread is sleeping
    synchronized (monitor) {
      monitor.notifyAll();
    }

    try {
      thread.join();  //  ----> Hangs here
    } catch (InterruptedException e) {
      LOG.warn("Interrupted during join {}.", THREAD_NAME);
      Thread.currentThread().interrupt();
    }
  }
```

It is clearly hanging as the background thread did not exit, and I believe it is because `notify()` is being used to try to exit the thread, when it should really be interrupted. There is a chance that notify is called while the thread is not waiting, and if so, it will just fall back into the wait state and not exit until it wakes up again.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6658

## How was this patch tested?

Validated slow test is now fast locally.
