### PR TITLE
HDDS-6619. Add freon command to run r/w mix workload using ObjectStore APIs

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -1,0 +1,283 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+
+import org.apache.hadoop.ozone.client.ObjectStore;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClientFactory;
+import org.apache.hadoop.ozone.client.OzoneVolume;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.lock.OMLockMetrics;
+import org.apache.ozone.test.GenericTestUtils;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.raftlog.RaftLog;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * Test for OmBucketReadWriteKeyOps.
+ */
+public class TestOmBucketReadWriteKeyOps {
+
+  private String path;
+  private OzoneConfiguration conf = null;
+  private MiniOzoneCluster cluster = null;
+  private ObjectStore store = null;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestOmBucketReadWriteKeyOps.class);
+
+  @Before
+  public void setup() {
+    path = GenericTestUtils
+        .getTempPath(TestHadoopDirTreeGenerator.class.getSimpleName());
+    GenericTestUtils.setLogLevel(RaftLog.LOG, Level.DEBUG);
+    GenericTestUtils.setLogLevel(RaftServer.LOG, Level.DEBUG);
+    File baseDir = new File(path);
+    baseDir.mkdirs();
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  private void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   *
+   * @throws IOException
+   */
+  private void startCluster() throws Exception {
+    conf = getOzoneConfiguration();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.OBJECT_STORE.name());
+    cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
+    cluster.waitForClusterToBeReady();
+    cluster.waitTobeOutOfSafeMode();
+
+    store = OzoneClientFactory.getRpcClient(conf).getObjectStore();
+  }
+
+  protected OzoneConfiguration getOzoneConfiguration() {
+    return new OzoneConfiguration();
+  }
+
+  @Test
+  public void testOmBucketReadWriteKeyOps() throws Exception {
+    try {
+      startCluster();
+      FileOutputStream out = FileUtils.openOutputStream(new File(path,
+          "conf"));
+      cluster.getConf().writeXml(out);
+      out.getFD().sync();
+      out.close();
+
+      verifyFreonCommand(new ParameterBuilder().setTotalThreadCount(10)
+              .setNumOfReadOperations(3).setNumOfWriteOperations(5)
+              .setKeyCountForRead(2).setKeyCountForWrite(1));
+      verifyFreonCommand(new ParameterBuilder().setVolumeName("vol2")
+          .setBucketName("bucket1").setTotalThreadCount(10)
+          .setNumOfReadOperations(2).setNumOfWriteOperations(1)
+          .setKeyCountForRead(1).setKeyCountForWrite(3));
+
+    } finally {
+      shutdown();
+    }
+  }
+
+  private void verifyFreonCommand(ParameterBuilder parameterBuilder)
+      throws IOException {
+    store.createVolume(parameterBuilder.volumeName);
+    OzoneVolume volume = store.getVolume(parameterBuilder.volumeName);
+    volume.createBucket(parameterBuilder.bucketName);
+    OzoneBucket bucket = store.getVolume(parameterBuilder.volumeName)
+        .getBucket(parameterBuilder.bucketName);
+    String confPath = new File(path, "conf").getAbsolutePath();
+
+    long startTime = System.currentTimeMillis();
+    new Freon().execute(
+        new String[]{"-conf", confPath, "obrwk",
+            "-v", parameterBuilder.volumeName,
+            "-b", parameterBuilder.bucketName,
+            "-k", String.valueOf(parameterBuilder.keyCountForRead),
+            "-w", String.valueOf(parameterBuilder.keyCountForWrite),
+            "-g", String.valueOf(parameterBuilder.keySizeInBytes),
+            "-B", String.valueOf(parameterBuilder.bufferSize),
+            "-l", String.valueOf(parameterBuilder.length),
+            "-c", String.valueOf(parameterBuilder.totalThreadCount),
+            "-T", String.valueOf(parameterBuilder.readThreadPercentage),
+            "-R", String.valueOf(parameterBuilder.numOfReadOperations),
+            "-W", String.valueOf(parameterBuilder.numOfWriteOperations),
+            "-n", String.valueOf(1)});
+    long totalTime = System.currentTimeMillis() - startTime;
+    LOG.info("Total Execution Time: " + totalTime);
+
+    LOG.info("Started verifying OM bucket read/write ops key generation...");
+    verifyKeyCreation(parameterBuilder.keyCountForRead, bucket, "/readPath/");
+
+    int readThreadCount = (parameterBuilder.readThreadPercentage *
+        parameterBuilder.totalThreadCount) / 100;
+    int writeThreadCount = parameterBuilder.totalThreadCount - readThreadCount;
+    verifyKeyCreation(writeThreadCount * parameterBuilder.keyCountForWrite *
+        parameterBuilder.numOfWriteOperations, bucket, "/writePath/");
+
+    verifyOMLockMetrics(cluster.getOzoneManager().getMetadataManager().getLock()
+        .getOMLockMetrics());
+  }
+
+  private void verifyKeyCreation(int expectedCount, OzoneBucket bucket,
+                                 String keyPrefix) throws IOException {
+    int actual = 0;
+    Iterator<? extends OzoneKey> ozoneKeyIterator = bucket.listKeys(keyPrefix);
+    while (ozoneKeyIterator.hasNext()) {
+      ozoneKeyIterator.next();
+      ++actual;
+    }
+    Assert.assertEquals("Mismatch Count!", expectedCount, actual);
+  }
+
+  private void verifyOMLockMetrics(OMLockMetrics omLockMetrics) {
+    String readLockWaitingTimeMsStat =
+        omLockMetrics.getReadLockWaitingTimeMsStat();
+    LOG.info("Read Lock Waiting Time Stat: " + readLockWaitingTimeMsStat);
+    LOG.info("Longest Read Lock Waiting Time (ms): " +
+        omLockMetrics.getLongestReadLockWaitingTimeMs());
+    int readWaitingSamples =
+        Integer.parseInt(readLockWaitingTimeMsStat.split(" ")[2]);
+    Assert.assertTrue("Read Lock Waiting Samples should be positive",
+        readWaitingSamples > 0);
+
+    String readLockHeldTimeMsStat = omLockMetrics.getReadLockHeldTimeMsStat();
+    LOG.info("Read Lock Held Time Stat: " + readLockHeldTimeMsStat);
+    LOG.info("Longest Read Lock Held Time (ms): " +
+        omLockMetrics.getLongestReadLockHeldTimeMs());
+    int readHeldSamples =
+        Integer.parseInt(readLockHeldTimeMsStat.split(" ")[2]);
+    Assert.assertTrue("Read Lock Held Samples should be positive",
+        readHeldSamples > 0);
+
+    String writeLockWaitingTimeMsStat =
+        omLockMetrics.getWriteLockWaitingTimeMsStat();
+    LOG.info("Write Lock Waiting Time Stat: " + writeLockWaitingTimeMsStat);
+    LOG.info("Longest Write Lock Waiting Time (ms): " +
+        omLockMetrics.getLongestWriteLockWaitingTimeMs());
+    int writeWaitingSamples =
+        Integer.parseInt(writeLockWaitingTimeMsStat.split(" ")[2]);
+    Assert.assertTrue("Write Lock Waiting Samples should be positive",
+        writeWaitingSamples > 0);
+
+    String writeLockHeldTimeMsStat = omLockMetrics.getWriteLockHeldTimeMsStat();
+    LOG.info("Write Lock Held Time Stat: " + writeLockHeldTimeMsStat);
+    LOG.info("Longest Write Lock Held Time (ms): " +
+        omLockMetrics.getLongestWriteLockHeldTimeMs());
+    int writeHeldSamples =
+        Integer.parseInt(writeLockHeldTimeMsStat.split(" ")[2]);
+    Assert.assertTrue("Write Lock Held Samples should be positive",
+        writeHeldSamples > 0);
+  }
+
+  private static class ParameterBuilder {
+
+    private String volumeName = "vol1";
+    private String bucketName = "bucket1";
+    private int keyCountForRead = 100;
+    private int keyCountForWrite = 10;
+    private long keySizeInBytes = 256;
+    private int bufferSize = 64;
+    private int length = 10;
+    private int totalThreadCount = 100;
+    private int readThreadPercentage = 90;
+    private int numOfReadOperations = 50;
+    private int numOfWriteOperations = 10;
+
+    private ParameterBuilder setVolumeName(String volumeNameParam) {
+      volumeName = volumeNameParam;
+      return this;
+    }
+
+    private ParameterBuilder setBucketName(String bucketNameParam) {
+      bucketName = bucketNameParam;
+      return this;
+    }
+
+    private ParameterBuilder setKeyCountForRead(int keyCountForReadParam) {
+      keyCountForRead = keyCountForReadParam;
+      return this;
+    }
+
+    private ParameterBuilder setKeyCountForWrite(int keyCountForWriteParam) {
+      keyCountForWrite = keyCountForWriteParam;
+      return this;
+    }
+
+    private ParameterBuilder setKeySizeInBytes(long keySizeInBytesParam) {
+      keySizeInBytes = keySizeInBytesParam;
+      return this;
+    }
+
+    private ParameterBuilder setBufferSize(int bufferSizeParam) {
+      bufferSize = bufferSizeParam;
+      return this;
+    }
+
+    private ParameterBuilder setLength(int lengthParam) {
+      length = lengthParam;
+      return this;
+    }
+
+    private ParameterBuilder setTotalThreadCount(int totalThreadCountParam) {
+      totalThreadCount = totalThreadCountParam;
+      return this;
+    }
+
+    private ParameterBuilder setReadThreadPercentage(
+        int readThreadPercentageParam) {
+      readThreadPercentage = readThreadPercentageParam;
+      return this;
+    }
+
+    private ParameterBuilder setNumOfReadOperations(
+        int numOfReadOperationsParam) {
+      numOfReadOperations = numOfReadOperationsParam;
+      return this;
+    }
+
+    private ParameterBuilder setNumOfWriteOperations(
+        int numOfWriteOperationsParam) {
+      numOfWriteOperations = numOfWriteOperationsParam;
+      return this;
+    }
+  }
+}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -64,7 +64,8 @@ import picocli.CommandLine.Option;
         ClosedContainerReplicator.class,
         StreamingGenerator.class,
         SCMThroughputBenchmark.class,
