### PR TITLE
HDDS-6577. Configurations to reserve HDDS volume space.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -93,8 +93,8 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
     cachedValue.addAndGet(usedSpace);
   }
 
-  public void decrementUsedSpace(long usedSpace) {
-    cachedValue.addAndGet(-1 * usedSpace);
+  public void decrementUsedSpace(long reclaimedSpace) {
+    cachedValue.addAndGet(-1 * reclaimedSpace);
   }
 
   public void start() {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/fs/CachingSpaceUsageSource.java
@@ -89,6 +89,14 @@ public class CachingSpaceUsageSource implements SpaceUsageSource {
     return cachedValue.get();
   }
 
+  public void incrementUsedSpace(long usedSpace) {
+    cachedValue.addAndGet(usedSpace);
+  }
+
+  public void decrementUsedSpace(long usedSpace) {
+    cachedValue.addAndGet(-1 * usedSpace);
+  }
+
   public void start() {
     if (executor != null) {
       long initialDelay = cachedValue.get() > 0 ? refresh.toMillis() : 0;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -426,7 +426,7 @@ public abstract class ContainerData {
 
     this.writeBytes.addAndGet(bytes);
     /*
-       Decrement the cached Used Space in VolumeInfo as it
+       Increase the cached Used Space in VolumeInfo as it
        maybe not updated, DU or DedicatedDiskSpaceUsage runs
        periodically to update the Used Space in VolumeInfo.
      */

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/ContainerData.java
@@ -425,7 +425,12 @@ public abstract class ContainerData {
     long unused = getMaxSize() - getBytesUsed();
 
     this.writeBytes.addAndGet(bytes);
-
+    /*
+       Decrement the cached Used Space in VolumeInfo as it
+       maybe not updated, DU or DedicatedDiskSpaceUsage runs
+       periodically to update the Used Space in VolumeInfo.
+     */
+    this.getVolume().incrementUsedSpace(bytes);
     // only if container size < max size
     if (committedSpace && unused > 0) {
       //with this write, container size might breach max size

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -402,9 +402,9 @@ public abstract class StorageVolume
     }
   }
 
-  public void decrementUsedSpace(long usedSpace) {
+  public void decrementUsedSpace(long reclaimedSpace) {
     if (this.volumeInfo != null) {
-      this.volumeInfo.decrementUsedSpace(usedSpace);
+      this.volumeInfo.decrementUsedSpace(reclaimedSpace);
     }
   }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/StorageVolume.java
@@ -396,6 +396,18 @@ public abstract class StorageVolume
     return this.volumeInfo;
   }
 
+  public void incrementUsedSpace(long usedSpace) {
+    if (this.volumeInfo != null) {
+      this.volumeInfo.incrementUsedSpace(usedSpace);
+    }
+  }
+
+  public void decrementUsedSpace(long usedSpace) {
+    if (this.volumeInfo != null) {
+      this.volumeInfo.decrementUsedSpace(usedSpace);
+    }
+  }
+
   public VolumeSet getVolumeSet() {
     return this.volumeSet;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -206,6 +206,14 @@ public final class VolumeInfo {
     return Math.max(Math.min(avail, usage.getAvailable()), 0);
   }
 
+  public void incrementUsedSpace(long usedSpace) {
+    usage.incrementUsedSpace(usedSpace);
+  }
+
+  public void decrementUsedSpace(long usedSpace) {
+    usage.decrementUsedSpace(usedSpace);
+  }
+
   public void refreshNow() {
     usage.refreshNow();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfo.java
@@ -210,8 +210,8 @@ public final class VolumeInfo {
     usage.incrementUsedSpace(usedSpace);
   }
 
-  public void decrementUsedSpace(long usedSpace) {
-    usage.decrementUsedSpace(usedSpace);
+  public void decrementUsedSpace(long reclaimedSpace) {
+    usage.decrementUsedSpace(reclaimedSpace);
   }
 
   public void refreshNow() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -65,8 +65,8 @@ public class VolumeUsage implements SpaceUsageSource {
     source.incrementUsedSpace(usedSpace);
   }
 
-  public void decrementUsedSpace(long usedSpace) {
-    source.decrementUsedSpace(usedSpace);
+  public void decrementUsedSpace(long reclaimedSpace) {
+    source.decrementUsedSpace(reclaimedSpace);
   }
 
   /**

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeUsage.java
@@ -61,6 +61,14 @@ public class VolumeUsage implements SpaceUsageSource {
     return source.getUsedSpace();
   }
 
+  public void incrementUsedSpace(long usedSpace) {
+    source.incrementUsedSpace(usedSpace);
+  }
+
+  public void decrementUsedSpace(long usedSpace) {
+    source.decrementUsedSpace(usedSpace);
+  }
+
   /**
    * Get the space used by others except hdds.
    * DU is refreshed periodically and could be not exact,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -379,6 +379,7 @@ public class BlockDeletingService extends BackgroundService {
           containerData.decrPendingDeletionBlocks(deletedBlocksCount);
           containerData.decrBlockCount(deletedBlocksCount);
           containerData.decrBytesUsed(releasedBytes);
+          containerData.getVolume().decrementUsedSpace(releasedBytes);
         }
 
         if (!succeedBlocks.isEmpty()) {
@@ -489,10 +490,11 @@ public class BlockDeletingService extends BackgroundService {
               deletedBlocksCount, releasedBytes);
 
           // update count of pending deletion blocks, block count and used
-          // bytes in in-memory container status.
+          // bytes in in-memory container status and used space in volume.
           containerData.decrPendingDeletionBlocks(deletedBlocksCount);
           containerData.decrBlockCount(deletedBlocksCount);
           containerData.decrBytesUsed(releasedBytes);
+          containerData.getVolume().decrementUsedSpace(releasedBytes);
         }
 
         LOG.debug("Container: {}, deleted blocks: {}, space reclaimed: {}, " +

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/metadata/AbstractDatanodeStore.java
@@ -18,12 +18,14 @@
 package org.apache.hadoop.ozone.container.metadata;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.StringUtils;
 import org.apache.hadoop.hdds.annotation.InterfaceAudience;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters;
 import org.apache.hadoop.hdds.utils.MetadataKeyFilters.KeyPrefixFilter;
 import org.apache.hadoop.hdds.utils.db.BatchOperationHandler;
+import org.apache.hadoop.hdds.utils.db.DBProfile;
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -102,6 +104,12 @@ public abstract class AbstractDatanodeStore implements DatanodeStore {
       DBOptions options = dbProfile.getDBOptions();
       options.setCreateIfMissing(true);
       options.setCreateMissingColumnFamilies(true);
+
+      if (this.dbDef instanceof DatanodeSchemaOneDBDefinition ||
+          this.dbDef instanceof DatanodeSchemaTwoDBDefinition) {
+        long maxWalSize = DBProfile.toLong(StorageUnit.MB.toBytes(2));
+        options.setMaxTotalWalSize(maxWalSize);
+      }
 
       String rocksDbStat = config.getTrimmed(
               OZONE_METADATA_STORE_ROCKSDB_STATISTICS,

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -22,12 +22,14 @@ import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
+import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
 import org.apache.hadoop.ozone.container.keyvalue.ContainerTestVersionInfo;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
 import org.apache.hadoop.ozone.container.upgrade.VersionedDatanodeFeatures;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 
@@ -70,10 +72,12 @@ public class TestKeyValueContainerData {
     AtomicLong val = new AtomicLong(0);
     UUID pipelineId = UUID.randomUUID();
     UUID datanodeId = UUID.randomUUID();
+    HddsVolume vol = Mockito.mock(HddsVolume.class);
 
     KeyValueContainerData kvData = new KeyValueContainerData(containerId,
         layout,
         MAXSIZE, pipelineId.toString(), datanodeId.toString());
+    kvData.setVolume(vol);
 
     assertEquals(containerType, kvData.getContainerType());
     assertEquals(containerId, kvData.getContainerID());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBProfile.java
@@ -114,7 +114,7 @@ public enum DBProfile {
     }
   };
 
-  private static long toLong(double value) {
+  public static long toLong(double value) {
     BigDecimal temp = BigDecimal.valueOf(value);
     return temp.longValue();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Setting the `MaxTotalWalSize` for DN containers to `2MB`. RocksDB by default pre-allocates `141MB` WAL file for every container and it only uses less than `2MB` of it. 
- Updating the cached used space with chunk write and block delete. `CachingSpaceUsageSource` periodically refreshed the used space of a Volume. (`hdds.datanode.du.refresh.period=1h` for `DU` and `hdds.datanode.df.refresh.period=5m` for `DedicatedDiskSpaceUsage`). During the interval used space  is not updated, Hence the volume usage goes beyond the reserved space(`hdds.datanode.dir.du.reserved`)

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6577

## How was this patch tested?

This patch was tested manually using the docker cluster. 