### PR TITLE
HDDS-6453. Ozone start/stop script cannot resolve OM nodes in HA

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -114,7 +114,7 @@ public final class OmUtils {
    * @return {service.id -> [{@link InetSocketAddress}]}
    */
   public static Collection<InetSocketAddress> getOmHAAddressesById(
-          ConfigurationSource conf) {
+      ConfigurationSource conf) {
     Map<String, List<InetSocketAddress>> result = new HashMap<>();
     Collection<InetSocketAddress> omAddressList = new HashSet<>();
     for (String serviceId : conf.getTrimmedStringCollection(
@@ -129,7 +129,7 @@ public final class OmUtils {
           result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
         } else {
           LOG.warn("Address undefined for nodeId: {} for service {}", nodeId,
-                  serviceId);
+              serviceId);
         }
       }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -113,27 +113,57 @@ public final class OmUtils {
    * @param conf {@link ConfigurationSource}
    * @return {service.id -> [{@link InetSocketAddress}]}
    */
-  public static Map<String, List<InetSocketAddress>> getOmHAAddressesById(
-      ConfigurationSource conf) {
+  public static Collection<InetSocketAddress> getOmHAAddressesById(
+          ConfigurationSource conf) {
     Map<String, List<InetSocketAddress>> result = new HashMap<>();
+    Collection<InetSocketAddress> omAddressList = new HashSet<>();
     for (String serviceId : conf.getTrimmedStringCollection(
-        OZONE_OM_SERVICE_IDS_KEY)) {
+            OZONE_OM_SERVICE_IDS_KEY)) {
       if (!result.containsKey(serviceId)) {
         result.put(serviceId, new ArrayList<>());
       }
       for (String nodeId : getActiveOMNodeIds(conf, serviceId)) {
         String rpcAddr = getOmRpcAddress(conf,
-            ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
+                ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
         if (rpcAddr != null) {
           result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
         } else {
           LOG.warn("Address undefined for nodeId: {} for service {}", nodeId,
-              serviceId);
+                  serviceId);
         }
       }
+
+      for (InetSocketAddress addr : result.get(serviceId)) {
+        omAddressList.add(addr);
+      }
     }
-    return result;
+
+    return omAddressList;
   }
+
+//
+//  public static List<InetSocketAddress> getOmHAAddressesById(
+//      ConfigurationSource conf) {
+//    List<InetSocketAddress> ips = new ArrayList<>();
+//    for (String serviceId : conf.getTrimmedStringCollection(
+//        OZONE_OM_SERVICE_IDS_KEY)) {
+//      for (String nodeId : getActiveOMNodeIds(conf, serviceId)) {
+//        String rpcAddr = getOmRpcAddress(conf,
+//            ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
+//        if (rpcAddr != null) {
+//          // result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
+//          ips.add(NetUtils.createSocketAddr(rpcAddr));
+//        } else {
+//          LOG.warn("Address undefined for nodeId: {} for service {}", nodeId,
+//              serviceId);
+//        }
+//      }
+//    }
+//    for (InetSocketAddress addr : ips) {
+//      addr.getHostName();
+//    }
+//    return ips;
+//  }
 
   /**
    * Retrieve the socket address that is used by OM.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -117,8 +117,7 @@ public final class OmUtils {
           ConfigurationSource conf) {
     Map<String, List<InetSocketAddress>> result = new HashMap<>();
     Collection<InetSocketAddress> omAddressList = new HashSet<>();
-    for (String serviceId : conf.getTrimmedStringCollection(
-            OZONE_OM_SERVICE_IDS_KEY)) {
+    for (String serviceId : conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY)) {
       if (!result.containsKey(serviceId)) {
         result.put(serviceId, new ArrayList<>());
       }
@@ -140,30 +139,6 @@ public final class OmUtils {
 
     return omAddressList;
   }
-
-//
-//  public static List<InetSocketAddress> getOmHAAddressesById(
-//      ConfigurationSource conf) {
-//    List<InetSocketAddress> ips = new ArrayList<>();
-//    for (String serviceId : conf.getTrimmedStringCollection(
-//        OZONE_OM_SERVICE_IDS_KEY)) {
-//      for (String nodeId : getActiveOMNodeIds(conf, serviceId)) {
-//        String rpcAddr = getOmRpcAddress(conf,
-//            ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
-//        if (rpcAddr != null) {
-//          // result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
-//          ips.add(NetUtils.createSocketAddr(rpcAddr));
-//        } else {
-//          LOG.warn("Address undefined for nodeId: {} for service {}", nodeId,
-//              serviceId);
-//        }
-//      }
-//    }
-//    for (InetSocketAddress addr : ips) {
-//      addr.getHostName();
-//    }
-//    return ips;
-//  }
 
   /**
    * Retrieve the socket address that is used by OM.

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -117,13 +117,14 @@ public final class OmUtils {
           ConfigurationSource conf) {
     Map<String, List<InetSocketAddress>> result = new HashMap<>();
     Collection<InetSocketAddress> omAddressList = new HashSet<>();
-    for (String serviceId : conf.getTrimmedStringCollection(OZONE_OM_SERVICE_IDS_KEY)) {
+    for (String serviceId : conf.getTrimmedStringCollection(
+        OZONE_OM_SERVICE_IDS_KEY)) {
       if (!result.containsKey(serviceId)) {
         result.put(serviceId, new ArrayList<>());
       }
       for (String nodeId : getActiveOMNodeIds(conf, serviceId)) {
         String rpcAddr = getOmRpcAddress(conf,
-                ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
+            ConfUtils.addKeySuffixes(OZONE_OM_ADDRESS_KEY, serviceId, nodeId));
         if (rpcAddr != null) {
           result.get(serviceId).add(NetUtils.createSocketAddr(rpcAddr));
         } else {

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -101,11 +101,11 @@ public class TestOmUtils {
     assertFalse(rpcAddrs.isEmpty());
     assertFalse(rpcAddrs.isEmpty());
     assertTrue(rpcAddrs.stream().anyMatch(
-            a -> a.getAddress().getHostAddress().equals("1.1.1.1")));
+        a -> a.getAddress().getHostAddress().equals("1.1.1.1")));
     assertTrue(rpcAddrs.stream().anyMatch(
-            a -> a.getAddress().getHostAddress().equals("1.1.1.2")));
+        a -> a.getAddress().getHostAddress().equals("1.1.1.2")));
     assertTrue(rpcAddrs.stream().anyMatch(
-            a -> a.getAddress().getHostAddress().equals("1.1.1.3")));
+        a -> a.getAddress().getHostAddress().equals("1.1.1.3")));
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -97,17 +98,16 @@ public class TestOmUtils {
     conf.set("ozone.om.address.ozone1.node1", "1.1.1.1");
     conf.set("ozone.om.address.ozone1.node2", "1.1.1.2");
     conf.set("ozone.om.address.ozone1.node3", "1.1.1.3");
-    Map<String, List<InetSocketAddress>> addresses =
+    Collection<InetSocketAddress> rpcAddrs =
         OmUtils.getOmHAAddressesById(conf);
-    assertFalse(addresses.isEmpty());
-    List<InetSocketAddress> rpcAddrs = addresses.get("ozone1");
+    assertFalse(rpcAddrs.isEmpty());
     assertFalse(rpcAddrs.isEmpty());
     assertTrue(rpcAddrs.stream().anyMatch(
-        a -> a.getAddress().getHostAddress().equals("1.1.1.1")));
+            a -> a.getAddress().getHostAddress().equals("1.1.1.1")));
     assertTrue(rpcAddrs.stream().anyMatch(
-        a -> a.getAddress().getHostAddress().equals("1.1.1.2")));
+            a -> a.getAddress().getHostAddress().equals("1.1.1.2")));
     assertTrue(rpcAddrs.stream().anyMatch(
-        a -> a.getAddress().getHostAddress().equals("1.1.1.3")));
+            a -> a.getAddress().getHostAddress().equals("1.1.1.3")));
   }
 
   @Test

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/TestOmUtils.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -44,8 +44,7 @@ public class OzoneManagersCommandHandler implements Callable<Void> {
   public Void call() throws Exception {
     ConfigurationSource configSource =
         OzoneConfiguration.of(tool.getConf());
-    if (OmUtils.isServiceIdsDefined(
-        configSource)) {
+    if (OmUtils.isServiceIdsDefined(configSource)) {
       Collection<InetSocketAddress> addresses = OmUtils.getOmHAAddressesById(configSource);
       for (InetSocketAddress addr : addresses) {
         tool.printOut(addr.getHostName());

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -16,6 +16,8 @@
  */
 package org.apache.hadoop.ozone.conf;
 
+import java.net.InetSocketAddress;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import org.apache.hadoop.hdds.cli.HddsVersionProvider;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -44,7 +46,10 @@ public class OzoneManagersCommandHandler implements Callable<Void> {
         OzoneConfiguration.of(tool.getConf());
     if (OmUtils.isServiceIdsDefined(
         configSource)) {
-      tool.printOut(OmUtils.getOmHAAddressesById(configSource).toString());
+      Collection<InetSocketAddress> addresses = OmUtils.getOmHAAddressesById(configSource);
+      for (InetSocketAddress addr : addresses) {
+        tool.printOut(addr.getHostName());
+      }
     } else {
       tool.printOut(OmUtils.getOmAddress(configSource).getHostName());
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -46,7 +46,7 @@ public class OzoneManagersCommandHandler implements Callable<Void> {
         OzoneConfiguration.of(tool.getConf());
     if (OmUtils.isServiceIdsDefined(configSource)) {
       Collection<InetSocketAddress> addresses = OmUtils.getOmHAAddressesById(
-        configSource);
+          configSource);
       for (InetSocketAddress addr : addresses) {
         tool.printOut(addr.getHostName());
       }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/conf/OzoneManagersCommandHandler.java
@@ -45,7 +45,8 @@ public class OzoneManagersCommandHandler implements Callable<Void> {
     ConfigurationSource configSource =
         OzoneConfiguration.of(tool.getConf());
     if (OmUtils.isServiceIdsDefined(configSource)) {
-      Collection<InetSocketAddress> addresses = OmUtils.getOmHAAddressesById(configSource);
+      Collection<InetSocketAddress> addresses = OmUtils.getOmHAAddressesById(
+        configSource);
       for (InetSocketAddress addr : addresses) {
         tool.printOut(addr.getHostName());
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix the problem that the Ozone start and stop script resolve OM node, and ensure that the start-ozone.sh and stop-ozone.sh command is used to manage the start and stop services of the Ozone cluster.

## What is the link to the Apache JIRA

[HDDS-6453](https://issues.apache.org/jira/browse/HDDS-6453)

## How was this patch tested?
1. configure password-free login between Ozone cluster nodes
2. start the Ozone service on an Ozone node
```
start-ozone.sh
```
3. stop the Ozone service on an Ozone node
```
stop-ozone.sh
```
