### PR TITLE
HDDS-6474. Fixed File System Optimized(FSO) bucket list status.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -225,19 +225,29 @@ public class TestRootedOzoneFileSystemWithFSO
     Assert.assertTrue(deletes == prevDeletes + 1);
   }
 
+  /**
+   * Test the consistency of listStatusFSO with TableCache present.
+   */
   @Test
   public void testListStatusFSO() throws Exception {
+    // list keys batch size is 1024. Creating keys greater than the
+    // batch size to test batch listing of the keys.
+    int valueGreaterBatchSize = 1200;
     Path parent = new Path(getBucketPath(), "testListStatusFSO");
-    for (int i = 0; i < 1300; i++) {
+    for (int i = 0; i < valueGreaterBatchSize; i++) {
       Path key = new Path(parent, "tempKey" + i);
       ContractTestUtils.touch(getFs(), key);
-      // To add keys to the cache
+      /*
+      To add keys to the cache. listStatusFSO goes through the cache first.
+      The cache is not continuous and may be greater than the batch size.
+      This may cause inconsistency in the listing of keys.
+       */
       getFs().rename(key, new Path(parent, "key" + i));
     }
 
     FileStatus[] fileStatuses = getFs().listStatus(
         new Path(getBucketPath() + "/testListStatusFSO"));
-    Assert.assertEquals(1300, fileStatuses.length);
+    Assert.assertEquals(valueGreaterBatchSize, fileStatuses.length);
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystemWithFSO.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.fs.ozone;
 
 import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
 import org.junit.Assert;
@@ -222,6 +223,21 @@ public class TestRootedOzoneFileSystemWithFSO
     Assert.assertTrue(getFs().delete(volumePath1, true));
     long deletes = getOMMetrics().getNumKeyDeletes();
     Assert.assertTrue(deletes == prevDeletes + 1);
+  }
+
+  @Test
+  public void testListStatusFSO() throws Exception {
+    Path parent = new Path(getBucketPath(), "testListStatusFSO");
+    for (int i = 0; i < 1300; i++) {
+      Path key = new Path(parent, "tempKey" + i);
+      ContractTestUtils.touch(getFs(), key);
+      // To add keys to the cache
+      getFs().rename(key, new Path(parent, "key" + i));
+    }
+
+    FileStatus[] fileStatuses = getFs().listStatus(
+        new Path(getBucketPath() + "/testListStatusFSO"));
+    Assert.assertEquals(1300, fileStatuses.length);
   }
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1733,7 +1733,7 @@ public class KeyManagerImpl implements KeyManager {
         countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
             bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
             prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
-            countEntries, numEntries);
+            countEntries);
 
       } finally {
         metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
@@ -1796,9 +1796,9 @@ public class KeyManagerImpl implements KeyManager {
                 bucketName);
           try {
             listStatusFindDirsInTableCache(tempCacheDirMap,
-                metadataManager.getDirectoryTable(),
-                prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-                bucketName, countEntries, numEntries, deletedKeySet);
+                metadataManager.getDirectoryTable(), prefixKeyInDB,
+                seekDirInDB, prefixPath, startKey, volumeName,
+                bucketName, countEntries, deletedKeySet);
           } finally {
             metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
                 bucketName);
@@ -1822,7 +1822,7 @@ public class KeyManagerImpl implements KeyManager {
             countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
                 bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
                 prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
-                countEntries, numEntries);
+                countEntries);
           } finally {
             metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
                 bucketName);
@@ -1853,11 +1853,9 @@ public class KeyManagerImpl implements KeyManager {
     }
 
     // 2. Seek the given key in dir table.
