### PR TITLE
HDDS-6489 : Unit test to check cleanup tables for each OM response

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
@@ -54,7 +54,7 @@ public class OMAllocateBlockResponseWithFSO extends OMAllocateBlockResponse {
   }
 
   @Override
-  public void addToDBBatch(OMMetadataManager omMetadataManager,
+    public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
     OMFileRequest.addToOpenFileTable(omMetadataManager, batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/tenant/OMTenantCreateResponse.java
@@ -32,6 +32,7 @@ import javax.annotation.Nonnull;
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.TENANT_STATE_TABLE;
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.USER_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
 /**
@@ -39,7 +40,8 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
  */
 @CleanupTableInfo(cleanupTables = {
     TENANT_STATE_TABLE,
-    VOLUME_TABLE
+    VOLUME_TABLE,
+    USER_TABLE
 })
 public class OMTenantCreateResponse extends OMClientResponse {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeCreateResponse.java
@@ -34,12 +34,13 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.USER_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
 /**
  * Response for CreateVolume request.
  */
-@CleanupTableInfo(cleanupTables = VOLUME_TABLE)
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE, USER_TABLE})
 public class OMVolumeCreateResponse extends OMClientResponse {
 
   private PersistedUserVolumeInfo userVolumeInfo;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -37,7 +37,7 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 /**
  * Response for DeleteVolume request.
  */
-@CleanupTableInfo(cleanupTables = {VOLUME_TABLE,USER_TABLE})
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE, USER_TABLE})
 public class OMVolumeDeleteResponse extends OMClientResponse {
   private String volume;
   private String owner;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeDeleteResponse.java
@@ -31,12 +31,13 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.USER_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
 /**
  * Response for DeleteVolume request.
  */
-@CleanupTableInfo(cleanupTables = {VOLUME_TABLE})
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE,USER_TABLE})
 public class OMVolumeDeleteResponse extends OMClientResponse {
   private String volume;
   private String owner;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -34,12 +34,13 @@ import org.apache.hadoop.hdds.utils.db.BatchOperation;
 
 import javax.annotation.Nonnull;
 
+import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.USER_TABLE;
 import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 
 /**
  * Response for set owner request.
  */
-@CleanupTableInfo(cleanupTables = {VOLUME_TABLE})
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE,USER_TABLE})
 public class OMVolumeSetOwnerResponse extends OMClientResponse {
   private String oldOwner;
   private PersistedUserVolumeInfo oldOwnerVolumeList;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/volume/OMVolumeSetOwnerResponse.java
@@ -40,7 +40,7 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.VOLUME_TABLE;
 /**
  * Response for set owner request.
  */
-@CleanupTableInfo(cleanupTables = {VOLUME_TABLE,USER_TABLE})
+@CleanupTableInfo(cleanupTables = {VOLUME_TABLE, USER_TABLE})
 public class OMVolumeSetOwnerResponse extends OMClientResponse {
   private String oldOwner;
   private PersistedUserVolumeInfo oldOwnerVolumeList;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.ozone.om.response;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Maps;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -29,8 +28,6 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.DatanodeDetailsProto;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos.Pipeline;
 import org.apache.hadoop.hdds.server.ServerUtils;
-import org.apache.hadoop.hdds.utils.db.BatchOperation;
-import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.audit.AuditLogger;
@@ -39,7 +36,6 @@ import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ResolvedBucket;
-import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmVolumeArgs;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
@@ -49,15 +45,12 @@ import org.apache.hadoop.ozone.om.request.key.OMKeyCreateRequest;
 import org.apache.hadoop.ozone.om.response.file.OMFileCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.OMKeyCreateResponse;
 import org.apache.hadoop.ozone.om.response.key.OmKeyResponse;
-import org.apache.hadoop.ozone.om.response.s3.security.S3GetSecretResponse;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateFileRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.CreateKeyRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyLocation;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
-import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -65,28 +58,18 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.mockito.stubbing.Answer;
 import org.reflections.Reflections;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -123,7 +106,6 @@ public class TestCleanupTableInfo {
   private OzoneManagerDoubleBufferHelper dbh;
 
   private OzoneManager om;
-  private BatchOperation batchOperation;
 
   /**
    * Creates a mock Ozone Manager object.
@@ -158,7 +140,6 @@ public class TestCleanupTableInfo {
         .getDefault(new OzoneConfiguration()));
     addVolumeToMetaTable(aVolumeArgs());
     addBucketToMetaTable(aBucketInfo());
-    batchOperation = metaMgr.getStore().initBatchOperation();
   }
 
   @Test
@@ -186,259 +167,12 @@ public class TestCleanupTableInfo {
       }
     });
   }
-  private void mockTables(OMMetadataManager omMetadataManager,
-                          Set<String> updatedTables,
-                          boolean isFSO)
-      throws IOException, IllegalAccessException {
-    Map<String, Table> tableMap = omMetadataManager.listTables();
-    Map<Table, Table> mockedTableMap = new HashMap<>();
-    List<String> tables = new ArrayList<>(tableMap.keySet());
-    for (String table:tables) {
-      Table mockedTable = Mockito.spy(tableMap.get(table));
-      Answer answer = new Answer() {
-        @Override
-        public Object answer(InvocationOnMock invocationOnMock) {
-          String t = table;
-          if (isFSO) {
-            if (table.equals(OmMetadataManagerImpl.OPEN_KEY_TABLE)) {
-              t = OmMetadataManagerImpl.OPEN_FILE_TABLE;
-            }
-            if (table.equals(OmMetadataManagerImpl.KEY_TABLE)) {
-              t = OmMetadataManagerImpl.FILE_TABLE;
-            }
-          } else {
-            if (table.equals(OmMetadataManagerImpl.OPEN_FILE_TABLE)) {
-              t = OmMetadataManagerImpl.OPEN_KEY_TABLE;
-            }
-            if (table.equals(OmMetadataManagerImpl.FILE_TABLE)) {
-              t = OmMetadataManagerImpl.KEY_TABLE;
-            }
-          }
-          updatedTables.add(t);
-          return null;
-        }
-      };
-      Mockito.doAnswer(answer).when(mockedTable).put(any(), any());
-      Mockito.doAnswer(answer).when(mockedTable)
-          .putWithBatch(any(), any(), any());
-      Mockito.doAnswer(answer).when(mockedTable).delete(any());
-      Mockito.doAnswer(answer).when(mockedTable).deleteWithBatch(any(), any());
-      mockedTableMap.put(tableMap.get(table), mockedTable);
-      tableMap.put(table, mockedTable);
-    }
-    for (Field f:omMetadataManager.getClass().getDeclaredFields()) {
-      boolean isAccessible = f.isAccessible();
-      f.setAccessible(true);
-      try {
-        if (Table.class.isAssignableFrom(f.getType())) {
-          f.set(omMetadataManager,
-              mockedTableMap.getOrDefault(f.get(omMetadataManager),
-              (Table)f.get(omMetadataManager)));
-        }
-      } finally {
-        f.setAccessible(isAccessible);
-      }
-    }
-  }
-  private <T> T getMockObject(Class<T> type,
-                              Map<Class, Object> instanceMap,
-                              Status status,
-                              boolean isFSO) {
-    T instance =  Mockito.mock(type, invocationOnMock -> {
-      try {
-        return createInstance(invocationOnMock.getMethod().getReturnType(),
-            instanceMap, status, isFSO);
-      } catch (Throwable e) {
-        throw new RuntimeException(e);
-      }
-    });
-    instanceMap.put(type, instance);
-    return instance;
-  }
-  private List<Field> getFields(Class<?> type) {
-    List<Field> fields = new ArrayList<>();
-    while (type != Object.class) {
-      fields.addAll(Arrays.asList(type.getDeclaredFields()));
-      type = type.getSuperclass();
-    }
-    return fields;
-  }
-  private Object createInstance(Class<?> type,
-                                Map<Class, Object> instanceMap,
-                                Status status, boolean isFSO) {
-    if (instanceMap.containsKey(type)) {
-      return instanceMap.get(type);
-    }
-    Object instance = null;
-    try {
-      if (type.isArray()) {
-        return Array.newInstance(type.getComponentType(), 0);
-      } else if (type.equals(Void.TYPE)) {
-        return null;
-      } else if (type.isPrimitive()) {
-        if (Boolean.TYPE.equals(type)) {
-          return true;
-        } else if (Character.TYPE.equals(type)) {
-          return 'a';
-        } else if (Byte.TYPE.equals(type)) {
-          return 0xFF;
-        } else if (Short.TYPE.equals(type)) {
-          return (short) 0;
-        } else if (Integer.TYPE.equals(type)) {
-          return 0;
-        } else if (Long.TYPE.equals(type)) {
-          return (long) 0;
-        } else if (Float.TYPE.equals(type)) {
-          return (float) 0.0;
-        } else if (Double.TYPE.equals(type)) {
-          return 0.0;
-        } else if (Void.TYPE.equals(type)) {
-          return null;
-        }
-        return type.getName().toLowerCase().contains("bool") ? true : 0;
-      } else if (type.equals(OzoneManagerProtocolProtos.OMResponse.class)) {
-        return OzoneManagerProtocolProtos.OMResponse.newBuilder()
-            .setStatus(status).buildPartial();
-      } else if (type.equals(BucketLayout.class)) {
-        return isFSO ? BucketLayout.FILE_SYSTEM_OPTIMIZED
-            : BucketLayout.DEFAULT;
-      } else if (type.isEnum()) {
-        return type.getDeclaredFields()[0].get(type);
-      } else if (type.equals(String.class)) {
-        return "testString";
-      } else if (Map.class.isAssignableFrom(type)) {
-        return type.isInterface() ? Collections.EMPTY_MAP : type.newInstance();
-      } else if (List.class.isAssignableFrom(type)) {
-        return type.isInterface() ? Collections.EMPTY_LIST : type.newInstance();
-      } else if (Set.class.isAssignableFrom(type)) {
-        return type.isInterface() ? Collections.EMPTY_SET : type.newInstance();
-      }
-      if (OMClientResponse.class.isAssignableFrom(type)) {
-        Constructor<?>[] constructors = type.getDeclaredConstructors();
-        for (Constructor c:constructors) {
-          boolean accessible  = c.isAccessible();
-          c.setAccessible(true);
-          try {
-            Class<?>[] params = c.getParameterTypes();
-            boolean flag = false;
-            for (Class<?> p:params) {
-              if (p.equals(type)) {
-                flag = true;
-                break;
-              }
-            }
-            if (flag) {
-              continue;
-            }
-            instance = c.newInstance(Arrays.stream(params).map(p -> {
-              return createInstance(p, instanceMap, status, isFSO);
-            }).toArray());
-            break;
-          } catch (Exception e) {
-          } finally {
-            c.setAccessible(accessible);
-          }
-        }
-        for (Field f:getFields(type)) {
-          boolean isAccessible = f.isAccessible();
-          f.setAccessible(true);
-          try {
-            Object fInstance = createInstance(f.getType(), instanceMap,
-                status, isFSO);
-            f.set(instance, fInstance);
-          } catch (Exception e) {
-          } finally {
-            f.setAccessible(isAccessible);
-          }
-        }
 
-      } else {
-        instance = getMockObject(type, instanceMap, status, isFSO);
-      }
-    } catch (Exception e) {
-      instanceMap.put(type, instance);
-    }
-    return instance;
-  }
-  private Status getExpectedStatusForResponseClass(
-      Class<? extends OMClientResponse> responseClass) {
-    Map<Class<? extends OMClientResponse>, Status> responseClassStatusMap
-        = new HashMap<>();
-    responseClassStatusMap.put(S3GetSecretResponse.class, Status.OK);
-    return responseClassStatusMap.getOrDefault(responseClass, Status.OK);
-  }
 
-  @Test
-  public void checkCleanupTablesWithTableNames()
-      throws IOException, IllegalAccessException {
-    checkCleanupTablesWithTableNames(true);
-    checkCleanupTablesWithTableNames(false);
-  }
-  private void checkCleanupTablesWithTableNames(boolean isFSO)
-      throws IOException, IllegalAccessException {
-    OMMetadataManager omMetadataManager = om.getMetadataManager();
-    Set<Class<? extends OMClientResponse>> subTypes = responseClasses();
-    subTypes = subTypes.stream()
-        .filter(c -> c.isAnnotationPresent(CleanupTableInfo.class))
-        .collect(Collectors.toSet());
-    Set<String> updatedTables = new HashSet<>();
-    mockTables(omMetadataManager, updatedTables, isFSO);
-
-    Map<Class, Object> instanceMap = Maps.newHashMap();
-    for (Class<? extends OMClientResponse> subType : subTypes) {
-      if (subType.isAnnotationPresent(CleanupTableInfo.class) &&
-          !Modifier.isAbstract(subType.getModifiers()) &&
-          Arrays.stream(subType.getDeclaredMethods())
-              .anyMatch(m -> m.getName().equals("addToDBBatch"))) {
-        try {
-          updatedTables.clear();
-          instanceMap.clear();
-          CleanupTableInfo cleanupTableInfo =
-              subType.getAnnotation(CleanupTableInfo.class);
-          OMClientResponse omClientResponse =
-              (OMClientResponse) createInstance(subType,
-              instanceMap, getExpectedStatusForResponseClass(subType), isFSO);
-          omClientResponse.addToDBBatch(om.getMetadataManager(),
-              batchOperation);
-          Set<String> tables = Arrays.stream(cleanupTableInfo.cleanupTables())
-              .collect(Collectors.toSet());
-          if (isFSO) {
-            if (tables.contains(OmMetadataManagerImpl.KEY_TABLE)) {
-              tables.remove(OmMetadataManagerImpl.KEY_TABLE);
-              tables.add(OmMetadataManagerImpl.FILE_TABLE);
-            }
-            if (tables.contains(OmMetadataManagerImpl.OPEN_KEY_TABLE)) {
-              tables.remove(OmMetadataManagerImpl.OPEN_KEY_TABLE);
-              tables.add(OmMetadataManagerImpl.OPEN_FILE_TABLE);
-            }
-          } else {
-            if (tables.contains(OmMetadataManagerImpl.FILE_TABLE)) {
-              tables.remove(OmMetadataManagerImpl.FILE_TABLE);
-              tables.add(OmMetadataManagerImpl.KEY_TABLE);
-            }
-            if (tables.contains(OmMetadataManagerImpl.OPEN_FILE_TABLE)) {
-              tables.remove(OmMetadataManagerImpl.OPEN_FILE_TABLE);
-              tables.add(OmMetadataManagerImpl.OPEN_KEY_TABLE);
-            }
-          }
-          for (String t:updatedTables) {
-            Assert.assertTrue(
-                String.format("Response Class: {} Tables for Cleanup: {},"
-                        + " Tables Actually Updated: {}",
-                    subType, tables, updatedTables), tables.contains(t));
-          }
-        } catch (Exception e) {
-        }
-      }
-    }
-    instanceMap.clear();
-  }
   private Set<Class<? extends OMClientResponse>> responseClasses() {
     Reflections reflections = new Reflections(OM_RESPONSE_PACKAGE);
     return reflections.getSubTypesOf(OMClientResponse.class);
   }
-
-
 
   @Test
   public void testFileCreateRequestSetsAllTouchedTableCachesForEviction() {
@@ -495,6 +229,7 @@ public class TestCleanupTableInfo {
       }
     }
   }
+
   /**
    * Adds the volume info to the volumeTable in the MetadataManager, and also
    * add the value to the table's cache.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -192,8 +192,8 @@ public class TestCleanupTableInfo {
       throws IOException, IllegalAccessException {
     Map<String, Table> tableMap = omMetadataManager.listTables();
     Map<Table, Table> mockedTableMap = new HashMap<>();
-
-    for (String table:tableMap.keySet()) {
+    List<String> tables = new ArrayList<>(tableMap.keySet());
+    for (String table:tables) {
       Table mockedTable = Mockito.spy(tableMap.get(table));
       Answer answer = new Answer() {
         @Override
@@ -243,7 +243,7 @@ public class TestCleanupTableInfo {
   private <T> T getMockObject(Class<T> type,
                               Map<Class, Object> instanceMap,
                               Status status,
-                              boolean isFSO) throws IOException {
+                              boolean isFSO) {
     T instance =  Mockito.mock(type, invocationOnMock -> {
       try {
         return createInstance(invocationOnMock.getMethod().getReturnType(),
@@ -422,7 +422,10 @@ public class TestCleanupTableInfo {
             }
           }
           for (String t:updatedTables) {
-            Assert.assertTrue(tables.contains(t));
+            Assert.assertTrue(
+                String.format("Response Class: {} Tables for Cleanup: {},"
+                        + " Tables Actually Updated: {}",
+                    subType, tables, updatedTables), tables.contains(t));
           }
         } catch (Exception e) {
         }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfoResponses.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfoResponses.java
@@ -1,0 +1,331 @@
+package org.apache.hadoop.ozone.om.response;
+
+import com.google.common.collect.Maps;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.fs.SaveSpaceUsageToFile;
+import org.apache.hadoop.hdds.scm.storage.RatisBlockOutputStream;
+import org.apache.hadoop.hdds.server.ServerUtils;
+import org.apache.hadoop.hdds.utils.db.BatchOperation;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.OMMetadataManager;
+import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.response.s3.security.S3GetSecretResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.hadoop.ozone.om.response.TestCleanupTableInfo.OM_RESPONSE_PACKAGE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TestCleanupTableInfoResponses{
+
+  private static final Logger LOG = LoggerFactory.getLogger(
+      RatisBlockOutputStream.class);
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  /**
+   * Creates a spy object over an instantiated OMMetadataManager, giving the
+   * possibility to redefine behaviour. In the current implementation
+   * there isn't any behaviour which is redefined.
+   *
+   * @return the OMMetadataManager spy instance created.
+   * @throws IOException if I/O error occurs in setting up data store for the
+   *                     metadata manager.
+   */
+  private OMMetadataManager createOMMetadataManagerSpy(File folder) throws IOException {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    File newFolder = folder;
+    if (!newFolder.exists()) {
+      Assert.assertTrue(newFolder.mkdirs());
+    }
+    ServerUtils.setOzoneMetaDirPath(conf, newFolder.toString());
+    return spy(new OmMetadataManagerImpl(conf));
+  }
+
+  private void mockTables(OMMetadataManager omMetadataManager,
+                          Set<String> updatedTables,
+                          boolean isFSO)
+      throws IOException, IllegalAccessException {
+    Map<String, Table> tableMap = omMetadataManager.listTables();
+    Map<Table, Table> mockedTableMap = new HashMap<>();
+    List<String> tables = new ArrayList<>(tableMap.keySet());
+    for (String table:tables) {
+      Table mockedTable = Mockito.spy(tableMap.get(table));
+      Answer answer = invocationOnMock -> {
+        String t = table;
+        if (isFSO) {
+          if (table.equals(OmMetadataManagerImpl.OPEN_KEY_TABLE)) {
+            t = OmMetadataManagerImpl.OPEN_FILE_TABLE;
+          }
+          if (table.equals(OmMetadataManagerImpl.KEY_TABLE)) {
+            t = OmMetadataManagerImpl.FILE_TABLE;
+          }
+        } else {
+          if (table.equals(OmMetadataManagerImpl.OPEN_FILE_TABLE)) {
+            t = OmMetadataManagerImpl.OPEN_KEY_TABLE;
+          }
+          if (table.equals(OmMetadataManagerImpl.FILE_TABLE)) {
+            t = OmMetadataManagerImpl.KEY_TABLE;
+          }
+        }
+        updatedTables.add(t);
+        return null;
+      };
+      Mockito.lenient().doAnswer(answer).when(mockedTable).put(any(), any());
+      Mockito.lenient().doAnswer(answer).when(mockedTable)
+          .putWithBatch(any(), any(), any());
+      Mockito.lenient().doAnswer(answer).when(mockedTable).delete(any());
+      Mockito.lenient().doAnswer(answer).when(mockedTable).deleteWithBatch(any(), any());
+      mockedTableMap.put(tableMap.get(table), mockedTable);
+      tableMap.put(table, mockedTable);
+    }
+    for (Field f:omMetadataManager.getClass().getDeclaredFields()) {
+      boolean isAccessible = f.isAccessible();
+      f.setAccessible(true);
+      try {
+        if (Table.class.isAssignableFrom(f.getType())) {
+          f.set(omMetadataManager,
+              mockedTableMap.getOrDefault(f.get(omMetadataManager),
+                  (Table)f.get(omMetadataManager)));
+        }
+      } finally {
+        f.setAccessible(isAccessible);
+      }
+    }
+  }
+  private <T> T getMockObject(Class<T> type,
+                              Map<Class, Object> instanceMap,
+                              OzoneManagerProtocolProtos.Status status,
+                              boolean isFSO) {
+    T instance =  Mockito.mock(type, invocationOnMock -> {
+      try {
+        return createInstance(invocationOnMock.getMethod().getReturnType(),
+            instanceMap, status, isFSO);
+      } catch (Throwable e) {
+        throw new RuntimeException(e);
+      }
+    });
+    instanceMap.put(type, instance);
+    return instance;
+  }
+  private List<Field> getFields(Class<?> type) {
+    List<Field> fields = new ArrayList<>();
+    while (type != Object.class) {
+      fields.addAll(Arrays.asList(type.getDeclaredFields()));
+      type = type.getSuperclass();
+    }
+    return fields;
+  }
+  private Object createInstance(Class<?> type,
+                                Map<Class, Object> instanceMap,
+                                OzoneManagerProtocolProtos.Status status, boolean isFSO) {
+    if (instanceMap.containsKey(type)) {
+      return instanceMap.get(type);
+    }
+    Object instance = null;
+    if (type.isArray()) {
+      return Array.newInstance(type.getComponentType(), 0);
+    } else if (type.equals(Void.TYPE)) {
+      return null;
+    } else if (type.isPrimitive()) {
+      if (Boolean.TYPE.equals(type)) {
+        return true;
+      } else if (Character.TYPE.equals(type)) {
+        return 'a';
+      } else if (Byte.TYPE.equals(type)) {
+        return 0xFF;
+      } else if (Short.TYPE.equals(type)) {
+        return (short) 0;
+      } else if (Integer.TYPE.equals(type)) {
+        return 0;
+      } else if (Long.TYPE.equals(type)) {
+        return (long) 0;
+      } else if (Float.TYPE.equals(type)) {
+        return (float) 0.0;
+      } else if (Double.TYPE.equals(type)) {
+        return 0.0;
+      } else if (Void.TYPE.equals(type)) {
+        return null;
+      }
+    } else if (type.equals(OzoneManagerProtocolProtos.OMResponse.class)) {
+      return OzoneManagerProtocolProtos.OMResponse.newBuilder()
+          .setStatus(status).buildPartial();
+    } else if (type.equals(BucketLayout.class)) {
+      return isFSO ? BucketLayout.FILE_SYSTEM_OPTIMIZED
+          : BucketLayout.DEFAULT;
+    }
+    try {
+      if (type.isEnum()) {
+        return type.getDeclaredFields()[0].get(type);
+      } else if (type.equals(String.class)) {
+        return "testString";
+      } else if (Map.class.isAssignableFrom(type)) {
+        return type.isInterface() ? Collections.EMPTY_MAP : type.newInstance();
+      } else if (List.class.isAssignableFrom(type)) {
+        return type.isInterface() ? Collections.EMPTY_LIST : type.newInstance();
+      } else if (Set.class.isAssignableFrom(type)) {
+        return type.isInterface() ? Collections.EMPTY_SET : type.newInstance();
+      }
+    } catch (IllegalAccessException e) {
+      LOG.error("Could not access constructor for type {}",type.getName());
+      return null;
+    } catch (InstantiationException e) {
+      LOG.error("Could not instantiate instance of type {}",type.getName());
+      return null;
+    }
+    if (OMClientResponse.class.isAssignableFrom(type)) {
+      Constructor<?>[] constructors = type.getDeclaredConstructors();
+      for (Constructor c:constructors) {
+        boolean accessible  = c.isAccessible();
+        c.setAccessible(true);
+        try {
+          Class<?>[] params = c.getParameterTypes();
+          boolean flag = false;
+          for (Class<?> p:params) {
+            if (p.equals(type)) {
+              flag = true;
+              break;
+            }
+          }
+          if (flag) {
+            continue;
+          }
+          instance = c.newInstance(Arrays.stream(params).map(p -> {
+            return createInstance(p, instanceMap, status, isFSO);
+          }).toArray());
+          break;
+        } catch (Exception e) {
+          LOG.error("Error {} while creating instance using Constructor {} for type {} trying another constructor",e.getMessage(),c.getName(),type.getName());
+        } finally {
+          c.setAccessible(accessible);
+        }
+      }
+      for (Field f:getFields(type)) {
+        boolean isAccessible = f.isAccessible();
+        f.setAccessible(true);
+        try {
+          Object fInstance = createInstance(f.getType(), instanceMap,
+              status, isFSO);
+          f.set(instance, fInstance);
+        } catch (Exception e) {
+          LOG.error("Error {} while setting field {} of type {}",e.getMessage(),f.getName(),f.getType().getName());
+        } finally {
+          f.setAccessible(isAccessible);
+        }
+      }
+    } else {
+      instance = getMockObject(type, instanceMap, status, isFSO);
+    }
+    return instance;
+  }
+  private OzoneManagerProtocolProtos.Status getExpectedStatusForResponseClass(
+      Class<? extends OMClientResponse> responseClass) {
+    Map<Class<? extends OMClientResponse>, OzoneManagerProtocolProtos.Status> responseClassStatusMap
+        = new HashMap<>();
+    responseClassStatusMap.put(S3GetSecretResponse.class, OzoneManagerProtocolProtos.Status.OK);
+    return responseClassStatusMap.getOrDefault(responseClass, OzoneManagerProtocolProtos.Status.OK);
+  }
+
+  public Set<Class<? extends OMClientResponse>> responseClasses() {
+    Reflections reflections = new Reflections(OM_RESPONSE_PACKAGE);
+    return reflections.getSubTypesOf(OMClientResponse.class);
+  }
+
+  @Test
+  public void checkCleanupTablesWithTableNames()
+      throws IOException, IllegalAccessException {
+    checkCleanupTablesWithTableNames(true);
+    checkCleanupTablesWithTableNames(false);
+  }
+  private void checkCleanupTablesWithTableNames(boolean isFSO)
+      throws IOException, IllegalAccessException {
+    OMMetadataManager omMetadataManager = createOMMetadataManagerSpy(folder.newFolder());
+    BatchOperation batchOperation = omMetadataManager.getStore().initBatchOperation();
+    Set<Class<? extends OMClientResponse>> subTypes = responseClasses();
+    subTypes = subTypes.stream()
+        .filter(c -> c.isAnnotationPresent(CleanupTableInfo.class))
+        .collect(Collectors.toSet());
+    Set<String> updatedTables = new HashSet<>();
+    mockTables(omMetadataManager, updatedTables, isFSO);
+
+    Map<Class, Object> instanceMap = Maps.newHashMap();
+    for (Class<? extends OMClientResponse> subType : subTypes) {
+      if (subType.isAnnotationPresent(CleanupTableInfo.class) &&
+          !Modifier.isAbstract(subType.getModifiers()) &&
+          Arrays.stream(subType.getDeclaredMethods())
+              .anyMatch(m -> m.getName().equals("addToDBBatch"))) {
+        try {
+          updatedTables.clear();
+          instanceMap.clear();
+          CleanupTableInfo cleanupTableInfo =
+              subType.getAnnotation(CleanupTableInfo.class);
+          OMClientResponse omClientResponse =
+              (OMClientResponse) createInstance(subType,
+                  instanceMap, getExpectedStatusForResponseClass(subType), isFSO);
+          omClientResponse.addToDBBatch(omMetadataManager,
+              batchOperation);
+          Set<String> tables = Arrays.stream(cleanupTableInfo.cleanupTables())
+              .collect(Collectors.toSet());
+          if (isFSO) {
+            if (tables.contains(OmMetadataManagerImpl.KEY_TABLE)) {
+              tables.remove(OmMetadataManagerImpl.KEY_TABLE);
+              tables.add(OmMetadataManagerImpl.FILE_TABLE);
+            }
+            if (tables.contains(OmMetadataManagerImpl.OPEN_KEY_TABLE)) {
+              tables.remove(OmMetadataManagerImpl.OPEN_KEY_TABLE);
+              tables.add(OmMetadataManagerImpl.OPEN_FILE_TABLE);
+            }
+          } else {
+            if (tables.contains(OmMetadataManagerImpl.FILE_TABLE)) {
+              tables.remove(OmMetadataManagerImpl.FILE_TABLE);
+              tables.add(OmMetadataManagerImpl.KEY_TABLE);
+            }
+            if (tables.contains(OmMetadataManagerImpl.OPEN_FILE_TABLE)) {
+              tables.remove(OmMetadataManagerImpl.OPEN_FILE_TABLE);
+              tables.add(OmMetadataManagerImpl.OPEN_KEY_TABLE);
+            }
+          }
+          for (String t:updatedTables) {
+            Assert.assertTrue(
+                String.format("Response Class: {} Tables for Cleanup: {},"
+                        + " Tables Actually Updated: {}",
+                    subType, tables, updatedTables), tables.contains(t));
+          }
+        } catch (Exception e) {
+          LOG.error("Error while testing for Response Class {}", subType.getName());
+          e.printStackTrace();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## What is the link to the Apache JIRA

(Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HDDS-XXXX. Fix a typo in YYY.)
https://issues.apache.org/jira/browse/HDDS-6489

## How was this patch tested?
Patch contains Unit Test to check if CleanupTableInfo is clearing up the right set of tables wrt the tables pushed to the rocksdb.
The patch also goes on to fix existing bugs where there is a mismatch b/w the list of tables being cleared to the tables which are getting updated on the rocksdb.
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
