### PR TITLE
HDDS-6765. Get snapshot of write OMLockMetrics

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OMLockMetrics.java
@@ -203,5 +203,7 @@ public final class OMLockMetrics implements MetricsSource {
     MetricsRecordBuilder builder = collector.addRecord(SOURCE_NAME);
     readLockHeldTimeMsStat.snapshot(builder, all);
     readLockWaitingTimeMsStat.snapshot(builder, all);
+    writeLockHeldTimeMsStat.snapshot(builder, all);
+    writeLockWaitingTimeMsStat.snapshot(builder, all);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

To get the snapshot of the write `OMLockMetrics` for exposing `writeLockWaitingTimeMsStat`, `writeLockHeldTimeMsStat` over JMX.

To add the following lines to the `OMLockMetrics.getMetrics()` method:
```
writeLockHeldTimeMsStat.snapshot(builder, all);
writeLockWaitingTimeMsStat.snapshot(builder, all);
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6765

## How was this patch tested?

NA
