### PR TITLE
HDDS-6749. SCM includes itself as peer in addSCM request

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHAUtils.java
@@ -196,9 +196,9 @@ public final class SCMHAUtils {
   public static OzoneConfiguration removeSelfId(
       OzoneConfiguration configuration, String selfId) {
     final OzoneConfiguration conf = new OzoneConfiguration(configuration);
-    String scmNodes = conf.get(ConfUtils
-        .addKeySuffixes(ScmConfigKeys.OZONE_SCM_NODES_KEY,
-            getScmServiceId(conf)));
+    String scmNodesKey = ConfUtils.addKeySuffixes(
+        ScmConfigKeys.OZONE_SCM_NODES_KEY, getScmServiceId(conf));
+    String scmNodes = conf.get(scmNodesKey);
     if (scmNodes != null) {
       String[] parts = scmNodes.split(",");
       List<String> partsLeft = new ArrayList<>();
@@ -207,7 +207,7 @@ public final class SCMHAUtils {
           partsLeft.add(part);
         }
       }
-      conf.set(ScmConfigKeys.OZONE_SCM_NODES_KEY, String.join(",", partsLeft));
+      conf.set(scmNodesKey, String.join(",", partsLeft));
     }
     return conf;
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestSCMHAUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/TestSCMHAUtils.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.scm.ha.SCMHAUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NODES_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_NODE_ID_KEY;
+import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+/**
+ * Tests for {@code SCMHAUtils}.
+ */
+class TestSCMHAUtils {
+
+  @Test
+  void testRemoveSelfId() {
+    String service = "mySCM";
+    String selfId = "scm3";
+
+    OzoneConfiguration input = new OzoneConfiguration();
+    input.set(OZONE_SCM_SERVICE_IDS_KEY, service);
+    input.set(OZONE_SCM_NODES_KEY + "." + service, "scm1,scm2," + selfId);
+    input.set(OZONE_SCM_NODE_ID_KEY, selfId);
+
+    OzoneConfiguration output = SCMHAUtils.removeSelfId(input, selfId);
+    Collection<String> nodesWithoutSelf =
+        SCMHAUtils.getSCMNodeIds(output, service);
+
+    assertEquals(2, nodesWithoutSelf.size());
+    assertFalse(nodesWithoutSelf.contains(selfId));
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/scm/proxy/SCMBlockLocationFailoverProxyProvider.java
@@ -110,6 +110,9 @@ public class SCMBlockLocationFailoverProxyProvider implements
     SCMClientConfig config = conf.getObject(SCMClientConfig.class);
     this.maxRetryCount = config.getRetryCount();
     this.retryInterval = config.getRetryInterval();
+
+    LOG.info("Created block location fail-over proxy with {} nodes: {}",
+        scmNodeIds.size(), scmProxyInfoMap.values());
   }
 
   private synchronized void loadConfigs() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

SCM during start sends `addSCM` request to its peers.  It tries to exclude itself from the target list:

https://github.com/apache/ozone/blob/40461504478182af509db7098d4e173011d27e5a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/HAUtils.java#L119-L121

but `removeSelfId` does not work.  The bug is that it sets the generic `ozone.scm.nodes` property, leaving the SCM service-specific config key `ozone.scm.nodes.<service>` unchanged with 3 nodes.

https://issues.apache.org/jira/browse/HDDS-6749

## How was this patch tested?

Added unit test.

Also added log message to show list of peers the fail-over proxy is created with.  From HA acceptance test:

```
scm2_1      | 2022-05-13 22:49:10,532 [main] INFO proxy.SCMBlockLocationFailoverProxyProvider: Created block location fail-over proxy with 2 nodes: [nodeId=scm1,nodeAddress=scm1/172.18.0.10:9863, nodeId=scm3,nodeAddress=scm3/172.18.0.6:9863]
scm2_1      | 2022-05-13 22:49:36,580 [Listener at 0.0.0.0/9860] INFO proxy.SCMBlockLocationFailoverProxyProvider: Created block location fail-over proxy with 2 nodes: [nodeId=scm1,nodeAddress=scm1/172.18.0.10:9863, nodeId=scm3,nodeAddress=scm3/172.18.0.6:9863]
```

```
scm3_1      | 2022-05-13 22:49:38,931 [main] INFO proxy.SCMBlockLocationFailoverProxyProvider: Created block location fail-over proxy with 2 nodes: [nodeId=scm2,nodeAddress=scm2/172.18.0.9:9863, nodeId=scm1,nodeAddress=scm1/172.18.0.10:9863]
scm3_1      | 2022-05-13 22:49:46,296 [Listener at 0.0.0.0/9860] INFO proxy.SCMBlockLocationFailoverProxyProvider: Created block location fail-over proxy with 2 nodes: [nodeId=scm2,nodeAddress=scm2/172.18.0.9:9863, nodeId=scm1,nodeAddress=scm1/172.18.0.10:9863]
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2322096338