### PR TITLE
HDDS-6730. Migrate tests in hdds-tools to JUnit5

### DIFF
--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java
@@ -31,10 +31,10 @@ import org.apache.log4j.AppenderSkeleton;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.spi.LoggingEvent;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
@@ -62,7 +62,7 @@ public class TestInfoSubCommand {
   private Logger logger;
   private TestAppender appender;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     scmClient = mock(ScmClient.class);
     datanodes = createDatanodeDetails(3);
@@ -75,7 +75,7 @@ public class TestInfoSubCommand {
     logger.addAppender(appender);
   }
 
-  @After
+  @AfterEach
   public void after() {
     logger.removeAppender(appender);
   }
@@ -105,20 +105,20 @@ public class TestInfoSubCommand {
     List<LoggingEvent> replica = logs.stream()
         .filter(m -> m.getRenderedMessage().matches("(?s)^Replicas:.*"))
         .collect(Collectors.toList());
-    Assert.assertEquals(1, replica.size());
+    Assertions.assertEquals(1, replica.size());
 
     // Ensure each DN UUID is mentioned in the message:
     for (DatanodeDetails dn : datanodes) {
       Pattern pattern = Pattern.compile(".*" + dn.getUuid().toString() + ".*",
           Pattern.DOTALL);
       Matcher matcher = pattern.matcher(replica.get(0).getRenderedMessage());
-      Assert.assertTrue(matcher.matches());
+      Assertions.assertTrue(matcher.matches());
     }
     // Ensure ReplicaIndex is not mentioned as it was not passed in the proto:
     Pattern pattern = Pattern.compile(".*ReplicaIndex.*",
         Pattern.DOTALL);
     Matcher matcher = pattern.matcher(replica.get(0).getRenderedMessage());
-    Assert.assertEquals(includeIndex, matcher.matches());
+    Assertions.assertEquals(includeIndex, matcher.matches());
   }
 
   @Test
@@ -135,14 +135,14 @@ public class TestInfoSubCommand {
     List<LoggingEvent> replica = logs.stream()
         .filter(m -> m.getRenderedMessage().matches("(?s)^Replicas:.*"))
         .collect(Collectors.toList());
-    Assert.assertEquals(0, replica.size());
+    Assertions.assertEquals(0, replica.size());
 
     // Ensure we have an error logged:
     List<LoggingEvent> error = logs.stream()
         .filter(m -> m.getLevel() == Level.ERROR)
         .collect(Collectors.toList());
-    Assert.assertEquals(1, error.size());
-    Assert.assertTrue(error.get(0).getRenderedMessage()
+    Assertions.assertEquals(1, error.size());
+    Assertions.assertTrue(error.get(0).getRenderedMessage()
         .matches("(?s)^Unable to retrieve the replica details.*"));
   }
 
@@ -156,13 +156,13 @@ public class TestInfoSubCommand {
     cmd.execute(scmClient);
 
     List<LoggingEvent> logs = appender.getLog();
-    Assert.assertEquals(2, logs.size());
+    Assertions.assertEquals(2, logs.size());
     String error = logs.get(0).getRenderedMessage();
     String json = logs.get(1).getRenderedMessage();
 
-    Assert.assertTrue(error
+    Assertions.assertTrue(error
         .matches("(?s)^Unable to retrieve the replica details.*"));
-    Assert.assertFalse(json.matches("(?s).*replicas.*"));
+    Assertions.assertFalse(json.matches("(?s).*replicas.*"));
   }
 
   @Test
@@ -188,21 +188,21 @@ public class TestInfoSubCommand {
     cmd.execute(scmClient);
 
     List<LoggingEvent> logs = appender.getLog();
-    Assert.assertEquals(1, logs.size());
+    Assertions.assertEquals(1, logs.size());
 
     // Ensure each DN UUID is mentioned in the message after replicas:
     String json = logs.get(0).getRenderedMessage();
-    Assert.assertTrue(json.matches("(?s).*replicas.*"));
+    Assertions.assertTrue(json.matches("(?s).*replicas.*"));
     for (DatanodeDetails dn : datanodes) {
       Pattern pattern = Pattern.compile(
           ".*replicas.*" + dn.getUuid().toString() + ".*", Pattern.DOTALL);
       Matcher matcher = pattern.matcher(json);
-      Assert.assertTrue(matcher.matches());
+      Assertions.assertTrue(matcher.matches());
     }
     Pattern pattern = Pattern.compile(".*replicaIndex.*",
         Pattern.DOTALL);
     Matcher matcher = pattern.matcher(json);
-    Assert.assertTrue(matcher.matches());
+    Assertions.assertTrue(matcher.matches());
   }
 
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
@@ -23,10 +23,10 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -54,14 +53,14 @@ public class TestReportSubCommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new ReportSubcommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -79,7 +78,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": 0$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
     }
 
     for (ReplicationManagerReport.HealthState state :
@@ -87,7 +86,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": 0$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
     }
   }
 
@@ -106,9 +105,9 @@ public class TestReportSubCommand {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(outContent.toString("UTF-8"));
 
-    Assert.assertTrue(json.get("reportTimeStamp") != null);
-    Assert.assertTrue(json.get("stats") != null);
-    Assert.assertTrue(json.get("samples") != null);
+    Assertions.assertNotNull(json.get("reportTimeStamp"));
+    Assertions.assertNotNull(json.get("stats"));
+    Assertions.assertNotNull(json.get("samples"));
   }
 
   @Test
@@ -124,7 +123,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": " + counter + "$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
       counter++;
     }
 
