### PR TITLE
HDDS-6848. Ignore timeout replication tasks on datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReplicateContainerCommandHandler.java
@@ -66,12 +66,14 @@ public class ReplicateContainerCommandHandler implements CommandHandler {
     final List<DatanodeDetails> sourceDatanodes =
         replicateCommand.getSourceDatanodes();
     final long containerID = replicateCommand.getContainerID();
+    final long timeoutMs = replicateCommand.getTimeoutMs();
 
     Preconditions.checkArgument(sourceDatanodes.size() > 0,
         "Replication command is received for container %s "
             + "without source datanodes.", containerID);
 
-    supervisor.addTask(new ReplicationTask(containerID, sourceDatanodes));
+    supervisor.addTask(new ReplicationTask(containerID, sourceDatanodes,
+        timeoutMs));
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationSupervisorMetrics.java
@@ -66,6 +66,9 @@ public class ReplicationSupervisorMetrics implements MetricsSource {
             supervisor.getQueueSize())
         .addGauge(Interns.info("numRequestedReplications",
             "Number of requested replications"),
-            supervisor.getReplicationRequestCount());
+            supervisor.getReplicationRequestCount())
+        .addGauge(Interns.info("numTimeoutReplications",
+            "Number of timeout replications in queue"),
+            supervisor.getReplicationTimeoutCount());
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/replication/ReplicationTask.java
@@ -34,6 +34,8 @@ public class ReplicationTask {
 
   private List<DatanodeDetails> sources;
 
+  private final long timeoutMs;
+
   private final Instant queued = Instant.now();
 
   /**
@@ -43,10 +45,18 @@ public class ReplicationTask {
 
   public ReplicationTask(
       long containerId,
-      List<DatanodeDetails> sources
+      List<DatanodeDetails> sources) {
+    this(containerId, sources, 0L);
+  }
+
+  public ReplicationTask(
+      long containerId,
+      List<DatanodeDetails> sources,
+      long timeoutMs
   ) {
     this.containerId = containerId;
     this.sources = sources;
+    this.timeoutMs = timeoutMs;
   }
 
   @Override
@@ -74,6 +84,9 @@ public class ReplicationTask {
     return sources;
   }
 
+  public long getTimeoutMs() {
+    return timeoutMs;
+  }
   public Status getStatus() {
     return status;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -41,20 +41,28 @@ public class ReplicateContainerCommand
 
   private final long containerID;
   private final List<DatanodeDetails> sourceDatanodes;
+  private final long timeoutMs;
 
   public ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
+    this(containerID, sourceDatanodes, 0L);
+  }
+
+  public ReplicateContainerCommand(long containerID,
+      List<DatanodeDetails> sourceDatanodes, long timeoutMs) {
     super();
     this.containerID = containerID;
     this.sourceDatanodes = sourceDatanodes;
+    this.timeoutMs = timeoutMs;
   }
 
   // Should be called only for protobuf conversion
   public ReplicateContainerCommand(long containerID,
-      List<DatanodeDetails> sourceDatanodes, long id) {
+      List<DatanodeDetails> sourceDatanodes, long id, long timeoutMs) {
     super(id);
     this.containerID = containerID;
     this.sourceDatanodes = sourceDatanodes;
+    this.timeoutMs = timeoutMs;
   }
 
   @Override
@@ -66,7 +74,8 @@ public class ReplicateContainerCommand
   public ReplicateContainerCommandProto getProto() {
     Builder builder = ReplicateContainerCommandProto.newBuilder()
         .setCmdId(getId())
-        .setContainerID(containerID);
+        .setContainerID(containerID)
+        .setTimeoutMs(timeoutMs);
     for (DatanodeDetails dd : sourceDatanodes) {
       builder.addSources(dd.getProtoBufMessage());
     }
@@ -84,7 +93,7 @@ public class ReplicateContainerCommand
             .collect(Collectors.toList());
 
     return new ReplicateContainerCommand(protoMessage.getContainerID(),
-        datanodeDetails, protoMessage.getCmdId());
+        datanodeDetails, protoMessage.getCmdId(), protoMessage.getTimeoutMs());
 
   }
 
@@ -94,5 +103,9 @@ public class ReplicateContainerCommand
 
   public List<DatanodeDetails> getSourceDatanodes() {
     return sourceDatanodes;
+  }
+
+  public long getTimeoutMs() {
+    return timeoutMs;
   }
 }

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -409,6 +409,7 @@ message ReplicateContainerCommandProto {
   required int64 containerID = 1;
   repeated DatanodeDetailsProto sources = 2;
   required int64 cmdId = 3;
+  optional int64 timeoutMs = 4;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1449,7 +1449,8 @@ public class LegacyReplicationManager {
 
     final ContainerID id = container.containerID();
     final ReplicateContainerCommand replicateCommand =
-        new ReplicateContainerCommand(id.getId(), sources);
+        new ReplicateContainerCommand(id.getId(), sources,
+            rmConf.getEventTimeout());
     inflightReplication.computeIfAbsent(id, k -> new ArrayList<>());
     sendAndTrackDatanodeCommand(datanode, replicateCommand,
         action -> inflightReplication.get(id).add(action));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -85,6 +85,9 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   @Metric("Number of replication commands sent.")
   private MutableCounterLong numReplicationCmdsSent;
 
+  @Metric("Number of revoke replication commands sent.")
+  private MutableCounterLong numRevokeReplicationCmdsSent;
+
   @Metric("Number of replication commands completed.")
   private MutableCounterLong numReplicationCmdsCompleted;
 
@@ -173,6 +176,10 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     this.numReplicationCmdsSent.incr();
   }
 
+  public void incrNumRevokeReplicationCmdsSent() {
+    this.numRevokeReplicationCmdsSent.incr();
+  }
+
   public void incrNumReplicationCmdsCompleted() {
     this.numReplicationCmdsCompleted.incr();
   }
@@ -231,6 +238,10 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public long getNumReplicationCmdsSent() {
     return this.numReplicationCmdsSent.value();
+  }
+
+  public long getNumRevokeReplicationCmdsSent() {
+    return this.numRevokeReplicationCmdsSent.value();
   }
 
   public long getNumReplicationCmdsCompleted() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerMetrics.java
@@ -85,9 +85,6 @@ public final class ReplicationManagerMetrics implements MetricsSource {
   @Metric("Number of replication commands sent.")
   private MutableCounterLong numReplicationCmdsSent;
 
-  @Metric("Number of revoke replication commands sent.")
-  private MutableCounterLong numRevokeReplicationCmdsSent;
-
   @Metric("Number of replication commands completed.")
   private MutableCounterLong numReplicationCmdsCompleted;
 
@@ -176,10 +173,6 @@ public final class ReplicationManagerMetrics implements MetricsSource {
     this.numReplicationCmdsSent.incr();
   }
 
-  public void incrNumRevokeReplicationCmdsSent() {
-    this.numRevokeReplicationCmdsSent.incr();
-  }
-
   public void incrNumReplicationCmdsCompleted() {
     this.numReplicationCmdsCompleted.incr();
   }
@@ -238,10 +231,6 @@ public final class ReplicationManagerMetrics implements MetricsSource {
 
   public long getNumReplicationCmdsSent() {
     return this.numReplicationCmdsSent.value();
-  }
-
-  public long getNumRevokeReplicationCmdsSent() {
-    return this.numRevokeReplicationCmdsSent.value();
   }
 
   public long getNumReplicationCmdsCompleted() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a datanode crashes, the blocks on the datanode will be added to inflightReplication to fulfill the replication factor. 

When the datanode is restarted, the containers don't need to be replicated anymore, but the replication commands have been sent to datanodes. If the crashed datanodes holds many containers, there will be many replication commands which will cause jams on Datanodes's replication queue, and the big replication traffic will also cause problems to the whole cluster.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6848

## How was this patch tested?

unit test
