### PR TITLE
HDDS-6816. SCMContainerPlacementRackScatter should use original required node num to validate placement policy

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.scm.container.placement.algorithms;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.ContainerPlacementStatus;
@@ -85,7 +84,7 @@ public final class SCMContainerPlacementRackScatter
    *                     allocator, whether the favored nodes will be used
    *                     depends on whether the nodes meets the allocator's
    *                     requirement.
-   * @param nodesRequired - number of datanodes required.
+   * @param nodesRequiredToChoose - number of datanodes required.
    * @param dataSizeRequired - size required for the container.
    * @param metadataSizeRequired - size required for Ratis metadata.
    * @return List of datanodes.
@@ -93,12 +92,17 @@ public final class SCMContainerPlacementRackScatter
    */
   @Override
   public List<DatanodeDetails> chooseDatanodes(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
-      int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
-      throws SCMException {
-    Preconditions.checkArgument(nodesRequired > 0);
-    metrics.incrDatanodeRequestCount(nodesRequired);
-    final int originalNodesRequired = nodesRequired;
+      final List<DatanodeDetails> excludedNodes,
+      final List<DatanodeDetails> favoredNodes,
+      final int nodesRequiredToChoose, final long metadataSizeRequired,
+      final long dataSizeRequired) throws SCMException {
+    if (nodesRequiredToChoose <= 0) {
+      String errorMsg = "num of nodes required to choose should bigger" +
+          "than 0, but the given num is " + nodesRequiredToChoose;
+      throw new SCMException(errorMsg, null);
+    }
+    metrics.incrDatanodeRequestCount(nodesRequiredToChoose);
+    int nodesRequired = nodesRequiredToChoose;
     int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
     List<Node> availableNodes = networkTopology.getNodes(
         networkTopology.getMaxLevel());
@@ -216,7 +220,7 @@ public final class SCMContainerPlacementRackScatter
       }
     }
     ContainerPlacementStatus placementStatus =
-        validateContainerPlacement(chosenNodes, originalNodesRequired);
+        validateContainerPlacement(chosenNodes, nodesRequiredToChoose);
     if (!placementStatus.isPolicySatisfied()) {
       String errorMsg = "ContainerPlacementPolicy not met, currentRacks is" +
           placementStatus.actualPlacementCount() + "desired racks is" +

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -98,6 +98,7 @@ public final class SCMContainerPlacementRackScatter
       throws SCMException {
     Preconditions.checkArgument(nodesRequired > 0);
     metrics.incrDatanodeRequestCount(nodesRequired);
+    final int originalNodesRequired = nodesRequired;
     int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
     List<Node> availableNodes = networkTopology.getNodes(
         networkTopology.getMaxLevel());
@@ -215,11 +216,12 @@ public final class SCMContainerPlacementRackScatter
       }
     }
     ContainerPlacementStatus placementStatus =
-        validateContainerPlacement(chosenNodes, nodesRequired);
+        validateContainerPlacement(chosenNodes, originalNodesRequired);
     if (!placementStatus.isPolicySatisfied()) {
-      LOG.warn("ContainerPlacementPolicy not met, currentRacks is {}," +
-          " desired racks is {}.", placementStatus.actualPlacementCount(),
-          placementStatus.expectedPlacementCount());
+      String errorMsg = "ContainerPlacementPolicy not met, currentRacks is" +
+          placementStatus.actualPlacementCount() + "desired racks is" +
+          placementStatus.expectedPlacementCount();
+      throw new SCMException(errorMsg, null);
     }
     return chosenNodes;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?
SCMContainerPlacementRackScatter should use original required node num to validate placement policy.
when no datanodes which can met the placement policy are selected , an exception should be thrown out


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6816

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

UT