### PR TITLE
HDDS-6759: Add listblock API in MockDatanodeStorage

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.client;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ChunkInfo;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandRequestProto;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.ContainerCommandResponseProto;
@@ -99,6 +100,9 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
     case GetBlock:
       return result(request,
           r -> r.setGetBlock(getBlock(request.getGetBlock())));
+    case ListBlock:
+      return result(request,
+          r -> r.setListBlock(listBlock(request.getContainerID())));
     default:
       throw new IllegalArgumentException(
           "Mock version of datanode call " + request.getCmdType()
@@ -120,6 +124,11 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
     return GetBlockResponseProto.newBuilder()
         .setBlockData(datanodeStorage.getBlock(getBlock.getBlockID()))
         .build();
+  }
+
+  private ContainerProtos.ListBlockResponseProto listBlock(long containerID) {
+    return ContainerProtos.ListBlockResponseProto.newBuilder()
+        .addAllBlockData(datanodeStorage.listBlock(containerID)).build();
   }
 
   private PutBlockResponseProto putBlock(PutBlockRequestProto putBlock) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added listblock API in MockDatanodeStorage

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6759

## How was this patch tested?

This is mock class. So, this is helpful for tests.