### PR TITLE
HDDS-6657. Improve Ozone integrated Ranger configuration instructions

### DIFF
--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.md
@@ -46,6 +46,13 @@ Property|Value
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
 
+To use the RangerOzoneAuthorizer, you also need to add the following environment variables to ozone-env.sh:
+```
+export OZONE_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
+```
+* The location of the ranger-ozone-plugin jars depends on where the Ranger Plugin is installed.
+* If the ranger-ozone-plugin jars is installed on another node, copy it to the Ozone installation directory.
+
 The Ranger permissions corresponding to the Ozone operations are as follows:
 
 | operation&permission | Volume  permission | Bucket permission | Key permission |

--- a/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
+++ b/hadoop-hdds/docs/content/security/SecurityWithRanger.zh.md
@@ -37,6 +37,13 @@ Apache Ranger™ 是一个用于管理和监控 Hadoop 平台复杂数据权限�
 ozone.acl.enabled         | true
 ozone.acl.authorizer.class| org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer
 
+为了使用 RangerOzoneAuthorizer，还需要在 ozone-env.sh 中增加下面环境变量：
+```
+export OZONE_CLASSPATH="${OZONE_HOME}/share/ozone/lib/libext/*"
+```
+* ranger-ozone-plugin jars 具体路径取决于 Ranger Ozone plugin 安装配置。
+* 如果 ranger-ozone-plugin jars 安装在其他节点，需要拷贝到 Ozone 安装目录。
+
 Ozone各类操作对应Ranger权限如下：
 
 | operation&permission | Volume  permission | Bucket permission | Key permission |


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modified the Ozone integration Ranger documentation to indicate that the OZONE_CLASSPATH environment variable needs to be configured during the Ozone integration of Ranger to avoid the following errors:
```
[main] INFO org.apache.hadoop.ozone.security.OzoneDelegationTokenSecretManager: Loading token state into token manager.
[main] ERROR org.apache.hadoop.ozone.om.OzoneManagerStarter: OM start failed with exception
java.lang.RuntimeException: java.lang.RuntimeException: java.lang.ClassNotFoundException: Class org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer not found
        at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2699)
        at org.apache.hadoop.ozone.om.OzoneManager.getACLAuthorizerInstance(OzoneManager.java:716)
        at org.apache.hadoop.ozone.om.OzoneManager.instantiateServices(OzoneManager.java:632)
        at org.apache.hadoop.ozone.om.OzoneManager.<init>(OzoneManager.java:501)
        at org.apache.hadoop.ozone.om.OzoneManager.createOm(OzoneManager.java:558)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter$OMStarterHelper.start(OzoneManagerStarter.java:170)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.startOm(OzoneManagerStarter.java:83)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.call(OzoneManagerStarter.java:71)
        at org.apache.hadoop.hdds.cli.GenericCli.call(GenericCli.java:39)
        at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
        at picocli.CommandLine.access$1300(CommandLine.java:145)
        at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
        at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
        at picocli.CommandLine$AbstractParseResultHandler.handleParseResult(CommandLine.java:2172)
        at picocli.CommandLine.parseWithHandlers(CommandLine.java:2550)
        at picocli.CommandLine.parseWithHandler(CommandLine.java:2485)
        at org.apache.hadoop.hdds.cli.GenericCli.execute(GenericCli.java:96)
        at org.apache.hadoop.hdds.cli.GenericCli.run(GenericCli.java:87)
        at org.apache.hadoop.ozone.om.OzoneManagerStarter.main(OzoneManagerStarter.java:55)
Caused by: java.lang.RuntimeException: java.lang.ClassNotFoundException: Class org.apache.ranger.authorization.ozone.authorizer.RangerOzoneAuthorizer not found
        at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2667)
        at org.apache.hadoop.conf.Configuration.getClass(Configuration.java:2691)
        ... 19 more
```

## What is the link to the Apache JIRA

[HDDS-6657](https://issues.apache.org/jira/browse/HDDS-6657)