### PR TITLE
HDDS-6811. Bucket create message with layout type

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -101,6 +101,7 @@ import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.BucketEncryptionKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.DeleteTenantState;
 import org.apache.hadoop.ozone.om.helpers.OmBucketArgs;
@@ -625,6 +626,7 @@ public class RpcClient implements ClientProtocol {
         Boolean.FALSE : bucketArgs.getVersioning();
     StorageType storageType = bucketArgs.getStorageType() == null ?
         StorageType.DEFAULT : bucketArgs.getStorageType();
+    BucketLayout bucketLayout = bucketArgs.getBucketLayout();
     BucketEncryptionKeyInfo bek = null;
     if (bucketArgs.getEncryptionKey() != null) {
       bek = new BucketEncryptionKeyInfo.Builder()
@@ -648,7 +650,7 @@ public class RpcClient implements ClientProtocol {
         .setQuotaInBytes(bucketArgs.getQuotaInBytes())
         .setQuotaInNamespace(bucketArgs.getQuotaInNamespace())
         .setAcls(listOfAcls.stream().distinct().collect(Collectors.toList()))
-        .setBucketLayout(bucketArgs.getBucketLayout())
+        .setBucketLayout(bucketLayout)
         .setOwner(owner);
 
     if (bek != null) {
@@ -661,9 +663,10 @@ public class RpcClient implements ClientProtocol {
       builder.setDefaultReplicationConfig(defaultReplicationConfig);
     }
 
-    LOG.info("Creating Bucket: {}/{}, with {} as owner and Versioning {} and " +
-        "Storage Type set to {} and Encryption set to {} ",
-        volumeName, bucketName, owner, isVersionEnabled,
+    LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {}, {} as " +
+            "owner, Versioning {}, Storage Type set to {} and Encryption set " +
+            "to {} ",
+        volumeName, bucketName, bucketLayout, owner, isVersionEnabled,
         storageType, bek != null);
     ozoneManagerClient.createBucket(builder.build());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The `ozone sh bucket create` command throws an `INFO` message with Storage Type/Encryption and a few other details.

```
[root@quasar-wzsrji-4 ~]# ozone sh bucket create test/obs --layout=OBJECT_STORE
22/05/25 19:02:21 INFO rpc.RpcClient: Creating Bucket: test/obs, with om as owner and Versioning false and Storage Type set to DISK and Encryption set to false
```
It is good to have the bucket layout information as well in the `INFO` message.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6811

## How was this patch tested?

NA
