### PR TITLE
HDDS-6783. Recon tasks should write in batches to their databases

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.UUID;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -54,6 +56,17 @@ public interface ReconContainerMetadataManager {
                                 Integer count) throws IOException;
 
   /**
+   * Store the container to Key prefix mapping into a batch.
+   *
+   * @param batch the batch operation we store into
+   * @param containerKeyPrefix the containerId, key-prefix tuple.
+   * @param count              Count of Keys with that prefix.
+   */
+  void batchStoreContainerKeyMapping(BatchOperation batch,
+                                     ContainerKeyPrefix containerKeyPrefix,
+                                     Integer count) throws IOException;
+
+  /**
    * Store the containerID -> no. of keys count into the container DB store.
    *
    * @param containerID the containerID.
@@ -61,6 +74,17 @@ public interface ReconContainerMetadataManager {
    * @throws IOException
    */
   void storeContainerKeyCount(Long containerID, Long count) throws IOException;
+
+  /**
+   * Store the containerID -> no. of keys count into a batch.
+   *
+   * @param batch the batch operation we store into
+   * @param containerID the containerID.
+   * @param count count of the keys within the given containerID.
+   * @throws IOException
+   */
+  void batchStoreContainerKeyCounts(BatchOperation batch, Long containerID,
+                                    Long count) throws IOException;
 
   /**
    * Store the containerID -> ContainerReplicaWithTimestamp mapping to the
@@ -170,6 +194,17 @@ public interface ReconContainerMetadataManager {
       throws IOException;
 
   /**
+   * Add the deletion of an entry to a batch.
+   *
+   * @param batch the batch operation we add the deletion
+   * @param containerKeyPrefix container key prefix to be deleted.
+   * @throws IOException exception.
+   */
+  void batchDeleteContainerMapping(BatchOperation batch,
+                                   ContainerKeyPrefix containerKeyPrefix)
+      throws IOException;
+
+  /**
    * Get iterator to the entire container DB.
    * @return TableIterator
    */
