### PR TITLE
HDDS-6723. Close Rocks objects properly in OzoneManager

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBSstFileWriter.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBSstFileWriter.java
@@ -37,10 +37,11 @@ public class RDBSstFileWriter implements DumpFileWriter, Closeable {
   private SstFileWriter sstFileWriter;
   private File sstFile;
   private AtomicLong keyCounter;
+  private Options emptyOption = new Options();
 
   public RDBSstFileWriter() {
     EnvOptions envOptions = new EnvOptions();
-    this.sstFileWriter = new SstFileWriter(envOptions, new Options());
+    this.sstFileWriter = new SstFileWriter(envOptions, emptyOption);
     this.keyCounter = new AtomicLong(0);
   }
 
@@ -83,6 +84,7 @@ public class RDBSstFileWriter implements DumpFileWriter, Closeable {
       } finally {
         sstFileWriter.close();
         sstFileWriter = null;
+        emptyOption.close();
       }
 
       keyCounter.set(0);

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RocksDatabase.java
@@ -73,12 +73,11 @@ public final class RocksDatabase {
    * Read DB and return existing column families.
    *
    * @return a list of column families.
-   * @see RocksDB#listColumnFamilies(Options, String)
    */
   private static List<TableConfig> getColumnFamilies(File file)
       throws RocksDBException {
-    final List<TableConfig> columnFamilies = RocksDB.listColumnFamilies(
-            new Options(), file.getAbsolutePath())
+    final List<TableConfig> columnFamilies = listColumnFamiliesEmptyOptions(
+        file.getAbsolutePath())
         .stream()
         .map(TableConfig::newTableConfig)
         .collect(Collectors.toList());
@@ -86,6 +85,21 @@ public final class RocksDatabase {
       LOG.debug("Found column families in DB {}: {}", file, columnFamilies);
     }
     return columnFamilies;
+  }
+
+  /**
+   * Read DB column families without Options.
+   * @param path
+   * @return A list of column family names
+   * @throws RocksDBException
+   *
+   * @see RocksDB#listColumnFamilies(Options, String)
+   */
+  public static List<byte[]> listColumnFamiliesEmptyOptions(final String path)
+      throws RocksDBException {
+    try (Options emptyOptions = new Options()) {
+      return RocksDB.listColumnFamilies(emptyOptions, path);
+    }
   }
 
   static RocksDatabase open(File dbFile, DBOptions dbOptions,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2439,7 +2439,7 @@ public class KeyManagerImpl implements KeyManager {
           break;
         }
         fileInfo.setFileName(fileInfo.getKeyName());
-        String fullKeyPath =OMFileRequest.getAbsolutePath(
+        String fullKeyPath = OMFileRequest.getAbsolutePath(
             parentInfo.getKeyName(), fileInfo.getKeyName());
         fileInfo.setKeyName(fullKeyPath);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1550,7 +1550,7 @@ public class KeyManagerImpl implements KeyManager {
         bucketName);
     Table<String, OmKeyInfo> keyTable = metadataManager
         .getKeyTable(getBucketLayout(metadataManager, volName, buckName));
-    try(TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
         iterator = getIteratorForKeyInTableCache(recursive, startKey,
         volumeName, bucketName, cacheKeyMap, keyArgs, keyTable)) {
       findKeyInDbWithIterator(recursive, startKey, numEntries, volumeName,
@@ -1585,7 +1585,8 @@ public class KeyManagerImpl implements KeyManager {
     return fileStatusList;
   }
 
-  private TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>> getIteratorForKeyInTableCache(
+  private TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+      getIteratorForKeyInTableCache(
       boolean recursive, String startKey, String volumeName, String bucketName,
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,
       Table<String, OmKeyInfo> keyTable) {
@@ -1608,6 +1609,7 @@ public class KeyManagerImpl implements KeyManager {
     return iterator;
   }
 
+  @SuppressWarnings("parameternumber")
   private void findKeyInDbWithIterator(boolean recursive, String startKey,
       long numEntries, String volumeName, String bucketName, String keyName,
       TreeMap<String, OzoneFileStatus> cacheKeyMap, String keyArgs,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1752,7 +1752,8 @@ public class KeyManagerImpl implements KeyManager {
         metadataManager.getLock()
             .acquireReadLock(BUCKET_LOCK, volumeName, bucketName);
         try {
-          BucketLayout bucketLayout = getBucketLayout(metadataManager, volumeName, bucketName);
+          BucketLayout bucketLayout = getBucketLayout(
+              metadataManager, volumeName, bucketName);
           iterator = metadataManager.getKeyTable(bucketLayout).iterator();
           countEntries =
               getFilesAndDirsFromCacheWithBucket(volumeName, bucketName,
@@ -1766,7 +1767,8 @@ public class KeyManagerImpl implements KeyManager {
         }
         countEntries =
             getFilesFromDirectory(cacheFileMap, seekFileInDB, prefixPath,
-                prefixKeyInDB, countEntries, numEntries, deletedKeySet, iterator);
+                prefixKeyInDB, countEntries, numEntries, deletedKeySet,
+                iterator);
 
       } else {
         /*
@@ -1850,8 +1852,8 @@ public class KeyManagerImpl implements KeyManager {
                   .iterator();
               countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
                   bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
-                  prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
-                  countEntries, numEntries);
+                  prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath,
+                  startKey, countEntries, numEntries);
             } finally {
               metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
                   bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -2007,9 +2007,25 @@ public class KeyManagerImpl implements KeyManager {
       throws IOException {
 
     Table dirTable = metadataManager.getDirectoryTable();
-    TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
-            iterator = dirTable.iterator();
+    try (TableIterator<String,
+        ? extends Table.KeyValue<String, OmDirectoryInfo>>
+            iterator = dirTable.iterator()) {
 
+      return getDirectoriesWithIterator(cacheKeyMap, seekDirInDB, prefixPath,
+          prefixKeyInDB, countEntries, numEntries, recursive, volumeName,
+          bucketName, deletedKeySet, iterator);
+    }
+  }
+
+  @SuppressWarnings("parameternumber")
+  private int getDirectoriesWithIterator(
+      TreeMap<String, OzoneFileStatus> cacheKeyMap, String seekDirInDB,
+      String prefixPath, long prefixKeyInDB, int countEntries, long numEntries,
+      boolean recursive, String volumeName, String bucketName,
+      Set<String> deletedKeySet,
+      TableIterator<String,
+          ? extends Table.KeyValue<String, OmDirectoryInfo>> iterator)
+      throws IOException {
     iterator.seek(seekDirInDB);
 
     while (iterator.hasNext() && numEntries - countEntries > 0) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1713,162 +1713,167 @@ public class KeyManagerImpl implements KeyManager {
     TreeMap<String, OzoneFileStatus> tempCacheDirMap = new TreeMap<>();
 
     TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-        iterator;
+        iterator = null;
 
-    if (Strings.isNullOrEmpty(startKey)) {
-      OzoneFileStatus fileStatus = getFileStatus(args, clientAddress);
-      if (fileStatus.isFile()) {
-        return Collections.singletonList(fileStatus);
-      }
-
-      // Not required to search in DeletedTable because all the deleted
-      // keys will be marked directly in dirTable or in keyTable by
-      // breaking the pointer to its sub-dirs and sub-files. So, there is no
-      // issue of inconsistency.
-
-      /*
-       * keyName is a directory.
-       * Say, "/a" is the dir name and its objectID is 1024, then seek
-       * will be doing with "1024/" to get all immediate descendants.
-       */
-      if (fileStatus.getKeyInfo() != null) {
-        prefixKeyInDB = fileStatus.getKeyInfo().getObjectID();
-      } else {
-        // list root directory.
-        prefixKeyInDB = bucketId;
-      }
-      seekFileInDB = metadataManager.getOzonePathKey(
-              volumeId, bucketId, prefixKeyInDB, "");
-      seekDirInDB = metadataManager.getOzonePathKey(
-              volumeId, bucketId, prefixKeyInDB, "");
-
-      // Order of seek ->
-      // (1)Seek files in fileTable
-      // (2)Seek dirs in dirTable
-
-
-      // First under lock obtain both entries from dir/file cache and generate
-      // entries marked for delete.
-      metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-          bucketName);
-      try {
-        BucketLayout bucketLayout =
-            getBucketLayout(metadataManager, volumeName, bucketName);
-        iterator = metadataManager.getKeyTable(bucketLayout).iterator();
-        countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
-            bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
-            prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
-            countEntries, numEntries);
-
-      } finally {
-        metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-            bucketName);
-      }
-      countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-          prefixPath, prefixKeyInDB, countEntries, numEntries, deletedKeySet,
-          iterator);
-
-    } else {
-      /*
-       * startKey will be used in iterator seek and sets the beginning point
-       * for key traversal.
-       * keyName will be used as parentID where the user has requested to
-       * list the keys from.
-       *
-       * When recursive flag=false, parentID won't change between two pages.
-       * For example: OM has a namespace like,
-       *    /a/1...1M files and /a/b/1...1M files.
-       *    /a/1...1M directories and /a/b/1...1M directories.
-       * Listing "/a", will always have the parentID as "a" irrespective of
-       * the startKey value.
-       */
-
-      // Check startKey is an immediate child of keyName. For example,
-      // keyName=/a/ and expected startKey=/a/b. startKey can't be /xyz/b.
-      if (StringUtils.isNotBlank(keyName) &&
-          !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
-              "Returns empty list", startKey, keyName);
+    try {
+      if (Strings.isNullOrEmpty(startKey)) {
+        OzoneFileStatus fileStatus = getFileStatus(args, clientAddress);
+        if (fileStatus.isFile()) {
+          return Collections.singletonList(fileStatus);
         }
-        return Collections.emptyList();
-      }
 
-      // assign startKeyPath if prefixPath is empty string.
-      if (StringUtils.isBlank(prefixPath)) {
-        prefixPath = OzoneFSUtils.getParentDir(startKey);
-      }
+        // Not required to search in DeletedTable because all the deleted
+        // keys will be marked directly in dirTable or in keyTable by
+        // breaking the pointer to its sub-dirs and sub-files. So, there is no
+        // issue of inconsistency.
 
-      OmKeyArgs startKeyArgs = args.toBuilder()
-          .setKeyName(startKey)
-          .setSortDatanodesInPipeline(false)
-          .build();
-      OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(startKeyArgs,
-          null, true);
-
-      if (fileStatusInfo != null) {
-        prefixKeyInDB = fileStatusInfo.getKeyInfo().getParentObjectID();
-
-        if (fileStatusInfo.isDirectory()) {
-          seekDirInDB = metadataManager.getOzonePathKey(
-                  volumeId, bucketId, prefixKeyInDB,
-              fileStatusInfo.getKeyInfo().getFileName());
-
-          // Order of seek -> (1) Seek dirs only in dirTable. In OM, always
-          // the order of search is, first seek into fileTable and then
-          // dirTable. So, its not required to search again in the fileTable.
-
-          // Seek the given key in dirTable.
-          metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-          try {
-            listStatusFindDirsInTableCache(tempCacheDirMap,
-                metadataManager.getDirectoryTable(),
-                prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
-                bucketName, countEntries, numEntries, deletedKeySet);
-          } finally {
-            metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-          }
-
+        /*
+         * keyName is a directory.
+         * Say, "/a" is the dir name and its objectID is 1024, then seek
+         * will be doing with "1024/" to get all immediate descendants.
+         */
+        if (fileStatus.getKeyInfo() != null) {
+          prefixKeyInDB = fileStatus.getKeyInfo().getObjectID();
         } else {
-          seekFileInDB = metadataManager.getOzonePathKey(
-                  volumeId, bucketId, prefixKeyInDB,
-              fileStatusInfo.getKeyInfo().getFileName());
-          // begins from the first sub-dir under the parent dir
-          seekDirInDB = metadataManager.getOzonePathKey(
-                  volumeId, bucketId, prefixKeyInDB, "");
-
-          // First under lock obtain both entries from dir/file cache and
-          // generate entries marked for delete.
-          metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
-              bucketName);
-          try {
-            BucketLayout bucketLayout =
-                getBucketLayout(metadataManager, volumeName, bucketName);
-            iterator = metadataManager.getKeyTable(bucketLayout)
-                .iterator();
-            countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
-                bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
-                prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
-                countEntries, numEntries);
-          } finally {
-            metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
-                bucketName);
-          }
-
-          // 1. Seek the given key in key table.
-          countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
-              prefixPath, prefixKeyInDB, countEntries, numEntries,
-              deletedKeySet, iterator);
+          // list root directory.
+          prefixKeyInDB = bucketId;
         }
+        seekFileInDB = metadataManager.getOzonePathKey(
+            volumeId, bucketId, prefixKeyInDB, "");
+        seekDirInDB = metadataManager.getOzonePathKey(
+            volumeId, bucketId, prefixKeyInDB, "");
+
+        // Order of seek ->
+        // (1)Seek files in fileTable
+        // (2)Seek dirs in dirTable
+
+        // First under lock obtain both entries from dir/file cache and generate
+        // entries marked for delete.
+        metadataManager.getLock()
+            .acquireReadLock(BUCKET_LOCK, volumeName, bucketName);
+        try {
+          BucketLayout bucketLayout = getBucketLayout(metadataManager, volumeName, bucketName);
+          iterator = metadataManager.getKeyTable(bucketLayout).iterator();
+          countEntries =
+              getFilesAndDirsFromCacheWithBucket(volumeName, bucketName,
+                  cacheFileMap, tempCacheDirMap, deletedKeySet, prefixKeyInDB,
+                  seekFileInDB, seekDirInDB, prefixPath, startKey, countEntries,
+                  numEntries);
+
+        } finally {
+          metadataManager.getLock()
+              .releaseReadLock(BUCKET_LOCK, volumeName, bucketName);
+        }
+        countEntries =
+            getFilesFromDirectory(cacheFileMap, seekFileInDB, prefixPath,
+                prefixKeyInDB, countEntries, numEntries, deletedKeySet, iterator);
+
       } else {
-        // TODO: HDDS-4364: startKey can be a non-existed key
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("StartKey {} is a non-existed key and returning empty " +
-                    "list", startKey);
+        /*
+         * startKey will be used in iterator seek and sets the beginning point
+         * for key traversal.
+         * keyName will be used as parentID where the user has requested to
+         * list the keys from.
+         *
+         * When recursive flag=false, parentID won't change between two pages.
+         * For example: OM has a namespace like,
+         *    /a/1...1M files and /a/b/1...1M files.
+         *    /a/1...1M directories and /a/b/1...1M directories.
+         * Listing "/a", will always have the parentID as "a" irrespective of
+         * the startKey value.
+         */
+
+        // Check startKey is an immediate child of keyName. For example,
+        // keyName=/a/ and expected startKey=/a/b. startKey can't be /xyz/b.
+        if (StringUtils.isNotBlank(keyName) && !OzoneFSUtils
+            .isImmediateChild(keyName, startKey)) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("StartKey {} is not an immediate child of keyName {}. "
+                + "Returns empty list", startKey, keyName);
+          }
+          return Collections.emptyList();
         }
-        return Collections.emptyList();
+
+        // assign startKeyPath if prefixPath is empty string.
+        if (StringUtils.isBlank(prefixPath)) {
+          prefixPath = OzoneFSUtils.getParentDir(startKey);
+        }
+
+        OmKeyArgs startKeyArgs = args.toBuilder()
+            .setKeyName(startKey)
+            .setSortDatanodesInPipeline(false)
+            .build();
+        OzoneFileStatus fileStatusInfo = getOzoneFileStatusFSO(startKeyArgs,
+            null, true);
+
+        if (fileStatusInfo != null) {
+          prefixKeyInDB = fileStatusInfo.getKeyInfo().getParentObjectID();
+
+          if (fileStatusInfo.isDirectory()) {
+            seekDirInDB = metadataManager.getOzonePathKey(
+                volumeId, bucketId, prefixKeyInDB,
+                fileStatusInfo.getKeyInfo().getFileName());
+
+            // Order of seek -> (1) Seek dirs only in dirTable. In OM, always
+            // the order of search is, first seek into fileTable and then
+            // dirTable. So, its not required to search again in the fileTable.
+
+            // Seek the given key in dirTable.
+            metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+                bucketName);
+            try {
+              listStatusFindDirsInTableCache(tempCacheDirMap,
+                  metadataManager.getDirectoryTable(),
+                  prefixKeyInDB, seekDirInDB, prefixPath, startKey, volumeName,
+                  bucketName, countEntries, numEntries, deletedKeySet);
+            } finally {
+              metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+                  bucketName);
+            }
+
+          } else {
+            seekFileInDB = metadataManager.getOzonePathKey(
+                volumeId, bucketId, prefixKeyInDB,
+                fileStatusInfo.getKeyInfo().getFileName());
+            // begins from the first sub-dir under the parent dir
+            seekDirInDB = metadataManager.getOzonePathKey(
+                volumeId, bucketId, prefixKeyInDB, "");
+
+            // First under lock obtain both entries from dir/file cache and
+            // generate entries marked for delete.
+            metadataManager.getLock().acquireReadLock(BUCKET_LOCK, volumeName,
+                bucketName);
+            try {
+              BucketLayout bucketLayout =
+                  getBucketLayout(metadataManager, volumeName, bucketName);
+              iterator = metadataManager.getKeyTable(bucketLayout)
+                  .iterator();
+              countEntries = getFilesAndDirsFromCacheWithBucket(volumeName,
+                  bucketName, cacheFileMap, tempCacheDirMap, deletedKeySet,
+                  prefixKeyInDB, seekFileInDB, seekDirInDB, prefixPath, startKey,
+                  countEntries, numEntries);
+            } finally {
+              metadataManager.getLock().releaseReadLock(BUCKET_LOCK, volumeName,
+                  bucketName);
+            }
+
+            // 1. Seek the given key in key table.
+            countEntries = getFilesFromDirectory(cacheFileMap, seekFileInDB,
+                prefixPath, prefixKeyInDB, countEntries, numEntries,
+                deletedKeySet, iterator);
+          }
+        } else {
+          // TODO: HDDS-4364: startKey can be a non-existed key
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("StartKey {} is a non-existed key and returning empty "
+                + "list", startKey);
+          }
+          return Collections.emptyList();
+        }
+      }
+    } finally {
+      if (iterator != null) {
+        iterator.close();
       }
     }
 
