### PR TITLE
HDDS-6753. Bump gRPC to 1.46.0, protobuf-java to 3.19.2, ratis-thirdparty to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <ratis.version>2.2.0</ratis.version>
 
     <!-- Apache Ratis thirdparty version -->
-    <ratis.thirdparty.version>0.7.0</ratis.thirdparty.version>
+    <ratis.thirdparty.version>1.0.0</ratis.thirdparty.version>
 
     <distMgmtSnapshotsId>apache.snapshots.https</distMgmtSnapshotsId>
     <distMgmtSnapshotsName>Apache Development Snapshot Repository</distMgmtSnapshotsName>
@@ -195,11 +195,11 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
-    <grpc.protobuf-compile.version>3.12.0</grpc.protobuf-compile.version>
+    <grpc.protobuf-compile.version>3.19.2</grpc.protobuf-compile.version>
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
     <netty.version>4.1.63.Final</netty.version>
-    <io.grpc.version>1.38.0</io.grpc.version>
+    <io.grpc.version>1.46.0</io.grpc.version>
     <tcnative.version>2.0.38.Final</tcnative.version> <!-- See table for correct version -->
     <!-- Table for netty, grpc & tcnative version combinations  -->
     <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump grpc-java to 1.46.0, along with required deps.

```
io.grpc.version: 1.38.0 -> 1.46.0
protobuf-java: 3.12.0 -> 3.19.2 (required by grpc-java 1.46.0)
ratis-thirdparty: 0.7.0 -> 1.0.0 (also required by the gRPC version bump, otherwise protobuf compilation errs)
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6753

## How was this patch tested?

- [ ] Pending CI
