### PR TITLE
HDDS-6710. EC: Add EC pipeline minimum to MiniOzoneCluster

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneCluster.java
@@ -297,6 +297,7 @@ public interface MiniOzoneCluster {
     protected static final int ACTIVE_OMS_NOT_SET = -1;
     protected static final int ACTIVE_SCMS_NOT_SET = -1;
     protected static final int DEFAULT_PIPELINE_LIMIT = 3;
+    protected static final int DEFAULT_EC_PIPELINE_MINIMUM = 3;
     protected static final int DEFAULT_RATIS_RPC_TIMEOUT_SEC = 1;
 
     protected OzoneConfiguration conf;
@@ -340,6 +341,7 @@ public interface MiniOzoneCluster {
     protected boolean  startDataNodes = true;
     protected CertificateClient certClient;
     protected int pipelineNumLimit = DEFAULT_PIPELINE_LIMIT;
+    protected int ecPipelineMinimum = DEFAULT_EC_PIPELINE_MINIMUM;
 
     protected Builder(OzoneConfiguration conf) {
       this.conf = conf;
@@ -462,6 +464,16 @@ public interface MiniOzoneCluster {
      */
     public Builder setTotalPipelineNumLimit(int val) {
       pipelineNumLimit = val;
+      return this;
+    }
+
+    /**
+     * Sets the minimum number of pipelines for each EC replication config.
+     * @param val number of pipelines
+     * @return MiniOzoneCluster.Builder
+     */
+    public Builder setECPipelineMinimum(int val) {
+      ecPipelineMinimum = val;
       return this;
     }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hdds.scm.ha.SCMRatisServerImpl;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
+import org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.WritableECContainerProviderConfig;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.proxy.SCMClientConfig;
 import org.apache.hadoop.hdds.scm.proxy.SCMContainerLocationFailoverProxyProvider;
@@ -687,6 +688,10 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
       conf.setInt(ScmConfigKeys.OZONE_SCM_RATIS_PIPELINE_LIMIT,
           pipelineNumLimit >= DEFAULT_PIPELINE_LIMIT ?
               pipelineNumLimit : DEFAULT_PIPELINE_LIMIT);
+      WritableECContainerProviderConfig writableECContainerProviderConfig =
+          conf.getObject(WritableECContainerProviderConfig.class);
+      writableECContainerProviderConfig.setMinimumPipelines(ecPipelineMinimum);
+      conf.setFromObject(writableECContainerProviderConfig);
       conf.setTimeDuration(OMConfigKeys.OZONE_OM_RATIS_MINIMUM_TIMEOUT_KEY,
           DEFAULT_RATIS_RPC_TIMEOUT_SEC, TimeUnit.SECONDS);
       SCMClientConfig scmClientConfig = conf.getObject(SCMClientConfig.class);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added `MiniOzoneCluster#setECPipelineMinimum()` to change the `ozone.scm.ec.pipeline.minimum` config.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6710

## How was this patch tested?

Integration test in other (developing) branch has verified this config is effective.
(By creating a MiniOzoneCluster and write some EC keys to it, then check the number of containers created.)