### PR TITLE
HDDS-6706 Exposing Volume Information Metrics to the DataNode UI

### DIFF
--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -15,7 +15,7 @@
    limitations under the License.
 -->
 <html>
-<head><title>DataNode Hai yee</title></head>
+<head><title>DataNode UI</title></head>
 <body>
 <table class="table table-bordered table-striped" class="col-md-6">
     <tbody>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -14,7 +14,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
 -->
-
+<html>
+<head><title>DataNode Hai yee</title></head>
+<body>
 <table class="table table-bordered table-striped" class="col-md-6">
     <tbody>
     </tbody>
@@ -34,7 +36,6 @@
     </tr>
     </thead>
     <tbody>
-    <p>{{$info}}</p>
     <tr ng-repeat="volumeInfo in $ctrl.dnmetrics">
         <td>{{volumeInfo["tag.StorageDirectory"]}}</td>
         <td>{{volumeInfo["tag.StorageType"]}}</td>
@@ -46,3 +47,5 @@
     </tr>
     </tbody>
 </table>
+</body>
+</html>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -19,3 +19,30 @@
     <tbody>
     </tbody>
 </table>
+
+<h2>Volume Information</h2>
+<table class="table table-bordered table-striped" class="col-md-6">
+    <thead>
+    <tr>
+        <th>Directory</th>
+        <th>Storage Type</th>
+        <th>Volume Type</th>
+        <th>Used Space</th>
+        <th>Available Space</th>
+        <th>Reserved</th>
+        <th>Total Capacity</th>
+    </tr>
+    </thead>
+    <tbody>
+    <p>{{$info}}</p>
+    <tr ng-repeat="volumeInfo in $ctrl.dnmetrics">
+        <td>{{volumeInfo["tag.StorageDirectory"]}}</td>
+        <td>{{volumeInfo["tag.StorageType"]}}</td>
+        <td>{{volumeInfo["tag.VolumeType"]}}</td>
+        <td>{{volumeInfo.Used}}</td>
+        <td>{{volumeInfo.Available}}</td>
+        <td>{{volumeInfo.Reserved}}</td>
+        <td>{{volumeInfo.TotalCapacity}}</td>
+    </tr>
+    </tbody>
+</table>

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
@@ -29,7 +29,27 @@
             $http.get("jmx?qry=Hadoop:service=HddsDatanode,name=VolumeInfoMetrics*")
                 .then(function (result) {
                     ctrl.dnmetrics = result.data.beans;
+                    ctrl.dnmetrics.forEach(volume => {
+                 volume.Used = transform(volume.Used);
+                 volume.Available = transform(volume.Available);
+                 volume.Reserved = transform(volume.Reserved);
+                 volume.TotalCapacity = transform(volume.TotalCapacity);
+                })
                 });
         }
     });
+        function transform(v) {
+          var UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'ZB'];
+          var prev = 0, i = 0;
+          while (Math.floor(v) > 0 && i < UNITS.length) {
+            prev = v;
+            v /= 1024;
+            i += 1;
+          }
+          if (i > 0 && i < UNITS.length) {
+            v = prev;
+            i -= 1;
+          }
+          return Math.round(v * 100) / 100 + ' ' + UNITS[i];
+        }
 })();

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn.js
@@ -26,9 +26,9 @@
         },
         controller: function ($http) {
             var ctrl = this;
-            $http.get("jmx?qry=Hadoop:service=HddsDatanode,name=StorageContainerMetrics")
+            $http.get("jmx?qry=Hadoop:service=HddsDatanode,name=VolumeInfoMetrics*")
                 .then(function (result) {
-                    ctrl.dnmetrics = result.data.beans[0];
+                    ctrl.dnmetrics = result.data.beans;
                 });
         }
     });


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the patch [https://github.com/apache/ozone/pull/3430](url) got merged, I have decided to display some of the newly added metrics on to the DataNode web UI, in the form of a table. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6706

## How was this patch tested?

After opening the DataNode UI the correct Storage related information of the various volumes associated to the DataNode were displaced 


![UI Final](https://user-images.githubusercontent.com/98023601/171870786-2109bd8f-7ec8-4cbc-8032-34a73a480908.png)


