### PR TITLE
HDDS-6784. Missing close() for two RocksDB table iterators

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -360,14 +360,15 @@ public class SequenceIdGenerator {
     // upgrade containerId
     if (sequenceIdTable.get(CONTAINER_ID) == null) {
       long largestContainerId = 0;
-      TableIterator<ContainerID, ? extends KeyValue<ContainerID, ContainerInfo>>
-          iterator = scmMetadataStore.getContainerTable().iterator();
-      while (iterator.hasNext()) {
-        ContainerInfo containerInfo = iterator.next().getValue();
-        largestContainerId
-            = Long.max(containerInfo.getContainerID(), largestContainerId);
+      try (TableIterator<ContainerID,
+          ? extends KeyValue<ContainerID, ContainerInfo>> iterator =
+          scmMetadataStore.getContainerTable().iterator()) {
+        while (iterator.hasNext()) {
+          ContainerInfo containerInfo = iterator.next().getValue();
+          largestContainerId =
+              Long.max(containerInfo.getContainerID(), largestContainerId);
+        }
       }
-      iterator.close();
 
       sequenceIdTable.put(CONTAINER_ID, largestContainerId);
       LOG.info("upgrade {} to {}",

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -367,6 +367,8 @@ public class SequenceIdGenerator {
         largestContainerId
             = Long.max(containerInfo.getContainerID(), largestContainerId);
       }
+      iterator.close();
+
       sequenceIdTable.put(CONTAINER_ID, largestContainerId);
       LOG.info("upgrade {} to {}",
           CONTAINER_ID, sequenceIdTable.get(CONTAINER_ID));

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1305,6 +1305,8 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         break;
       }
     }
+    iterator.close();
+
     return response;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1290,22 +1290,22 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
       }
     }
 
-    TableIterator<String, ? extends KeyValue<String, OmMultipartKeyInfo>>
-        iterator = getMultipartInfoTable().iterator();
-    iterator.seek(prefixKey);
+    try (TableIterator<String, ? extends KeyValue<String, OmMultipartKeyInfo>>
+        iterator = getMultipartInfoTable().iterator()) {
+      iterator.seek(prefixKey);
 
-    while (iterator.hasNext()) {
-      KeyValue<String, OmMultipartKeyInfo> entry = iterator.next();
-      if (entry.getKey().startsWith(prefixKey)) {
-        // If it is marked for abort, skip it.
-        if (!aborted.contains(entry.getKey())) {
-          response.add(entry.getKey());
+      while (iterator.hasNext()) {
+        KeyValue<String, OmMultipartKeyInfo> entry = iterator.next();
+        if (entry.getKey().startsWith(prefixKey)) {
+          // If it is marked for abort, skip it.
+          if (!aborted.contains(entry.getKey())) {
+            response.add(entry.getKey());
+          }
+        } else {
+          break;
         }
-      } else {
-        break;
       }
     }
-    iterator.close();
 
     return response;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are two places where the RocksDB table iterators aren't properly closed. Inspired by https://github.com/apache/ozone/pull/3131#discussion_r878296430

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6784

## How was this patch tested?

- All existing tests should pass.