### PR TITLE
HDDS-6808. EC: Fix datanode exclusion check in client

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -249,7 +249,8 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     // If the failure is NOT caused by other reasons (e.g. container full),
     // we assume it is caused by DN failure and exclude the failed DN.
     failedStreams.stream()
-        .filter(s -> !checkIfContainerToExclude(s.getIoException()))
+        .filter(s -> !checkIfContainerToExclude(
+            HddsClientUtils.checkForException(s.getIoException())))
         .forEach(s -> blockOutputStreamEntryPool.getExcludeList()
             .addDatanode(s.getDatanodeDetails()));
   }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockDatanodeStorage.java
@@ -40,10 +40,10 @@ public class MockDatanodeStorage {
 
   private final Map<String, ByteString> data = new HashMap<>();
 
-  private boolean failed = false;
+  private IOException exception = null;
 
-  public void setStorageFailed() {
-    this.failed = true;
+  public void setStorageFailed(IOException reason) {
+    this.exception = reason;
   }
 
   public void putBlock(DatanodeBlockID blockID, BlockData blockData) {
@@ -57,8 +57,8 @@ public class MockDatanodeStorage {
   public void writeChunk(
       DatanodeBlockID blockID,
       ChunkInfo chunkInfo, ByteString bytes) throws IOException {
-    if (failed) {
-      throw new IOException("This storage was marked as failed.");
+    if (exception != null) {
+      throw exception;
     }
     data.put(createKey(blockID, chunkInfo),
         ByteString.copyFrom(bytes.toByteArray()));

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/MockXceiverClientSpi.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos.WriteChunk
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType;
 import org.apache.hadoop.hdds.scm.XceiverClientReply;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerNotOpenException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 
 import java.io.IOException;
@@ -86,6 +87,8 @@ public class MockXceiverClientSpi extends XceiverClientSpi {
           r -> {
             try {
               return r.setWriteChunk(writeChunk(request.getWriteChunk()));
+            } catch (ContainerNotOpenException e) {
+              return r.setResult(Result.CLOSED_CONTAINER_IO);
             } catch (IOException e) {
               return r.setResult(Result.IO_EXCEPTION);
             }

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -85,10 +85,8 @@ public class TestOzoneECClient {
   private final XceiverClientFactory factoryStub =
       new MockXceiverClientFactory();
   private OzoneConfiguration conf = new OzoneConfiguration();
-  private final int requiredNodes = dataBlocks + parityBlocks;
-  private final int totalNodes = 15;
   private MultiNodePipelineBlockAllocator allocator =
-      new MultiNodePipelineBlockAllocator(conf, requiredNodes, totalNodes);
+      new MultiNodePipelineBlockAllocator(conf, dataBlocks + parityBlocks, 15);
   private final MockOmTransport transportStub = new MockOmTransport(allocator);
   private final RawErasureEncoder encoder =
       new RSRawErasureCoderFactory().createEncoder(

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -817,13 +817,18 @@ public class TestOzoneECClient {
   }
 
   @Test
-  public void testExcludeFailedDN() throws IOException {
-    testExcludeFailedDN(IntStream.range(0, 3), IntStream.range(3, 5));
+  public void testExcludeOnDNFailure() throws IOException {
+    testExcludeFailedDN(IntStream.range(0, 5), IntStream.empty());
   }
 
   @Test
-  public void testNotExcludeClosedDN() throws IOException {
+  public void testExcludeOnDNClosed() throws IOException {
     testExcludeFailedDN(IntStream.empty(), IntStream.range(0, 5));
+  }
+
+  @Test
+  public void testExcludeOnDNMixed() throws IOException {
+    testExcludeFailedDN(IntStream.range(0, 3), IntStream.range(3, 5));
   }
 
   private void testExcludeFailedDN(IntStream failedDNIndex,

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -833,6 +833,11 @@ public class TestOzoneECClient {
 
   private void testExcludeFailedDN(IntStream failedDNIndex,
       IntStream closedDNIndex) throws IOException {
+    close();
+    OzoneConfiguration con = new OzoneConfiguration();
+    MultiNodePipelineBlockAllocator blkAllocator =
+        new MultiNodePipelineBlockAllocator(con, dataBlocks + parityBlocks, 10);
+    createNewClient(con, blkAllocator);
 
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -848,7 +853,7 @@ public class TestOzoneECClient {
       Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream ecKeyOut = (ECKeyOutputStream) out.getOutputStream();
 
-      List<HddsProtos.DatanodeDetailsProto> dns = allocator.getClusterDns();
+      List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
 
       // Then let's mark datanodes with closed container
       List<DatanodeDetails> closedDNs = closedDNIndex
@@ -863,7 +868,7 @@ public class TestOzoneECClient {
           .collect(Collectors.toList());
       ((MockXceiverClientFactory) factoryStub).setFailedStorages(failedDNs);
 
-      for (int i = 0; i < dns.size() * 10; i++) {
+      for (int i = 0; i < dataBlocks; i++) {
         out.write(inputChunks[i % dataBlocks]);
       }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We should call HddsClientUtils.checkForException before calling checkIfContainerToExclude.

This bug was introduced in HDDS-6400 (#3372).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6808

## How was this patch tested?

* With the patch: https://github.com/kaijchen/ozone/runs/6650562194?check_suite_focus=true
* Without the patch: https://github.com/kaijchen/ozone/runs/6650731778?check_suite_focus=true#step:5:1649