### PR TITLE
HDDS-6675. Avoid repeating some S3 tests for different bucket types

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone/test.sh
@@ -39,8 +39,11 @@ execute_robot_test scm gdpr
 
 execute_robot_test scm security/ozone-secure-token.robot
 
+exclude=""
 for bucket in erasure link generated; do
-  execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket} s3
+  execute_robot_test scm -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
+  # some tests are independent of the bucket type, only need to be run once
+  exclude="--exclude no-bucket-type"
 done
 
 execute_robot_test scm recon

--- a/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozonesecure/test.sh
@@ -43,8 +43,11 @@ for scheme in ofs o3fs; do
   done
 done
 
+exclude=""
 for bucket in encrypted link generated; do
-  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} s3
+  execute_robot_test s3g -v BUCKET:${bucket} -N s3-${bucket} ${exclude} s3
+  # some tests are independent of the bucket type, only need to be run once
+  exclude="--exclude no-bucket-type"
 done
 
 #expects 4 pipelines, should be run before

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketcreate.robot
@@ -21,6 +21,7 @@ Resource            ../commonlib.robot
 Resource            commonawslib.robot
 Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
+Default Tags        no-bucket-type
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878

--- a/hadoop-ozone/dist/src/main/smoketest/s3/bucketdelete.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/bucketdelete.robot
@@ -39,6 +39,7 @@ Delete existing bucket
     Execute AWSS3APICli        delete-bucket --bucket ${bucket}
 
 Delete non-existent bucket
+    [tags]    no-bucket-type
     ${randStr} =   Generate Ozone String
     ${result} =    Execute AWSS3APICli and checkrc    delete-bucket --bucket nosuchbucket-${randStr}    255
                    Should contain                     ${result}                              NoSuchBucket

--- a/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/buckethead.robot
@@ -28,8 +28,11 @@ ${BUCKET}             generated
 
 *** Test Cases ***
 
-Head Bucket not existent
+Head Bucket
     ${result} =         Execute AWSS3APICli     head-bucket --bucket ${BUCKET}
+
+Head Bucket not existent
+    [tags]    no-bucket-type
     ${randStr} =        Generate Ozone String
     ${result} =         Execute AWSS3APICli and checkrc      head-bucket --bucket ozonenosuchbucketqqweqwe-${randStr}  255
                         Should contain          ${result}    404

--- a/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/webui.robot
@@ -21,6 +21,7 @@ Resource            ../commonlib.robot
 Resource            ./commonawslib.robot
 Test Timeout        5 minutes
 Suite Setup         Setup s3 tests
+Default Tags        no-bucket-type
 
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878


### PR DESCRIPTION
## What changes were proposed in this pull request?

Some S3 tests are independent of the bucket type parameter.  Currently these are run for regular bucket, link, encrypted bucket and EC bucket.  Save some time by running only once per environment (secure/unsecure).

https://issues.apache.org/jira/browse/HDDS-6675

## How was this patch tested?

Verified that tagged tests are run only once, e.g.:
https://github.com/adoroszlai/hadoop-ozone/runs/6236210729#step:5:344
https://github.com/adoroszlai/hadoop-ozone/runs/6236210729#step:5:463