### PR TITLE
HDDS-6767. Add network location in Recon's datanode page

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/NodeEndpoint.java
@@ -148,6 +148,7 @@ public class NodeEndpoint {
           .withBuildDate(nodeManager.getBuildDate(datanode))
           .withLayoutVersion(
               dnInfo.getLastKnownLayoutVersion().getMetadataLayoutVersion())
+          .withNetworkLocation(datanode.getNetworkLocation())
           .build());
     });
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
@@ -77,6 +77,9 @@ public final class DatanodeMetadata {
   @XmlElement(name = "layoutVersion")
   private int layoutVersion;
 
+  @XmlElement(name = "networkLocation")
+  private String networkLocation;
+
   private DatanodeMetadata(Builder builder) {
     this.hostname = builder.hostname;
     this.uuid = builder.uuid;
@@ -93,6 +96,7 @@ public final class DatanodeMetadata {
     this.revision = builder.revision;
     this.buildDate = builder.buildDate;
     this.layoutVersion = builder.layoutVersion;
+    this.networkLocation = builder.networkLocation;
   }
 
   public String getHostname() {
@@ -183,6 +187,7 @@ public final class DatanodeMetadata {
     private String revision;
     private String buildDate;
     private int layoutVersion;
+    private String networkLocation;
 
     public Builder() {
       this.containers = 0;
@@ -266,6 +271,10 @@ public final class DatanodeMetadata {
       return this;
     }
 
+    public Builder withNetworkLocation(String networkLocation) {
+      this.networkLocation = networkLocation;
+      return this;
+    }
     /**
      * Constructs DatanodeMetadata.
      *

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/types/DatanodeMetadata.java
@@ -154,8 +154,13 @@ public final class DatanodeMetadata {
   public String getBuildDate() {
     return buildDate;
   }
+
   public int getLayoutVersion() {
     return layoutVersion;
+  }
+
+  public String getNetworkLocation() {
+    return networkLocation;
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -53,6 +53,7 @@ interface IDatanodeResponse {
   setupTime: number;
   revision: string;
   buildDate: string;
+  networkLocation: string;
 }
 
 interface IDatanodesResponse {
@@ -77,6 +78,7 @@ interface IDatanode {
   setupTime: number;
   revision: string;
   buildDate: string;
+  networkLocation: string;
 }
 
 interface IPipeline {
@@ -272,6 +274,15 @@ const COLUMNS = [
     isSearchable: true,
     sorter: (a: IDatanode, b: IDatanode) => a.buildDate.localeCompare(b.buildDate),
     defaultSortOrder: 'ascend' as const
+  },
+  {
+    title: 'NetworkLocation',
+    dataIndex: 'networkLocation',
+    key: 'networkLocation',
+    isVisible: true,
+    isSearchable: true,
+    sorter: (a: IDatanode, b: IDatanode) => a.networkLocation.localeCompare(b.networkLocation),
+    defaultSortOrder: 'ascend' as const
   }
 ];
 
@@ -342,7 +353,8 @@ export class Datanodes extends React.Component<Record<string, object>, IDatanode
           version: datanode.version,
           setupTime: datanode.setupTime,
           revision: datanode.revision,
-          buildDate: datanode.buildDate
+          buildDate: datanode.buildDate,
+          networkLocation: datanode.networkLocation
         };
       });
 

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -216,7 +216,7 @@ const COLUMNS = [
       <Icon type='info-circle'/>
     </Tooltip>
   </span>,
-    dataIndex: 'leaderCount',
+    dataIndex: 'leader Count',
     key: 'leaderCount',
     isVisible: true,
     isSearchable: true,
@@ -248,7 +248,7 @@ const COLUMNS = [
     defaultSortOrder: 'ascend' as const
   },
   {
-    title: 'SetupTime',
+    title: 'Setup Time',
     dataIndex: 'setupTime',
     key: 'setupTime',
     isVisible: true,
@@ -267,7 +267,7 @@ const COLUMNS = [
     defaultSortOrder: 'ascend' as const
   },
   {
-    title: 'BuildDate',
+    title: 'Build Date',
     dataIndex: 'buildDate',
     key: 'buildDate',
     isVisible: true,
@@ -276,7 +276,7 @@ const COLUMNS = [
     defaultSortOrder: 'ascend' as const
   },
   {
-    title: 'NetworkLocation',
+    title: 'Network Location',
     dataIndex: 'networkLocation',
     key: 'networkLocation',
     isVisible: true,


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently the network location information is not shown in Recon's Datanode page, this information would be quite useful when networktopology is in use.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6767

## How was this patch tested?

![Screenshot 2022-05-19 185959](https://user-images.githubusercontent.com/14933944/169279046-f56fd181-56b2-4462-8d0d-22b10ee86bc2.png)

