### PR TITLE
HDDS-6728. SCM UI not showing correct HA roles

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.ratis.RatisHelper;
 import org.apache.hadoop.hdds.scm.AddSCMRequest;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
-import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.util.Time;
@@ -260,12 +259,8 @@ public class SCMRatisServerImpl implements SCMRatisServer {
         LOG.error("SCM Ratis PeerInetAddress {} is unresolvable",
             peer.getAddress());
       }
-      boolean isLocal = false;
-      if (peerInetAddress != null) {
-        isLocal = NetUtils.isLocalAddress(peerInetAddress);
-      }
       ratisRoles.add((peer.getAddress() == null ? "" :
-              peer.getAddress().concat(isLocal ?
+          peer.getAddress().concat(peer == getLeader() ?
                   ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
                   ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))
                   .concat(":".concat(peer.getId().toString()))
@@ -353,4 +348,14 @@ public class SCMRatisServerImpl implements SCMRatisServer {
         UUID.fromString(clusterId.replace(OzoneConsts.CLUSTER_ID_PREFIX, "")));
   }
 
+  private RaftPeer getLeader() {
+    if (division.getInfo().isLeader()) {
+      return division.getPeer();
+    } else {
+      ByteString leaderId = division.getInfo().getRoleInfoProto()
+          .getFollowerInfo().getLeaderInfo().getId().getId();
+      return leaderId.isEmpty() ? null :
+          division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
+    }
+  }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java
@@ -249,6 +249,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
   @Override
   public List<String> getRatisRoles() throws IOException {
     Collection<RaftPeer> peers = division.getGroup().getPeers();
+    RaftPeer leader = getLeader();
     List<String> ratisRoles = new ArrayList<>();
     for (RaftPeer peer : peers) {
       InetAddress peerInetAddress = null;
@@ -260,7 +261,7 @@ public class SCMRatisServerImpl implements SCMRatisServer {
             peer.getAddress());
       }
       ratisRoles.add((peer.getAddress() == null ? "" :
-          peer.getAddress().concat(peer == getLeader() ?
+          peer.getAddress().concat(peer.equals(leader) ?
                   ":".concat(RaftProtos.RaftPeerRole.LEADER.toString()) :
                   ":".concat(RaftProtos.RaftPeerRole.FOLLOWER.toString()))
                   .concat(":".concat(peer.getId().toString()))

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestStorageContainerManagerHA.java
@@ -45,7 +45,9 @@ import org.junit.Test;
 
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -250,5 +252,17 @@ public class TestStorageContainerManagerHA {
     conf2.setBoolean(ScmConfigKeys.OZONE_SCM_SKIP_BOOTSTRAP_VALIDATION_KEY,
         true);
     Assert.assertTrue(StorageContainerManager.scmBootstrap(conf2));
+  }
+
+  @Test
+  public void testGetRatisRolesDetail() throws IOException {
+    Set<String> resultSet = new HashSet<>();
+    for (StorageContainerManager scm: cluster.getStorageContainerManagers()) {
+      resultSet.addAll(scm.getScmHAManager().getRatisServer().getRatisRoles());
+    }
+    System.out.println(resultSet);
+    Assert.assertEquals(3, resultSet.size());
+    Assert.assertEquals(1,
+        resultSet.stream().filter(x -> x.contains("LEADER")).count());
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current logic to decide the LEADER of SCM is to check if the RaftPeer is local, https://github.com/apache/ozone/blob/master/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMRatisServerImpl.java#L268

I assuem this is because the "scm roles" requests are forwarded to the LEADER SCM, so the invoker is always the leader, thus "isLocal" is used to decide which SCM is LEADER.

But in SCM UI, the "SCM HA (roles)" information are retrived by invoking "getRatisRoles" by each SCM, not forwarded to the LEADER SCM, thus each SCM will consider itself as the LEADER in UI.

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6728

## How was this patch tested?

unit test.
