### PR TITLE
HDDS-6823. Intermittent failure in TestOzoneECClient#testExcludeOnDNMixed

### DIFF
--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -848,12 +848,16 @@ public class TestOzoneECClient {
         dataBlocks, parityBlocks, ECReplicationConfig.EcCodec.RS, chunkSize);
 
     try (OzoneOutputStream out = bucket.createKey(keyName,
-        (long) dataBlocks * chunkSize, repConfig, new HashMap<>())) {
+        2L * dataBlocks * chunkSize, repConfig, new HashMap<>())) {
 
       Assert.assertTrue(out.getOutputStream() instanceof ECKeyOutputStream);
       ECKeyOutputStream ecKeyOut = (ECKeyOutputStream) out.getOutputStream();
 
       List<HddsProtos.DatanodeDetailsProto> dns = blkAllocator.getClusterDns();
+
+      for (int i = 0; i < dataBlocks; i++) {
+        out.write(inputChunks[i % dataBlocks]);
+      }
 
       // Then let's mark datanodes with closed container
       List<DatanodeDetails> closedDNs = closedDNIndex


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix intermittent failure in TestOzoneECClient#testExcludeOnDNMixed.

https://github.com/apache/ozone/runs/6701276416?check_suite_focus=true

## What is the link to the Apache JIRA

HDDS-6823

## How was this patch tested?

Tested manually by repeating the test 100x in `for` loop.
And also tested with all other tests in TestOzoneECClient.