@@ -2421,25 +2426,26 @@ public class KeyManagerImpl implements KeyManager {
     long countEntries = 0;
 
     Table fileTable = metadataManager.getFileTable();
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-        iterator = fileTable.iterator();
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+        iterator = fileTable.iterator()) {
 
-    iterator.seek(seekFileInDB);
+      iterator.seek(seekFileInDB);
 
-    while (iterator.hasNext() && numEntries - countEntries > 0) {
-      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
-      OmKeyInfo fileInfo = entry.getValue();
-      if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
-          parentInfo.getObjectID())) {
-        break;
+      while (iterator.hasNext() && numEntries - countEntries > 0) {
+        Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
+        OmKeyInfo fileInfo = entry.getValue();
+        if (!OMFileRequest.isImmediateChild(fileInfo.getParentObjectID(),
+            parentInfo.getObjectID())) {
+          break;
+        }
+        fileInfo.setFileName(fileInfo.getKeyName());
+        String fullKeyPath =OMFileRequest.getAbsolutePath(
+            parentInfo.getKeyName(), fileInfo.getKeyName());
+        fileInfo.setKeyName(fullKeyPath);
+
+        files.add(fileInfo);
+        countEntries++;
       }
-      fileInfo.setFileName(fileInfo.getKeyName());
-      String fullKeyPath = OMFileRequest.getAbsolutePath(
-          parentInfo.getKeyName(), fileInfo.getKeyName());
-      fileInfo.setKeyName(fullKeyPath);
-
-      files.add(fileInfo);
-      countEntries++;
     }
 
     return files;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -902,7 +902,8 @@ public final class OMFileRequest {
     // Check dirTable entries for any sub paths.
     String seekDirInDB = metaMgr.getOzonePathKey(volumeId, bucketId,
             omKeyInfo.getObjectID(), "");
-    try (TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
+    try (TableIterator<String, ? extends
+        Table.KeyValue<String, OmDirectoryInfo>>
             iterator = dirTable.iterator()) {
 
       iterator.seek(seekDirInDB);
@@ -910,7 +911,8 @@ public final class OMFileRequest {
       if (iterator.hasNext()) {
         Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
         OmDirectoryInfo dirInfo = entry.getValue();
-        return isImmediateChild(dirInfo.getParentObjectID(), omKeyInfo.getObjectID());
+        return isImmediateChild(dirInfo.getParentObjectID(),
+            omKeyInfo.getObjectID());
       }
 
     }
@@ -955,7 +957,8 @@ public final class OMFileRequest {
       if (iterator.hasNext()) {
         Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
         OmKeyInfo fileInfo = entry.getValue();
-        return isImmediateChild(fileInfo.getParentObjectID(), omKeyInfo.getObjectID()); // found a sub path file
+        return isImmediateChild(fileInfo.getParentObjectID(),
+            omKeyInfo.getObjectID()); // found a sub path file
       }
     }
     return false; // no sub paths found

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -902,16 +902,17 @@ public final class OMFileRequest {
     // Check dirTable entries for any sub paths.
     String seekDirInDB = metaMgr.getOzonePathKey(volumeId, bucketId,
             omKeyInfo.getObjectID(), "");
-    TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
-            iterator = dirTable.iterator();
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmDirectoryInfo>>
+            iterator = dirTable.iterator()) {
 
-    iterator.seek(seekDirInDB);
+      iterator.seek(seekDirInDB);
 
-    if (iterator.hasNext()) {
-      Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
-      OmDirectoryInfo dirInfo = entry.getValue();
-      return isImmediateChild(dirInfo.getParentObjectID(),
-              omKeyInfo.getObjectID());
+      if (iterator.hasNext()) {
+        Table.KeyValue<String, OmDirectoryInfo> entry = iterator.next();
+        OmDirectoryInfo dirInfo = entry.getValue();
+        return isImmediateChild(dirInfo.getParentObjectID(), omKeyInfo.getObjectID());
+      }
+
     }
     return false; // no sub paths found
   }
@@ -946,16 +947,16 @@ public final class OMFileRequest {
     // Check fileTable entries for any sub paths.
     String seekFileInDB = metaMgr.getOzonePathKey(volumeId, bucketId,
             omKeyInfo.getObjectID(), "");
-    TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
-            iterator = fileTable.iterator();
+    try (TableIterator<String, ? extends Table.KeyValue<String, OmKeyInfo>>
+            iterator = fileTable.iterator()) {
 
-    iterator.seek(seekFileInDB);
+      iterator.seek(seekFileInDB);
 
-    if (iterator.hasNext()) {
-      Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
-      OmKeyInfo fileInfo = entry.getValue();
-      return isImmediateChild(fileInfo.getParentObjectID(),
-              omKeyInfo.getObjectID()); // found a sub path file
+      if (iterator.hasNext()) {
+        Table.KeyValue<String, OmKeyInfo> entry = iterator.next();
+        OmKeyInfo fileInfo = entry.getValue();
+        return isImmediateChild(fileInfo.getParentObjectID(), omKeyInfo.getObjectID()); // found a sub path file
+      }
     }
     return false; // no sub paths found
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Callable;
 
 import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
+import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.kohsuke.MetaInfServices;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
@@ -45,8 +46,8 @@ public class ListTables implements Callable<Void>, SubcommandWithParent {
 
   @Override
   public Void call() throws Exception {
-    List<byte[]> columnFamilies = RocksDB.listColumnFamilies(new Options(),
-            parent.getDbPath());
+    List<byte[]> columnFamilies = RocksDatabase.listColumnFamiliesEmptyOptions(
+        parent.getDbPath());
     for (byte[] b : columnFamilies) {
       System.out.println(new String(b, StandardCharsets.UTF_8));
     }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/ListTables.java
@@ -26,8 +26,6 @@ import org.apache.hadoop.hdds.cli.SubcommandWithParent;
 
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.kohsuke.MetaInfServices;
-import org.rocksdb.Options;
-import org.rocksdb.RocksDB;
 import picocli.CommandLine;
 
 /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RocksDBUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RocksDBUtils.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.ozone.debug;
 
 import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.rocksdb.ColumnFamilyDescriptor;
-import org.rocksdb.Options;
-import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
 import java.util.ArrayList;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RocksDBUtils.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/debug/RocksDBUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.debug;
 
+import org.apache.hadoop.hdds.utils.db.RocksDatabase;
 import org.rocksdb.ColumnFamilyDescriptor;
 import org.rocksdb.Options;
 import org.rocksdb.RocksDB;
@@ -38,7 +39,7 @@ public final class RocksDBUtils {
   public static List<ColumnFamilyDescriptor> getColumnFamilyDescriptors(
       String dbPath) throws RocksDBException {
     List<ColumnFamilyDescriptor> cfs = new ArrayList<>();
-    List<byte[]> cfList = RocksDB.listColumnFamilies(new Options(), dbPath);
+    List<byte[]> cfList = RocksDatabase.listColumnFamiliesEmptyOptions(dbPath);
     if (cfList != null) {
       for (byte[] b : cfList) {
         cfs.add(new ColumnFamilyDescriptor(b));


### PR DESCRIPTION
Change-Id: I5e2f906508d92c1c21555aa51d9b5c97744f26cd
(cherry picked from commit c1cda1d8e99555282b991f174d0bf597c0deb950)

## What changes were proposed in this pull request?

Close RocksDB objects when they are not used.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6723

## How was this patch tested?

This is tested in an internal branch, ran a few workloads.
The RocksDB jar was replaced with a custom build which prints memory leak in stdout. This is the code: https://github.com/jojochuang/rocksdb/commits/debug_memory_leak

With this change, most of the leaks are now gone, except during OM initialization when load DB. Didn't care much about them as they account for very little memory usage.