### PR TITLE
HDDS-6673. Reduce OzoneFS test combinations in ozonesecure

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -54,8 +54,8 @@ execute_robot_test scm admincli
 
 execute_debug_tests
 
-execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-fso-ofs-link ozonefs/ozonefs.robot
-execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-fso-o3fs-bucket ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:link -N ozonefs-ofs-link ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:bucket -N ozonefs-o3fs-bucket ozonefs/ozonefs.robot
 
 execute_robot_test scm ec/basic.robot
 

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -37,11 +37,8 @@ execute_robot_test scm basic
 
 execute_robot_test scm security
 
-for scheme in ofs o3fs; do
-  for bucket in link bucket; do
-    execute_robot_test scm -v SCHEME:${scheme} -v BUCKET_TYPE:${bucket} -N ozonefs-${scheme}-${bucket} ozonefs/ozonefs.robot
-  done
-done
+execute_robot_test scm -v SCHEME:ofs -v BUCKET_TYPE:bucket -N ozonefs-ofs-bucket ozonefs/ozonefs.robot
+execute_robot_test scm -v SCHEME:o3fs -v BUCKET_TYPE:link -N ozonefs-o3fs-link ozonefs/ozonefs.robot
 
 for bucket in encrypted link generated; do
   execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3


### PR DESCRIPTION
## What changes were proposed in this pull request?

`ozonefs.robot` test has two parameters: FS type (ofs, o3fs) and bucket type (normal, link).  `ozone` environment (unsecure) tests only 2 combinations, based on the assumption that the parameters are independent, i.e. bucket type-specific behavior is not at the FS level.  But `ozonesecure` tests all 2x2 combinations.  We could save a few minutes by running only 2 combinations there as well.  To be on the safe side, run the other 2 combinations.  So all combinations are still covered together by the two environments.

https://issues.apache.org/jira/browse/HDDS-6673

## How was this patch tested?

Verified that only `ozonefs-ofs-bucket` and `ozonefs-o3fs-link` combinations are run in `ozonesecure`:
https://github.com/adoroszlai/hadoop-ozone/runs/6235762566#step:5:307