### PR TITLE
HDDS-6872. TestAuthorizationV4QueryParser should pass offline

### DIFF
--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
@@ -103,8 +103,8 @@ public class TestAuthorizationV4QueryParser {
   }
 
   /**
-   * Based on
-   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html">AWS example</a>
+   * Based on <a href="https://docs.aws.amazon.com
+   * /AmazonS3/latest/API/sigv4-query-string-auth.html">AWS example</a>.
    */
   @Test
   public void testWithAWSExample() throws Exception {

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/s3/signature/TestAuthorizationV4QueryParser.java
@@ -102,11 +102,11 @@ public class TestAuthorizationV4QueryParser {
     //passed
   }
 
-  @Test
   /**
-   * Based on https://docs.aws.amazon
-   * .com/AmazonS3/latest/API/sigv4-query-string-auth.html.
+   * Based on
+   * <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html">AWS example</a>
    */
+  @Test
   public void testWithAWSExample() throws Exception {
 
     Map<String, String> queryParams = new HashMap<>();
@@ -131,7 +131,7 @@ public class TestAuthorizationV4QueryParser {
     final SignatureInfo signatureInfo = parser.parseSignature();
 
     LowerCaseKeyStringMap headers = new LowerCaseKeyStringMap();
-    headers.put("host", "examplebucket.s3.amazonaws.com");
+    headers.put("host", "localhost");
 
     final String stringToSign =
         StringToSignProducer.createSignatureBase(signatureInfo, "https", "GET",
@@ -142,7 +142,7 @@ public class TestAuthorizationV4QueryParser {
             + "20130524T000000Z\n"
             + "20130524/us-east-1/s3/aws4_request\n"
             +
-            "3bfa292879f6447bbcda7001decf97f4a54dc650c8942174ae0a9121cf58ad04",
+            "521c030411bb1ad61412d44aff2a1b0916e473d2dc275ada8e5569c16ecdee36",
         stringToSign);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

TestAuthorizationV4QueryParser.testWithAWSExample cannot be passed without internet connection. 

It requires the internet because the test passes "examplebucket.s3.amazonaws.com" to an HTTP header. This hostname is attempted to be resolved during the test.

Such tests make creating a CI pipeline in a restricted infrastructure difficult.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6872

## How was this patch tested?

Units tests passed
