### PR TITLE
HDDS-6815: EC: getFileCheckSum should return null EC files until ECFileChecksum implemented.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.io.MD5Hash;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.util.CrcUtil;
@@ -51,6 +52,14 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
       OzoneClientConfig.ChecksumCombineMode checksumCombineMode,
       ClientProtocol rpcClient) throws IOException {
     super(volume, bucket, keyName, length, checksumCombineMode, rpcClient);
+  }
+
+  public ReplicatedFileChecksumHelper(OzoneVolume volume, OzoneBucket bucket,
+      String keyName, long length,
+      OzoneClientConfig.ChecksumCombineMode checksumCombineMode,
+      ClientProtocol rpcClient, OmKeyInfo keyInfo) throws IOException {
+    super(volume, bucket, keyName, length, checksumCombineMode, rpcClient,
+        keyInfo);
   }
 
 

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -213,6 +213,7 @@ public final class OzoneClientUtils {
         .setLatestVersionLocation(true).build();
     OmKeyInfo keyInfo = rpcClient.getOzoneManagerClient().lookupKey(keyArgs);
 
+    // TODO: return null util ECFileChecksum is implemented.
     if (keyInfo.getReplicationConfig()
         .getReplicationType() == HddsProtos.ReplicationType.EC) {
       return null;

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/OzoneClientUtils.java
@@ -33,6 +33,8 @@ import org.apache.hadoop.ozone.client.checksum.ReplicatedFileChecksumHelper;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 
 import java.io.IOException;
 import java.util.Set;
@@ -205,8 +207,19 @@ public final class OzoneClientUtils {
     if (keyName.length() == 0) {
       return null;
     }
-    BaseFileChecksumHelper helper = new ReplicatedFileChecksumHelper(
-        volume, bucket, keyName, length, combineMode, rpcClient);
+    OmKeyArgs keyArgs = new OmKeyArgs.Builder().setVolumeName(volume.getName())
+        .setBucketName(bucket.getName()).setKeyName(keyName)
+        .setRefreshPipeline(true).setSortDatanodesInPipeline(true)
+        .setLatestVersionLocation(true).build();
+    OmKeyInfo keyInfo = rpcClient.getOzoneManagerClient().lookupKey(keyArgs);
+
+    if (keyInfo.getReplicationConfig()
+        .getReplicationType() == HddsProtos.ReplicationType.EC) {
+      return null;
+    }
+    BaseFileChecksumHelper helper =
+        new ReplicatedFileChecksumHelper(volume, bucket, keyName, length,
+            combineMode, rpcClient, keyInfo);
     helper.compute();
     return helper.getFileChecksum();
   }

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -99,8 +99,8 @@ public class TestOzoneClientUtils {
     } finally {
       Mockito.reset(volume);
       Mockito.reset(bucket);
-      Mockito.reset(volume);
-      Mockito.reset(volume);
+      Mockito.reset(clientProtocol);
+      Mockito.reset(ozoneManagerProtocol);
     }
   }
 

--- a/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
+++ b/hadoop-ozone/ozonefs-common/src/test/java/org/apache/hadoop/fs/ozone/TestOzoneClientUtils.java
@@ -28,12 +28,16 @@ import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.protocol.ClientProtocol;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.io.IOException;
 
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -70,6 +74,34 @@ public class TestOzoneClientUtils {
             clientProtocol);
 
     assertNull(checksum);
+  }
+
+  @Test
+  public void testGetFileChecksumForECFileShouldReturnNull()
+      throws IOException {
+    OzoneVolume volume = mock(OzoneVolume.class);
+    OzoneBucket bucket = mock(OzoneBucket.class);
+    ClientProtocol clientProtocol = mock(ClientProtocol.class);
+    OzoneManagerProtocol ozoneManagerProtocol =
+        mock(OzoneManagerProtocol.class);
+    try {
+      OmKeyInfo omKeyInfo = new OmKeyInfo.Builder()
+          .setReplicationConfig(new ECReplicationConfig("rs-3-2-1024K"))
+          .setVolumeName("vol").setBucketName("bucket").setKeyName("mykey")
+          .setDataSize(10).setCreationTime(1).setModificationTime(1).build();
+      Mockito.when(clientProtocol.getOzoneManagerClient())
+          .thenReturn(ozoneManagerProtocol);
+      Mockito.when(ozoneManagerProtocol.lookupKey(any())).thenReturn(omKeyInfo);
+      FileChecksum checksum = OzoneClientUtils
+          .getFileChecksumWithCombineMode(volume, bucket, "test", 1,
+              OzoneClientConfig.ChecksumCombineMode.MD5MD5CRC, clientProtocol);
+      assertNull(checksum);
+    } finally {
+      Mockito.reset(volume);
+      Mockito.reset(bucket);
+      Mockito.reset(volume);
+      Mockito.reset(volume);
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

GetFileChecksum is implemented only for Ratis based file layout. For EC files layout, we have no implementation ready yet. This JIRA is to return null for EC files until we have the implementation ready. Otherwise, we will get the wrong CRC unknowingly for EC files.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6815

## How was this patch tested?

Added a UT.
