### PR TITLE
HDDS-6572. EC: RM. add inflightActionManager and split moveSchudler from legacy RM

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -27,11 +27,11 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.container.replication.MoveScheduler.MoveResult;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMService;
 import org.apache.hadoop.hdds.scm.net.NetworkTopology;
@@ -107,7 +107,7 @@ public class ContainerBalancer implements SCMService {
   private FindTargetStrategy findTargetStrategy;
   private FindSourceStrategy findSourceStrategy;
   private Map<ContainerMoveSelection,
-      CompletableFuture<LegacyReplicationManager.MoveResult>>
+      CompletableFuture<MoveResult>>
       moveSelectionToFutureMap;
   private IterationResult iterationResult;
 
@@ -586,7 +586,7 @@ public class ContainerBalancer implements SCMService {
   private boolean moveContainer(DatanodeDetails source,
                                 ContainerMoveSelection moveSelection) {
     ContainerID containerID = moveSelection.getContainerID();
-    CompletableFuture<LegacyReplicationManager.MoveResult> future;
+    CompletableFuture<MoveResult> future;
     try {
       ContainerInfo containerInfo = containerManager.getContainer(containerID);
       future = replicationManager
@@ -599,7 +599,7 @@ public class ContainerBalancer implements SCMService {
                   source.getUuidString(),
                   moveSelection.getTargetNode().getUuidString(), ex);
             } else {
-              if (result == LegacyReplicationManager.MoveResult.COMPLETED) {
+              if (result == MoveResult.COMPLETED) {
                 metrics.incrementDataSizeMovedGBInLatestIteration(
                     containerInfo.getUsedBytes() / OzoneConsts.GB);
                 metrics.incrementNumContainerMovesCompletedInLatestIteration(1);
@@ -630,9 +630,9 @@ public class ContainerBalancer implements SCMService {
       if (future.isCompletedExceptionally()) {
         return false;
       } else {
-        LegacyReplicationManager.MoveResult result = future.join();
+        MoveResult result = future.join();
         moveSelectionToFutureMap.put(moveSelection, future);
-        return result == LegacyReplicationManager.MoveResult.COMPLETED;
+        return result == MoveResult.COMPLETED;
       }
     } else {
       moveSelectionToFutureMap.put(moveSelection, future);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/InflightAction.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/InflightAction.java
@@ -15,21 +15,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
 /**
-* InflightAction is a Wrapper class to hold the InflightAction
-* with its start time and the target datanode.
-*/
+ * InflightAction is a Wrapper class to hold the InflightAction
+ * with its start time and the target datanode.
+ */
 public class InflightAction {
   private final DatanodeDetails datanode;
   private final long time;
 
   public InflightAction(final DatanodeDetails datanode,
-                         final long time) {
+                        final long time) {
     this.datanode = datanode;
     this.time = time;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/InflightActionManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/InflightActionManager.java
@@ -1,0 +1,658 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import com.google.protobuf.GeneratedMessage;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ContainerReplicaCount;
+import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.container.replication.MoveScheduler.MoveResult;
+import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * InflightActionManager manages all the inflight actions, including
+ * inflightDeletion, inflightReplication and InflightECReconstruct.
+ */
+public class InflightActionManager {
+
+  public static final Logger LOG =
+      LoggerFactory.getLogger(InflightActionManager.class);
+
+  /**
+   * This is used for tracking container replication commands which are issued
+   * by ReplicationManager and not yet complete.
+   */
+  private final Map<ContainerID, List<InflightAction>> inflightReplication;
+
+  /**
+   * This is used for tracking container deletion commands which are issued
+   * by ReplicationManager and not yet complete.
+   */
+  private final Map<ContainerID, List<InflightAction>> inflightDeletion;
+
+  /**
+   * This is used for tracking EC recovery commands which are issued
+   * by ReplicationManager and not yet complete.
+   */
+  private final Map<ContainerID, List<InflightAction>> inflightECReconstruct;
+
+  /**
+   * Reference to the ContainerManager.
+   */
+  private final ContainerManager containerManager;
+
+
+  /**
+   * Used to lookup the health of a nodes or the nodes operational state.
+   */
+  private final NodeManager nodeManager;
+
+  /**
+   * inflight action timeout.
+   */
+  private final long eventTimeout;
+
+  private final Clock clock;
+
+  /**
+   * Minimum number of replica in a healthy state for maintenance.
+   */
+  private int minHealthyForMaintenance;
+
+  /**
+   * PlacementPolicy which is used to identify where a container
+   * should be replicated.
+   */
+  private final PlacementPolicy containerPlacement;
+
+  /**
+   * EventPublisher to fire Replicate and Delete container events.
+   */
+  private final EventPublisher eventPublisher;
+
+  /**
+   * SCMContext from StorageContainerManager.
+   */
+  private final SCMContext scmContext;
+
+  /**
+   * Replication progress related metrics.
+   */
+  private ReplicationManagerMetrics metrics;
+
+  private final MoveScheduler moveScheduler;
+
+  @SuppressWarnings("parameternumber")
+  public InflightActionManager(final ContainerManager containerManager,
+                               final NodeManager nodeManager,
+                               final long eventTimeout, Clock clock,
+                               final MoveScheduler moveScheduler,
+                               final int minHealthyForMaintenance,
+                               final PlacementPolicy containerPlacement,
+                               final EventPublisher eventPublisher,
+                               final SCMContext scmContext) {
+    inflightReplication = new ConcurrentHashMap<>();
+    inflightDeletion = new ConcurrentHashMap<>();
+    inflightECReconstruct = new ConcurrentHashMap<>();
+    this.containerManager = containerManager;
+    this.nodeManager = nodeManager;
+    this.eventTimeout = eventTimeout;
+    this.clock = clock;
+    this.metrics = null;
+    this.moveScheduler = moveScheduler;
+    this.minHealthyForMaintenance = minHealthyForMaintenance;
+    this.containerPlacement = containerPlacement;
+    this.eventPublisher = eventPublisher;
+    this.scmContext = scmContext;
+  }
+
+  protected void setMetrics(ReplicationManagerMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  public Map<ContainerID, List<InflightAction>> getInflightReplication() {
+    return inflightReplication;
+  }
+
+  public Map<ContainerID, List<InflightAction>> getInflightDeletion() {
+    return inflightDeletion;
+  }
+
+  public Map<ContainerID, List<InflightAction>> getInflightECReconstruct() {
+    return inflightECReconstruct;
+  }
+
+  public void addInflightReplication(
+      ContainerID id, InflightAction inflightAction) {
+    inflightReplication.computeIfAbsent(id, k -> new ArrayList<>());
+    inflightReplication.get(id).add(inflightAction);
+  }
+
+  public void addInflightDeletion(
+      ContainerID id, InflightAction inflightAction) {
+    inflightDeletion.computeIfAbsent(id, k -> new ArrayList<>());
+    inflightDeletion.get(id).add(inflightAction);
+  }
+
+  public void addInflightECReconstruct(
+      ContainerID id, InflightAction inflightAction) {
+    inflightECReconstruct.computeIfAbsent(id, k -> new ArrayList<>());
+    inflightECReconstruct.get(id).add(inflightAction);
+  }
+
+  public void clearInflightActions() {
+    inflightDeletion.clear();
+    inflightECReconstruct.clear();
+    inflightReplication.clear();
+  }
+
+  /**
+  * Reconciles the InflightActions for a given container.
+  */
+  public void updateContainerInflightActions(final ContainerInfo container) {
+    updateContainerInflightReplication(container);
+    updateContainerInflightDeletion(container);
+    updateContainerInflightECReconstruct(container);
+  }
+
+  private void updateContainerInflightReplication(
+      final ContainerInfo container) {
+    try {
+      final Set<ContainerReplica> replicas =
+          containerManager.getContainerReplicas(container.containerID());
+      updateInflightActionInternal(container, inflightReplication,
+          action -> replicas.stream().anyMatch(
+              r -> r.getDatanodeDetails().equals(action.getDatanode())),
+          () -> metrics.incrNumReplicationCmdsTimeout(),
+          action -> updateCompletedReplicationMetrics(container, action));
+    } catch (ContainerNotFoundException e) {
+      LOG.warn("fail to update InflightReplication, " +
+          "container not found : {}", container);
+    }
+  }
+
+  private void updateContainerInflightDeletion(final ContainerInfo container) {
+    try {
+      final Set<ContainerReplica> replicas =
+          containerManager.getContainerReplicas(container.containerID());
+      updateInflightActionInternal(container, inflightDeletion,
+          action -> replicas.stream().noneMatch(
+              r -> r.getDatanodeDetails().equals(action.getDatanode())),
+          () -> metrics.incrNumDeletionCmdsTimeout(),
+          action -> updateCompletedDeletionMetrics(container, action));
+    } catch (ContainerNotFoundException e) {
+      LOG.warn("fail to update InflightReplication, " +
+          "container not found : {}", container);
+    }
+  }
+
+  private void updateContainerInflightECReconstruct(
+      final ContainerInfo container) {
+    //no op for now, implement later
+  }
+
+  private void updateCompletedReplicationMetrics(
+      ContainerInfo container, InflightAction action) {
+    metrics.incrNumReplicationCmdsCompleted();
+    metrics.incrNumReplicationBytesCompleted(container.getUsedBytes());
+    metrics.addReplicationTime(clock.millis() - action.getTime());
+  }
+
+  private void updateCompletedDeletionMetrics(
+      ContainerInfo container, InflightAction action) {
+    metrics.incrNumDeletionCmdsCompleted();
+    metrics.incrNumDeletionBytesCompleted(container.getUsedBytes());
+    metrics.addDeletionTime(clock.millis() - action.getTime());
+  }
+
+  /**
+   * Given a ContainerID, lookup the ContainerInfo and then return a
+   * ContainerReplicaCount object for the container.
+   * @param containerID The ID of the container
+   * @return ContainerReplicaCount for the given container
+   * @throws ContainerNotFoundException
+   */
+  public ContainerReplicaCount getContainerReplicaCount(ContainerID containerID)
+      throws ContainerNotFoundException {
+    ContainerInfo container = containerManager.getContainer(containerID);
+    return getContainerReplicaCount(container);
+  }
+
+  /**
+   * Given a container, obtain the set of known replica for it, and return a
+   * ContainerReplicaCount object. This object will contain the set of replica
+   * as well as all information required to determine if the container is over
+   * or under replicated, including the delta of replica required to repair the
+   * over or under replication.
+   *
+   * @param container The container to create a ContainerReplicaCount for
+   * @return ContainerReplicaCount representing the replicated state of the
+   *         container.
+   * @throws ContainerNotFoundException
+   */
+  private ContainerReplicaCount getContainerReplicaCount(
+      ContainerInfo container) throws ContainerNotFoundException {
+    // TODO: using a RW lock for only read
+    synchronized (container) {
+      final Set<ContainerReplica> replica = containerManager
+          .getContainerReplicas(container.containerID());
+      return getContainerReplicaCount(container, replica);
+    }
+  }
+
+  /**
+   * Given a container and its set of replicas, create and return a
+   * ContainerReplicaCount representing the container.
+   *
+   * @param container The container for which to construct a
+   *                  ContainerReplicaCount
+   * @param replica The set of existing replica for this container
+   * @return ContainerReplicaCount representing the current state of the
+   *         container
+   */
+  protected ContainerReplicaCount getContainerReplicaCount(
+      ContainerInfo container, Set<ContainerReplica> replica) {
+    return new ContainerReplicaCount(
+        container,
+        replica,
+        getInflightAdd(container.containerID()),
+        getInflightDel(container.containerID()),
+        container.getReplicationConfig().getRequiredNodes(),
+        minHealthyForMaintenance);
+  }
+
+  /**
+   * Returns the number replica which are pending creation for the given
+   * container ID.
+   * @param id The ContainerID for which to check the pending replica
+   * @return The number of inflight additions or zero if none
+   */
+  private int getInflightAdd(final ContainerID id) {
+    return inflightReplication.getOrDefault(id, Collections.emptyList()).size();
+  }
+
+  /**
+   * Returns the number replica which are pending delete for the given
+   * container ID.
+   * @param id The ContainerID for which to check the pending replica
+   * @return The number of inflight deletes or zero if none
+   */
+  private int getInflightDel(final ContainerID id) {
+    return inflightDeletion.getOrDefault(id, Collections.emptyList()).size();
+  }
+
+  /**
+   * Reconciles the specified InflightActions for a given container.
+   *
+   * @param container Container to update
+   * @param inflightActions inflightReplication (or) inflightDeletion
+   * @param filter filter to check if the operation is completed
+   * @param timeoutCounter update timeout metrics
+   * @param completedCounter update completed metrics
+   */
+  private void updateInflightActionInternal(
+      final ContainerInfo container,
+      final Map<ContainerID, List<InflightAction>> inflightActions,
+      final Predicate<InflightAction> filter,
+      final Runnable timeoutCounter,
+      final Consumer<InflightAction> completedCounter) {
+    final ContainerID id = container.containerID();
+    final long deadline = clock.millis() - eventTimeout;
+    if (inflightActions.containsKey(id)) {
+      final List<InflightAction> actions = inflightActions.get(id);
+
+      Iterator<InflightAction> iter = actions.iterator();
+      while (iter.hasNext()) {
+        try {
+          InflightAction a = iter.next();
+          NodeStatus status = nodeManager.getNodeStatus(a.getDatanode());
+          boolean isUnhealthy =
+              status.getHealth() != HddsProtos.NodeState.HEALTHY;
+          boolean isCompleted = filter.test(a);
+          boolean isTimeout = a.getTime() < deadline;
+          boolean isNotInService = status.getOperationalState() !=
+              HddsProtos.NodeOperationalState.IN_SERVICE;
+          if (isCompleted || isUnhealthy || isTimeout || isNotInService) {
+            iter.remove();
+
+            if (isTimeout) {
+              timeoutCounter.run();
+            } else if (isCompleted) {
+              completedCounter.accept(a);
+            }
+
+            updateMoveIfNeeded(isUnhealthy, isCompleted, isTimeout,
+                isNotInService, container, a.getDatanode(), inflightActions);
+          }
+        } catch (NodeNotFoundException | ContainerNotFoundException e) {
+          // Should not happen, but if it does, just remove the action as the
+          // node somehow does not exist;
+          iter.remove();
+        }
+      }
+      if (actions.isEmpty()) {
+        inflightActions.remove(id);
+      }
+    }
+  }
+
+  /**
+   * update inflight move if needed.
+   *
+   * @param isUnhealthy is the datanode unhealthy
+   * @param isCompleted is the action completed
+   * @param isTimeout is the action timeout
+   * @param container Container to update
+   * @param dn datanode which is removed from the inflightActions
+   * @param inflightActions inflightReplication (or) inflightDeletion
+   */
+  private void updateMoveIfNeeded(
+      final boolean isUnhealthy,
+      final boolean isCompleted, final boolean isTimeout,
+      final boolean isNotInService,
+      final ContainerInfo container, final DatanodeDetails dn,
+      final Map<ContainerID, List<InflightAction>> inflightActions)
+      throws ContainerNotFoundException {
+    // make sure inflightMove contains the container
+    ContainerID id = container.containerID();
+
+    // make sure the datanode , which is removed from inflightActions,
+    // is source or target datanode.
+    MoveDataNodePair kv = moveScheduler.getMoveDataNodePair(id);
+    if (kv == null) {
+      return;
+    }
+    final boolean isSource = kv.getSrc().equals(dn);
+    final boolean isTarget = kv.getTgt().equals(dn);
+    if (!isSource && !isTarget) {
+      return;
+    }
+    final boolean isInflightReplication =
+        inflightActions.equals(inflightReplication);
+
+    /*
+     * there are some case:
+     **********************************************************
+     *              * InflightReplication  * InflightDeletion *
+     **********************************************************
+     *source removed*     unexpected       *    expected      *
+     **********************************************************
+     *target removed*      expected        *   unexpected     *
+     **********************************************************
+     * unexpected action may happen somehow. to make it deterministic,
+     * if unexpected action happens, we just fail the completableFuture.
+     */
+
+    if (isSource && isInflightReplication) {
+      //if RM is reinitialize, inflightMove will be restored,
+      //but inflightMoveFuture not. so there will be a case that
+      //container is in inflightMove, but not in inflightMoveFuture.
+      moveScheduler.compleleteMoveFutureWithResult(id,
+          MoveResult.UNEXPECTED_REMOVE_SOURCE_AT_INFLIGHT_REPLICATION);
+      moveScheduler.completeMove(id.getProtobuf());
+      return;
+    }
+
+    if (isTarget && !isInflightReplication) {
+      moveScheduler.compleleteMoveFutureWithResult(id,
+          MoveResult.UNEXPECTED_REMOVE_TARGET_AT_INFLIGHT_DELETION);
+      moveScheduler.completeMove(id.getProtobuf());
+      return;
+    }
+
+    if (!(isInflightReplication && isCompleted)) {
+      if (isInflightReplication) {
+        if (isUnhealthy) {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
+        } else if (isNotInService) {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
+        } else {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.REPLICATION_FAIL_TIME_OUT);
+        }
+      } else {
+        if (isUnhealthy) {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.DELETION_FAIL_NODE_UNHEALTHY);
+        } else if (isTimeout) {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.DELETION_FAIL_TIME_OUT);
+        } else if (isNotInService) {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.DELETION_FAIL_NODE_NOT_IN_SERVICE);
+        } else {
+          moveScheduler.compleleteMoveFutureWithResult(id,
+              MoveResult.COMPLETED);
+        }
+      }
+      moveScheduler.completeMove(id.getProtobuf());
+    } else {
+      deleteSrcDnForMove(container,
+          containerManager.getContainerReplicas(id));
+    }
+  }
+
+  /**
+   * if the container is in inflightMove, handle move.
+   * This function assumes replication has been completed
+   *
+   * @param cif ContainerInfo
+   * @param replicaSet An Set of replicas, which may have excess replicas
+   */
+  protected void deleteSrcDnForMove(final ContainerInfo cif,
+                                  final Set<ContainerReplica> replicaSet) {
+    final ContainerID cid = cif.containerID();
+    MoveDataNodePair movePair = moveScheduler.getMoveDataNodePair(cid);
+    if (movePair == null) {
+      return;
+    }
+    final DatanodeDetails srcDn = movePair.getSrc();
+    ContainerReplicaCount replicaCount =
+        getContainerReplicaCount(cif, replicaSet);
+
+    if (!replicaSet.stream()
+        .anyMatch(r -> r.getDatanodeDetails().equals(srcDn))) {
+      // if the target is present but source disappears somehow,
+      // we can consider move is successful.
+      moveScheduler.compleleteMoveFutureWithResult(cid, MoveResult.COMPLETED);
+      moveScheduler.completeMove(cid.getProtobuf());
+      return;
+    }
+
+    int replicationFactor =
+        cif.getReplicationConfig().getRequiredNodes();
+    ContainerPlacementStatus currentCPS =
+        getPlacementStatus(replicaSet, replicationFactor);
+    Set<ContainerReplica> newReplicaSet = replicaSet.
+        stream().collect(Collectors.toSet());
+    newReplicaSet.removeIf(r -> r.getDatanodeDetails().equals(srcDn));
+    ContainerPlacementStatus newCPS =
+        getPlacementStatus(newReplicaSet, replicationFactor);
+
+    if (replicaCount.isOverReplicated() &&
+        isPlacementStatusActuallyEqual(currentCPS, newCPS)) {
+      sendDeleteCommand(cif, srcDn, true);
+    } else {
+      // if source and target datanode are both in the replicaset,
+      // but we can not delete source datanode for now (e.g.,
+      // there is only 3 replicas or not policy-statisfied , etc.),
+      // we just complete the future without sending a delete command.
+      LOG.info("can not remove source replica after successfully " +
+          "replicated to target datanode");
+      moveScheduler.compleleteMoveFutureWithResult(
+          cid, MoveResult.DELETE_FAIL_POLICY);
+      moveScheduler.completeMove(cid.getProtobuf());
+    }
+  }
+
+  /**
+   * Given a set of ContainerReplica, transform it to a list of DatanodeDetails
+   * and then check if the list meets the container placement policy.
+   * @param replicas List of containerReplica
+   * @param replicationFactor Expected Replication Factor of the containe
+   * @return ContainerPlacementStatus indicating if the policy is met or not
+   */
+  protected ContainerPlacementStatus getPlacementStatus(
+      Set<ContainerReplica> replicas, int replicationFactor) {
+    List<DatanodeDetails> replicaDns = replicas.stream()
+        .map(ContainerReplica::getDatanodeDetails)
+        .collect(Collectors.toList());
+    return containerPlacement.validateContainerPlacement(
+        replicaDns, replicationFactor);
+  }
+
+  /**
+   * whether the given two ContainerPlacementStatus are actually equal.
+   *
+   * @param cps1 ContainerPlacementStatus
+   * @param cps2 ContainerPlacementStatus
+   */
+  protected boolean isPlacementStatusActuallyEqual(
+      ContainerPlacementStatus cps1,
+      ContainerPlacementStatus cps2) {
+    return (!cps1.isPolicySatisfied() &&
+        cps1.actualPlacementCount() == cps2.actualPlacementCount()) ||
+        cps1.isPolicySatisfied() && cps2.isPolicySatisfied();
+  }
+
+  public boolean isContainerReplicatingOrDeleting(ContainerID containerID) {
+    return inflightReplication.containsKey(containerID) ||
+        inflightDeletion.containsKey(containerID);
+  }
+
+
+
+  //todo : following command-sending functions will be removed
+  // after wrap command sending actions to a standalone class or function.
+
+  /**
+   * Sends replicate container command for the given container to the given
+   * datanode.
+   *
+   * @param container Container to be replicated
+   * @param datanode The destination datanode to replicate
+   * @param sources List of source nodes from where we can replicate
+   */
+  protected void sendReplicateCommand(final ContainerInfo container,
+                                    final DatanodeDetails datanode,
+                                    final List<DatanodeDetails> sources) {
+
+    LOG.info("Sending replicate container command for container {}" +
+            " to datanode {} from datanodes {}",
+        container.containerID(), datanode, sources);
+
+    final ContainerID id = container.containerID();
+    final ReplicateContainerCommand replicateCommand =
+        new ReplicateContainerCommand(id.getId(), sources);
+    inflightReplication.computeIfAbsent(id, k -> new ArrayList<>());
+    sendAndTrackDatanodeCommand(datanode, replicateCommand,
+        action -> inflightReplication.get(id).add(action));
+
+    metrics.incrNumReplicationCmdsSent();
+    metrics.incrNumReplicationBytesTotal(container.getUsedBytes());
+  }
+
+  /**
+   * Sends delete container command for the given container to the given
+   * datanode.
+   *
+   * @param container Container to be deleted
+   * @param datanode The datanode on which the replica should be deleted
+   * @param force Should be set to true to delete an OPEN replica
+   */
+  protected void sendDeleteCommand(final ContainerInfo container,
+                                 final DatanodeDetails datanode,
+                                 final boolean force) {
+
+    LOG.info("Sending delete container command for container {}" +
+        " to datanode {}", container.containerID(), datanode);
+
+    final ContainerID id = container.containerID();
+    final DeleteContainerCommand deleteCommand =
+        new DeleteContainerCommand(id.getId(), force);
+    inflightDeletion.computeIfAbsent(id, k -> new ArrayList<>());
+    sendAndTrackDatanodeCommand(datanode, deleteCommand,
+        action -> inflightDeletion.get(id).add(action));
+
+    metrics.incrNumDeletionCmdsSent();
+    metrics.incrNumDeletionBytesTotal(container.getUsedBytes());
+  }
+
+  /**
+   * Creates CommandForDatanode with the given SCMCommand and fires
+   * DATANODE_COMMAND event to event queue.
+   *
+   * Tracks the command using the given tracker.
+   *
+   * @param datanode Datanode to which the command has to be sent
+   * @param command SCMCommand to be sent
+   * @param tracker Tracker which tracks the inflight actions
+   * @param <T> Type of SCMCommand
+   */
+  private <T extends GeneratedMessage> void sendAndTrackDatanodeCommand(
+      final DatanodeDetails datanode,
+      final SCMCommand<T> command,
+      final Consumer<InflightAction> tracker) {
+    try {
+      command.setTerm(scmContext.getTermOfLeader());
+    } catch (NotLeaderException nle) {
+      LOG.warn("Skip sending datanode command,"
+          + " since current SCM is not leader.", nle);
+      return;
+    }
+    final CommandForDatanode<T> datanodeCommand =
+        new CommandForDatanode<>(datanode.getUuid(), command);
+    eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
+    tracker.accept(new InflightAction(datanode, clock.millis()));
+  }
+}
+

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MoveScheduler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MoveScheduler.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
+import org.apache.hadoop.hdds.scm.metadata.Replicate;
+import org.apache.hadoop.hdds.utils.db.Table;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * MoveScheduler schedule move options.
+ */
+public interface MoveScheduler {
+
+  /**
+   * This is used for indicating the result of move option and
+   * the corresponding reason. this is useful for tracking
+   * the result of move option
+   */
+  enum MoveResult {
+    // both replication and deletion are completed
+    COMPLETED,
+    // RM is not running
+    FAIL_NOT_RUNNING,
+    // RM is not ratis leader
+    FAIL_NOT_LEADER,
+    // replication fail because the container does not exist in src
+    REPLICATION_FAIL_NOT_EXIST_IN_SOURCE,
+    // replication fail because the container exists in target
+    REPLICATION_FAIL_EXIST_IN_TARGET,
+    // replication fail because the container is not cloesed
+    REPLICATION_FAIL_CONTAINER_NOT_CLOSED,
+    // replication fail because the container is in inflightDeletion
+    REPLICATION_FAIL_INFLIGHT_DELETION,
+    // replication fail because the container is in inflightReplication
+    REPLICATION_FAIL_INFLIGHT_REPLICATION,
+    // replication fail because of timeout
+    REPLICATION_FAIL_TIME_OUT,
+    // replication fail because of node is not in service
+    REPLICATION_FAIL_NODE_NOT_IN_SERVICE,
+    // replication fail because node is unhealthy
+    REPLICATION_FAIL_NODE_UNHEALTHY,
+    // deletion fail because of node is not in service
+    DELETION_FAIL_NODE_NOT_IN_SERVICE,
+    // replication succeed, but deletion fail because of timeout
+    DELETION_FAIL_TIME_OUT,
+    // replication succeed, but deletion fail because because
+    // node is unhealthy
+    DELETION_FAIL_NODE_UNHEALTHY,
+    // replication succeed, but if we delete the container from
+    // the source datanode , the policy(eg, replica num or
+    // rack location) will not be satisfied, so we should not delete
+    // the container
+    DELETE_FAIL_POLICY,
+    //  replicas + target - src does not satisfy placement policy
+    PLACEMENT_POLICY_NOT_SATISFIED,
+    //unexpected action, remove src at inflightReplication
+    UNEXPECTED_REMOVE_SOURCE_AT_INFLIGHT_REPLICATION,
+    //unexpected action, remove target at inflightDeletion
+    UNEXPECTED_REMOVE_TARGET_AT_INFLIGHT_DELETION,
+    //write DB error
+    FAIL_CAN_NOT_RECORD_TO_DB
+  }
+  /**
+   * completeMove a move action for a given container.
+   *
+   * @param contianerIDProto Container to which the move option is finished
+   */
+  @Replicate
+  void completeMove(HddsProtos.ContainerID contianerIDProto);
+
+  /**
+   * start a move action for a given container.
+   *
+   * @param contianerIDProto Container to move
+   * @param mp encapsulates the source and target datanode infos
+   */
+  @Replicate
+  void startMove(HddsProtos.ContainerID contianerIDProto,
+                 HddsProtos.MoveDataNodePairProto mp) throws IOException;
+
+  /**
+   * get the MoveDataNodePair of the giver container.
+   *
+   * @param cid Container to move
+   * @return null if cid is not found in MoveScheduler,
+   *          or the corresponding MoveDataNodePair
+   */
+  MoveDataNodePair getMoveDataNodePair(ContainerID cid);
+
+  /**
+   * add a completeFuture for tracking and replying move.
+   */
+  void addMoveCompleteFuture(
+      ContainerID cid, CompletableFuture<MoveResult> moveFuture);
+
+  /**
+   * complete the CompletableFuture of the container in the given Map with
+   * a given MoveResult.
+   */
+  void compleleteMoveFutureWithResult(ContainerID cid, MoveResult mr);
+
+  /**
+   * Reinitialize the MoveScheduler with DB if become leader.
+   */
+  void reinitialize(Table<ContainerID,
+      MoveDataNodePair> moveTable) throws IOException;
+
+  /**
+   * get all the inflight move info.
+   */
+  Map<ContainerID, MoveDataNodePair> getInflightMove();
+
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MoveSchedulerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/MoveSchedulerImpl.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
+import org.apache.hadoop.hdds.scm.ha.SCMHAInvocationHandler;
+import org.apache.hadoop.hdds.scm.ha.SCMRatisServer;
+import org.apache.hadoop.hdds.scm.metadata.DBTransactionBuffer;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.ratis.util.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Proxy;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.apache.hadoop.hdds.protocol.proto.SCMRatisProtocol.RequestType.MOVE;
+
+/**
+ * Ratis based MoveScheduler, db operations are stored in
+ * DBTransactionBuffer until a snapshot is taken.
+ */
+public final class MoveSchedulerImpl implements MoveScheduler {
+  public static final Logger LOG =
+      LoggerFactory.getLogger(MoveSchedulerImpl.class);
+
+  private Table<ContainerID, MoveDataNodePair> moveTable;
+  private final DBTransactionBuffer transactionBuffer;
+
+  /**
+   * This is used for tracking container move commands
+   * which are not yet complete, and reply to client when
+   * complete or failed. note that, this will not be stored
+   * in db
+   */
+  private final Map<ContainerID,
+      CompletableFuture<MoveResult>> inflightMoveFuture;
+
+  /**
+   * This is used for tracking container move commands
+   * which are not yet complete. note that, this will be stored
+   * in db.
+   */
+  private final Map<ContainerID, MoveDataNodePair> inflightMove;
+
+  private MoveSchedulerImpl(
+      Table<ContainerID, MoveDataNodePair> moveTable,
+      DBTransactionBuffer transactionBuffer) throws IOException {
+    this.moveTable = moveTable;
+    this.transactionBuffer = transactionBuffer;
+    this.inflightMove = new ConcurrentHashMap<>();
+    this.inflightMoveFuture = new ConcurrentHashMap<>();
+    initialize();
+  }
+
+  @Override
+  public void completeMove(HddsProtos.ContainerID contianerIDProto) {
+    ContainerID cid = null;
+    try {
+      cid = ContainerID.getFromProtobuf(contianerIDProto);
+      transactionBuffer.removeFromBuffer(moveTable, cid);
+    } catch (IOException e) {
+      LOG.warn("Exception while completing move {}", cid);
+    }
+    inflightMove.remove(cid);
+  }
+
+  @Override
+  public void startMove(HddsProtos.ContainerID contianerIDProto,
+                        HddsProtos.MoveDataNodePairProto mdnpp)
+      throws IOException {
+    ContainerID cid = null;
+    MoveDataNodePair mp;
+    try {
+      cid = ContainerID.getFromProtobuf(contianerIDProto);
+      mp = MoveDataNodePair.getFromProtobuf(mdnpp);
+      if (!inflightMove.containsKey(cid)) {
+        transactionBuffer.addToBuffer(moveTable, cid, mp);
+        inflightMove.putIfAbsent(cid, mp);
+      }
+    } catch (IOException e) {
+      LOG.warn("Exception while completing move {}", cid);
+    }
+  }
+
+  @Override
+  public void addMoveCompleteFuture(
+      ContainerID cid, CompletableFuture<MoveResult> moveFuture) {
+    inflightMoveFuture.putIfAbsent(cid, moveFuture);
+  }
+
+  /**
+   * complete the CompletableFuture of the container in the given Map with
+   * a given MoveResult.
+   */
+  @Override
+  public void compleleteMoveFutureWithResult(ContainerID cid, MoveResult mr) {
+    if (inflightMoveFuture.containsKey(cid)) {
+      inflightMoveFuture.get(cid).complete(mr);
+      inflightMoveFuture.remove(cid);
+    }
+  }
+
+  @Override
+  public MoveDataNodePair getMoveDataNodePair(ContainerID cid) {
+    return inflightMove.get(cid);
+  }
+
+  @Override
+  public void reinitialize(Table<ContainerID,
+      MoveDataNodePair> mt) throws IOException {
+    moveTable = mt;
+    inflightMove.clear();
+    inflightMoveFuture.clear();
+    initialize();
+  }
+
+  private void initialize() throws IOException {
+    TableIterator<ContainerID,
+        ? extends Table.KeyValue<ContainerID, MoveDataNodePair>>
+        iterator = moveTable.iterator();
+
+    while (iterator.hasNext()) {
+      Table.KeyValue<ContainerID, MoveDataNodePair> kv = iterator.next();
+      final ContainerID cid = kv.getKey();
+      final MoveDataNodePair mp = kv.getValue();
+      Preconditions.assertNotNull(cid,
+          "moved container id should not be null");
+      Preconditions.assertNotNull(mp,
+          "MoveDataNodePair container id should not be null");
+      inflightMove.put(cid, mp);
+    }
+  }
+
+  @Override
+  public Map<ContainerID, MoveDataNodePair> getInflightMove() {
+    return inflightMove;
+  }
+
+  /**
+   * Builder for Ratis based MoveSchedule.
+   */
+  public static class Builder {
+    private Table<ContainerID, MoveDataNodePair> moveTable;
+    private DBTransactionBuffer transactionBuffer;
+    private SCMRatisServer ratisServer;
+
+    public Builder setRatisServer(final SCMRatisServer scmRatisServer) {
+      ratisServer = scmRatisServer;
+      return this;
+    }
+
+    public Builder setMoveTable(
+        final Table<ContainerID, MoveDataNodePair> mt) {
+      moveTable = mt;
+      return this;
+    }
+
+    public Builder setDBTransactionBuffer(DBTransactionBuffer trxBuffer) {
+      transactionBuffer = trxBuffer;
+      return this;
+    }
+
+    public MoveScheduler build() throws IOException {
+      Preconditions.assertNotNull(moveTable, "moveTable is null");
+      Preconditions.assertNotNull(transactionBuffer,
+          "transactionBuffer is null");
+
+      final MoveScheduler impl =
+          new MoveSchedulerImpl(moveTable, transactionBuffer);
+
+      final SCMHAInvocationHandler invocationHandler
+          = new SCMHAInvocationHandler(MOVE, impl, ratisServer);
+
+      return (MoveScheduler) Proxy.newProxyInstance(
+          SCMHAInvocationHandler.class.getClassLoader(),
+          new Class<?>[]{MoveScheduler.class},
+          invocationHandler);
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -38,7 +38,6 @@ import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.MoveResult;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManagerStub;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
@@ -50,6 +49,7 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
+import org.apache.hadoop.hdds.scm.container.replication.MoveScheduler.MoveResult;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -28,16 +28,15 @@ import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.MockNodeManager;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
-import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager.MoveResult;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementPolicyFactory;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementMetrics;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
+import org.apache.hadoop.hdds.scm.container.replication.MoveScheduler.MoveResult;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
@@ -869,7 +868,7 @@ public class TestContainerBalancer {
     }
   }
 
-  private CompletableFuture<LegacyReplicationManager.MoveResult>
+  private CompletableFuture<MoveResult>
       genCompletableFuture(int sleepMilSec) {
     return CompletableFuture.supplyAsync(() -> {
       try {
@@ -877,7 +876,7 @@ public class TestContainerBalancer {
       } catch (InterruptedException e) {
         e.printStackTrace();
       }
-      return LegacyReplicationManager.MoveResult.COMPLETED;
+      return MoveResult.COMPLETED;
     });
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

1 extract moveScheduler from Legacy RM to a standalone interface and implementation.
2 add inflightActionManager to manager all the inflight actions in a standalone class.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6572

## How was this patch tested?

current RM UT
