### PR TITLE
HDDS-6756. NPE raised by RpcClient if ServiceInfo certificates empty

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.security.InvalidKeyException;
 import java.security.PrivilegedExceptionAction;
 import java.security.SecureRandom;
+import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -253,6 +254,14 @@ public class RpcClient implements ClientProtocol {
       caCertPem = serviceInfoEx.getCaCertificate();
       caCertPems = serviceInfoEx.getCaCertPemList();
       if (caCertPems == null || caCertPems.isEmpty()) {
+        if (caCertPem == null) {
+          LOG.error("RpcClient received empty caCertPems from serviceInfo");
+          CertificateException ex = new CertificateException(
+              "No caCerts found; caCertPem can" +
+                  " not be null when caCertPems is empty or null"
+          );
+          throw new IOException(ex);
+        }
         caCertPems = Collections.singletonList(caCertPem);
       }
       x509Certificates = OzoneSecurityUtil.convertToX509(caCertPems);


### PR DESCRIPTION
## What changes were proposed in this pull request?
To have the` RpcClient` raise a certificate exception and log the error should the serviceinfo `OMRequest` it makes return no certificates (`caCertPemList` empty and `caCertificate` null).

Currently should the serviceinfo OmRequest return _null_ or `empy` list of certificates and `null` certifcate, it raises an NPE.  This PR fixes this by logging the error and raising a descriptive certificate exception. 


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6756

## How was this patch tested?

Manual testing with docker cluster and intellij ozone developments environments.
