### PR TITLE
HDDS-6708. [FSO] Make normalize keyPath on key rename request

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -89,11 +89,13 @@ public class OMKeyRenameRequest extends OMKeyRequest {
     KeyArgs renameKeyArgs = renameKeyRequest.getKeyArgs();
 
     String srcKey = renameKeyArgs.getKeyName();
-    srcKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
-        srcKey, getBucketLayout());
     String dstKey = renameKeyRequest.getToKeyName();
-    dstKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
-        dstKey, getBucketLayout());
+    if (getBucketLayout().isFileSystemOptimized()) {
+      srcKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+          srcKey, getBucketLayout());
+      dstKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+          dstKey, getBucketLayout());
+    }
 
     // Set modification time & srcKeyName.
     KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -88,12 +88,19 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
     KeyArgs renameKeyArgs = renameKeyRequest.getKeyArgs();
 
-    // Set modification time.
+    String srcKey = renameKeyArgs.getKeyName();
+    srcKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        srcKey, getBucketLayout());
+    String dstKey = renameKeyRequest.getToKeyName();
+    dstKey = validateAndNormalizeKey(ozoneManager.getEnableFileSystemPaths(),
+        dstKey, getBucketLayout());
+
+    // Set modification time & srcKeyName.
     KeyArgs.Builder newKeyArgs = renameKeyArgs.toBuilder()
-            .setModificationTime(Time.now());
+        .setModificationTime(Time.now()).setKeyName(srcKey);
 
     return getOmRequest().toBuilder()
-        .setRenameKeyRequest(renameKeyRequest.toBuilder()
+        .setRenameKeyRequest(renameKeyRequest.toBuilder().setToKeyName(dstKey)
             .setKeyArgs(newKeyArgs))
         .setUserInfo(getUserIfNotExists(ozoneManager)).build();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRenameRequestWithFSO.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.request.key;
+
+import org.apache.hadoop.ozone.OmUtils;
+import org.apache.hadoop.ozone.OzoneConsts;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.RenameKeyRequest;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.UUID;
+
+/**
+ * Tests RenameKeyWithFSO request.
+ */
+public class TestOMKeyRenameRequestWithFSO extends TestOMKeyRequest {
+
+  @Test
+  public void testPreExecuteWithUnNormalizedPath() throws Exception {
+    String toKeyName =
+        "///root" + OzoneConsts.OZONE_URI_DELIMITER +
+            OzoneConsts.OZONE_URI_DELIMITER +
+            UUID.randomUUID();
+    String fromKeyName =
+        "///root/sub-dir" + OzoneConsts.OZONE_URI_DELIMITER +
+            OzoneConsts.OZONE_URI_DELIMITER +
+            UUID.randomUUID();
+    OMRequest modifiedOmRequest =
+        doPreExecute(createRenameKeyRequest(toKeyName, fromKeyName));
+    String normalizedSrcName =
+        modifiedOmRequest.getRenameKeyRequest().getToKeyName();
+    String normalizedDstName =
+        modifiedOmRequest.getRenameKeyRequest().getKeyArgs().getKeyName();
+    String expectedSrcKeyName = OmUtils.normalizeKey(toKeyName, false);
+    String expectedDstKeyName = OmUtils.normalizeKey(fromKeyName, false);
+    Assert.assertEquals(expectedSrcKeyName, normalizedSrcName);
+    Assert.assertEquals(expectedDstKeyName, normalizedDstName);
+  }
+
+  /**
+   * Create OMRequest which encapsulates RenameKeyRequest.
+   *
+   * @return OMRequest
+   */
+  private OMRequest createRenameKeyRequest(String toKeyName,
+      String fromKeyName) {
+    KeyArgs keyArgs = KeyArgs.newBuilder().setKeyName(fromKeyName)
+        .setVolumeName(volumeName).setBucketName(bucketName).build();
+
+    RenameKeyRequest renameKeyRequest = RenameKeyRequest.newBuilder()
+        .setKeyArgs(keyArgs).setToKeyName(toKeyName).build();
+
+    return OMRequest.newBuilder()
+        .setClientId(UUID.randomUUID().toString())
+        .setRenameKeyRequest(renameKeyRequest)
+        .setCmdType(OzoneManagerProtocolProtos.Type.RenameKey).build();
+  }
+
+  private OMRequest doPreExecute(OMRequest originalOmRequest) throws Exception {
+    OMKeyRenameRequest omKeyRenameRequest =
+        new OMKeyRenameRequest(originalOmRequest, getBucketLayout());
+
+    OMRequest modifiedOmRequest = omKeyRenameRequest.preExecute(ozoneManager);
+
+    // Will not be equal, as UserInfo will be set and modification time is
+    // set in KeyArgs.
+    Assert.assertNotEquals(originalOmRequest, modifiedOmRequest);
+
+    Assert.assertTrue(modifiedOmRequest.getRenameKeyRequest()
+        .getKeyArgs().getModificationTime() > 0);
+
+    return modifiedOmRequest;
+  }
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+}

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicOzoneFileSystem.java
@@ -328,7 +328,9 @@ public class BasicOzoneFileSystem extends FileSystem {
     }
 
     if (adapter.isFSOptimizedBucket()) {
-      return renameFSO(srcPath, dstPath);
+      String srcKey = pathToKey(src);
+      String dstKey = pathToKey(dst);
+      return renameFSO(srcKey, dstKey);
     }
 
     // Check if the source exists


### PR DESCRIPTION
## What changes were proposed in this pull request?

Path normalization missed in o3fs#renameKeyWithFSO, which will result in extra "/" in OM operations especially checkACLs logic.

Fix: Convert #pathToKey() on ozone client and perform #validateAndNormalizeKey() at OM RenameRequest.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6708

## How was this patch tested?

Added UT.
