### PR TITLE
HDDS-6650. S3MultipartUpload support update bucket usedNamespace.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -48,6 +48,10 @@ Wait Til Date Past
     ${sleepSeconds} =   Subtract Date From Date  ${date}  ${latestDate}
     Run Keyword If      ${sleepSeconds} > 0      Sleep  ${sleepSeconds}
 
+Set bucket
+    ${var} =    Set Variable    legacy/source-bucket
+    [Return]    ${var}
+
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878
 ${BUCKET}             generated
@@ -103,14 +107,19 @@ Test Multipart Upload Complete
     ${result} =         Execute AWSS3APICli     upload-part --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 2 --body /tmp/part2 --upload-id ${uploadID}
     ${eTag2} =          Execute and checkrc     echo '${result}' | jq -r '.ETag'   0
                         Should contain          ${result}    ETag
-    ${result} =         Execute                 ozone sh bucket info ${PREFIX} | jq .usedNamespace
-                        Should Be Equal         ${result}       1
+
 #complete multipart upload
+    ${testBucket} =     Run Keyword if          '${BUCKET}' == 'link'    Set bucket
+    ...                 ELSE                    Set Variable    s3v/${BUCKET}
+    ${result} =         Execute                 ozone sh bucket info ${testBucket} | jq .usedNamespace
+    ${namespace1} =     Evaluate    ${result} + 1
     ${result} =         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'
                         Should contain          ${result}    ${BUCKET}
                         Should contain          ${result}    ${PREFIX}/multipartKey1
                         Should contain          ${result}    ETag
-
+    ${result} =         Execute                 ozone sh bucket info ${testBucket} | jq .usedNamespace
+    ${namespace2} =	    Convert To Integer	    ${result}
+                        Should Be Equal         ${namespace2}       ${namespace1}
 
 #read file and check the key
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 /tmp/${PREFIX}-multipartKey1.result

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -48,10 +48,6 @@ Wait Til Date Past
     ${sleepSeconds} =   Subtract Date From Date  ${date}  ${latestDate}
     Run Keyword If      ${sleepSeconds} > 0      Sleep  ${sleepSeconds}
 
-Set bucket
-    ${var} =    Set Variable    legacy/source-bucket
-    [Return]    ${var}
-
 *** Variables ***
 ${ENDPOINT_URL}       http://s3g:9878
 ${BUCKET}             generated
@@ -107,19 +103,14 @@ Test Multipart Upload Complete
     ${result} =         Execute AWSS3APICli     upload-part --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 2 --body /tmp/part2 --upload-id ${uploadID}
     ${eTag2} =          Execute and checkrc     echo '${result}' | jq -r '.ETag'   0
                         Should contain          ${result}    ETag
-
+    ${result} =         Execute                 ozone sh bucket info ${PREFIX} | jq .usedNamespace
+                        Should Be Equal         ${result}       1
 #complete multipart upload
-    ${testBucket} =     Run Keyword if          '${BUCKET}' == 'link'    Set bucket
-    ...                 ELSE                    Set Variable    s3v/${BUCKET}
-    ${result} =         Execute                 ozone sh bucket info ${testBucket} | jq .usedNamespace
-    ${namespace1} =     Evaluate    ${result} + 1
     ${result} =         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'
                         Should contain          ${result}    ${BUCKET}
                         Should contain          ${result}    ${PREFIX}/multipartKey1
                         Should contain          ${result}    ETag
-    ${result} =         Execute                 ozone sh bucket info ${testBucket} | jq .usedNamespace
-    ${namespace2} =	    Convert To Integer	    ${result}
-                        Should Be Equal         ${namespace2}       ${namespace1}
+
 
 #read file and check the key
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 /tmp/${PREFIX}-multipartKey1.result

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -103,14 +103,12 @@ Test Multipart Upload Complete
     ${result} =         Execute AWSS3APICli     upload-part --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 2 --body /tmp/part2 --upload-id ${uploadID}
     ${eTag2} =          Execute and checkrc     echo '${result}' | jq -r '.ETag'   0
                         Should contain          ${result}    ETag
-    ${result} =         Execute                 ozone sh bucket info ${PREFIX} | jq .usedNamespace
-                        Should Be Equal         ${result}       1
+
 #complete multipart upload
     ${result} =         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'
                         Should contain          ${result}    ${BUCKET}
                         Should contain          ${result}    ${PREFIX}/multipartKey1
                         Should contain          ${result}    ETag
-
 
 #read file and check the key
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 /tmp/${PREFIX}-multipartKey1.result