@@ -134,14 +133,14 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": " + counter + "$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
 
       // Check the correct samples are returned
       p = Pattern.compile(
           "^First 100 " + state + " containers:\n"
               + containerList(0, counter) + "$", Pattern.MULTILINE);
       m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
       counter++;
     }
   }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -38,6 +37,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -78,7 +79,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": 0$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
     }
 
     for (ReplicationManagerReport.HealthState state :
@@ -86,7 +87,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": 0$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
     }
   }
 
@@ -105,9 +106,9 @@ public class TestReportSubCommand {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(outContent.toString("UTF-8"));
 
-    Assertions.assertNotNull(json.get("reportTimeStamp"));
-    Assertions.assertNotNull(json.get("stats"));
-    Assertions.assertNotNull(json.get("samples"));
+    assertNotNull(json.get("reportTimeStamp"));
+    assertNotNull(json.get("stats"));
+    assertNotNull(json.get("samples"));
   }
 
   @Test
@@ -123,7 +124,7 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": " + counter + "$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
       counter++;
     }
 
@@ -133,14 +134,14 @@ public class TestReportSubCommand {
       Pattern p = Pattern.compile(
           "^" + state.toString() + ": " + counter + "$", Pattern.MULTILINE);
       Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
 
       // Check the correct samples are returned
       p = Pattern.compile(
           "^First 100 " + state + " containers:\n"
               + containerList(0, counter) + "$", Pattern.MULTILINE);
       m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
       counter++;
     }
   }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -22,9 +22,10 @@ import org.apache.hadoop.hdds.scm.cli.ContainerBalancerStopSubcommand;
 import org.apache.hadoop.hdds.scm.cli.ContainerBalancerStartSubcommand;
 import org.apache.hadoop.hdds.scm.cli.ContainerBalancerStatusSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayOutputStream;
