### PR TITLE
HDDS-6659: EC: Add BlockGroupLen info as part of PutBlock in EC Writes for helping in recovery.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConsts.java
@@ -454,4 +454,7 @@ public final class OzoneConsts {
   public static final String DELEGATION_TOKEN_KIND = "kind";
   public static final String DELEGATION_TOKEN_SERVICE = "service";
   public static final String DELEGATION_TOKEN_RENEWER = "renewer";
+
+  // EC Constants
+  public static final String BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK = "blockGroupLen";
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockOutputStreamEntry.java
@@ -269,7 +269,7 @@ public class ECBlockOutputStreamEntry extends BlockOutputStreamEntry {
         .build();
   }
 
-  void executePutBlock(boolean isClose) {
+  void executePutBlock(boolean isClose, long blockGroupLength) {
     if (!isInitialized()) {
       return;
     }
@@ -278,7 +278,7 @@ public class ECBlockOutputStreamEntry extends BlockOutputStreamEntry {
         continue;
       }
       try {
-        stream.executePutBlock(isClose, true);
+        stream.executePutBlock(isClose, true, blockGroupLength);
       } catch (Exception e) {
         stream.setIoException(e);
       }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -226,7 +226,9 @@ public final class ECKeyOutputStream extends KeyOutputStream {
       handleFailedStreams(false);
       return StripeWriteStatus.FAILED;
     }
-    currentStreamEntry.executePutBlock(close);
+    currentStreamEntry.executePutBlock(close,
+        blockOutputStreamEntryPool.getCurrentStreamEntry()
+            .getCurrentPosition());
 
     if (hasPutBlockFailure()) {
       handleFailedStreams(true);
@@ -284,8 +286,9 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     // TODO: we should alter the put block calls to share CRC to each stream.
     ECBlockOutputStreamEntry streamEntry =
         blockOutputStreamEntryPool.getCurrentStreamEntry();
-    streamEntry
-        .executePutBlock(isLastStripe);
+    streamEntry.executePutBlock(isLastStripe,
+        blockOutputStreamEntryPool.getCurrentStreamEntry()
+            .getCurrentPosition());
 
     if (hasPutBlockFailure()) {
       handleFailedStreams(true);

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -94,5 +94,4 @@ public class MockDatanodeStorage {
   public String getFullBlockData(BlockID blockID) {
     return this.fullBlockData.get(blockID);
   }
-
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -94,4 +94,5 @@ public class MockDatanodeStorage {
   public String getFullBlockData(BlockID blockID) {
     return this.fullBlockData.get(blockID);
   }
+
 }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -26,10 +26,12 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.BlockOutputStreamEntry;
 import org.apache.hadoop.ozone.client.io.BlockStreamAccessor;
 import org.apache.hadoop.ozone.client.io.ECKeyOutputStream;
@@ -58,6 +60,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -345,6 +348,50 @@ public class TestOzoneECClient {
       Assert.assertEquals(expected, parityBlockData);
       Assert.assertEquals(expected.length(), parityBlockData.length());
 
+    }
+  }
+
+  @Test
+  public void testPutBlockHasBlockGroupLen() throws IOException {
+    OzoneBucket bucket = writeIntoECKey(inputChunks, keyName, null);
+    OzoneKey key = bucket.getKey(keyName);
+    Assert.assertEquals(keyName, key.getName());
+    try (OzoneInputStream is = bucket.readKey(keyName)) {
+      byte[] fileContent = new byte[chunkSize];
+      for (int i = 0; i < dataBlocks; i++) {
+        Assert.assertEquals(inputChunks[i].length, is.read(fileContent));
+        Assert.assertTrue(Arrays.equals(inputChunks[i], fileContent));
+      }
+
+      Map<DatanodeDetails, MockDatanodeStorage> storages =
+          ((MockXceiverClientFactory) factoryStub).getStorages();
+      OzoneManagerProtocolProtos.KeyLocationList blockList =
+          transportStub.getKeys().get(volumeName).get(bucketName).get(keyName).
+              getKeyLocationListList().get(0);
+
+      // Check all node putBlock requests has block group length included.
+      for (int i = 0; i < dataBlocks + parityBlocks; i++) {
+        MockDatanodeStorage mockDatanodeStorage = storages.get(
+            getMatchingStorage(storages,
+                blockList.getKeyLocations(0).getPipeline().getMembers(i)
+                    .getUuid()));
+        final OzoneKeyDetails keyDetails = bucket.getKey(keyName);
+
+        ContainerProtos.BlockData block = mockDatanodeStorage.getBlock(
+            ContainerProtos.DatanodeBlockID.newBuilder().setContainerID(
+                keyDetails.getOzoneKeyLocations().get(0).getContainerID())
+                .setLocalID(
+                    keyDetails.getOzoneKeyLocations().get(0).getLocalID())
+                .setBlockCommitSequenceId(1).build());
+
+        List<ContainerProtos.KeyValue> metadataList =
+            block.getMetadataList().stream().filter(kv -> kv.getKey()
+                .equals(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK))
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(3 * chunkSize,
+            Long.valueOf(metadataList.get(0).getValue()).longValue());
+      }
     }
   }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -389,8 +389,8 @@ public class TestOzoneECClient {
                 .equals(OzoneConsts.BLOCK_GROUP_LEN_KEY_IN_PUT_BLOCK))
                 .collect(Collectors.toList());
 
-        Assert.assertEquals(3 * chunkSize,
-            Long.valueOf(metadataList.get(0).getValue()).longValue());
+        Assert.assertEquals(3L * chunkSize,
+            Long.parseLong(metadataList.get(0).getValue()));
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Sending the current block group length on putblock call

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6659

## How was this patch tested?

Added test to verify.