-        OmBucketReadWriteFileOps.class},
+        OmBucketReadWriteFileOps.class,
+        OmBucketReadWriteKeyOps.class},
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class Freon extends GenericCli {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketReadWriteKeyOps.java
@@ -1,0 +1,309 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.freon;
+
+import com.codahale.metrics.Timer;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.cli.HddsVersionProvider;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+
+/**
+ * Synthetic read/write key operations workload generator tool.
+ */
+@Command(name = "obrwk",
+    aliases = "om-bucket-read-write-key-ops",
+    description = "Creates keys, performs respective read/write " +
+        "operations to measure lock performance.",
+    versionProvider = HddsVersionProvider.class,
+    mixinStandardHelpOptions = true,
+    showDefaultValues = true)
+
+public class OmBucketReadWriteKeyOps extends BaseFreonGenerator
+    implements Callable<Void> {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OmBucketReadWriteKeyOps.class);
+
+  @Option(names = {"-v", "--volume"},
+      description = "Name of the volume which contains the test data. Will be"
+          + " created if missing.",
+      defaultValue = "vol1")
+  private String volumeName;
+
+  @Option(names = {"-b", "--bucket"},
+      description = "Name of the bucket which contains the test data. Will be"
+          + " created if missing.",
+      defaultValue = "bucket1")
+  private String bucketName;
+
+  @Option(names = {"-k", "--key-count-for-read"},
+      description = "Number of keys to be created for read operations.",
+      defaultValue = "100")
+  private int keyCountForRead;
+
+  @Option(names = {"-w", "--key-count-for-write"},
+      description = "Number of keys to be created for write operations.",
+      defaultValue = "10")
+  private int keyCountForWrite;
+
+  @Option(names = {"-g", "--key-size"},
+      description = "Size of the generated key (in bytes).",
+      defaultValue = "256")
+  private long keySizeInBytes;
+
+  @Option(names = {"-B", "--buffer"},
+      description = "Size of buffer used to generated the key content.",
+      defaultValue = "64")
+  private int bufferSize;
+
+  @Option(names = {"-l", "--name-len"},
+      description = "Length of the random name of path you want to create.",
+      defaultValue = "10")
+  private int length;
+
+  @Option(names = {"-c", "--total-thread-count"},
+      description = "Total number of threads to be executed.",
+      defaultValue = "100")
+  private int totalThreadCount;
+
+  @Option(names = {"-T", "--read-thread-percentage"},
+      description = "Percentage of the total number of threads to be " +
+          "allocated for read operations. The remaining percentage of " +
+          "threads will be allocated for write operations.",
+      defaultValue = "90")
+  private int readThreadPercentage;
+
+  @Option(names = {"-R", "--num-of-read-operations"},
+      description = "Number of read operations to be performed by each thread.",
+      defaultValue = "50")
+  private int numOfReadOperations;
+
+  @Option(names = {"-W", "--num-of-write-operations"},
+      description = "Number of write operations to be performed by each " +
+          "thread.",
+      defaultValue = "10")
+  private int numOfWriteOperations;
+
+  @Option(names = {"-o", "--om-service-id"},
+      description = "OM Service ID"
+  )
+  private String omServiceID = null;
+
+  @CommandLine.Mixin
+  private FreonReplicationOptions replication;
+
+  private Timer timer;
+
+  private ContentGenerator contentGenerator;
+
+  private Map<String, String> metadata;
+
+  private ReplicationConfig replicationConfig;
+
+  private OzoneBucket bucket;
+
+  private int readThreadCount;
+  private int writeThreadCount;
+
+  @Override
+  public Void call() throws Exception {
+    init();
+
+    readThreadCount = (readThreadPercentage * totalThreadCount) / 100;
+    writeThreadCount = totalThreadCount - readThreadCount;
+
+    print("volumeName: " + volumeName);
+    print("bucketName: " + bucketName);
+    print("keyCountForRead: " + keyCountForRead);
+    print("keyCountForWrite: " + keyCountForWrite);
+    print("keySizeInBytes: " + keySizeInBytes);
+    print("bufferSize: " + bufferSize);
+    print("totalThreadCount: " + totalThreadCount);
+    print("readThreadPercentage: " + readThreadPercentage);
+    print("writeThreadPercentage: " + (100 - readThreadPercentage));
+    print("readThreadCount: " + readThreadCount);
+    print("writeThreadCount: " + writeThreadCount);
+    print("numOfReadOperations: " + numOfReadOperations);
+    print("numOfWriteOperations: " + numOfWriteOperations);
+    print("omServiceID: " + omServiceID);
+
+    OzoneConfiguration ozoneConfiguration = createOzoneConfiguration();
+    replicationConfig = replication.fromParamsOrConfig(ozoneConfiguration);
+
+    contentGenerator = new ContentGenerator(keySizeInBytes, bufferSize);
+    metadata = new HashMap<>();
+
+    try (OzoneClient rpcClient = createOzoneClient(omServiceID,
+        ozoneConfiguration)) {
+      ensureVolumeAndBucketExist(rpcClient, volumeName, bucketName);
+      bucket = rpcClient.getObjectStore().getVolume(volumeName)
+          .getBucket(bucketName);
+
+      timer = getMetrics().timer("key-create");
+
+      runTests(this::mainMethod);
+    }
+
+    return null;
+  }
+
+  private void mainMethod(long counter) throws Exception {
+
+    int readResult = readOperations();
+    int writeResult = writeOperations();
+
+    print("Total Keys Read: " + readResult);
+    print("Total Keys Written: " + writeResult * keyCountForWrite);
+
+    // TODO: print read/write lock metrics (HDDS-6435, HDDS-6436).
+  }
+
+  private int readOperations() throws Exception {
+
+    // Create keyCountForRead (defaultValue = 100) keys under
+    // rootPath/readPath
+    String readPath = "".concat(OzoneConsts.OM_KEY_PREFIX).concat("readPath");
+    createKeys(readPath, keyCountForRead);
+
+    // Start readThreadCount (defaultValue = 90) concurrent read threads
+    // performing numOfReadOperations (defaultValue = 50) iterations
+    // of read operations (bucket.listKeys(readPath))
+    ExecutorService readService = Executors.newFixedThreadPool(readThreadCount);
+    CompletionService<Integer> readExecutorCompletionService =
+        new ExecutorCompletionService<>(readService);
+    List<Future<Integer>> readFutures = new ArrayList<>();
+    for (int i = 0; i < readThreadCount; i++) {
+      readFutures.add(readExecutorCompletionService.submit(() -> {
+        int readCount = 0;
+        try {
+          for (int j = 0; j < numOfReadOperations; j++) {
+            Iterator<? extends OzoneKey> ozoneKeyIterator =
+                bucket.listKeys("/readPath/");
+            while (ozoneKeyIterator.hasNext()) {
+              ozoneKeyIterator.next();
+              ++readCount;
+            }
+          }
+        } catch (IOException e) {
+          LOG.warn("Exception while listing keys ", e);
+        }
+        return readCount;
+      }));
+    }
+
+    int readResult = 0;
+    for (int i = 0; i < readFutures.size(); i++) {
+      try {
+        readResult += readExecutorCompletionService.take().get();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      } catch (ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
+    readService.shutdown();
+
+    return readResult;
+  }
+
+  private int writeOperations() throws Exception {
+
+    // Start writeThreadCount (defaultValue = 10) concurrent write threads
+    // performing numOfWriteOperations (defaultValue = 10) iterations
+    // of write operations (createKeys(writePath))
+    String writePath = "".concat(OzoneConsts.OM_KEY_PREFIX).concat("writePath");
+
+    ExecutorService writeService =
+        Executors.newFixedThreadPool(writeThreadCount);
+    CompletionService<Integer> writeExecutorCompletionService =
+        new ExecutorCompletionService<>(writeService);
+    List<Future<Integer>> writeFutures = new ArrayList<>();
+    for (int i = 0; i < writeThreadCount; i++) {
+      writeFutures.add(writeExecutorCompletionService.submit(() -> {
+        int writeCount = 0;
+        try {
+          for (int j = 0; j < numOfWriteOperations; j++) {
+            createKeys(writePath, keyCountForWrite);
+            writeCount++;
+          }
+        } catch (IOException e) {
+          LOG.warn("Exception while creating key ", e);
+        }
+        return writeCount;
+      }));
+    }
+
+    int writeResult = 0;
+    for (int i = 0; i < writeFutures.size(); i++) {
+      try {
+        writeResult += writeExecutorCompletionService.take().get();
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      } catch (ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
+    writeService.shutdown();
+
+    return writeResult;
+  }
+
+  private void createKey(String path) throws Exception {
+    String keyName = path.concat(OzoneConsts.OM_KEY_PREFIX)
+        .concat(RandomStringUtils.randomAlphanumeric(length));
+
+    timer.time(() -> {
+      try (OutputStream stream = bucket.createKey(keyName, keySizeInBytes,
+          replicationConfig, metadata)) {
+        contentGenerator.write(stream);
+        stream.flush();
+      }
+      return null;
+    });
+  }
+
+  private void createKeys(String path, int keyCount) throws Exception {
+    for (int i = 0; i < keyCount; i++) {
+      createKey(path);
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

To develop a new Ozone Freon command tool where one can generate a synthetic read and write operation mix workload using `OBJECT_STORE ("OBS")` APIs.

**Step-1:** Create `keyCountForRead` (defaultValue = 100) keys under path/readPath
**Step-2:** Start `readThreadCount` (defaultValue = 90) concurrent read threads
        &emsp;each new Thread (() ->{
            &emsp;&emsp;for(1...`numOfReadOperations` (defaultValue = 50))
                &emsp;&emsp;&emsp;bucket.listKeys(_path/readPath_)
        &emsp;}
**Step-3:** Start `writeThreadCount` (defaultValue = 10) concurrent write threads
        &emsp;each new Thread (() -> {
            &emsp;&emsp;for(1...`numOfWriteOperations` (defaultValue = 10))
                &emsp;&emsp;&emsp;bucket.createKey(_path/writePath/file-random-keypath_)
        &emsp;}

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6619

## How was this patch tested?

Added integration tests.
