### PR TITLE
HDDS-6731. Migrate simple tests in hdds-server-framework to JUnit5

### DIFF
--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/exceptions/TestSCMExceptionResultCodes.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/exceptions/TestSCMExceptionResultCodes.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.exceptions;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes;
 import org.apache.hadoop.hdds.protocol.proto.
     ScmBlockLocationProtocolProtos.Status;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Result code mappping between SCMException and the protobuf definitions.
@@ -32,20 +32,17 @@ public class TestSCMExceptionResultCodes {
   public void codeMapping() {
     // ResultCode = SCMException definition
     // Status = protobuf definition
-    Assert.assertEquals(ResultCodes.values().length, Status.values().length);
+    Assertions.assertEquals(ResultCodes.values().length,
+        Status.values().length);
     for (int i = 0; i < ResultCodes.values().length; i++) {
       ResultCodes codeValue = ResultCodes.values()[i];
       Status protoBufValue = Status.values()[i];
-      Assert.assertTrue(String
-          .format("Protobuf/Enum constant name mismatch %s %s", codeValue,
-              protoBufValue), sameName(codeValue.name(), protoBufValue.name()));
+      Assertions.assertEquals(codeValue.name(), protoBufValue.name(),
+          String.format("Protobuf/Enum constant name mismatch %s %s",
+              codeValue, protoBufValue));
       ResultCodes converted = ResultCodes.values()[protoBufValue.ordinal()];
-      Assert.assertEquals(codeValue, converted);
+      Assertions.assertEquals(codeValue, converted);
     }
-  }
-
-  private boolean sameName(String codeValue, String protoBufValue) {
-    return codeValue.equals(protoBufValue);
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
@@ -50,10 +50,10 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.hadoop.security.token.Token;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +72,7 @@ public class TestOzoneBlockTokenIdentifier {
   private static KeyPair keyPair;
   private static X509Certificate cert;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     File base = new File(BASEDIR);
     FileUtil.fullyDelete(base);
@@ -86,7 +86,7 @@ public class TestOzoneBlockTokenIdentifier {
         .generateCertificate("CN=OzoneMaster", keyPair, 30, "SHA256withRSA");
   }
 
-  @After
+  @AfterEach
   public void cleanUp() throws Exception {
     // KeyStoreTestUtil.cleanupSSLConfig(KEYSTORES_DIR, sslConfsDir);
   }
@@ -174,8 +174,8 @@ public class TestOzoneBlockTokenIdentifier {
     decodedTokenId.readFields(new DataInputStream(
         new ByteArrayInputStream(decodedToken.getIdentifier())));
 
-    Assert.assertEquals(decodedTokenId, tokenId);
-    Assert.assertEquals(decodedTokenId.getMaxLength(), maxLength);
+    Assertions.assertEquals(tokenId, decodedTokenId);
+    Assertions.assertEquals(maxLength, decodedTokenId.getMaxLength());
 
     // Verify a decoded signed Token with public key(certificate)
     boolean isValidToken = verifyTokenAsymmetric(decodedTokenId, decodedToken

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerC
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient;
 import org.apache.hadoop.security.token.Token;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +35,7 @@ import java.time.Instant;
 import java.util.concurrent.TimeUnit;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
@@ -22,10 +22,9 @@ import org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec;
 import org.apache.hadoop.hdds.security.x509.exceptions.CertificateException;
 import org.apache.hadoop.hdds.security.x509.keys.KeyCodec;
 import org.bouncycastle.cert.X509CertificateHolder;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -56,11 +55,11 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_METADATA_DIR_NAME;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NAMES;
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.FAILURE;
 import static org.apache.hadoop.hdds.security.x509.certificate.utils.CertificateCodec.getPEMEncodedString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test class for {@link DefaultCertificateClient}.
@@ -81,7 +80,7 @@ public class TestDefaultCertificateClient {
   private KeyCodec omKeyCodec;
   private KeyCodec dnKeyCodec;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     OzoneConfiguration config = new OzoneConfiguration();
     config.setStrings(OZONE_SCM_NAMES, "localhost");
@@ -116,7 +115,7 @@ public class TestDefaultCertificateClient {
     dnCertClient = new DNCertificateClient(dnSecurityConfig, certSerialId);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     omCertClient = null;
     dnCertClient = null;
@@ -186,7 +185,7 @@ public class TestDefaultCertificateClient {
         x509Certificate.getSerialNumber().toString());
     assertNotNull(cert);
     assertTrue(cert.getEncoded().length > 0);
-    assertEquals(cert, x509Certificate);
+    assertEquals(x509Certificate, cert);
 
     // TODO: test verifyCertificate once implemented.
   }
@@ -230,7 +229,7 @@ public class TestDefaultCertificateClient {
             omSecurityConfig.getProvider());
     rsaSignature.initVerify(omCertClient.getPublicKey());
     rsaSignature.update(data);
-    Assert.assertTrue(rsaSignature.verify(hash));
+    assertTrue(rsaSignature.verify(hash));
   }
 
   /**
@@ -385,16 +384,14 @@ public class TestDefaultCertificateClient {
 
 
     // Check for DN.
-    assertEquals(dnCertClient.init(), FAILURE);
-    assertTrue(dnClientLog.getOutput().contains("Keypair validation " +
-        "failed"));
+    assertEquals(FAILURE, dnCertClient.init());
+    assertTrue(dnClientLog.getOutput().contains("Keypair validation failed"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
 
     // Check for OM.
-    assertEquals(omCertClient.init(), FAILURE);
-    assertTrue(omClientLog.getOutput().contains("Keypair validation " +
-        "failed"));
+    assertEquals(FAILURE, omCertClient.init());
+    assertTrue(omClientLog.getOutput().contains("Keypair validation failed"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
 
@@ -418,14 +415,13 @@ public class TestDefaultCertificateClient {
     dnCertCodec.writeCertificate(new X509CertificateHolder(
         x509Certificate.getEncoded()));
     // Check for DN.
-    assertEquals(dnCertClient.init(), FAILURE);
-    assertTrue(dnClientLog.getOutput().contains("Keypair validation " +
-        "failed"));
+    assertEquals(FAILURE, dnCertClient.init());
+    assertTrue(dnClientLog.getOutput().contains("Keypair validation failed"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
 
     // Check for OM.
-    assertEquals(omCertClient.init(), FAILURE);
+    assertEquals(FAILURE, omCertClient.init());
     assertTrue(omClientLog.getOutput().contains("Keypair validation failed"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
@@ -433,7 +429,7 @@ public class TestDefaultCertificateClient {
     // Case 3. Expect failure when certificate is generated from different
     // private key and certificate validation fails.
 
-    // Re write the correct public key.
+    // Re-write the correct public key.
     FileUtils.deleteQuietly(Paths.get(
         omSecurityConfig.getKeyLocation(OM_COMPONENT).toString(),
         omSecurityConfig.getPublicKeyFileName()).toFile());
@@ -445,16 +441,16 @@ public class TestDefaultCertificateClient {
     dnKeyCodec.writePublicKey(keyPair.getPublic());
 
     // Check for DN.
-    assertEquals(dnCertClient.init(), FAILURE);
-    assertTrue(dnClientLog.getOutput().contains("Stored certificate is " +
-        "generated with different"));
+    assertEquals(FAILURE, dnCertClient.init());
+    assertTrue(dnClientLog.getOutput()
+        .contains("Stored certificate is generated with different"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
 
     //Check for OM.
-    assertEquals(omCertClient.init(), FAILURE);
-    assertTrue(omClientLog.getOutput().contains("Stored certificate is " +
-        "generated with different"));
+    assertEquals(FAILURE, omCertClient.init());
+    assertTrue(omClientLog.getOutput()
+        .contains("Stored certificate is generated with different"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();
 
@@ -468,11 +464,11 @@ public class TestDefaultCertificateClient {
         dnSecurityConfig.getPublicKeyFileName()).toFile());
 
     // Check for DN.
-    assertEquals(dnCertClient.init(), FAILURE);
+    assertEquals(FAILURE, dnCertClient.init());
     assertTrue(dnClientLog.getOutput().contains("Can't recover public key"));
 
     // Check for OM.
-    assertEquals(omCertClient.init(), FAILURE);
+    assertEquals(FAILURE, omCertClient.init());
     assertTrue(omClientLog.getOutput().contains("Can't recover public key"));
     dnClientLog.clearOutput();
     omClientLog.clearOutput();

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestHDDSKeyGenerator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestHDDSKeyGenerator.java
@@ -29,9 +29,9 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.security.x509.SecurityConfig;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for HDDS Key Generator.
@@ -39,7 +39,7 @@ import org.junit.Test;
 public class TestHDDSKeyGenerator {
   private SecurityConfig config;
 
-  @Before
+  @BeforeEach
   public void init() {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(OZONE_METADATA_DIRS,  GenericTestUtils.getTempPath("testpath"));
@@ -58,11 +58,11 @@ public class TestHDDSKeyGenerator {
       throws NoSuchProviderException, NoSuchAlgorithmException {
     HDDSKeyGenerator keyGen = new HDDSKeyGenerator(config.getConfiguration());
     KeyPair keyPair = keyGen.generateKey();
-    Assert.assertEquals(config.getKeyAlgo(),
+    Assertions.assertEquals(config.getKeyAlgo(),
         keyPair.getPrivate().getAlgorithm());
     PKCS8EncodedKeySpec keySpec =
         new PKCS8EncodedKeySpec(keyPair.getPrivate().getEncoded());
-    Assert.assertEquals("PKCS#8", keySpec.getFormat());
+    Assertions.assertEquals("PKCS#8", keySpec.getFormat());
   }
 
   /**
@@ -80,7 +80,7 @@ public class TestHDDSKeyGenerator {
     KeyPair keyPair = keyGen.generateKey(4096);
     PublicKey publicKey = keyPair.getPublic();
     if (publicKey instanceof RSAPublicKey) {
-      Assert.assertEquals(4096,
+      Assertions.assertEquals(4096,
           ((RSAPublicKey)(publicKey)).getModulus().bitLength());
     }
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 
 import org.apache.hadoop.hdds.client.OzoneQuota;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test the json object printer.
@@ -46,7 +46,7 @@ public class TestJsonUtils {
   }
 
   private static void assertContains(String str, String part) {
-    assertTrue("Expected JSON to contain '" + part + "', but didn't: " + str,
-        str.contains(part));
+    assertTrue(str.contains(part),
+        "Expected JSON to contain '" + part + "', but didn't: " + str);
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 
@@ -40,13 +40,13 @@ public class TestEventQueue {
 
   private AtomicLong eventTotal = new AtomicLong();
 
-  @Before
+  @BeforeEach
   public void startEventQueue() {
     DefaultMetricsSystem.initialize(getClass().getSimpleName());
     queue = new EventQueue();
   }
 
-  @After
+  @AfterEach
   public void stopEventQueue() {
     DefaultMetricsSystem.shutdown();
     queue.close();
@@ -61,7 +61,7 @@ public class TestEventQueue {
 
     queue.fireEvent(EVENT1, 11L);
     queue.processAll(1000);
-    Assert.assertEquals(11, result[0]);
+    Assertions.assertEquals(11, result[0]);
 
   }
 
@@ -94,19 +94,19 @@ public class TestEventQueue {
 
     // As it is fixed threadpool executor with 10 threads, all should be
     // scheduled.
-    Assert.assertEquals(11, eventExecutor.queuedEvents());
+    Assertions.assertEquals(11, eventExecutor.queuedEvents());
 
     // As we don't see all 10 events scheduled.
-    Assert.assertTrue(eventExecutor.scheduledEvents() > 1 &&
+    Assertions.assertTrue(eventExecutor.scheduledEvents() > 1 &&
         eventExecutor.scheduledEvents() <= 10);
 
     queue.processAll(60000);
 
-    Assert.assertTrue(eventExecutor.scheduledEvents() == 11);
+    Assertions.assertEquals(11, eventExecutor.scheduledEvents());
 
-    Assert.assertEquals(166, eventTotal.intValue());
+    Assertions.assertEquals(166, eventTotal.intValue());
 
-    Assert.assertEquals(11, eventExecutor.successfulEvents());
+    Assertions.assertEquals(11, eventExecutor.successfulEvents());
     eventTotal.set(0);
 
   }
@@ -135,8 +135,8 @@ public class TestEventQueue {
 
     queue.fireEvent(EVENT2, 23L);
     queue.processAll(1000);
-    Assert.assertEquals(23, result[0]);
-    Assert.assertEquals(23, result[1]);
+    Assertions.assertEquals(23, result[0]);
+    Assertions.assertEquals(23, result[1]);
 
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueueChain.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueueChain.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdds.server.events;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * More realistic event test with sending event from one listener.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdds.server.events;
 import org.apache.hadoop.hdds.HddsIdFactory;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.ozone.lease.LeaseManager;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Objects;
@@ -43,14 +43,14 @@ public class TestEventWatcher {
 
   private LeaseManager<Long> leaseManager;
 
-  @Before
+  @BeforeEach
   public void startLeaseManager() {
     DefaultMetricsSystem.instance();
     leaseManager = new LeaseManager<>("Test", 2000L);
     leaseManager.start();
   }
 
-  @After
+  @AfterEach
   public void stopLeaseManager() {
     leaseManager.shutdown();
     DefaultMetricsSystem.shutdown();
@@ -79,21 +79,24 @@ public class TestEventWatcher {
     queue.fireEvent(WATCH_UNDER_REPLICATED,
         new UnderreplicatedEvent(id2, "C2"));
 
-    Assert.assertEquals(0, underReplicatedEvents.getReceivedEvents().size());
+    Assertions.assertEquals(0,
+        underReplicatedEvents.getReceivedEvents().size());
 
     Thread.sleep(1000);
 
     queue.fireEvent(REPLICATION_COMPLETED,
         new ReplicationCompletedEvent(id1, "C2", "D1"));
 
-    Assert.assertEquals(0, underReplicatedEvents.getReceivedEvents().size());
+    Assertions.assertEquals(0,
+        underReplicatedEvents.getReceivedEvents().size());
 
     Thread.sleep(1500);
 
     queue.processAll(1000L);
 
-    Assert.assertEquals(1, underReplicatedEvents.getReceivedEvents().size());
-    Assert.assertEquals(id2,
+    Assertions.assertEquals(1,
+        underReplicatedEvents.getReceivedEvents().size());
+    Assertions.assertEquals(id2,
         underReplicatedEvents.getReceivedEvents().get(0).id);
 
   }
@@ -129,14 +132,14 @@ public class TestEventWatcher {
     List<UnderreplicatedEvent> c1todo = replicationWatcher
         .getTimeoutEvents(e -> e.containerId.equalsIgnoreCase("C1"));
 
-    Assert.assertEquals(2, c1todo.size());
-    Assert.assertTrue(replicationWatcher.contains(event1));
+    Assertions.assertEquals(2, c1todo.size());
+    Assertions.assertTrue(replicationWatcher.contains(event1));
     Thread.sleep(1500L);
 
     c1todo = replicationWatcher
         .getTimeoutEvents(e -> e.containerId.equalsIgnoreCase("C1"));
-    Assert.assertEquals(0, c1todo.size());
-    Assert.assertFalse(replicationWatcher.contains(event1));
+    Assertions.assertEquals(0, c1todo.size());
+    Assertions.assertFalse(replicationWatcher.contains(event1));
 
   }
 
@@ -192,19 +195,18 @@ public class TestEventWatcher {
     EventWatcherMetrics metrics = replicationWatcher.getMetrics();
 
     //3 events are received
-    Assert.assertEquals(3, metrics.getTrackedEvents().value());
+    Assertions.assertEquals(3, metrics.getTrackedEvents().value());
 
     //completed + timed out = all messages
-    Assert.assertEquals(
+    Assertions.assertEquals(metrics.getTrackedEvents().value(),
+        metrics.getCompletedEvents().value() +
+            metrics.getTimedOutEvents().value(),
         "number of timed out and completed messages should be the same as the"
-            + " all messages",
-        metrics.getTrackedEvents().value(),
-        metrics.getCompletedEvents().value() + metrics.getTimedOutEvents()
-            .value());
+            + " all messages");
 
     //_at least_ two are timed out.
-    Assert.assertTrue("At least two events should be timed out.",
-        metrics.getTimedOutEvents().value() >= 2);
+    Assertions.assertTrue(metrics.getTimedOutEvents().value() >= 2,
+        "At least two events should be timed out.");
 
     DefaultMetricsSystem.shutdown();
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdds.server.http;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Common ozone/hdds web methods.
@@ -95,13 +95,13 @@ public class TestBaseHttpServer {
 
     conf.set("addresskey", "0.0.0.0:1234");
 
-    Assert.assertEquals("/0.0.0.0:1234", baseHttpServer
+    Assertions.assertEquals("/0.0.0.0:1234", baseHttpServer
         .getBindAddress("bindhostkey", "addresskey",
             "default", 65).toString());
 
     conf.set("bindhostkey", "1.2.3.4");
 
-    Assert.assertEquals("/1.2.3.4:1234", baseHttpServer
+    Assertions.assertEquals("/1.2.3.4:1234", baseHttpServer
         .getBindAddress("bindhostkey", "addresskey",
             "default", 65).toString());
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHtmlQuoting.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHtmlQuoting.java
@@ -17,15 +17,16 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import javax.servlet.http.HttpServletRequest;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Testing HTML Quoting.
@@ -51,7 +52,7 @@ public class TestHtmlQuoting {
     assertEquals("&amp;&amp;&amp;", HtmlQuoting.quoteHtmlChars("&&&"));
     assertEquals(" &apos;\n", HtmlQuoting.quoteHtmlChars(" '\n"));
     assertEquals("&quot;", HtmlQuoting.quoteHtmlChars("\""));
-    assertEquals(null, HtmlQuoting.quoteHtmlChars(null));
+    assertNull(HtmlQuoting.quoteHtmlChars(null));
   }
 
   private void runRoundTrip(String str) throws Exception {
@@ -80,20 +81,20 @@ public class TestHtmlQuoting {
         new HttpServer2.QuotingInputFilter.RequestQuoter(mockReq);
 
     Mockito.doReturn("a<b").when(mockReq).getParameter("x");
-    assertEquals("Test simple param quoting",
-        "a&lt;b", quoter.getParameter("x"));
+    assertEquals("a&lt;b", quoter.getParameter("x"),
+        "Test simple param quoting");
 
     Mockito.doReturn(null).when(mockReq).getParameter("x");
-    assertEquals("Test that missing parameters dont cause NPE",
-        null, quoter.getParameter("x"));
+    assertNull(quoter.getParameter("x"),
+        "Test that missing parameters dont cause NPE");
 
     Mockito.doReturn(new String[] {"a<b", "b"}).when(mockReq)
         .getParameterValues("x");
-    assertArrayEquals("Test escaping of an array",
-        new String[] {"a&lt;b", "b"}, quoter.getParameterValues("x"));
+    assertArrayEquals(new String[] {"a&lt;b", "b"},
+        quoter.getParameterValues("x"), "Test escaping of an array");
 
     Mockito.doReturn(null).when(mockReq).getParameterValues("x");
-    assertArrayEquals("Test that missing parameters dont cause NPE for array",
-        null, quoter.getParameterValues("x"));
+    assertNull(quoter.getParameterValues("x"),
+        "Test that missing parameters dont cause NPE for array");
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLog.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLog.java
@@ -20,11 +20,11 @@ package org.apache.hadoop.hdds.server.http;
 import org.apache.log4j.Logger;
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.RequestLog;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
  * Testing HttpRequestLog.
@@ -34,7 +34,7 @@ public class TestHttpRequestLog {
   @Test
   public void testAppenderUndefined() {
     RequestLog requestLog = HttpRequestLog.getRequestLog("test");
-    assertNull("RequestLog should be null", requestLog);
+    assertNull(requestLog, "RequestLog should be null");
   }
 
   @Test
@@ -44,8 +44,8 @@ public class TestHttpRequestLog {
     Logger.getLogger("http.requests.test").addAppender(requestLogAppender);
     RequestLog requestLog = HttpRequestLog.getRequestLog("test");
     Logger.getLogger("http.requests.test").removeAppender(requestLogAppender);
-    assertNotNull("RequestLog should not be null", requestLog);
-    assertEquals("Class mismatch",
-        CustomRequestLog.class, requestLog.getClass());
+    assertNotNull(requestLog, "RequestLog should not be null");
+    assertEquals(CustomRequestLog.class, requestLog.getClass(),
+        "Class mismatch");
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLogAppender.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLogAppender.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Http request log appender.
@@ -32,9 +32,9 @@ public class TestHttpRequestLogAppender {
     HttpRequestLogAppender requestLogAppender = new HttpRequestLogAppender();
     requestLogAppender.setFilename("jetty-namenode-yyyy_mm_dd.log");
     requestLogAppender.setRetainDays(17);
-    assertEquals("Filename mismatch", "jetty-namenode-yyyy_mm_dd.log",
-        requestLogAppender.getFilename());
-    assertEquals("Retain days mismatch", 17,
-        requestLogAppender.getRetainDays());
+    assertEquals("jetty-namenode-yyyy_mm_dd.log",
+        requestLogAppender.getFilename(), "Filename mismatch");
+    assertEquals(17, requestLogAppender.getRetainDays(),
+        "Retain days mismatch");
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.hdds.server.http;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.eclipse.jetty.server.ServerConnector;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Testing HttpServer2.

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
@@ -17,12 +17,11 @@
  */
 package org.apache.hadoop.hdds.server.http;
 
-import java.io.IOException;
-
 import org.apache.hadoop.hdds.server.http.ProfileServlet.Event;
 import org.apache.hadoop.hdds.server.http.ProfileServlet.Output;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test prometheus Sink.
@@ -30,7 +29,7 @@ import org.junit.Test;
 public class TestProfileServlet {
 
   @Test
-  public void testNameValidation() throws IOException {
+  public void testNameValidation() {
     ProfileServlet.validateFileName(
         ProfileServlet.generateFileName(1, Output.FLAMEGRAPH, Event.ALLOC));
     ProfileServlet.validateFileName(
@@ -40,22 +39,26 @@ public class TestProfileServlet {
             Event.L1_DCACHE_LOAD_MISSES));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNameValidationWithNewLine() throws IOException {
-    ProfileServlet.validateFileName(
-        "test\n" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
-            Event.ALLOC));
-    ProfileServlet.validateFileName(
-        "test\n" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+  @Test
+  public void testNameValidationWithNewLine() {
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> ProfileServlet.validateFileName("test\n" +
+            ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
+                Event.ALLOC)));
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> ProfileServlet.validateFileName("test\n" +
+            ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC)));
   }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testNameValidationWithSlash() throws IOException {
-    ProfileServlet.validateFileName(
-        "../" + ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
-            Event.ALLOC));
-    ProfileServlet.validateFileName(
-        "../" + ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC));
+  @Test
+  public void testNameValidationWithSlash() {
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> ProfileServlet.validateFileName("../" +
+            ProfileServlet.generateFileName(1, Output.FLAMEGRAPH,
+                Event.ALLOC)));
+    Assertions.assertThrows(IllegalArgumentException.class,
+        () -> ProfileServlet.validateFileName("../" +
+            ProfileServlet.generateFileName(1, Output.SVG, Event.ALLOC)));
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsSink.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsSink.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test prometheus Sink.
@@ -71,7 +71,7 @@ public class TestPrometheusMetricsSink {
   private static final int COUNTER_1 = 123;
   private static final int COUNTER_2 = 234;
 
-  @Before
+  @BeforeEach
   public void init() {
     metrics = DefaultMetricsSystem.instance();
 
@@ -80,7 +80,7 @@ public class TestPrometheusMetricsSink {
     metrics.register("Prometheus", "Prometheus", sink);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     metrics.stop();
     metrics.shutdown();
@@ -98,10 +98,10 @@ public class TestPrometheusMetricsSink {
     String writtenMetrics = publishMetricsAndGetOutput();
 
     //THEN
-    Assert.assertTrue(
-        "The expected metric line is missing from prometheus metrics output",
+    Assertions.assertTrue(
         writtenMetrics.contains(
-            "test_metrics_num_bucket_create_fails{context=\"dfs\"")
+            "test_metrics_num_bucket_create_fails{context=\"dfs\""),
+        "The expected metric line is missing from prometheus metrics output"
     );
   }
 
@@ -120,16 +120,13 @@ public class TestPrometheusMetricsSink {
     String writtenMetrics = publishMetricsAndGetOutput();
 
     // THEN
-    Assert.assertTrue(
-        "The expected metric line is missing from prometheus metrics output",
-        writtenMetrics.contains(
-            "rpc_metrics_counter{port=\"2345\""));
+    Assertions.assertTrue(
+        writtenMetrics.contains("rpc_metrics_counter{port=\"2345\""),
+        "The expected metric line is missing from prometheus metrics output");
 
-    Assert.assertTrue(
-        "The expected metric line is missing from prometheus metrics "
-            + "output",
-        writtenMetrics.contains(
-            "rpc_metrics_counter{port=\"1234\""));
+    Assertions.assertTrue(
+        writtenMetrics.contains("rpc_metrics_counter{port=\"1234\""),
+        "The expected metric line is missing from prometheus metrics output");
   }
 
   @Test
@@ -147,20 +144,20 @@ public class TestPrometheusMetricsSink {
     String writtenMetrics = publishMetricsAndGetOutput();
 
     // THEN
-    Assert.assertEquals(1, StringUtils.countMatches(writtenMetrics,
+    Assertions.assertEquals(1, StringUtils.countMatches(writtenMetrics,
         "# TYPE same_name_counter"));
   }
 
   @Test
   public void testNamingCamelCase() {
     //THEN
-    Assert.assertEquals("rpc_time_some_metrics",
+    Assertions.assertEquals("rpc_time_some_metrics",
         sink.prometheusName("RpcTime", "SomeMetrics"));
 
-    Assert.assertEquals("om_rpc_time_om_info_keys",
+    Assertions.assertEquals("om_rpc_time_om_info_keys",
         sink.prometheusName("OMRpcTime", "OMInfoKeys"));
 
-    Assert.assertEquals("rpc_time_small",
+    Assertions.assertEquals("rpc_time_small",
         sink.prometheusName("RpcTime", "small"));
   }
 
@@ -168,7 +165,7 @@ public class TestPrometheusMetricsSink {
   public void testNamingRocksDB() {
     //RocksDB metrics are handled differently.
     // THEN
-    Assert.assertEquals("rocksdb_om_db_num_open_connections",
+    Assertions.assertEquals("rocksdb_om_db_num_open_connections",
         sink.prometheusName("Rocksdb_om.db", "num_open_connections"));
   }
 
@@ -180,7 +177,7 @@ public class TestPrometheusMetricsSink {
         + "RATIS-THREE-47659e3d-40c9-43b3-9792-4982fc279aba";
 
     // THEN
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "scm_pipeline_metrics_"
             + "num_blocks_allocated_"
             + "ratis_three_47659e3d_40c9_43b3_9792_4982fc279aba",
@@ -194,7 +191,7 @@ public class TestPrometheusMetricsSink {
     String metricName = "GcTimeMillisG1 Young Generation";
 
     // THEN
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "jvm_metrics_gc_time_millis_g1_young_generation",
         sink.prometheusName(recordName, metricName));
   }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
@@ -28,8 +28,8 @@ import org.apache.ratis.protocol.RaftGroupId;
 import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.metrics.SegmentedRaftLogMetrics;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test RatisDropwizardRexporter.
@@ -57,12 +57,11 @@ public class TestRatisDropwizardExports {
     StringWriter writer = new StringWriter();
     TextFormat.write004(writer, collector.metricFamilySamples());
 
-    System.out.println(writer.toString());
+    System.out.println(writer);
 
-    Assert.assertFalse("Instance name is not moved to be a tag",
-        writer.toString()
-            .contains("ratis_core_ratis_log_worker_instance_syncTime"));
-
+    Assertions.assertFalse(writer.toString()
+            .contains("ratis_core_ratis_log_worker_instance_syncTime"),
+        "Instance name is not moved to be a tag");
   }
 
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
@@ -18,8 +18,8 @@
  */
 package org.apache.hadoop.hdds.utils.db;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.rocksdb.RocksIterator;
@@ -27,9 +27,10 @@ import org.rocksdb.RocksIterator;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -49,7 +50,7 @@ public class TestRDBStoreIterator {
   private RocksIterator rocksDBIteratorMock;
   private RDBTable rocksTableMock;
 
-  @Before
+  @BeforeEach
   public void setup() {
     rocksDBIteratorMock = mock(RocksIterator.class);
     rocksTableMock = mock(RDBTable.class);
@@ -221,10 +222,11 @@ public class TestRDBStoreIterator {
     verifier.verify(rocksTableMock, times(1)).delete(testKey);
   }
 
-  @Test(expected = UnsupportedOperationException.class)
-  public void testRemoveFromDBWithoutDBTableSet() throws Exception {
+  @Test
+  public void testRemoveFromDBWithoutDBTableSet() {
     RDBStoreIterator iter = new RDBStoreIterator(rocksDBIteratorMock);
-    iter.removeFromDB();
+    assertThrows(UnsupportedOperationException.class,
+        iter::removeFromDB);
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate simple tests in hdds-server-framework to JUnit5, "simple" means without `@Rule` and `@Parameter`.

Also included some minor cleanups such as the parameter order in `assertEquals(expected, actual)`.

Tests migrated:

```
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/scm/exceptions/TestSCMExceptionResultCodes.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TestOzoneBlockTokenIdentifier.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/token/TokenVerifierTests.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestDefaultCertificateClient.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/keys/TestHDDSKeyGenerator.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/TestJsonUtils.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueue.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventQueueChain.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/events/TestEventWatcher.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestBaseHttpServer.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHtmlQuoting.java 
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLog.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpRequestLogAppender.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestHttpServer2.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestProfileServlet.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestPrometheusMetricsSink.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisDropwizardExports.java
hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/TestRDBStoreIterator.java
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6731

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/2320759408