@@ -35,11 +36,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
- * Unit tests to validate the the ContainerBalancerSubCommand class includes the
+ * Unit tests to validate the ContainerBalancerSubCommand class includes the
  * correct output when executed against a mock client.
  */
 public class TestContainerBalancerSubCommand {
@@ -53,7 +53,7 @@ public class TestContainerBalancerSubCommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     stopCmd = new ContainerBalancerStopSubcommand();
     startCmd = new ContainerBalancerStartSubcommand();
@@ -62,7 +62,7 @@ public class TestContainerBalancerSubCommand {
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -82,7 +82,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sRunning.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sNot\\sRunning.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class TestContainerBalancerSubCommand {
 
     Pattern p = Pattern.compile("^Stopping\\sContainerBalancer...");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -127,7 +127,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile("^Container\\sBalancer\\sstarted" +
         "\\ssuccessfully.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class TestContainerBalancerSubCommand {
         "\\sBalancer.");
 
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.scm.cli.ContainerBalancerStartSubcommand;
 import org.apache.hadoop.hdds.scm.cli.ContainerBalancerStatusSubcommand;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -36,6 +35,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -82,7 +82,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sRunning.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -98,7 +98,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile(
         "^ContainerBalancer\\sis\\sNot\\sRunning.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -108,7 +108,7 @@ public class TestContainerBalancerSubCommand {
 
     Pattern p = Pattern.compile("^Stopping\\sContainerBalancer...");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -127,7 +127,7 @@ public class TestContainerBalancerSubCommand {
     Pattern p = Pattern.compile("^Container\\sBalancer\\sstarted" +
         "\\ssuccessfully.");
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -147,7 +147,7 @@ public class TestContainerBalancerSubCommand {
         "\\sBalancer.");
 
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
@@ -19,9 +19,10 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,13 +36,11 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 
 /**
- * Unit tests to validate the the DecommissionSubCommand class includes the
+ * Unit tests to validate the DecommissionSubCommand class includes the
  * correct output when executed against a mock client.
  */
 public class TestDecommissionSubCommand {
@@ -53,14 +52,14 @@ public class TestDecommissionSubCommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new DecommissionSubCommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -79,15 +78,15 @@ public class TestDecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -104,7 +103,7 @@ public class TestDecommissionSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      fail("Should not succeed without an exception");
+      Assertions.fail("Should not succeed without an exception");
     } catch (IOException e) {
        // Expected
     }
@@ -112,19 +111,19 @@ public class TestDecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 
@@ -78,15 +79,15 @@ public class TestDecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -103,7 +104,7 @@ public class TestDecommissionSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      Assertions.fail("Should not succeed without an exception");
+      fail("Should not succeed without an exception");
     } catch (IOException e) {
        // Expected
     }
@@ -111,19 +112,19 @@ public class TestDecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\sdecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mockito.Mockito;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.any;
 
@@ -82,17 +82,17 @@ public class TestListInfoSubcommand {
     Pattern p = Pattern.compile(
         "^Operational State:\\s+IN_SERVICE$", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
     // Should also have a node with the state DECOMMISSIONING
     p = Pattern.compile(
         "^Operational State:\\s+DECOMMISSIONING$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
     for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
       p = Pattern.compile(
           "^Health State:\\s+" + state + "$", Pattern.MULTILINE);
       m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      Assertions.assertTrue(m.find());
+      assertTrue(m.find());
     }
     // Ensure the nodes are ordered by health state HEALTHY,
     // HEALTHY_READONLY, STALE, DEAD
@@ -100,7 +100,7 @@ public class TestListInfoSubcommand {
         Pattern.DOTALL);
 
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   private List<HddsProtos.Node> getNodeDetails() {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
@@ -19,9 +19,10 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
@@ -34,12 +35,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.any;
 
 /**
- * Unit tests to validate the the TestListInfoSubCommand class includes the
+ * Unit tests to validate the TestListInfoSubCommand class includes the
  * correct output when executed against a mock client.
  */
 public class TestListInfoSubcommand {
@@ -51,14 +51,14 @@ public class TestListInfoSubcommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new ListInfoSubcommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -82,17 +82,17 @@ public class TestListInfoSubcommand {
     Pattern p = Pattern.compile(
         "^Operational State:\\s+IN_SERVICE$", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
     // Should also have a node with the state DECOMMISSIONING
     p = Pattern.compile(
         "^Operational State:\\s+DECOMMISSIONING$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
     for (HddsProtos.NodeState state : HddsProtos.NodeState.values()) {
       p = Pattern.compile(
           "^Health State:\\s+" + state + "$", Pattern.MULTILINE);
       m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-      assertTrue(m.find());
+      Assertions.assertTrue(m.find());
     }
     // Ensure the nodes are ordered by health state HEALTHY,
     // HEALTHY_READONLY, STALE, DEAD
@@ -100,7 +100,7 @@ public class TestListInfoSubcommand {
         Pattern.DOTALL);
 
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   private List<HddsProtos.Node> getNodeDetails() {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
@@ -81,15 +82,15 @@ public class TestMaintenanceSubCommand {
         "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
         Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -107,7 +108,7 @@ public class TestMaintenanceSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      Assertions.fail("Should not succeed without an exception");
+      fail("Should not succeed without an exception");
     } catch (IOException e) {
       // Expected
     }
@@ -116,19 +117,19 @@ public class TestMaintenanceSubCommand {
         "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
         Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
@@ -19,9 +19,10 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,14 +36,12 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 
 /**
- * Unit tests to validate the the DecommissionSubCommand class includes the
+ * Unit tests to validate the DecommissionSubCommand class includes the
  * correct output when executed against a mock client.
  */
 public class TestMaintenanceSubCommand {
@@ -54,14 +53,14 @@ public class TestMaintenanceSubCommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new MaintenanceSubCommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -82,15 +81,15 @@ public class TestMaintenanceSubCommand {
         "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
         Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -108,7 +107,7 @@ public class TestMaintenanceSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      fail("Should not succeed without an exception");
+      Assertions.fail("Should not succeed without an exception");
     } catch (IOException e) {
       // Expected
     }
@@ -117,19 +116,19 @@ public class TestMaintenanceSubCommand {
         "^Entering\\smaintenance\\smode\\son\\sdatanode\\(s\\)",
         Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +35,8 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 
@@ -78,15 +79,15 @@ public class TestRecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
   @Test
@@ -103,7 +104,7 @@ public class TestRecommissionSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      Assertions.fail("Should not succeed without an exception");
+      fail("Should not succeed without an exception");
     } catch (IOException e) {
       // Expected
     }
@@ -111,19 +112,19 @@ public class TestRecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    Assertions.assertTrue(m.find());
+    assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
@@ -19,9 +19,10 @@ package org.apache.hadoop.hdds.scm.cli.datanode;
 
 import org.apache.hadoop.hdds.scm.DatanodeAdminError;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -35,8 +36,6 @@ import java.util.regex.Pattern;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.mock;
 
@@ -53,14 +52,14 @@ public class TestRecommissionSubCommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new RecommissionSubCommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -79,15 +78,15 @@ public class TestRecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
   @Test
@@ -104,7 +103,7 @@ public class TestRecommissionSubCommand {
     c.parseArgs("host1", "host2");
     try {
       cmd.execute(scmClient);
-      fail("Should not succeed without an exception");
+      Assertions.fail("Should not succeed without an exception");
     } catch (IOException e) {
       // Expected
     }
@@ -112,19 +111,19 @@ public class TestRecommissionSubCommand {
     Pattern p = Pattern.compile(
         "^Started\\srecommissioning\\sdatanode\\(s\\)", Pattern.MULTILINE);
     Matcher m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host1$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^host2$", Pattern.MULTILINE);
     m = p.matcher(outContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
 
     p = Pattern.compile("^Error: host1: host1 error$", Pattern.MULTILINE);
     m = p.matcher(errContent.toString(DEFAULT_ENCODING));
-    assertTrue(m.find());
+    Assertions.assertTrue(m.find());
   }
 
 }

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestUsageInfoSubcommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestUsageInfoSubcommand.java
@@ -22,10 +22,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
@@ -52,14 +52,14 @@ public class TestUsageInfoSubcommand {
   private final PrintStream originalErr = System.err;
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
 
-  @Before
+  @BeforeEach
   public void setup() throws UnsupportedEncodingException {
     cmd = new UsageInfoSubcommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -79,18 +79,18 @@ public class TestUsageInfoSubcommand {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(outContent.toString("UTF-8"));
 
-    Assert.assertEquals(ARRAY, json.getNodeType());
-    Assert.assertTrue(json.get(0).get("datanodeDetails") != null);
-    Assert.assertEquals(10, json.get(0).get("ozoneUsed").longValue());
-    Assert.assertEquals(100, json.get(0).get("capacity").longValue());
-    Assert.assertEquals(80, json.get(0).get("remaining").longValue());
-    Assert.assertEquals(20, json.get(0).get("totalUsed").longValue());
+    Assertions.assertEquals(ARRAY, json.getNodeType());
+    Assertions.assertNotNull(json.get(0).get("datanodeDetails"));
+    Assertions.assertEquals(10, json.get(0).get("ozoneUsed").longValue());
+    Assertions.assertEquals(100, json.get(0).get("capacity").longValue());
+    Assertions.assertEquals(80, json.get(0).get("remaining").longValue());
+    Assertions.assertEquals(20, json.get(0).get("totalUsed").longValue());
 
-    Assert.assertEquals(20.00,
+    Assertions.assertEquals(20.00,
         json.get(0).get("totalUsedPercent").doubleValue(), 0.001);
-    Assert.assertEquals(10.00,
+    Assertions.assertEquals(10.00,
         json.get(0).get("ozoneUsedPercent").doubleValue(), 0.001);
-    Assert.assertEquals(80.00,
+    Assertions.assertEquals(80.00,
         json.get(0).get("remainingPercent").doubleValue(), 0.001);
   }
 

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import picocli.CommandLine;
 
@@ -58,7 +58,7 @@ public class TestListPipelinesSubCommand {
   private static final String DEFAULT_ENCODING = StandardCharsets.UTF_8.name();
   private ScmClient scmClient;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     cmd = new ListPipelinesSubcommand();
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
@@ -69,7 +69,7 @@ public class TestListPipelinesSubCommand {
         .thenAnswer(invocation -> createPipelines());
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     System.setOut(originalOut);
     System.setErr(originalErr);
@@ -80,7 +80,7 @@ public class TestListPipelinesSubCommand {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs();
     cmd.execute(scmClient);
-    Assert.assertEquals(6, outContent.toString(DEFAULT_ENCODING)
+    Assertions.assertEquals(6, outContent.toString(DEFAULT_ENCODING)
         .split(System.getProperty("line.separator")).length);
   }
 
@@ -90,16 +90,17 @@ public class TestListPipelinesSubCommand {
     c.parseArgs("-s", "OPEN");
     cmd.execute(scmClient);
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(3, output.split(
+    Assertions.assertEquals(3, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testExceptionIfReplicationWithoutType() throws IOException {
+  @Test
+  public void testExceptionIfReplicationWithoutType() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE");
-    cmd.execute(scmClient);
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> cmd.execute(scmClient));
   }
 
   @Test
@@ -109,9 +110,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -121,9 +122,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(2, output.split(
+    Assertions.assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -133,16 +134,17 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(2, output.split(
+    Assertions.assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void factorAndReplicationAreMutuallyExclusive() throws IOException {
+  @Test
+  public void factorAndReplicationAreMutuallyExclusive() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE", "-ffc", "ONE");
-    cmd.execute(scmClient);
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> cmd.execute(scmClient));
   }
 
   @Test
@@ -152,9 +154,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1,
+    Assertions.assertEquals(-1,
         output.indexOf("ReplicationConfig: RATIS"));
   }
 
@@ -165,10 +167,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("CLOSED"));
-    Assert.assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -178,10 +180,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assert.assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assert.assertEquals(-1, output.indexOf("CLOSED"));
-    Assert.assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   private List<Pipeline> createPipelines() {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,8 +43,6 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -81,7 +80,7 @@ public class TestListPipelinesSubCommand {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs();
     cmd.execute(scmClient);
-    assertEquals(6, outContent.toString(DEFAULT_ENCODING)
+    Assertions.assertEquals(6, outContent.toString(DEFAULT_ENCODING)
         .split(System.getProperty("line.separator")).length);
   }
 
@@ -91,16 +90,17 @@ public class TestListPipelinesSubCommand {
     c.parseArgs("-s", "OPEN");
     cmd.execute(scmClient);
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(3, output.split(
+    Assertions.assertEquals(3, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
   }
 
   @Test
   public void testExceptionIfReplicationWithoutType() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE");
-    assertThrows(IllegalArgumentException.class, () -> cmd.execute(scmClient));
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> cmd.execute(scmClient));
   }
 
   @Test
@@ -110,9 +110,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -122,9 +122,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(2, output.split(
+    Assertions.assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -134,16 +134,16 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(2, output.split(
+    Assertions.assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
   public void factorAndReplicationAreMutuallyExclusive() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE", "-ffc", "ONE");
-    assertThrows(IllegalArgumentException.class,
+    Assertions.assertThrows(IllegalArgumentException.class,
         () -> cmd.execute(scmClient));
   }
 
@@ -154,9 +154,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1,
+    Assertions.assertEquals(-1,
         output.indexOf("ReplicationConfig: RATIS"));
   }
 
@@ -167,10 +167,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("CLOSED"));
-    assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -180,10 +180,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    assertEquals(1, output.split(
+    Assertions.assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    assertEquals(-1, output.indexOf("CLOSED"));
-    assertEquals(-1, output.indexOf("EC"));
+    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
+    Assertions.assertEquals(-1, output.indexOf("EC"));
   }
 
   private List<Pipeline> createPipelines() {

--- a/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
+++ b/hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
@@ -27,7 +27,6 @@ import org.apache.hadoop.hdds.scm.client.ScmClient;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -43,6 +42,8 @@ import java.util.UUID;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -80,7 +81,7 @@ public class TestListPipelinesSubCommand {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs();
     cmd.execute(scmClient);
-    Assertions.assertEquals(6, outContent.toString(DEFAULT_ENCODING)
+    assertEquals(6, outContent.toString(DEFAULT_ENCODING)
         .split(System.getProperty("line.separator")).length);
   }
 
@@ -90,17 +91,16 @@ public class TestListPipelinesSubCommand {
     c.parseArgs("-s", "OPEN");
     cmd.execute(scmClient);
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(3, output.split(
+    assertEquals(3, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
+    assertEquals(-1, output.indexOf("CLOSED"));
   }
 
   @Test
   public void testExceptionIfReplicationWithoutType() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE");
-    Assertions.assertThrows(IllegalArgumentException.class,
-        () -> cmd.execute(scmClient));
+    assertThrows(IllegalArgumentException.class, () -> cmd.execute(scmClient));
   }
 
   @Test
@@ -110,9 +110,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(1, output.split(
+    assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("EC"));
+    assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -122,9 +122,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(2, output.split(
+    assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("EC"));
+    assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -134,16 +134,16 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(2, output.split(
+    assertEquals(2, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("EC"));
+    assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
   public void factorAndReplicationAreMutuallyExclusive() {
     CommandLine c = new CommandLine(cmd);
     c.parseArgs("-r", "THREE", "-ffc", "ONE");
-    Assertions.assertThrows(IllegalArgumentException.class,
+    assertThrows(IllegalArgumentException.class,
         () -> cmd.execute(scmClient));
   }
 
@@ -154,9 +154,9 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(1, output.split(
+    assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1,
+    assertEquals(-1,
         output.indexOf("ReplicationConfig: RATIS"));
   }
 
@@ -167,10 +167,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(1, output.split(
+    assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
-    Assertions.assertEquals(-1, output.indexOf("EC"));
+    assertEquals(-1, output.indexOf("CLOSED"));
+    assertEquals(-1, output.indexOf("EC"));
   }
 
   @Test
@@ -180,10 +180,10 @@ public class TestListPipelinesSubCommand {
     cmd.execute(scmClient);
 
     String output = outContent.toString(DEFAULT_ENCODING);
-    Assertions.assertEquals(1, output.split(
+    assertEquals(1, output.split(
         System.getProperty("line.separator")).length);
-    Assertions.assertEquals(-1, output.indexOf("CLOSED"));
-    Assertions.assertEquals(-1, output.indexOf("EC"));
+    assertEquals(-1, output.indexOf("CLOSED"));
+    assertEquals(-1, output.indexOf("EC"));
   }
 
   private List<Pipeline> createPipelines() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate tests in hdds-tools to JUnit5.

1. Substitute JUnit4 api with JUnit5 api.
2. ~~Replace static imports of assertions.~~
3. Do some minor cleanup (such as replacing `assertTrue` with `assertEquals` when possible).

Tests migrated:

```
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/pipeline/TestListPipelinesSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestContainerBalancerSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestRecommissionSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestUsageInfoSubcommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestDecommissionSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestMaintenanceSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/datanode/TestListInfoSubcommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestReportSubCommand.java
./hadoop-hdds/tools/src/test/java/org/apache/hadoop/hdds/scm/cli/container/TestInfoSubCommand.java 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6730

## How was this patch tested?

Verified the migrated tests were executed:
https://github.com/kaijchen/ozone/runs/6387042561?check_suite_focus=true#step:5:1330

Full CI
https://github.com/kaijchen/ozone/actions/runs/2306714519