### PR TITLE
HDDS-6705 Add metrics for volume statistics including disk capacity, usage, Reserved

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -119,16 +119,8 @@ public class HddsVolume extends StorageVolume {
       this.volumeInfoStats = new VolumeInfoStats(b.getVolumeRootStr(),this);
       this.committedBytes = new AtomicLong(0);
 
-      System.out.println(volumeInfoStats.getUsed());
-      System.out.println(volumeInfoStats.getStorageType());
-      System.out.println(volumeInfoStats.getAvailable());
-      System.out.println(volumeInfoStats.getReserved());
-      System.out.println(volumeInfoStats.getTotalCapacity());
-      System.out.println(volumeInfoStats.getStorageDirectory());
-      System.out.println(volumeInfoStats.getDatanodeUuid());
-
       LOG.info("Creating HddsVolume: {} of storage type : {} capacity : {}",
-              getStorageDir(), b.getStorageType(), getVolumeInfo().getCapacity());
+          getStorageDir(), b.getStorageType(), getVolumeInfo().getCapacity());
 
       initialize();
     } else {
@@ -152,30 +144,30 @@ public class HddsVolume extends StorageVolume {
   private void initialize() throws IOException {
     VolumeState intialVolumeState = analyzeVolumeState();
     switch (intialVolumeState) {
-      case NON_EXISTENT:
-        // Root directory does not exist. Create it.
-        if (!getStorageDir().mkdirs()) {
-          throw new IOException("Cannot create directory " + getStorageDir());
-        }
-        setState(VolumeState.NOT_FORMATTED);
-        createVersionFile();
-        break;
-      case NOT_FORMATTED:
-        // Version File does not exist. Create it.
-        createVersionFile();
-        break;
-      case NOT_INITIALIZED:
-        // Version File exists. Verify its correctness and update property fields.
-        readVersionFile();
-        setState(VolumeState.NORMAL);
-        break;
-      case INCONSISTENT:
-        // Volume Root is in an inconsistent state. Skip loading this volume.
-        throw new IOException("Volume is in an " + VolumeState.INCONSISTENT +
-                " state. Skipped loading volume: " + getStorageDir().getPath());
-      default:
-        throw new IOException("Unrecognized initial state : " +
-                intialVolumeState + "of volume : " + getStorageDir());
+    case NON_EXISTENT:
+      // Root directory does not exist. Create it.
+      if (!getStorageDir().mkdirs()) {
+        throw new IOException("Cannot create directory " + getStorageDir());
+      }
+      setState(VolumeState.NOT_FORMATTED);
+      createVersionFile();
+      break;
+    case NOT_FORMATTED:
+      // Version File does not exist. Create it.
+      createVersionFile();
+      break;
+    case NOT_INITIALIZED:
+      // Version File exists. Verify its correctness and update property fields.
+      readVersionFile();
+      setState(VolumeState.NORMAL);
+      break;
+    case INCONSISTENT:
+      // Volume Root is in an inconsistent state. Skip loading this volume.
+      throw new IOException("Volume is in an " + VolumeState.INCONSISTENT +
+          " state. Skipped loading volume: " + getStorageDir().getPath());
+    default:
+      throw new IOException("Unrecognized initial state : " +
+          intialVolumeState + "of volume : " + getStorageDir());
     }
   }
 
@@ -187,8 +179,8 @@ public class HddsVolume extends StorageVolume {
     if (!getStorageDir().isDirectory()) {
       // Volume Root exists but is not a directory.
       LOG.warn("Volume {} exists but is not a directory,"
-                      + " current volume state: {}.",
-              getStorageDir().getPath(), VolumeState.INCONSISTENT);
+          + " current volume state: {}.",
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
       return VolumeState.INCONSISTENT;
     }
     File[] files = getStorageDir().listFiles();
@@ -199,8 +191,8 @@ public class HddsVolume extends StorageVolume {
     if (!getVersionFile().exists()) {
       // Volume Root is non empty but VERSION file does not exist.
       LOG.warn("VERSION file does not exist in volume {},"
-                      + " current volume state: {}.",
-              getStorageDir().getPath(), VolumeState.INCONSISTENT);
+          + " current volume state: {}.",
+          getStorageDir().getPath(), VolumeState.INCONSISTENT);
       return VolumeState.INCONSISTENT;
     }
     // Volume Root and VERSION file exist.
@@ -209,7 +201,7 @@ public class HddsVolume extends StorageVolume {
 
   public void format(String cid) throws IOException {
     Preconditions.checkNotNull(cid, "clusterID cannot be null while " +
-            "formatting Volume");
+        "formatting Volume");
     this.clusterID = cid;
     initialize();
   }
@@ -227,7 +219,7 @@ public class HddsVolume extends StorageVolume {
       // HddsDatanodeService does not have the cluster information yet. Wait
       // for registration with SCM.
       LOG.debug("ClusterID not available. Cannot format the volume {}",
-              getStorageDir().getPath());
+          getStorageDir().getPath());
       setState(VolumeState.NOT_FORMATTED);
     } else {
       // Write the version file to disk.
@@ -238,22 +230,22 @@ public class HddsVolume extends StorageVolume {
 
   private void writeVersionFile() throws IOException {
     Preconditions.checkNotNull(this.storageID,
-            "StorageID cannot be null in Version File");
+        "StorageID cannot be null in Version File");
     Preconditions.checkNotNull(this.clusterID,
-            "ClusterID cannot be null in Version File");
+        "ClusterID cannot be null in Version File");
     Preconditions.checkNotNull(this.datanodeUuid,
-            "DatanodeUUID cannot be null in Version File");
+        "DatanodeUUID cannot be null in Version File");
     Preconditions.checkArgument(this.cTime > 0,
-            "Creation Time should be positive");
+        "Creation Time should be positive");
     Preconditions.checkArgument(this.layoutVersion ==
-                    getLatestVersion().getVersion(),
-            "Version File should have the latest LayOutVersion");
+            getLatestVersion().getVersion(),
+        "Version File should have the latest LayOutVersion");
 
     File versionFile = getVersionFile();
     LOG.debug("Writing Version file to disk, {}", versionFile);
 
     DatanodeVersionFile dnVersionFile = new DatanodeVersionFile(this.storageID,
-            this.clusterID, this.datanodeUuid, this.cTime, this.layoutVersion);
+        this.clusterID, this.datanodeUuid, this.cTime, this.layoutVersion);
     dnVersionFile.createVersionFile(versionFile);
   }
 
