### PR TITLE
HDDS-6703. Disable failing testPrepareDownedOM until Ratis upgrade

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.ozone.test.LambdaTestUtils;
 import org.apache.ozone.test.tag.Slow;
+import org.apache.ratis.util.ExitUtils;
 import org.junit.Assert;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.BeforeEach;
@@ -162,6 +163,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
     // it missed once it receives the prepare transaction.
     cluster.restartOzoneManager(downedOM, true);
     runningOms.add(shutdownOMIndex, downedOM);
+    ExitUtils.assertNotTerminated();
 
     // Make sure all OMs are prepared and still have data.
     assertClusterPrepared(prepareIndex, runningOms);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerPrepare.java
@@ -52,6 +52,7 @@ import org.apache.ratis.util.ExitUtils;
 import org.junit.Assert;
 import org.apache.ozone.test.tag.Flaky;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -132,6 +133,7 @@ public class TestOzoneManagerPrepare extends TestOzoneManagerHA {
    * @throws Exception
    */
   @Test
+  @Disabled("RATIS-1481") // until upgrade to Ratis 2.3.0
   public void testPrepareDownedOM() throws Exception {
     // Index of the OM that will be shut down during this test.
     final int shutdownOMIndex = 2;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3297,6 +3297,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (canProceed) {
       // Stop RPC server before stop metadataManager
       omRpcServer.stop();
+      omRpcServer.join();
       isOmRpcServerRunning = false;
       omRpcServerStopped = true;
       LOG.info("RPC server is stopped. Spend " +

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -3297,7 +3297,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     if (canProceed) {
       // Stop RPC server before stop metadataManager
       omRpcServer.stop();
-      omRpcServer.join();
       isOmRpcServerRunning = false;
       omRpcServerStopped = true;
       LOG.info("RPC server is stopped. Spend " +


### PR DESCRIPTION
## What changes were proposed in this pull request?

HDDS-6685 changed install snapshot logic in OM, restarting various OM components during the process.  However, it does not wait for OM RPC server to stop, leading to intermittent `BindException` a bit later during start.

```
2022-05-05 13:41:05,653 [pool-2368-thread-1] ERROR om.OzoneManager (ExitUtils.java:terminate(133)) - Terminating with exit status 1: Failed to start RPC Server.
java.net.BindException: Problem binding to [localhost:39581] java.net.BindException: Address already in use; For more details see:  http://wiki.apache.org/hadoop/BindException
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.hadoop.net.NetUtils.wrapWithMessage(NetUtils.java:913)
	at org.apache.hadoop.net.NetUtils.wrapException(NetUtils.java:809)
	at org.apache.hadoop.ipc.Server.bind(Server.java:640)
	at org.apache.hadoop.ipc.Server$Listener.<init>(Server.java:1225)
	at org.apache.hadoop.ipc.Server.<init>(Server.java:3117)
	at org.apache.hadoop.ipc.RPC$Server.<init>(RPC.java:1062)
	at org.apache.hadoop.ipc.ProtobufRpcEngine2$Server.<init>(ProtobufRpcEngine2.java:464)
	at org.apache.hadoop.ipc.ProtobufRpcEngine$Server.<init>(ProtobufRpcEngine.java:434)
	at org.apache.hadoop.ipc.ProtobufRpcEngine.getServer(ProtobufRpcEngine.java:361)
	at org.apache.hadoop.ipc.RPC$Builder.build(RPC.java:853)
	at org.apache.hadoop.ozone.om.OzoneManager.startRpcServer(OzoneManager.java:1084)
	at org.apache.hadoop.ozone.om.OzoneManager.getRpcServer(OzoneManager.java:1054)
	at org.apache.hadoop.ozone.om.OzoneManager.installCheckpoint(OzoneManager.java:3366)
	at org.apache.hadoop.ozone.om.OzoneManager.installCheckpoint(OzoneManager.java:3254)
	at org.apache.hadoop.ozone.om.OzoneManager.installSnapshotFromLeader(OzoneManager.java:3231)
```

Note that `TestOzoneManagerPrepare` may still fail at a later step, but not due to `BindException`.

https://issues.apache.org/jira/browse/HDDS-6703

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/6308878370