### PR TITLE
HDDS-6737. Migrate parameterized tests in hdds-server-framework to JUnit5

### DIFF
--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -141,6 +141,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
   </dependencies>
 
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
@@ -31,6 +31,7 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.nio.file.Files;
@@ -38,7 +39,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -50,6 +50,7 @@ import static org.apache.hadoop.hdds.security.x509.certificate.client.Certificat
 import static org.apache.hadoop.hdds.security.x509.certificate.client.CertificateClient.InitResponse.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * Test class for {@link DefaultCertificateClient}.
@@ -69,16 +70,17 @@ public class TestCertificateClientInit {
   private static final String DN_COMPONENT = DNCertificateClient.COMPONENT_NAME;
   private static final String OM_COMPONENT = OMCertificateClient.COMPONENT_NAME;
 
-  private static Stream<Object[]> parameters() {
-    return Arrays.stream(new Object[][]{
-        {false, false, false, GETCERT},
-        {false, false, true, FAILURE},
-        {false, true, false, FAILURE},
-        {true, false, false, FAILURE},
-        {false, true, true, FAILURE},
-        {true, true, false, GETCERT},
-        {true, false, true, SUCCESS},
-        {true, true, true, SUCCESS}});
+  private static Stream<Arguments> parameters() {
+    return Stream.of(
+        arguments(false, false, false, GETCERT),
+        arguments(false, false, true, FAILURE),
+        arguments(false, true, false, FAILURE),
+        arguments(true, false, false, FAILURE),
+        arguments(false, true, true, FAILURE),
+        arguments(true, true, false, GETCERT),
+        arguments(true, false, true, SUCCESS),
+        arguments(true, true, true, SUCCESS)
+    );
   }
 
   @BeforeEach

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
@@ -24,7 +24,10 @@ import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 /**
  * Test Ratis metrics renaming.
@@ -32,9 +35,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 public class TestRatisNameRewrite {
 
 
-  private static Stream<Object[]> parameters() {
+  private static Stream<Arguments> parameters() {
     return Stream.of(
-        new Object[] {
+        arguments(
             "ratis.log_appender"
                 + ".851cb00a-af97-455a-b079-d94a77d2a936@group-C14654DE8C2C"
                 + ".follower_65f881ea-8794-403d-be77-a030ed79c341_match_index",
@@ -43,8 +46,8 @@ public class TestRatisNameRewrite {
             new String[] {"851cb00a-af97-455a-b079-d94a77d2a936",
                 "group-C14654DE8C2C",
                 "65f881ea-8794-403d-be77-a030ed79c341"}
-        },
-        new Object[] {
+        ),
+        arguments(
             "ratis_grpc.log_appender.72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67@group"
                 + "-72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67"
                 + ".grpc_log_appender_follower_75fa730a-59f0-4547"
@@ -54,15 +57,15 @@ public class TestRatisNameRewrite {
             new String[] {"72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67",
                 "group-72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67",
                 "75fa730a-59f0-4547-bd68-216162c263eb"}
-        },
-        new Object[] {
+        ),
+        arguments(
             "ratis_core.ratis_log_worker.72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67"
                 + ".dataQueueSize",
             "ratis_core.ratis_log_worker.dataQueueSize",
             new String[] {"instance"},
             new String[] {"72caaf3a-fb1c-4da4-9cc0-a2ce21bb8e67"}
-        },
-        new Object[] {
+        ),
+        arguments(
             "ratis_grpc.log_appender.8e505d6e-12a4-4660-80e3-eb735879db06"
                 + "@group-49616B7F02CE.grpc_log_appender_follower_a4b099a7"
                 + "-511f-4fef-85bf-b9eeddd7c270_latency",
@@ -70,8 +73,8 @@ public class TestRatisNameRewrite {
             new String[] {"instance", "group", "follower"},
             new String[] {"8e505d6e-12a4-4660-80e3-eb735879db06",
                 "group-49616B7F02CE", "a4b099a7-511f-4fef-85bf-b9eeddd7c270"}
-        },
-        new Object[] {
+        ),
+        arguments(
             "ratis_grpc.log_appender.8e505d6e-12a4-4660-80e3-eb735879db06"
                 + "@group-49616B7F02CE.grpc_log_appender_follower_a4b099a7"
                 + "-511f-4fef-85bf-b9eeddd7c270_success_reply_count",
@@ -80,8 +83,7 @@ public class TestRatisNameRewrite {
             new String[] {"instance", "group", "follower"},
             new String[] {"8e505d6e-12a4-4660-80e3-eb735879db06",
                 "group-49616B7F02CE", "a4b099a7-511f-4fef-85bf-b9eeddd7c270"}
-        }
-
+        )
     );
   }
 

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
@@ -20,30 +20,20 @@ package org.apache.hadoop.hdds.server.http;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
-import org.junit.Assert;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test Ratis metrics renaming.
  */
-@RunWith(Parameterized.class)
 public class TestRatisNameRewrite {
 
-  private List<String> names = new ArrayList<>();
-  private List<String> values = new ArrayList<>();
 
-  private String originalName;
-  private String expectedName;
-
-  private List<String> expectedTagNames;
-  private List<String> expectedTagValues;
-
-  @Parameterized.Parameters
-  public static List<Object[]> parameters() {
-    return Arrays.asList(
+  private static Stream<Object[]> parameters() {
+    return Stream.of(
         new Object[] {
             "ratis.log_appender"
                 + ".851cb00a-af97-455a-b079-d94a77d2a936@group-C14654DE8C2C"
@@ -95,23 +85,20 @@ public class TestRatisNameRewrite {
     );
   }
 
-  public TestRatisNameRewrite(String originalName, String expectedName,
+  @ParameterizedTest
+  @MethodSource("parameters")
+  public void normalizeRatisMetricName(String originalName, String expectedName,
       String[] expectedTagNames, String[] expectedTagValues) {
-    this.originalName = originalName;
-    this.expectedName = expectedName;
-    this.expectedTagNames = Arrays.asList(expectedTagNames);
-    this.expectedTagValues = Arrays.asList(expectedTagValues);
-  }
 
-  @Test
-  public void normalizeRatisMetricName() {
+    List<String> names = new ArrayList<>();
+    List<String> values = new ArrayList<>();
 
     String cleanName = new RatisNameRewriteSampleBuilder()
         .normalizeRatisMetric(originalName, names, values);
 
-    Assert.assertEquals(expectedName, cleanName);
-    Assert.assertEquals(expectedTagNames, names);
-    Assert.assertEquals(expectedTagValues, values);
+    Assertions.assertEquals(expectedName, cleanName);
+    Assertions.assertEquals(Arrays.asList(expectedTagNames), names);
+    Assertions.assertEquals(Arrays.asList(expectedTagValues), values);
 
   }
 }

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -75,7 +75,7 @@ public class TestTableCache {
     epochs.add(2L);
     epochs.add(3L);
     epochs.add(4L);
-    // On a full table cache if some one calls cleanup it is a no-op.
+    // On a full table cache if someone calls cleanup it is a no-op.
     tableCache.evictCache(epochs);
 
     for (int i = 5; i < 10; i++) {
@@ -136,7 +136,7 @@ public class TestTableCache {
 
   @ParameterizedTest
   @EnumSource(TableCache.CacheType.class)
-  public void testPartialTableCacheWithNotContinousEntries(
+  public void testPartialTableCacheWithNotContinuousEntries(
       TableCache.CacheType cacheType) {
 
     createTableCache(cacheType);
@@ -246,7 +246,7 @@ public class TestTableCache {
 
       Assertions.assertEquals(0, tableCache.size());
 
-      // Overrided entries would have been deleted.
+      // Overridden entries would have been deleted.
       Assertions.assertEquals(0, tableCache.getEpochEntries().size());
     }
 
@@ -268,13 +268,13 @@ public class TestTableCache {
         new CacheValue<>(Optional.of(Long.toString(2)), 2));
 
 
-    //Override entries
+    // Override entries
     tableCache.put(new CacheKey<>(Long.toString(0)),
         new CacheValue<>(Optional.of(Long.toString(0)), 3));
     tableCache.put(new CacheKey<>(Long.toString(1)),
         new CacheValue<>(Optional.of(Long.toString(1)), 4));
 
-    // Finally mark them for deleted
+    // Finally, mark them for deleted
     tableCache.put(new CacheKey<>(Long.toString(0)),
         new CacheValue<>(Optional.absent(), 5));
     tableCache.put(new CacheKey<>(Long.toString(1)),
@@ -314,7 +314,7 @@ public class TestTableCache {
 
       Assertions.assertEquals(1, tableCache.size());
 
-      // Epoch entries which are overrided also will be cleaned up.
+      // Epoch entries which are overridden also will be cleaned up.
       Assertions.assertEquals(0, tableCache.getEpochEntries().size());
     }
 
@@ -330,7 +330,7 @@ public class TestTableCache {
 
       Assertions.assertEquals(0, tableCache.size());
 
-      // Epoch entries which are overrided now would have been deleted.
+      // Epoch entries which are overridden now would have been deleted.
       Assertions.assertEquals(0, tableCache.getEpochEntries().size());
     } else {
       tableCache.evictCache(epochs);
@@ -393,7 +393,7 @@ public class TestTableCache {
     if (cacheType == TableCache.CacheType.PARTIAL_CACHE) {
       int deleted = 5;
 
-      // cleanup first 5 entires
+      // cleanup first 5 entries
 
       ArrayList<Long> epochs = new ArrayList<>();
       epochs.add(1L);

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -30,8 +30,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
 
@@ -39,9 +37,6 @@ import org.slf4j.event.Level;
  * Class tests partial table cache.
  */
 public class TestTableCache {
-
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TestTableCache.class);
 
   private TableCache<CacheKey<String>, CacheValue<String>> tableCache;
 
@@ -57,13 +52,12 @@ public class TestTableCache {
     GenericTestUtils.setLogLevel(FullTableCache.LOG, Level.DEBUG);
   }
 
-  public void createTableCache(TableCache.CacheType cacheType) {
+  private void createTableCache(TableCache.CacheType cacheType) {
     if (cacheType == TableCache.CacheType.FULL_CACHE) {
       tableCache = new FullTableCache<>();
     } else {
       tableCache = new PartialTableCache<>();
     }
-    LOG.info("cacheType: {}", cacheType);
   }
 
   @ParameterizedTest

--- a/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
+++ b/hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
@@ -22,14 +22,13 @@ package org.apache.hadoop.hdds.utils.db.cache;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.stream.Stream;
 
 import com.google.common.base.Optional;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.slf4j.event.Level;
 
 
@@ -39,13 +38,6 @@ import org.slf4j.event.Level;
 public class TestTableCache {
 
   private TableCache<CacheKey<String>, CacheValue<String>> tableCache;
-
-  private static Stream<TableCache.CacheType> policy() {
-    return Stream.of(
-        TableCache.CacheType.FULL_CACHE,
-        TableCache.CacheType.PARTIAL_CACHE
-    );
-  }
 
   @BeforeAll
   public static void setLogLevel() {
@@ -61,7 +53,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testPartialTableCache(TableCache.CacheType cacheType) {
 
     createTableCache(cacheType);
@@ -93,7 +85,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testTableCacheWithRenameKey(TableCache.CacheType cacheType) {
 
     createTableCache(cacheType);
@@ -143,7 +135,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testPartialTableCacheWithNotContinousEntries(
       TableCache.CacheType cacheType) {
 
@@ -195,7 +187,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testPartialTableCacheWithOverrideEntries(
       TableCache.CacheType cacheType) {
 
@@ -262,7 +254,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testPartialTableCacheWithOverrideAndDelete(
       TableCache.CacheType cacheType) {
 
@@ -355,7 +347,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testPartialTableCacheParallel(
       TableCache.CacheType cacheType) throws Exception {
 
@@ -441,7 +433,7 @@ public class TestTableCache {
   }
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testTableCache(TableCache.CacheType cacheType) {
 
     createTableCache(cacheType);
@@ -472,7 +464,7 @@ public class TestTableCache {
 
 
   @ParameterizedTest
-  @MethodSource("policy")
+  @EnumSource(TableCache.CacheType.class)
   public void testTableCacheWithNonConsecutiveEpochList(
       TableCache.CacheType cacheType) {
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Tests migrated

```
./hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/security/x509/certificate/client/TestCertificateClientInit.java
./hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/server/http/TestRatisNameRewrite.java
./hadoop-hdds/framework/src/test/java/org/apache/hadoop/hdds/utils/db/cache/TestTableCache.java
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6737

## How was this patch tested?

CI