### PR TITLE
HDDS-6674. Create compat acceptance split

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -233,6 +233,7 @@ jobs:
         suite:
           - secure
           - unsecure
+          - compat
           - HA
           - MR
           - misc

--- a/hadoop-ozone/dist/src/main/compose/compatibility/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/compatibility/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:compat
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 

--- a/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:compat
+
 # Version that will be run using the local build.
 : "${OZONE_CURRENT_VERSION:=1.3.0}"
 export OZONE_CURRENT_VERSION

--- a/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/xcompat/test.sh
@@ -15,6 +15,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#suite:compat
+
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
 basename=$(basename ${COMPOSE_DIR})


### PR DESCRIPTION
## What changes were proposed in this pull request?

Extract compatibility-related acceptance tests from `misc` into a separate suite.  This reduces time needed to repeat in case of failure.

https://issues.apache.org/jira/browse/HDDS-6674

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2247936865