### PR TITLE
HDDS-6850. Bump kotlin-stdlib to 1.6.21 due to CVE-2022-24329

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1407,7 +1407,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.4.31</version>
+        <version>1.6.21</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumping kotlin-stdlib to 1.6.21.

[CVE-2022-24329](https://nvd.nist.gov/vuln/detail/CVE-2022-24329)

1.6.21 seems to be the latest stable version [as of now](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6850

## How was this patch tested?

- Should be good as long as the existing test suites all pass.