### PR TITLE
HDDS-6716. Adopt RATIS-1560

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/FollowerAppendLogEntryGenerator.java
@@ -336,7 +336,7 @@ public class FollowerAppendLogEntryGenerator extends BaseAppendLogGenerator
             .build());
     RaftClient client = RaftClient.newBuilder()
         .setClientId(clientId)
-        .setProperties(new RaftProperties(true))
+        .setProperties(new RaftProperties())
         .setRaftGroup(group)
         .build();
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/LeaderAppendLogEntryGenerator.java
@@ -265,7 +265,7 @@ public class LeaderAppendLogEntryGenerator extends BaseAppendLogGenerator
             .build());
     RaftClient client = RaftClient.newBuilder()
         .setClientId(clientId)
-        .setProperties(new RaftProperties(true))
+        .setProperties(new RaftProperties())
         .setRaftGroup(group)
         .build();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

RATIS-1560 removed the `RaftProperties(boolean)` constructor (while cleaning up XML-related code for security).

This PR prepares for upgrade to upcoming Ratis 2.3.0.

https://issues.apache.org/jira/browse/HDDS-6716

## How was this patch tested?

Compiled Ozone.

https://github.com/adoroszlai/hadoop-ozone/runs/6354676594