### PR TITLE
HDDS-6837. Fix duplicate headers returned in response.

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/HttpServer2.java
@@ -1674,7 +1674,7 @@ public final class HttpServer2 implements FilterContainer {
       } else if (mime.startsWith("application/xml")) {
         httpResponse.setContentType("text/xml; charset=utf-8");
       }
-      headerMap.forEach((k, v) -> httpResponse.addHeader(k, v));
+      headerMap.forEach((k, v) -> httpResponse.setHeader(k, v));
       chain.doFilter(quoted, httpResponse);
     }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/NoCacheFilter.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/NoCacheFilter.java
@@ -42,9 +42,9 @@ public class NoCacheFilter implements Filter {
     HttpServletResponse httpRes = (HttpServletResponse) res;
     httpRes.setHeader("Cache-Control", "no-cache");
     long now = System.currentTimeMillis();
-    httpRes.addDateHeader("Expires", now);
-    httpRes.addDateHeader("Date", now);
-    httpRes.addHeader("Pragma", "no-cache");
+    httpRes.setDateHeader("Expires", now);
+    httpRes.setDateHeader("Date", now);
+    httpRes.setHeader("Pragma", "no-cache");
     chain.doFilter(req, res);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When processing response headers, always update if the header is present instead of adding headers to the response.

https://issues.apache.org/jira/browse/HDDS-6837

## How was this patch tested?

```
➜  ~ curl --insecure -I https://ritesh718-1.ritesh718.root.hwx.site:9879/static/
HTTP/1.1 200 OK
Date: Thu, 09 Jun 2022 23:42:15 GMT
Content-Type: text/html
Strict-Transport-Security: max-age=63072000; includeSubDomains;
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
X-FRAME-OPTIONS: SAMEORIGIN
Last-Modified: Wed, 01 Jun 2022 17:23:28 GMT
Accept-Ranges: bytes
Content-Length: 3106
```