### PR TITLE
HDDS-6750. Migrate simple tests in hdds-server-scm to JUnit5

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/TestSCMCommonPlacementPolicy.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.List;
@@ -42,7 +42,7 @@ public class TestSCMCommonPlacementPolicy {
   private NodeManager nodeManager;
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     nodeManager = new MockNodeManager(true, 10);
     conf = SCMTestUtils.getConf();
@@ -56,7 +56,7 @@ public class TestSCMCommonPlacementPolicy {
         nodeManager.getNodes(NodeStatus.inServiceHealthy());
     List<DatanodeDetails> result = dummyPlacementPolicy.getResultSet(3, list);
     Set<DatanodeDetails> resultSet = new HashSet<>(result);
-    Assert.assertNotEquals(1, resultSet.size());
+    Assertions.assertNotEquals(1, resultSet.size());
   }
 
   private static class DummyPlacementPolicy extends SCMCommonPlacementPolicy {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -46,10 +46,10 @@ import org.apache.hadoop.hdds.protocol.proto
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -93,7 +93,7 @@ public class TestDeletedBlockLog {
   private Map<Long, Set<ContainerReplica>> replicas = new HashMap<>();
   private ScmBlockDeletingServiceMetrics metrics;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     testDir = GenericTestUtils.getTestDir(
         TestDeletedBlockLog.class.getSimpleName());
@@ -148,7 +148,7 @@ public class TestDeletedBlockLog {
       for (Map.Entry<ContainerID, Long> e : map.entrySet()) {
         ContainerInfo info = containers.get(e.getKey().getId());
         try {
-          Assert.assertTrue(e.getValue() > info.getDeleteTransactionId());
+          Assertions.assertTrue(e.getValue() > info.getDeleteTransactionId());
         } catch (AssertionError err) {
           throw new Exception("New TxnId " + e.getValue() + " < " + info
               .getDeleteTransactionId());
@@ -181,7 +181,7 @@ public class TestDeletedBlockLog {
     replicas.put(cid, replicaSet);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     deletedBlockLog.close();
     scm.stop();
@@ -278,24 +278,24 @@ public class TestDeletedBlockLog {
   public void testContainerManagerTransactionId() throws Exception {
     // Initially all containers should have deleteTransactionId as 0
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assert.assertEquals(0, containerInfo.getDeleteTransactionId());
+      Assertions.assertEquals(0, containerInfo.getDeleteTransactionId());
     }
 
     // Create 30 TXs
     addTransactions(generateData(30), false);
     // Since transactions are not yet flushed deleteTransactionId should be
     // 0 for all containers
-    Assert.assertEquals(0, getTransactions(1000).size());
+    Assertions.assertEquals(0, getTransactions(1000).size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assert.assertEquals(0, containerInfo.getDeleteTransactionId());
+      Assertions.assertEquals(0, containerInfo.getDeleteTransactionId());
     }
 
     scmHADBTransactionBuffer.flush();
     // After flush there should be 30 transactions in deleteTable
     // All containers should have positive deleteTransactionId
-    Assert.assertEquals(30, getTransactions(1000).size());
+    Assertions.assertEquals(30, getTransactions(1000).size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
-      Assert.assertTrue(containerInfo.getDeleteTransactionId() > 0);
+      Assertions.assertTrue(containerInfo.getDeleteTransactionId() > 0);
     }
   }
 
@@ -321,12 +321,12 @@ public class TestDeletedBlockLog {
     incrementCount(txIDs);
     blocks = getTransactions(40 * BLOCKS_PER_TXN);
     for (DeletedBlocksTransaction block : blocks) {
-      Assert.assertEquals(-1, block.getCount());
+      Assertions.assertEquals(-1, block.getCount());
     }
 
     // If all TXs are failed, getTransactions call will always return nothing.
     blocks = getTransactions(40 * BLOCKS_PER_TXN);
-    Assert.assertEquals(blocks.size(), 0);
+    Assertions.assertEquals(blocks.size(), 0);
   }
 
   @Test
@@ -342,17 +342,17 @@ public class TestDeletedBlockLog {
     blocks.remove(blocks.size() - 1);
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN);
-    Assert.assertEquals(30, blocks.size());
+    Assertions.assertEquals(30, blocks.size());
     commitTransactions(blocks, dnList.get(1), dnList.get(2),
         DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
             .build());
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN);
-    Assert.assertEquals(30, blocks.size());
+    Assertions.assertEquals(30, blocks.size());
     commitTransactions(blocks, dnList.get(0));
 
     blocks = getTransactions(50 * BLOCKS_PER_TXN);
-    Assert.assertEquals(0, blocks.size());
+    Assertions.assertEquals(0, blocks.size());
   }
 
   @Test
@@ -385,7 +385,7 @@ public class TestDeletedBlockLog {
             scm.getScmMetadataStore().getDeletedBlocksTXTable().iterator()) {
           AtomicInteger count = new AtomicInteger();
           iter.forEachRemaining((keyValue) -> count.incrementAndGet());
-          Assert.assertEquals(added, count.get() + committed);
+          Assertions.assertEquals(added, count.get() + committed);
         }
       }
     }
@@ -409,10 +409,10 @@ public class TestDeletedBlockLog {
         metrics);
     List<DeletedBlocksTransaction> blocks =
         getTransactions(BLOCKS_PER_TXN * 10);
-    Assert.assertEquals(10, blocks.size());
+    Assertions.assertEquals(10, blocks.size());
     commitTransactions(blocks);
     blocks = getTransactions(BLOCKS_PER_TXN * 40);
-    Assert.assertEquals(40, blocks.size());
+    Assertions.assertEquals(40, blocks.size());
     commitTransactions(blocks);
 
     // close db and reopen it again to make sure
@@ -427,8 +427,8 @@ public class TestDeletedBlockLog {
         scm.getSequenceIdGen(),
         metrics);
     blocks = getTransactions(BLOCKS_PER_TXN * 40);
-    Assert.assertEquals(0, blocks.size());
-    //Assert.assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
+    Assertions.assertEquals(0, blocks.size());
+    //Assertions.assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
   }
 
   @Test
@@ -459,7 +459,7 @@ public class TestDeletedBlockLog {
 
     blocks = getTransactions(txNum * BLOCKS_PER_TXN);
     // There should be one txn remaining
-    Assert.assertEquals(1, blocks.size());
+    Assertions.assertEquals(1, blocks.size());
 
     // add two transactions for same container
     containerID = blocks.get(0).getContainerID();
@@ -474,7 +474,7 @@ public class TestDeletedBlockLog {
 
     // get should return two transactions for the same container
     blocks = getTransactions(txNum);
-    Assert.assertEquals(2, blocks.size());
+    Assertions.assertEquals(2, blocks.size());
   }
 
   private void mockContainerInfo(long containerID, DatanodeDetails dd)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/command/TestCommandStatusReportHandler.java
@@ -34,8 +34,8 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher
 import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,8 +43,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Unit test for command status report handler.
@@ -55,7 +55,7 @@ public class TestCommandStatusReportHandler implements EventPublisher {
       .getLogger(TestCommandStatusReportHandler.class);
   private CommandStatusReportHandler cmdStatusReportHandler;
 
-  @Before
+  @BeforeEach
   public void setup() {
     cmdStatusReportHandler = new CommandStatusReportHandler();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -204,7 +204,8 @@ public class TestCloseContainerEventHandler {
     i = 0;
     for (DatanodeDetails details : pipelineManager
         .getPipeline(container.getPipelineID()).getNodes()) {
-      Assertions.assertEquals(closeCount[i], nodeManager.getCommandCount(details));
+      Assertions.assertEquals(closeCount[i],
+          nodeManager.getCommandCount(details));
       i++;
     }
     eventQueue.fireEvent(CLOSE_CONTAINER, id);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestCloseContainerEventHandler.java
@@ -54,10 +54,10 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE_
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.CLOSE_CONTAINER;
 import static org.apache.hadoop.hdds.scm.events.SCMEvents.DATANODE_COMMAND;
 
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the closeContainerEventHandler class.
@@ -76,7 +76,7 @@ public class TestCloseContainerEventHandler {
   private static SCMHAManager scmhaManager;
   private static SequenceIdGenerator sequenceIdGen;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     configuration = SCMTestUtils.getConf();
     size = (long)configuration.getStorageSize(OZONE_SCM_CONTAINER_SIZE,
@@ -130,7 +130,7 @@ public class TestCloseContainerEventHandler {
     HddsTestUtils.openAllRatisPipelines(pipelineManager);
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (containerManager != null) {
       containerManager.close();
@@ -151,7 +151,7 @@ public class TestCloseContainerEventHandler {
     eventQueue.fireEvent(CLOSE_CONTAINER,
         ContainerID.valueOf(Math.abs(RandomUtils.nextInt())));
     eventQueue.processAll(1000);
-    Assert.assertTrue(logCapturer.getOutput()
+    Assertions.assertTrue(logCapturer.getOutput()
         .contains("Close container Event triggered for container"));
   }
 
@@ -163,7 +163,7 @@ public class TestCloseContainerEventHandler {
     eventQueue.fireEvent(CLOSE_CONTAINER,
         ContainerID.valueOf(id));
     eventQueue.processAll(1000);
-    Assert.assertTrue(logCapturer.getOutput()
+    Assertions.assertTrue(logCapturer.getOutput()
         .contains("Failed to close the container"));
   }
 
@@ -178,9 +178,9 @@ public class TestCloseContainerEventHandler {
     int closeCount = nodeManager.getCommandCount(datanode);
     eventQueue.fireEvent(CLOSE_CONTAINER, id);
     eventQueue.processAll(1000);
-    Assert.assertEquals(closeCount + 1,
+    Assertions.assertEquals(closeCount + 1,
         nodeManager.getCommandCount(datanode));
-    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSING,
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSING,
         containerManager.getContainer(id).getState());
   }
 
@@ -204,7 +204,7 @@ public class TestCloseContainerEventHandler {
     i = 0;
     for (DatanodeDetails details : pipelineManager
         .getPipeline(container.getPipelineID()).getNodes()) {
-      Assert.assertEquals(closeCount[i], nodeManager.getCommandCount(details));
+      Assertions.assertEquals(closeCount[i], nodeManager.getCommandCount(details));
       i++;
     }
     eventQueue.fireEvent(CLOSE_CONTAINER, id);
@@ -213,9 +213,9 @@ public class TestCloseContainerEventHandler {
     // Make sure close is queued for each datanode on the pipeline
     for (DatanodeDetails details : pipelineManager
         .getPipeline(container.getPipelineID()).getNodes()) {
-      Assert.assertEquals(closeCount[i] + 1,
+      Assertions.assertEquals(closeCount[i] + 1,
           nodeManager.getCommandCount(details));
-      Assert.assertEquals(HddsProtos.LifeCycleState.CLOSING,
+      Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSING,
           containerManager.getContainer(id).getState());
       i++;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerActionsHandler.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.ContainerActionsFromDatanode;
 import org.apache.hadoop.hdds.server.events.EventQueue;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.times;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -176,7 +176,8 @@ public class TestContainerManagerImpl {
     final ContainerInfo admin = containerManager
         .allocateContainer(new ECReplicationConfig(3, 2), "admin");
     Assertions.assertEquals(1, containerManager.getContainers().size());
-    Assertions.assertNotNull(containerManager.getContainer(admin.containerID()));
+    Assertions.assertNotNull(
+        containerManager.getContainer(admin.containerID()));
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerManagerImpl.java
@@ -38,10 +38,10 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 
 
@@ -57,7 +57,7 @@ public class TestContainerManagerImpl {
   private SequenceIdGenerator sequenceIdGen;
   private NodeManager nodeManager;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     final OzoneConfiguration conf = SCMTestUtils.getConf();
     testDir = GenericTestUtils.getTestDir(
@@ -78,7 +78,7 @@ public class TestContainerManagerImpl {
         SCMDBDefinition.CONTAINERS.getTable(dbStore));
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (containerManager != null) {
       containerManager.close();
@@ -93,13 +93,13 @@ public class TestContainerManagerImpl {
 
   @Test
   public void testAllocateContainer() throws Exception {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         containerManager.getContainers().isEmpty());
     final ContainerInfo container = containerManager.allocateContainer(
         RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
-    Assert.assertEquals(1, containerManager.getContainers().size());
-    Assert.assertNotNull(containerManager.getContainer(
+    Assertions.assertEquals(1, containerManager.getContainers().size());
+    Assertions.assertNotNull(containerManager.getContainer(
         container.containerID()));
   }
 
@@ -109,25 +109,25 @@ public class TestContainerManagerImpl {
         RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "admin");
     final ContainerID cid = container.containerID();
-    Assert.assertEquals(HddsProtos.LifeCycleState.OPEN,
+    Assertions.assertEquals(HddsProtos.LifeCycleState.OPEN,
         containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.FINALIZE);
-    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSING,
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSING,
         containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.QUASI_CLOSE);
-    Assert.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED,
+    Assertions.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED,
         containerManager.getContainer(cid).getState());
     containerManager.updateContainerState(cid,
         HddsProtos.LifeCycleEvent.FORCE_CLOSE);
-    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSED,
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSED,
         containerManager.getContainer(cid).getState());
   }
 
   @Test
   public void testGetContainers() throws Exception {
-    Assert.assertTrue(
+    Assertions.assertTrue(
         containerManager.getContainers().isEmpty());
 
     ContainerID[] cidArray = new ContainerID[10];
@@ -138,22 +138,22 @@ public class TestContainerManagerImpl {
       cidArray[i] = container.containerID();
     }
 
-    Assert.assertEquals(10,
+    Assertions.assertEquals(10,
         containerManager.getContainers(cidArray[0], 10).size());
-    Assert.assertEquals(10,
+    Assertions.assertEquals(10,
         containerManager.getContainers(cidArray[0], 100).size());
 
     containerManager.updateContainerState(cidArray[0],
         HddsProtos.LifeCycleEvent.FINALIZE);
-    Assert.assertEquals(9,
+    Assertions.assertEquals(9,
         containerManager.getContainers(HddsProtos.LifeCycleState.OPEN).size());
-    Assert.assertEquals(1, containerManager
+    Assertions.assertEquals(1, containerManager
         .getContainers(HddsProtos.LifeCycleState.CLOSING).size());
     containerManager.updateContainerState(cidArray[1],
         HddsProtos.LifeCycleEvent.FINALIZE);
-    Assert.assertEquals(8,
+    Assertions.assertEquals(8,
         containerManager.getContainers(HddsProtos.LifeCycleState.OPEN).size());
-    Assert.assertEquals(2, containerManager
+    Assertions.assertEquals(2, containerManager
         .getContainers(HddsProtos.LifeCycleState.CLOSING).size());
     containerManager.updateContainerState(cidArray[1],
         HddsProtos.LifeCycleEvent.QUASI_CLOSE);
@@ -161,13 +161,13 @@ public class TestContainerManagerImpl {
         HddsProtos.LifeCycleEvent.FINALIZE);
     containerManager.updateContainerState(cidArray[2],
         HddsProtos.LifeCycleEvent.CLOSE);
-    Assert.assertEquals(7, containerManager.
+    Assertions.assertEquals(7, containerManager.
         getContainerStateCount(HddsProtos.LifeCycleState.OPEN));
-    Assert.assertEquals(1, containerManager
+    Assertions.assertEquals(1, containerManager
         .getContainerStateCount(HddsProtos.LifeCycleState.CLOSING));
-    Assert.assertEquals(1, containerManager
+    Assertions.assertEquals(1, containerManager
         .getContainerStateCount(HddsProtos.LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, containerManager
+    Assertions.assertEquals(1, containerManager
         .getContainerStateCount(HddsProtos.LifeCycleState.CLOSED));
   }
 
@@ -175,8 +175,8 @@ public class TestContainerManagerImpl {
   public void testAllocateContainersWithECReplicationConfig() throws Exception {
     final ContainerInfo admin = containerManager
         .allocateContainer(new ECReplicationConfig(3, 2), "admin");
-    Assert.assertEquals(1, containerManager.getContainers().size());
-    Assert.assertNotNull(containerManager.getContainer(admin.containerID()));
+    Assertions.assertEquals(1, containerManager.getContainers().size());
+    Assertions.assertNotNull(containerManager.getContainer(admin.containerID()));
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReportHandler.java
@@ -46,10 +46,10 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -62,7 +62,7 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getECContainer;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getReplicas;
 import static org.apache.hadoop.hdds.scm.HddsTestUtils.getContainer;
@@ -81,7 +81,7 @@ public class TestContainerReportHandler {
   private SCMHAManager scmhaManager;
   private PipelineManager pipelineManager;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InvalidStateTransitionException {
     final OzoneConfiguration conf = SCMTestUtils.getConf();
     nodeManager = new MockNodeManager(true, 10);
@@ -143,7 +143,7 @@ public class TestContainerReportHandler {
 
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     containerStateManager.close();
     if (dbStore != null) {
@@ -203,7 +203,7 @@ public class TestContainerReportHandler {
     final ContainerReportFromDatanode containerReportFromDatanode =
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
-    Assert.assertEquals(2, containerManager.getContainerReplicas(
+    Assertions.assertEquals(2, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
 
   }
@@ -263,7 +263,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeFour, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assert.assertEquals(4, containerManager.getContainerReplicas(
+    Assertions.assertEquals(4, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
   }
 
@@ -333,7 +333,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assert.assertEquals(LifeCycleState.CLOSED,
+    Assertions.assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(containerOne.containerID()).getState());
   }
 
@@ -401,7 +401,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assert.assertEquals(LifeCycleState.QUASI_CLOSED,
+    Assertions.assertEquals(LifeCycleState.QUASI_CLOSED,
         containerManager.getContainer(containerOne.containerID()).getState());
   }
 
@@ -473,7 +473,7 @@ public class TestContainerReportHandler {
         new ContainerReportFromDatanode(datanodeOne, containerReport);
     reportHandler.onMessage(containerReportFromDatanode, publisher);
 
-    Assert.assertEquals(LifeCycleState.CLOSED,
+    Assertions.assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(containerOne.containerID()).getState());
   }
 
@@ -817,7 +817,7 @@ public class TestContainerReportHandler {
     Mockito.verify(publisher, Mockito.times(1))
         .fireEvent(Mockito.any(), Mockito.any(CommandForDatanode.class));
 
-    Assert.assertEquals(0, containerManager.getContainerReplicas(
+    Assertions.assertEquals(0, containerManager.getContainerReplicas(
         containerOne.containerID()).size());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerStateManager.java
@@ -44,10 +44,10 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.util.Time;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.mockito.Mockito.when;
@@ -64,7 +64,7 @@ public class TestContainerStateManager {
   private DBStore dbStore;
   private Pipeline pipeline;
 
-  @Before
+  @BeforeEach
   public void init() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
     scmhaManager = SCMHAManagerStub.getInstance(true);
@@ -95,7 +95,7 @@ public class TestContainerStateManager {
 
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     containerStateManager.close();
     if (dbStore != null) {
@@ -123,7 +123,7 @@ public class TestContainerStateManager {
         .getContainerReplicas(c1.containerID());
 
     //THEN
-    Assert.assertEquals(3, replicas.size());
+    Assertions.assertEquals(3, replicas.size());
   }
 
   @Test
@@ -142,8 +142,8 @@ public class TestContainerStateManager {
     Set<ContainerReplica> replicas = containerStateManager
         .getContainerReplicas(c1.containerID());
 
-    Assert.assertEquals(2, replicas.size());
-    Assert.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
+    Assertions.assertEquals(2, replicas.size());
+    Assertions.assertEquals(3, c1.getReplicationConfig().getRequiredNodes());
   }
 
   private void addReplica(ContainerInfo cont, DatanodeDetails node) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestIncrementalContainerReportHandler.java
@@ -50,10 +50,10 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -89,7 +89,7 @@ public class TestIncrementalContainerReportHandler {
   private DBStore dbStore;
   private SCMHAManager scmhaManager;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, InvalidStateTransitionException {
     final OzoneConfiguration conf = new OzoneConfiguration();
     final String path =
@@ -171,7 +171,7 @@ public class TestIncrementalContainerReportHandler {
 
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     containerStateManager.close();
     if (dbStore != null) {
@@ -211,7 +211,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icrFromDatanode, publisher);
-    Assert.assertEquals(LifeCycleState.CLOSED,
+    Assertions.assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(container.containerID()).getState());
   }
 
@@ -245,7 +245,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icrFromDatanode, publisher);
-    Assert.assertEquals(LifeCycleState.QUASI_CLOSED,
+    Assertions.assertEquals(LifeCycleState.QUASI_CLOSED,
         containerManager.getContainer(container.containerID()).getState());
   }
 
@@ -282,7 +282,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icr, publisher);
-    Assert.assertEquals(LifeCycleState.CLOSED,
+    Assertions.assertEquals(LifeCycleState.CLOSED,
         containerManager.getContainer(container.containerID()).getState());
   }
 
@@ -306,7 +306,7 @@ public class TestIncrementalContainerReportHandler {
     containerStateManager.addContainer(container.getProtobuf());
     containerReplicas.forEach(r -> containerStateManager.updateContainerReplica(
         container.containerID(), r));
-    Assert.assertEquals(3, containerStateManager
+    Assertions.assertEquals(3, containerStateManager
         .getContainerReplicas(container.containerID()).size());
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -316,7 +316,7 @@ public class TestIncrementalContainerReportHandler {
         new IncrementalContainerReportFromDatanode(
             datanodeOne, containerReport);
     reportHandler.onMessage(icr, publisher);
-    Assert.assertEquals(2, containerStateManager
+    Assertions.assertEquals(2, containerStateManager
         .getContainerReplicas(container.containerID()).size());
   }
 
@@ -339,7 +339,7 @@ public class TestIncrementalContainerReportHandler {
     containerStateManager.addContainer(container.getProtobuf());
     containerStateManager.addContainer(containerTwo.getProtobuf());
 
-    Assert.assertEquals(0, nodeManager.getContainers(datanode).size());
+    Assertions.assertEquals(0, nodeManager.getContainers(datanode).size());
 
     final IncrementalContainerReportProto containerReport =
         getIncrementalContainerReportProto(container.containerID(),
@@ -375,21 +375,21 @@ public class TestIncrementalContainerReportHandler {
         if (nmContainers.contains(container.containerID())) {
           // If we find "container" in the NM, then we must also have it in
           // Container Manager.
-          Assert.assertEquals(1, containerStateManager
+          Assertions.assertEquals(1, containerStateManager
               .getContainerReplicas(container.containerID())
               .size());
-          Assert.assertEquals(2, nmContainers.size());
+          Assertions.assertEquals(2, nmContainers.size());
         } else {
           // If the race condition occurs as mentioned in HDDS-5249, then this
           // assert should fail. We will have found nothing for "container" in
           // NM, but have found something for it in ContainerManager, and that
           // should not happen. It should be in both, or neither.
-          Assert.assertEquals(0, containerStateManager
+          Assertions.assertEquals(0, containerStateManager
               .getContainerReplicas(container.containerID())
               .size());
-          Assert.assertEquals(1, nmContainers.size());
+          Assertions.assertEquals(1, nmContainers.size());
         }
-        Assert.assertEquals(1, containerStateManager
+        Assertions.assertEquals(1, containerStateManager
             .getContainerReplicas(containerTwo.containerID())
             .size());
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -59,10 +59,10 @@ import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionExcepti
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -120,7 +120,7 @@ public class TestReplicationManager {
   private PipelineManager pipelineManager;
   private SCMHAManager scmhaManager;
 
-  @Before
+  @BeforeEach
   public void setup()
       throws IOException, InterruptedException,
       NodeNotFoundException, InvalidStateTransitionException {
@@ -232,7 +232,7 @@ public class TestReplicationManager {
     Thread.sleep(100L);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     containerStateManager.close();
     if (dbStore != null) {
@@ -247,14 +247,14 @@ public class TestReplicationManager {
    */
   @Test
   public void testReplicationManagerRestart() throws InterruptedException {
-    Assert.assertTrue(replicationManager.isRunning());
+    Assertions.assertTrue(replicationManager.isRunning());
     replicationManager.stop();
     // Stop is a non-blocking call, it might take sometime for the
     // ReplicationManager to shutdown
     Thread.sleep(500);
-    Assert.assertFalse(replicationManager.isRunning());
+    Assertions.assertFalse(replicationManager.isRunning());
     replicationManager.start();
-    Assert.assertTrue(replicationManager.isRunning());
+    Assertions.assertTrue(replicationManager.isRunning());
   }
 
   /**
@@ -269,8 +269,8 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.OPEN));
-    Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.OPEN));
+    Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
   }
 
   /**
@@ -302,7 +302,7 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
+    Assertions.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
 
     // Update the OPEN to CLOSING
@@ -312,10 +312,10 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentCloseCommandCount + 6, datanodeCommandHandler
+    Assertions.assertEquals(currentCloseCommandCount + 6, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSING));
   }
 
 
@@ -348,16 +348,16 @@ public class TestReplicationManager {
     // Two of the replicas are in OPEN state
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentCloseCommandCount + 2, datanodeCommandHandler
+    Assertions.assertEquals(currentCloseCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.closeContainerCommand,
         replicaTwo.getDatanodeDetails()));
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.closeContainerCommand,
         replicaThree.getDatanodeDetails()));
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
   }
 
   /**
@@ -387,10 +387,10 @@ public class TestReplicationManager {
     // container will not be closed. ReplicationManager should take no action.
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+    Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
@@ -432,7 +432,7 @@ public class TestReplicationManager {
     // container will not be closed. ReplicationManager should take no action.
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+    Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
 
     // Make the first replica unhealthy
     final ContainerReplica unhealthyReplica = getReplicas(
@@ -443,12 +443,12 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaOne.getDatanodeDetails()));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
 
     // Now we will delete the unhealthy replica from in-memory.
@@ -462,23 +462,23 @@ public class TestReplicationManager {
     eventQueue.processAll(1000);
 
     // We should get replicate command
-    Assert.assertEquals(currentReplicateCommandCount + 1,
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount + 1,
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assert.assertEquals(currentBytesToReplicate + 100L,
+    Assertions.assertEquals(currentBytesToReplicate + 100L,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assert.assertEquals(1, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
     // We should have one under replicated and one quasi_closed_stuck
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
     // Now we add the missing replica back
@@ -497,19 +497,19 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertEquals(0, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(0, replicationManager.getMetrics()
+    Assertions.assertEquals(0, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightReplication());
-    Assert.assertEquals(currentReplicationCommandCompleted + 1,
+    Assertions.assertEquals(currentReplicationCommandCompleted + 1,
         replicationManager.getMetrics().getNumReplicationCmdsCompleted());
-    Assert.assertEquals(currentBytesCompleted + 100L,
+    Assertions.assertEquals(currentBytesCompleted + 100L,
         replicationManager.getMetrics().getNumReplicationBytesCompleted());
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -544,19 +544,19 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
     // Now we remove the replica according to inflight
@@ -583,19 +583,19 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(0, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(0, replicationManager.getMetrics()
+    Assertions.assertEquals(0, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightDeletion());
-    Assert.assertEquals(currentDeleteCommandCompleted + 1,
+    Assertions.assertEquals(currentDeleteCommandCompleted + 1,
         replicationManager.getMetrics().getNumDeletionCmdsCompleted());
-    Assert.assertEquals(deleteBytesCompleted + 101,
+    Assertions.assertEquals(deleteBytesCompleted + 101,
         replicationManager.getMetrics().getNumDeletionBytesCompleted());
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -632,22 +632,22 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaOne.getDatanodeDetails()));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
 
     final long currentDeleteCommandCompleted = replicationManager.getMetrics()
@@ -658,17 +658,17 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertEquals(currentDeleteCommandCompleted + 1,
+    Assertions.assertEquals(currentDeleteCommandCompleted + 1,
         replicationManager.getMetrics().getNumDeletionCmdsCompleted());
-    Assert.assertEquals(0, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(0, replicationManager.getMetrics()
+    Assertions.assertEquals(0, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightDeletion());
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
@@ -698,22 +698,22 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentReplicateCommandCount + 1,
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount + 1,
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assert.assertEquals(currentBytesToReplicate + 100,
+    Assertions.assertEquals(currentBytesToReplicate + 100,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assert.assertEquals(1, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
 
     final long currentReplicateCommandCompleted = replicationManager
@@ -732,19 +732,19 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertEquals(currentReplicateCommandCompleted + 1,
+    Assertions.assertEquals(currentReplicateCommandCompleted + 1,
         replicationManager.getMetrics().getNumReplicationCmdsCompleted());
-    Assert.assertEquals(currentReplicateBytesCompleted + 100,
+    Assertions.assertEquals(currentReplicateBytesCompleted + 100,
         replicationManager.getMetrics().getNumReplicationBytesCompleted());
-    Assert.assertEquals(0, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(0, replicationManager.getMetrics()
+    Assertions.assertEquals(0, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightReplication());
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
@@ -803,7 +803,7 @@ public class TestReplicationManager {
             .equals(SCMCommandProto.Type.replicateContainerCommand))
         .findFirst();
 
-    Assert.assertTrue(replicateCommand.isPresent());
+    Assertions.assertTrue(replicateCommand.isPresent());
 
     DatanodeDetails newNode = createDatanodeDetails(
         replicateCommand.get().getDatanodeId());
@@ -812,12 +812,12 @@ public class TestReplicationManager {
     containerStateManager.updateContainerReplica(id, newReplica);
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNHEALTHY));
 
     /*
@@ -827,18 +827,18 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     // ReplicaTwo should be deleted, that is the unhealthy one
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaTwo.getDatanodeDetails()));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(currentBytesToDelete + 99,
+    Assertions.assertEquals(currentBytesToDelete + 99,
         replicationManager.getMetrics().getNumDeletionBytesTotal());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
     containerStateManager.removeContainerReplica(id, replicaTwo);
@@ -847,12 +847,12 @@ public class TestReplicationManager {
         .getNumDeletionCmdsCompleted();
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNHEALTHY));
     /*
      * We have now removed unhealthy replica, next iteration of
@@ -863,28 +863,28 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertEquals(0, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(0, replicationManager.getMetrics()
+    Assertions.assertEquals(0, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightDeletion());
-    Assert.assertEquals(currentDeleteCommandCompleted + 1,
+    Assertions.assertEquals(currentDeleteCommandCompleted + 1,
         replicationManager.getMetrics().getNumDeletionCmdsCompleted());
 
-    Assert.assertEquals(currentReplicateCommandCount + 2,
+    Assertions.assertEquals(currentReplicateCommandCount + 2,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount + 2,
+    Assertions.assertEquals(currentReplicateCommandCount + 2,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
     report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.UNHEALTHY));
   }
 
@@ -915,12 +915,12 @@ public class TestReplicationManager {
     eventQueue.processAll(1000);
 
     // All the replicas have same BCSID, so all of them will be closed.
-    Assert.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
+    Assertions.assertEquals(currentCloseCommandCount + 3, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.closeContainerCommand));
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
-    Assert.assertEquals(0, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.QUASI_CLOSED));
+    Assertions.assertEquals(0, report.getStat(
         ReplicationManagerReport.HealthState.QUASI_CLOSED_STUCK));
   }
 
@@ -945,13 +945,13 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(0, datanodeCommandHandler.getInvocation());
+    Assertions.assertEquals(0, datanodeCommandHandler.getInvocation());
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assert.assertEquals(0, report.getStat(s));
+      Assertions.assertEquals(0, report.getStat(s));
     }
   }
 
@@ -982,8 +982,8 @@ public class TestReplicationManager {
         .onMessage(id, eventQueue);
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.OPEN));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.OPEN));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.OPEN_UNHEALTHY));
   }
 
@@ -1007,7 +1007,7 @@ public class TestReplicationManager {
     replicationManager.processAll();
     // Wait for EventQueue to call the event handler
     eventQueue.processAll(1000);
-    Assert.assertEquals(2, datanodeCommandHandler.getInvocation());
+    Assertions.assertEquals(2, datanodeCommandHandler.getInvocation());
   }
 
   @Test
@@ -1018,7 +1018,7 @@ public class TestReplicationManager {
     //default is not included in ozone-site.xml but generated from annotation
     //to the ozone-site-generated.xml which should be loaded by the
     // OzoneConfiguration.
-    Assert.assertEquals(1800000, rmc.getEventTimeout());
+    Assertions.assertEquals(1800000, rmc.getEventTimeout());
 
   }
 
@@ -1061,19 +1061,19 @@ public class TestReplicationManager {
     // At this stage, due to the mocked calls to validateContainerPlacement
     // the policy will not be satisfied, and replication will be triggered.
 
-    Assert.assertEquals(currentReplicateCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentReplicateCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount + 1,
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assert.assertEquals(currentBytesToReplicate + 100,
+    Assertions.assertEquals(currentBytesToReplicate + 100,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assert.assertEquals(1, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
-    Assert.assertEquals(1, report.getStat(
+    Assertions.assertEquals(1, report.getStat(LifeCycleState.CLOSED));
+    Assertions.assertEquals(1, report.getStat(
         ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
     // Now make it so that all containers seem mis-replicated no matter how
@@ -1094,12 +1094,12 @@ public class TestReplicationManager {
     // At this stage, due to the mocked calls to validateContainerPlacement
     // the mis-replicated racks will not have improved, so expect to see nothing
     // scheduled.
-    Assert.assertEquals(currentReplicateCommandCount, datanodeCommandHandler
+    Assertions.assertEquals(currentReplicateCommandCount, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount,
+    Assertions.assertEquals(currentReplicateCommandCount,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightReplication().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
   }
 
@@ -1144,16 +1144,16 @@ public class TestReplicationManager {
     // The unhealthy replica should be removed, but not the other replica
     // as each time we test with 3 replicas, Mockito ensures it returns
     // mis-replicated
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
 
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaFive.getDatanodeDetails()));
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
     assertOverReplicatedCount(1);
   }
@@ -1190,12 +1190,12 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + 1,
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
     assertOverReplicatedCount(1);
@@ -1237,12 +1237,12 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + 2,
+    Assertions.assertEquals(currentDeleteCommandCount + 2,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
   }
 
@@ -1425,12 +1425,12 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
+    Assertions.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
         .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + 2,
+    Assertions.assertEquals(currentDeleteCommandCount + 2,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
-    Assert.assertEquals(1, replicationManager.getInflightDeletion().size());
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
     // Get the DECOM and Maint replica and ensure none of them are scheduled
     // for removal
@@ -1441,7 +1441,7 @@ public class TestReplicationManager {
         .filter(r -> r.getDatanodeDetails().getPersistedOpState() != IN_SERVICE)
         .collect(Collectors.toSet());
     for (ContainerReplica r : decom) {
-      Assert.assertFalse(datanodeCommandHandler.received(
+      Assertions.assertFalse(datanodeCommandHandler.received(
           SCMCommandProto.Type.deleteContainerCommand,
           r.getDatanodeDetails()));
     }
@@ -1483,12 +1483,12 @@ public class TestReplicationManager {
     DatanodeDetails dn3 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
     CompletableFuture<MoveResult> cf =
         replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(scmLogs.getOutput().contains(
+    Assertions.assertTrue(scmLogs.getOutput().contains(
         "receive a move request about container"));
     Thread.sleep(100L);
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.replicateContainerCommand, dn3));
-    Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.replicateContainerCommand));
 
     //replicate container to dn3
@@ -1496,16 +1496,16 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand, dn1.getDatanodeDetails()));
-    Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.deleteContainerCommand));
     containerStateManager.removeContainerReplica(id, dn1);
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertTrue(cf.isDone() && cf.get() == MoveResult.COMPLETED);
+    Assertions.assertTrue(cf.isDone() && cf.get() == MoveResult.COMPLETED);
   }
 
   /**
@@ -1524,12 +1524,12 @@ public class TestReplicationManager {
         new NodeStatus(IN_SERVICE, HEALTHY), CLOSED);
     DatanodeDetails dn3 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
     replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(scmLogs.getOutput().contains(
+    Assertions.assertTrue(scmLogs.getOutput().contains(
         "receive a move request about container"));
     Thread.sleep(100L);
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.replicateContainerCommand, dn3));
-    Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.replicateContainerCommand));
 
     //crash happens, restart scm.
@@ -1537,22 +1537,22 @@ public class TestReplicationManager {
     resetReplicationManager();
     replicationManager.getMoveScheduler()
         .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-    Assert.assertTrue(replicationManager.getMoveScheduler()
+    Assertions.assertTrue(replicationManager.getMoveScheduler()
         .getInflightMove().containsKey(id));
     MoveDataNodePair kv = replicationManager.getMoveScheduler()
         .getInflightMove().get(id);
-    Assert.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
-    Assert.assertEquals(kv.getTgt(), dn3);
+    Assertions.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
+    Assertions.assertEquals(kv.getTgt(), dn3);
     serviceManager.notifyStatusChanged();
 
     Thread.sleep(100L);
     // now, the container is not over-replicated,
     // so no deleteContainerCommand will be sent
-    Assert.assertFalse(datanodeCommandHandler.received(
+    Assertions.assertFalse(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand, dn1.getDatanodeDetails()));
     //replica does not exist in target datanode, so a replicateContainerCommand
     //will be sent again at notifyStatusChanged#onLeaderReadyAndOutOfSafeMode
-    Assert.assertEquals(2, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(2, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.replicateContainerCommand));
 
 
@@ -1562,7 +1562,7 @@ public class TestReplicationManager {
     eventQueue.processAll(1000);
 
     //deleteContainerCommand is sent, but the src replica is not deleted now
-    Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.deleteContainerCommand));
 
     //crash happens, restart scm.
@@ -1570,17 +1570,17 @@ public class TestReplicationManager {
     resetReplicationManager();
     replicationManager.getMoveScheduler()
         .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-    Assert.assertTrue(replicationManager.getMoveScheduler()
+    Assertions.assertTrue(replicationManager.getMoveScheduler()
         .getInflightMove().containsKey(id));
     kv = replicationManager.getMoveScheduler()
         .getInflightMove().get(id);
-    Assert.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
-    Assert.assertEquals(kv.getTgt(), dn3);
+    Assertions.assertEquals(kv.getSrc(), dn1.getDatanodeDetails());
+    Assertions.assertEquals(kv.getTgt(), dn3);
     serviceManager.notifyStatusChanged();
 
     //after restart and the container is over-replicated now,
     //deleteContainerCommand will be sent again
-    Assert.assertEquals(2, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(2, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.deleteContainerCommand));
     containerStateManager.removeContainerReplica(id, dn1);
 
@@ -1594,7 +1594,7 @@ public class TestReplicationManager {
     resetReplicationManager();
     replicationManager.getMoveScheduler()
         .reinitialize(SCMDBDefinition.MOVE.getTable(dbStore));
-    Assert.assertFalse(replicationManager.getMoveScheduler()
+    Assertions.assertFalse(replicationManager.getMoveScheduler()
         .getInflightMove().containsKey(id));
 
     //completeableFuture is not stored in DB, so after scm crash and
@@ -1619,12 +1619,12 @@ public class TestReplicationManager {
     DatanodeDetails dn4 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
     CompletableFuture<MoveResult> cf =
         replicationManager.move(id, dn1.getDatanodeDetails(), dn4);
-    Assert.assertTrue(scmLogs.getOutput().contains(
+    Assertions.assertTrue(scmLogs.getOutput().contains(
         "receive a move request about container"));
     Thread.sleep(100L);
-    Assert.assertTrue(datanodeCommandHandler.received(
+    Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.replicateContainerCommand, dn4));
-    Assert.assertEquals(1, datanodeCommandHandler.getInvocationCount(
+    Assertions.assertEquals(1, datanodeCommandHandler.getInvocationCount(
         SCMCommandProto.Type.replicateContainerCommand));
 
     //replicate container to dn4
@@ -1636,10 +1636,10 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertFalse(datanodeCommandHandler.received(
+    Assertions.assertFalse(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand, dn1.getDatanodeDetails()));
 
-    Assert.assertTrue(cf.isDone() && cf.get() == MoveResult.DELETE_FAIL_POLICY);
+    Assertions.assertTrue(cf.isDone() && cf.get() == MoveResult.DELETE_FAIL_POLICY);
   }
 
 
@@ -1660,14 +1660,14 @@ public class TestReplicationManager {
     DatanodeDetails dn3 = addNode(new NodeStatus(IN_SERVICE, HEALTHY));
     CompletableFuture<MoveResult> cf =
         replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(scmLogs.getOutput().contains(
+    Assertions.assertTrue(scmLogs.getOutput().contains(
         "receive a move request about container"));
 
     nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, STALE));
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
 
     nodeManager.setNodeStatus(dn3, new NodeStatus(IN_SERVICE, HEALTHY));
@@ -1680,7 +1680,7 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.DELETION_FAIL_NODE_UNHEALTHY);
   }
 
@@ -1711,32 +1711,32 @@ public class TestReplicationManager {
     replicationManager.stop();
     Thread.sleep(100L);
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.FAIL_NOT_RUNNING);
     replicationManager.start();
     Thread.sleep(100L);
 
     //container in not in OPEN state
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
     //open -> closing
     containerStateManager.updateContainerState(id.getProtobuf(),
         LifeCycleEvent.FINALIZE);
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
     //closing -> quasi_closed
     containerStateManager.updateContainerState(id.getProtobuf(),
         LifeCycleEvent.QUASI_CLOSE);
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_CONTAINER_NOT_CLOSED);
 
     //quasi_closed -> closed
     containerStateManager.updateContainerState(id.getProtobuf(),
         LifeCycleEvent.FORCE_CLOSE);
-    Assert.assertTrue(LifeCycleState.CLOSED ==
+    Assertions.assertTrue(LifeCycleState.CLOSED ==
         containerStateManager.getContainer(id).getState());
 
     //Node is not in healthy state
@@ -1745,10 +1745,10 @@ public class TestReplicationManager {
         nodeManager.setNodeStatus(dn3,
             new NodeStatus(IN_SERVICE, state));
         cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-        Assert.assertTrue(cf.isDone() && cf.get() ==
+        Assertions.assertTrue(cf.isDone() && cf.get() ==
             MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
         cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
-        Assert.assertTrue(cf.isDone() && cf.get() ==
+        Assertions.assertTrue(cf.isDone() && cf.get() ==
             MoveResult.REPLICATION_FAIL_NODE_UNHEALTHY);
       }
     }
@@ -1761,10 +1761,10 @@ public class TestReplicationManager {
         nodeManager.setNodeStatus(dn3,
             new NodeStatus(state, HEALTHY));
         cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-        Assert.assertTrue(cf.isDone() && cf.get() ==
+        Assertions.assertTrue(cf.isDone() && cf.get() ==
             MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
         cf = replicationManager.move(id, dn3, dn1.getDatanodeDetails());
-        Assert.assertTrue(cf.isDone() && cf.get() ==
+        Assertions.assertTrue(cf.isDone() && cf.get() ==
             MoveResult.REPLICATION_FAIL_NODE_NOT_IN_SERVICE);
       }
     }
@@ -1773,12 +1773,12 @@ public class TestReplicationManager {
     //container exists in target datanode
     cf = replicationManager.move(id, dn1.getDatanodeDetails(),
         dn2.getDatanodeDetails());
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_EXIST_IN_TARGET);
 
     //container does not exist in source datanode
     cf = replicationManager.move(id, dn3, dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_NOT_EXIST_IN_SOURCE);
 
     //make container over relplicated to test the
@@ -1789,7 +1789,7 @@ public class TestReplicationManager {
     //waiting for inflightDeletion generation
     eventQueue.processAll(1000);
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_INFLIGHT_DELETION);
     resetReplicationManager();
 
@@ -1802,7 +1802,7 @@ public class TestReplicationManager {
     //waiting for inflightReplication generation
     eventQueue.processAll(1000);
     cf = replicationManager.move(id, dn1.getDatanodeDetails(), dn3);
-    Assert.assertTrue(cf.isDone() && cf.get() ==
+    Assertions.assertTrue(cf.isDone() && cf.get() ==
         MoveResult.REPLICATION_FAIL_INFLIGHT_REPLICATION);
   }
 
@@ -1822,7 +1822,7 @@ public class TestReplicationManager {
     // scheduled
     clock.fastForward(timeout + 1000);
     assertReplicaScheduled(1);
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getNumReplicationCmdsTimeout());
   }
 
@@ -1845,7 +1845,7 @@ public class TestReplicationManager {
     // scheduled
     clock.fastForward(timeout + 1000);
     assertDeleteScheduled(1);
-    Assert.assertEquals(1, replicationManager.getMetrics()
+    Assertions.assertEquals(1, replicationManager.getMetrics()
         .getNumDeletionCmdsTimeout());
   }
 
@@ -1965,10 +1965,10 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentReplicateCommandCount + delta,
+    Assertions.assertEquals(currentReplicateCommandCount + delta,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.replicateContainerCommand));
-    Assert.assertEquals(currentReplicateCommandCount + delta,
+    Assertions.assertEquals(currentReplicateCommandCount + delta,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
   }
 
@@ -1978,32 +1978,32 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assert.assertEquals(currentDeleteCommandCount + delta,
+    Assertions.assertEquals(currentDeleteCommandCount + delta,
         datanodeCommandHandler.getInvocationCount(
             SCMCommandProto.Type.deleteContainerCommand));
-    Assert.assertEquals(currentDeleteCommandCount + delta,
+    Assertions.assertEquals(currentDeleteCommandCount + delta,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
   }
 
   private void assertUnderReplicatedCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(count, report.getStat(
+    Assertions.assertEquals(count, report.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
   private void assertMissingCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(count, report.getStat(
+    Assertions.assertEquals(count, report.getStat(
         ReplicationManagerReport.HealthState.MISSING));
   }
 
   private void assertOverReplicatedCount(int count) {
     ReplicationManagerReport report = replicationManager.getContainerReport();
-    Assert.assertEquals(count, report.getStat(
+    Assertions.assertEquals(count, report.getStat(
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     containerStateManager.close();
     replicationManager.stop();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManager.java
@@ -443,8 +443,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaOne.getDatanodeDetails()));
@@ -469,7 +470,8 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumReplicationCmdsSent());
     Assertions.assertEquals(currentBytesToReplicate + 100L,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
@@ -497,7 +499,8 @@ public class TestReplicationManager {
     replicationManager.processAll();
     eventQueue.processAll(1000);
 
-    Assertions.assertEquals(0, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(0,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightReplication());
     Assertions.assertEquals(currentReplicationCommandCompleted + 1,
@@ -544,8 +547,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
     Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
@@ -632,8 +636,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
         replicaOne.getDatanodeDetails()));
@@ -705,7 +710,8 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumReplicationCmdsSent());
     Assertions.assertEquals(currentBytesToReplicate + 100,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
@@ -736,7 +742,8 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumReplicationCmdsCompleted());
     Assertions.assertEquals(currentReplicateBytesCompleted + 100,
         replicationManager.getMetrics().getNumReplicationBytesCompleted());
-    Assertions.assertEquals(0, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(0,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(0, replicationManager.getMetrics()
         .getInflightReplication());
 
@@ -827,8 +834,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     // ReplicaTwo should be deleted, that is the unhealthy one
     Assertions.assertTrue(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand,
@@ -837,7 +845,8 @@ public class TestReplicationManager {
         replicationManager.getMetrics().getNumDeletionCmdsSent());
     Assertions.assertEquals(currentBytesToDelete + 99,
         replicationManager.getMetrics().getNumDeletionBytesTotal());
-    Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightDeletion().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightDeletion());
 
@@ -874,7 +883,8 @@ public class TestReplicationManager {
             SCMCommandProto.Type.replicateContainerCommand));
     Assertions.assertEquals(currentReplicateCommandCount + 2,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
@@ -1061,13 +1071,15 @@ public class TestReplicationManager {
     // At this stage, due to the mocked calls to validateContainerPlacement
     // the policy will not be satisfied, and replication will be triggered.
 
-    Assertions.assertEquals(currentReplicateCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
+    Assertions.assertEquals(currentReplicateCommandCount + 1,
+        datanodeCommandHandler.getInvocationCount(
+            SCMCommandProto.Type.replicateContainerCommand));
     Assertions.assertEquals(currentReplicateCommandCount + 1,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
     Assertions.assertEquals(currentBytesToReplicate + 100,
         replicationManager.getMetrics().getNumReplicationBytesTotal());
-    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
 
@@ -1098,7 +1110,8 @@ public class TestReplicationManager {
         .getInvocationCount(SCMCommandProto.Type.replicateContainerCommand));
     Assertions.assertEquals(currentReplicateCommandCount,
         replicationManager.getMetrics().getNumReplicationCmdsSent());
-    Assertions.assertEquals(1, replicationManager.getInflightReplication().size());
+    Assertions.assertEquals(1,
+        replicationManager.getInflightReplication().size());
     Assertions.assertEquals(1, replicationManager.getMetrics()
         .getInflightReplication());
   }
@@ -1144,8 +1157,9 @@ public class TestReplicationManager {
     // The unhealthy replica should be removed, but not the other replica
     // as each time we test with 3 replicas, Mockito ensures it returns
     // mis-replicated
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
 
@@ -1190,8 +1204,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 1, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 1,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertEquals(currentDeleteCommandCount + 1,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
     Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
@@ -1237,8 +1252,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 2,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertEquals(currentDeleteCommandCount + 2,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
     Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
@@ -1425,8 +1441,9 @@ public class TestReplicationManager {
 
     replicationManager.processAll();
     eventQueue.processAll(1000);
-    Assertions.assertEquals(currentDeleteCommandCount + 2, datanodeCommandHandler
-        .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
+    Assertions.assertEquals(currentDeleteCommandCount + 2,
+        datanodeCommandHandler
+            .getInvocationCount(SCMCommandProto.Type.deleteContainerCommand));
     Assertions.assertEquals(currentDeleteCommandCount + 2,
         replicationManager.getMetrics().getNumDeletionCmdsSent());
     Assertions.assertEquals(1, replicationManager.getInflightDeletion().size());
@@ -1639,7 +1656,8 @@ public class TestReplicationManager {
     Assertions.assertFalse(datanodeCommandHandler.received(
         SCMCommandProto.Type.deleteContainerCommand, dn1.getDatanodeDetails()));
 
-    Assertions.assertTrue(cf.isDone() && cf.get() == MoveResult.DELETE_FAIL_POLICY);
+    Assertions.assertTrue(cf.isDone() &&
+        cf.get() == MoveResult.DELETE_FAIL_POLICY);
   }
 
 
@@ -1736,7 +1754,7 @@ public class TestReplicationManager {
     //quasi_closed -> closed
     containerStateManager.updateContainerState(id.getProtobuf(),
         LifeCycleEvent.FORCE_CLOSE);
-    Assertions.assertTrue(LifeCycleState.CLOSED ==
+    Assertions.assertSame(LifeCycleState.CLOSED,
         containerStateManager.getContainer(id).getState());
 
     //Node is not in healthy state

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/TestUnknownContainerReport.java
@@ -52,9 +52,9 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -72,7 +72,7 @@ public class TestUnknownContainerReport {
   private DBStore dbStore;
   private SCMHAManager scmhaManager;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     final OzoneConfiguration conf = SCMTestUtils.getConf();
     this.nodeManager = new MockNodeManager(true, 10);
@@ -98,7 +98,7 @@ public class TestUnknownContainerReport {
         .thenThrow(new ContainerNotFoundException());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     containerStateManager.close();
     if (dbStore != null) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestFindTargetStrategy.java
@@ -26,8 +26,8 @@ import org.apache.hadoop.hdds.scm.net.NetworkTopologyImpl;
 import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.DatanodeUsageInfo;
-import org.junit.Test;
-import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -37,7 +37,7 @@ import static org.apache.hadoop.hdds.scm.net.NetConstants.LEAF_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.NODEGROUP_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.RACK_SCHEMA;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.ROOT_SCHEMA;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for all the implementations of FindTargetStrategy.
@@ -77,15 +77,15 @@ public class TestFindTargetStrategy {
 
     Object[] sortedPotentialTargetArray = potentialTargets.toArray();
 
-    Assert.assertEquals(sortedPotentialTargetArray.length, 3);
+    Assertions.assertEquals(sortedPotentialTargetArray.length, 3);
 
     //make sure after sorting target for source, the potentialTargets is
     //sorted in descending order of usage
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
         .getDatanodeDetails(), dui3.getDatanodeDetails());
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
         .getDatanodeDetails(), dui2.getDatanodeDetails());
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
         .getDatanodeDetails(), dui1.getDatanodeDetails());
 
   }
@@ -171,26 +171,26 @@ public class TestFindTargetStrategy {
         findTargetGreedyByNetworkTopology.getPotentialTargets();
 
     Object[] sortedPotentialTargetArray = potentialTargets.toArray();
-    Assert.assertEquals(sortedPotentialTargetArray.length, 5);
+    Assertions.assertEquals(sortedPotentialTargetArray.length, 5);
 
     // although target1 has the highest usage, it has the nearest network
     // topology distance to source, so it should be at the head of the
     // sorted PotentialTargetArray
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[0])
         .getDatanodeDetails(), target1);
 
     // these targets have same network topology distance to source,
     // so they should be sorted by usage
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[1])
         .getDatanodeDetails(), target4);
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[2])
         .getDatanodeDetails(), target3);
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[3])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[3])
         .getDatanodeDetails(), target2);
 
     //target5 has the lowest usage , but it has the farthest distance to source
     //so it should be at the tail of the sorted PotentialTargetArray
-    Assert.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[4])
+    Assertions.assertEquals(((DatanodeUsageInfo)sortedPotentialTargetArray[4])
         .getDatanodeDetails(), target5);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -40,9 +40,9 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
@@ -68,7 +68,7 @@ public class TestContainerPlacementFactory {
   // node manager
   private NodeManager nodeManager;
 
-  @Before
+  @BeforeEach
   public void setup() {
     //initialize network topology instance
     conf = new OzoneConfiguration();
@@ -149,12 +149,12 @@ public class TestContainerPlacementFactory {
     int nodeNum = 3;
     List<DatanodeDetails> datanodeDetails =
         policy.chooseDatanodes(null, null, nodeNum, 15, 15);
-    Assert.assertEquals(nodeNum, datanodeDetails.size());
-    Assert.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
+    Assertions.assertEquals(nodeNum, datanodeDetails.size());
+    Assertions.assertTrue(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(1)));
-    Assert.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
+    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(0),
         datanodeDetails.get(2)));
-    Assert.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
+    Assertions.assertFalse(cluster.isSameParent(datanodeDetails.get(1),
         datanodeDetails.get(2)));
   }
 
@@ -162,14 +162,14 @@ public class TestContainerPlacementFactory {
   public void testDefaultPolicy() throws IOException {
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getPolicy(conf, null, null, true, null);
-    Assert.assertSame(SCMContainerPlacementRandom.class, policy.getClass());
+    Assertions.assertSame(SCMContainerPlacementRandom.class, policy.getClass());
   }
 
   @Test
   public void testECPolicy() throws IOException {
     PlacementPolicy policy = ContainerPlacementPolicyFactory
         .getECPolicy(conf, null, null, true, null);
-    Assert.assertSame(SCMContainerPlacementRackScatter.class,
+    Assertions.assertSame(SCMContainerPlacementRackScatter.class,
         policy.getClass());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -191,19 +191,24 @@ public class TestContainerPlacementFactory {
     }
   }
 
-  @Test(expected = SCMException.class)
-  public void testConstuctorNotFound() throws SCMException {
+  @Test
+  public void testConstuctorNotFound() {
     // set a placement class which does't have the right constructor implemented
     conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         DummyImpl.class.getName());
-    ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null);
+
+    Assertions.assertThrows(SCMException.class, () ->
+        ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null)
+    );
   }
 
-  @Test(expected = RuntimeException.class)
-  public void testClassNotImplemented() throws SCMException {
+  @Test
+  public void testClassNotImplemented() {
     // set a placement class not implemented
     conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         "org.apache.hadoop.hdds.scm.container.placement.algorithm.HelloWorld");
-    ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null);
+    Assertions.assertThrows(RuntimeException.class, () ->
+        ContainerPlacementPolicyFactory.getPolicy(conf, null, null, true, null)
+    );
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementStatusDefault.java
@@ -18,10 +18,10 @@
 
 package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 
-import org.junit.Test;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertFalse;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Test for the ContainerPlacementStatusDefault class.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -134,14 +134,14 @@ public class TestSCMContainerPlacementCapacity {
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
       Assertions.assertNotEquals(
-          "Datanode 0 should not been selected: excluded by parameter",
-          datanodes.get(0), datanode0Details);
+          datanodes.get(0), datanode0Details,
+          "Datanode 0 should not been selected: excluded by parameter");
       Assertions.assertNotEquals(
-          "Datanode 1 should not been selected: excluded by parameter",
-          datanodes.get(1), datanode0Details);
+          datanodes.get(1), datanode0Details,
+          "Datanode 1 should not been selected: excluded by parameter");
       Assertions.assertNotEquals(
-          "Datanode 2 should not been selected: not enough space there",
-          datanodes.get(2), datanode0Details);
+          datanodes.get(2), datanode0Details,
+          "Datanode 2 should not been selected: not enough space there");
 
       selectedCount
           .put(datanode0Details, selectedCount.get(datanode0Details) + 1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.mockito.Matchers.anyObject;
@@ -130,16 +130,16 @@ public class TestSCMContainerPlacementCapacity {
           .chooseDatanodes(existingNodes, null, 1, 15, 15);
 
       //then
-      Assert.assertEquals(1, datanodeDetails.size());
+      Assertions.assertEquals(1, datanodeDetails.size());
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 0 should not been selected: excluded by parameter",
           datanodes.get(0), datanode0Details);
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 1 should not been selected: excluded by parameter",
           datanodes.get(1), datanode0Details);
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 2 should not been selected: not enough space there",
           datanodes.get(2), datanode0Details);
 
@@ -149,9 +149,9 @@ public class TestSCMContainerPlacementCapacity {
     }
 
     //datanode 6 has more space than datanode 3 and datanode 4.
-    Assert.assertTrue(selectedCount.get(datanodes.get(3)) < selectedCount
+    Assertions.assertTrue(selectedCount.get(datanodes.get(3)) < selectedCount
         .get(datanodes.get(6)));
-    Assert.assertTrue(selectedCount.get(datanodes.get(4)) < selectedCount
+    Assertions.assertTrue(selectedCount.get(datanodes.get(4)) < selectedCount
         .get(datanodes.get(6)));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -34,12 +34,12 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
-import org.junit.Assert;
-import org.junit.Test;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
 
@@ -103,16 +103,16 @@ public class TestSCMContainerPlacementRandom {
           .chooseDatanodes(existingNodes, null, 1, 15, 15);
 
       //then
-      Assert.assertEquals(1, datanodeDetails.size());
+      Assertions.assertEquals(1, datanodeDetails.size());
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 0 should not been selected: excluded by parameter",
           datanodes.get(0), datanode0Details);
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 1 should not been selected: excluded by parameter",
           datanodes.get(1), datanode0Details);
-      Assert.assertNotEquals(
+      Assertions.assertNotEquals(
           "Datanode 2 should not been selected: not enough space there",
           datanodes.get(2), datanode0Details);
 
@@ -215,11 +215,11 @@ public class TestSCMContainerPlacementRandom {
         new SCMContainerPlacementRandom(mockNodeManager, conf, null, true,
             null);
 
-    Assert.assertTrue(
+    Assertions.assertTrue(
         scmContainerPlacementRandom.isValidNode(datanodes.get(0), 15L, 15L));
-    Assert.assertFalse(
+    Assertions.assertFalse(
         scmContainerPlacementRandom.isValidNode(datanodes.get(1), 15L, 15L));
-    Assert.assertFalse(
+    Assertions.assertFalse(
         scmContainerPlacementRandom.isValidNode(datanodes.get(2), 15L, 15L));
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRandom.java
@@ -107,14 +107,14 @@ public class TestSCMContainerPlacementRandom {
       DatanodeDetails datanode0Details = datanodeDetails.get(0);
 
       Assertions.assertNotEquals(
-          "Datanode 0 should not been selected: excluded by parameter",
-          datanodes.get(0), datanode0Details);
+          datanodes.get(0), datanode0Details,
+          "Datanode 0 should not been selected: excluded by parameter");
       Assertions.assertNotEquals(
-          "Datanode 1 should not been selected: excluded by parameter",
-          datanodes.get(1), datanode0Details);
+          datanodes.get(1), datanode0Details,
+          "Datanode 1 should not been selected: excluded by parameter");
       Assertions.assertNotEquals(
-          "Datanode 2 should not been selected: not enough space there",
-          datanodes.get(2), datanode0Details);
+          datanodes.get(2), datanode0Details,
+          "Datanode 2 should not been selected: not enough space there");
 
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManagerMetrics.java
@@ -19,10 +19,10 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.test.MetricsAsserts.getLongGauge;
@@ -36,7 +36,7 @@ public class TestReplicationManagerMetrics {
   private ReplicationManager replicationManager;
   private ReplicationManagerMetrics metrics;
 
-  @Before
+  @BeforeEach
   public void setup() {
     ReplicationManagerReport report = new ReplicationManagerReport();
 
@@ -59,24 +59,24 @@ public class TestReplicationManagerMetrics {
     metrics = ReplicationManagerMetrics.create(replicationManager);
   }
 
-  @After
+  @AfterEach
   public void after() {
     metrics.unRegister();
   }
 
   @Test
   public void testLifeCycleStateMetricsPresent() {
-    Assert.assertEquals(HddsProtos.LifeCycleState.OPEN.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.OPEN.getNumber(),
         getGauge("NumOpenContainers"));
-    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSING.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSING.getNumber(),
         getGauge("NumClosingContainers"));
-    Assert.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.QUASI_CLOSED.getNumber(),
         getGauge("NumQuasiClosedContainers"));
-    Assert.assertEquals(HddsProtos.LifeCycleState.CLOSED.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.CLOSED.getNumber(),
         getGauge("NumClosedContainers"));
-    Assert.assertEquals(HddsProtos.LifeCycleState.DELETING.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.DELETING.getNumber(),
         getGauge("NumDeletingContainers"));
-    Assert.assertEquals(HddsProtos.LifeCycleState.DELETED.getNumber(),
+    Assertions.assertEquals(HddsProtos.LifeCycleState.DELETED.getNumber(),
         getGauge("NumDeletedContainers"));
   }
 
@@ -84,7 +84,7 @@ public class TestReplicationManagerMetrics {
   public void testHealthStateMetricsPresent() {
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assert.assertEquals(s.ordinal(), getGauge(s.getMetricName()));
+      Assertions.assertEquals(s.ordinal(), getGauge(s.getMetricName()));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestContainerReplicaCount.java
@@ -24,14 +24,14 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ContainerReplicaCount;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos
     .NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos
@@ -45,14 +45,14 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos
 import static org.apache.hadoop.hdds.protocol.proto
     .StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.CLOSED;
 import static org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto.State.OPEN;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 /**
  * Class used to test the ContainerReplicaCount class.
  */
 public class TestContainerReplicaCount {
 
-  @Before
+  @BeforeEach
   public void setup() {
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/states/TestECContainerReplicaCount.java
@@ -27,9 +27,9 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ECContainerReplicaCount;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -51,7 +51,7 @@ public class TestECContainerReplicaCount {
   private ECReplicationConfig repConfig;
   private ContainerInfo container;
 
-  @Before
+  @BeforeEach
   public void setup() {
     repConfig = new ECReplicationConfig(3, 2);
     container = createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
@@ -65,8 +65,8 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 5));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.unRecoverable());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.unRecoverable());
   }
 
   @Test
@@ -76,9 +76,9 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertEquals(5,
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(5,
         rcnt.missingNonMaintenanceIndexes().get(0).intValue());
   }
 
@@ -92,9 +92,9 @@ public class TestECContainerReplicaCount {
     delete.add(1);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertEquals(1,
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(1,
         rcnt.missingNonMaintenanceIndexes().get(0).intValue());
   }
 
@@ -110,8 +110,8 @@ public class TestECContainerReplicaCount {
     delete.add(2);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
   }
 
   @Test
@@ -127,9 +127,9 @@ public class TestECContainerReplicaCount {
     delete.add(2);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertEquals(2,
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertEquals(1, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(2,
         rcnt.missingNonMaintenanceIndexes().get(0).intValue());
   }
 
@@ -141,15 +141,15 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_MAINTENANCE, 5));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 0);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
     rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
     List<Integer> delete = new ArrayList<>();
     delete.add(1);
     rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 0);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
   }
 
   @Test
@@ -163,9 +163,9 @@ public class TestECContainerReplicaCount {
     delete.add(1);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
-    Assert.assertTrue(rcnt.isOverReplicated());
-    Assert.assertEquals(2, rcnt.overReplicatedIndexes().get(0).intValue());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertTrue(rcnt.isOverReplicated());
+    Assertions.assertEquals(2, rcnt.overReplicatedIndexes().get(0).intValue());
   }
 
   @Test
@@ -179,9 +179,9 @@ public class TestECContainerReplicaCount {
     delete.add(1);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertTrue(rcnt.isOverReplicated());
-    Assert.assertEquals(2, rcnt.overReplicatedIndexes().get(0).intValue());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertTrue(rcnt.isOverReplicated());
+    Assertions.assertEquals(2, rcnt.overReplicatedIndexes().get(0).intValue());
   }
 
   @Test
@@ -193,11 +193,11 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_MAINTENANCE, 5), Pair.of(IN_MAINTENANCE, 1));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(4, rcnt.additionalMaintenanceCopiesNeeded());
     for (int i = 1; i <= repConfig.getRequiredNodes(); i++) {
-      Assert.assertTrue(rcnt.maintenanceOnlyIndexes().contains(i));
+      Assertions.assertTrue(rcnt.maintenanceOnlyIndexes().contains(i));
     }
   }
 
@@ -209,24 +209,24 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_MAINTENANCE, 5), Pair.of(IN_MAINTENANCE, 1));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
 
     // Repeat the test with redundancy of 2. Once the maintenance copies go
     // offline, we should be able to lost 2 more containers.
     rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 2);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
-    Assert.assertEquals(5, rcnt.maintenanceOnlyIndexes().get(0).intValue());
+    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertEquals(5, rcnt.maintenanceOnlyIndexes().get(0).intValue());
   }
 
   @Test
@@ -239,14 +239,14 @@ public class TestECContainerReplicaCount {
     delete.add(1);
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(2, rcnt.maintenanceOnlyIndexes().size());
-    Assert.assertTrue(rcnt.maintenanceOnlyIndexes().contains(1));
-    Assert.assertTrue(rcnt.maintenanceOnlyIndexes().contains(5));
+    Assertions.assertEquals(2, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes().contains(1));
+    Assertions.assertTrue(rcnt.maintenanceOnlyIndexes().contains(5));
   }
 
   @Test
@@ -258,24 +258,24 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 5));
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertTrue(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertTrue(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
 
     // Repeat the test with redundancy of 2. Once the maintenance copies go
     // offline, we should be able to lost 2 more containers.
     rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 2);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(1, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
-    Assert.assertEquals(5, rcnt.maintenanceOnlyIndexes().get(0).intValue());
+    Assertions.assertEquals(1, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertEquals(5, rcnt.maintenanceOnlyIndexes().get(0).intValue());
   }
 
   @Test
@@ -289,7 +289,7 @@ public class TestECContainerReplicaCount {
     // EC Parity is 2, which is max redundancy, but we have a
     // maintenanceRedundancy of 5, which is not possible. Only 2 more copies
     // should be needed.
-    Assert.assertEquals(2, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertEquals(2, rcnt.additionalMaintenanceCopiesNeeded());
     // After replication, zero should be needed
     replica =
         registerNodes(Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2),
@@ -298,7 +298,7 @@ public class TestECContainerReplicaCount {
             Pair.of(IN_SERVICE, 5));
     rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 5);
-    Assert.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
 
   }
 
@@ -310,16 +310,16 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
-    Assert.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
     // Even though we don't need new copies, the following call will return
     // any indexes only have a maintenance copy.
-    Assert.assertEquals(0, rcnt.maintenanceOnlyIndexes().size());
+    Assertions.assertEquals(0, rcnt.maintenanceOnlyIndexes().size());
 
-    Assert.assertEquals(2, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(4));
-    Assert.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(5));
+    Assertions.assertEquals(2, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(4));
+    Assertions.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(5));
   }
 
   @Test
@@ -333,12 +333,12 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
 
-    Assert.assertEquals(2, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(1));
-    Assert.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(5));
+    Assertions.assertEquals(2, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(1));
+    Assertions.assertTrue(rcnt.missingNonMaintenanceIndexes().contains(5));
   }
 
   @Test
@@ -353,10 +353,10 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, new ArrayList<>(), delete, 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
 
-    Assert.assertEquals(0, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(0, rcnt.missingNonMaintenanceIndexes().size());
   }
 
   @Test
@@ -371,26 +371,26 @@ public class TestECContainerReplicaCount {
 
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         replica, add, new ArrayList<>(), 1);
-    Assert.assertFalse(rcnt.isSufficientlyReplicated());
-    Assert.assertFalse(rcnt.isOverReplicated());
+    Assertions.assertFalse(rcnt.isSufficientlyReplicated());
+    Assertions.assertFalse(rcnt.isOverReplicated());
 
-    Assert.assertEquals(0, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(0, rcnt.missingNonMaintenanceIndexes().size());
   }
 
   @Test
   public void testMissing() {
     ECContainerReplicaCount rcnt = new ECContainerReplicaCount(container,
         new HashSet<>(), new ArrayList<>(), new ArrayList<>(), 1);
-    Assert.assertTrue(rcnt.unRecoverable());
-    Assert.assertEquals(5, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertTrue(rcnt.unRecoverable());
+    Assertions.assertEquals(5, rcnt.missingNonMaintenanceIndexes().size());
 
     Set<ContainerReplica> replica =
         registerNodes(Pair.of(IN_SERVICE, 1), Pair.of(IN_MAINTENANCE, 2));
     rcnt = new ECContainerReplicaCount(container, replica, new ArrayList<>(),
         new ArrayList<>(), 1);
-    Assert.assertTrue(rcnt.unRecoverable());
-    Assert.assertEquals(3, rcnt.missingNonMaintenanceIndexes().size());
-    Assert.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
+    Assertions.assertTrue(rcnt.unRecoverable());
+    Assertions.assertEquals(3, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertEquals(0, rcnt.additionalMaintenanceCopiesNeeded());
 
     replica =
         registerNodes(Pair.of(DECOMMISSIONED, 1), Pair.of(DECOMMISSIONED, 2),
@@ -399,8 +399,8 @@ public class TestECContainerReplicaCount {
     rcnt = new ECContainerReplicaCount(container, replica, new ArrayList<>(),
         new ArrayList<>(), 1);
     // Not missing as the decommission replicas are still online
-    Assert.assertFalse(rcnt.unRecoverable());
-    Assert.assertEquals(5, rcnt.missingNonMaintenanceIndexes().size());
+    Assertions.assertFalse(rcnt.unRecoverable());
+    Assertions.assertEquals(5, rcnt.missingNonMaintenanceIndexes().size());
   }
 
   private Set<ContainerReplica> registerNodes(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestReplicationAnnotation.java
@@ -26,9 +26,9 @@ import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
 import org.apache.ratis.grpc.GrpcTlsConfig;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.apache.ratis.server.RaftServer;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Proxy;
@@ -44,7 +44,7 @@ public class TestReplicationAnnotation {
   private SCMHAInvocationHandler scmhaInvocationHandler;
   private SCMRatisServer scmRatisServer;
 
-  @Before
+  @BeforeEach
   public void setup() {
     scmRatisServer = new SCMRatisServer() {
       @Override
@@ -118,10 +118,10 @@ public class TestReplicationAnnotation {
 
     try {
       proxy.addContainer(HddsProtos.ContainerInfoProto.getDefaultInstance());
-      Assert.fail("Cannot reach here: should have seen a IOException");
+      Assertions.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException ignore) {
-      Assert.assertNotNull(ignore.getMessage() != null);
-      Assert.assertEquals("submitRequest is called.",
+      Assertions.assertNotNull(ignore.getMessage() != null);
+      Assertions.assertEquals("submitRequest is called.",
           ignore.getMessage());
     }
 
@@ -139,10 +139,10 @@ public class TestReplicationAnnotation {
       certificateStore.storeValidCertificate(BigInteger.valueOf(100L),
           KeyStoreTestUtil.generateCertificate("CN=Test", keyPair, 30,
           "SHA256withRSA"), HddsProtos.NodeType.DATANODE);
-      Assert.fail("Cannot reach here: should have seen a IOException");
+      Assertions.fail("Cannot reach here: should have seen a IOException");
     } catch (IOException ignore) {
-      Assert.assertNotNull(ignore.getMessage() != null);
-      Assert.assertEquals("submitRequest is called.",
+      Assertions.assertNotNull(ignore.getMessage() != null);
+      Assertions.assertEquals("submitRequest is called.",
           ignore.getMessage());
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMContext.java
@@ -20,12 +20,12 @@ package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for SCMContext.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.utils.HddsServerUtil;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
@@ -53,7 +53,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVIC
 public class TestSCMHAConfiguration {
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf = new OzoneConfiguration();
   }
@@ -121,64 +121,64 @@ public class TestSCMHAConfiguration {
     port = 9880;
 
     // Validate configs.
-    Assert.assertEquals("localhost:" + port++,
+    Assertions.assertEquals("localhost:" + port++,
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_ADDRESS_KEY,
         scmServiceId, "scm1")));
-    Assert.assertEquals(port,
+    Assertions.assertEquals(port,
         conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_PORT_KEY,
         scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1",
+    Assertions.assertEquals("172.28.9.1",
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_BLOCK_CLIENT_BIND_HOST_KEY,
             scmServiceId, "scm1")));
 
 
-    Assert.assertEquals("localhost:" + port++,
+    Assertions.assertEquals("localhost:" + port++,
         conf.get(ConfUtils.addKeySuffixes(
             OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY, scmServiceId, "scm1")));
-    Assert.assertEquals(port, conf.getInt(ConfUtils.addKeySuffixes(
+    Assertions.assertEquals(port, conf.getInt(ConfUtils.addKeySuffixes(
         OZONE_SCM_SECURITY_SERVICE_PORT_KEY, scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1",
+    Assertions.assertEquals("172.28.9.1",
         conf.get(ConfUtils.addKeySuffixes(
             OZONE_SCM_SECURITY_SERVICE_BIND_HOST_KEY, scmServiceId, "scm1")));
 
 
-    Assert.assertEquals("localhost:" + port++,
+    Assertions.assertEquals("localhost:" + port++,
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_ADDRESS_KEY,
             scmServiceId, "scm1")));
-    Assert.assertEquals(port,
+    Assertions.assertEquals(port,
         conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_PORT_KEY,
             scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(
+    Assertions.assertEquals("172.28.9.1", conf.get(
         ConfUtils.addKeySuffixes(OZONE_SCM_CLIENT_BIND_HOST_KEY, scmServiceId,
         "scm1")));
 
-    Assert.assertEquals("localhost:" + port++,
+    Assertions.assertEquals("localhost:" + port++,
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_ADDRESS_KEY,
             scmServiceId, "scm1")));
-    Assert.assertEquals(port,
+    Assertions.assertEquals(port,
         conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
             scmServiceId, "scm1"), 9999));
-    Assert.assertEquals("172.28.9.1", conf.get(
+    Assertions.assertEquals("172.28.9.1", conf.get(
         ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_BIND_HOST_KEY, scmServiceId,
         "scm1")));
 
 
-    Assert.assertEquals("localhost:" + port++,
+    Assertions.assertEquals("localhost:" + port++,
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_ADDRESS_KEY,
         scmServiceId, "scm1")));
-    Assert.assertEquals("172.28.9.1",
+    Assertions.assertEquals("172.28.9.1",
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_HTTP_BIND_HOST_KEY,
         scmServiceId, "scm1")));
 
-    Assert.assertEquals("localhost", conf.get(ConfUtils.addKeySuffixes(
+    Assertions.assertEquals("localhost", conf.get(ConfUtils.addKeySuffixes(
         OZONE_SCM_ADDRESS_KEY, scmServiceId,
         "scm1")));
 
-    Assert.assertEquals("/var/scm-metadata1",
+    Assertions.assertEquals("/var/scm-metadata1",
         conf.get(ConfUtils.addKeySuffixes(OZONE_SCM_DB_DIRS, scmServiceId,
         "scm1")));
 
-    Assert.assertEquals(port++,
+    Assertions.assertEquals(port++,
         conf.getInt(ConfUtils.addKeySuffixes(OZONE_SCM_RATIS_PORT_KEY,
         scmServiceId, "scm1"), 9999));
 
@@ -212,8 +212,8 @@ public class TestSCMHAConfiguration {
 
     SCMHANodeDetails scmhaNodeDetails = SCMHANodeDetails.loadSCMHAConfig(conf);
 
-    Assert.assertEquals("10000", conf.get(OZONE_SCM_RATIS_PORT_KEY));
-    Assert.assertEquals("10001", conf.get(OZONE_SCM_GRPC_PORT_KEY));
+    Assertions.assertEquals("10000", conf.get(OZONE_SCM_RATIS_PORT_KEY));
+    Assertions.assertEquals("10001", conf.get(OZONE_SCM_GRPC_PORT_KEY));
 
 
     InetSocketAddress clientAddress =
@@ -223,33 +223,33 @@ public class TestSCMHAConfiguration {
         NetUtils.createSocketAddr("0.0.0.0", 9896);
     InetSocketAddress datanodeAddress =
         NetUtils.createSocketAddr("0.0.0.0", 9898);
-    Assert.assertEquals(clientAddress, scmhaNodeDetails.getLocalNodeDetails()
+    Assertions.assertEquals(clientAddress, scmhaNodeDetails.getLocalNodeDetails()
             .getClientProtocolServerAddress());
-    Assert.assertEquals(blockAddress, scmhaNodeDetails.getLocalNodeDetails()
+    Assertions.assertEquals(blockAddress, scmhaNodeDetails.getLocalNodeDetails()
         .getBlockProtocolServerAddress());
-    Assert.assertEquals(datanodeAddress, scmhaNodeDetails.getLocalNodeDetails()
+    Assertions.assertEquals(datanodeAddress, scmhaNodeDetails.getLocalNodeDetails()
         .getDatanodeProtocolServerAddress());
 
-    Assert.assertEquals(10000,
+    Assertions.assertEquals(10000,
         scmhaNodeDetails.getLocalNodeDetails().getRatisPort());
-    Assert.assertEquals(10001,
+    Assertions.assertEquals(10001,
         scmhaNodeDetails.getLocalNodeDetails().getGrpcPort());
 
     for (SCMNodeDetails peer : scmhaNodeDetails.getPeerNodeDetails()) {
-      Assert.assertEquals(clientAddress, peer.getClientProtocolServerAddress());
-      Assert.assertEquals(blockAddress, peer.getBlockProtocolServerAddress());
-      Assert.assertEquals(datanodeAddress,
+      Assertions.assertEquals(clientAddress, peer.getClientProtocolServerAddress());
+      Assertions.assertEquals(blockAddress, peer.getBlockProtocolServerAddress());
+      Assertions.assertEquals(datanodeAddress,
           peer.getDatanodeProtocolServerAddress());
 
-      Assert.assertEquals(10000, peer.getRatisPort());
-      Assert.assertEquals(10001,
+      Assertions.assertEquals(10000, peer.getRatisPort());
+      Assertions.assertEquals(10001,
           peer.getGrpcPort());
     }
 
 
     // Security protocol address is not set in SCMHANode Details.
     // Check conf is properly set with expected port.
-    Assert.assertEquals(
+    Assertions.assertEquals(
         NetUtils.createSocketAddr("0.0.0.0", 9899),
         HddsServerUtil.getScmSecurityInetAddress(conf));
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMHAConfiguration.java
@@ -223,12 +223,14 @@ public class TestSCMHAConfiguration {
         NetUtils.createSocketAddr("0.0.0.0", 9896);
     InetSocketAddress datanodeAddress =
         NetUtils.createSocketAddr("0.0.0.0", 9898);
-    Assertions.assertEquals(clientAddress, scmhaNodeDetails.getLocalNodeDetails()
+    Assertions.assertEquals(clientAddress,
+        scmhaNodeDetails.getLocalNodeDetails()
             .getClientProtocolServerAddress());
     Assertions.assertEquals(blockAddress, scmhaNodeDetails.getLocalNodeDetails()
         .getBlockProtocolServerAddress());
-    Assertions.assertEquals(datanodeAddress, scmhaNodeDetails.getLocalNodeDetails()
-        .getDatanodeProtocolServerAddress());
+    Assertions.assertEquals(datanodeAddress,
+        scmhaNodeDetails.getLocalNodeDetails()
+            .getDatanodeProtocolServerAddress());
 
     Assertions.assertEquals(10000,
         scmhaNodeDetails.getLocalNodeDetails().getRatisPort());
@@ -236,8 +238,10 @@ public class TestSCMHAConfiguration {
         scmhaNodeDetails.getLocalNodeDetails().getGrpcPort());
 
     for (SCMNodeDetails peer : scmhaNodeDetails.getPeerNodeDetails()) {
-      Assertions.assertEquals(clientAddress, peer.getClientProtocolServerAddress());
-      Assertions.assertEquals(blockAddress, peer.getBlockProtocolServerAddress());
+      Assertions.assertEquals(clientAddress,
+          peer.getClientProtocolServerAddress());
+      Assertions.assertEquals(blockAddress,
+          peer.getBlockProtocolServerAddress());
       Assertions.assertEquals(datanodeAddress,
           peer.getDatanodeProtocolServerAddress());
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
@@ -48,23 +48,25 @@ public class TestSCMRatisRequest {
         SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void testEncodeWithNonProto() throws Exception {
+  @Test
+  public void testEncodeWithNonProto() {
     PipelineID pipelineID = PipelineID.randomId();
     // Non proto args
     Object[] args = new Object[] {pipelineID};
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, "test",
         new Class[]{pipelineID.getClass()}, args);
     // Should throw exception there.
-    request.encode();
+    Assertions.assertThrows(InvalidProtocolBufferException.class,
+        request::encode);
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void testDecodeWithNonProto() throws Exception {
+  @Test
+  public void testDecodeWithNonProto() {
     // Non proto message
     Message message = Message.valueOf("randomMessage");
     // Should throw exception there.
-    SCMRatisRequest.decode(message);
+    Assertions.assertThrows(InvalidProtocolBufferException.class,
+        () -> SCMRatisRequest.decode(message));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisRequest.java
@@ -22,8 +22,8 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.ratis.protocol.Message;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,9 +42,9 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{pipelineID.getProtobuf().getClass()}, args);
-    Assert.assertEquals(operation,
+    Assertions.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
-    Assert.assertEquals(args[0],
+    Assertions.assertEquals(args[0],
         SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 
@@ -77,9 +77,9 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{pids.getClass()}, args);
-    Assert.assertEquals(operation,
+    Assertions.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
-    Assert.assertEquals(args[0],
+    Assertions.assertEquals(args[0],
         SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 
@@ -89,9 +89,9 @@ public class TestSCMRatisRequest {
     String operation = "test";
     SCMRatisRequest request = SCMRatisRequest.of(PIPELINE, operation,
         new Class[]{value.getClass()}, value);
-    Assert.assertEquals(operation,
+    Assertions.assertEquals(operation,
         SCMRatisRequest.decode(request.encode()).getOperation());
-    Assert.assertEquals(value,
+    Assertions.assertEquals(value,
         SCMRatisRequest.decode(request.encode()).getArguments()[0]);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
@@ -27,9 +27,9 @@ import org.apache.ratis.protocol.RaftGroupMemberId;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.protocol.exceptions.LeaderNotReadyException;
 import org.apache.ratis.protocol.exceptions.RaftException;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for SCMRatisResponse.
@@ -37,7 +37,7 @@ import org.junit.Test;
 public class TestSCMRatisResponse {
   private RaftGroupMemberId raftId;
 
-  @Before
+  @BeforeEach
   public void init() {
     raftId = RaftGroupMemberId.valueOf(
         RaftPeerId.valueOf("peer"), RaftGroupId.randomId());
@@ -56,8 +56,8 @@ public class TestSCMRatisResponse {
         .setLogIndex(1L)
         .build();
     SCMRatisResponse response = SCMRatisResponse.decode(reply);
-    Assert.assertTrue(response.isSuccess());
-    Assert.assertEquals(Message.EMPTY,
+    Assertions.assertTrue(response.isSuccess());
+    Assertions.assertEquals(Message.EMPTY,
         SCMRatisResponse.encode(response.getResult()));
   }
 
@@ -74,9 +74,9 @@ public class TestSCMRatisResponse {
         .setLogIndex(1L)
         .build();
     SCMRatisResponse response = SCMRatisResponse.decode(reply);
-    Assert.assertFalse(response.isSuccess());
-    Assert.assertTrue(response.getException() instanceof RaftException);
-    Assert.assertNull(response.getResult());
+    Assertions.assertFalse(response.isSuccess());
+    Assertions.assertTrue(response.getException() instanceof RaftException);
+    Assertions.assertNull(response.getResult());
   }
 
   @Test(expected =  InvalidProtocolBufferException.class)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMRatisResponse.java
@@ -79,11 +79,12 @@ public class TestSCMRatisResponse {
     Assertions.assertNull(response.getResult());
   }
 
-  @Test(expected =  InvalidProtocolBufferException.class)
-  public void testEncodeFailureWithNonProto() throws Exception {
+  @Test
+  public void testEncodeFailureWithNonProto() {
     // Non proto input
     Message message = Message.valueOf("test");
     // Should fail with exception.
-    SCMRatisResponse.encode(message);
+    Assertions.assertThrows(InvalidProtocolBufferException.class,
+        () -> SCMRatisResponse.encode(message));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMServiceManager.java
@@ -19,10 +19,10 @@
 package org.apache.hadoop.hdds.scm.ha;
 
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link SCMServiceManager}.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSequenceIDGenerator.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSequenceIDGenerator.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStore;
 import org.apache.hadoop.hdds.scm.metadata.SCMMetadataStoreImpl;
 import org.apache.hadoop.hdds.scm.metadata.SCMDBTransactionBufferImpl;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SEQUENCE_ID_BATCH_SIZE;
 
@@ -43,33 +43,33 @@ public class TestSequenceIDGenerator {
         conf, scmHAManager, scmMetadataStore.getSequenceIdTable());
 
     // the first batch is [1, 1000]
-    Assert.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
 
     // default batchSize is 1000, the next batch is [1001, 2000]
     sequenceIdGen.invalidateBatch();
-    Assert.assertEquals(1001, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(1002, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(1003, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(1001, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(1002, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(1003, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(1001, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(1002, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(1003, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(1001, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(1002, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(1003, sequenceIdGen.getNextId("otherKey"));
 
     // default batchSize is 1000, the next batch is [2001, 3000]
     sequenceIdGen.invalidateBatch();
-    Assert.assertEquals(2001, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(2002, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(2003, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(2001, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(2002, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(2003, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(2001, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(2002, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(2003, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(2001, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(2002, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(2003, sequenceIdGen.getNextId("otherKey"));
   }
 
   @Test
@@ -88,32 +88,32 @@ public class TestSequenceIDGenerator {
         conf, scmHAManager, scmMetadataStore.getSequenceIdTable());
 
     // the first batch is [1, 100]
-    Assert.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(1L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(2L, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(3L, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(1L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(2L, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(3L, sequenceIdGen.getNextId("otherKey"));
 
     // the next batch is [101, 200]
     sequenceIdGen.invalidateBatch();
-    Assert.assertEquals(101, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(102, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(103, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(101, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(102, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(103, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(101, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(102, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(103, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(101, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(102, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(103, sequenceIdGen.getNextId("otherKey"));
 
     // the next batch is [201, 300]
     sequenceIdGen.invalidateBatch();
-    Assert.assertEquals(201, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(202, sequenceIdGen.getNextId("someKey"));
-    Assert.assertEquals(203, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(201, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(202, sequenceIdGen.getNextId("someKey"));
+    Assertions.assertEquals(203, sequenceIdGen.getNextId("someKey"));
 
-    Assert.assertEquals(201, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(202, sequenceIdGen.getNextId("otherKey"));
-    Assert.assertEquals(203, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(201, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(202, sequenceIdGen.getNextId("otherKey"));
+    Assertions.assertEquals(203, sequenceIdGen.getNextId("otherKey"));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestStatefulServiceStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/TestStatefulServiceStateManagerImpl.java
@@ -28,10 +28,10 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -45,7 +45,7 @@ public class TestStatefulServiceStateManagerImpl {
   private Table<String, ByteString> statefulServiceConfig;
   private StatefulServiceStateManager stateManager;
 
-  @Before
+  @BeforeEach
   public void setup() throws AuthenticationException, IOException {
     conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
@@ -64,7 +64,7 @@ public class TestStatefulServiceStateManagerImpl {
             .build();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (dbStore != null) {
       dbStore.close();
@@ -83,7 +83,7 @@ public class TestStatefulServiceStateManagerImpl {
     stateManager.saveConfiguration(serviceName,
         ByteString.copyFromUtf8(message));
     scmhaManager.asSCMHADBTransactionBuffer().flush();
-    Assert.assertEquals(ByteString.copyFromUtf8(message),
+    Assertions.assertEquals(ByteString.copyFromUtf8(message),
         stateManager.readConfiguration(serviceName));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestBigIntegerCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestBigIntegerCodec.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hdds.scm.ha.io;
 
 import com.google.protobuf.ByteString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
 
@@ -37,6 +37,6 @@ public class TestBigIntegerCodec {
 
     BigInteger actual =
         (BigInteger) bigIntegerCodec.deserialize(BigInteger.class, byteString);
-    Assert.assertEquals(bigInteger, actual);
+    Assertions.assertEquals(bigInteger, actual);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.ha.io;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.apache.hadoop.security.ssl.KeyStoreTestUtil;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
@@ -46,7 +46,7 @@ public class TestX509CertificateCodec {
     X509Certificate actual = (X509Certificate)
         x509CertificateCodec.deserialize(X509Certificate.class, byteString);
 
-    Assert.assertEquals(x509Certificate, actual);
+    Assertions.assertEquals(x509Certificate, actual);
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/ha/io/TestX509CertificateCodec.java
@@ -50,12 +50,13 @@ public class TestX509CertificateCodec {
 
   }
 
-  @Test(expected = InvalidProtocolBufferException.class)
-  public void testCodecError() throws Exception {
+  @Test
+  public void testCodecError() {
 
     X509CertificateCodec x509CertificateCodec = new X509CertificateCodec();
     ByteString byteString = ByteString.copyFrom("dummy".getBytes(UTF_8));
 
-    x509CertificateCodec.deserialize(X509Certificate.class, byteString);
+    Assertions.assertThrows(InvalidProtocolBufferException.class, () ->
+        x509CertificateCodec.deserialize(X509Certificate.class, byteString));
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestPipelineIDCodec.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/metadata/TestPipelineIDCodec.java
@@ -18,11 +18,11 @@
 
 package org.apache.hadoop.hdds.scm.metadata;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
@@ -31,9 +31,9 @@ import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,7 +54,7 @@ public class TestCommandQueueReportHandler implements EventPublisher {
   private SCMNodeManager nodeManager;
 
 
-  @Before
+  @BeforeEach
   public void resetEventCollector() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
     SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
@@ -85,8 +85,8 @@ public class TestCommandQueueReportHandler implements EventPublisher {
     for (int i = 0; i < commandCount; i++) {
       int storedCount = nodeManager.getNodeQueuedCommandCount(dn,
           commandReport.getReport().getCommand(i));
-      Assert.assertEquals(commandReport.getReport().getCount(i), storedCount);
-      Assert.assertTrue(storedCount > 0);
+      Assertions.assertEquals(commandReport.getReport().getCount(i), storedCount);
+      Assertions.assertTrue(storedCount > 0);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestCommandQueueReportHandler.java
@@ -85,7 +85,8 @@ public class TestCommandQueueReportHandler implements EventPublisher {
     for (int i = 0; i < commandCount; i++) {
       int storedCount = nodeManager.getNodeQueuedCommandCount(dn,
           commandReport.getReport().getCommand(i));
-      Assertions.assertEquals(commandReport.getReport().getCount(i), storedCount);
+      Assertions.assertEquals(commandReport.getReport().getCount(i),
+          storedCount);
       Assertions.assertTrue(storedCount > 0);
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -36,7 +36,6 @@ import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -82,10 +81,6 @@ public class TestDatanodeAdminMonitor {
 
     monitor =
         new DatanodeAdminMonitorImpl(conf, eventQueue, nodeManager, repManager);
-  }
-
-  @AfterEach
-  public void teardown() {
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDatanodeAdminMonitor.java
@@ -36,17 +36,17 @@ import org.apache.hadoop.hdds.server.events.EventHandler;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.ENTERING_MAINTENANCE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_MAINTENANCE;
@@ -68,7 +68,7 @@ public class TestDatanodeAdminMonitor {
   private ReplicationManager repManager;
   private EventQueue eventQueue;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, AuthenticationException {
     conf = new OzoneConfiguration();
 
@@ -84,7 +84,7 @@ public class TestDatanodeAdminMonitor {
         new DatanodeAdminMonitorImpl(conf, eventQueue, nodeManager, repManager);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestDeadNodeHandler.java
@@ -67,10 +67,10 @@ import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -89,7 +89,7 @@ public class TestDeadNodeHandler {
   private String storageDir;
   private SCMContext scmContext;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, AuthenticationException {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.setTimeDuration(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
@@ -124,7 +124,7 @@ public class TestDeadNodeHandler {
     publisher = Mockito.mock(EventPublisher.class);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     scm.stop();
     scm.join();
@@ -221,28 +221,28 @@ public class TestDeadNodeHandler {
     // First set the node to IN_MAINTENANCE and ensure the container replicas
     // are not removed on the dead event
     datanode1 = nodeManager.getNodeByUuid(datanode1.getUuidString());
-    Assert.assertTrue(
+    Assertions.assertTrue(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
     nodeManager.setNodeOperationalState(datanode1,
         HddsProtos.NodeOperationalState.IN_MAINTENANCE);
     deadNodeHandler.onMessage(datanode1, publisher);
     // make sure the node is removed from
     // ClusterNetworkTopology when it is considered as dead
-    Assert.assertFalse(
+    Assertions.assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
     Set<ContainerReplica> container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));
-    Assert.assertEquals(2, container1Replicas.size());
+    Assertions.assertEquals(2, container1Replicas.size());
 
     Set<ContainerReplica> container2Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container2.getContainerID()));
-    Assert.assertEquals(2, container2Replicas.size());
+    Assertions.assertEquals(2, container2Replicas.size());
 
     Set<ContainerReplica> container3Replicas = containerManager
             .getContainerReplicas(
                 ContainerID.valueOf(container3.getContainerID()));
-    Assert.assertEquals(1, container3Replicas.size());
+    Assertions.assertEquals(1, container3Replicas.size());
 
 
     // Now set the node to anything other than IN_MAINTENANCE and the relevant
@@ -252,30 +252,30 @@ public class TestDeadNodeHandler {
     deadNodeHandler.onMessage(datanode1, publisher);
     //datanode1 has been removed from ClusterNetworkTopology, another
     //deadNodeHandler.onMessage call will not change this
-    Assert.assertFalse(
+    Assertions.assertFalse(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
     container1Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container1.getContainerID()));
-    Assert.assertEquals(1, container1Replicas.size());
-    Assert.assertEquals(datanode2,
+    Assertions.assertEquals(1, container1Replicas.size());
+    Assertions.assertEquals(datanode2,
         container1Replicas.iterator().next().getDatanodeDetails());
 
     container2Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container2.getContainerID()));
-    Assert.assertEquals(1, container2Replicas.size());
-    Assert.assertEquals(datanode2,
+    Assertions.assertEquals(1, container2Replicas.size());
+    Assertions.assertEquals(datanode2,
         container2Replicas.iterator().next().getDatanodeDetails());
 
     container3Replicas = containerManager
         .getContainerReplicas(ContainerID.valueOf(container3.getContainerID()));
-    Assert.assertEquals(1, container3Replicas.size());
-    Assert.assertEquals(datanode3,
+    Assertions.assertEquals(1, container3Replicas.size());
+    Assertions.assertEquals(datanode3,
         container3Replicas.iterator().next().getDatanodeDetails());
 
     //datanode will be added back to ClusterNetworkTopology if it resurrects
     healthyReadOnlyNodeHandler.onMessage(datanode1, publisher);
-    Assert.assertTrue(
+    Assertions.assertTrue(
         nodeManager.getClusterNetworkTopologyMap().contains(datanode1));
 
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeDecommissionManager.java
@@ -30,16 +30,16 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.Arrays;
 import java.util.ArrayList;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.assertj.core.api.Fail.fail;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 /**
  * Unit tests for the decommision manager.
@@ -53,7 +53,7 @@ public class TestNodeDecommissionManager {
   private OzoneConfiguration conf;
   private String storageDir;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     storageDir = GenericTestUtils.getTempPath(

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeReportHandler.java
@@ -40,9 +40,9 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +62,7 @@ public class TestNodeReportHandler implements EventPublisher {
   private String metaStoragePath = GenericTestUtils.getRandomizedTempPath()
       .concat("/metadata-" + UUID.randomUUID().toString());
 
-  @Before
+  @BeforeEach
   public void resetEventCollector() throws IOException {
     OzoneConfiguration conf = new OzoneConfiguration();
     SCMStorageConfig storageConfig = Mockito.mock(SCMStorageConfig.class);
@@ -90,15 +90,15 @@ public class TestNodeReportHandler implements EventPublisher {
         .createMetadataStorageReport(metaStoragePath, 100, 10, 90, null);
 
     SCMNodeMetric nodeMetric = nodeManager.getNodeStat(dn);
-    Assert.assertNull(nodeMetric);
+    Assertions.assertNull(nodeMetric);
 
     nodeManager.register(dn, getNodeReport(dn, Arrays.asList(storageOne),
         Arrays.asList(metaStorageOne)).getReport(), null);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assert.assertTrue(nodeMetric.get().getCapacity().get() == 100);
-    Assert.assertTrue(nodeMetric.get().getRemaining().get() == 90);
-    Assert.assertTrue(nodeMetric.get().getScmUsed().get() == 10);
+    Assertions.assertTrue(nodeMetric.get().getCapacity().get() == 100);
+    Assertions.assertTrue(nodeMetric.get().getRemaining().get() == 90);
+    Assertions.assertTrue(nodeMetric.get().getScmUsed().get() == 10);
 
     StorageReportProto storageTwo = HddsTestUtils
         .createStorageReport(dn.getUuid(), storagePath, 100, 10, 90, null);
@@ -107,9 +107,9 @@ public class TestNodeReportHandler implements EventPublisher {
             Arrays.asList(metaStorageOne)), this);
     nodeMetric = nodeManager.getNodeStat(dn);
 
-    Assert.assertTrue(nodeMetric.get().getCapacity().get() == 200);
-    Assert.assertTrue(nodeMetric.get().getRemaining().get() == 180);
-    Assert.assertTrue(nodeMetric.get().getScmUsed().get() == 20);
+    Assertions.assertTrue(nodeMetric.get().getCapacity().get() == 200);
+    Assertions.assertTrue(nodeMetric.get().getRemaining().get() == 180);
+    Assertions.assertTrue(nodeMetric.get().getScmUsed().get() == 20);
 
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -33,10 +33,10 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.util.Time;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -46,8 +46,8 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 
@@ -62,7 +62,7 @@ public class TestNodeStateManager {
   private ConfigurationSource conf;
   private MockEventPublisher eventPublisher;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     conf = new ConfigurationSource() {
       @Override
@@ -90,7 +90,7 @@ public class TestNodeStateManager {
     nsm = new NodeStateManager(conf, eventPublisher, mockVersionManager);
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
   }
 
@@ -246,14 +246,14 @@ public class TestNodeStateManager {
 
     Set<ContainerID> containerSet = nsm.getContainers(dn.getUuid());
     assertEquals(2, containerSet.size());
-    Assert.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
-    Assert.assertTrue(containerSet.contains(ContainerID.valueOf(2)));
+    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
+    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(2)));
 
     nsm.removeContainer(dn.getUuid(), ContainerID.valueOf(2));
     containerSet = nsm.getContainers(dn.getUuid());
     assertEquals(1, containerSet.size());
-    Assert.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
-    Assert.assertFalse(containerSet.contains(ContainerID.valueOf(2)));
+    Assertions.assertTrue(containerSet.contains(ContainerID.valueOf(1)));
+    Assertions.assertFalse(containerSet.contains(ContainerID.valueOf(2)));
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestNodeStateManager.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.util.Time;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -88,10 +87,6 @@ public class TestNodeStateManager {
     Mockito.when(mockVersionManager.getSoftwareLayoutVersion())
         .thenReturn(maxLayoutVersion());
     nsm = new NodeStateManager(conf, eventPublisher, mockVersionManager);
-  }
-
-  @AfterEach
-  public void tearDown() {
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
@@ -117,14 +117,14 @@ public class TestStatisticsUpdate {
         Mockito.mock(EventPublisher.class));
 
     SCMNodeStat stat = nodeManager.getStats();
-    Assertions.assertEquals(300L, stat.getCapacity().get().longValue());
-    Assertions.assertEquals(270L, stat.getRemaining().get().longValue());
-    Assertions.assertEquals(30L, stat.getScmUsed().get().longValue());
+    Assertions.assertEquals(300L, stat.getCapacity().get());
+    Assertions.assertEquals(270L, stat.getRemaining().get());
+    Assertions.assertEquals(30L, stat.getScmUsed().get());
 
     SCMNodeMetric nodeStat = nodeManager.getNodeStat(datanode1);
-    Assertions.assertEquals(100L, nodeStat.get().getCapacity().get().longValue());
-    Assertions.assertEquals(90L, nodeStat.get().getRemaining().get().longValue());
-    Assertions.assertEquals(10L, nodeStat.get().getScmUsed().get().longValue());
+    Assertions.assertEquals(100L, nodeStat.get().getCapacity().get());
+    Assertions.assertEquals(90L, nodeStat.get().getRemaining().get());
+    Assertions.assertEquals(10L, nodeStat.get().getScmUsed().get());
 
     //TODO: Support logic to mark a node as dead in NodeManager.
 
@@ -143,10 +143,10 @@ public class TestStatisticsUpdate {
     nodeManager.processHeartbeat(datanode2, layoutInfo);
     //THEN statistics in SCM should changed.
     stat = nodeManager.getStats();
-    Assertions.assertEquals(200L, stat.getCapacity().get().longValue());
+    Assertions.assertEquals(200L, stat.getCapacity().get());
     Assertions.assertEquals(180L,
-        stat.getRemaining().get().longValue());
-    Assertions.assertEquals(20L, stat.getScmUsed().get().longValue());
+        stat.getRemaining().get());
+    Assertions.assertEquals(20L, stat.getScmUsed().get());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/TestStatisticsUpdate.java
@@ -43,9 +43,9 @@ import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
 import org.apache.hadoop.security.authentication.client
     .AuthenticationException;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -61,7 +61,7 @@ public class TestStatisticsUpdate {
   private NodeManager nodeManager;
   private NodeReportHandler nodeReportHandler;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException, AuthenticationException {
     final OzoneConfiguration conf = new OzoneConfiguration();
     final String storageDir = GenericTestUtils.getTempPath(
@@ -117,14 +117,14 @@ public class TestStatisticsUpdate {
         Mockito.mock(EventPublisher.class));
 
     SCMNodeStat stat = nodeManager.getStats();
-    Assert.assertEquals(300L, stat.getCapacity().get().longValue());
-    Assert.assertEquals(270L, stat.getRemaining().get().longValue());
-    Assert.assertEquals(30L, stat.getScmUsed().get().longValue());
+    Assertions.assertEquals(300L, stat.getCapacity().get().longValue());
+    Assertions.assertEquals(270L, stat.getRemaining().get().longValue());
+    Assertions.assertEquals(30L, stat.getScmUsed().get().longValue());
 
     SCMNodeMetric nodeStat = nodeManager.getNodeStat(datanode1);
-    Assert.assertEquals(100L, nodeStat.get().getCapacity().get().longValue());
-    Assert.assertEquals(90L, nodeStat.get().getRemaining().get().longValue());
-    Assert.assertEquals(10L, nodeStat.get().getScmUsed().get().longValue());
+    Assertions.assertEquals(100L, nodeStat.get().getCapacity().get().longValue());
+    Assertions.assertEquals(90L, nodeStat.get().getRemaining().get().longValue());
+    Assertions.assertEquals(10L, nodeStat.get().getScmUsed().get().longValue());
 
     //TODO: Support logic to mark a node as dead in NodeManager.
 
@@ -143,10 +143,10 @@ public class TestStatisticsUpdate {
     nodeManager.processHeartbeat(datanode2, layoutInfo);
     //THEN statistics in SCM should changed.
     stat = nodeManager.getStats();
-    Assert.assertEquals(200L, stat.getCapacity().get().longValue());
-    Assert.assertEquals(180L,
+    Assertions.assertEquals(200L, stat.getCapacity().get().longValue());
+    Assertions.assertEquals(180L,
         stat.getRemaining().get().longValue());
-    Assert.assertEquals(20L, stat.getScmUsed().get().longValue());
+    Assertions.assertEquals(20L, stat.getScmUsed().get().longValue());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNodeStateMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/node/states/TestNodeStateMap.java
@@ -29,10 +29,10 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 
-import static junit.framework.TestCase.assertEquals;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class to test the NodeStateMap class, which is an internal class used by
@@ -43,12 +43,12 @@ public class TestNodeStateMap {
 
   private NodeStateMap map;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     map = new NodeStateMap();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestBackgroundPipelineScrubber.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestBackgroundPipelineScrubber.java
@@ -22,16 +22,16 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.safemode.SCMSafeModeManager.SafeModeStatus;
 import org.apache.ozone.test.TestClock;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneOffset;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
@@ -48,7 +48,7 @@ public class TestBackgroundPipelineScrubber {
   private OzoneConfiguration conf;
   private TestClock testClock;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
     this.scmContext = SCMContext.emptyContext();
@@ -62,7 +62,7 @@ public class TestBackgroundPipelineScrubber {
         scmContext, testClock);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
     scrubber.stop();
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestECPipelineProvider.java
@@ -29,9 +29,9 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -57,7 +57,7 @@ public class TestECPipelineProvider {
       Mockito.mock(PipelineStateManager.class);
   private PlacementPolicy placementPolicy = Mockito.mock(PlacementPolicy.class);
   private long containerSizeBytes;
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     conf = new OzoneConfiguration();
     provider = new ECPipelineProvider(
@@ -85,14 +85,14 @@ public class TestECPipelineProvider {
   public void testSimplePipelineCanBeCreatedWithIndexes() throws IOException {
     ECReplicationConfig ecConf = new ECReplicationConfig(3, 2);
     Pipeline pipeline = provider.create(ecConf);
-    Assert.assertEquals(EC, pipeline.getType());
-    Assert.assertEquals(ecConf.getData() + ecConf.getParity(),
+    Assertions.assertEquals(EC, pipeline.getType());
+    Assertions.assertEquals(ecConf.getData() + ecConf.getParity(),
         pipeline.getNodes().size());
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     List<DatanodeDetails> dns = pipeline.getNodes();
     for (int i = 0; i < ecConf.getRequiredNodes(); i++) {
       // EC DN indexes are numbered starting from 1 to N.
-      Assert.assertEquals(i + 1, pipeline.getReplicaIndex(dns.get(i)));
+      Assertions.assertEquals(i + 1, pipeline.getReplicaIndex(dns.get(i)));
     }
   }
 
@@ -103,11 +103,11 @@ public class TestECPipelineProvider {
     Set<ContainerReplica> replicas = createContainerReplicas(4);
     Pipeline pipeline = provider.createForRead(ecConf, replicas);
 
-    Assert.assertEquals(EC, pipeline.getType());
-    Assert.assertEquals(4, pipeline.getNodes().size());
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(EC, pipeline.getType());
+    Assertions.assertEquals(4, pipeline.getNodes().size());
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     for (ContainerReplica r : replicas) {
-      Assert.assertEquals(r.getReplicaIndex(),
+      Assertions.assertEquals(r.getReplicaIndex(),
           pipeline.getReplicaIndex(r.getDatanodeDetails()));
     }
   }
@@ -124,8 +124,8 @@ public class TestECPipelineProvider {
     favoredNodes.add(MockDatanodeDetails.randomDatanodeDetails());
 
     Pipeline pipeline = provider.create(ecConf, excludedNodes, favoredNodes);
-    Assert.assertEquals(EC, pipeline.getType());
-    Assert.assertEquals(ecConf.getData() + ecConf.getParity(),
+    Assertions.assertEquals(EC, pipeline.getType());
+    Assertions.assertEquals(ecConf.getData() + ecConf.getParity(),
         pipeline.getNodes().size());
 
     verify(placementPolicy).chooseDatanodes(excludedNodes, favoredNodes,

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineActionHandler.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hdds.scm.server.SCMDatanodeHeartbeatDispatcher.Pipeline
 import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.util.UUID;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -52,10 +52,10 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.TestClock;
 import org.apache.ratis.protocol.exceptions.NotLeaderException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
@@ -76,8 +76,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_ALLOCA
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.ALLOCATED;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Tests for PipelineManagerImpl.
@@ -93,7 +93,7 @@ public class TestPipelineManagerImpl {
   private StorageContainerManager scm;
   private TestClock testClock;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     testClock = new TestClock(Instant.now(), ZoneOffset.UTC);
     conf = SCMTestUtils.getConf();
@@ -117,7 +117,7 @@ public class TestPipelineManagerImpl {
     serviceManager = new SCMServiceManager();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (dbStore != null) {
       dbStore.close();
@@ -155,16 +155,16 @@ public class TestPipelineManagerImpl {
         new SCMHADBTransactionBufferStub(dbStore);
     PipelineManagerImpl pipelineManager =
         createPipelineManager(true, buffer1);
-    Assert.assertTrue(pipelineManager.getPipelines().isEmpty());
+    Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
     Pipeline pipeline1 = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline1.getId()));
 
     Pipeline pipeline2 = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.ONE));
-    Assert.assertEquals(2, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
+    Assertions.assertEquals(2, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline2.getId()));
     buffer1.close();
     pipelineManager.close();
 
@@ -173,13 +173,13 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager2 =
         createPipelineManager(true, buffer2);
     // Should be able to load previous pipelines.
-    Assert.assertFalse(pipelineManager2.getPipelines().isEmpty());
-    Assert.assertEquals(2, pipelineManager.getPipelines().size());
+    Assertions.assertFalse(pipelineManager2.getPipelines().isEmpty());
+    Assertions.assertEquals(2, pipelineManager.getPipelines().size());
     Pipeline pipeline3 = pipelineManager2.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
     buffer2.close();
-    Assert.assertEquals(3, pipelineManager2.getPipelines().size());
-    Assert.assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
+    Assertions.assertEquals(3, pipelineManager2.getPipelines().size());
+    Assertions.assertTrue(pipelineManager2.containsPipeline(pipeline3.getId()));
 
     pipelineManager2.close();
   }
@@ -187,7 +187,7 @@ public class TestPipelineManagerImpl {
   @Test
   public void testCreatePipelineShouldFailOnFollower() throws Exception {
     PipelineManagerImpl pipelineManager = createPipelineManager(false);
-    Assert.assertTrue(pipelineManager.getPipelines().isEmpty());
+    Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
     try {
       pipelineManager
           .createPipeline(RatisReplicationConfig
@@ -197,7 +197,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -209,47 +209,47 @@ public class TestPipelineManagerImpl {
         SCMDBDefinition.PIPELINES.getTable(dbStore);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     buffer.flush();
-    Assert.assertEquals(ALLOCATED,
+    Assertions.assertEquals(ALLOCATED,
         pipelineStore.get(pipeline.getId()).getPipelineState());
     PipelineID pipelineID = pipeline.getId();
 
     pipelineManager.openPipeline(pipelineID);
     pipelineManager.addContainerToPipeline(pipelineID, ContainerID.valueOf(1));
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
     buffer.flush();
-    Assert.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
+    Assertions.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
 
     pipelineManager.deactivatePipeline(pipeline.getId());
-    Assert.assertEquals(Pipeline.PipelineState.DORMANT,
+    Assertions.assertEquals(Pipeline.PipelineState.DORMANT,
         pipelineManager.getPipeline(pipelineID).getPipelineState());
     buffer.flush();
-    Assert.assertEquals(Pipeline.PipelineState.DORMANT,
+    Assertions.assertEquals(Pipeline.PipelineState.DORMANT,
         pipelineStore.get(pipeline.getId()).getPipelineState());
-    Assert.assertFalse(pipelineManager
+    Assertions.assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
-    Assert.assertEquals(1, pipelineManager.getPipelineCount(
+    Assertions.assertEquals(1, pipelineManager.getPipelineCount(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.DORMANT));
 
     pipelineManager.activatePipeline(pipeline.getId());
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
-    Assert.assertEquals(1, pipelineManager.getPipelineCount(
+    Assertions.assertEquals(1, pipelineManager.getPipelineCount(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN));
     buffer.flush();
-    Assert.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
+    Assertions.assertTrue(pipelineStore.get(pipeline.getId()).isOpen());
     pipelineManager.close();
   }
 
@@ -258,9 +258,9 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
     assert pipelineManager.getScmhaManager() instanceof SCMHAManagerStub;
     ((SCMHAManagerStub) pipelineManager.getScmhaManager()).setIsLeader(false);
@@ -271,7 +271,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -279,9 +279,9 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
     assert pipelineManager.getScmhaManager() instanceof SCMHAManagerStub;
     ((SCMHAManagerStub) pipelineManager.getScmhaManager()).setIsLeader(false);
@@ -292,7 +292,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -300,9 +300,9 @@ public class TestPipelineManagerImpl {
     PipelineManagerImpl pipelineManager = createPipelineManager(true);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
     assert pipelineManager.getScmhaManager() instanceof SCMHAManagerStub;
     ((SCMHAManagerStub) pipelineManager.getScmhaManager()).setIsLeader(false);
@@ -313,7 +313,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -323,9 +323,9 @@ public class TestPipelineManagerImpl {
     // Create a pipeline
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
 
     // Open the pipeline
     pipelineManager.openPipeline(pipeline.getId());
@@ -338,7 +338,7 @@ public class TestPipelineManagerImpl {
             addContainer(containerInfo.getProtobuf());
     //Add Container to PipelineStateMap
     pipelineManager.addContainerToPipeline(pipeline.getId(), containerID);
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN).contains(pipeline));
@@ -348,9 +348,9 @@ public class TestPipelineManagerImpl {
       fail();
     } catch (IOException ioe) {
       // Should not be able to remove the OPEN pipeline.
-      Assert.assertEquals(1, pipelineManager.getPipelines().size());
+      Assertions.assertEquals(1, pipelineManager.getPipelines().size());
     } catch (Exception e) {
-      Assert.fail("Should not reach here.");
+      Assertions.fail("Should not reach here.");
     }
 
     // Destroy pipeline
@@ -372,9 +372,9 @@ public class TestPipelineManagerImpl {
     pipelineManager.setScmContext(scmContext);
     Pipeline pipeline = pipelineManager.createPipeline(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE));
-    Assert.assertEquals(1, pipelineManager.getPipelines().size());
-    Assert.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
-    Assert.assertEquals(ALLOCATED, pipeline.getPipelineState());
+    Assertions.assertEquals(1, pipelineManager.getPipelines().size());
+    Assertions.assertTrue(pipelineManager.containsPipeline(pipeline.getId()));
+    Assertions.assertEquals(ALLOCATED, pipeline.getPipelineState());
     // Change to follower
     assert pipelineManager.getScmhaManager() instanceof SCMHAManagerStub;
     ((SCMHAManagerStub) pipelineManager.getScmhaManager()).setIsLeader(false);
@@ -385,7 +385,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -401,7 +401,7 @@ public class TestPipelineManagerImpl {
 
     // pipeline is not healthy until all dns report
     List<DatanodeDetails> nodes = pipeline.getNodes();
-    Assert.assertFalse(
+    Assertions.assertFalse(
         pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     // get pipeline report from each dn in the pipeline
     PipelineReportHandler pipelineReportHandler =
@@ -448,7 +448,7 @@ public class TestPipelineManagerImpl {
         SCMPipelineMetrics.class.getSimpleName());
     long numPipelineAllocated = getLongCounter("NumPipelineAllocated",
         metrics);
-    Assert.assertEquals(0, numPipelineAllocated);
+    Assertions.assertEquals(0, numPipelineAllocated);
 
     // 3 DNs are unhealthy.
     // Create 5 pipelines (Use up 15 Datanodes)
@@ -457,17 +457,17 @@ public class TestPipelineManagerImpl {
       Pipeline pipeline = pipelineManager
           .createPipeline(RatisReplicationConfig
               .getInstance(ReplicationFactor.THREE));
-      Assert.assertNotNull(pipeline);
+      Assertions.assertNotNull(pipeline);
     }
 
     metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     numPipelineAllocated = getLongCounter("NumPipelineAllocated", metrics);
-    Assert.assertEquals(maxPipelineCount, numPipelineAllocated);
+    Assertions.assertEquals(maxPipelineCount, numPipelineAllocated);
 
     long numPipelineCreateFailed = getLongCounter(
         "NumPipelineCreationFailed", metrics);
-    Assert.assertEquals(0, numPipelineCreateFailed);
+    Assertions.assertEquals(0, numPipelineCreateFailed);
 
     //This should fail...
     try {
@@ -477,18 +477,18 @@ public class TestPipelineManagerImpl {
       fail();
     } catch (SCMException ioe) {
       // pipeline creation failed this time.
-      Assert.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
+      Assertions.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
           ioe.getResult());
     }
 
     metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
     numPipelineAllocated = getLongCounter("NumPipelineAllocated", metrics);
-    Assert.assertEquals(maxPipelineCount, numPipelineAllocated);
+    Assertions.assertEquals(maxPipelineCount, numPipelineAllocated);
 
     numPipelineCreateFailed = getLongCounter(
         "NumPipelineCreationFailed", metrics);
-    Assert.assertEquals(1, numPipelineCreateFailed);
+    Assertions.assertEquals(1, numPipelineCreateFailed);
 
     // clean up
     pipelineManager.close();
@@ -509,7 +509,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.close();
     // new pipeline manager loads the pipelines from the db in ALLOCATED state
     pipelineManager = createPipelineManager(true);
-    Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     SCMSafeModeManager scmSafeModeManager =
@@ -522,12 +522,12 @@ public class TestPipelineManagerImpl {
 
     // Report pipelines with leaders
     List<DatanodeDetails> nodes = pipeline.getNodes();
-    Assert.assertEquals(3, nodes.size());
+    Assertions.assertEquals(3, nodes.size());
     // Send report for all but no leader
     nodes.forEach(dn -> sendPipelineReport(dn, pipeline, pipelineReportHandler,
         false));
 
-    Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     nodes.subList(0, 2).forEach(dn -> sendPipelineReport(dn, pipeline,
@@ -535,7 +535,7 @@ public class TestPipelineManagerImpl {
     sendPipelineReport(nodes.get(nodes.size() - 1), pipeline,
         pipelineReportHandler, true);
 
-    Assert.assertEquals(Pipeline.PipelineState.OPEN,
+    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
         pipelineManager.getPipeline(pipeline.getId()).getPipelineState());
 
     pipelineManager.close();
@@ -553,11 +553,11 @@ public class TestPipelineManagerImpl {
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
     // At this point, pipeline is not at OPEN stage.
-    Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
         allocatedPipeline.getPipelineState());
 
     // pipeline should be seen in pipelineManager as ALLOCATED.
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
@@ -569,7 +569,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.closePipeline(closedPipeline, true);
 
     // pipeline should be seen in pipelineManager as CLOSED.
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
@@ -581,13 +581,13 @@ public class TestPipelineManagerImpl {
 
     // The allocatedPipeline should not be scrubbed as the interval has not
     // yet passed.
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
 
     // The closedPipeline should be scrubbed, as they are scrubbed immediately
-    Assert.assertFalse(pipelineManager
+    Assertions.assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.CLOSED).contains(closedPipeline));
@@ -597,7 +597,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.scrubPipelines();
 
     // The allocatedPipeline should now be scrubbed as the interval has passed
-    Assert.assertFalse(pipelineManager
+    Assertions.assertFalse(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(allocatedPipeline));
@@ -616,11 +616,11 @@ public class TestPipelineManagerImpl {
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE));
     // At this point, pipeline is not at OPEN stage.
-    Assert.assertEquals(Pipeline.PipelineState.ALLOCATED,
+    Assertions.assertEquals(Pipeline.PipelineState.ALLOCATED,
         pipeline.getPipelineState());
 
     // pipeline should be seen in pipelineManager as ALLOCATED.
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
                 .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.ALLOCATED).contains(pipeline));
@@ -637,7 +637,7 @@ public class TestPipelineManagerImpl {
       return;
     }
     // Should not reach here.
-    Assert.fail();
+    Assertions.fail();
   }
 
   @Test
@@ -658,7 +658,7 @@ public class TestPipelineManagerImpl {
       fail("Pipelines should not have been created");
     } catch (IOException e) {
       // No pipeline is created.
-      Assert.assertTrue(pipelineManager.getPipelines().isEmpty());
+      Assertions.assertTrue(pipelineManager.getPipelines().isEmpty());
     }
 
     // Ensure a pipeline of factor ONE can be created - no exceptions should be
@@ -666,7 +666,7 @@ public class TestPipelineManagerImpl {
     Pipeline pipeline = pipelineManager
         .createPipeline(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE));
-    Assert.assertTrue(pipelineManager
+    Assertions.assertTrue(pipelineManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE))
         .contains(pipeline));
@@ -694,21 +694,21 @@ public class TestPipelineManagerImpl {
 
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, false));
-    Assert.assertTrue(pipelineManager.getSafeModeStatus());
-    Assert.assertFalse(pipelineManager.isPipelineCreationAllowed());
+    Assertions.assertTrue(pipelineManager.getSafeModeStatus());
+    Assertions.assertFalse(pipelineManager.isPipelineCreationAllowed());
 
     // First pass pre-check as true, but safemode still on
     // Simulate safemode check exiting.
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(true, true));
-    Assert.assertTrue(pipelineManager.getSafeModeStatus());
-    Assert.assertTrue(pipelineManager.isPipelineCreationAllowed());
+    Assertions.assertTrue(pipelineManager.getSafeModeStatus());
+    Assertions.assertTrue(pipelineManager.isPipelineCreationAllowed());
 
     // Then also turn safemode off
     scmContext.updateSafeModeStatus(
         new SCMSafeModeManager.SafeModeStatus(false, true));
-    Assert.assertFalse(pipelineManager.getSafeModeStatus());
-    Assert.assertTrue(pipelineManager.isPipelineCreationAllowed());
+    Assertions.assertFalse(pipelineManager.getSafeModeStatus());
+    Assertions.assertTrue(pipelineManager.isPipelineCreationAllowed());
     pipelineManager.close();
   }
 
@@ -729,7 +729,7 @@ public class TestPipelineManagerImpl {
     pipelineManager.getStateManager().updatePipelineState(
             pipelineID.getProtobuf(), HddsProtos.PipelineState.PIPELINE_CLOSED);
     buffer.flush();
-    Assert.assertTrue(pipelineStore.get(pipelineID).isClosed());
+    Assertions.assertTrue(pipelineStore.get(pipelineID).isClosed());
     pipelineManager.addContainerToPipelineSCMStart(pipelineID,
             ContainerID.valueOf(2));
     assertTrue(logCapturer.getOutput().contains("Container " +
@@ -781,9 +781,9 @@ public class TestPipelineManagerImpl {
     Set<ContainerReplica> replicas = createContainerReplicasList(dns);
     Pipeline pipeline = pipelineManager.createPipelineForRead(
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE), replicas);
-    Assert.assertEquals(3, pipeline.getNodes().size());
+    Assertions.assertEquals(3, pipeline.getNodes().size());
     for (DatanodeDetails dn : pipeline.getNodes())  {
-      Assert.assertTrue(dns.contains(dn));
+      Assertions.assertTrue(dns.contains(dn));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -477,7 +477,8 @@ public class TestPipelineManagerImpl {
       fail();
     } catch (SCMException ioe) {
       // pipeline creation failed this time.
-      Assertions.assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
+      Assertions.assertEquals(
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
           ioe.getResult());
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineManagerImpl.java
@@ -413,11 +413,11 @@ public class TestPipelineManagerImpl {
         pipelineReportHandler, true);
 
     // pipeline is healthy when all dns report
-    Assert
-        .assertTrue(pipelineManager.getPipeline(pipeline.getId()).isHealthy());
+    Assertions.assertTrue(
+        pipelineManager.getPipeline(pipeline.getId()).isHealthy());
     // pipeline should now move to open state
-    Assert
-        .assertTrue(pipelineManager.getPipeline(pipeline.getId()).isOpen());
+    Assertions.assertTrue(
+        pipelineManager.getPipeline(pipeline.getId()).isOpen());
 
     // close the pipeline
     pipelineManager.closePipeline(pipeline, false);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -367,17 +367,20 @@ public class TestPipelineStateManagerImpl {
 
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assertions.assertEquals(1, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(1,
+        stateManager.getContainers(pipeline.getId()).size());
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assertions.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(0,
+        stateManager.getContainers(pipeline.getId()).size());
 
     // add two containers in the pipeline
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(++containerID));
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(++containerID));
-    Assertions.assertEquals(2, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(2,
+        stateManager.getContainers(pipeline.getId()).size());
 
     // move pipeline to closing state
     finalizePipeline(pipelineProto);
@@ -386,7 +389,8 @@ public class TestPipelineStateManagerImpl {
         ContainerID.valueOf(containerID));
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(--containerID));
-    Assertions.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(0,
+        stateManager.getContainers(pipeline.getId()).size());
 
     // clean up
     removePipeline(pipelineProto);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateManagerImpl.java
@@ -41,10 +41,10 @@ import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -63,7 +63,7 @@ public class TestPipelineStateManagerImpl {
   private File testDir;
   private DBStore dbStore;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     final OzoneConfiguration conf = SCMTestUtils.getConf();
     testDir = GenericTestUtils.getTestDir(
@@ -83,7 +83,7 @@ public class TestPipelineStateManagerImpl {
         .build();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (dbStore != null) {
       dbStore.close();
@@ -119,10 +119,10 @@ public class TestPipelineStateManagerImpl {
         ClientVersion.CURRENT_VERSION);
     try {
       stateManager.addPipeline(pipelineProto);
-      Assert.fail("Pipeline should not have been added");
+      Assertions.fail("Pipeline should not have been added");
     } catch (StateMachineException e) {
       // replication factor and number of nodes in the pipeline do not match
-      Assert.assertTrue(e.getMessage().contains("do not match"));
+      Assertions.assertTrue(e.getMessage().contains("do not match"));
     }
 
     // add a pipeline
@@ -132,15 +132,15 @@ public class TestPipelineStateManagerImpl {
 
     try {
       stateManager.addPipeline(pipelineProto);
-      Assert.fail("Pipeline should not have been added");
+      Assertions.fail("Pipeline should not have been added");
     } catch (IOException e) {
       // Can not add a pipeline twice
-      Assert.assertTrue(e.getMessage().contains("Duplicate pipeline ID"));
+      Assertions.assertTrue(e.getMessage().contains("Duplicate pipeline ID"));
     }
 
     // verify pipeline returned is same
     Pipeline pipeline1 = stateManager.getPipeline(pipeline.getId());
-    Assert.assertTrue(pipeline.getId().equals(pipeline1.getId()));
+    Assertions.assertTrue(pipeline.getId().equals(pipeline1.getId()));
 
     // clean up
     finalizePipeline(pipelineProto);
@@ -150,7 +150,7 @@ public class TestPipelineStateManagerImpl {
   @Test
   public void testGetPipelines() throws IOException {
     // In start there should be no pipelines
-    Assert.assertTrue(stateManager.getPipelines().isEmpty());
+    Assertions.assertTrue(stateManager.getPipelines().isEmpty());
 
     Set<HddsProtos.Pipeline> pipelines = new HashSet<>();
     HddsProtos.Pipeline pipeline = createDummyPipeline(1).getProtobufMessage(
@@ -165,10 +165,10 @@ public class TestPipelineStateManagerImpl {
     Set<Pipeline> pipelines1 = new HashSet<>(stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.ONE)));
-    Assert.assertEquals(pipelines1.size(), pipelines.size());
+    Assertions.assertEquals(pipelines1.size(), pipelines.size());
 
     pipelines1 = new HashSet<>(stateManager.getPipelines());
-    Assert.assertEquals(pipelines1.size(), pipelines.size());
+    Assertions.assertEquals(pipelines1.size(), pipelines.size());
 
     // clean up
     for (HddsProtos.Pipeline pipeline1 : pipelines) {
@@ -215,9 +215,9 @@ public class TestPipelineStateManagerImpl {
         List<Pipeline> pipelines1 =
             stateManager.getPipelines(
                 ReplicationConfig.fromProtoTypeAndFactor(type, factor));
-        Assert.assertEquals(15, pipelines1.size());
+        Assertions.assertEquals(15, pipelines1.size());
         pipelines1.stream().forEach(p -> {
-          Assert.assertEquals(type, p.getType());
+          Assertions.assertEquals(type, p.getType());
         });
       }
     }
@@ -279,10 +279,10 @@ public class TestPipelineStateManagerImpl {
               stateManager.getPipelines(
                   ReplicationConfig.fromProtoTypeAndFactor(type, factor),
                   state);
-          Assert.assertEquals(5, pipelines1.size());
+          Assertions.assertEquals(5, pipelines1.size());
           pipelines1.forEach(p -> {
-            Assert.assertEquals(type, p.getType());
-            Assert.assertEquals(state, p.getPipelineState());
+            Assertions.assertEquals(type, p.getType());
+            Assertions.assertEquals(state, p.getPipelineState());
           });
         }
       }
@@ -316,17 +316,17 @@ public class TestPipelineStateManagerImpl {
     //verify the number of containers returned
     Set<ContainerID> containerIDs =
         stateManager.getContainers(pipeline.getId());
-    Assert.assertEquals(containerIDs.size(), containerID);
+    Assertions.assertEquals(containerIDs.size(), containerID);
 
     finalizePipeline(pipelineProto);
     removePipeline(pipelineProto);
     try {
       stateManager.addContainerToPipeline(pipeline.getId(),
           ContainerID.valueOf(++containerID));
-      Assert.fail("Container should not have been added");
+      Assertions.fail("Container should not have been added");
     } catch (IOException e) {
       // Can not add a container to removed pipeline
-      Assert.assertTrue(e.getMessage().contains("not found"));
+      Assertions.assertTrue(e.getMessage().contains("not found"));
     }
   }
 
@@ -343,10 +343,10 @@ public class TestPipelineStateManagerImpl {
 
     try {
       removePipeline(pipelineProto);
-      Assert.fail("Pipeline should not have been removed");
+      Assertions.fail("Pipeline should not have been removed");
     } catch (IOException e) {
       // can not remove a pipeline which already has containers
-      Assert.assertTrue(e.getMessage().contains("not yet closed"));
+      Assertions.assertTrue(e.getMessage().contains("not yet closed"));
     }
 
     // close the pipeline
@@ -367,17 +367,17 @@ public class TestPipelineStateManagerImpl {
 
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assert.assertEquals(1, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(1, stateManager.getContainers(pipeline.getId()).size());
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(containerID));
-    Assert.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
 
     // add two containers in the pipeline
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(++containerID));
     stateManager.addContainerToPipeline(pipeline.getId(),
         ContainerID.valueOf(++containerID));
-    Assert.assertEquals(2, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(2, stateManager.getContainers(pipeline.getId()).size());
 
     // move pipeline to closing state
     finalizePipeline(pipelineProto);
@@ -386,7 +386,7 @@ public class TestPipelineStateManagerImpl {
         ContainerID.valueOf(containerID));
     stateManager.removeContainerFromPipeline(pipeline.getId(),
         ContainerID.valueOf(--containerID));
-    Assert.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
+    Assertions.assertEquals(0, stateManager.getContainers(pipeline.getId()).size());
 
     // clean up
     removePipeline(pipelineProto);
@@ -400,7 +400,7 @@ public class TestPipelineStateManagerImpl {
     stateManager.addPipeline(pipelineProto);
     // finalize on ALLOCATED pipeline
     finalizePipeline(pipelineProto);
-    Assert.assertEquals(Pipeline.PipelineState.CLOSED,
+    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -412,7 +412,7 @@ public class TestPipelineStateManagerImpl {
     openPipeline(pipelineProto);
     // finalize on OPEN pipeline
     finalizePipeline(pipelineProto);
-    Assert.assertEquals(Pipeline.PipelineState.CLOSED,
+    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -425,7 +425,7 @@ public class TestPipelineStateManagerImpl {
     finalizePipeline(pipelineProto);
     // finalize should work on already closed pipeline
     finalizePipeline(pipelineProto);
-    Assert.assertEquals(Pipeline.PipelineState.CLOSED,
+    Assertions.assertEquals(Pipeline.PipelineState.CLOSED,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     removePipeline(pipelineProto);
@@ -439,12 +439,12 @@ public class TestPipelineStateManagerImpl {
     stateManager.addPipeline(pipelineProto);
     // open on ALLOCATED pipeline
     openPipeline(pipelineProto);
-    Assert.assertEquals(Pipeline.PipelineState.OPEN,
+    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
 
     openPipeline(pipelineProto);
     // open should work on already open pipeline
-    Assert.assertEquals(Pipeline.PipelineState.OPEN,
+    Assertions.assertEquals(Pipeline.PipelineState.OPEN,
         stateManager.getPipeline(pipeline.getId()).getPipelineState());
     // clean up
     finalizePipeline(pipelineProto);
@@ -459,7 +459,7 @@ public class TestPipelineStateManagerImpl {
     HddsProtos.Pipeline pipelineProto = pipeline
         .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
-    Assert.assertEquals(0, stateManager
+    Assertions.assertEquals(0, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -467,7 +467,7 @@ public class TestPipelineStateManagerImpl {
 
     // pipeline in open state should be reported
     openPipeline(pipelineProto);
-    Assert.assertEquals(1, stateManager
+    Assertions.assertEquals(1, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -482,7 +482,7 @@ public class TestPipelineStateManagerImpl {
         .getProtobufMessage(ClientVersion.CURRENT_VERSION);
     // pipeline in open state should be reported
     stateManager.addPipeline(pipelineProto2);
-    Assert.assertEquals(2, stateManager
+    Assertions.assertEquals(2, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)
@@ -490,7 +490,7 @@ public class TestPipelineStateManagerImpl {
 
     // pipeline in closed state should not be reported
     finalizePipeline(pipelineProto2);
-    Assert.assertEquals(1, stateManager
+    Assertions.assertEquals(1, stateManager
         .getPipelines(RatisReplicationConfig
             .getInstance(ReplicationFactor.THREE),
             Pipeline.PipelineState.OPEN)

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateMap.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipelineStateMap.java
@@ -20,15 +20,15 @@ package org.apache.hadoop.hdds.scm.pipeline;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests for PipelineStateMap.
@@ -38,12 +38,12 @@ public class TestPipelineStateMap {
 
   private PipelineStateMap map;
 
-  @Before
+  @BeforeEach
   public void setup() {
     map = new PipelineStateMap();
   }
 
-  @After
+  @AfterEach
   public void teardown() throws IOException {
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -281,12 +281,12 @@ public class TestRatisPipelineProvider {
     List<DatanodeDetails> nodes = pipeline.getNodes();
 
     assertTrue(
-        "nodes of new pipeline cannot be all from open pipelines",
-        nodes.stream().noneMatch(membersOfOpenPipelines::contains));
+        nodes.stream().noneMatch(membersOfOpenPipelines::contains),
+        "nodes of new pipeline cannot be all from open pipelines");
 
     assertTrue(
-        "at least 1 node should have been from members of closed pipelines",
-        nodes.stream().anyMatch(membersOfClosedPipelines::contains));
+        nodes.stream().anyMatch(membersOfClosedPipelines::contains),
+        "at least 1 node should have been from members of closed pipelines");
     cleanup();
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestRatisPipelineProvider.java
@@ -42,9 +42,9 @@ import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.Assume;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,10 +59,10 @@ import java.util.stream.Collectors;
 import static org.apache.commons.collections.CollectionUtils.intersection;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CONTAINER_SIZE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for RatisPipelineProvider.
@@ -236,8 +236,8 @@ public class TestRatisPipelineProvider {
         RatisReplicationConfig.getInstance(ReplicationFactor.THREE),
         replicas);
 
-    Assert.assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
-    Assert.assertEquals(pipeline2.getNodeSet(), pipeline3.getNodeSet());
+    Assertions.assertEquals(pipeline1.getNodeSet(), pipeline2.getNodeSet());
+    Assertions.assertEquals(pipeline2.getNodeSet(), pipeline3.getNodeSet());
     cleanup();
   }
 
@@ -331,10 +331,10 @@ public class TestRatisPipelineProvider {
       }
       try {
         provider.create(RatisReplicationConfig.getInstance(factor));
-        Assert.fail("Expected SCMException for large container size with " +
+        Assertions.fail("Expected SCMException for large container size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
-        Assert.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
+        Assertions.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
       }
     }
 
@@ -347,10 +347,10 @@ public class TestRatisPipelineProvider {
       }
       try {
         provider.create(RatisReplicationConfig.getInstance(factor));
-        Assert.fail("Expected SCMException for large metadata size with " +
+        Assertions.fail("Expected SCMException for large metadata size with " +
             "replication factor " + factor.toString());
       } catch (SCMException ex) {
-        Assert.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
+        Assertions.assertTrue(ex.getMessage().contains(expectedErrorSubstring));
       }
     }
     cleanup();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSimplePipelineProvider.java
@@ -36,10 +36,10 @@ import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -58,7 +58,7 @@ public class TestSimplePipelineProvider {
   private File testDir;
   private DBStore dbStore;
 
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     nodeManager = new MockNodeManager(true, 10);
     final OzoneConfiguration conf = SCMTestUtils.getConf();
@@ -77,7 +77,7 @@ public class TestSimplePipelineProvider {
     provider = new SimplePipelineProvider(nodeManager, stateManager);
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     if (dbStore != null) {
       dbStore.close();
@@ -94,13 +94,13 @@ public class TestSimplePipelineProvider {
     HddsProtos.Pipeline pipelineProto = pipeline.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto);
-    Assert.assertEquals(pipeline.getType(),
+    Assertions.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
-    Assert.assertEquals(pipeline.getReplicationConfig().getRequiredNodes(),
+    Assertions.assertEquals(pipeline.getReplicationConfig().getRequiredNodes(),
         factor.getNumber());
-    Assert.assertEquals(pipeline.getPipelineState(),
+    Assertions.assertEquals(pipeline.getPipelineState(),
         Pipeline.PipelineState.OPEN);
-    Assert.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     Pipeline pipeline1 =
@@ -108,14 +108,14 @@ public class TestSimplePipelineProvider {
     HddsProtos.Pipeline pipelineProto1 = pipeline1.getProtobufMessage(
         ClientVersion.CURRENT_VERSION);
     stateManager.addPipeline(pipelineProto1);
-    Assert.assertEquals(pipeline1.getType(),
+    Assertions.assertEquals(pipeline1.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ((StandaloneReplicationConfig) pipeline1.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assert.assertEquals(pipeline1.getPipelineState(),
+    Assertions.assertEquals(pipeline1.getPipelineState(),
         Pipeline.PipelineState.OPEN);
-    Assert.assertEquals(pipeline1.getNodes().size(), factor.getNumber());
+    Assertions.assertEquals(pipeline1.getNodes().size(), factor.getNumber());
   }
 
   private List<DatanodeDetails> createListOfNodes(int nodeCount) {
@@ -132,25 +132,25 @@ public class TestSimplePipelineProvider {
     Pipeline pipeline =
         provider.create(StandaloneReplicationConfig.getInstance(factor),
             createListOfNodes(factor.getNumber()));
-    Assert.assertEquals(pipeline.getType(),
+    Assertions.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ((StandaloneReplicationConfig) pipeline.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assert.assertEquals(pipeline.getPipelineState(),
+    Assertions.assertEquals(pipeline.getPipelineState(),
         Pipeline.PipelineState.OPEN);
-    Assert.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
 
     factor = HddsProtos.ReplicationFactor.ONE;
     pipeline = provider.create(StandaloneReplicationConfig.getInstance(factor),
         createListOfNodes(factor.getNumber()));
-    Assert.assertEquals(pipeline.getType(),
+    Assertions.assertEquals(pipeline.getType(),
         HddsProtos.ReplicationType.STAND_ALONE);
-    Assert.assertEquals(
+    Assertions.assertEquals(
         ((StandaloneReplicationConfig) pipeline.getReplicationConfig())
             .getReplicationFactor(), factor);
-    Assert.assertEquals(pipeline.getPipelineState(),
+    Assertions.assertEquals(pipeline.getPipelineState(),
         Pipeline.PipelineState.OPEN);
-    Assert.assertEquals(pipeline.getNodes().size(), factor.getNumber());
+    Assertions.assertEquals(pipeline.getNodes().size(), factor.getNumber());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -40,8 +40,8 @@ import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoo
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -62,12 +62,12 @@ import java.util.UUID;
 import static org.apache.hadoop.hdds.conf.StorageUnit.BYTES;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.CLOSED;
 import static org.apache.hadoop.hdds.scm.pipeline.Pipeline.PipelineState.OPEN;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -94,7 +94,7 @@ public class TestWritableECContainerProvider {
 
   private Map<ContainerID, ContainerInfo> containers;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
     repConfig = new ECReplicationConfig(3, 2);
     conf = new OzoneConfiguration();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/choose/algorithms/TestPipelineChoosePolicyFactory.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.hdds.scm.ScmConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.exceptions.SCMException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -42,7 +42,7 @@ public class TestPipelineChoosePolicyFactory {
 
   private ScmConfig scmConfig;
 
-  @Before
+  @BeforeEach
   public void setup() {
     //initialize network topology instance
     conf = new OzoneConfiguration();
@@ -53,7 +53,7 @@ public class TestPipelineChoosePolicyFactory {
   public void testDefaultPolicy() throws IOException {
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory
         .getPolicy(conf);
-    Assert.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 
@@ -78,7 +78,7 @@ public class TestPipelineChoosePolicyFactory {
     // set a policy class which does't have the right constructor implemented
     scmConfig.setPipelineChoosePolicyName(DummyImpl.class.getName());
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory.getPolicy(conf);
-    Assert.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 
@@ -88,7 +88,7 @@ public class TestPipelineChoosePolicyFactory {
     conf.set(ScmConfigKeys.OZONE_SCM_CONTAINER_PLACEMENT_IMPL_KEY,
         "org.apache.hadoop.hdds.scm.pipeline.choose.policy.HelloWorld");
     PipelineChoosePolicy policy = PipelineChoosePolicyFactory.getPolicy(conf);
-    Assert.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
+    Assertions.assertSame(OZONE_SCM_PIPELINE_CHOOSE_POLICY_IMPL_DEFAULT,
         policy.getClass());
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
@@ -55,18 +55,20 @@ public class TestLeaderChoosePolicy {
         MinLeaderCountChoosePolicy.class);
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test
   public void testClassNotImplemented() {
     // set a class not implemented
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_LEADER_CHOOSING_POLICY,
         "org.apache.hadoop.hdds.scm.pipeline.leader.choose.algorithms" +
             ".HelloWorld");
-    new RatisPipelineProvider(
-        mock(NodeManager.class),
-        mock(PipelineStateManagerImpl.class),
-        conf,
-        mock(EventPublisher.class),
-        SCMContext.emptyContext());
+    Assertions.assertThrows(RuntimeException.class, () ->
+        new RatisPipelineProvider(
+            mock(NodeManager.class),
+            mock(PipelineStateManagerImpl.class),
+            conf,
+            mock(EventPublisher.class),
+            SCMContext.emptyContext())
+    );
 
     // expecting exception
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/leader/choose/algorithms/TestLeaderChoosePolicy.java
@@ -24,9 +24,9 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineStateManagerImpl;
 import org.apache.hadoop.hdds.scm.pipeline.RatisPipelineProvider;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.mockito.Mockito.mock;
 
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.mock;
 public class TestLeaderChoosePolicy {
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() {
     //initialize network topology instance
     conf = new OzoneConfiguration();
@@ -50,7 +50,7 @@ public class TestLeaderChoosePolicy {
         conf,
         mock(EventPublisher.class),
         SCMContext.emptyContext());
-    Assert.assertSame(
+    Assertions.assertSame(
         ratisPipelineProvider.getLeaderChoosePolicy().getClass(),
         MinLeaderCountChoosePolicy.class);
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/safemode/TestHealthyPipelineSafeModeRule.java
@@ -47,8 +47,8 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.ozone.common.MonotonicClock;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.slf4j.LoggerFactory;
 
 /**
@@ -102,7 +102,7 @@ public class TestHealthyPipelineSafeModeRule {
           scmSafeModeManager.getHealthyPipelineSafeModeRule();
 
       // This should be immediately satisfied, as no pipelines are there yet.
-      Assert.assertTrue(healthyPipelineSafeModeRule.validate());
+      Assertions.assertTrue(healthyPipelineSafeModeRule.validate());
     } finally {
       scmMetadataStore.getStore().close();
       FileUtil.fullyDelete(new File(storageDir));
@@ -183,7 +183,7 @@ public class TestHealthyPipelineSafeModeRule {
           scmSafeModeManager.getHealthyPipelineSafeModeRule();
 
       // No datanodes have sent pipelinereport from datanode
-      Assert.assertFalse(healthyPipelineSafeModeRule.validate());
+      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
 
       // Fire pipeline report from all datanodes in first pipeline, as here we
       // have 3 pipelines, 10% is 0.3, when doing ceil it is 1. So, we should
@@ -283,7 +283,7 @@ public class TestHealthyPipelineSafeModeRule {
 
 
       // No pipeline event have sent to SCMSafemodeManager
-      Assert.assertFalse(healthyPipelineSafeModeRule.validate());
+      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
 
 
       GenericTestUtils.LogCapturer logCapturer =
@@ -297,7 +297,7 @@ public class TestHealthyPipelineSafeModeRule {
       GenericTestUtils.waitFor(() -> logCapturer.getOutput().contains(
           "reported count is 1"),
           1000, 5000);
-      Assert.assertFalse(healthyPipelineSafeModeRule.validate());
+      Assertions.assertFalse(healthyPipelineSafeModeRule.validate());
 
       firePipelineEvent(pipeline2, eventQueue);
       firePipelineEvent(pipeline3, eventQueue);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMBlockProtocolServer.java
@@ -31,10 +31,10 @@ import org.apache.hadoop.hdds.scm.protocol.ScmBlockLocationProtocolServerSideTra
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.ozone.test.GenericTestUtils;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -55,7 +55,7 @@ public class TestSCMBlockProtocolServer {
   private ScmBlockLocationProtocolServerSideTranslatorPB service;
   private static final int NODE_COUNT = 10;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     config = new OzoneConfiguration();
     File dir = GenericTestUtils.getRandomizedTestDir();
@@ -77,7 +77,7 @@ public class TestSCMBlockProtocolServer {
         Mockito.mock(ProtocolMessageMetrics.class));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (scm != null) {
       scm.stop();
@@ -99,7 +99,7 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assert.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
 
     // illegal client 1
     client += "X";
@@ -107,14 +107,14 @@ public class TestSCMBlockProtocolServer {
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assert.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
     // illegal client 2
     client = "/default-rack";
     datanodeDetails = server.sortDatanodes(nodes, client);
     System.out.println("client = " + client);
     datanodeDetails.stream().forEach(
         node -> System.out.println(node.toString()));
-    Assert.assertTrue(datanodeDetails.size() == NODE_COUNT);
+    Assertions.assertTrue(datanodeDetails.size() == NODE_COUNT);
 
     // unknown node to sort
     nodes.add(UUID.randomUUID().toString());
@@ -126,7 +126,7 @@ public class TestSCMBlockProtocolServer {
             .build();
     ScmBlockLocationProtocolProtos.SortDatanodesResponseProto resp =
         service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
-    Assert.assertTrue(resp.getNodeList().size() == NODE_COUNT);
+    Assertions.assertTrue(resp.getNodeList().size() == NODE_COUNT);
     System.out.println("client = " + client);
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
@@ -143,7 +143,7 @@ public class TestSCMBlockProtocolServer {
         .build();
     resp = service.sortDatanodes(request, ClientVersion.CURRENT_VERSION);
     System.out.println("client = " + client);
-    Assert.assertTrue(resp.getNodeList().size() == 0);
+    Assertions.assertTrue(resp.getNodeList().size() == 0);
     resp.getNodeList().stream().forEach(
         node -> System.out.println(node.getNetworkName()));
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMContainerMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMContainerMetrics.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.metrics2.lib.Interns;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test metrics that represent container states.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestSCMDatanodeHeartbeatDispatcher.java
@@ -43,8 +43,8 @@ import org.apache.hadoop.hdds.server.events.Event;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReregisterCommand;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanodeDetails;
@@ -76,9 +76,9 @@ public class TestSCMDatanodeHeartbeatDispatcher {
               @Override
               public <PAYLOAD, EVENT extends Event<PAYLOAD>> void fireEvent(
                   EVENT event, PAYLOAD payload) {
-                Assert.assertEquals(event, NODE_REPORT);
+                Assertions.assertEquals(event, NODE_REPORT);
                 eventReceived.incrementAndGet();
-                Assert.assertEquals(nodeReport,
+                Assertions.assertEquals(nodeReport,
                     ((NodeReportFromDatanode)payload).getReport());
 
               }
@@ -92,7 +92,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
         .setNodeReport(nodeReport)
         .build();
     dispatcher.dispatch(heartbeat);
-    Assert.assertEquals(1, eventReceived.get());
+    Assertions.assertEquals(1, eventReceived.get());
 
 
   }
@@ -119,16 +119,16 @@ public class TestSCMDatanodeHeartbeatDispatcher {
               @Override
               public <PAYLOAD, EVENT extends Event<PAYLOAD>> void fireEvent(
                   EVENT event, PAYLOAD payload) {
-                Assert.assertTrue(
+                Assertions.assertTrue(
                     event.equals(CONTAINER_REPORT)
                         || event.equals(CMD_STATUS_REPORT));
 
                 if (payload instanceof ContainerReportFromDatanode) {
-                  Assert.assertEquals(containerReport,
+                  Assertions.assertEquals(containerReport,
                       ((ContainerReportFromDatanode) payload).getReport());
                 }
                 if (payload instanceof CommandStatusReportFromDatanode) {
-                  Assert.assertEquals(commandStatusReport,
+                  Assertions.assertEquals(commandStatusReport,
                       ((CommandStatusReportFromDatanode) payload).getReport());
                 }
                 eventReceived.incrementAndGet();
@@ -144,7 +144,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
             .addCommandStatusReports(commandStatusReport)
             .build();
     dispatcher.dispatch(heartbeat);
-    Assert.assertEquals(2, eventReceived.get());
+    Assertions.assertEquals(2, eventReceived.get());
 
 
   }
@@ -167,10 +167,10 @@ public class TestSCMDatanodeHeartbeatDispatcher {
               @Override
               public <PAYLOAD, EVENT extends Event<PAYLOAD>> void fireEvent(
                   EVENT event, PAYLOAD payload) {
-                Assert.assertTrue(event.equals(COMMAND_QUEUE_REPORT));
+                Assertions.assertTrue(event.equals(COMMAND_QUEUE_REPORT));
 
                 if (payload instanceof CommandQueueReportFromDatanode) {
-                  Assert.assertEquals(commandQueueReport,
+                  Assertions.assertEquals(commandQueueReport,
                       ((CommandQueueReportFromDatanode) payload).getReport());
                 }
                 eventReceived.incrementAndGet();
@@ -186,7 +186,7 @@ public class TestSCMDatanodeHeartbeatDispatcher {
             .setCommandQueueReport(commandQueueReport)
             .build();
     dispatcher.dispatch(heartbeat);
-    Assert.assertEquals(1, eventReceived.get());
+    Assertions.assertEquals(1, eventReceived.get());
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
@@ -18,9 +18,9 @@
 package org.apache.hadoop.hdds.scm.server;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -29,10 +29,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
@@ -49,14 +49,14 @@ public class TestStorageContainerManagerStarter {
 
   private MockSCMStarter mock;
 
-  @Before
+  @BeforeEach
   public void setUpStreams() throws UnsupportedEncodingException {
     System.setOut(new PrintStream(outContent, false, DEFAULT_ENCODING));
     System.setErr(new PrintStream(errContent, false, DEFAULT_ENCODING));
     mock = new MockSCMStarter();
   }
 
-  @After
+  @AfterEach
   public void restoreStreams() {
     System.setOut(originalOut);
     System.setErr(originalErr);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -70,13 +70,13 @@ import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayo
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createEndpoint;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -91,7 +91,7 @@ public class TestEndPoint {
   private static File testDir;
   private static OzoneConfiguration config;
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     if (scmServer != null) {
       scmServer.stop();
@@ -99,7 +99,7 @@ public class TestEndPoint {
     FileUtil.fullyDelete(testDir);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     serverAddress = SCMTestUtils.getReuseableAddress();
     scmServerImpl = new ScmTestMock();
@@ -126,10 +126,10 @@ public class TestEndPoint {
             serverAddress, 1000)) {
       SCMVersionResponseProto responseProto = rpcEndPoint.getEndPoint()
           .getVersion(null);
-      Assert.assertNotNull(responseProto);
-      Assert.assertEquals(VersionInfo.DESCRIPTION_KEY,
+      Assertions.assertNotNull(responseProto);
+      Assertions.assertEquals(VersionInfo.DESCRIPTION_KEY,
           responseProto.getKeys(0).getKey());
-      Assert.assertEquals(VersionInfo.getLatestVersion().getDescription(),
+      Assertions.assertEquals(VersionInfo.getLatestVersion().getDescription(),
           responseProto.getKeys(0).getValue());
     }
   }
@@ -154,11 +154,11 @@ public class TestEndPoint {
 
       // if version call worked the endpoint should automatically move to the
       // next state.
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
           newState);
 
       // Now rpcEndpoint should remember the version it got from SCM
-      Assert.assertNotNull(rpcEndPoint.getVersion());
+      Assertions.assertNotNull(rpcEndPoint.getVersion());
     }
   }
 
@@ -184,11 +184,11 @@ public class TestEndPoint {
 
       // if version call worked the endpoint should automatically move to the
       // next state.
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
           newState);
 
       // Now rpcEndpoint should remember the version it got from SCM
-      Assert.assertNotNull(rpcEndPoint.getVersion());
+      Assertions.assertNotNull(rpcEndPoint.getVersion());
 
       // Now change server cluster ID, so datanode cluster ID will be
       // different from SCM server response cluster ID.
@@ -196,17 +196,17 @@ public class TestEndPoint {
       scmServerImpl.setClusterId(newClusterId);
       rpcEndPoint.setState(EndpointStateMachine.EndPointStates.GETVERSION);
       newState = versionTask.call();
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
           newState);
       List<HddsVolume> volumesList = StorageVolumeUtil.getHddsVolumesList(
           ozoneContainer.getVolumeSet().getFailedVolumesList());
-      Assert.assertTrue(volumesList.size() == 1);
-      Assert.assertTrue(logCapturer.getOutput()
+      Assertions.assertTrue(volumesList.size() == 1);
+      Assertions.assertTrue(logCapturer.getOutput()
           .contains("org.apache.hadoop.ozone.common" +
               ".InconsistentStorageStateException: Mismatched ClusterIDs"));
-      Assert.assertTrue(ozoneContainer.getVolumeSet().getVolumesList().size()
+      Assertions.assertTrue(ozoneContainer.getVolumeSet().getVolumesList().size()
           == 0);
-      Assert.assertTrue(ozoneContainer.getVolumeSet().getFailedVolumesList()
+      Assertions.assertTrue(ozoneContainer.getVolumeSet().getFailedVolumesList()
           .size() == 1);
 
     }
@@ -233,7 +233,7 @@ public class TestEndPoint {
 
       // This version call did NOT work, so endpoint should remain in the same
       // state.
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
           newState);
     }
   }
@@ -263,8 +263,8 @@ public class TestEndPoint {
       EndpointStateMachine.EndPointStates newState = versionTask.call();
       long end = Time.monotonicNow();
       scmServerImpl.setRpcResponseDelay(0);
-      Assert.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
+      Assertions.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
           newState);
     }
   }
@@ -284,13 +284,13 @@ public class TestEndPoint {
               HddsTestUtils.getRandomContainerReports(10),
               HddsTestUtils.getRandomPipelineReports(),
               defaultLayoutVersionProto());
-      Assert.assertNotNull(responseProto);
-      Assert.assertEquals(nodeToRegister.getUuidString(),
+      Assertions.assertNotNull(responseProto);
+      Assertions.assertEquals(nodeToRegister.getUuidString(),
           responseProto.getDatanodeUUID());
-      Assert.assertNotNull(responseProto.getClusterID());
-      Assert.assertEquals(10, scmServerImpl.
+      Assertions.assertNotNull(responseProto.getClusterID());
+      Assertions.assertEquals(10, scmServerImpl.
           getContainerCountsForDatanode(nodeToRegister));
-      Assert.assertEquals(1, scmServerImpl.getNodeReportsCount(nodeToRegister));
+      Assertions.assertEquals(1, scmServerImpl.getNodeReportsCount(nodeToRegister));
     }
   }
 
@@ -347,7 +347,7 @@ public class TestEndPoint {
     try (EndpointStateMachine rpcEndpoint =
         registerTaskHelper(serverAddress, 1000, false)) {
       // Successful register should move us to Heartbeat state.
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
           rpcEndpoint.getState());
     }
   }
@@ -357,7 +357,7 @@ public class TestEndPoint {
     InetSocketAddress address = SCMTestUtils.getReuseableAddress();
     try (EndpointStateMachine rpcEndpoint =
         registerTaskHelper(address, 1000, false)) {
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.REGISTER,
           rpcEndpoint.getState());
     }
   }
@@ -369,7 +369,7 @@ public class TestEndPoint {
         registerTaskHelper(address, 1000, true)) {
       // No Container ID, therefore we tell the datanode that we would like to
       // shutdown.
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.SHUTDOWN,
           rpcEndpoint.getState());
     }
   }
@@ -383,7 +383,7 @@ public class TestEndPoint {
     registerTaskHelper(serverAddress, 1000, false).close();
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
-    Assert.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
+    Assertions.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
   }
 
   @Test
@@ -401,8 +401,8 @@ public class TestEndPoint {
 
       SCMHeartbeatResponseProto responseProto = rpcEndPoint.getEndPoint()
           .sendHeartbeat(request);
-      Assert.assertNotNull(responseProto);
-      Assert.assertEquals(0, responseProto.getCommandsCount());
+      Assertions.assertNotNull(responseProto);
+      Assertions.assertEquals(0, responseProto.getCommandsCount());
     }
   }
 
@@ -507,9 +507,9 @@ public class TestEndPoint {
               stateMachine.getLayoutVersionManager());
       endpointTask.setDatanodeDetailsProto(datanodeDetailsProto);
       endpointTask.call();
-      Assert.assertNotNull(endpointTask.getDatanodeDetailsProto());
+      Assertions.assertNotNull(endpointTask.getDatanodeDetailsProto());
 
-      Assert.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
+      Assertions.assertEquals(EndpointStateMachine.EndPointStates.HEARTBEAT,
           rpcEndPoint.getState());
       return stateContext;
     }
@@ -537,7 +537,7 @@ public class TestEndPoint {
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
     // 6s is introduced by DeleteBlocksCommandHandler#stop
-    Assert.assertThat(end - start,
+    Assertions.assertThat(end - start,
         lessThanOrEqualTo(rpcTimeout + tolerance + 6000));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -69,7 +69,6 @@ import static org.apache.hadoop.hdds.protocol.MockDatanodeDetails.randomDatanode
 import static org.apache.hadoop.ozone.container.upgrade.UpgradeUtils.defaultLayoutVersionProto;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.container.common.ContainerTestUtils.createEndpoint;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -200,14 +199,13 @@ public class TestEndPoint {
           newState);
       List<HddsVolume> volumesList = StorageVolumeUtil.getHddsVolumesList(
           ozoneContainer.getVolumeSet().getFailedVolumesList());
-      Assertions.assertTrue(volumesList.size() == 1);
+      assertEquals(1, volumesList.size());
       Assertions.assertTrue(logCapturer.getOutput()
           .contains("org.apache.hadoop.ozone.common" +
               ".InconsistentStorageStateException: Mismatched ClusterIDs"));
-      Assertions.assertTrue(ozoneContainer.getVolumeSet().getVolumesList().size()
-          == 0);
-      Assertions.assertTrue(ozoneContainer.getVolumeSet().getFailedVolumesList()
-          .size() == 1);
+      assertEquals(0, ozoneContainer.getVolumeSet().getVolumesList().size());
+      assertEquals(1, ozoneContainer.getVolumeSet().getFailedVolumesList()
+          .size());
 
     }
   }
@@ -263,7 +261,7 @@ public class TestEndPoint {
       EndpointStateMachine.EndPointStates newState = versionTask.call();
       long end = Time.monotonicNow();
       scmServerImpl.setRpcResponseDelay(0);
-      Assertions.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
+      Assertions.assertTrue(end - start <= rpcTimeout + tolerance);
       Assertions.assertEquals(EndpointStateMachine.EndPointStates.GETVERSION,
           newState);
     }
@@ -383,7 +381,7 @@ public class TestEndPoint {
     registerTaskHelper(serverAddress, 1000, false).close();
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
-    Assertions.assertThat(end - start, lessThanOrEqualTo(rpcTimeout + tolerance));
+    Assertions.assertTrue(end - start <= rpcTimeout + tolerance);
   }
 
   @Test
@@ -433,7 +431,7 @@ public class TestEndPoint {
           serverAddress, 3000);
       Map<Long, CommandStatus> map = stateContext.getCommandStatusMap();
       assertNotNull(map);
-      assertEquals("Should have 1 objects", 1, map.size());
+      assertEquals(1, map.size(), "Should have 1 objects");
       assertTrue(map.containsKey(3L));
       assertEquals(Type.deleteBlocksCommand, map.get(3L).getType());
       assertEquals(Status.PENDING, map.get(3L).getStatus());
@@ -537,8 +535,7 @@ public class TestEndPoint {
     long end = Time.monotonicNow();
     scmServerImpl.setRpcResponseDelay(0);
     // 6s is introduced by DeleteBlocksCommandHandler#stop
-    Assertions.assertThat(end - start,
-        lessThanOrEqualTo(rpcTimeout + tolerance + 6000));
+    Assertions.assertTrue(end - start <= rpcTimeout + tolerance + 6000);
   }
 
   private StateContext getContext(DatanodeDetails datanodeDetails) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/common/TestEndPoint.java
@@ -288,7 +288,8 @@ public class TestEndPoint {
       Assertions.assertNotNull(responseProto.getClusterID());
       Assertions.assertEquals(10, scmServerImpl.
           getContainerCountsForDatanode(nodeToRegister));
-      Assertions.assertEquals(1, scmServerImpl.getNodeReportsCount(nodeToRegister));
+      Assertions.assertEquals(1,
+          scmServerImpl.getNodeReportsCount(nodeToRegister));
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestContainerPlacement.java
@@ -30,9 +30,9 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.Test;
 
 /**
  * Asserts that allocation strategy works as expected.
@@ -111,14 +111,14 @@ public class TestContainerPlacement {
     // This is a very bold claim, and needs large number of I/O operations.
     // The claim in this assertion is that we improved the data distribution
     // of this cluster in relation to the start state of the cluster.
-    Assert.assertTrue(beforeCapacity.getStandardDeviation() >
+    Assertions.assertTrue(beforeCapacity.getStandardDeviation() >
         postCapacity.getStandardDeviation());
 
     // This asserts that Capacity placement yields a better placement
     // algorithm than random placement, since both cluster started at an
     // identical state.
 
-    Assert.assertTrue(postRandom.getStandardDeviation() >
+    Assertions.assertTrue(postRandom.getStandardDeviation() >
         postCapacity.getStandardDeviation());
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/container/placement/TestDatanodeMetrics.java
@@ -19,11 +19,11 @@ package org.apache.hadoop.ozone.container.placement;
 
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeMetric;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.SCMNodeStat;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests that test Metrics that support placement.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -48,11 +48,11 @@ import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 
 import org.apache.hadoop.ozone.upgrade.LayoutVersionManager;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import static org.junit.Assert.assertEquals;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 /**
@@ -64,7 +64,7 @@ public class TestSCMNodeMetrics {
 
   private static DatanodeDetails registeredDatanode;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
 
     OzoneConfiguration source = new OzoneConfiguration();
@@ -92,7 +92,7 @@ public class TestSCMNodeMetrics {
 
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws IOException {
     nodeManager.close();
   }
@@ -155,7 +155,7 @@ public class TestSCMNodeMetrics {
         .addStorageReport(storageReport).build();
 
     nodeManager.processNodeReport(registeredDatanode, nodeReport);
-    Assert.assertEquals("NumNodeReportProcessed", nrProcessed + 1,
+    Assertions.assertEquals("NumNodeReportProcessed", nrProcessed + 1,
         getCounter("NumNodeReportProcessed"));
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/ozone/scm/node/TestSCMNodeMetrics.java
@@ -114,8 +114,8 @@ public class TestSCMNodeMetrics {
         .build();
     nodeManager.processHeartbeat(registeredDatanode, layoutInfo);
 
-    assertEquals("NumHBProcessed", hbProcessed + 1,
-        getCounter("NumHBProcessed"));
+    assertEquals(hbProcessed + 1, getCounter("NumHBProcessed"),
+        "NumHBProcessed");
   }
 
   /**
@@ -134,8 +134,8 @@ public class TestSCMNodeMetrics {
     nodeManager.processHeartbeat(MockDatanodeDetails
         .randomDatanodeDetails(), layoutInfo);
 
-    assertEquals("NumHBProcessingFailed", hbProcessedFailed + 1,
-        getCounter("NumHBProcessingFailed"));
+    assertEquals(hbProcessedFailed + 1, getCounter("NumHBProcessingFailed"),
+        "NumHBProcessingFailed");
   }
 
   /**
@@ -155,8 +155,9 @@ public class TestSCMNodeMetrics {
         .addStorageReport(storageReport).build();
 
     nodeManager.processNodeReport(registeredDatanode, nodeReport);
-    Assertions.assertEquals("NumNodeReportProcessed", nrProcessed + 1,
-        getCounter("NumNodeReportProcessed"));
+    Assertions.assertEquals(nrProcessed + 1,
+        getCounter("NumNodeReportProcessed"),
+        "NumNodeReportProcessed");
   }
 
   /**
@@ -176,8 +177,8 @@ public class TestSCMNodeMetrics {
         .addStorageReport(storageReport).build();
 
     nodeManager.processNodeReport(randomDatanode, nodeReport);
-    assertEquals("NumNodeReportProcessingFailed", nrProcessed + 1,
-        getCounter("NumNodeReportProcessingFailed"));
+    assertEquals(nrProcessed + 1, getCounter("NumNodeReportProcessingFailed"),
+        "NumNodeReportProcessingFailed");
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate simple tests in hdds-server-scm to JUnit5, in which "simple" means without `@Rule` and `@RunWith`.

Steps of the migration, each corresponding to one commit:

1. Run the following `sed` command against each file to substitute the class names.
2. Fix errors mannually (c7872672de5795609d6d4b118b4f605dd6c892b9).
3. Fix checkstyle (LineLength).

``` bash
sed -i $1 \
	-e 's/org.junit.After;/org.junit.jupiter.api.AfterEach;/' \
	-e 's/@After$/@AfterEach/' \
	-e 's/org.junit.AfterClass;/org.junit.jupiter.api.AfterAll;/' \
	-e 's/@AfterClass$/@AfterAll/' \
	-e 's/org.junit.Before;/org.junit.jupiter.api.BeforeEach;/' \
	-e 's/@Before$/@BeforeEach/' \
	-e 's/org.junit.BeforeClass;/org.junit.jupiter.api.BeforeAll;/' \
	-e 's/@BeforeClass$/@BeforeAll/' \
	-e 's/org.junit.Test/org.junit.jupiter.api.Test/' \
	-e 's/org.junit.Assert/org.junit.jupiter.api.Assertions/' \
	-e 's/junit.framework.TestCase/org.junit.jupiter.api.Assertions/' \
	-e 's/Assert\./Assertions./'
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6750

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/2326780703