### PR TITLE
HDDS-6679. Further splits integration tests

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -308,8 +308,11 @@ jobs:
       matrix:
         profile:
           - client
-          - filesystem-hdds
+          - filesystem
+          - hdds
+          - om
           - ozone
+          - scm
           - flaky
       fail-fast: false
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -2228,7 +2228,41 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </build>
     </profile>
     <profile>
-      <id>filesystem-hdds</id>
+      <id>om</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>org.apache.hadoop.ozone.om.**</include>
+              </includes>
+              <excludedGroups>flaky | slow</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>scm</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>org.apache.hadoop.ozone.scm.**</include>
+              </includes>
+              <excludedGroups>flaky | slow</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>filesystem</id>
       <build>
         <plugins>
           <plugin>
@@ -2237,6 +2271,22 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
             <configuration>
               <includes>
                 <include>org.apache.hadoop.fs.ozone.**</include>
+              </includes>
+              <excludedGroups>flaky | slow</excludedGroups>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>hdds</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <includes>
                 <include>org.apache.hadoop.hdds.**</include>
               </includes>
               <excludedGroups>flaky | slow</excludedGroups>
@@ -2258,6 +2308,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               </includes>
               <excludes>
                 <exclude>org.apache.hadoop.ozone.client.**</exclude>
+                <exclude>org.apache.hadoop.ozone.om.**</exclude>
+                <exclude>org.apache.hadoop.ozone.scm.**</exclude>
               </excludes>
               <excludedGroups>flaky | slow</excludedGroups>
             </configuration>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently integration tests are the slowest part of CI.  Increasing parallel runs can reduce wall-clock time required for the complete workflow.  There are two limiting factors: 1. constant overhead of compilation, 2. keeping split definitions manageable.

https://issues.apache.org/jira/browse/HDDS-6679

## How was this patch tested?

CI finished in 1.5 hours instead of 2 hours:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2253586336