### PR TITLE
HDDS-6788. Sort Ozone list Status output for FSO buckets.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -38,6 +38,7 @@ import org.junit.AfterClass;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.List;
 
@@ -199,9 +200,18 @@ public class TestListStatus {
 
     System.out.println("BEGIN:::keyPrefix---> " + keyPrefix + ":::---> " +
         startKey);
-    for (OzoneFileStatus st : statuses) {
-      System.out.println("status:"  + st);
+
+    for (int i = 0; i < statuses.size() - 1; i++) {
+      OzoneFileStatus stCurr = statuses.get(i);
+      OzoneFileStatus stNext = statuses.get(i + 1);
+
+      System.out.println("status:"  + stCurr);
+      Assert.assertTrue(stCurr.getPath().compareTo(stNext.getPath()) < 0);
     }
+
+    OzoneFileStatus stNext = statuses.get(statuses.size() - 1);
+    System.out.println("status:"  + stNext);
+
     System.out.println("END:::keyPrefix---> " + keyPrefix + ":::---> " +
         startKey);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -38,7 +38,6 @@ import org.junit.AfterClass;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.UUID;
 import java.util.List;
 
@@ -153,11 +152,12 @@ public class TestListStatus {
     // f) check with non existing start key>>>
     checkKeyList("", "a7", 100, 6);
 
-    // g) check if half prefix works <<<<
-    // checkKeyList("b", "", 100, 4);
-
-    // h) check half prefix with non-existing start key
-    // checkKeyList("b", "b5", 100, 2);
+    // TODO: Enable the following test after listKeys changes
+//    // g) check if half prefix works <<<<
+//     checkKeyList("b", "", 100, 4);
+//
+//    // h) check half prefix with non-existing start key
+//     checkKeyList("b", "b5", 100, 2);
   }
 
   private static void createFile(OzoneBucket bucket, String keyName)
@@ -209,8 +209,10 @@ public class TestListStatus {
       Assert.assertTrue(stCurr.getPath().compareTo(stNext.getPath()) < 0);
     }
 
-    OzoneFileStatus stNext = statuses.get(statuses.size() - 1);
-    System.out.println("status:"  + stNext);
+    if (!statuses.isEmpty()) {
+      OzoneFileStatus stNext = statuses.get(statuses.size() - 1);
+      System.out.println("status:" + stNext);
+    }
 
     System.out.println("END:::keyPrefix---> " + keyPrefix + ":::---> " +
         startKey);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.hdds.client.RatisReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.StorageType;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.ozone.client.*;
+import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
+import org.junit.*;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
+
+/**
+ * Check that list status output is sorted.
+ */
+public class TestListStatus {
+
+  private static MiniOzoneCluster cluster = null;
+  private static OzoneConfiguration conf;
+  private static String clusterId;
+  private static String scmId;
+  private static String omId;
+
+  private static OzoneBucket legacyOzoneBucket;
+  private static OzoneBucket fsoOzoneBucket;
+
+  @Rule
+  public Timeout timeout = new Timeout(1200000);
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_ENABLE_FILESYSTEM_PATHS,
+        true);
+    clusterId = UUID.randomUUID().toString();
+    scmId = UUID.randomUUID().toString();
+    omId = UUID.randomUUID().toString();
+    cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
+        .setScmId(scmId).setOmId(omId).build();
+    cluster.waitForClusterToBeReady();
+
+    // create a volume and a LEGACY bucket
+    legacyOzoneBucket = TestDataUtil
+        .createVolumeAndBucket(cluster, BucketLayout.LEGACY);
+    String volumeName = legacyOzoneBucket.getVolumeName();
+
+    // create a volume and a FSO bucket
+    BucketArgs omBucketArgs;
+    BucketArgs.Builder builder = BucketArgs.newBuilder();
+    builder.setStorageType(StorageType.DISK);
+    builder.setBucketLayout(BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    omBucketArgs = builder.build();
+    OzoneClient client = cluster.getClient();
+    OzoneVolume ozoneVolume = client.getObjectStore().getVolume(volumeName);
+
+    String fsoBucketName = "bucket" + RandomStringUtils.randomNumeric(5);
+    ozoneVolume.createBucket(fsoBucketName, omBucketArgs);
+    fsoOzoneBucket = ozoneVolume.getBucket(fsoBucketName);
+
+    // Set the number of keys to be processed during batch operate.
+    conf.setInt(OZONE_FS_ITERATE_BATCH_SIZE, 5);
+
+    initFSNameSpace();
+  }
+
+  @AfterClass
+  public static void teardownClass() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+
+  private static void initFSNameSpace() throws Exception {
+    /*
+    Keys Namespace:
+    "a1"      Dir
+    "a1/a11"  Dir
+    "a1/a12"  File
+    "a1/a13"  File
+    "a2"      File
+    "a3"      Dir
+    "a3/a31"  Dir
+    "a3/a32"  File
+    "a8"      File
+    "a9"      Dir
+    "a10"     File
+
+    "b1"      File
+    "b2"      File
+    "b3"      File
+    "b4"      File
+     */
+    buildNameSpaceTree(fsoOzoneBucket);
+  }
+
+  @Test
+  public void testSortedListStatus() throws Exception {
+    // a) test if output is sorted
+    checkKeyList("", "", 1000, 10);
+
+    // b) number of keys returns is expected
+    checkKeyList("", "", 2, 2);
+
+    // c) check if full prefix works
+    checkKeyList("a1", "", 100, 3);
+
+    //  d) check if full prefix with numEntries work
+    checkKeyList("a1", "", 2, 2);
+
+    // e) check if existing start key >>>
+    checkKeyList("a1", "a1/a12", 100, 2);
+
+    // f) check with non existing start key>>>
+    checkKeyList("", "a7", 100, 6);
+
+    // g) check if half prefix works <<<<
+    // checkKeyList("b", "", 100, 4);
+
+    // h) check half prefix with non-existing start key
+    // checkKeyList("b", "b5", 100, 2);
+  }
+
+  private static void createFile(OzoneBucket bucket, String keyName) throws IOException {
+    try (OzoneOutputStream oos = bucket.createFile(keyName, 0,
+        RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
+        true, false)) {
+
+    }
+  }
+  private static void buildNameSpaceTree(OzoneBucket ozoneBucket)
+      throws Exception {
+    ozoneBucket.createDirectory("/a1");
+    createFile(ozoneBucket, "/a2");
+    ozoneBucket.createDirectory("/a3");
+    createFile(ozoneBucket, "/a8");
+    ozoneBucket.createDirectory("/a9");
+    createFile(ozoneBucket, "/a10");
+
+    ozoneBucket.createDirectory("/a1/a11");
+    createFile(ozoneBucket,"/a1/a12");
+    createFile(ozoneBucket,"/a1/a13");
+
+    ozoneBucket.createDirectory("/a3/a31");
+    createFile(ozoneBucket,"/a3/a32");
+
+    createFile(ozoneBucket,"/b1");
+    createFile(ozoneBucket,"/b2");
+    createFile(ozoneBucket,"/b7");
+    createFile(ozoneBucket,"/b8");
+  }
+
+  private void checkKeyList(String keyPrefix, String startKey,
+                            long numEntries, int expectedNumKeys) throws Exception {
+
+    List<OzoneFileStatus> statuses =
+        fsoOzoneBucket.listStatus(keyPrefix, false, startKey, numEntries);
+    Assert.assertEquals(expectedNumKeys, statuses.size());
+
+    System.out.println("BEGIN:::keyPrefix---> " + keyPrefix + ":::---> " +
+        startKey);
+    for (OzoneFileStatus st : statuses) {
+      System.out.println("status:"  + st);
+    }
+    System.out.println("END:::keyPrefix---> " + keyPrefix + ":::---> " +
+        startKey);
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -23,15 +23,23 @@ import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
-import org.apache.hadoop.ozone.client.*;
+import org.apache.hadoop.ozone.client.BucketArgs;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.client.OzoneClient;
+import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OzoneFileStatus;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.AfterClass;
 import org.junit.rules.Timeout;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.UUID;
+import java.util.List;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FS_ITERATE_BATCH_SIZE;
 
@@ -151,11 +159,12 @@ public class TestListStatus {
     // checkKeyList("b", "b5", 100, 2);
   }
 
-  private static void createFile(OzoneBucket bucket, String keyName) throws IOException {
+  private static void createFile(OzoneBucket bucket, String keyName)
+      throws IOException {
     try (OzoneOutputStream oos = bucket.createFile(keyName, 0,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE),
         true, false)) {
-
+      oos.flush();
     }
   }
   private static void buildNameSpaceTree(OzoneBucket ozoneBucket)
@@ -168,20 +177,21 @@ public class TestListStatus {
     createFile(ozoneBucket, "/a10");
 
     ozoneBucket.createDirectory("/a1/a11");
-    createFile(ozoneBucket,"/a1/a12");
-    createFile(ozoneBucket,"/a1/a13");
+    createFile(ozoneBucket, "/a1/a12");
+    createFile(ozoneBucket, "/a1/a13");
 
     ozoneBucket.createDirectory("/a3/a31");
-    createFile(ozoneBucket,"/a3/a32");
+    createFile(ozoneBucket, "/a3/a32");
 
-    createFile(ozoneBucket,"/b1");
-    createFile(ozoneBucket,"/b2");
-    createFile(ozoneBucket,"/b7");
-    createFile(ozoneBucket,"/b8");
+    createFile(ozoneBucket, "/b1");
+    createFile(ozoneBucket, "/b2");
+    createFile(ozoneBucket, "/b7");
+    createFile(ozoneBucket, "/b8");
   }
 
   private void checkKeyList(String keyPrefix, String startKey,
-                            long numEntries, int expectedNumKeys) throws Exception {
+                            long numEntries, int expectedNumKeys)
+      throws Exception {
 
     List<OzoneFileStatus> statuses =
         fsoOzoneBucket.listStatus(keyPrefix, false, startKey, numEntries);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestListStatus.java
@@ -91,26 +91,23 @@ public class TestListStatus {
 
   @Test
   public void testSortedListStatus() throws Exception {
-//    // a) test if output is sorted
-//    checkKeyList("", "", 1000, 10);
-//
-//    // b) number of keys returns is expected
-//    checkKeyList("", "", 2, 2);
-//
-//    // c) check if full prefix works
-//    checkKeyList("a1", "", 100, 3);
-//
-//    //  d) check if full prefix with numEntries work
-//    checkKeyList("a1", "", 2, 2);
-//
-//    // e) check if existing start key >>>
-//    checkKeyList("a1", "a1/a12", 100, 2);
-//
-//    // f) check with non existing start key>>>
-//    checkKeyList("", "a7", 100, 6);
+    // a) test if output is sorted
+    checkKeyList("", "", 1000, 10);
 
-    // g) check if full prefix with numEntries work
-    checkKeyList("a1/", "a1/", 100, 2);
+    // b) number of keys returns is expected
+    checkKeyList("", "", 2, 2);
+
+    // c) check if full prefix works
+    checkKeyList("a1", "", 100, 3);
+
+    //  d) check if full prefix with numEntries work
+    checkKeyList("a1", "", 2, 2);
+
+    // e) check if existing start key >>>
+    checkKeyList("a1", "a1/a12", 100, 2);
+
+    // f) check with non existing start key>>>
+    checkKeyList("", "a7", 100, 6);
 
     // TODO: Enable the following test after listKeys changes
 //    // g) check if half prefix works <<<<

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1501,9 +1501,9 @@ public class KeyManagerImpl implements KeyManager {
       return fileStatusList;
     }
 
-    Preconditions.checkArgument(!recursive);
     boolean useNewIterator = true;
     if (isBucketFSOptimized(volName, buckName)) {
+      Preconditions.checkArgument(!recursive);
       if (useNewIterator) {
         OzoneListStatusHelper statusHelper =
             new OzoneListStatusHelper(metadataManager, scmBlockSize,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1507,8 +1507,11 @@ public class KeyManagerImpl implements KeyManager {
         OzoneListStatusHelper statusHelper =
             new OzoneListStatusHelper(metadataManager, scmBlockSize,
                 this::getOzoneFileStatusFSO);
-        return statusHelper.listStatusFSO(args, recursive, startKey, numEntries,
-            clientAddress);
+        Map<String, OzoneFileStatus> cacheFileMap = new HashMap<>();
+        Map<String, OzoneFileStatus> cacheDirMap = new HashMap<>();
+        statusHelper.listStatusFSO(args, recursive, startKey, numEntries,
+            clientAddress, cacheDirMap, cacheFileMap);
+        return buildFinalStatusList(cacheFileMap, cacheDirMap, args, clientAddress);
       } else {
         return listStatusFSO(args, recursive, startKey, numEntries,
             clientAddress);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1415,7 +1415,7 @@ public class KeyManagerImpl implements KeyManager {
     refreshPipeline(Arrays.asList(key));
   }
 
-  private boolean isKeyDeleted(String key, Table keyTable) {
+  public static boolean isKeyDeleted(String key, Table keyTable) {
     CacheValue<OmKeyInfo> omKeyInfoCacheValue
         = keyTable.getCacheValue(new CacheKey(key));
     return omKeyInfoCacheValue != null
@@ -1501,6 +1501,7 @@ public class KeyManagerImpl implements KeyManager {
       return fileStatusList;
     }
 
+    Preconditions.checkArgument(!recursive);
     boolean useNewIterator = true;
     if (isBucketFSOptimized(volName, buckName)) {
       if (useNewIterator) {
@@ -1508,10 +1509,9 @@ public class KeyManagerImpl implements KeyManager {
             new OzoneListStatusHelper(metadataManager, scmBlockSize,
                 this::getOzoneFileStatusFSO);
         Collection<OzoneFileStatus> statuses =
-            statusHelper.listStatusFSO(args, recursive, startKey, numEntries,
+            statusHelper.listStatusFSO(args, startKey, numEntries,
             clientAddress);
-        return buildFinalStatusList(statuses,
-            args, clientAddress);
+        return buildFinalStatusList(statuses, args, clientAddress);
       } else {
         return listStatusFSO(args, recursive, startKey, numEntries,
             clientAddress);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1500,9 +1500,19 @@ public class KeyManagerImpl implements KeyManager {
     if (numEntries <= 0) {
       return fileStatusList;
     }
+
+    boolean useNewIterator = true;
     if (isBucketFSOptimized(volName, buckName)) {
-      return listStatusFSO(args, recursive, startKey, numEntries,
-          clientAddress);
+      if (useNewIterator) {
+        OzoneListStatusHelper statusHelper =
+            new OzoneListStatusHelper(metadataManager, scmBlockSize,
+                this::getOzoneFileStatusFSO);
+        return statusHelper.listStatusFSO(args, recursive, startKey, numEntries,
+            clientAddress);
+      } else {
+        return listStatusFSO(args, recursive, startKey, numEntries,
+            clientAddress);
+      }
     }
 
     String volumeName = args.getVolumeName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -1511,7 +1511,8 @@ public class KeyManagerImpl implements KeyManager {
         Map<String, OzoneFileStatus> cacheDirMap = new HashMap<>();
         statusHelper.listStatusFSO(args, recursive, startKey, numEntries,
             clientAddress, cacheDirMap, cacheFileMap);
-        return buildFinalStatusList(cacheFileMap, cacheDirMap, args, clientAddress);
+        return buildFinalStatusList(cacheFileMap, cacheDirMap,
+            args, clientAddress);
       } else {
         return listStatusFSO(args, recursive, startKey, numEntries,
             clientAddress);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -63,6 +63,9 @@ public class OzoneListStatusHelper {
                           boolean skipFileNotFoundError) throws IOException;
   }
 
+  /**
+   * Interface for iteration of Heap Entries.
+   */
   public interface ClosableIterator extends Iterator<HeapEntry>, Closeable {
 
   }
@@ -157,7 +160,7 @@ public class OzoneListStatusHelper {
 
     // fetch the sorted output using a min heap iterator where
     // every remove from the heap will give the smallest entry.
-    try(MinHeapIterator heapIterator = new MinHeapIterator(metadataManager,
+    try (MinHeapIterator heapIterator = new MinHeapIterator(metadataManager,
         dbPrefixKey, bucketLayout, startKeyPrefix, volumeName, bucketName)) {
 
       while (map.size() < numEntries && heapIterator.hasNext()) {
@@ -200,7 +203,7 @@ public class OzoneListStatusHelper {
   }
 
   /**
-   * Enum of types of entries in the heap
+   * Enum of types of entries in the heap.
    */
   public enum EntryType {
     DIR_CACHE,
@@ -223,7 +226,7 @@ public class OzoneListStatusHelper {
   }
 
   /**
-   * Entry to be added to the heap
+   * Entry to be added to the heap.
    */
   private static class HeapEntry implements Comparable<HeapEntry> {
     private final EntryType entryType;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -37,11 +37,8 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.List;
 import java.util.TreeMap;
 import java.util.Map;
 import java.util.TreeSet;
@@ -83,7 +80,8 @@ public class OzoneListStatusHelper {
 
   public void listStatusFSO(OmKeyArgs args,
       boolean recursive, String startKey, long numEntries,
-      String clientAddress, Map<String, OzoneFileStatus> cacheDirMap, Map<String, OzoneFileStatus> cacheFileMap)
+      String clientAddress, Map<String, OzoneFileStatus> cacheDirMap,
+                            Map<String, OzoneFileStatus> cacheFileMap)
       throws IOException {
     Preconditions.checkArgument(!recursive);
     Preconditions.checkNotNull(args, "Key args can not be null");
@@ -176,7 +174,7 @@ public class OzoneListStatusHelper {
         } else {
           cacheFileMap.put(status.getPath(), status);
         }
-       count++;
+        count++;
       }
     }
   }
@@ -185,7 +183,6 @@ public class OzoneListStatusHelper {
   private String getDbKey(String key, OmKeyArgs args,
                           OmBucketInfo omBucketInfo) throws IOException {
     long startKeyParentId;
-    java.nio.file.Path file = Paths.get(key);
     String parent = OzoneFSUtils.getParentDir(key);
 
     OmKeyArgs startKeyArgs = args.toBuilder()
@@ -197,7 +194,7 @@ public class OzoneListStatusHelper {
     Preconditions.checkNotNull(fileStatusInfo);
     startKeyParentId = getId(fileStatusInfo, omBucketInfo);
     return metadataManager.
-        getOzonePathKey(startKeyParentId, file.getFileName().toString());
+        getOzonePathKey(startKeyParentId, OzoneFSUtils.getFileName(key));
   }
 
   private long getId(OzoneFileStatus fileStatus, OmBucketInfo omBucketInfo) {
@@ -297,7 +294,7 @@ public class OzoneListStatusHelper {
   }
 
   /**
-   * Iterator class for Ozone keys
+   * Iterator class for Ozone keys.
    */
   public interface OzoneKeyIterator extends
       Iterator<HeapEntry<? extends WithParentObjectId>>, Closeable {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -208,8 +208,8 @@ public class OzoneListStatusHelper {
   public enum EntryType {
     DIR_CACHE,
     FILE_CACHE,
-    RAW_FILE_DB,
-    RAW_DIR_DB;
+    RAW_DIR_DB,
+    RAW_FILE_DB;
 
     public boolean isDir() {
       switch (this) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -38,7 +38,16 @@ import org.slf4j.LoggerFactory;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.PriorityQueue;
+import java.util.Set;
+import java.util.NoSuchElementException;
 
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
@@ -91,15 +100,20 @@ public class OzoneListStatusHelper {
     /**
      * a) If the keyname is a file just return one entry
      * b) if the keyname is root, then return the value of the bucket
-     * c) if the keyname is a different bucket than root, fetch the direcoty parent id
+     * c) if the keyname is a different bucket than root,
+     * fetch the direcoty parent id
      *
      * if the startkey exists
      * a) check the start key is a child ot key, else return emptry list
-     * b) chekc if the start key is a child chil of keynae, then reset the key to parent of start key
+     * b) chekc if the start key is a child chil of keynae,
+     * then reset the key to parent of start key
      * c) if start key is non existent then seek to the neatest key
-     * d) if the keyname is not a dir or a file, it can either be invalid name or a prefix path
-     *     in case, this is called as part of listStatus fail as the real dir/file should exist
-     *     else, try to find the parent of keyname and use that as the prefix, use the rest of the path to construct prefix path
+     * d) if the keyname is not a dir or a file, it can either be
+     * invalid name or a prefix path
+     *     in case, this is called as part of listStatus fail as the
+     *     real dir/file should exist
+     *     else, try to find the parent of keyname and use that as the prefix,
+     *     use the rest of the path to construct prefix path
      */
 
 
@@ -193,7 +207,7 @@ public class OzoneListStatusHelper {
   }
 
   /**
-   * Enum of types of entries
+   * Enum of types of entries.
    */
   public enum EntryType {
     DIR_CACHE,
@@ -211,15 +225,16 @@ public class OzoneListStatusHelper {
         return false;
       default:
         throw new IllegalArgumentException();
-    }
+      }
     }
   }
 
   /**
-   * Entry which is added to heap
+   * Entry which is added to heap.
    * @param <T>
    */
-  private static class HeapEntry<T extends WithParentObjectId> implements Comparable<HeapEntry> {
+  private static class HeapEntry<T extends WithParentObjectId>
+      implements Comparable<HeapEntry> {
     private final EntryType entryType;
     private final String key;
     private final T value;
@@ -239,7 +254,7 @@ public class OzoneListStatusHelper {
         return false;
       }
 
-      if (! (other instanceof HeapEntry)) {
+      if (!(other instanceof HeapEntry)) {
         return false;
       }
 
@@ -276,10 +291,17 @@ public class OzoneListStatusHelper {
     }
   }
 
+  /**
+   * Iterator class for Ozone keys
+   */
   public interface OzoneKeyIterator extends
       Iterator<HeapEntry<? extends WithParentObjectId>>, Closeable {
   }
 
+  /**
+   * Raw iterator over db tables.
+   * @param <T>
+   */
   private static class RawIter<T extends WithParentObjectId>
       implements OzoneKeyIterator {
 
@@ -372,7 +394,7 @@ public class OzoneListStatusHelper {
 
     private final EntryType entryType;
 
-    public CacheIter(EntryType entryType, Iterator<Map.Entry<CacheKey<String>,
+    CacheIter(EntryType entryType, Iterator<Map.Entry<CacheKey<String>,
         CacheValue<T>>> cacheIter, String startKey, String prefixKey) {
       this.cacheDeletedKeySet = new TreeSet<>();
       this.cacheKeyMap = new TreeMap<>();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -1,0 +1,440 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.*;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.*;
+
+
+public class OzoneListStatusHelper {
+
+  @FunctionalInterface
+  public interface GetFileStatusHelper {
+    OzoneFileStatus apply(OmKeyArgs args, String clientAddress,
+                          boolean skipFileNotFoundError) throws IOException;
+  }
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(OzoneListStatusHelper.class);
+
+  private final OMMetadataManager metadataManager;
+  private final long scmBlockSize;
+
+  GetFileStatusHelper getStatusHelper;
+
+  OzoneListStatusHelper(OMMetadataManager metadataManager, long scmBlockSize, GetFileStatusHelper func) {
+    this.metadataManager = metadataManager;
+    this.scmBlockSize = scmBlockSize;
+    this.getStatusHelper = func;
+  }
+
+  public List<OzoneFileStatus> listStatusFSO(OmKeyArgs args, boolean recursive,
+                                             String startKey, long numEntries, String clientAddress)
+      throws IOException {
+    Preconditions.checkArgument(!recursive);
+    Preconditions.checkNotNull(args, "Key args can not be null");
+
+    if (numEntries <= 0) {
+      return new ArrayList<>();
+    }
+
+    final ArrayList<OzoneFileStatus> fileStatuses = new ArrayList<>();
+
+    final String volumeName = args.getVolumeName();
+    final String bucketName = args.getBucketName();
+    final String keyName = args.getKeyName();
+    String prefixKey = keyName;
+
+    /**
+     * a) If the keyname is a file just return one entry
+     * b) if the keyname is root, then return the value of the bucket
+     * c) if the keyname is a different bucket than root, fetch the direcoty parent id
+     *
+     * if the startkey exists
+     * a) check the start key is a child ot key, else return emptry list
+     * b) chekc if the start key is a child chil of keynae, then reset the key to parent of start key
+     * c) if start key is non existent then seek to the neatest key
+     * d) if the keyname is not a dir or a file, it can either be invalid name or a prefix path
+     *     in case, this is called as part of listStatus fail as the real dir/file should exist
+     *     else, try to find the parent of keyname and use that as the prefix, use the rest of the path to construct prefix path
+     */
+
+
+    if (StringUtils.isNotBlank(keyName) && StringUtils.isNotBlank(startKey) &&
+        !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
+            "Returns empty list", startKey, keyName);
+      }
+      return Collections.emptyList();
+    }
+
+    String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        metadataManager.getBucketTable().get(bucketKey);
+    if (omBucketInfo == null) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
+            "Returns empty list", startKey, keyName);
+      }
+      return Collections.emptyList();
+    }
+
+    BucketLayout bucketLayout = omBucketInfo.getBucketLayout();
+
+    OzoneFileStatus fileStatus = getStatusHelper.apply(args, clientAddress, true);
+
+    String dbPrefixKey;
+    if (fileStatus == null) {
+      dbPrefixKey = getDbKey(keyName, args, omBucketInfo);
+      prefixKey = OzoneFSUtils.getParentDir(keyName);
+    } else {
+      if (fileStatus.isFile()) {
+        return Collections.singletonList(fileStatus);
+      }
+      long id = getId(fileStatus, omBucketInfo);
+      dbPrefixKey = metadataManager.getOzonePathKey(id, "");
+    }
+
+    String startKeyPrefix = Strings.isNullOrEmpty(startKey) ? "" : getDbKey(startKey, args, omBucketInfo);
+
+    try (MinHeapIterator heapIterator = new MinHeapIterator(metadataManager, dbPrefixKey, bucketLayout, startKeyPrefix)) {
+
+      while (fileStatuses.size() < numEntries && heapIterator.hasNext()) {
+        HeapEntry entry = heapIterator.next();
+        OzoneFileStatus status = entry.getStatus(prefixKey, scmBlockSize, volumeName, bucketName);
+        LOG.info("returning status:{} keyname:{} startkey:{} numEntries:{}", status, prefixKey, startKey, numEntries);
+        fileStatuses.add(status);
+      }
+    }
+
+    return fileStatuses;
+  }
+
+
+  private String getDbKey(String key, OmKeyArgs args, OmBucketInfo omBucketInfo) throws IOException {
+    long startKeyParentId;
+    java.nio.file.Path file = Paths.get(key);
+    String parent = OzoneFSUtils.getParentDir(key);
+
+    OmKeyArgs startKeyArgs = args.toBuilder()
+        .setKeyName(parent)
+        .setSortDatanodesInPipeline(false)
+        .build();
+    OzoneFileStatus fileStatusInfo = getStatusHelper.apply(startKeyArgs,
+        null, true);
+
+    startKeyParentId = getId(fileStatusInfo, omBucketInfo);
+    return metadataManager.getOzonePathKey(startKeyParentId, file.getFileName().toString());
+  }
+
+  private long getId(OzoneFileStatus fileStatus, OmBucketInfo omBucketInfo) {
+    if (fileStatus.getKeyInfo() != null) {
+      return fileStatus.getKeyInfo().getObjectID();
+    } else {
+      // assert root is null
+      // list root directory.
+      return omBucketInfo.getObjectID();
+    }
+  }
+  public enum EntryType {
+    DIR_CACHE,
+    FILE_CACHE,
+    RAW_FILE_DB,
+    RAW_DIR_DB;
+
+    public boolean isDir() {
+      switch (this) {
+        case DIR_CACHE:
+        case RAW_DIR_DB:
+          return true;
+        case FILE_CACHE:
+        case RAW_FILE_DB:
+          return false;
+        default:
+          throw new IllegalArgumentException();
+      }
+
+    }
+  }
+  public static class HeapEntry<T extends WithParentObjectId> implements Comparable<HeapEntry> {
+    private final EntryType entryType;
+    private final String key;
+    T value;
+
+    HeapEntry(EntryType entryType, String key, T value) {
+      this.entryType = entryType;
+      this.key = key;
+      this.value = value;
+    }
+
+    public int compareTo(HeapEntry other) {
+      return this.key.compareTo(other.key);
+    }
+
+    public String getKey() {
+      return key;
+    }
+
+    public OzoneFileStatus getStatus(String prefixPath, long scmBlockSize, String volumeName, String bucketName) {
+      OmKeyInfo keyInfo;
+      if (entryType.isDir()) {
+        OmDirectoryInfo dirInfo = (OmDirectoryInfo) value;
+        String dirName = OMFileRequest.getAbsolutePath(prefixPath,
+            dirInfo.getName());
+        keyInfo = OMFileRequest.getOmKeyInfo(volumeName,
+            bucketName, dirInfo, dirName);
+      } else {
+        keyInfo = (OmKeyInfo) value;
+        keyInfo.setFileName(keyInfo.getKeyName());
+        String fullKeyPath = OMFileRequest.getAbsolutePath(prefixPath,
+            keyInfo.getKeyName());
+        keyInfo.setKeyName(fullKeyPath);
+      }
+      return new OzoneFileStatus(keyInfo, scmBlockSize, entryType.isDir());
+    }
+  }
+
+  public interface OzoneKeyIterator extends Iterator<HeapEntry<? extends WithParentObjectId>>, Closeable {
+
+  }
+
+  private static class RawIter<T extends WithParentObjectId> implements OzoneKeyIterator {
+
+    private final EntryType iterType;
+    private final String prefixKey;
+
+    private final TableIterator<String, ? extends Table.KeyValue<String, T>> tableIterator;
+    private final Set<String> cacheDeletedKeySet;
+    private HeapEntry currentKey;
+
+    RawIter(EntryType iterType, TableIterator<String, ? extends Table.KeyValue<String, T>> tableIterator,
+            String prefixKey, String startKey, Set<String> cacheDeletedKeySet) throws IOException {
+      this.iterType = iterType;
+      this.tableIterator = tableIterator;
+      this.prefixKey = prefixKey;
+      this.cacheDeletedKeySet = cacheDeletedKeySet;
+      this.currentKey = null;
+      if (!StringUtils.isBlank(prefixKey)) {
+        tableIterator.seek(prefixKey);
+      }
+
+      if (!StringUtils.isBlank(startKey)) {
+        tableIterator.seek(startKey);
+      }
+
+      getNextKey();
+    }
+
+    private void getNextKey() throws IOException {
+      while (tableIterator.hasNext() && currentKey == null) {
+        Table.KeyValue<String, T> entry = tableIterator.next();
+        String entryKey = entry.getKey();
+        if (entryKey.startsWith(prefixKey)) {
+          if (!cacheDeletedKeySet.contains(entryKey)) {
+            currentKey = new HeapEntry(iterType, entryKey, entry.getValue());
+          }
+        } else {
+          break;
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      try {
+        getNextKey();
+      } catch (Throwable t) {
+        throw new NoSuchElementException();
+      }
+      return currentKey != null;
+    }
+
+    public HeapEntry next() {
+      try {
+        getNextKey();
+      } catch (Throwable t) {
+        throw new NoSuchElementException();
+      }
+      HeapEntry ret = currentKey;
+      currentKey = null;
+
+      return ret;
+    }
+
+    public void close() {
+
+    }
+  }
+
+  private static class CacheIter< T extends WithParentObjectId> implements OzoneKeyIterator {
+    private final Set<String> cacheDeletedKeySet;
+    private final Map<String, T> cacheKeyMap;
+
+    private final Iterator<Map.Entry<String, T>> cacheCreatedKeyIter;
+
+    private final Iterator<Map.Entry<CacheKey<String>, CacheValue<T>>> cacheIter;
+
+    private final String prefixKey;
+    private final String startKey;
+
+
+    private final EntryType entryType;
+
+    public CacheIter(EntryType entryType, Iterator<Map.Entry<CacheKey<String>, CacheValue<T>>> cacheIter,
+                     String startKey, String prefixKey) {
+      this.cacheDeletedKeySet = new TreeSet<>();
+      this.cacheKeyMap = new TreeMap<>();
+
+      this.cacheIter = cacheIter;
+      this.startKey = startKey;
+      this.prefixKey = prefixKey;
+      this.entryType = entryType;
+
+      getCacheValues();
+
+      cacheCreatedKeyIter = cacheKeyMap.entrySet().iterator();
+    }
+
+    private void getCacheValues() {
+      while (cacheIter.hasNext()) {
+        Map.Entry<CacheKey<String>, CacheValue<T>> entry =
+            cacheIter.next();
+        String cacheKey = entry.getKey().getCacheKey();
+        T cacheOmInfo = entry.getValue().getCacheValue();
+        // cacheOmKeyInfo is null if an entry is deleted in cache
+        if (cacheOmInfo == null) {
+          cacheDeletedKeySet.add(cacheKey);
+          continue;
+        }
+
+        if (StringUtils.isBlank(startKey)) {
+          // startKey is null or empty, then the seekKeyInDB="1024/"
+          if (cacheKey.startsWith(prefixKey)) {
+            cacheKeyMap.put(cacheKey, cacheOmInfo);
+          }
+        } else {
+          // startKey not empty, then the seekKeyInDB="1024/b" and
+          // seekKeyInDBWithOnlyParentID = "1024/". This is to avoid case of
+          // parentID with "102444" cache entries.
+          // Here, it has to list all the keys after "1024/b" and requires >=0
+          // string comparison.
+          if (cacheKey.startsWith(prefixKey) &&
+              cacheKey.compareTo(startKey) >= 0) {
+            cacheKeyMap.put(cacheKey, cacheOmInfo);
+          }
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      return cacheCreatedKeyIter.hasNext();
+    }
+
+    public HeapEntry next() {
+      Map.Entry<String, T> entry = cacheCreatedKeyIter.next();
+      return new HeapEntry(entryType, entry.getKey(), entry.getValue());
+    }
+
+    public void close() {
+
+    }
+
+    public Set<String> getDeletedKeySet() {
+      return cacheDeletedKeySet;
+    }
+  }
+
+  public static class MinHeapIterator implements Iterator<HeapEntry<? extends WithParentObjectId>>, Closeable {
+
+    private final PriorityQueue<HeapEntry<? extends WithParentObjectId>> minHeap = new PriorityQueue<>();
+    private final ArrayList<Iterator<HeapEntry<? extends WithParentObjectId>>> iterators = new ArrayList<>();
+
+    RawIter<OmDirectoryInfo> rawDirIter;
+    RawIter<OmKeyInfo> rawFileIter;
+
+    CacheIter<OmKeyInfo> cacheFileIter;
+    CacheIter<OmDirectoryInfo> cacheDirIter;
+
+    String prefixKey;
+
+
+    MinHeapIterator(OMMetadataManager omMetadataManager, String prefixKey,
+                    BucketLayout bucketLayout, String startKey) throws IOException {
+
+      this.prefixKey = prefixKey;
+
+      cacheDirIter =
+          new CacheIter<>(EntryType.DIR_CACHE, omMetadataManager.getDirectoryTable().cacheIterator(), prefixKey, startKey);
+      cacheFileIter =
+          new CacheIter<>(EntryType.FILE_CACHE, omMetadataManager.getKeyTable(bucketLayout).cacheIterator(), prefixKey, startKey);
+
+      rawDirIter =
+          new RawIter<>(EntryType.RAW_DIR_DB, omMetadataManager.getDirectoryTable().iterator(),
+              prefixKey, startKey, cacheDirIter.getDeletedKeySet());
+      rawFileIter =
+          new RawIter<>(EntryType.RAW_FILE_DB, omMetadataManager.getKeyTable(bucketLayout).iterator(),
+              prefixKey, startKey, cacheFileIter.getDeletedKeySet());
+
+
+      iterators.add(EntryType.DIR_CACHE.ordinal(), cacheDirIter);
+      iterators.add(EntryType.FILE_CACHE.ordinal(), cacheFileIter);
+      iterators.add(EntryType.RAW_FILE_DB.ordinal(), rawFileIter);
+      iterators.add(EntryType.RAW_DIR_DB.ordinal(), rawDirIter);
+      insertFirstElement();
+
+    }
+
+    public void insertFirstElement() {
+      for (Iterator<HeapEntry<? extends WithParentObjectId>> iter : iterators) {
+        if (iter.hasNext()) {
+          minHeap.add(iter.next());
+        }
+      }
+    }
+
+    public boolean hasNext() {
+      return !minHeap.isEmpty();
+    }
+
+    public HeapEntry<? extends WithParentObjectId> next() {
+      HeapEntry<? extends WithParentObjectId> heapEntry = minHeap.remove();
+      Iterator<HeapEntry<? extends WithParentObjectId>> iter = iterators.get(heapEntry.entryType.ordinal());
+      if (iter.hasNext()) {
+        minHeap.add(iter.next());
+      }
+
+      return heapEntry;
+    }
+
+    public void close() throws IOException {
+    }
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneListStatusHelper.java
@@ -91,6 +91,7 @@ public class OzoneListStatusHelper {
       return new ArrayList<>();
     }
 
+    boolean listKeysMode = false;
     final String volumeName = args.getVolumeName();
     final String bucketName = args.getBucketName();
     String keyName = args.getKeyName();
@@ -115,7 +116,6 @@ public class OzoneListStatusHelper {
      *     use the rest of the path to construct prefix path
      */
 
-
     String bucketKey = metadataManager.getBucketKey(volumeName, bucketName);
     OmBucketInfo omBucketInfo =
         metadataManager.getBucketTable().get(bucketKey);
@@ -130,7 +130,7 @@ public class OzoneListStatusHelper {
     boolean pathNameChanged = false;
     if (StringUtils.isNotBlank(startKey)) {
       if (StringUtils.isNotBlank(keyName)) {
-        if ( !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
+        if (!listKeysMode && !OzoneFSUtils.isImmediateChild(keyName, startKey)) {
           if (LOG.isDebugEnabled()) {
             LOG.debug("StartKey {} is not an immediate child of keyName {}. " +
                 "Returns empty list", startKey, keyName);
@@ -151,10 +151,10 @@ public class OzoneListStatusHelper {
           .setSortDatanodesInPipeline(false)
           .build();
        fileStatus = getStatusHelper.apply(startKeyArgs,
-          null, true);
+           null, true);
     } else {
       fileStatus =
-          getStatusHelper.apply(args, clientAddress, true);
+          getStatusHelper.apply(args, clientAddress, listKeysMode);
     }
 
     String dbPrefixKey;


### PR DESCRIPTION
## What changes were proposed in this pull request?
With FSO buckets, S3 list keys output is not sorted.

Amazon S3 list Objects returning the output sorted.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html
Since listKeys relies on listStatus for FSO buckets, this jira proposes to make listStatus output sorted


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6788

## How was this patch tested?
Added a new test to check for sorted output
