### PR TITLE
HDDS-6676. KeyValueContainerData#getProtoBufMessage() should set block count

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -260,6 +260,7 @@ public class KeyValueContainerData extends ContainerData {
     builder.setContainerID(this.getContainerID());
     builder.setContainerPath(this.getContainerPath());
     builder.setState(this.getState());
+    builder.setBlockCount(this.getBlockCount());
 
     for (Map.Entry<String, String> entry : getMetadata().entrySet()) {
       ContainerProtos.KeyValue.Builder keyValBuilder =


### PR DESCRIPTION
## What changes were proposed in this pull request?

When implementing HDDS-6518, I found `KeyValueContainerData#getProtoBufMessage()` does not set block count.

Although it is an optional field in `ContainerData`, I think we should set it to make `ReadContainer` command more useful.

HDDS-6518 may not get merged since another approach HDDS-6665 is taken. So I filed a separate Jira for this improvement.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6676

## How was this patch tested?

See `TestReplicationService#testReadContainer` in #3351.
But I don't think there is a need to add new test in this PR.