### PR TITLE
HDDS-6870. Clean up isTenantAdmin to use UGI

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMultiTenantManagerImpl.java
@@ -672,8 +672,7 @@ public class OMMultiTenantManagerImpl implements OMMultiTenantManager {
     } else {
       return isTenantAdmin(callerUgi.getShortUserName(), tenantId, delegated)
           || isTenantAdmin(callerUgi.getUserName(), tenantId, delegated)
-          || ozoneManager.isAdmin(callerUgi.getShortUserName())
-          || ozoneManager.isAdmin(callerUgi.getUserName());
+          || ozoneManager.isAdmin(callerUgi);
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -4026,7 +4026,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     }
   }
 
-  public boolean isAdmin(String username) {
+  @VisibleForTesting
+  private boolean isAdmin(String username) {
     if (omAdminUsernames == null) {
       return false;
     } else {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/upgrade/OMFinalizeUpgradeRequest.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Finaliz
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,12 +67,13 @@ public class OMFinalizeUpgradeRequest extends OMClientRequest {
     OMClientResponse response = null;
 
     try {
-      if (ozoneManager.getAclsEnabled()
-          && !ozoneManager.isAdmin(createUGI())) {
-        throw new OMException("Access denied for user "
-            + createUGI() + ". "
-            + "Superuser privilege is required to finalize upgrade.",
-            OMException.ResultCodes.ACCESS_DENIED);
+      if (ozoneManager.getAclsEnabled()) {
+        final UserGroupInformation ugi = createUGI();
+        if (!ozoneManager.isAdmin(ugi)) {
+          throw new OMException("Access denied for user " + ugi + ". "
+              + "Superuser privilege is required to finalize upgrade.",
+              OMException.ResultCodes.ACCESS_DENIED);
+        }
       }
 
       FinalizeUpgradeRequest request =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.KeyArgs
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareRequest;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.UserInfo;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.ratis.proto.RaftProtos;
 import org.apache.ratis.protocol.exceptions.StateMachineException;
@@ -66,7 +67,6 @@ public class TestOzoneManagerStateMachine {
         Mockito.mock(OzoneManagerRatisServer.class);
     OzoneManager ozoneManager = Mockito.mock(OzoneManager.class);
     // Allow testing of prepare pre-append gate.
-    when(ozoneManager.isAdmin(any(String.class))).thenReturn(true);
     when(ozoneManager.isAdmin(any(UserGroupInformation.class)))
         .thenReturn(true);
 
@@ -270,8 +270,12 @@ public class TestOzoneManagerStateMachine {
         .setCreateKeyRequest(CreateKeyRequest.newBuilder().setKeyArgs(args))
         .setCmdType(Type.CreateKey)
         .setClientId("123")
+        .setUserInfo(UserInfo
+            .newBuilder()
+            .setUserName("user")
+            .setHostName("localhost")
+            .setRemoteAddress("127.0.0.1"))
         .build();
-
     // Without prepare enabled, the txn should be returned unaltered.
     TransactionContext submittedTrx = mockTransactionContext(createKeyRequest);
     TransactionContext returnedTrx =
@@ -288,6 +292,11 @@ public class TestOzoneManagerStateMachine {
                 .setArgs(PrepareRequestArgs.getDefaultInstance()))
         .setCmdType(Type.Prepare)
         .setClientId("123")
+        .setUserInfo(UserInfo
+            .newBuilder()
+            .setUserName("user")
+            .setHostName("localhost")
+            .setRemoteAddress("127.0.0.1"))
         .build();
 
     submittedTrx = mockTransactionContext(prepareRequest);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -134,7 +134,6 @@ public class TestOMKeyRequest {
     when(ozoneManager.isRatisEnabled()).thenReturn(true);
     auditLogger = Mockito.mock(AuditLogger.class);
     when(ozoneManager.getAuditLogger()).thenReturn(auditLogger);
-    when(ozoneManager.isAdmin(any(String.class))).thenReturn(true);
     when(ozoneManager.isAdmin(any(UserGroupInformation.class)))
         .thenReturn(true);
     when(ozoneManager.getBucketInfo(anyString(), anyString())).thenReturn(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid duplication of dealing with short and full names that are part of UGI. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6870

## How was this patch tested?

Existing tests run by CI