### PR TITLE
HDDS-6819. Add LEGACY to AllowedBucketLayouts in CreateBucketHandler

### DIFF
--- a/hadoop-hdds/docs/content/feature/PrefixFSO.md
+++ b/hadoop-hdds/docs/content/feature/PrefixFSO.md
@@ -66,7 +66,7 @@ Following picture describes the OM metadata changes while performing a rename
 
 The following configuration can be configured in `ozone-site.xml` to define the default value for bucket layout during bucket creation
 if the client has not specified the bucket layout argument.
-Supported values are `OBJECT_STORE` and `FILE_SYSTEM_OPTIMIZED`.
+Supported values are `OBJECT_STORE`, `FILE_SYSTEM_OPTIMIZED` and `LEGACY`.
 
 By default, this config value is empty. Ozone will default to `LEGACY` bucket layout if it finds an empty config value.
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -1088,4 +1088,38 @@ public class TestOzoneShellHA {
     testVolumes.forEach(vol -> execute(ozoneShell, new String[] {
         "volume", "delete", vol}));
   }
+
+  @Test
+  public void testClientBucketLayoutValidation() {
+    String volName = "/vol-" + UUID.randomUUID();
+    String[] args =
+        new String[]{"volume", "create", "o3://" + omServiceId + volName};
+    execute(ozoneShell, args);
+
+    args = new String[]{
+        "bucket", "create", "o3://" + omServiceId + volName + "/buck-1",
+        "--layout", ""
+    };
+    try {
+      execute(ozoneShell, args);
+      Assert.fail("Should throw exception on unsupported bucket layouts!");
+    } catch (Exception e) {
+      GenericTestUtils.assertExceptionContains(
+          "expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] ",
+          e);
+    }
+
+    args = new String[]{
+        "bucket", "create", "o3://" + omServiceId + volName + "/buck-2",
+        "--layout", "INVALID"
+    };
+    try {
+      execute(ozoneShell, args);
+      Assert.fail("Should throw exception on unsupported bucket layouts!");
+    } catch (Exception e) {
+      GenericTestUtils.assertExceptionContains(
+          "expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] ",
+          e);
+    }
+  }
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -62,7 +62,7 @@ public class CreateBucketHandler extends BucketHandler {
   enum AllowedBucketLayouts {
     FILE_SYSTEM_OPTIMIZED("FILE_SYSTEM_OPTIMIZED"),
     OBJECT_STORE("OBJECT_STORE"),
-    DEFAULT("");
+    LEGACY("LEGACY");
 
     // Assigning a value to each enum
     private final String layout;
@@ -79,8 +79,7 @@ public class CreateBucketHandler extends BucketHandler {
   }
 
   @Option(names = { "--layout", "-l" },
-      description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}",
-      defaultValue = "")
+      description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}")
   private AllowedBucketLayouts allowedBucketLayout;
 
   @CommandLine.Mixin
@@ -100,12 +99,14 @@ public class CreateBucketHandler extends BucketHandler {
       ownerName = UserGroupInformation.getCurrentUser().getShortUserName();
     }
 
-    BucketArgs.Builder bb;
-    BucketLayout bucketLayout =
-        BucketLayout.fromString(allowedBucketLayout.toString());
-    bb = new BucketArgs.Builder().setStorageType(StorageType.DEFAULT)
-        .setVersioning(false).setBucketLayout(bucketLayout)
-        .setOwner(ownerName);
+    BucketArgs.Builder bb =
+        new BucketArgs.Builder().setStorageType(StorageType.DEFAULT)
+            .setVersioning(false).setOwner(ownerName);
+    if (allowedBucketLayout != null) {
+      BucketLayout bucketLayout =
+          BucketLayout.fromString(allowedBucketLayout.toString());
+      bb.setBucketLayout(bucketLayout);
+    }
     // TODO: New Client talking to old server, will it create a LEGACY bucket?
 
     if (isGdprEnforced != null) {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java
@@ -59,24 +59,7 @@ public class CreateBucketHandler extends BucketHandler {
               " user if not specified")
   private String ownerName;
 
-  enum AllowedBucketLayouts {
-    FILE_SYSTEM_OPTIMIZED("FILE_SYSTEM_OPTIMIZED"),
-    OBJECT_STORE("OBJECT_STORE"),
-    LEGACY("LEGACY");
-
-    // Assigning a value to each enum
-    private final String layout;
-    AllowedBucketLayouts(String layout) {
-      this.layout = layout;
-    }
-
-    // Overriding toString() method to return the value passed to the
-    // constructor.
-    @Override
-    public String toString() {
-      return this.layout;
-    }
-  }
+  enum AllowedBucketLayouts { FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY }
 
   @Option(names = { "--layout", "-l" },
       description = "Allowed Bucket Layouts: ${COMPLETION-CANDIDATES}")


### PR DESCRIPTION
## What changes were proposed in this pull request?

This task is to add `LEGACY` to `AllowedBucketLayouts` in the `CreateBucketHandler` class.

[CreateBucketHandler.java#L65](https://github.com/apache/ozone/blob/master/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/bucket/CreateBucketHandler.java#L65)

```
enum AllowedBucketLayouts {
    FILE_SYSTEM_OPTIMIZED("FILE_SYSTEM_OPTIMIZED"),
    OBJECT_STORE("OBJECT_STORE"),
    LEGACY("LEGACY")
```

While executing the `ozone sh bucket create` command and passing an `INVALID` bucket layout, we currently get the following error message:
```
Invalid value for option '--layout': expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, DEFAULT, ] (case-sensitive) but was 'INVALID'
```

After the changes, this would be modified to:
```
Invalid value for option '--layout': expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] (case-sensitive) but was 'INVALID'
```

Similarly, `ozone sh bucket create --help` gives the following description for `"-l"`, `"--layout"`:
```
-l, --layout=<allowedBucketLayout>
                           Allowed Bucket Layouts: FILE_SYSTEM_OPTIMIZED,
                           OBJECT_STORE,
```

After the changes, this would be modified to:
```
-l, --layout=<allowedBucketLayout>
                           Allowed Bucket Layouts: FILE_SYSTEM_OPTIMIZED,
                           OBJECT_STORE, LEGACY
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6819

## How was this patch tested?

Added integration tests.
