### PR TITLE
HDDS-6719. Verify build from source release tarball in CI

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -99,12 +99,20 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       - name: Run a full build
-        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist
+        run: hadoop-ozone/dev-support/checks/build.sh -Pcoverage -Pdist -Psrc
       - name: Store binaries for tests
         uses: actions/upload-artifact@v2
         with:
           name: ozone-bin
-          path: hadoop-ozone/dist/target/ozone*.tar.gz
+          path: |
+            hadoop-ozone/dist/target/ozone-*.tar.gz
+            !hadoop-ozone/dist/target/ozone-*-src.tar.gz
+          retention-days: 1
+      - name: Store source tarball for compilation
+        uses: actions/upload-artifact@v2
+        with:
+          name: ozone-src
+          path: hadoop-ozone/dist/target/ozone-*-src.tar.gz
           retention-days: 1
       - name: Delete temporary build artifacts before caching
         run: |
@@ -115,6 +123,7 @@ jobs:
   compile:
     needs:
       - build-info
+      - build
     runs-on: ubuntu-18.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-compile == 'true'
@@ -123,8 +132,13 @@ jobs:
         java: [ 11 ]
       fail-fast: false
     steps:
-      - name: Checkout project
-        uses: actions/checkout@v2
+      - name: Download Ozone source tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: ozone-src
+      - name: Untar sources
+        run: |
+          tar --strip-components 1 -xzvf ozone*-src.tar.gz
       - name: Cache for maven dependencies
         uses: actions/cache@v2
         with:

--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -97,7 +97,7 @@ load bats-assert/load.bash
   run dev-support/ci/selective_ci_checks.sh 9aebf6e25
 
   assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","unit"]'
-  assert_output -p needs-build=false
+  assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false
@@ -121,7 +121,7 @@ load bats-assert/load.bash
   run dev-support/ci/selective_ci_checks.sh 1dd1d0ba3
 
   assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","unit"]'
-  assert_output -p needs-build=false
+  assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false
@@ -133,7 +133,7 @@ load bats-assert/load.bash
   run dev-support/ci/selective_ci_checks.sh 88383d1d5
 
   assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs","unit"]'
-  assert_output -p needs-build=false
+  assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false
@@ -145,7 +145,7 @@ load bats-assert/load.bash
   run dev-support/ci/selective_ci_checks.sh 61396ba9f
 
   assert_output -p 'basic-checks=["rat","author","checkstyle","findbugs"]'
-  assert_output -p needs-build=false
+  assert_output -p needs-build=true
   assert_output -p needs-compile=true
   assert_output -p needs-compose-tests=false
   assert_output -p needs-dependency-check=false

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -521,12 +521,14 @@ function set_outputs() {
     initialization::ga_output basic-checks \
         "$(initialization::parameters_to_json ${BASIC_CHECKS})"
 
-    if [[ "${compose_tests_needed}" == "true" ]] || [[ "${kubernetes_tests_needed}" == "true" ]]; then
+    : ${compile_needed:=false}
+
+    if [[ "${compile_needed}" == "true" ]] ||  [[ "${compose_tests_needed}" == "true" ]] || [[ "${kubernetes_tests_needed}" == "true" ]]; then
         build_needed=true
     fi
 
     initialization::ga_output needs-build "${build_needed:-false}"
-    initialization::ga_output needs-compile "${compile_needed:-false}"
+    initialization::ga_output needs-compile "${compile_needed}"
     initialization::ga_output needs-compose-tests "${compose_tests_needed}"
     initialization::ga_output needs-dependency-check "${dependency_check_needed}"
     initialization::ga_output needs-integration-tests "${integration_tests_needed}"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change _compile_ check to work against source tarball created by _build_ check to ensure the contents of the tarball can be compiled.  The goal is to catch changes that become a problem only at release time.

https://issues.apache.org/jira/browse/HDDS-6719

## How was this patch tested?

Regular CI:

1. _build_ check uploaded source tarball: https://github.com/adoroszlai/hadoop-ozone/runs/6355813051#step:8:19
2. _compile_ check used it instead of git repo: https://github.com/adoroszlai/hadoop-ozone/runs/6356144283#step:3:1
3. checks using binary tarball still work fine: https://github.com/adoroszlai/hadoop-ozone/runs/6356144521