### PR TITLE
HDDS-6836. Fix Ozone http header configuration

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/conf/OzoneConfiguration.java
@@ -283,13 +283,14 @@ public class OzoneConfiguration extends Configuration
   }
 
   @Override
-  public Map<String, String> getPropsWithPrefix(String confPrefix) {
+  public Map<String, String> getPropsMatchPrefixAndTrimPrefix(
+      String keyPrefix) {
     Properties props = getProps();
     Map<String, String> configMap = new HashMap<>();
     for (String name : props.stringPropertyNames()) {
-      if (name.startsWith(confPrefix)) {
+      if (name.startsWith(keyPrefix)) {
         String value = get(name);
-        String keyName = name.substring(confPrefix.length());
+        String keyName = name.substring(keyPrefix.length());
         configMap.put(keyName, value);
       }
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/ratis/RatisHelper.java
@@ -334,7 +334,7 @@ public final class RatisHelper {
 
   private static Map<String, String> getDatanodeRatisPrefixProps(
       ConfigurationSource configuration) {
-    return configuration.getPropsWithPrefix(
+    return configuration.getPropsMatchPrefixAndTrimPrefix(
         StringUtils.appendIfNotPresent(HDDS_DATANODE_RATIS_PREFIX_KEY, '.'));
   }
 

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -117,6 +117,17 @@ public interface ConfigurationSource {
     return configMap;
   }
 
+  default Map<String, String> getPropsMatchingPrefix(String confPrefix) {
+    Map<String, String> configMap = new HashMap<>();
+    for (String name : getConfigKeys()) {
+      if (name.startsWith(confPrefix)) {
+        String value = get(name);
+        configMap.put(name, value);
+      }
+    }
+    return configMap;
+  }
+
   /**
    * Create a Configuration object and inject the required configuration values.
    *

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -105,22 +105,37 @@ public interface ConfigurationSource {
     return valueString.trim().split("\\s*[,\n]\\s*");
   }
 
-  default Map<String, String> getPropsWithPrefix(String confPrefix) {
+  /**
+   * Gets the configuration entries where the key contains the prefix. This
+   * method will strip the prefix from the key in the return Map.
+   * Example: somePrefix.key->value will be key->value in the returned map.
+   * @param keyPrefix Prefix to search.
+   * @return Map containing keys that match and their values.
+   */
+  default Map<String, String> getPropsMatchPrefixAndTrimPrefix(
+      String keyPrefix) {
     Map<String, String> configMap = new HashMap<>();
     for (String name : getConfigKeys()) {
-      if (name.startsWith(confPrefix)) {
+      if (name.startsWith(keyPrefix)) {
         String value = get(name);
-        String keyName = name.substring(confPrefix.length());
+        String keyName = name.substring(keyPrefix.length());
         configMap.put(keyName, value);
       }
     }
     return configMap;
   }
 
-  default Map<String, String> getPropsMatchingPrefix(String confPrefix) {
+  /**
+   * Gets the configuration entries where the key contains the prefix.
+   * This method will return the entire key including the predix in the returned
+   * map.
+   * @param keyPrefix Prefix to search.
+   * @return Map containing keys that match and their values.
+   */
+  default Map<String, String> getPropsMatchPrefix(String keyPrefix) {
     Map<String, String> configMap = new HashMap<>();
     for (String name : getConfigKeys()) {
-      if (name.startsWith(confPrefix)) {
+      if (name.startsWith(keyPrefix)) {
         String value = get(name);
         configMap.put(name, value);
       }

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationSourceTest.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationSourceTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
 package org.apache.hadoop.hdds.conf;
 
 import org.junit.Assert;

--- a/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationSourceTest.java
+++ b/hadoop-hdds/config/src/test/java/org/apache/hadoop/hdds/conf/ConfigurationSourceTest.java
@@ -1,0 +1,32 @@
+package org.apache.hadoop.hdds.conf;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+class ConfigurationSourceTest {
+
+  @Test
+  void getPropsMatchPrefixAndTrimPrefix() {
+    MutableConfigurationSource c = new InMemoryConfiguration();
+    c.set("somePrefix.key", "value");
+    ConfigurationSource config = c;
+    Map<String, String> entry =
+        config.getPropsMatchPrefixAndTrimPrefix("somePrefix.");
+    Assert.assertEquals("key", entry.keySet().toArray()[0]);
+    Assert.assertEquals("value", entry.values().toArray()[0]);
+  }
+
+  @Test
+  void getPropsMatchPrefix() {
+    MutableConfigurationSource c = new InMemoryConfiguration();
+    c.set("somePrefix.key", "value");
+    ConfigurationSource config = c;
+    Map<String, String> entry =
+        config.getPropsMatchPrefix("somePrefix.");
+    Assert.assertEquals("somePrefix.key",
+        entry.keySet().toArray()[0]);
+    Assert.assertEquals("value", entry.values().toArray()[0]);
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -621,8 +621,8 @@ public final class HttpServer2 implements FilterContainer {
     final String appDir = getWebAppsPath(name);
     addDefaultApps(contexts, appDir, conf);
     webServer.setHandler(handlers);
-    Map<String, String> headers = setHeaders(conf);
-    addGlobalFilter("safety", QuotingInputFilter.class.getName(), headers);
+    Map<String, String> config = generateFilterConfiguration(conf);
+    addGlobalFilter("safety", QuotingInputFilter.class.getName(), config);
     final FilterInitializer[] initializers = getFilterInitializers(conf);
     if (initializers != null) {
       conf.set(BIND_ADDRESS, hostName);
@@ -1742,16 +1742,24 @@ public final class HttpServer2 implements FilterContainer {
     }
   }
 
-  private Map<String, String> setHeaders(ConfigurationSource conf) {
-    Map<String, String> headers = new HashMap<>();
-    headers.putAll(getDefaultHeaders());
+  /**
+   * Generate the configuration for the Quoting filter used.
+   * @param conf global configuration
+   * @return relevant configuration
+   */
+  private Map<String, String>
+  generateFilterConfiguration(ConfigurationSource conf) {
+    Map<String, String> config = new HashMap<>();
+
+    // Add headers to the configuration.
+    config.putAll(getDefaultHeaders());
     if (this.xFrameOptionIsEnabled) {
-      headers.put(HTTP_HEADER_PREFIX + X_FRAME_OPTIONS,
+      config.put(HTTP_HEADER_PREFIX + X_FRAME_OPTIONS,
           this.xFrameOption.toString());
     }
     // Config overrides default
-    headers.putAll(conf.getPropsMatchingPrefix(HTTP_HEADER_PREFIX));
-    return headers;
+    config.putAll(conf.getPropsMatchingPrefix(HTTP_HEADER_PREFIX));
+    return config;
   }
 
   private Map<String, String> getDefaultHeaders() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -195,9 +195,9 @@ public final class HttpServer2 implements FilterContainer {
   private final SignerSecretProvider secretProvider;
   private XFrameOption xFrameOption;
   private boolean xFrameOptionIsEnabled;
-  public static final String HTTP_HEADER_PREFIX = "hadoop.http.header.";
+  public static final String HTTP_HEADER_PREFIX = "ozone.http.header.";
   private static final String HTTP_HEADER_REGEX =
-      "hadoop\\.http\\.header\\.([a-zA-Z\\-_]+)";
+      "ozone\\.http\\.header\\.([a-zA-Z\\-_]+)";
   static final String X_XSS_PROTECTION =
       "X-XSS-Protection:1; mode=block";
   static final String X_CONTENT_TYPE_OPTIONS =
@@ -621,9 +621,8 @@ public final class HttpServer2 implements FilterContainer {
     final String appDir = getWebAppsPath(name);
     addDefaultApps(contexts, appDir, conf);
     webServer.setHandler(handlers);
-
-    Map<String, String> xFrameParams = setHeaders(conf);
-    addGlobalFilter("safety", QuotingInputFilter.class.getName(), xFrameParams);
+    Map<String, String> headers = setHeaders(conf);
+    addGlobalFilter("safety", QuotingInputFilter.class.getName(), headers);
     final FilterInitializer[] initializers = getFilterInitializers(conf);
     if (initializers != null) {
       conf.set(BIND_ADDRESS, hostName);
@@ -1744,14 +1743,15 @@ public final class HttpServer2 implements FilterContainer {
   }
 
   private Map<String, String> setHeaders(ConfigurationSource conf) {
-    Map<String, String> xFrameParams = new HashMap<>();
-
-    xFrameParams.putAll(getDefaultHeaders());
+    Map<String, String> headers = new HashMap<>();
+    headers.putAll(getDefaultHeaders());
     if (this.xFrameOptionIsEnabled) {
-      xFrameParams.put(HTTP_HEADER_PREFIX + X_FRAME_OPTIONS,
+      headers.put(HTTP_HEADER_PREFIX + X_FRAME_OPTIONS,
           this.xFrameOption.toString());
     }
-    return xFrameParams;
+    // Config overrides default
+    headers.putAll(conf.getPropsMatchingPrefix(HTTP_HEADER_PREFIX));
+    return headers;
   }
 
   private Map<String, String> getDefaultHeaders() {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -1747,10 +1747,9 @@ public final class HttpServer2 implements FilterContainer {
    * @param conf global configuration
    * @return relevant configuration
    */
-  private Map<String, String>
-  generateFilterConfiguration(ConfigurationSource conf) {
+  private Map<String, String> generateFilterConfiguration(
+      ConfigurationSource conf) {
     Map<String, String> config = new HashMap<>();
-
     // Add headers to the configuration.
     config.putAll(getDefaultHeaders());
     if (this.xFrameOptionIsEnabled) {
@@ -1758,7 +1757,7 @@ public final class HttpServer2 implements FilterContainer {
           this.xFrameOption.toString());
     }
     // Config overrides default
-    config.putAll(conf.getPropsMatchingPrefix(HTTP_HEADER_PREFIX));
+    config.putAll(conf.getPropsMatchPrefix(HTTP_HEADER_PREFIX));
     return config;
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -724,7 +724,8 @@ public final class OzoneManagerRatisServer {
 
   private static Map<String, String> getOMHAConfigs(
       ConfigurationSource configuration) {
-    return configuration.getPropsWithPrefix(OZONE_OM_HA_PREFIX + ".");
+    return configuration
+        .getPropsMatchPrefixAndTrimPrefix(OZONE_OM_HA_PREFIX + ".");
   }
 
   /**

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/scm/ReconStorageContainerManagerFacade.java
@@ -244,7 +244,7 @@ public class ReconStorageContainerManagerFacade
     OzoneConfiguration reconScmConfiguration =
         new OzoneConfiguration(configuration);
     Map<String, String> reconScmConfigs =
-        configuration.getPropsWithPrefix(RECON_SCM_CONFIG_PREFIX);
+        configuration.getPropsMatchPrefixAndTrimPrefix(RECON_SCM_CONFIG_PREFIX);
     for (Map.Entry<String, String> entry : reconScmConfigs.entrySet()) {
       reconScmConfiguration.set(entry.getKey(), entry.getValue());
     }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, there is no mechanism in place to configure additional headers to be set for the various Http endpoints hosted by Ozone including S3G.

This change adds
1. `ozone.http.header.<HEADER>` as a configuration key that can point to the value to be returned for a header. 
2. Adds the ability for configuration to do a prefix match.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6836

## How was this patch tested?

![image](https://user-images.githubusercontent.com/774455/172303587-6349c789-c378-48fe-af67-7a96ca4c645a.png)