--- a/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/MultipartUpload.robot
@@ -103,12 +103,14 @@ Test Multipart Upload Complete
     ${result} =         Execute AWSS3APICli     upload-part --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --part-number 2 --body /tmp/part2 --upload-id ${uploadID}
     ${eTag2} =          Execute and checkrc     echo '${result}' | jq -r '.ETag'   0
                         Should contain          ${result}    ETag
-
+    ${result} =         Execute                 ozone sh bucket info ${PREFIX} | jq .usedNamespace
+                        Should Be Equal         ${result}       1
 #complete multipart upload
     ${result} =         Execute AWSS3APICli     complete-multipart-upload --upload-id ${uploadID} --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 --multipart-upload 'Parts=[{ETag=${eTag1},PartNumber=1},{ETag=${eTag2},PartNumber=2}]'
                         Should contain          ${result}    ${BUCKET}
                         Should contain          ${result}    ${PREFIX}/multipartKey1
                         Should contain          ${result}    ETag
+
 
 #read file and check the key
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/multipartKey1 /tmp/${PREFIX}-multipartKey1.result

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -229,6 +229,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               trxnLogIndex, ozoneManager.isRatisEnabled());
           long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
           usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
+        } else {
+          checkBucketQuotaInNamespace(omBucketInfo, 1L);
+          omBucketInfo.incrUsedNamespace(1L);
         }
 
         String dbBucketKey = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -229,9 +229,6 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
               trxnLogIndex, ozoneManager.isRatisEnabled());
           long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
           usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
-        } else {
-          checkBucketQuotaInNamespace(omBucketInfo, 1L);
-          omBucketInfo.incrUsedNamespace(1L);
         }
 
         String dbBucketKey = null;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -223,21 +223,26 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         OmKeyInfo keyToDelete =
             omMetadataManager.getKeyTable(getBucketLayout()).get(dbOzoneKey);
         long usedBytesDiff = 0;
+        boolean isNamespaceUpdate = false;
         if (keyToDelete != null && !omBucketInfo.getIsVersionEnabled()) {
           oldKeyVersionsToDelete = getOldVersionsToCleanUp(dbOzoneKey,
               keyToDelete, omMetadataManager,
               trxnLogIndex, ozoneManager.isRatisEnabled());
           long numCopy = keyToDelete.getReplicationConfig().getRequiredNodes();
           usedBytesDiff -= keyToDelete.getDataSize() * numCopy;
+        } else {
+          checkBucketQuotaInNamespace(omBucketInfo, 1L);
+          omBucketInfo.incrUsedNamespace(1L);
+          isNamespaceUpdate = true;
         }
 
-        String dbBucketKey = null;
+        String dbBucketKey = omMetadataManager.getBucketKey(
+            omBucketInfo.getVolumeName(), omBucketInfo.getBucketName());
         if (usedBytesDiff != 0) {
           omBucketInfo.incrUsedBytes(usedBytesDiff);
-          dbBucketKey = omMetadataManager.getBucketKey(
-              omBucketInfo.getVolumeName(), omBucketInfo.getBucketName());
-        } else {
-          // If no bucket size changed, prevent from updating bucket object
+        } else if (!isNamespaceUpdate){
+          // If no bucket size and Namespace changed, prevent from updating
+          // bucket object.
           omBucketInfo = null;
         }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -240,7 +240,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
             omBucketInfo.getVolumeName(), omBucketInfo.getBucketName());
         if (usedBytesDiff != 0) {
           omBucketInfo.incrUsedBytes(usedBytesDiff);
-        } else if (!isNamespaceUpdate){
+        } else if (!isNamespaceUpdate) {
           // If no bucket size and Namespace changed, prevent from updating
           // bucket object.
           omBucketInfo = null;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -23,6 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
 import org.junit.Assert;
@@ -148,6 +150,12 @@ public class TestS3MultipartUploadCompleteRequest
     Assert.assertNotNull(omMetadataManager
         .getKeyTable(s3MultipartUploadCompleteRequest.getBucketLayout())
         .get(getOzoneDBKey(volumeName, bucketName, keyName)));
+
+    OmBucketInfo omBucketInfo = omMetadataManager.getBucketTable()
+        .getCacheValue(new CacheKey<>(
+            omMetadataManager.getBucketKey(volumeName, bucketName)))
+        .getCacheValue();
+    Assert.assertEquals(1L, omBucketInfo.getUsedNamespace());
   }
 
   protected void addVolumeAndBucket(String volumeName, String bucketName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

S3MultipartUpload hasn't support usedNamespace. Currently when we upload key, only usedBytes will be updated.

<img width="351" alt="image" src="https://user-images.githubusercontent.com/13825159/167844815-937d8e82-5480-480d-9f2c-d19bcfcf9bbc.png">

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6650

## How was this patch tested?

Add new test case.
