### PR TITLE
HDDS-6669. Exercise OM in ozonescripts environment

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozonescripts/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonescripts/test.sh
@@ -37,6 +37,7 @@ start_docker_env 1
 ${COMPOSE_DIR}/start.sh
 ${COMPOSE_DIR}/ps.sh
 
+execute_robot_test scm basic/single_node.robot
 execute_robot_test scm admincli/pipeline.robot
 
 ${COMPOSE_DIR}/stop.sh

--- a/hadoop-ozone/dist/src/main/smoketest/basic/single_node.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/single_node.robot
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+*** Settings ***
+Documentation       Smoketest for one datanode
+Library             OperatingSystem
+Resource            ../commonlib.robot
+Resource            ../ozone-lib/freon.robot
+Test Timeout        5 minutes
+
+*** Test Cases ***
+
+Basic Freon smoketest for one datanode
+    Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
+    ${random} =        Generate Random String    10
+    Freon OCKG    prefix=${random}   args=--replication ONE --replication-type RATIS
+    Freon OCKV    prefix=${random}


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-4556 added smoketest for `start-ozone.sh` and `stop-ozone.sh`.  However, OM is not exercised by pipeline operations, only DN and SCM.  Thus the test passes even if OM is not started successfully.  This can be reproduced by temporarily changing `start.sh` to not start OM by commenting lines:

https://github.com/apache/ozone/blob/81b6bbad14141ddbfad0aa1ff97044490dc9aa79/hadoop-ozone/dist/src/main/compose/ozonescripts/start.sh#L25-L26

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozonescripts
$ ./test.sh
...
Pipeline :: Test ozone admin pipeline command                         | PASS |
7 tests, 7 passed, 0 failed
...
$ echo $?
0
```

This change adds another test case that verifies OM, too.

https://issues.apache.org/jira/browse/HDDS-6669

## How was this patch tested?

Verified that the test fails with the temporary breaking change in place:

```
$ cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozonescripts
$ ./test.sh
...
Basic Freon smoketest for one datanode                                | FAIL |
Test timeout 5 minutes exceeded.
...
$ echo $?
1
```

And passes normally:
https://github.com/adoroszlai/hadoop-ozone/runs/6226303357#step:5:1112