### PR TITLE
HDDS-6779. Register metricSink after initialization

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/Gateway.java
@@ -91,8 +91,8 @@ public class Gateway extends GenericCli {
         Gateway.class, originalArgs, LOG);
 
     LOG.info("Starting Ozone S3 gateway");
-    httpServer.start();
     HddsServerUtil.initializeMetrics(ozoneConfiguration, "S3Gateway");
+    httpServer.start();
   }
 
   public void stop() throws Exception {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current registration of prometheus sink is before the initialization of s3gateway MetricsImpl.

The symptom is the s3g prom page doesn't show detail metrics. Although the current prom page (http://s3g:9878/prom) does show the metrics, it's because of the patch of [HADOOP-17081](https://issues.apache.org/jira/browse/HADOOP-17081). But in our production cluster, the S3g still got some performance issue, seems related to the MetricsSink's half-blocking attribute of SinkQueue.

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6779

## How was this patch tested?

N.A.
