### PR TITLE
HDDS-6777. Upgrade to JUnit 5.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,8 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <hamcrest.version>1.3</hamcrest.version>
     <powermock1.version>1.6.5</powermock1.version>
     <powermock2.version>2.0.4</powermock2.version>
-    <junit.jupiter.version>5.7.0</junit.jupiter.version>
-    <junit.platform.version>1.7.0</junit.platform.version>
+    <junit.jupiter.version>5.8.2</junit.jupiter.version>
+    <junit.platform.version>1.8.2</junit.platform.version>
 
     <!-- Maven protoc compiler -->
     <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

JUnit 5.8.2 was released in November 28, 2021.

It brings useful changes to `@TempDir` for replacing `TemporaryFolder` in JUnit4.

Release notes:

* https://junit.org/junit5/docs/5.8.0/release-notes/index.html
* https://junit.org/junit5/docs/5.8.2/release-notes/index.html

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6777

## How was this patch tested?

Verified by existing CI: https://github.com/kaijchen/ozone/actions/runs/2356547743