### PR TITLE
HDDS-6778. Bump Guava to 31.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <spotbugs.version>3.1.12</spotbugs.version>
     <dnsjava.version>2.1.7</dnsjava.version>
 
-    <guava.version>30.1.1-jre</guava.version>
+    <guava.version>31.1-jre</guava.version>
     <guice.version>4.0</guice.version>
     <gson.version>2.2.4</gson.version>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bump Guava to 31.1, which is the latest release currently.

https://issues.apache.org/jira/browse/HDDS-6778

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2356568893