-    if (countEntries < numEntries) {
-      getDirectories(cacheDirMap, seekDirInDB, prefixPath,
-          prefixKeyInDB, numEntries, recursive,
-          volumeName, bucketName, deletedKeySet);
-    }
+    getDirectories(cacheDirMap, seekDirInDB, prefixPath,
+        prefixKeyInDB, numEntries, recursive,
+        volumeName, bucketName, deletedKeySet);
 
 
     return buildFinalStatusList(cacheFileMap, cacheDirMap, args,
@@ -1916,11 +1914,11 @@ public class KeyManagerImpl implements KeyManager {
    */
   @SuppressWarnings("parameternumber")
   private int getFilesAndDirsFromCacheWithBucket(String volumeName,
-      String bucketName, Map<String, OzoneFileStatus> cacheFileMap,
-      Map<String, OzoneFileStatus> tempCacheDirMap,
-      Set<String> deletedKeySet, long prefixKeyInDB,
-      String seekFileInDB,  String seekDirInDB, String prefixPath,
-      String startKey, int countEntries, long numEntries) throws IOException {
+       String bucketName, Map<String, OzoneFileStatus> cacheFileMap,
+       Map<String, OzoneFileStatus> tempCacheDirMap,
+       Set<String> deletedKeySet, long prefixKeyInDB,
+       String seekFileInDB, String seekDirInDB, String prefixPath,
+       String startKey, int countEntries) throws IOException {
 
 
     // First under lock obtain both entries from dir/file cache and generate
@@ -1928,16 +1926,15 @@ public class KeyManagerImpl implements KeyManager {
     BucketLayout bucketLayout = getBucketLayout(metadataManager, volumeName,
         bucketName);
     countEntries = listStatusFindFilesInTableCache(cacheFileMap, metadataManager
-            .getKeyTable(bucketLayout),
-        prefixKeyInDB, seekFileInDB, prefixPath, startKey, countEntries,
-        numEntries, deletedKeySet);
+            .getKeyTable(bucketLayout), prefixKeyInDB, seekFileInDB, prefixPath,
+        startKey, countEntries, deletedKeySet);
 
     // Don't count entries from dir cache, as first we need to return all
     // files and then directories.
     listStatusFindDirsInTableCache(tempCacheDirMap,
         metadataManager.getDirectoryTable(),
         prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-        bucketName, countEntries, numEntries, deletedKeySet);
+        bucketName, countEntries, deletedKeySet);
 
     return countEntries;
   }
@@ -2021,16 +2018,16 @@ public class KeyManagerImpl implements KeyManager {
    */
   @SuppressWarnings("parameternumber")
   private int listStatusFindFilesInTableCache(
-          Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
-          OmKeyInfo> keyTable, long prefixKeyInDB, String seekKeyInDB,
-          String prefixKeyPath, String startKey, int countEntries,
-          long numEntries, Set<String> deletedKeySet) {
+      Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
+      OmKeyInfo> keyTable, long prefixKeyInDB, String seekKeyInDB,
+      String prefixKeyPath, String startKey, int countEntries,
+      Set<String> deletedKeySet) {
 
     Iterator<Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>>>
             cacheIter = keyTable.cacheIterator();
 
     // TODO: recursive list will be handled in HDDS-4360 jira.
-    while (cacheIter.hasNext() && numEntries - countEntries > 0) {
+    while (cacheIter.hasNext()) {
       Map.Entry<CacheKey<String>, CacheValue<OmKeyInfo>> entry =
               cacheIter.next();
       String cacheKey = entry.getKey().getCacheKey();
@@ -2063,11 +2060,10 @@ public class KeyManagerImpl implements KeyManager {
    */
   @SuppressWarnings("parameternumber")
   private int listStatusFindDirsInTableCache(
-          Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
-          OmDirectoryInfo> dirTable, long prefixKeyInDB, String seekKeyInDB,
-          String prefixKeyPath, String startKey, String volumeName,
-          String bucketName, int countEntries, long numEntries,
-          Set<String> deletedKeySet) {
+      Map<String, OzoneFileStatus> cacheKeyMap, Table<String,
+      OmDirectoryInfo> dirTable, long prefixKeyInDB, String seekKeyInDB,
+      String prefixKeyPath, String startKey, String volumeName,
+      String bucketName, int countEntries, Set<String> deletedKeySet) {
 
     Iterator<Map.Entry<CacheKey<String>, CacheValue<OmDirectoryInfo>>>
             cacheIter = dirTable.cacheIterator();
@@ -2075,7 +2071,7 @@ public class KeyManagerImpl implements KeyManager {
     // 1. "1024/"   -> startKey is null or empty
     // 2. "1024/b"  -> startKey exists
     // TODO: recursive list will be handled in HDDS-4360 jira.
-    while (cacheIter.hasNext() && numEntries - countEntries > 0) {
+    while (cacheIter.hasNext()) {
       Map.Entry<CacheKey<String>, CacheValue<OmDirectoryInfo>> entry =
               cacheIter.next();
       String cacheKey = entry.getKey().getCacheKey();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1740,8 +1740,7 @@ public class KeyManagerImpl implements KeyManager {
             bucketName);
       }
       countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-          prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet,
-          iterator);
+          prefixPath, prefixKeyInDB, numEntries, deletedKeySet, iterator);
 
     } else {
       /*
@@ -1831,8 +1830,7 @@ public class KeyManagerImpl implements KeyManager {
 
           // 1. Seek the given key in key table.
           countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-              prefixPath, prefixKeyInDB, countEntries, numEntries,
-              deletedKeySet, iterator);
+              prefixPath, prefixKeyInDB, numEntries, deletedKeySet, iterator);
         }
       } else {
         // TODO: HDDS-4364: startKey can be a non-existed key
@@ -1857,7 +1855,7 @@ public class KeyManagerImpl implements KeyManager {
     // 2. Seek the given key in dir table.
     if (countEntries < numEntries) {
       getDirectories(cacheDirMap, seekDirInDB, prefixPath,
-          prefixKeyInDB, countEntries, numEntries, recursive,
+          prefixKeyInDB, numEntries, recursive,
           volumeName, bucketName, deletedKeySet);
     }
 
@@ -1948,16 +1946,15 @@ public class KeyManagerImpl implements KeyManager {
   protected int getDirectories(
       TreeMap<String, OzoneFileStatus> cacheKeyMap,
       String seekDirInDB, String prefixPath, long prefixKeyInDB,
-      int countEntries, long numEntries, boolean recursive,
-      String volumeName, String bucketName, Set<String> deletedKeySet)
-      throws IOException {
+      long numEntries, boolean recursive, String volumeName,
+      String bucketName, Set<String> deletedKeySet) throws IOException {
 
     Table dirTable = metadataManager.getDirectoryTable();
     TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
             iterator = dirTable.iterator();
 
     iterator.seek(seekDirInDB);
-    countEntries = 0;
+    int countEntries = 0;
     while (iterator.hasNext() && numEntries - countEntries > 0) {
       Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
       OmDirectoryInfo dirInfo = entry.getValue();
@@ -1990,12 +1987,11 @@ public class KeyManagerImpl implements KeyManager {
   private int getFilesFromDirectory(
       TreeMap<String, OzoneFileStatus> cacheKeyMap,
       String seekKeyInDB, String prefixKeyPath, long prefixKeyInDB,
-      int countEntries, long numEntries, Set<String> deletedKeySet,
+      long numEntries, Set<String> deletedKeySet,
       TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-          iterator)
-      throws IOException {
+          iterator) throws IOException {
     iterator.seek(seekKeyInDB);
-    countEntries = 0;
+    int countEntries = 0;
     while (iterator.hasNext() && numEntries - countEntries > 0) {
       Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
       OmKeyInfo keyInfo = entry.getValue();


### PR DESCRIPTION
## What changes were proposed in this pull request?

List status is done as a batch process. In `liststatusFSO`, it goes through the cache, and if the cache size is greater than the batch size we return just the cache. The problem is that the cache has gaps and the keys that are within these gaps are ignored. List status continues the listing from the last element (which is a sorted cache) of the batch so we do not iterate over the keys in the gaps again. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6474

## How was this patch tested?

This patch was tested on a cluster.
