### PR TITLE
HDDS-6735. Provide configuration for enabling OMLockMetrics

### DIFF
--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2867,6 +2867,15 @@
   </property>
 
   <property>
+    <name>ozone.om.lock.metrics.collection.enable</name>
+    <tag>OZONE, OM</tag>
+    <value>false</value>
+    <description>Defaults to false. If true, the OMLockMetrics collection is
+      enabled. If false, it is disabled.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.client.key.provider.cache.expiry</name>
     <tag>OZONE, CLIENT, SECURITY</tag>
     <value>10d</value>

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -2870,8 +2870,8 @@
     <name>ozone.om.lock.metrics.collection.enable</name>
     <tag>OZONE, OM</tag>
     <value>false</value>
-    <description>Defaults to false. If true, the OMLockMetrics collection is
-      enabled. If false, it is disabled.
+    <description>If set to true, enables OMLockMetrics collection. Defaults to
+      false/disabled.
     </description>
   </property>
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/OMConfigKeys.java
@@ -348,4 +348,12 @@ public final class OMConfigKeys {
   public static final String OZONE_OM_KEY_PATH_LOCK_ENABLED =
       "ozone.om.key.path.lock.enabled";
   public static final boolean OZONE_OM_KEY_PATH_LOCK_ENABLED_DEFAULT = false;
+
+  /**
+   * This configuration shall be enabled to use the OMLockMetrics collection.
+   */
+  public static final String OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY =
+      "ozone.om.lock.metrics.collection.enable";
+  public static final boolean OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_DEFAULT =
+      false;
 }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/lock/TestOzoneManagerLock.java
@@ -35,6 +35,7 @@ import org.junit.rules.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -450,7 +451,9 @@ public class TestOzoneManagerLock {
                                           String[] resourceName,
                                           int threadCount)
       throws InterruptedException {
-    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY, true);
+    OzoneManagerLock lock = new OzoneManagerLock(conf);
     Thread[] threads = new Thread[threadCount];
 
     for (int i = 0; i < threads.length; i++) {
@@ -487,7 +490,9 @@ public class TestOzoneManagerLock {
                                            String[] resourceName,
                                            int threadCount)
       throws InterruptedException {
-    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY, true);
+    OzoneManagerLock lock = new OzoneManagerLock(conf);
     Thread[] threads = new Thread[threadCount];
 
     for (int i = 0; i < threads.length; i++) {
@@ -524,7 +529,9 @@ public class TestOzoneManagerLock {
       OzoneManagerLock.Resource resource, String[] resourceName,
       int readThreadCount, int writeThreadCount)
       throws InterruptedException {
-    OzoneManagerLock lock = new OzoneManagerLock(new OzoneConfiguration());
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.setBoolean(OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY, true);
+    OzoneManagerLock lock = new OzoneManagerLock(conf);
     Thread[] readThreads = new Thread[readThreadCount];
     Thread[] writeThreads = new Thread[writeThreadCount];
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteFileOps.java
@@ -85,6 +85,8 @@ public class TestOmBucketReadWriteFileOps {
     conf = getOzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         BucketLayout.LEGACY.name());
+    conf.setBoolean(OMConfigKeys.OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY,
+        true);
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/freon/TestOmBucketReadWriteKeyOps.java
@@ -86,6 +86,8 @@ public class TestOmBucketReadWriteKeyOps {
     conf = getOzoneConfiguration();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
         BucketLayout.OBJECT_STORE.name());
+    conf.setBoolean(OMConfigKeys.OZONE_OM_LOCK_METRICS_COLLECTION_ENABLE_KEY,
+        true);
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
     cluster.waitForClusterToBeReady();
     cluster.waitTobeOutOfSafeMode();


### PR DESCRIPTION
## What changes were proposed in this pull request?

To introduce a configuration: `ozone.om.lock.metrics.collection.enable` (default value = `false`) to disable `OMLockMetrics` related code collection by default.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6735

## How was this patch tested?

Existing unit and integration test-cases.
