### PR TITLE
HDDS-6827. Need proper error message when "RATIS" replication-type is passed with EC codec

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -186,7 +186,7 @@ public interface ReplicationConfig {
           factor = ReplicationFactor.valueOf(replication);
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException(replication +
-              " is not supported for RATIS replication type", e);
+              " is not supported for " + type + " replication type", e);
         }
       }
       replicationConfig = fromTypeAndFactor(type, factor);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -182,7 +182,12 @@ public interface ReplicationConfig {
       try {
         factor = ReplicationFactor.valueOf(Integer.parseInt(replication));
       } catch (NumberFormatException ex) {
-        factor = ReplicationFactor.valueOf(replication);
+        try {
+          factor = ReplicationFactor.valueOf(replication);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException(replication +
+              " is not supported for RATIS replication type", e);
+        }
       }
       replicationConfig = fromTypeAndFactor(type, factor);
       break;

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -62,3 +62,9 @@ Test EC Key Ratis Bucket
                     Execute                             ozone sh key put --replication=rs-3-2-1024k --type=EC /${prefix}vol1/${prefix}ratis/${prefix}1mbEC /tmp/1mb
                     Key Should Match Local File         /${prefix}vol1/${prefix}ratis/${prefix}1mbEC    /tmp/1mb
                     Verify Key EC Replication Config    /${prefix}vol1/${prefix}ratis/${prefix}1mbEC    RS    3    2    1048576
+
+Test Ratis Type with EC Replication
+    ${message} =    Execute             ozone sh bucket create --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo
+                    Should contain      ${message}      not supported
+    ${message} =    Execute             ozone sh key put --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo/${prefix}bar /tmp/1mb
+                    Should contain      ${message}     not supported

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -67,4 +67,4 @@ Test Ratis Type with EC Replication
     ${message} =    Execute             ozone sh bucket create --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo
                     Should contain      ${message}      not supported
     ${message} =    Execute             ozone sh key put --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo/${prefix}bar /tmp/1mb
-                    Should contain      ${message}     not supported
+                    Should contain      ${message}      not supported

--- a/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/ec/basic.robot
@@ -63,8 +63,20 @@ Test EC Key Ratis Bucket
                     Key Should Match Local File         /${prefix}vol1/${prefix}ratis/${prefix}1mbEC    /tmp/1mb
                     Verify Key EC Replication Config    /${prefix}vol1/${prefix}ratis/${prefix}1mbEC    RS    3    2    1048576
 
-Test Ratis Type with EC Replication
-    ${message} =    Execute             ozone sh bucket create --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo
-                    Should contain      ${message}      not supported
-    ${message} =    Execute             ozone sh key put --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo/${prefix}bar /tmp/1mb
-                    Should contain      ${message}      not supported
+Test RATIS or STAND_ALONE Type with EC Replication
+    ${message} =    Execute And Ignore Error    ozone sh bucket create --replication=rs-3-2-1024k --type=RATIS /${prefix}vol1/${prefix}foo
+                    Should contain              ${message}          RATIS
+                    Should contain              ${message}          rs-3-2-1024k
+                    Should contain              ${message}          not supported
+    ${message} =    Execute And Ignore Error    ozone sh key put --replication=rs-6-3-1024k --type=RATIS /${prefix}vol1/${prefix}foo/${prefix}bar /tmp/1mb
+                    Should contain              ${message}          RATIS
+                    Should contain              ${message}          rs-6-3-1024k
+                    Should contain              ${message}          not supported
+    ${message} =    Execute And Ignore Error    ozone sh bucket create --replication=rs-6-3-1024k --type=STAND_ALONE /${prefix}vol1/${prefix}foo
+                    Should contain              ${message}          STAND_ALONE
+                    Should contain              ${message}          rs-6-3-1024k
+                    Should contain              ${message}          not supported
+    ${message} =    Execute And Ignore Error    ozone sh key put --replication=rs-3-2-1024k --type=STAND_ALONE /${prefix}vol1/${prefix}foo/${prefix}bar /tmp/1mb
+                    Should contain              ${message}          STAND_ALONE
+                    Should contain              ${message}          rs-3-2-1024k
+                    Should contain              ${message}          not supported

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -72,6 +72,8 @@ import org.junit.Assert;
 
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_URI_DELIMITER;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -381,6 +383,18 @@ public class TestOzoneShellHA {
   private ArrayList<LinkedTreeMap<String, String>> parseOutputIntoArrayList()
       throws UnsupportedEncodingException {
     return new Gson().fromJson(out.toString(DEFAULT_ENCODING), ArrayList.class);
+  }
+
+  @Test
+  public void testRATISTypeECReplication() {
+    String[] args = new String[] {"bucket", "create", "/vol/bucket",
+        "--type=RATIS", "--replication=rs-3-2-1024k"};
+    Throwable t = assertThrows(ExecutionException.class,
+        () -> execute(ozoneShell, args));
+    Throwable c = t.getCause();
+    assertTrue(c instanceof IllegalArgumentException);
+    assertEquals("rs-3-2-1024k is not supported for RATIS replication type",
+        c.getMessage());
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/shell/TestOzoneShellHA.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.cli.OzoneAdmin;
+import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.ozone.OFSPath;
 import org.apache.hadoop.fs.ozone.OzoneFsShell;
@@ -387,14 +388,17 @@ public class TestOzoneShellHA {
 
   @Test
   public void testRATISTypeECReplication() {
-    String[] args = new String[] {"bucket", "create", "/vol/bucket",
-        "--type=RATIS", "--replication=rs-3-2-1024k"};
-    Throwable t = assertThrows(ExecutionException.class,
-        () -> execute(ozoneShell, args));
-    Throwable c = t.getCause();
-    assertTrue(c instanceof IllegalArgumentException);
-    assertEquals("rs-3-2-1024k is not supported for RATIS replication type",
-        c.getMessage());
+    for (ReplicationType type : new ReplicationType[]{
+        ReplicationType.RATIS, ReplicationType.STAND_ALONE}) {
+      String[] args = new String[]{"bucket", "create", "/vol/bucket",
+          "--type=" + type, "--replication=rs-3-2-1024k"};
+      Throwable t = assertThrows(ExecutionException.class,
+          () -> execute(ozoneShell, args));
+      Throwable c = t.getCause();
+      assertTrue(c instanceof IllegalArgumentException);
+      assertEquals("rs-3-2-1024k is not supported for " +
+              type + " replication type", c.getMessage());
+    }
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

See https://issues.apache.org/jira/browse/HDDS-6827

## How was this patch tested?

Integration test and acceptance test.

Manual test:
```console
$ ./ozone sh bucket create /vol/bkt --type=RATIS --replication=rs-3-2-1024k
rs-3-2-1024k is not supported for RATIS replication type
$ ./ozone sh key put /vol/bkt/key ~/.bashrc --type=RATIS --replication=rs-3-2-1024k
rs-3-2-1024k is not supported for RATIS replication type
```
