### PR TITLE
HDDS-6846. HeadOp ignored for link bucket

### DIFF
--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -122,6 +122,10 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <artifactId>spotbugs-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/OmKeyArgs.java
@@ -187,6 +187,7 @@ public final class OmKeyArgs implements Auditable {
         .addAllMetadata(metadata)
         .setRefreshPipeline(refreshPipeline)
         .setSortDatanodesInPipeline(sortDatanodesInPipeline)
+        .setHeadOp(headOp)
         .setLatestVersionLocation(latestVersionLocation)
         .setAcls(acls);
   }

--- a/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyArgs.java
+++ b/hadoop-ozone/common/src/test/java/org/apache/hadoop/ozone/om/helpers/TestOmKeyArgs.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om.helpers;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test for {@link OmKeyArgs}.
+ */
+class TestOmKeyArgs {
+
+  @ParameterizedTest
+  @ValueSource(booleans = { true, false })
+  void toBuilderPreservesHeadOp(boolean headOp) {
+    OmKeyArgs subject = new OmKeyArgs.Builder()
+        .setHeadOp(headOp)
+        .build();
+
+    assertEquals(headOp, subject.isHeadOp());
+    assertEquals(headOp, subject.toBuilder().build().isHeadOp());
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OmKeyArgs` has a flag to indicate if the request is a "head" operation (e.g. existence check, metadata request) or if data is needed as well.  We can skip a few resource-intensive tasks for "head".

This flag is ignored for link buckets because it is lost during `OmKeyArgs -> Builder -> OmKeyArgs` conversion:

https://github.com/apache/ozone/blob/7847e663c45adfc3566679959936da3125474d80/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ResolvedBucket.java#L70-L75

which is called in some `OzoneManager` read ops, e.g.:

https://github.com/apache/ozone/blob/7847e663c45adfc3566679959936da3125474d80/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L2810

https://github.com/apache/ozone/blob/7847e663c45adfc3566679959936da3125474d80/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java#L3402

https://issues.apache.org/jira/browse/HDDS-6846

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2462972124