@@ -189,5 +224,8 @@ public interface ReconContainerMetadataManager {
    * @param count no. of new containers to add to containers total count.
    */
   void incrementContainerCountBy(long count);
+
+  void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
+      throws IOException;
 
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconContainerMetadataManager.java
@@ -52,6 +52,7 @@ public interface ReconContainerMetadataManager {
    * @param containerKeyPrefix the containerId, key-prefix tuple.
    * @param count              Count of Keys with that prefix.
    */
+  @Deprecated
   void storeContainerKeyMapping(ContainerKeyPrefix containerKeyPrefix,
                                 Integer count) throws IOException;
 
@@ -73,6 +74,7 @@ public interface ReconContainerMetadataManager {
    * @param count count of the keys within the given containerID.
    * @throws IOException
    */
+  @Deprecated
   void storeContainerKeyCount(Long containerID, Long count) throws IOException;
 
   /**
@@ -190,6 +192,7 @@ public interface ReconContainerMetadataManager {
    * @param containerKeyPrefix container key prefix to be deleted.
    * @throws IOException exception.
    */
+  @Deprecated
   void deleteContainerMapping(ContainerKeyPrefix containerKeyPrefix)
       throws IOException;
 
@@ -225,6 +228,11 @@ public interface ReconContainerMetadataManager {
    */
   void incrementContainerCountBy(long count);
 
+  /**
+   * Commit a batch operation into the containerDbStore.
+   *
+   * @param rdbBatchOperation batch operation we want to commit
+   */
   void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
       throws IOException;
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
@@ -33,6 +33,7 @@ public interface ReconNamespaceSummaryManager {
 
   void clearNSSummaryTable() throws IOException;
 
+  @Deprecated
   void storeNSSummary(long objectId, NSSummary nsSummary) throws IOException;
 
   void batchStoreNSSummaries(BatchOperation batch, long objectId,

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/ReconNamespaceSummaryManager.java
@@ -19,6 +19,8 @@
 package org.apache.hadoop.ozone.recon.spi;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 
 import java.io.IOException;
@@ -33,7 +35,13 @@ public interface ReconNamespaceSummaryManager {
 
   void storeNSSummary(long objectId, NSSummary nsSummary) throws IOException;
 
+  void batchStoreNSSummaries(BatchOperation batch, long objectId,
+                             NSSummary nsSummary) throws IOException;
+
   void deleteNSSummary(long objectId) throws IOException;
 
   NSSummary getNSSummary(long objectId) throws IOException;
+
+  void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
+      throws IOException;
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconContainerMetadataManagerImpl.java
@@ -37,6 +37,7 @@ import javax.inject.Singleton;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.api.types.ContainerKeyPrefix;
 import org.apache.hadoop.ozone.recon.api.types.ContainerMetadata;
@@ -141,6 +142,23 @@ public class ReconContainerMetadataManagerImpl
   }
 
   /**
+   * Concatenate the containerID and Key Prefix using a delimiter and store the
+   * count into a batch.
+   *
+   * @param batch the batch we store into
+   * @param containerKeyPrefix the containerID, key-prefix tuple.
+   * @param count Count of the keys matching that prefix.
+   * @throws IOException on failure.
+   */
+  @Override
+  public void batchStoreContainerKeyMapping(BatchOperation batch,
+                                            ContainerKeyPrefix
+                                                containerKeyPrefix,
+                                            Integer count) throws IOException {
+    containerKeyTable.putWithBatch(batch, containerKeyPrefix, count);
+  }
+
+  /**
    * Store the containerID -> no. of keys count into the container DB store.
    *
    * @param containerID the containerID.
@@ -151,6 +169,21 @@ public class ReconContainerMetadataManagerImpl
   public void storeContainerKeyCount(Long containerID, Long count)
       throws IOException {
     containerKeyCountTable.put(containerID, count);
+  }
+
+  /**
+   * Store the containerID -> no. of keys count into a batch.
+   *
+   * @param batch the batch we store into
+   * @param containerID the containerID.
+   * @param count count of the keys within the given containerID.
+   * @throws IOException on failure.
+   */
+  @Override
+  public void batchStoreContainerKeyCounts(BatchOperation batch,
+                                           Long containerID,
+                                           Long count) throws IOException {
+    containerKeyCountTable.putWithBatch(batch, containerID, count);
   }
 
   /**
@@ -415,6 +448,13 @@ public class ReconContainerMetadataManagerImpl
     containerKeyTable.delete(containerKeyPrefix);
   }
 
+  @Override
+  public void batchDeleteContainerMapping(BatchOperation batch,
+                                          ContainerKeyPrefix containerKeyPrefix)
+      throws IOException {
+    containerKeyTable.deleteWithBatch(batch, containerKeyPrefix);
+  }
+
   /**
    * Get total count of containers.
    *
@@ -454,5 +494,16 @@ public class ReconContainerMetadataManagerImpl
   public void incrementContainerCountBy(long count) {
     long containersCount = getCountForContainers();
     storeContainerCount(containersCount + count);
+  }
+
+  /**
+   * Commit a batch operation into the containerDbStore.
+   *
+   * @param rdbBatchOperation batch operation we want to commit
+   */
+  @Override
+  public void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
+      throws IOException {
+    this.containerDbStore.commitBatchOperation(rdbBatchOperation);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
@@ -18,7 +18,9 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
 import org.apache.hadoop.hdds.utils.db.DBStore;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 import org.apache.hadoop.ozone.recon.spi.ReconNamespaceSummaryManager;
@@ -57,6 +59,13 @@ public class ReconNamespaceSummaryManagerImpl
   }
 
   @Override
+  public void batchStoreNSSummaries(BatchOperation batch,
+                                    long objectId, NSSummary nsSummary)
+      throws IOException {
+    nsSummaryTable.putWithBatch(batch, objectId, nsSummary);
+  }
+
+  @Override
   public void deleteNSSummary(long objectId) throws IOException {
     nsSummaryTable.delete(objectId);
   }
@@ -64,6 +73,11 @@ public class ReconNamespaceSummaryManagerImpl
   @Override
   public NSSummary getNSSummary(long objectId) throws IOException {
     return nsSummaryTable.get(objectId);
+  }
+
+  public void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
+      throws IOException {
+    this.namespaceDbStore.commitBatchOperation(rdbBatchOperation);
   }
 
   public Table getNSSummaryTable() {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/ReconNamespaceSummaryManagerImpl.java
@@ -75,6 +75,7 @@ public class ReconNamespaceSummaryManagerImpl
     return nsSummaryTable.get(objectId);
   }
 
+  @Override
   public void commitBatchOperation(RDBBatchOperation rdbBatchOperation)
       throws IOException {
     this.namespaceDbStore.commitBatchOperation(rdbBatchOperation);

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/FileSizeCountTask.java
@@ -36,10 +36,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.KEY_TABLE;
@@ -165,6 +167,9 @@ public class FileSizeCountTask implements ReconOmTask {
    */
   private void writeCountsToDB(boolean isDbTruncated,
                                Map<FileSizeCountKey, Long> fileSizeCountMap) {
+    List<FileCountBySize> insertToDb = new ArrayList<>();
+    List<FileCountBySize> updateInDb = new ArrayList<>();
+
     fileSizeCountMap.keySet().forEach((FileSizeCountKey key) -> {
       FileCountBySize newRecord = new FileCountBySize();
       newRecord.setVolume(key.volume);
@@ -185,17 +190,19 @@ public class FileSizeCountTask implements ReconOmTask {
             fileCountBySizeDao.findById(recordToFind);
         if (fileCountRecord == null && newRecord.getCount() > 0L) {
           // insert new row only for non-zero counts.
-          fileCountBySizeDao.insert(newRecord);
+          insertToDb.add(newRecord);
         } else if (fileCountRecord != null) {
           newRecord.setCount(fileCountRecord.getCount() +
               fileSizeCountMap.get(key));
-          fileCountBySizeDao.update(newRecord);
+          updateInDb.add(newRecord);
         }
       } else if (newRecord.getCount() > 0) {
         // insert new row only for non-zero counts.
-        fileCountBySizeDao.insert(newRecord);
+        insertToDb.add(newRecord);
       }
     });
+    fileCountBySizeDao.insert(insertToDb);
+    fileCountBySizeDao.update(updateInDb);
   }
 
   private FileSizeCountKey getFileSizeCountKey(OmKeyInfo omKeyInfo) {

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -246,11 +246,15 @@ public class NSSummaryTask implements ReconOmTask {
   private void handlePutKeyEvent(OmKeyInfo keyInfo, Map<Long,
       NSSummary> nsSummaryMap) throws IOException {
     long parentObjectId = keyInfo.getParentObjectID();
+    // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {
+      // If we don't have it in this batch we try to get it from the DB
       nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
     }
     if (nsSummary == null) {
+      // If we don't have it locally and in the DB we create a new instance
+      // as this is a new ID
       nsSummary = new NSSummary();
     }
     int numOfFile = nsSummary.getNumOfFiles();
@@ -273,22 +277,30 @@ public class NSSummaryTask implements ReconOmTask {
     long objectId = directoryInfo.getObjectID();
     // write the dir name to the current directory
     String dirName = directoryInfo.getName();
+    // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary curNSSummary = nsSummaryMap.get(objectId);
     if (curNSSummary == null) {
+      // If we don't have it in this batch we try to get it from the DB
       curNSSummary = reconNamespaceSummaryManager.getNSSummary(objectId);
     }
     if (curNSSummary == null) {
+      // If we don't have it locally and in the DB we create a new instance
+      // as this is a new ID
       curNSSummary = new NSSummary();
     }
     curNSSummary.setDirName(dirName);
     nsSummaryMap.put(objectId, curNSSummary);
 
-    // write the child dir list to the parent directory
+    // Write the child dir list to the parent directory
+    // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {
+      // If we don't have it in this batch we try to get it from the DB
       nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
     }
     if (nsSummary == null) {
+      // If we don't have it locally and in the DB we create a new instance
+      // as this is a new ID
       nsSummary = new NSSummary();
     }
     nsSummary.addChildDir(objectId);
@@ -299,8 +311,10 @@ public class NSSummaryTask implements ReconOmTask {
                                     Map<Long, NSSummary> nsSummaryMap)
           throws IOException {
     long parentObjectId = keyInfo.getParentObjectID();
+    // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {
+      // If we don't have it in this batch we try to get it from the DB
       nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
     }
 
@@ -331,8 +345,10 @@ public class NSSummaryTask implements ReconOmTask {
           throws IOException {
     long parentObjectId = directoryInfo.getParentObjectID();
     long objectId = directoryInfo.getObjectID();
+    // Try to get the NSSummary from our local map that maps NSSummaries to IDs
     NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
     if (nsSummary == null) {
+      // If we don't have it in this batch we try to get it from the DB
       nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
     }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/NSSummaryTask.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.ozone.recon.tasks;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -35,7 +36,9 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DIRECTORY_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
@@ -81,6 +84,7 @@ public class NSSummaryTask implements ReconOmTask {
   public Pair<String, Boolean> process(OMUpdateEventBatch events) {
     Iterator<OMDBUpdateEvent> eventIterator = events.getIterator();
     final Collection<String> taskTables = getTaskTables();
+    Map<Long, NSSummary> nsSummaryMap = new HashMap<>();
 
     while (eventIterator.hasNext()) {
       OMDBUpdateEvent<String, ? extends
@@ -106,22 +110,22 @@ public class NSSummaryTask implements ReconOmTask {
 
           switch (action) {
           case PUT:
-            writeOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
             break;
 
           case DELETE:
-            deleteOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            handleDeleteKeyEvent(updatedKeyInfo, nsSummaryMap);
             break;
 
           case UPDATE:
             if (oldKeyInfo != null) {
               // delete first, then put
-              deleteOmKeyInfoOnNamespaceDB(oldKeyInfo);
+              handleDeleteKeyEvent(oldKeyInfo, nsSummaryMap);
             } else {
               LOG.warn("Update event does not have the old keyInfo for {}.",
                       updatedKey);
             }
-            writeOmKeyInfoOnNamespaceDB(updatedKeyInfo);
+            handlePutKeyEvent(updatedKeyInfo, nsSummaryMap);
             break;
 
           default:
@@ -137,22 +141,22 @@ public class NSSummaryTask implements ReconOmTask {
 
           switch (action) {
           case PUT:
-            writeOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
+            handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
             break;
 
           case DELETE:
-            deleteOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
+            handleDeleteDirEvent(updatedDirectoryInfo, nsSummaryMap);
             break;
 
           case UPDATE:
             if (oldDirectoryInfo != null) {
               // delete first, then put
-              deleteOmDirectoryInfoOnNamespaceDB(oldDirectoryInfo);
+              handleDeleteDirEvent(oldDirectoryInfo, nsSummaryMap);
             } else {
               LOG.warn("Update event does not have the old dirInfo for {}.",
                       updatedKey);
             }
-            writeOmDirectoryInfoOnNamespaceDB(updatedDirectoryInfo);
+            handlePutDirEvent(updatedDirectoryInfo, nsSummaryMap);
             break;
 
           default:
@@ -166,12 +170,21 @@ public class NSSummaryTask implements ReconOmTask {
         return new ImmutablePair<>(getTaskName(), false);
       }
     }
+
+    try {
+      writeNSSummariesToDB(nsSummaryMap);
+    } catch (IOException e) {
+      LOG.error("Unable to write Namespace Summary data in Recon DB.", e);
+      return new ImmutablePair<>(getTaskName(), false);
+    }
+
     LOG.info("Completed a process run of NSSummaryTask");
     return new ImmutablePair<>(getTaskName(), true);
   }
 
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    Map<Long, NSSummary> nsSummaryMap = new HashMap<>();
 
     try {
       // reinit Recon RocksDB's namespace CF.
@@ -184,7 +197,7 @@ public class NSSummaryTask implements ReconOmTask {
       while (dirTableIter.hasNext()) {
         Table.KeyValue<String, OmDirectoryInfo> kv = dirTableIter.next();
         OmDirectoryInfo directoryInfo = kv.getValue();
-        writeOmDirectoryInfoOnNamespaceDB(directoryInfo);
+        handlePutDirEvent(directoryInfo, nsSummaryMap);
       }
 
       // Get fileTable used by FSO
@@ -196,7 +209,7 @@ public class NSSummaryTask implements ReconOmTask {
       while (keyTableIter.hasNext()) {
         Table.KeyValue<String, OmKeyInfo> kv = keyTableIter.next();
         OmKeyInfo keyInfo = kv.getValue();
-        writeOmKeyInfoOnNamespaceDB(keyInfo);
+        handlePutKeyEvent(keyInfo, nsSummaryMap);
       }
 
     } catch (IOException ioEx) {
@@ -205,15 +218,38 @@ public class NSSummaryTask implements ReconOmTask {
       return new ImmutablePair<>(getTaskName(), false);
     }
 
+    try {
+      writeNSSummariesToDB(nsSummaryMap);
+    } catch (IOException e) {
+      LOG.error("Unable to write Namespace Summary data in Recon DB.", e);
+      return new ImmutablePair<>(getTaskName(), false);
+    }
     LOG.info("Completed a reprocess run of NSSummaryTask");
     return new ImmutablePair<>(getTaskName(), true);
   }
 
-  private void writeOmKeyInfoOnNamespaceDB(OmKeyInfo keyInfo)
-          throws IOException {
+  private void writeNSSummariesToDB(Map<Long, NSSummary> nsSummaryMap)
+      throws IOException {
+    RDBBatchOperation rdbBatchOperation = new RDBBatchOperation();
+    nsSummaryMap.keySet().forEach((Long key) -> {
+      try {
+        reconNamespaceSummaryManager.batchStoreNSSummaries(rdbBatchOperation,
+            key, nsSummaryMap.get(key));
+      } catch (IOException e) {
+        LOG.error("Unable to write Namespace Summary data in Recon DB.",
+            e);
+      }
+    });
+    reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
+  }
+
+  private void handlePutKeyEvent(OmKeyInfo keyInfo, Map<Long,
+      NSSummary> nsSummaryMap) throws IOException {
     long parentObjectId = keyInfo.getParentObjectID();
-    NSSummary nsSummary = reconNamespaceSummaryManager
-            .getNSSummary(parentObjectId);
+    NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
+    if (nsSummary == null) {
+      nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    }
     if (nsSummary == null) {
       nsSummary = new NSSummary();
     }
@@ -227,38 +263,46 @@ public class NSSummaryTask implements ReconOmTask {
 
     ++fileBucket[binIndex];
     nsSummary.setFileSizeBucket(fileBucket);
-    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+    nsSummaryMap.put(parentObjectId, nsSummary);
   }
 
-  private void writeOmDirectoryInfoOnNamespaceDB(OmDirectoryInfo directoryInfo)
+  private void handlePutDirEvent(OmDirectoryInfo directoryInfo,
+                                 Map<Long, NSSummary> nsSummaryMap)
           throws IOException {
     long parentObjectId = directoryInfo.getParentObjectID();
     long objectId = directoryInfo.getObjectID();
     // write the dir name to the current directory
     String dirName = directoryInfo.getName();
-    NSSummary curNSSummary =
-            reconNamespaceSummaryManager.getNSSummary(objectId);
+    NSSummary curNSSummary = nsSummaryMap.get(objectId);
+    if (curNSSummary == null) {
+      curNSSummary = reconNamespaceSummaryManager.getNSSummary(objectId);
+    }
     if (curNSSummary == null) {
       curNSSummary = new NSSummary();
     }
     curNSSummary.setDirName(dirName);
-    reconNamespaceSummaryManager.storeNSSummary(objectId, curNSSummary);
+    nsSummaryMap.put(objectId, curNSSummary);
 
     // write the child dir list to the parent directory
-    NSSummary nsSummary = reconNamespaceSummaryManager
-            .getNSSummary(parentObjectId);
+    NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
+    if (nsSummary == null) {
+      nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    }
     if (nsSummary == null) {
       nsSummary = new NSSummary();
     }
     nsSummary.addChildDir(objectId);
-    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+    nsSummaryMap.put(parentObjectId, nsSummary);
   }
 
-  private void deleteOmKeyInfoOnNamespaceDB(OmKeyInfo keyInfo)
+  private void handleDeleteKeyEvent(OmKeyInfo keyInfo,
+                                    Map<Long, NSSummary> nsSummaryMap)
           throws IOException {
     long parentObjectId = keyInfo.getParentObjectID();
-    NSSummary nsSummary = reconNamespaceSummaryManager
-            .getNSSummary(parentObjectId);
+    NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
+    if (nsSummary == null) {
+      nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    }
 
     // Just in case the OmKeyInfo isn't correctly written.
     if (nsSummary == null) {
@@ -279,15 +323,18 @@ public class NSSummaryTask implements ReconOmTask {
     nsSummary.setSizeOfFiles(sizeOfFile - dataSize);
     --fileBucket[binIndex];
     nsSummary.setFileSizeBucket(fileBucket);
-    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+    nsSummaryMap.put(parentObjectId, nsSummary);
   }
 
-  private void deleteOmDirectoryInfoOnNamespaceDB(OmDirectoryInfo directoryInfo)
+  private void handleDeleteDirEvent(OmDirectoryInfo directoryInfo,
+                                    Map<Long, NSSummary> nsSummaryMap)
           throws IOException {
     long parentObjectId = directoryInfo.getParentObjectID();
     long objectId = directoryInfo.getObjectID();
-    NSSummary nsSummary = reconNamespaceSummaryManager
-            .getNSSummary(parentObjectId);
+    NSSummary nsSummary = nsSummaryMap.get(parentObjectId);
+    if (nsSummary == null) {
+      nsSummary = reconNamespaceSummaryManager.getNSSummary(parentObjectId);
+    }
 
     // Just in case the OmDirectoryInfo isn't correctly written.
     if (nsSummary == null) {
@@ -296,7 +343,7 @@ public class NSSummaryTask implements ReconOmTask {
     }
 
     nsSummary.removeChildDir(objectId);
-    reconNamespaceSummaryManager.storeNSSummary(parentObjectId, nsSummary);
+    nsSummaryMap.put(parentObjectId, nsSummary);
   }
 }
 

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/tasks/TableCountTask.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
-import org.apache.hadoop.ozone.recon.ReconUtils;
 import org.apache.hadoop.ozone.recon.recovery.ReconOMMetadataManager;
 import org.hadoop.ozone.recon.schema.tables.daos.GlobalStatsDao;
 import org.hadoop.ozone.recon.schema.tables.pojos.GlobalStats;
@@ -33,11 +32,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+
+import static org.jooq.impl.DSL.currentTimestamp;
+import static org.jooq.impl.DSL.select;
+import static org.jooq.impl.DSL.using;
 
 /**
  * Class to iterate over the OM DB and store the total counts of volumes,
@@ -69,18 +75,18 @@ public class TableCountTask implements ReconOmTask {
    */
   @Override
   public Pair<String, Boolean> reprocess(OMMetadataManager omMetadataManager) {
+    HashMap<String, Long> objectCountMap = initializeCountMap();
     for (String tableName : getTaskTables()) {
       Table table = omMetadataManager.getTable(tableName);
       try (TableIterator keyIter = table.iterator()) {
         long count = getCount(keyIter);
-        ReconUtils.upsertGlobalStatsTable(sqlConfiguration, globalStatsDao,
-            getRowKeyFromTable(tableName),
-            count);
+        objectCountMap.put(getRowKeyFromTable(tableName), count);
       } catch (IOException ioEx) {
         LOG.error("Unable to populate Table Count in Recon DB.", ioEx);
         return new ImmutablePair<>(getTaskName(), false);
       }
     }
+    writeCountsToDB(objectCountMap);
     LOG.info("Completed a 'reprocess' run of TableCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
   }
@@ -149,14 +155,33 @@ public class TableCountTask implements ReconOmTask {
         return new ImmutablePair<>(getTaskName(), false);
       }
     }
-    for (Entry<String, Long> entry: objectCountMap.entrySet()) {
-      ReconUtils.upsertGlobalStatsTable(sqlConfiguration, globalStatsDao,
-          entry.getKey(),
-          entry.getValue());
-    }
+    writeCountsToDB(objectCountMap);
 
     LOG.info("Completed a 'process' run of TableCountTask.");
     return new ImmutablePair<>(getTaskName(), true);
+  }
+
+  private void writeCountsToDB(Map<String, Long> objectCountMap) {
+    List<GlobalStats> insertGlobalStats = new ArrayList<>();
+    List<GlobalStats> updateGlobalStats = new ArrayList<>();
+
+    for (Entry<String, Long> entry: objectCountMap.entrySet()) {
+      Timestamp now =
+          using(sqlConfiguration).fetchValue(select(currentTimestamp()));
+      GlobalStats record = globalStatsDao.fetchOneByKey(entry.getKey());
+      GlobalStats newRecord
+          = new GlobalStats(entry.getKey(), entry.getValue(), now);
+
+      // Insert a new record for key if it does not exist
+      if (record == null) {
+        insertGlobalStats.add(newRecord);
+      } else {
+        updateGlobalStats.add(newRecord);
+      }
+    }
+
+    globalStatsDao.insert(insertGlobalStats);
+    globalStatsDao.update(updateGlobalStats);
   }
 
   private HashMap<String, Long> initializeCountMap() {

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/spi/impl/TestReconNamespaceSummaryManagerImpl.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.recon.spi.impl;
 
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.recon.ReconTestInjector;
 import org.apache.hadoop.ozone.recon.api.types.NSSummary;
 import org.junit.Assert;
@@ -104,9 +105,11 @@ public class TestReconNamespaceSummaryManagerImpl {
     hmap.put(1L, new NSSummary(1, 2, testBucket, TEST_CHILD_DIR, "dir1"));
     hmap.put(2L, new NSSummary(3, 4, testBucket, TEST_CHILD_DIR, "dir2"));
     hmap.put(3L, new NSSummary(5, 6, testBucket, TEST_CHILD_DIR, "dir3"));
+    RDBBatchOperation rdbBatchOperation = new RDBBatchOperation();
     for (Map.Entry entry: hmap.entrySet()) {
-      reconNamespaceSummaryManager.storeNSSummary(
+      reconNamespaceSummaryManager.batchStoreNSSummaries(rdbBatchOperation,
               (long)entry.getKey(), (NSSummary)entry.getValue());
     }
+    reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/tasks/TestNSSummaryTask.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.ozone.recon.tasks;
 
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.RDBBatchOperation;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
@@ -136,7 +137,10 @@ public class TestNSSummaryTask {
 
     // write a NSSummary prior to reprocess and verify it got cleaned up after.
     NSSummary staleNSSummary = new NSSummary();
-    reconNamespaceSummaryManager.storeNSSummary(-1L, staleNSSummary);
+    RDBBatchOperation rdbBatchOperation = new RDBBatchOperation();
+    reconNamespaceSummaryManager.batchStoreNSSummaries(rdbBatchOperation, -1L,
+        staleNSSummary);
+    reconNamespaceSummaryManager.commitBatchOperation(rdbBatchOperation);
     NSSummaryTask nsSummaryTask = new NSSummaryTask(
             reconNamespaceSummaryManager);
     nsSummaryTask.reprocess(reconOMMetadataManager);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Each Recon task after processing the recent events committed the changes one by one into their databases. We want to have Recon to be resilient against failure between updates to OM copy DB and post processing task. To handle this problem, at first I changed that each task commits the changes in one batch, so we either have all the changes committed or none. After this change I will be able to have the last committed sequence number for each task and I can resend the events again in case of a failure. 

Two tasks are writing into RocksDB (ContainerKeyMapperTask and NSSummaryTask), in those cases I write every change in one batch. The other two tasks (FileSizeCountTask and TableCountTask) are using jOOQ generated DAO classes to handle their databases. With that I didn't find upsert query or anything similar, so I batched the updates and insert separately. This could be improved in the future, but for now this to cause a problem is an event with a small probability of occurrence.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6783

## How was this patch tested?

Existing tests related to the Recon tasks.