@@ -269,15 +261,15 @@ public class HddsVolume extends StorageVolume {
     Properties props = DatanodeVersionFile.readFrom(versionFile);
     if (props.isEmpty()) {
       throw new InconsistentStorageStateException(
-              "Version file " + versionFile + " is missing");
+          "Version file " + versionFile + " is missing");
     }
 
     LOG.debug("Reading Version file from disk, {}", versionFile);
     this.storageID = HddsVolumeUtil.getStorageID(props, versionFile);
     this.clusterID = HddsVolumeUtil.getClusterID(props, versionFile,
-            this.clusterID);
+        this.clusterID);
     this.datanodeUuid = HddsVolumeUtil.getDatanodeUUID(props, versionFile,
-            this.datanodeUuid);
+        this.datanodeUuid);
     this.cTime = HddsVolumeUtil.getCreationTime(props, versionFile);
     this.layoutVersion = HddsVolumeUtil.getLayOutVersion(props, versionFile);
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -114,7 +114,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getReadBytes() {
-    return readBytes.value();
+    return 1000L;
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -114,7 +114,7 @@ public class VolumeIOStats {
    * @return long
    */
   public long getReadBytes() {
-    return 1000L;
+    return readBytes.value();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoStats.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.fs.StorageType;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableGaugeLong;
+import org.apache.hadoop.ozone.OzoneConsts;
+
+/**
+ * This class is used to track Volume IO stats for each HDDS Volume.
+ */
+@Metrics(about = "Ozone Volume Information Metrics", context = OzoneConsts.OZONE)
+public class VolumeInfoStats {
+
+    private String metricsSourceName = VolumeInfoStats.class.getSimpleName();
+    private String VolumeRootStr;
+    private HddsVolume volume;
+
+    private StorageType storageType;
+    private @Metric
+    MutableGaugeLong spaceUsed;
+    private @Metric
+    MutableGaugeLong spaceAvailable;
+    private @Metric
+    MutableGaugeLong spaceReserved;
+    private @Metric
+    MutableGaugeLong capacity;
+    private @Metric
+    MutableGaugeLong totalCapacity;
+
+
+    @Deprecated
+    public VolumeInfoStats() {
+        init();
+    }
+
+    /**
+     * @param identifier Typically, path to volume root. e.g. /data/hdds
+     */
+    public VolumeInfoStats(String identifier, HddsVolume ref) {
+        this.metricsSourceName += '-' + identifier;
+        this.VolumeRootStr = identifier;
+        this.volume = ref;
+        init();
+    }
+
+    public void init() {
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+        ms.register(metricsSourceName, "Volume Info Statistics", this);
+        storageType = volume.getStorageType();
+    }
+
+    public void unregister() {
+        MetricsSystem ms = DefaultMetricsSystem.instance();
+        ms.unregisterSource(metricsSourceName);
+    }
+
+    public String getMetricsSourceName() {
+        return metricsSourceName;
+    }
+
+    /**
+     * Return the Storage Directory for the Volume
+     */
+    public String getStorageDirectory() {
+        return volume.getStorageDir().toString();
+    }
+
+    /**
+     * Return the Storage Directory for the Volume
+     */
+    public String getDatanodeUuid() {
+        return volume.getDatanodeUuid();
+    }
+
+
+    /**
+     * Return the Storage type for the Volume
+     */
+    public String getStorageType() {
+        if (storageType != volume.getStorageType()) {
+            storageType = volume.getStorageType();
+        }
+        return storageType.name();
+    }
+
+    /**
+     * Test conservative avail space.
+     * |----used----|   (avail)   |++++++++reserved++++++++|
+     * |<------- capacity ------->|
+     * |<------------------- Total capacity -------------->|
+     * A) avail = capacity - used
+     * B) avail = fsAvail - Max(reserved - other, 0);
+     */
+
+    /**
+     * Return the Storage type for the Volume
+     */
+    public long getUsed() {
+        spaceUsed.set(volume.getVolumeInfo().getScmUsed());
+        return spaceUsed.value();
+    }
+
+    /**
+     * Return the Total Available capacity of the Volume.
+     */
+    public long getAvailable() {
+        spaceAvailable.set(volume.getVolumeInfo().getAvailable());
+        return spaceAvailable.value();
+    }
+
+    /**
+     * Return the Total Reserved of the Volume.
+     */
+    public long getReserved() {
+        spaceReserved.set(volume.getVolumeInfo().getReservedInBytes());
+        return spaceReserved.value();
+    }
+
+    /**
+     * Return the Total capacity of the Volume.
+     */
+    public long getCapacity() {
+        capacity.set(spaceUsed.value() + spaceAvailable.value());
+        return capacity.value();
+    }
+
+    /**
+     * Return the Total capacity of the Volume.
+     */
+    public long getTotalCapacity() {
+        totalCapacity.set(
+                spaceUsed.value() + spaceAvailable.value() + spaceReserved.value());
+        return totalCapacity.value();
+    }
+
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoStats.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.metrics2.MetricsSystem;
 import org.apache.hadoop.metrics2.annotation.Metric;
 import org.apache.hadoop.metrics2.annotation.Metrics;
@@ -36,17 +35,11 @@ public class VolumeInfoStats {
     private String VolumeRootStr;
     private HddsVolume volume;
 
-    private StorageType storageType;
-    private @Metric
-    MutableGaugeLong spaceUsed;
-    private @Metric
-    MutableGaugeLong spaceAvailable;
-    private @Metric
-    MutableGaugeLong spaceReserved;
-    private @Metric
-    MutableGaugeLong capacity;
-    private @Metric
-    MutableGaugeLong totalCapacity;
+    private @Metric MutableGaugeLong spaceUsed;
+    private @Metric MutableGaugeLong spaceAvailable;
+    private @Metric MutableGaugeLong spaceReserved;
+    private @Metric MutableGaugeLong capacity;
+    private @Metric MutableGaugeLong totalCapacity;
 
 
     @Deprecated
@@ -67,7 +60,12 @@ public class VolumeInfoStats {
     public void init() {
         MetricsSystem ms = DefaultMetricsSystem.instance();
         ms.register(metricsSourceName, "Volume Info Statistics", this);
-        storageType = volume.getStorageType();
+        spaceUsed.set(volume.getVolumeInfo().getScmUsed());
+        spaceAvailable.set(volume.getVolumeInfo().getAvailable());
+        spaceReserved.set(volume.getVolumeInfo().getReservedInBytes());
+        capacity.set(spaceUsed.value() + spaceAvailable.value());
+        totalCapacity.set(
+                spaceUsed.value() + spaceAvailable.value() + spaceReserved.value());
     }
 
     public void unregister() {
@@ -77,31 +75,6 @@ public class VolumeInfoStats {
 
     public String getMetricsSourceName() {
         return metricsSourceName;
-    }
-
-    /**
-     * Return the Storage Directory for the Volume
-     */
-    public String getStorageDirectory() {
-        return volume.getStorageDir().toString();
-    }
-
-    /**
-     * Return the Storage Directory for the Volume
-     */
-    public String getDatanodeUuid() {
-        return volume.getDatanodeUuid();
-    }
-
-
-    /**
-     * Return the Storage type for the Volume
-     */
-    public String getStorageType() {
-        if (storageType != volume.getStorageType()) {
-            storageType = volume.getStorageType();
-        }
-        return storageType.name();
     }
 
     /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add metrics for volume statistics including disk capacity, usage, type (SSD/HDD).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6705

## How was this patch tested?

The Metrics have been exposed onto the JMX of the DataNode 

```
{
    "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoStats-/tmp/hadoop-arafat2198/dfs/data",
    "modelerType" : "VolumeInfoStats-/tmp/hadoop-arafat2198/dfs/data",
    "tag.Context" : "ozone",
    "tag.Hostname" : "arafat2198-Aspire-A315-51",
    "Capacity" : 425151766528,
    "SpaceAvailable" : 425151766528,
    "SpaceReserved" : 0,
    "SpaceUsed" : 0,
    "TotalCapacity" : 425151766528
  }
```