### PR TITLE
HDDS-6748. Intermittent timeout in TestECBlockReconstructedInputStream#testReadDataWithUnbuffer

### DIFF
--- a/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedInputStream.java
+++ b/hadoop-hdds/client/src/test/java/org/apache/hadoop/ozone/client/io/TestECBlockReconstructedInputStream.java
@@ -107,7 +107,7 @@ public class TestECBlockReconstructedInputStream {
 
   @Test
   public void testReadDataByteBufferMultipleStripes() throws IOException {
-    int readBufferSize = random.nextInt(4096);
+    int readBufferSize = 4096;
     // 3 stripes and a partial chunk
     int blockLength = repConfig.getEcChunkSize() * repConfig.getData() * 3
         + repConfig.getEcChunkSize() - 1;
@@ -155,7 +155,7 @@ public class TestECBlockReconstructedInputStream {
   @Test
   public void testReadDataWithUnbuffer() throws IOException {
     // Read buffer is 16kb + 5 bytes so it does not align with stripes exactly
-    int readBufferSize = random.nextInt(1024 * 16 + 5);
+    int readBufferSize = 1024 * 16 + 5;
     // 3 stripes and a partial chunk
     int blockLength = repConfig.getEcChunkSize() * repConfig.getData() * 3
         + repConfig.getEcChunkSize() - 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use fixed read buffer size instead of random one, which could even be 0.  Too small buffer leads to long execution times and intermittent timeouts.

(We can restore randomness, if desired, by enforcing minimum size.)

https://issues.apache.org/jira/browse/HDDS-6748

## How was this patch tested?

Repeated successfully 100x:
https://github.com/adoroszlai/hadoop-ozone/runs/6434203328

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/6430180619#step:5:3562