### PR TITLE
HDDS-6838. [FSO] Sets OM default to LEGACY for an older client's bucket create request

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.ozone.MiniOzoneCluster;
+import org.apache.hadoop.ozone.ClientVersion;
+import org.apache.hadoop.ozone.TestDataUtil;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.client.OzoneBucket;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.junit.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.Timeout;
+
+import java.io.IOException;
+import java.util.UUID;
+
+/**
+ * Tests to verify bucket ops with older version client.
+ */
+public class TestBucketLayoutWithOlderClient {
+
+  private static MiniOzoneCluster cluster = null;
+  private static OzoneConfiguration conf;
+  private static String clusterId;
+  private static String scmId;
+  private static String omId;
+  private static String volumeName;
+  private static String bucketName;
+  private static FileSystem fs;
+
+  @Rule
+  public Timeout timeout = new Timeout(1200000);
+
+  /**
+   * Create a MiniDFSCluster for testing.
+   * <p>
+   *
+   * @throws IOException
+   */
+  @BeforeClass
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    clusterId = UUID.randomUUID().toString();
+    scmId = UUID.randomUUID().toString();
+    omId = UUID.randomUUID().toString();
+    conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+    cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
+        .setScmId(scmId).setOmId(omId).build();
+    cluster.waitForClusterToBeReady();
+  }
+
+  @Test
+  public void testCreateBucketWithOlderClient() throws Exception {
+    // create a volume and a bucket
+    OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster, null);
+    volumeName = bucket.getVolumeName();
+    bucketName = bucket.getName();
+
+    // OM defaulted bucket layout
+    Assert.assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
+
+    // Sets bucket layout explicitly
+    OzoneBucket fsobucket = TestDataUtil
+        .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
+        fsobucket.getBucketLayout());
+
+    // Create bucket request by an older client.
+    // Here sets ClientVersion.DEFAULT_VERSION
+    String buckName = "buck-1-legacy-" + UUID.randomUUID();
+    OzoneManager.setTestSecureOmFlag(true);
+    OzoneManagerProtocolProtos.OMRequest createBucketReq =
+        OzoneManagerProtocolProtos.OMRequest
+            .newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.CreateBucket)
+            .setVersion(ClientVersion.DEFAULT_VERSION.toProtoValue())
+            .setClientId(UUID.randomUUID().toString())
+            .setCreateBucketRequest(
+                OzoneManagerProtocolProtos.CreateBucketRequest.newBuilder()
+                    .setBucketInfo(
+                        OzoneManagerProtocolProtos.BucketInfo.newBuilder()
+                            .setVolumeName(volumeName).setBucketName(buckName)
+                            .setIsVersionEnabled(false).setStorageType(
+                            OzoneManagerProtocolProtos.StorageTypeProto.DISK)
+                            .build())
+                    .build()).build();
+
+    OzoneManagerProtocolProtos.OMResponse
+        omResponse = cluster.getOzoneManager().getOmServerProtocol()
+        .submitRequest(null, createBucketReq);
+
+    Assert.assertEquals(omResponse.getStatus(),
+        OzoneManagerProtocolProtos.Status.OK);
+
+    OmBucketInfo bucketInfo =
+        cluster.getOzoneManager().getBucketInfo(volumeName, buckName);
+    Assert.assertNotNull(bucketInfo);
+    Assert.assertEquals(BucketLayout.LEGACY, bucketInfo.getBucketLayout());
+  }
+
+  /**
+   * Shutdown MiniDFSCluster.
+   */
+  @AfterClass
+  public static void shutdown() {
+    if (cluster != null) {
+      cluster.shutdown();
+    }
+  }
+}

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -16,7 +16,6 @@
  */
 package org.apache.hadoop.ozone.om;
 
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.TestDataUtil;
@@ -45,9 +44,6 @@ public class TestBucketLayoutWithOlderClient {
   private static String clusterId;
   private static String scmId;
   private static String omId;
-  private static String volumeName;
-  private static String bucketName;
-  private static FileSystem fs;
 
   @Rule
   public Timeout timeout = new Timeout(1200000);
@@ -75,8 +71,8 @@ public class TestBucketLayoutWithOlderClient {
   public void testCreateBucketWithOlderClient() throws Exception {
     // create a volume and a bucket
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster, null);
-    volumeName = bucket.getVolumeName();
-    bucketName = bucket.getName();
+    String volumeName = bucket.getVolumeName();
+    String bucketName = bucket.getName();
 
     // OM defaulted bucket layout
     Assert.assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestBucketLayoutWithOlderClient.java
@@ -61,7 +61,7 @@ public class TestBucketLayoutWithOlderClient {
     scmId = UUID.randomUUID().toString();
     omId = UUID.randomUUID().toString();
     conf.set(OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
-        BucketLayout.FILE_SYSTEM_OPTIMIZED.name());
+        BucketLayout.OBJECT_STORE.name());
     cluster = MiniOzoneCluster.newBuilder(conf).setClusterId(clusterId)
         .setScmId(scmId).setOmId(omId).build();
     cluster.waitForClusterToBeReady();
@@ -69,15 +69,13 @@ public class TestBucketLayoutWithOlderClient {
 
   @Test
   public void testCreateBucketWithOlderClient() throws Exception {
-    // create a volume and a bucket
+    // create a volume and a bucket without bucket layout argument
     OzoneBucket bucket = TestDataUtil.createVolumeAndBucket(cluster, null);
     String volumeName = bucket.getVolumeName();
-    String bucketName = bucket.getName();
-
     // OM defaulted bucket layout
     Assert.assertEquals(BucketLayout.OBJECT_STORE, bucket.getBucketLayout());
 
-    // Sets bucket layout explicitly
+    // Sets bucket layout explicitly.
     OzoneBucket fsobucket = TestDataUtil
         .createVolumeAndBucket(cluster, BucketLayout.FILE_SYSTEM_OPTIMIZED);
     Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.crypto.key.KeyProviderCryptoExtension;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.ClientVersion;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneAcl;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -154,16 +155,15 @@ public class OMBucketCreateRequest extends OMClientRequest {
 
     // bucketInfo.hasBucketLayout() would be true when user sets bucket layout.
     // Now, OM will create bucket with the user specified bucket layout.
-    // When the value is not specified by the user, OM will use the
-    // "ozone.default.bucket.layout" configured value.
+    // When the value is not specified by the user, OM will use
+    // "ozone.default.bucket.layout" configured value for the newer ozone
+    // client and LEGACY for an older ozone client.
     if (!bucketInfo.hasBucketLayout()) {
-      // Bucket Layout argument was not passed during bucket creation.
-      String omDefaultBucketLayout = ozoneManager.getOMDefaultBucketLayout();
-      BucketLayout defaultType = BucketLayout.fromString(omDefaultBucketLayout);
-      omBucketInfo = OmBucketInfo.getFromProtobuf(bucketInfo, defaultType);
-      LOG.debug("Bucket Layout not present for volume/bucket = {}/{}, "
-              + "initialising with default bucket layout" + ": {}", volumeName,
-          bucketName, omDefaultBucketLayout);
+      BucketLayout defaultBucketLayout =
+          getDefaultBucketLayout(ozoneManager, bucketInfo, volumeName,
+              bucketName);
+      omBucketInfo =
+          OmBucketInfo.getFromProtobuf(bucketInfo, defaultBucketLayout);
     } else {
       omBucketInfo = OmBucketInfo.getFromProtobuf(bucketInfo);
     }
@@ -267,6 +267,36 @@ public class OMBucketCreateRequest extends OMClientRequest {
       LOG.error("Bucket creation failed for bucket:{} in volume:{}",
           bucketName, volumeName, exception);
       return omClientResponse;
+    }
+  }
+
+  private BucketLayout getDefaultBucketLayout(OzoneManager ozoneManager,
+      BucketInfo bucketInfo, String volumeName, String bucketName) {
+
+    if (getOmRequest().getVersion() <
+        ClientVersion.BUCKET_LAYOUT_SUPPORT.toProtoValue()) {
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Bucket Layout not present for volume/bucket = {}/{}, "
+                + "initialising with default bucket layout" +
+                ": {} as client is an older version: {}",
+            volumeName, bucketName, bucketInfo, BucketLayout.LEGACY,
+            getOmRequest().getVersion());
+      }
+      return BucketLayout.LEGACY;
+    } else {
+      // Bucket Layout argument was not passed during bucket creation.
+      String omDefaultBucketLayout = ozoneManager.getOMDefaultBucketLayout();
+      BucketLayout defaultBuckLayout =
+          BucketLayout.fromString(omDefaultBucketLayout);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Bucket Layout not present for volume/bucket = {}/{}, "
+                + "initialising with default bucket layout" + ": {}",
+            volumeName, bucketName, omDefaultBucketLayout);
+      }
+
+      return defaultBuckLayout;
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -160,8 +160,7 @@ public class OMBucketCreateRequest extends OMClientRequest {
     // client and LEGACY for an older ozone client.
     if (!bucketInfo.hasBucketLayout()) {
       BucketLayout defaultBucketLayout =
-          getDefaultBucketLayout(ozoneManager, bucketInfo, volumeName,
-              bucketName);
+          getDefaultBucketLayout(ozoneManager, volumeName, bucketName);
       omBucketInfo =
           OmBucketInfo.getFromProtobuf(bucketInfo, defaultBucketLayout);
     } else {
@@ -271,21 +270,22 @@ public class OMBucketCreateRequest extends OMClientRequest {
   }
 
   private BucketLayout getDefaultBucketLayout(OzoneManager ozoneManager,
-      BucketInfo bucketInfo, String volumeName, String bucketName) {
+      String volumeName, String bucketName) {
 
     if (getOmRequest().getVersion() <
         ClientVersion.BUCKET_LAYOUT_SUPPORT.toProtoValue()) {
 
       if (LOG.isDebugEnabled()) {
+        // Older client will default bucket layout to LEGACY to
+        // make its operations backward compatible.
         LOG.debug("Bucket Layout not present for volume/bucket = {}/{}, "
                 + "initialising with default bucket layout" +
-                ": {} as client is an older version: {}",
-            volumeName, bucketName, bucketInfo, BucketLayout.LEGACY,
-            getOmRequest().getVersion());
+                ": {} as client is an older version: {}", volumeName,
+            bucketName, BucketLayout.LEGACY, getOmRequest().getVersion());
       }
       return BucketLayout.LEGACY;
     } else {
-      // Bucket Layout argument was not passed during bucket creation.
+      // Newer client will default to the configured value.
       String omDefaultBucketLayout = ozoneManager.getOMDefaultBucketLayout();
       BucketLayout defaultBuckLayout =
           BucketLayout.fromString(omDefaultBucketLayout);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketCreateRequest.java
@@ -275,14 +275,12 @@ public class OMBucketCreateRequest extends OMClientRequest {
     if (getOmRequest().getVersion() <
         ClientVersion.BUCKET_LAYOUT_SUPPORT.toProtoValue()) {
 
-      if (LOG.isDebugEnabled()) {
-        // Older client will default bucket layout to LEGACY to
-        // make its operations backward compatible.
-        LOG.debug("Bucket Layout not present for volume/bucket = {}/{}, "
-                + "initialising with default bucket layout" +
-                ": {} as client is an older version: {}", volumeName,
-            bucketName, BucketLayout.LEGACY, getOmRequest().getVersion());
-      }
+      // Older client will default bucket layout to LEGACY to
+      // make its operations backward compatible.
+      LOG.info("Bucket Layout not present for volume/bucket = {}/{}, "
+              + "initialising with default bucket layout" +
+              ": {} as client is an older version: {}", volumeName,
+          bucketName, BucketLayout.LEGACY, getOmRequest().getVersion());
       return BucketLayout.LEGACY;
     } else {
       // Newer client will default to the configured value.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Presently, older clients can create bucket other than LEGACY bucket layout if admin sets ozone.default.bucket.layout default value to FSO or OBS.

For example, ozone.default.bucket.layout = FILE_SYSTEM_OPTIMIZED in OM server.

Say, Older Client creates a bucket, OM will use the default value and creates an FSO bucket.

Now, older client can't perform any key operations to this bucket as older client's operations not supported on FSO/OBS buckets layout types.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6838

## How was this patch tested?

Added test case
