### PR TITLE
HDDS-6786. Bad value for metric NumBytesCommittedCount in testContainerStateMachineMetrics

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/transport/server/ratis/ContainerStateMachine.java
@@ -853,11 +853,11 @@ public class ContainerStateMachine extends BaseStateMachine {
                     + "{} Container Result: {}", gid, r.getCmdType(), index,
                 r.getMessage(), r.getResult());
           }
-          applyTransactionFuture.complete(r::toByteString);
           if (cmdType == Type.WriteChunk || cmdType == Type.PutSmallFile) {
             metrics.incNumBytesCommittedCount(
                 requestProto.getWriteChunk().getChunkData().getLen());
           }
+          applyTransactionFuture.complete(r::toByteString);
           // add the entry to the applyTransactionCompletionMap only if the
           // stateMachine is healthy i.e, there has been no applyTransaction
           // failures before.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix:

```
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 15.107 s <<< FAILURE! - in org.apache.hadoop.ozone.container.common.transport.server.ratis.TestCSMMetrics
[ERROR] org.apache.hadoop.ozone.container.common.transport.server.ratis.TestCSMMetrics.testContainerStateMachineMetrics  Time elapsed: 15.033 s  <<< FAILURE!
java.lang.AssertionError: Bad value for metric NumBytesCommittedCount expected:<1024> but was:<0>
  ...
  at org.apache.hadoop.test.MetricsAsserts.assertCounter(MetricsAsserts.java:230)
  at org.apache.hadoop.ozone.container.common.transport.server.ratis.TestCSMMetrics.runContainerStateMachineMetrics(TestCSMMetrics.java:156)
  at org.apache.hadoop.ozone.container.common.transport.server.ratis.TestCSMMetrics.testContainerStateMachineMetrics(TestCSMMetrics.java:89)
```

The test may reach metrics assertions in the main thread earlier than the state machine increases the byte counter in `ContainerOp` thread.

https://issues.apache.org/jira/browse/HDDS-6786

## How was this patch tested?

Repeated 100x without failure:
https://github.com/adoroszlai/hadoop-ozone/runs/6543225987

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2366748150