### PR TITLE
HDDS-6715. Avoid using GrpcClientProtocolService.LOG

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestRatisPipelineLeader.java
@@ -34,9 +34,6 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.tag.Flaky;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.DFS_RATIS_LEADER_ELECTION_MINIMUM_TIMEOUT_DURATION_KEY;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
-import org.apache.ratis.grpc.client.GrpcClientProtocolService;
 import org.apache.ratis.protocol.ClientId;
 import org.apache.ratis.protocol.GroupInfoReply;
 import org.apache.ratis.protocol.GroupInfoRequest;
@@ -46,7 +43,9 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
 
 /**
  * Test pipeline leader information is correctly used.
@@ -55,7 +54,7 @@ import org.slf4j.LoggerFactory;
 public class TestRatisPipelineLeader {
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
-  private static final org.slf4j.Logger LOG =
+  private static final Logger LOG =
       LoggerFactory.getLogger(TestRatisPipelineLeader.class);
 
   @BeforeAll
@@ -97,9 +96,11 @@ public class TestRatisPipelineLeader {
     // Verify client connects to Leader without NotLeaderException
     XceiverClientRatis xceiverClientRatis =
         XceiverClientRatis.newXceiverClientRatis(ratisPipeline, conf);
-    Logger.getLogger(GrpcClientProtocolService.class).setLevel(Level.DEBUG);
+    final Logger log = LoggerFactory.getLogger(
+        "org.apache.ratis.grpc.server.GrpcClientProtocolService");
+    GenericTestUtils.setLogLevel(log, Level.DEBUG);
     GenericTestUtils.LogCapturer logCapturer =
-        GenericTestUtils.LogCapturer.captureLogs(GrpcClientProtocolService.LOG);
+        GenericTestUtils.LogCapturer.captureLogs(log);
     xceiverClientRatis.connect();
     ContainerProtocolCalls.createContainer(xceiverClientRatis, 1L, null);
     logCapturer.stopCapturing();


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1497 moved `GrpcClientProtocolService` to a different package and made its `LOG` private.  This breaks `TestRatisPipelineLeader`.  HDDS-6461 addressed this while upgrading to a Ratis snapshot (on feature branch).

This PR only cherry-picks the compatibility change without the version bump.

(cherry-picks commit eaef7eabc7df6e9e0ff0f7acefd4afcdc73918e3)

Note: I think this should be merged manually using Git CLI, to preserve author information.

https://issues.apache.org/jira/browse/HDDS-6715

## How was this patch tested?

```
$ mvn -DfailIfNoTests=false -Dtest=TestRatisPipelineLeader clean test
...
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 72.781 s - in org.apache.hadoop.hdds.scm.TestRatisPipelineLeader
```