### PR TITLE
HDDS-6828 Revert RockDB version pending leak fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1640,7 +1640,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>7.2.2</version>
+        <version>6.29.5</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Revert the upgrade of RocksDB across a major version bump
This is to avoid memory leaks due to lack of close for
RocksObject inherited objects.

The upgrade should be done only once the leaks have been fixed.
Without the leak fix, the newer version of RocksDB makes it impossible
to run any long-running load.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6828


## How was this patch tested?

This is the older release train. I ran a basic build and waiting for CI run.