### PR TITLE
HDDS-6869. Use UGI when checking Upgrade priv

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMCancelPrepareRequest.java
@@ -62,9 +62,9 @@ public class OMCancelPrepareRequest extends OMClientRequest {
     OMClientResponse response = null;
 
     try {
-      String username = getOmRequest().getUserInfo().getUserName();
-      if (ozoneManager.getAclsEnabled() && !ozoneManager.isAdmin(username)) {
-        throw new OMException("Access denied for user " + username + ". " +
+      if (ozoneManager.getAclsEnabled() && !ozoneManager.isAdmin(createUGI())) {
+        throw new OMException("Access denied for user "
+            + createUGI() + ". " +
             "Superuser privilege is required to cancel ozone manager " +
             "preparation.",
             OMException.ResultCodes.ACCESS_DENIED);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
@@ -66,10 +66,11 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
     OMClientResponse response = null;
 
     try {
-      String username = getOmRequest().getUserInfo().getUserName();
-      if (ozoneManager.getAclsEnabled() && !ozoneManager.isAdmin(username)) {
-        throw new OMException("Access denied for user " + username + ". " +
-            "Superuser privilege is required to finalize upgrade.",
+      if (ozoneManager.getAclsEnabled()
+          && !ozoneManager.isAdmin(createUGI())) {
+        throw new OMException("Access denied for user "
+            + createUGI() + ". "
+            + "Superuser privilege is required to finalize upgrade.",
             OMException.ResultCodes.ACCESS_DENIED);
       }
 


### PR DESCRIPTION


## What changes were proposed in this pull request?

When checking for admin privileges in the OM Upgrade path, the check is
only run against the short name representation of the UGI. The check
should be done against variations of the user name. Ideally, the check
should be against UGI Objects but the admin list created also takes in a
string representation of the user name via config.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6869

## How was this patch tested?

Local secure cluster with an upgrade finalization test.
