### PR TITLE
HDDS-6874. Migrate simple tests in hdds-common to JUnit5

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -38,12 +38,12 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_D
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 
-import static org.hamcrest.core.Is.is;
 import org.junit.jupiter.api.Assertions;
-import static org.junit.jupiter.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import org.junit.jupiter.api.Test;
 
 /**
  * Testing HddsUtils.
@@ -52,13 +52,13 @@ public class TestHddsUtils {
 
   @Test
   public void testGetHostName() {
-    Assertions.assertEquals(Optional.of("localhost"),
+    assertEquals(Optional.of("localhost"),
         HddsUtils.getHostName("localhost:1234"));
 
-    Assertions.assertEquals(Optional.of("localhost"),
+    assertEquals(Optional.of("localhost"),
         HddsUtils.getHostName("localhost"));
 
-    Assertions.assertEquals(Optional.empty(),
+    assertEquals(Optional.empty(),
         HddsUtils.getHostName(":1234"));
   }
 
@@ -91,26 +91,26 @@ public class TestHddsUtils {
     // Verify valid IP address setup
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "1.2.3.4");
     addresses = getSCMAddressForDatanodes(conf);
-    assertThat(addresses.size(), is(1));
+    assertEquals(1, addresses.size());
     addr = addresses.iterator().next();
-    assertThat(addr.getHostName(), is("1.2.3.4"));
-    assertThat(addr.getPort(), is(OZONE_SCM_DATANODE_PORT_DEFAULT));
+    assertEquals("1.2.3.4", addr.getHostName());
+    assertEquals(OZONE_SCM_DATANODE_PORT_DEFAULT, addr.getPort());
 
     // Verify valid hostname setup
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "scm1");
     addresses = getSCMAddressForDatanodes(conf);
-    assertThat(addresses.size(), is(1));
+    assertEquals(1, addresses.size());
     addr = addresses.iterator().next();
-    assertThat(addr.getHostName(), is("scm1"));
-    assertThat(addr.getPort(), is(OZONE_SCM_DATANODE_PORT_DEFAULT));
+    assertEquals("scm1", addr.getHostName());
+    assertEquals(OZONE_SCM_DATANODE_PORT_DEFAULT, addr.getPort());
 
     // Verify valid hostname and port
     conf.setStrings(ScmConfigKeys.OZONE_SCM_NAMES, "scm1:1234");
     addresses = getSCMAddressForDatanodes(conf);
-    assertThat(addresses.size(), is(1));
+    assertEquals(1, addresses.size());
     addr = addresses.iterator().next();
-    assertThat(addr.getHostName(), is("scm1"));
-    assertThat(addr.getPort(), is(1234));
+    assertEquals("scm1", addr.getHostName());
+    assertEquals(1234, addr.getPort());
 
     final Map<String, Integer> hostsAndPorts = new HashMap<>();
     hostsAndPorts.put("scm1", 1234);
@@ -121,7 +121,7 @@ public class TestHddsUtils {
     conf.setStrings(
         ScmConfigKeys.OZONE_SCM_NAMES, "scm1:1234,scm2:2345,scm3:3456");
     addresses = getSCMAddressForDatanodes(conf);
-    assertThat(addresses.size(), is(3));
+    assertEquals(3, addresses.size());
     it = addresses.iterator();
     HashMap<String, Integer> expected1 = new HashMap<>(hostsAndPorts);
     while (it.hasNext()) {
@@ -135,7 +135,7 @@ public class TestHddsUtils {
     conf.setStrings(
         ScmConfigKeys.OZONE_SCM_NAMES, " scm1:1234, scm2:2345 , scm3:3456 ");
     addresses = getSCMAddressForDatanodes(conf);
-    assertThat(addresses.size(), is(3));
+    assertEquals(3, addresses.size());
     it = addresses.iterator();
     HashMap<String, Integer> expected2 = new HashMap<>(hostsAndPorts);
     while (it.hasNext()) {
@@ -206,15 +206,13 @@ public class TestHddsUtils {
         HddsUtils.getSCMAddressForDatanodes(conf);
 
     Assertions.assertNotNull(scmAddressList);
-    Assertions.assertEquals(3, scmAddressList.size());
+    assertEquals(3, scmAddressList.size());
 
-    Iterator<InetSocketAddress> it = scmAddressList.iterator();
-    while (it.hasNext()) {
-      InetSocketAddress next = it.next();
-      expected.remove(next.getHostName()  + ":" + next.getPort());
+    for (InetSocketAddress next : scmAddressList) {
+      expected.remove(next.getHostName() + ":" + next.getPort());
     }
 
-    Assertions.assertTrue(expected.size() == 0);
+    assertEquals(0, expected.size());
 
   }
 
@@ -228,16 +226,14 @@ public class TestHddsUtils {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT,
         testnum1);
-    Assertions.assertTrue(Integer.parseInt(testnum1) ==
-        HddsUtils.getNumberFromConfigKeys(
-            conf,
+    assertEquals(Integer.parseInt(testnum1),
+        HddsUtils.getNumberFromConfigKeys(conf,
             OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT).orElse(0));
 
     /* Test to return first unempty key number from list */
     /* first key is absent */
-    Assertions.assertTrue(Integer.parseInt(testnum1) ==
-        HddsUtils.getNumberFromConfigKeys(
-            conf,
+    assertEquals(Integer.parseInt(testnum1),
+        HddsUtils.getNumberFromConfigKeys(conf,
             ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
                 serviceId, nodeId),
             OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT).orElse(0));
@@ -246,9 +242,8 @@ public class TestHddsUtils {
     conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
             serviceId, nodeId),
         testnum2);
-    Assertions.assertTrue(Integer.parseInt(testnum2) ==
-        HddsUtils.getNumberFromConfigKeys(
-            conf,
+    assertEquals(Integer.parseInt(testnum2),
+        HddsUtils.getNumberFromConfigKeys(conf,
             ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
                 serviceId, nodeId),
             OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT).orElse(0));

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/TestHddsUtils.java
@@ -39,11 +39,11 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_K
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT;
 
 import static org.hamcrest.core.Is.is;
-import org.junit.Assert;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import static org.junit.jupiter.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
 
 /**
  * Testing HddsUtils.
@@ -52,13 +52,13 @@ public class TestHddsUtils {
 
   @Test
   public void testGetHostName() {
-    Assert.assertEquals(Optional.of("localhost"),
+    Assertions.assertEquals(Optional.of("localhost"),
         HddsUtils.getHostName("localhost:1234"));
 
-    Assert.assertEquals(Optional.of("localhost"),
+    Assertions.assertEquals(Optional.of("localhost"),
         HddsUtils.getHostName("localhost"));
 
-    Assert.assertEquals(Optional.empty(),
+    Assertions.assertEquals(Optional.empty(),
         HddsUtils.getHostName(":1234"));
   }
 
@@ -205,8 +205,8 @@ public class TestHddsUtils {
     Collection<InetSocketAddress> scmAddressList =
         HddsUtils.getSCMAddressForDatanodes(conf);
 
-    Assert.assertNotNull(scmAddressList);
-    Assert.assertEquals(3, scmAddressList.size());
+    Assertions.assertNotNull(scmAddressList);
+    Assertions.assertEquals(3, scmAddressList.size());
 
     Iterator<InetSocketAddress> it = scmAddressList.iterator();
     while (it.hasNext()) {
@@ -214,7 +214,7 @@ public class TestHddsUtils {
       expected.remove(next.getHostName()  + ":" + next.getPort());
     }
 
-    Assert.assertTrue(expected.size() == 0);
+    Assertions.assertTrue(expected.size() == 0);
 
   }
 
@@ -228,14 +228,14 @@ public class TestHddsUtils {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(ScmConfigKeys.OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT,
         testnum1);
-    Assert.assertTrue(Integer.parseInt(testnum1) ==
+    Assertions.assertTrue(Integer.parseInt(testnum1) ==
         HddsUtils.getNumberFromConfigKeys(
             conf,
             OZONE_SCM_PIPELINE_OWNER_CONTAINER_COUNT).orElse(0));
 
     /* Test to return first unempty key number from list */
     /* first key is absent */
-    Assert.assertTrue(Integer.parseInt(testnum1) ==
+    Assertions.assertTrue(Integer.parseInt(testnum1) ==
         HddsUtils.getNumberFromConfigKeys(
             conf,
             ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
@@ -246,7 +246,7 @@ public class TestHddsUtils {
     conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,
             serviceId, nodeId),
         testnum2);
-    Assert.assertTrue(Integer.parseInt(testnum2) ==
+    Assertions.assertTrue(Integer.parseInt(testnum2) ==
         HddsUtils.getNumberFromConfigKeys(
             conf,
             ConfUtils.addKeySuffixes(OZONE_SCM_DATANODE_PORT_KEY,

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -26,7 +25,8 @@ import java.util.Map;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.XOR;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Unit test for ECReplicationConfig.
@@ -45,10 +45,10 @@ public class TestECReplicationConfig {
 
     for (Map.Entry<String, ECReplicationConfig> e : valid.entrySet()) {
       ECReplicationConfig ec = new ECReplicationConfig(e.getKey());
-      Assertions.assertEquals(e.getValue().getData(), ec.getData());
-      Assertions.assertEquals(e.getValue().getParity(), ec.getParity());
-      Assertions.assertEquals(e.getValue().getCodec(), ec.getCodec());
-      Assertions.assertEquals(e.getValue().getEcChunkSize(), ec.getEcChunkSize());
+      assertEquals(e.getValue().getData(), ec.getData());
+      assertEquals(e.getValue().getParity(), ec.getParity());
+      assertEquals(e.getValue().getCodec(), ec.getCodec());
+      assertEquals(e.getValue().getEcChunkSize(), ec.getEcChunkSize());
     }
   }
 
@@ -63,12 +63,8 @@ public class TestECReplicationConfig {
         "x3-2"
     };
     for (String s : invalid) {
-      try {
-        new ECReplicationConfig(s);
-        fail(s + " should not parse correctly");
-      } catch (IllegalArgumentException e) {
-        // ignore, this expected
-      }
+      assertThrows(IllegalArgumentException.class,
+          () -> new ECReplicationConfig(s));
     }
   }
 
@@ -81,11 +77,11 @@ public class TestECReplicationConfig {
     HddsProtos.ECReplicationConfig proto = orig.toProto();
 
     ECReplicationConfig recovered = new ECReplicationConfig(proto);
-    Assertions.assertEquals(orig.getData(), recovered.getData());
-    Assertions.assertEquals(orig.getParity(), recovered.getParity());
-    Assertions.assertEquals(orig.getCodec(), recovered.getCodec());
-    Assertions.assertEquals(orig.getEcChunkSize(), recovered.getEcChunkSize());
-    Assertions.assertTrue(orig.equals(recovered));
+    assertEquals(orig.getData(), recovered.getData());
+    assertEquals(orig.getParity(), recovered.getParity());
+    assertEquals(orig.getCodec(), recovered.getCodec());
+    assertEquals(orig.getEcChunkSize(), recovered.getEcChunkSize());
+    assertEquals(orig, recovered);
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestECReplicationConfig.java
@@ -18,15 +18,15 @@
 package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.RS;
 import static org.apache.hadoop.hdds.client.ECReplicationConfig.EcCodec.XOR;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Unit test for ECReplicationConfig.
@@ -45,10 +45,10 @@ public class TestECReplicationConfig {
 
     for (Map.Entry<String, ECReplicationConfig> e : valid.entrySet()) {
       ECReplicationConfig ec = new ECReplicationConfig(e.getKey());
-      Assert.assertEquals(e.getValue().getData(), ec.getData());
-      Assert.assertEquals(e.getValue().getParity(), ec.getParity());
-      Assert.assertEquals(e.getValue().getCodec(), ec.getCodec());
-      Assert.assertEquals(e.getValue().getEcChunkSize(), ec.getEcChunkSize());
+      Assertions.assertEquals(e.getValue().getData(), ec.getData());
+      Assertions.assertEquals(e.getValue().getParity(), ec.getParity());
+      Assertions.assertEquals(e.getValue().getCodec(), ec.getCodec());
+      Assertions.assertEquals(e.getValue().getEcChunkSize(), ec.getEcChunkSize());
     }
   }
 
@@ -81,11 +81,11 @@ public class TestECReplicationConfig {
     HddsProtos.ECReplicationConfig proto = orig.toProto();
 
     ECReplicationConfig recovered = new ECReplicationConfig(proto);
-    Assert.assertEquals(orig.getData(), recovered.getData());
-    Assert.assertEquals(orig.getParity(), recovered.getParity());
-    Assert.assertEquals(orig.getCodec(), recovered.getCodec());
-    Assert.assertEquals(orig.getEcChunkSize(), recovered.getEcChunkSize());
-    Assert.assertTrue(orig.equals(recovered));
+    Assertions.assertEquals(orig.getData(), recovered.getData());
+    Assertions.assertEquals(orig.getParity(), recovered.getParity());
+    Assertions.assertEquals(orig.getCodec(), recovered.getCodec());
+    Assertions.assertEquals(orig.getEcChunkSize(), recovered.getEcChunkSize());
+    Assertions.assertTrue(orig.equals(recovered));
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.client;
 
 import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/client/TestReplicationConfigValidator.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.ONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test ReplicationConfig validator.
@@ -56,7 +57,7 @@ public class TestReplicationConfigValidator {
 
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testCustomValidation() {
     MutableConfigurationSource config = new InMemoryConfiguration();
     config.set("ozone.replication.allowed-configs", "RATIS/THREE");
@@ -66,8 +67,8 @@ public class TestReplicationConfigValidator {
 
     validator.validate(RatisReplicationConfig.getInstance(THREE));
 
-    validator.validate(RatisReplicationConfig.getInstance(ONE));
-    //exception is expected
+    assertThrows(IllegalArgumentException.class,
+        () -> validator.validate(RatisReplicationConfig.getInstance(ONE)));
 
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestGeneratedConfigurationOverwrite.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestGeneratedConfigurationOverwrite.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdds.conf;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -40,13 +40,13 @@ public class TestGeneratedConfigurationOverwrite {
 
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void overwriteConfigFile() throws Exception {
     Files.move(generatedConfigurationPath, generatedConfigurationPathBak);
     conf = new OzoneConfiguration();
   }
 
-  @After
+  @AfterEach
   public void recoverConfigFile() throws Exception {
     Files.move(generatedConfigurationPathBak, generatedConfigurationPath);
   }
@@ -54,13 +54,13 @@ public class TestGeneratedConfigurationOverwrite {
   @Test
   public void getConfigurationObject() {
     // Check Config Type of String
-    Assert.assertNotNull(
+    Assertions.assertNotNull(
         conf.getObject(SimpleConfiguration.class).getBindHost());
     // Check Config Type of Int
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         conf.getObject(SimpleConfiguration.class).getPort(), 0);
     // Check Config Type of Time
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         conf.getObject(SimpleConfiguration.class).getWaitTime(), 0);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestCachingSpaceUsageSource.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.fs;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.fs.MockSpaceUsageCheckParams.Builder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 
 import java.io.File;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDU.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDU.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hdds.fs;
 
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.util.Shell;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.ozone.OzoneConsts.KB;
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
@@ -41,14 +41,14 @@ public class TestDU {
 
   private static final File DIR = getTestDir(TestDU.class.getSimpleName());
 
-  @Before
+  @BeforeEach
   public void setUp() {
     assumeFalse(Shell.WINDOWS);
     FileUtil.fullyDelete(DIR);
     assertTrue(DIR.mkdirs());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     FileUtil.fullyDelete(DIR);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDUFactory.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDUFactory.java
@@ -21,7 +21,7 @@ import java.io.File;
 import java.time.Duration;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDedicatedDiskSpaceUsage.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDedicatedDiskSpaceUsage.java
@@ -18,16 +18,16 @@
 package org.apache.hadoop.hdds.fs;
 
 import org.apache.hadoop.fs.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 
 import static org.apache.hadoop.hdds.fs.TestDU.createFile;
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link DedicatedDiskSpaceUsage}.
@@ -39,13 +39,13 @@ public class TestDedicatedDiskSpaceUsage {
 
   private static final int FILE_SIZE = 1024;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     FileUtil.fullyDelete(DIR);
     assertTrue(DIR.mkdirs());
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws IOException {
     FileUtil.fullyDelete(DIR);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDedicatedDiskSpaceUsageFactory.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestDedicatedDiskSpaceUsageFactory.java
@@ -24,7 +24,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 
 import static org.apache.hadoop.hdds.fs.DedicatedDiskSpaceUsageFactory.Conf.configKeyForRefreshPeriod;
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSaveSpaceUsageToFile.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSaveSpaceUsageToFile.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hdds.fs;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.FileUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,9 +32,9 @@ import java.util.OptionalLong;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
 import static org.apache.ozone.test.GenericTestUtils.waitFor;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for {@link SaveSpaceUsageToFile}.
@@ -51,14 +51,14 @@ public class TestSaveSpaceUsageToFile {
 
   private File file;
 
-  @Before
+  @BeforeEach
   public void setup() {
     FileUtil.fullyDelete(DIR);
     assertTrue(DIR.mkdirs());
     file = new File(DIR, "space_usage.txt");
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     FileUtil.fullyDelete(DIR);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSpaceUsageFactory.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/fs/TestSpaceUsageFactory.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 
 import static org.apache.hadoop.hdds.fs.SpaceUsageCheckFactory.Conf.configKeyForClassName;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -58,7 +58,7 @@ public class TestSpaceUsageFactory {
     return factoryClass.cast(factory);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() {
     capturer = LogCapturer.captureLogs(
         LoggerFactory.getLogger(SpaceUsageCheckFactory.class));

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/protocol/TestDatanodeDetails.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hdds.protocol;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails.Port;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.Set;
 
@@ -27,9 +27,9 @@ import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.ALL_PORT
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS;
 import static org.apache.hadoop.ozone.ClientVersion.DEFAULT_VERSION;
 import static org.apache.hadoop.ozone.ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test for {@link DatanodeDetails}.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestContainerCommandRequestMessage.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestContainerCommandRequestMessage.java
@@ -36,8 +36,8 @@ import org.apache.hadoop.ozone.common.ChecksumData;
 import org.apache.hadoop.ozone.common.OzoneChecksumException;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Testing {@link ContainerCommandRequestMessage}. */
 public class TestContainerCommandRequestMessage {
@@ -150,6 +150,6 @@ public class TestContainerCommandRequestMessage {
         = ContainerCommandRequestMessage.toMessage(original, null);
     final ContainerCommandRequestProto computed
         = ContainerCommandRequestMessage.toProto(message.getContent(), null);
-    Assert.assertEquals(original, computed);
+    Assertions.assertEquals(original, computed);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.ratis;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ratis.conf.RaftProperties;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test RatisHelper class.
@@ -42,11 +42,11 @@ public class TestRatisHelper {
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
 
-    Assert.assertEquals("30s",
+    Assertions.assertEquals("30s",
         raftProperties.get("raft.client.rpc.watch.request.timeout"));
-    Assert.assertEquals("30s",
+    Assertions.assertEquals("30s",
         raftProperties.get("raft.client.rpc.request.timeout"));
-    Assert.assertNull(
+    Assertions.assertNull(
         raftProperties.get("raft.server.rpc.watch.request.timeout"));
 
   }
@@ -67,16 +67,16 @@ public class TestRatisHelper {
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftClientProperties(ozoneConfiguration, raftProperties);
 
-    Assert.assertEquals("30MB",
+    Assertions.assertEquals("30MB",
         raftProperties.get("raft.grpc.message.size.max"));
-    Assert.assertEquals("1MB",
+    Assertions.assertEquals("1MB",
         raftProperties.get("raft.grpc.flow.control.window"));
 
     // As we dont match tls and server raft.grpc properties. So they should
     // be null.
-    Assert.assertNull(raftProperties.get("raft.grpc.tls.set"));
-    Assert.assertNull(raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
-    Assert.assertNull(raftProperties.get("raft.grpc.server.port"));
+    Assertions.assertNull(raftProperties.get("raft.grpc.tls.set"));
+    Assertions.assertNull(raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
+    Assertions.assertNull(raftProperties.get("raft.grpc.server.port"));
 
   }
 
@@ -100,15 +100,15 @@ public class TestRatisHelper {
     RatisHelper.createRaftServerProperties(ozoneConfiguration,
         raftProperties);
 
-    Assert.assertEquals("30MB",
+    Assertions.assertEquals("30MB",
         raftProperties.get("raft.grpc.message.size.max"));
-    Assert.assertEquals("1MB",
+    Assertions.assertEquals("1MB",
         raftProperties.get("raft.grpc.flow.control.window"));
-    Assert.assertEquals("true",
+    Assertions.assertEquals("true",
         raftProperties.get("raft.grpc.tls.enabled"));
-    Assert.assertEquals("true",
+    Assertions.assertEquals("true",
         raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
-    Assert.assertEquals("100",
+    Assertions.assertEquals("100",
         raftProperties.get("raft.grpc.server.port"));
 
   }
@@ -127,11 +127,11 @@ public class TestRatisHelper {
     RaftProperties raftProperties = new RaftProperties();
     RatisHelper.createRaftServerProperties(ozoneConfiguration, raftProperties);
 
-    Assert.assertEquals("30s",
+    Assertions.assertEquals("30s",
         raftProperties.get("raft.server.rpc.watch.request.timeout"));
-    Assert.assertEquals("30s",
+    Assertions.assertEquals("30s",
         raftProperties.get("raft.server.rpc.request.timeout"));
-    Assert.assertNull(raftProperties.get("raft.client.rpc.request.timeout"));
+    Assertions.assertNull(raftProperties.get("raft.client.rpc.request.timeout"));
 
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestRatisHelper.java
@@ -75,7 +75,8 @@ public class TestRatisHelper {
     // As we dont match tls and server raft.grpc properties. So they should
     // be null.
     Assertions.assertNull(raftProperties.get("raft.grpc.tls.set"));
-    Assertions.assertNull(raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
+    Assertions.assertNull(
+        raftProperties.get("raft.grpc.tls.mutual_authn.enabled"));
     Assertions.assertNull(raftProperties.get("raft.grpc.server.port"));
 
   }
@@ -131,7 +132,8 @@ public class TestRatisHelper {
         raftProperties.get("raft.server.rpc.watch.request.timeout"));
     Assertions.assertEquals("30s",
         raftProperties.get("raft.server.rpc.request.timeout"));
-    Assertions.assertNull(raftProperties.get("raft.client.rpc.request.timeout"));
+    Assertions.assertNull(
+        raftProperties.get("raft.client.rpc.request.timeout"));
 
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/ratis/TestServerNotLeaderException.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.hdds.ratis;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /** Class to test {@link ServerNotLeaderException} parsing. **/
 
@@ -34,7 +34,7 @@ public class TestServerNotLeaderException {
         "Server:cf0bc565-a41b-4784-a24d-3048d5a5b013 is not the leader. "
             + "Suggested leader is Server:scm5-3.scm5.root.hwx.site:9863";
     ServerNotLeaderException snle = new ServerNotLeaderException(msg);
-    Assert.assertEquals(snle.getSuggestedLeader(), "scm5-3.scm5.root.hwx" +
+    Assertions.assertEquals(snle.getSuggestedLeader(), "scm5-3.scm5.root.hwx" +
         ".site:9863");
 
     String message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
@@ -42,7 +42,7 @@ public class TestServerNotLeaderException {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
-    Assert.assertEquals("scm5-3.scm5.root.hwx.site:9863",
+    Assertions.assertEquals("scm5-3.scm5.root.hwx.site:9863",
         snle.getSuggestedLeader());
 
     // Test hostname with out "."
@@ -51,7 +51,7 @@ public class TestServerNotLeaderException {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
-    Assert.assertEquals("localhost:98634",
+    Assertions.assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
     message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
@@ -59,7 +59,7 @@ public class TestServerNotLeaderException {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
-    Assert.assertEquals(null,
+    Assertions.assertEquals(null,
         snle.getSuggestedLeader());
 
     message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
@@ -67,7 +67,7 @@ public class TestServerNotLeaderException {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java:96)";
     snle = new ServerNotLeaderException(message);
-    Assert.assertEquals("localhost:98634",
+    Assertions.assertEquals("localhost:98634",
         snle.getSuggestedLeader());
 
     message = "Server:7fdd7170-75cc-4e11-b343-c2657c2f2f39 is not the " +
@@ -75,7 +75,7 @@ public class TestServerNotLeaderException {
         "at org.apache.hadoop.hdds.ratis.ServerNotLeaderException" +
         ".convertToNotLeaderException(ServerNotLeaderException.java)";
     snle = new ServerNotLeaderException(message);
-    Assert.assertEquals(null,
+    Assertions.assertEquals(null,
         snle.getSuggestedLeader());
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerInfo.java
@@ -22,8 +22,8 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -44,34 +44,34 @@ public class TestContainerInfo {
     HddsProtos.ContainerInfoProto proto = container.getProtobuf();
 
     // No EC Config
-    Assert.assertFalse(proto.hasEcReplicationConfig());
-    Assert.assertEquals(THREE, proto.getReplicationFactor());
-    Assert.assertEquals(RATIS, proto.getReplicationType());
+    Assertions.assertFalse(proto.hasEcReplicationConfig());
+    Assertions.assertEquals(THREE, proto.getReplicationFactor());
+    Assertions.assertEquals(RATIS, proto.getReplicationType());
 
     // Reconstruct object from Proto
     ContainerInfo recovered = ContainerInfo.fromProtobuf(proto);
-    Assert.assertEquals(RATIS, recovered.getReplicationType());
-    Assert.assertTrue(
+    Assertions.assertEquals(RATIS, recovered.getReplicationType());
+    Assertions.assertTrue(
         recovered.getReplicationConfig() instanceof RatisReplicationConfig);
 
     // EC Config
     container = createContainerInfo(new ECReplicationConfig(3, 2));
     proto = container.getProtobuf();
 
-    Assert.assertEquals(3, proto.getEcReplicationConfig().getData());
-    Assert.assertEquals(2, proto.getEcReplicationConfig().getParity());
-    Assert.assertFalse(proto.hasReplicationFactor());
-    Assert.assertEquals(EC, proto.getReplicationType());
+    Assertions.assertEquals(3, proto.getEcReplicationConfig().getData());
+    Assertions.assertEquals(2, proto.getEcReplicationConfig().getParity());
+    Assertions.assertFalse(proto.hasReplicationFactor());
+    Assertions.assertEquals(EC, proto.getReplicationType());
 
     // Reconstruct object from Proto
     recovered = ContainerInfo.fromProtobuf(proto);
-    Assert.assertEquals(EC, recovered.getReplicationType());
-    Assert.assertTrue(
+    Assertions.assertEquals(EC, recovered.getReplicationType());
+    Assertions.assertTrue(
         recovered.getReplicationConfig() instanceof ECReplicationConfig);
     ECReplicationConfig config =
         (ECReplicationConfig)recovered.getReplicationConfig();
-    Assert.assertEquals(3, config.getData());
-    Assert.assertEquals(2, config.getParity());
+    Assertions.assertEquals(3, config.getData());
+    Assertions.assertEquals(2, config.getParity());
   }
 
   private ContainerInfo createContainerInfo(ReplicationConfig repConfig) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplicaInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestContainerReplicaInfo.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hdds.scm.container;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -46,17 +46,17 @@ public class TestContainerReplicaInfo {
 
     ContainerReplicaInfo info = ContainerReplicaInfo.fromProto(proto);
 
-    Assert.assertEquals(proto.getContainerID(), info.getContainerID());
-    Assert.assertEquals(proto.getBytesUsed(), info.getBytesUsed());
-    Assert.assertEquals(proto.getKeyCount(), info.getKeyCount());
-    Assert.assertEquals(proto.getPlaceOfBirth(),
+    Assertions.assertEquals(proto.getContainerID(), info.getContainerID());
+    Assertions.assertEquals(proto.getBytesUsed(), info.getBytesUsed());
+    Assertions.assertEquals(proto.getKeyCount(), info.getKeyCount());
+    Assertions.assertEquals(proto.getPlaceOfBirth(),
         info.getPlaceOfBirth().toString());
-    Assert.assertEquals(DatanodeDetails.getFromProtoBuf(
+    Assertions.assertEquals(DatanodeDetails.getFromProtoBuf(
         proto.getDatanodeDetails()), info.getDatanodeDetails());
-    Assert.assertEquals(proto.getSequenceID(), info.getSequenceId());
-    Assert.assertEquals(proto.getState(), info.getState());
+    Assertions.assertEquals(proto.getSequenceID(), info.getSequenceId());
+    Assertions.assertEquals(proto.getState(), info.getState());
     // If replicaIndex is not in the proto, then -1 should be returned
-    Assert.assertEquals(-1, info.getReplicaIndex());
+    Assertions.assertEquals(-1, info.getReplicaIndex());
   }
 
   @Test
@@ -76,15 +76,15 @@ public class TestContainerReplicaInfo {
 
     ContainerReplicaInfo info = ContainerReplicaInfo.fromProto(proto);
 
-    Assert.assertEquals(proto.getContainerID(), info.getContainerID());
-    Assert.assertEquals(proto.getBytesUsed(), info.getBytesUsed());
-    Assert.assertEquals(proto.getKeyCount(), info.getKeyCount());
-    Assert.assertEquals(proto.getPlaceOfBirth(),
+    Assertions.assertEquals(proto.getContainerID(), info.getContainerID());
+    Assertions.assertEquals(proto.getBytesUsed(), info.getBytesUsed());
+    Assertions.assertEquals(proto.getKeyCount(), info.getKeyCount());
+    Assertions.assertEquals(proto.getPlaceOfBirth(),
         info.getPlaceOfBirth().toString());
-    Assert.assertEquals(DatanodeDetails.getFromProtoBuf(
+    Assertions.assertEquals(DatanodeDetails.getFromProtoBuf(
         proto.getDatanodeDetails()), info.getDatanodeDetails());
-    Assert.assertEquals(proto.getSequenceID(), info.getSequenceId());
-    Assert.assertEquals(proto.getState(), info.getState());
-    Assert.assertEquals(4, info.getReplicaIndex());
+    Assertions.assertEquals(proto.getSequenceID(), info.getSequenceId());
+    Assertions.assertEquals(proto.getState(), info.getState());
+    Assertions.assertEquals(4, info.getReplicaIndex());
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -21,9 +21,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.JsonUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -40,7 +40,7 @@ public class TestReplicationManagerReport {
 
   private ReplicationManagerReport report;
 
-  @Before
+  @BeforeEach
   public void setup() {
     report = new ReplicationManagerReport();
   }
@@ -55,18 +55,18 @@ public class TestReplicationManagerReport {
     report.increment(HddsProtos.LifeCycleState.CLOSED);
     report.increment(HddsProtos.LifeCycleState.CLOSED);
 
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         report.getStat(HddsProtos.LifeCycleState.OPEN));
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         report.getStat(HddsProtos.LifeCycleState.CLOSED));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         report.getStat(HddsProtos.LifeCycleState.QUASI_CLOSED));
   }
 
@@ -93,29 +93,29 @@ public class TestReplicationManagerReport {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(jsonString);
 
-    Assert.assertTrue(json.get("reportTimeStamp").longValue() > 0);
+    Assertions.assertTrue(json.get("reportTimeStamp").longValue() > 0);
     JsonNode stats = json.get("stats");
-    Assert.assertEquals(1, stats.get("OPEN").longValue());
-    Assert.assertEquals(0, stats.get("CLOSING").longValue());
-    Assert.assertEquals(0, stats.get("QUASI_CLOSED").longValue());
-    Assert.assertEquals(2, stats.get("CLOSED").longValue());
-    Assert.assertEquals(0, stats.get("DELETING").longValue());
-    Assert.assertEquals(0, stats.get("DELETED").longValue());
+    Assertions.assertEquals(1, stats.get("OPEN").longValue());
+    Assertions.assertEquals(0, stats.get("CLOSING").longValue());
+    Assertions.assertEquals(0, stats.get("QUASI_CLOSED").longValue());
+    Assertions.assertEquals(2, stats.get("CLOSED").longValue());
+    Assertions.assertEquals(0, stats.get("DELETING").longValue());
+    Assertions.assertEquals(0, stats.get("DELETED").longValue());
 
-    Assert.assertEquals(2, stats.get("UNDER_REPLICATED").longValue());
-    Assert.assertEquals(1, stats.get("OVER_REPLICATED").longValue());
-    Assert.assertEquals(0, stats.get("MIS_REPLICATED").longValue());
-    Assert.assertEquals(0, stats.get("MISSING").longValue());
-    Assert.assertEquals(0, stats.get("UNHEALTHY").longValue());
-    Assert.assertEquals(0, stats.get("EMPTY").longValue());
-    Assert.assertEquals(0, stats.get("OPEN_UNHEALTHY").longValue());
-    Assert.assertEquals(0, stats.get("QUASI_CLOSED_STUCK").longValue());
+    Assertions.assertEquals(2, stats.get("UNDER_REPLICATED").longValue());
+    Assertions.assertEquals(1, stats.get("OVER_REPLICATED").longValue());
+    Assertions.assertEquals(0, stats.get("MIS_REPLICATED").longValue());
+    Assertions.assertEquals(0, stats.get("MISSING").longValue());
+    Assertions.assertEquals(0, stats.get("UNHEALTHY").longValue());
+    Assertions.assertEquals(0, stats.get("EMPTY").longValue());
+    Assertions.assertEquals(0, stats.get("OPEN_UNHEALTHY").longValue());
+    Assertions.assertEquals(0, stats.get("QUASI_CLOSED_STUCK").longValue());
 
     JsonNode samples = json.get("samples");
-    Assert.assertEquals(ARRAY, samples.get("UNDER_REPLICATED").getNodeType());
-    Assert.assertEquals(1, samples.get("UNDER_REPLICATED").get(0).longValue());
-    Assert.assertEquals(2, samples.get("UNDER_REPLICATED").get(1).longValue());
-    Assert.assertEquals(3, samples.get("OVER_REPLICATED").get(0).longValue());
+    Assertions.assertEquals(ARRAY, samples.get("UNDER_REPLICATED").getNodeType());
+    Assertions.assertEquals(1, samples.get("UNDER_REPLICATED").get(0).longValue());
+    Assertions.assertEquals(2, samples.get("UNDER_REPLICATED").get(1).longValue());
+    Assertions.assertEquals(3, samples.get("OVER_REPLICATED").get(0).longValue());
   }
 
   @Test
@@ -130,27 +130,27 @@ public class TestReplicationManagerReport {
         ReplicationManagerReport.HealthState.OVER_REPLICATED,
         new ContainerID(3));
 
-    Assert.assertEquals(2,
+    Assertions.assertEquals(2,
         report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assert.assertEquals(1,
+    Assertions.assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
     List<ContainerID> sample =
         report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-    Assert.assertEquals(new ContainerID(1), sample.get(0));
-    Assert.assertEquals(new ContainerID(2), sample.get(1));
-    Assert.assertEquals(2, sample.size());
+    Assertions.assertEquals(new ContainerID(1), sample.get(0));
+    Assertions.assertEquals(new ContainerID(2), sample.get(1));
+    Assertions.assertEquals(2, sample.size());
 
     sample =
         report.getSample(ReplicationManagerReport.HealthState.OVER_REPLICATED);
-    Assert.assertEquals(new ContainerID(3), sample.get(0));
-    Assert.assertEquals(1, sample.size());
+    Assertions.assertEquals(new ContainerID(3), sample.get(0));
+    Assertions.assertEquals(1, sample.size());
 
     sample =
         report.getSample(ReplicationManagerReport.HealthState.MIS_REPLICATED);
-    Assert.assertEquals(0, sample.size());
+    Assertions.assertEquals(0, sample.size());
   }
 
   @Test
@@ -162,9 +162,9 @@ public class TestReplicationManagerReport {
     }
     List<ContainerID> sample =
         report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-    Assert.assertEquals(ReplicationManagerReport.SAMPLE_LIMIT, sample.size());
+    Assertions.assertEquals(ReplicationManagerReport.SAMPLE_LIMIT, sample.size());
     for (int i = 0; i < ReplicationManagerReport.SAMPLE_LIMIT; i++) {
-      Assert.assertEquals(new ContainerID(i), sample.get(i));
+      Assertions.assertEquals(new ContainerID(i), sample.get(i));
     }
   }
 
@@ -187,16 +187,16 @@ public class TestReplicationManagerReport {
     HddsProtos.ReplicationManagerReportProto proto = report.toProtobuf();
     ReplicationManagerReport newReport
         = ReplicationManagerReport.fromProtobuf(proto);
-    Assert.assertEquals(report.getReportTimeStamp(),
+    Assertions.assertEquals(report.getReportTimeStamp(),
         newReport.getReportTimeStamp());
 
     for (HddsProtos.LifeCycleState s : HddsProtos.LifeCycleState.values()) {
-      Assert.assertEquals(report.getStat(s), newReport.getStat(s));
+      Assertions.assertEquals(report.getStat(s), newReport.getStat(s));
     }
 
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assert.assertTrue(report.getSample(s).equals(newReport.getSample(s)));
+      Assertions.assertTrue(report.getSample(s).equals(newReport.getSample(s)));
     }
   }
 
@@ -225,7 +225,7 @@ public class TestReplicationManagerReport {
     // Ensure no exception is thrown
     ReplicationManagerReport newReport =
         ReplicationManagerReport.fromProtobuf(proto.build());
-    Assert.assertEquals(20, newReport.getStat(
+    Assertions.assertEquals(20, newReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.server.JsonUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,9 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.fasterxml.jackson.databind.node.JsonNodeType.ARRAY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for the ReplicationManagerReport class.
@@ -56,18 +57,18 @@ public class TestReplicationManagerReport {
     report.increment(HddsProtos.LifeCycleState.CLOSED);
     report.increment(HddsProtos.LifeCycleState.CLOSED);
 
-    Assertions.assertEquals(2,
+    assertEquals(2,
         report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assertions.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
-    Assertions.assertEquals(1,
+    assertEquals(1,
         report.getStat(HddsProtos.LifeCycleState.OPEN));
-    Assertions.assertEquals(2,
+    assertEquals(2,
         report.getStat(HddsProtos.LifeCycleState.CLOSED));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         report.getStat(HddsProtos.LifeCycleState.QUASI_CLOSED));
   }
 
@@ -94,29 +95,29 @@ public class TestReplicationManagerReport {
     ObjectMapper mapper = new ObjectMapper();
     JsonNode json = mapper.readTree(jsonString);
 
-    Assertions.assertTrue(json.get("reportTimeStamp").longValue() > 0);
+    assertTrue(json.get("reportTimeStamp").longValue() > 0);
     JsonNode stats = json.get("stats");
-    Assertions.assertEquals(1, stats.get("OPEN").longValue());
-    Assertions.assertEquals(0, stats.get("CLOSING").longValue());
-    Assertions.assertEquals(0, stats.get("QUASI_CLOSED").longValue());
-    Assertions.assertEquals(2, stats.get("CLOSED").longValue());
-    Assertions.assertEquals(0, stats.get("DELETING").longValue());
-    Assertions.assertEquals(0, stats.get("DELETED").longValue());
+    assertEquals(1, stats.get("OPEN").longValue());
+    assertEquals(0, stats.get("CLOSING").longValue());
+    assertEquals(0, stats.get("QUASI_CLOSED").longValue());
+    assertEquals(2, stats.get("CLOSED").longValue());
+    assertEquals(0, stats.get("DELETING").longValue());
+    assertEquals(0, stats.get("DELETED").longValue());
 
-    Assertions.assertEquals(2, stats.get("UNDER_REPLICATED").longValue());
-    Assertions.assertEquals(1, stats.get("OVER_REPLICATED").longValue());
-    Assertions.assertEquals(0, stats.get("MIS_REPLICATED").longValue());
-    Assertions.assertEquals(0, stats.get("MISSING").longValue());
-    Assertions.assertEquals(0, stats.get("UNHEALTHY").longValue());
-    Assertions.assertEquals(0, stats.get("EMPTY").longValue());
-    Assertions.assertEquals(0, stats.get("OPEN_UNHEALTHY").longValue());
-    Assertions.assertEquals(0, stats.get("QUASI_CLOSED_STUCK").longValue());
+    assertEquals(2, stats.get("UNDER_REPLICATED").longValue());
+    assertEquals(1, stats.get("OVER_REPLICATED").longValue());
+    assertEquals(0, stats.get("MIS_REPLICATED").longValue());
+    assertEquals(0, stats.get("MISSING").longValue());
+    assertEquals(0, stats.get("UNHEALTHY").longValue());
+    assertEquals(0, stats.get("EMPTY").longValue());
+    assertEquals(0, stats.get("OPEN_UNHEALTHY").longValue());
+    assertEquals(0, stats.get("QUASI_CLOSED_STUCK").longValue());
 
     JsonNode samples = json.get("samples");
-    Assertions.assertEquals(ARRAY, samples.get("UNDER_REPLICATED").getNodeType());
-    Assertions.assertEquals(1, samples.get("UNDER_REPLICATED").get(0).longValue());
-    Assertions.assertEquals(2, samples.get("UNDER_REPLICATED").get(1).longValue());
-    Assertions.assertEquals(3, samples.get("OVER_REPLICATED").get(0).longValue());
+    assertEquals(ARRAY, samples.get("UNDER_REPLICATED").getNodeType());
+    assertEquals(1, samples.get("UNDER_REPLICATED").get(0).longValue());
+    assertEquals(2, samples.get("UNDER_REPLICATED").get(1).longValue());
+    assertEquals(3, samples.get("OVER_REPLICATED").get(0).longValue());
   }
 
   @Test
@@ -131,27 +132,27 @@ public class TestReplicationManagerReport {
         ReplicationManagerReport.HealthState.OVER_REPLICATED,
         new ContainerID(3));
 
-    Assertions.assertEquals(2,
+    assertEquals(2,
         report.getStat(ReplicationManagerReport.HealthState.UNDER_REPLICATED));
-    Assertions.assertEquals(1,
+    assertEquals(1,
         report.getStat(ReplicationManagerReport.HealthState.OVER_REPLICATED));
-    Assertions.assertEquals(0,
+    assertEquals(0,
         report.getStat(ReplicationManagerReport.HealthState.MIS_REPLICATED));
 
     List<ContainerID> sample =
         report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-    Assertions.assertEquals(new ContainerID(1), sample.get(0));
-    Assertions.assertEquals(new ContainerID(2), sample.get(1));
-    Assertions.assertEquals(2, sample.size());
+    assertEquals(new ContainerID(1), sample.get(0));
+    assertEquals(new ContainerID(2), sample.get(1));
+    assertEquals(2, sample.size());
 
     sample =
         report.getSample(ReplicationManagerReport.HealthState.OVER_REPLICATED);
-    Assertions.assertEquals(new ContainerID(3), sample.get(0));
-    Assertions.assertEquals(1, sample.size());
+    assertEquals(new ContainerID(3), sample.get(0));
+    assertEquals(1, sample.size());
 
     sample =
         report.getSample(ReplicationManagerReport.HealthState.MIS_REPLICATED);
-    Assertions.assertEquals(0, sample.size());
+    assertEquals(0, sample.size());
   }
 
   @Test
@@ -163,9 +164,9 @@ public class TestReplicationManagerReport {
     }
     List<ContainerID> sample =
         report.getSample(ReplicationManagerReport.HealthState.UNDER_REPLICATED);
-    Assertions.assertEquals(ReplicationManagerReport.SAMPLE_LIMIT, sample.size());
+    assertEquals(ReplicationManagerReport.SAMPLE_LIMIT, sample.size());
     for (int i = 0; i < ReplicationManagerReport.SAMPLE_LIMIT; i++) {
-      Assertions.assertEquals(new ContainerID(i), sample.get(i));
+      assertEquals(new ContainerID(i), sample.get(i));
     }
   }
 
@@ -188,16 +189,16 @@ public class TestReplicationManagerReport {
     HddsProtos.ReplicationManagerReportProto proto = report.toProtobuf();
     ReplicationManagerReport newReport
         = ReplicationManagerReport.fromProtobuf(proto);
-    Assertions.assertEquals(report.getReportTimeStamp(),
+    assertEquals(report.getReportTimeStamp(),
         newReport.getReportTimeStamp());
 
     for (HddsProtos.LifeCycleState s : HddsProtos.LifeCycleState.values()) {
-      Assertions.assertEquals(report.getStat(s), newReport.getStat(s));
+      assertEquals(report.getStat(s), newReport.getStat(s));
     }
 
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assertions.assertEquals(report.getSample(s), newReport.getSample(s));
+      assertEquals(report.getSample(s), newReport.getSample(s));
     }
   }
 
@@ -226,7 +227,7 @@ public class TestReplicationManagerReport {
     // Ensure no exception is thrown
     ReplicationManagerReport newReport =
         ReplicationManagerReport.fromProtobuf(proto.build());
-    Assertions.assertEquals(20, newReport.getStat(
+    assertEquals(20, newReport.getStat(
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/TestReplicationManagerReport.java
@@ -32,6 +32,7 @@ import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.fasterxml.jackson.databind.node.JsonNodeType.ARRAY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the ReplicationManagerReport class.
@@ -196,7 +197,7 @@ public class TestReplicationManagerReport {
 
     for (ReplicationManagerReport.HealthState s :
         ReplicationManagerReport.HealthState.values()) {
-      Assertions.assertTrue(report.getSample(s).equals(newReport.getSample(s)));
+      Assertions.assertEquals(report.getSample(s), newReport.getSample(s));
     }
   }
 
@@ -229,17 +230,19 @@ public class TestReplicationManagerReport {
         ReplicationManagerReport.HealthState.UNDER_REPLICATED));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testStatCannotBeSetTwice() {
     report.setStat(HddsProtos.LifeCycleState.CLOSED.toString(), 10);
-    report.setStat(HddsProtos.LifeCycleState.CLOSED.toString(), 10);
+    assertThrows(IllegalStateException.class, () -> report
+        .setStat(HddsProtos.LifeCycleState.CLOSED.toString(), 10));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test
   public void testSampleCannotBeSetTwice() {
     List<ContainerID> containers = new ArrayList<>();
     containers.add(ContainerID.valueOf(1));
     report.setSample(HddsProtos.LifeCycleState.CLOSED.toString(), containers);
-    report.setSample(HddsProtos.LifeCycleState.CLOSED.toString(), containers);
+    assertThrows(IllegalStateException.class, () -> report
+        .setSample(HddsProtos.LifeCycleState.CLOSED.toString(), containers));
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/container/common/helpers/TestExcludeList.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdds.scm.container.common.helpers;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.ozone.test.TestClock;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 import java.time.ZoneOffset;
@@ -39,9 +39,9 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.1").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assert.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertTrue(list.getDatanodes().size() == 1);
     clock.fastForward(11);
-    Assert.assertTrue(list.getDatanodes().size() == 0);
+    Assertions.assertTrue(list.getDatanodes().size() == 0);
     list.addDatanode(DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
         .setIpAddress("127.0.0.2").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
@@ -50,7 +50,7 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.3").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assert.assertTrue(list.getDatanodes().size() == 2);
+    Assertions.assertTrue(list.getDatanodes().size() == 2);
   }
 
   @Test
@@ -60,8 +60,8 @@ public class TestExcludeList {
         .setIpAddress("127.0.0.1").setHostName("localhost").addPort(
             DatanodeDetails.newPort(DatanodeDetails.Port.Name.STANDALONE, 2001))
         .build());
-    Assert.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertTrue(list.getDatanodes().size() == 1);
     clock.fastForward(1);
-    Assert.assertTrue(list.getDatanodes().size() == 1);
+    Assertions.assertTrue(list.getDatanodes().size() == 1);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
@@ -22,9 +22,9 @@ import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class TestSCMNodeInfo {
   private String scmServiceId = "scmserviceId";
   private String[] nodes = new String[]{"scm1", "scm2", "scm3"};
 
-  @Before
+  @BeforeEach
   public void setup() {
     conf.set(ScmConfigKeys.OZONE_SCM_SERVICE_IDS_KEY, scmServiceId);
     conf.set(ScmConfigKeys.OZONE_SCM_NODES_KEY + "." + scmServiceId,
@@ -92,15 +92,15 @@ public class TestSCMNodeInfo {
 
     int count = 1;
     for (SCMNodeInfo scmNodeInfo : scmNodeInfos) {
-      Assert.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
-      Assert.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
-      Assert.assertEquals("localhost:" + ++port,
+      Assertions.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
+      Assertions.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
+      Assertions.assertEquals("localhost:" + ++port,
           scmNodeInfo.getBlockClientAddress());
-      Assert.assertEquals("localhost:" + ++port,
+      Assertions.assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmSecurityAddress());
-      Assert.assertEquals("localhost:" + ++port,
+      Assertions.assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmClientAddress());
-      Assert.assertEquals("localhost:" + ++port,
+      Assertions.assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmDatanodeAddress());
     }
   }
@@ -116,16 +116,16 @@ public class TestSCMNodeInfo {
 
     int count = 1;
     for (SCMNodeInfo scmNodeInfo : scmNodeInfos) {
-      Assert.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
-      Assert.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
-      Assert.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
+      Assertions.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
+      Assertions.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
+      Assertions.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
           scmNodeInfo.getBlockClientAddress());
-      Assert.assertEquals("localhost:" +
+      Assertions.assertEquals("localhost:" +
               OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
           scmNodeInfo.getScmSecurityAddress());
-      Assert.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
+      Assertions.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
           scmNodeInfo.getScmClientAddress());
-      Assert.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
+      Assertions.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
           scmNodeInfo.getScmDatanodeAddress());
     }
 
@@ -150,15 +150,15 @@ public class TestSCMNodeInfo {
 
     List< SCMNodeInfo > scmNodeInfos = SCMNodeInfo.buildNodeInfo(config);
 
-    Assert.assertNotNull(scmNodeInfos);
-    Assert.assertTrue(scmNodeInfos.size() == 1);
-    Assert.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
+    Assertions.assertNotNull(scmNodeInfos);
+    Assertions.assertTrue(scmNodeInfos.size() == 1);
+    Assertions.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
         scmNodeInfos.get(0).getBlockClientAddress());
-    Assert.assertEquals("localhost:" + OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
+    Assertions.assertEquals("localhost:" + OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmSecurityAddress());
-    Assert.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
+    Assertions.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmClientAddress());
-    Assert.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
+    Assertions.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmDatanodeAddress());
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
@@ -41,6 +41,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_K
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for {@link SCMNodeInfo}.
@@ -132,14 +133,15 @@ public class TestSCMNodeInfo {
 
   }
 
-  @Test(expected = ConfigurationException.class)
+  @Test
   public void testSCMHANodeInfoWithMissingSCMAddress() {
     conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_ADDRESS_KEY,
         scmServiceId, "scm1"), "localhost");
     conf.set(ConfUtils.addKeySuffixes(OZONE_SCM_ADDRESS_KEY,
         scmServiceId, "scm1"), "localhost");
 
-    SCMNodeInfo.buildNodeInfo(conf);
+    assertThrows(ConfigurationException.class,
+        () -> SCMNodeInfo.buildNodeInfo(conf));
   }
 
   @Test
@@ -151,7 +153,7 @@ public class TestSCMNodeInfo {
     List< SCMNodeInfo > scmNodeInfos = SCMNodeInfo.buildNodeInfo(config);
 
     Assertions.assertNotNull(scmNodeInfos);
-    Assertions.assertTrue(scmNodeInfos.size() == 1);
+    Assertions.assertEquals(1, scmNodeInfos.size());
     Assertions.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
         scmNodeInfos.get(0).getBlockClientAddress());
     Assertions.assertEquals("localhost:" + OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/ha/TestSCMNodeInfo.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.conf.ConfigurationException;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.ozone.ha.ConfUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -41,6 +40,8 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_PORT_K
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_ADDRESS_KEY;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_SECURITY_SERVICE_PORT_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
@@ -93,15 +94,15 @@ public class TestSCMNodeInfo {
 
     int count = 1;
     for (SCMNodeInfo scmNodeInfo : scmNodeInfos) {
-      Assertions.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
-      Assertions.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
-      Assertions.assertEquals("localhost:" + ++port,
+      assertEquals(scmServiceId, scmNodeInfo.getServiceId());
+      assertEquals("scm" + count++, scmNodeInfo.getNodeId());
+      assertEquals("localhost:" + ++port,
           scmNodeInfo.getBlockClientAddress());
-      Assertions.assertEquals("localhost:" + ++port,
+      assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmSecurityAddress());
-      Assertions.assertEquals("localhost:" + ++port,
+      assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmClientAddress());
-      Assertions.assertEquals("localhost:" + ++port,
+      assertEquals("localhost:" + ++port,
           scmNodeInfo.getScmDatanodeAddress());
     }
   }
@@ -117,16 +118,16 @@ public class TestSCMNodeInfo {
 
     int count = 1;
     for (SCMNodeInfo scmNodeInfo : scmNodeInfos) {
-      Assertions.assertEquals(scmServiceId, scmNodeInfo.getServiceId());
-      Assertions.assertEquals("scm" + count++, scmNodeInfo.getNodeId());
-      Assertions.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
+      assertEquals(scmServiceId, scmNodeInfo.getServiceId());
+      assertEquals("scm" + count++, scmNodeInfo.getNodeId());
+      assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
           scmNodeInfo.getBlockClientAddress());
-      Assertions.assertEquals("localhost:" +
+      assertEquals("localhost:" +
               OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
           scmNodeInfo.getScmSecurityAddress());
-      Assertions.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
+      assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
           scmNodeInfo.getScmClientAddress());
-      Assertions.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
+      assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
           scmNodeInfo.getScmDatanodeAddress());
     }
 
@@ -152,15 +153,15 @@ public class TestSCMNodeInfo {
 
     List< SCMNodeInfo > scmNodeInfos = SCMNodeInfo.buildNodeInfo(config);
 
-    Assertions.assertNotNull(scmNodeInfos);
-    Assertions.assertEquals(1, scmNodeInfos.size());
-    Assertions.assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
+    assertNotNull(scmNodeInfos);
+    assertEquals(1, scmNodeInfos.size());
+    assertEquals("localhost:" + OZONE_SCM_BLOCK_CLIENT_PORT_DEFAULT,
         scmNodeInfos.get(0).getBlockClientAddress());
-    Assertions.assertEquals("localhost:" + OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
+    assertEquals("localhost:" + OZONE_SCM_SECURITY_SERVICE_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmSecurityAddress());
-    Assertions.assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
+    assertEquals("localhost:" + OZONE_SCM_CLIENT_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmClientAddress());
-    Assertions.assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
+    assertEquals("localhost:" + OZONE_SCM_DATANODE_PORT_DEFAULT,
         scmNodeInfos.get(0).getScmDatanodeAddress());
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNetUtils.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.net;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -29,6 +28,8 @@ import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.V0_PORTS
 import static org.apache.hadoop.hdds.protocol.TestDatanodeDetails.assertPorts;
 import static org.apache.hadoop.ozone.ClientVersion.DEFAULT_VERSION;
 import static org.apache.hadoop.ozone.ClientVersion.VERSION_HANDLES_UNKNOWN_DN_PORTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test for {@link Pipeline}.
@@ -58,15 +59,15 @@ public class TestPipeline {
 
     //when EC config is empty/null
     HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(1);
-    Assertions.assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
+    assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
 
 
     //when EC config is NOT empty
     subject = MockPipeline.createEcPipeline();
 
     protobufMessage = subject.getProtobufMessage(1);
-    Assertions.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
-    Assertions.assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
+    assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
+    assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
 
   }
 
@@ -77,7 +78,7 @@ public class TestPipeline {
     Pipeline reloadedPipeline = Pipeline.getFromProtobuf(protobufMessage);
 
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      Assertions.assertEquals(pipeline.getReplicaIndex(dn),
+      assertEquals(pipeline.getReplicaIndex(dn),
           reloadedPipeline.getReplicaIndex(dn));
     }
   }
@@ -85,29 +86,29 @@ public class TestPipeline {
   @Test
   public void testECPipelineIsAlwaysHealthy() {
     Pipeline pipeline = MockPipeline.createEcPipeline();
-    Assertions.assertTrue(pipeline.isHealthy());
+    assertTrue(pipeline.isHealthy());
   }
 
   @Test
   public void testBuilderCopiesAllFieldsFromOtherPipeline() {
     Pipeline original = MockPipeline.createEcPipeline();
     Pipeline copied = Pipeline.newBuilder(original).build();
-    Assertions.assertEquals(original.getId(), copied.getId());
-    Assertions.assertEquals(original.getReplicationConfig(),
+    assertEquals(original.getId(), copied.getId());
+    assertEquals(original.getReplicationConfig(),
         copied.getReplicationConfig());
-    Assertions.assertEquals(original.getPipelineState(), copied.getPipelineState());
-    Assertions.assertEquals(original.getId(), copied.getId());
-    Assertions.assertEquals(original.getId(), copied.getId());
-    Assertions.assertEquals(original.getId(), copied.getId());
-    Assertions.assertEquals(original.getNodeSet(), copied.getNodeSet());
-    Assertions.assertEquals(original.getNodesInOrder(), copied.getNodesInOrder());
-    Assertions.assertEquals(original.getLeaderId(), copied.getLeaderId());
-    Assertions.assertEquals(original.getCreationTimestamp(),
+    assertEquals(original.getPipelineState(), copied.getPipelineState());
+    assertEquals(original.getId(), copied.getId());
+    assertEquals(original.getId(), copied.getId());
+    assertEquals(original.getId(), copied.getId());
+    assertEquals(original.getNodeSet(), copied.getNodeSet());
+    assertEquals(original.getNodesInOrder(), copied.getNodesInOrder());
+    assertEquals(original.getLeaderId(), copied.getLeaderId());
+    assertEquals(original.getCreationTimestamp(),
         copied.getCreationTimestamp());
-    Assertions.assertEquals(original.getSuggestedLeaderId(),
+    assertEquals(original.getSuggestedLeaderId(),
         copied.getSuggestedLeaderId());
     for (DatanodeDetails dn : original.getNodes()) {
-      Assertions.assertEquals(original.getReplicaIndex(dn),
+      assertEquals(original.getReplicaIndex(dn),
           copied.getReplicaIndex(dn));
     }
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hdds.scm.pipeline;
 
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 
@@ -58,14 +58,14 @@ public class TestPipeline {
 
     //when EC config is empty/null
     HddsProtos.Pipeline protobufMessage = subject.getProtobufMessage(1);
-    Assert.assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
+    Assertions.assertEquals(0, protobufMessage.getEcReplicationConfig().getData());
 
 
     //when EC config is NOT empty
     subject = MockPipeline.createEcPipeline();
 
     protobufMessage = subject.getProtobufMessage(1);
-    Assert.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
+    Assertions.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
     Assert
         .assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
 
@@ -78,7 +78,7 @@ public class TestPipeline {
     Pipeline reloadedPipeline = Pipeline.getFromProtobuf(protobufMessage);
 
     for (DatanodeDetails dn : pipeline.getNodes()) {
-      Assert.assertEquals(pipeline.getReplicaIndex(dn),
+      Assertions.assertEquals(pipeline.getReplicaIndex(dn),
           reloadedPipeline.getReplicaIndex(dn));
     }
   }
@@ -86,29 +86,29 @@ public class TestPipeline {
   @Test
   public void testECPipelineIsAlwaysHealthy() throws IOException {
     Pipeline pipeline = MockPipeline.createEcPipeline();
-    Assert.assertTrue(pipeline.isHealthy());
+    Assertions.assertTrue(pipeline.isHealthy());
   }
 
   @Test
   public void testBuilderCopiesAllFieldsFromOtherPipeline() {
     Pipeline original = MockPipeline.createEcPipeline();
     Pipeline copied = Pipeline.newBuilder(original).build();
-    Assert.assertEquals(original.getId(), copied.getId());
-    Assert.assertEquals(original.getReplicationConfig(),
+    Assertions.assertEquals(original.getId(), copied.getId());
+    Assertions.assertEquals(original.getReplicationConfig(),
         copied.getReplicationConfig());
-    Assert.assertEquals(original.getPipelineState(), copied.getPipelineState());
-    Assert.assertEquals(original.getId(), copied.getId());
-    Assert.assertEquals(original.getId(), copied.getId());
-    Assert.assertEquals(original.getId(), copied.getId());
-    Assert.assertEquals(original.getNodeSet(), copied.getNodeSet());
-    Assert.assertEquals(original.getNodesInOrder(), copied.getNodesInOrder());
-    Assert.assertEquals(original.getLeaderId(), copied.getLeaderId());
-    Assert.assertEquals(original.getCreationTimestamp(),
+    Assertions.assertEquals(original.getPipelineState(), copied.getPipelineState());
+    Assertions.assertEquals(original.getId(), copied.getId());
+    Assertions.assertEquals(original.getId(), copied.getId());
+    Assertions.assertEquals(original.getId(), copied.getId());
+    Assertions.assertEquals(original.getNodeSet(), copied.getNodeSet());
+    Assertions.assertEquals(original.getNodesInOrder(), copied.getNodesInOrder());
+    Assertions.assertEquals(original.getLeaderId(), copied.getLeaderId());
+    Assertions.assertEquals(original.getCreationTimestamp(),
         copied.getCreationTimestamp());
-    Assert.assertEquals(original.getSuggestedLeaderId(),
+    Assertions.assertEquals(original.getSuggestedLeaderId(),
         copied.getSuggestedLeaderId());
     for (DatanodeDetails dn : original.getNodes()) {
-      Assert.assertEquals(original.getReplicaIndex(dn),
+      Assertions.assertEquals(original.getReplicaIndex(dn),
           copied.getReplicaIndex(dn));
     }
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestPipeline.java
@@ -66,8 +66,7 @@ public class TestPipeline {
 
     protobufMessage = subject.getProtobufMessage(1);
     Assertions.assertEquals(3, protobufMessage.getEcReplicationConfig().getData());
-    Assert
-        .assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
+    Assertions.assertEquals(2, protobufMessage.getEcReplicationConfig().getParity());
 
   }
 
@@ -84,7 +83,7 @@ public class TestPipeline {
   }
 
   @Test
-  public void testECPipelineIsAlwaysHealthy() throws IOException {
+  public void testECPipelineIsAlwaysHealthy() {
     Pipeline pipeline = MockPipeline.createEcPipeline();
     Assertions.assertTrue(pipeline.isHealthy());
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTraceAllMethod.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTraceAllMethod.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hdds.tracing;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for {@link TraceAllMethod}.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
@@ -22,10 +22,10 @@ import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.Service;
 import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.ServiceImpl;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.tracing.TracingUtil.createProxy;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test for {@link TracingUtil}.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/upgrade/TestHDDSLayoutVersionManager.java
@@ -23,9 +23,9 @@ import static org.apache.hadoop.hdds.upgrade.HDDSLayoutFeature.INITIAL_VERSION;
 import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutVersion;
 import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON_FINALIZE;
 import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON_FIRST_UPGRADE_START;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
@@ -38,8 +38,8 @@ import java.util.Optional;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockDnUpgradeAction;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockScmUpgradeAction;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Class to test HDDS upgrade action registrations.
@@ -58,9 +58,9 @@ public class TestHDDSLayoutVersionManager {
 
     //Cluster is finalized, hence should not register.
     Optional<HDDSUpgradeAction> action = INITIAL_VERSION.scmAction(ON_FINALIZE);
-    Assert.assertFalse(action.isPresent());
+    Assertions.assertFalse(action.isPresent());
     action = DATANODE_SCHEMA_V2.datanodeAction(ON_FIRST_UPGRADE_START);
-    Assert.assertFalse(action.isPresent());
+    Assertions.assertFalse(action.isPresent());
 
     // Start from an unfinalized version manager.
     lvm = mock(HDDSLayoutVersionManager.class);

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestHddsIdFactory.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestHddsIdFactory.java
@@ -26,11 +26,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.hadoop.hdds.HddsIdFactory;
-import org.junit.After;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterEach;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test the JMX interface for the rocksdb metastore implementation.
@@ -41,7 +41,7 @@ public class TestHddsIdFactory {
   private static final int IDS_PER_THREAD = 10000;
   private static final int NUM_OF_THREADS = 5;
 
-  @After
+  @AfterEach
   public void cleanup() {
     ID_SET.clear();
   }
@@ -65,7 +65,7 @@ public class TestHddsIdFactory {
         for (int idNum = 0; idNum < IDS_PER_THREAD; idNum++) {
           long var = HddsIdFactory.getLongId();
           if (ID_SET.contains(var)) {
-            Assert.fail("Duplicate id found");
+            Assertions.fail("Duplicate id found");
           }
           ID_SET.add(var);
         }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -17,8 +17,8 @@
 package org.apache.hadoop.hdds.utils;
 
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -56,9 +56,9 @@ public class TestResourceLimitCache {
       }
       return null;
     });
-    Assert.assertTrue(!future.isDone());
+    Assertions.assertTrue(!future.isDone());
     Thread.sleep(100);
-    Assert.assertTrue(!future.isDone());
+    Assertions.assertTrue(!future.isDone());
 
     // remove 4 so that permits are released for key 1 to be put. Currently map
     // has acquired 6 permits out of 10
@@ -66,8 +66,8 @@ public class TestResourceLimitCache {
 
     GenericTestUtils.waitFor(future::isDone, 100, 1000);
     // map has the key 1
-    Assert.assertTrue(future.isDone() && !future.isCompletedExceptionally());
-    Assert.assertNotNull(resourceCache.get(1));
+    Assertions.assertTrue(future.isDone() && !future.isCompletedExceptionally());
+    Assertions.assertNotNull(resourceCache.get(1));
 
     // Create a future which blocks to put 4. Currently map has acquired 7
     // permits out of 10
@@ -79,9 +79,9 @@ public class TestResourceLimitCache {
         return null;
       }
     }, pool);
-    Assert.assertTrue(!future.isDone());
+    Assertions.assertTrue(!future.isDone());
     Thread.sleep(100);
-    Assert.assertTrue(!future.isDone());
+    Assertions.assertTrue(!future.isDone());
 
     // Shutdown the thread pool for putting key 4
     pool.shutdownNow();
@@ -89,7 +89,7 @@ public class TestResourceLimitCache {
     future.cancel(true);
     // remove key 1 so currently map has acquired 6 permits out of 10
     resourceCache.remove(1);
-    Assert.assertNull(resourceCache.get(4));
+    Assertions.assertNull(resourceCache.get(4));
   }
 
   @Test(timeout = 5000)
@@ -124,7 +124,7 @@ public class TestResourceLimitCache {
 
     // THEN
     for (Integer k : removedKeys) {
-      Assert.assertNull(resourceCache.get(k));
+      Assertions.assertNull(resourceCache.get(k));
     }
     // can put new entries
     for (int i = 1; i <= removedKeys.length; ++i) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -67,7 +67,8 @@ public class TestResourceLimitCache {
 
     GenericTestUtils.waitFor(future::isDone, 100, 1000);
     // map has the key 1
-    Assertions.assertTrue(future.isDone() && !future.isCompletedExceptionally());
+    Assertions.assertTrue(future.isDone());
+    Assertions.assertFalse(future.isCompletedExceptionally());
     Assertions.assertNotNull(resourceCache.get(1));
 
     // Create a future which blocks to put 4. Currently map has acquired 7

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceLimitCache.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hdds.utils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,7 +49,7 @@ public class TestResourceLimitCache {
 
     // Create a future which blocks to put 1. Currently map has acquired 10
     // permits out of 10
-    CompletableFuture future = CompletableFuture.supplyAsync(() -> {
+    CompletableFuture<String> future = CompletableFuture.supplyAsync(() -> {
       try {
         return resourceCache.put(1, "a");
       } catch (InterruptedException e) {
@@ -56,9 +57,9 @@ public class TestResourceLimitCache {
       }
       return null;
     });
-    Assertions.assertTrue(!future.isDone());
+    Assertions.assertFalse(future.isDone());
     Thread.sleep(100);
-    Assertions.assertTrue(!future.isDone());
+    Assertions.assertFalse(future.isDone());
 
     // remove 4 so that permits are released for key 1 to be put. Currently map
     // has acquired 6 permits out of 10
@@ -79,9 +80,9 @@ public class TestResourceLimitCache {
         return null;
       }
     }, pool);
-    Assertions.assertTrue(!future.isDone());
+    Assertions.assertFalse(future.isDone());
     Thread.sleep(100);
-    Assertions.assertTrue(!future.isDone());
+    Assertions.assertFalse(future.isDone());
 
     // Shutdown the thread pool for putting key 4
     pool.shutdownNow();
@@ -92,17 +93,20 @@ public class TestResourceLimitCache {
     Assertions.assertNull(resourceCache.get(4));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5)
   public void testRemove() throws Exception {
     testRemove(cache -> cache.remove(2), 2);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5)
   public void testRemoveIf() throws Exception {
     testRemove(cache -> cache.removeIf(k -> k <= 2), 1, 2);
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5)
   public void testClear() throws Exception {
     testRemove(Cache::clear, 1, 2, 3);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceSemaphore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceSemaphore.java
@@ -19,12 +19,16 @@ package org.apache.hadoop.hdds.utils;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Test for ResourceSemaphore.
  */
 public class TestResourceSemaphore {
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(1)
   public void testGroup() {
     final ResourceSemaphore.Group g = new ResourceSemaphore.Group(3, 1);
 
@@ -49,16 +53,8 @@ public class TestResourceSemaphore {
     g.release(0, 0);
     assertUsed(g, 0, 0);
 
-    try {
-      g.release(1, 0);
-      Assertions.fail("Should have failed.");
-    } catch (IllegalStateException e) {
-    }
-    try {
-      g.release(0, 1);
-      Assertions.fail("Should have failed.");
-    } catch (IllegalStateException e) {
-    }
+    assertThrows(IllegalStateException.class, () -> g.release(1, 0));
+    assertThrows(IllegalStateException.class, () -> g.release(0, 1));
   }
 
   static void assertUsed(ResourceSemaphore.Group g, int... expected) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceSemaphore.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestResourceSemaphore.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for ResourceSemaphore.
@@ -51,26 +51,26 @@ public class TestResourceSemaphore {
 
     try {
       g.release(1, 0);
-      Assert.fail("Should have failed.");
+      Assertions.fail("Should have failed.");
     } catch (IllegalStateException e) {
     }
     try {
       g.release(0, 1);
-      Assert.fail("Should have failed.");
+      Assertions.fail("Should have failed.");
     } catch (IllegalStateException e) {
     }
   }
 
   static void assertUsed(ResourceSemaphore.Group g, int... expected) {
-    Assert.assertEquals(expected.length, g.resourceSize());
+    Assertions.assertEquals(expected.length, g.resourceSize());
     for (int i = 0; i < expected.length; i++) {
-      Assert.assertEquals(expected[i], g.get(i).used());
+      Assertions.assertEquals(expected[i], g.get(i).used());
     }
   }
 
   static void assertAcquire(ResourceSemaphore.Group g, boolean expected,
       int... permits) {
     final boolean computed = g.tryAcquire(permits);
-    Assert.assertEquals(expected, computed);
+    Assertions.assertEquals(expected, computed);
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestRetriableTask.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/utils/TestRetriableTask.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hdds.utils;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryPolicy;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/TestOzoneConsts.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/TestOzoneConsts.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.ozone;
 
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Ozone Constants (e.g. for compatibility).
@@ -28,7 +28,7 @@ public class TestOzoneConsts {
   @Test
   public void testOzoneTenantPolicyLabelCompatibility() {
     // Value of the policy label should not be changed
-    Assert.assertEquals(
+    Assertions.assertEquals(
         "OzoneTenant", OzoneConsts.OZONE_TENANT_RANGER_POLICY_LABEL);
   }
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.ozone.audit;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,10 +35,10 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.FAILURE;
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.SUCCESS;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.MatcherAssertions.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsIterableContainingInOrder;
 
@@ -102,7 +102,7 @@ public class TestOzoneAuditLogger {
           .withResult(SUCCESS)
           .withException(null).build();
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     File file = new File("audit.log");
     if (FileUtils.deleteQuietly(file)) {
@@ -113,7 +113,7 @@ public class TestOzoneAuditLogger {
     }
   }
 
-  @Before
+  @BeforeEach
   public void init() {
     AUDIT.refreshDebugCmdSet();
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/audit/TestOzoneAuditLogger.java
@@ -35,7 +35,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.FAILURE;
 import static org.apache.hadoop.ozone.audit.AuditEventStatus.SUCCESS;
-import static org.hamcrest.MatcherAssertions.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -166,11 +166,11 @@ public class TestOzoneAuditLogger {
   @Test
   public void messageIncludesAllParts() {
     String message = WRITE_FAIL_MSG.getFormattedMessage();
-    assertTrue(message, message.contains(USER));
-    assertTrue(message, message.contains(IP_ADDRESS));
-    assertTrue(message, message.contains(DummyAction.CREATE_VOLUME.name()));
-    assertTrue(message, message.contains(PARAMS.toString()));
-    assertTrue(message, message.contains(FAILURE.getStatus()));
+    assertTrue(message.contains(USER), message);
+    assertTrue(message.contains(IP_ADDRESS), message);
+    assertTrue(message.contains(DummyAction.CREATE_VOLUME.name()), message);
+    assertTrue(message.contains(PARAMS.toString()), message);
+    assertTrue(message.contains(FAILURE.getStatus()), message);
   }
 
   /**

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.common;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -54,10 +54,10 @@ public class TestChecksum {
     // A checksum is calculate for each bytesPerChecksum number of bytes in
     // the data. Since that value is 10 here and the data length is 55, we
     // should have 6 checksums in checksumData.
-    Assert.assertEquals(6, checksumData.getChecksums().size());
+    Assertions.assertEquals(6, checksumData.getChecksums().size());
 
     // Checksum verification should pass
-    Assert.assertTrue("Checksum mismatch",
+    Assertions.assertTrue("Checksum mismatch",
         Checksum.verifyChecksum(data, checksumData));
   }
 
@@ -75,7 +75,7 @@ public class TestChecksum {
     // mismatch
     data[50] = (byte) (data[50] + 1);
     ChecksumData newChecksumData = checksum.computeChecksum(data);
-    Assert.assertNotEquals("Checksums should not match for different data",
+    Assertions.assertNotEquals("Checksums should not match for different data",
         originalChecksumData, newChecksumData);
   }
 
@@ -92,7 +92,7 @@ public class TestChecksum {
     Checksum checksum2 = getChecksum(ContainerProtos.ChecksumType.CRC32);
 
     // The two checksums should not match as they have different types
-    Assert.assertNotEquals(
+    Assertions.assertNotEquals(
         "Checksums should not match for different checksum types",
         checksum1, checksum2);
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksum.java
@@ -57,8 +57,8 @@ public class TestChecksum {
     Assertions.assertEquals(6, checksumData.getChecksums().size());
 
     // Checksum verification should pass
-    Assertions.assertTrue("Checksum mismatch",
-        Checksum.verifyChecksum(data, checksumData));
+    Assertions.assertTrue(Checksum.verifyChecksum(data, checksumData),
+        "Checksum mismatch");
   }
 
   /**
@@ -75,8 +75,8 @@ public class TestChecksum {
     // mismatch
     data[50] = (byte) (data[50] + 1);
     ChecksumData newChecksumData = checksum.computeChecksum(data);
-    Assertions.assertNotEquals("Checksums should not match for different data",
-        originalChecksumData, newChecksumData);
+    Assertions.assertNotEquals(originalChecksumData, newChecksumData,
+        "Checksums should not match for different data");
   }
 
   /**
@@ -92,8 +92,7 @@ public class TestChecksum {
     Checksum checksum2 = getChecksum(ContainerProtos.ChecksumType.CRC32);
 
     // The two checksums should not match as they have different types
-    Assertions.assertNotEquals(
-        "Checksums should not match for different checksum types",
-        checksum1, checksum2);
+    Assertions.assertNotEquals(checksum1, checksum2,
+        "Checksums should not match for different checksum types");
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumByteBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumByteBuffer.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.ozone.common;
 
 import org.apache.hadoop.util.PureJavaCrc32;
 import org.apache.hadoop.util.PureJavaCrc32C;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Random;
@@ -96,7 +96,7 @@ public class TestChecksumByteBuffer {
     }
 
     private void checkSame() {
-      Assert.assertEquals(expected.getValue(), testee.getValue());
+      Assertions.assertEquals(expected.getValue(), testee.getValue());
     }
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChecksumImplsComputeSameValues.java
@@ -21,14 +21,14 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.util.NativeCRC32Wrapper;
 import org.apache.hadoop.util.PureJavaCrc32;
 import org.apache.hadoop.util.PureJavaCrc32C;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.CRC32;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Tests to verify that different checksum implementations compute the same

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
@@ -30,8 +30,8 @@ import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.hdds.utils.MockGatheringChannel;
 
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
 
 /**
@@ -114,14 +114,14 @@ public class TestChunkBuffer {
     System.out.println("n=" + n + ", impl=" + impl);
 
     // check position, remaining
-    Assert.assertEquals(0, impl.position());
-    Assert.assertEquals(n, impl.remaining());
-    Assert.assertEquals(n, impl.limit());
+    Assertions.assertEquals(0, impl.position());
+    Assertions.assertEquals(n, impl.remaining());
+    Assertions.assertEquals(n, impl.limit());
 
     impl.put(expected);
-    Assert.assertEquals(n, impl.position());
-    Assert.assertEquals(0, impl.remaining());
-    Assert.assertEquals(n, impl.limit());
+    Assertions.assertEquals(n, impl.position());
+    Assertions.assertEquals(0, impl.remaining());
+    Assertions.assertEquals(n, impl.limit());
 
     // duplicate
     assertDuplicate(expected, impl);
@@ -159,8 +159,8 @@ public class TestChunkBuffer {
       byte[] expected, ChunkBuffer impl, int bpc) {
     final int n = expected.length;
     final ChunkBuffer duplicated = impl.duplicate(0, n);
-    Assert.assertEquals(0, duplicated.position());
-    Assert.assertEquals(n, duplicated.remaining());
+    Assertions.assertEquals(0, duplicated.position());
+    Assertions.assertEquals(n, duplicated.remaining());
 
     final int numChecksums = (n + bpc - 1) / bpc;
     final Iterator<ByteBuffer> i = duplicated.iterate(bpc).iterator();
@@ -169,55 +169,55 @@ public class TestChunkBuffer {
       final ByteBuffer b = i.next();
       final int expectedRemaining = j < numChecksums - 1 ?
           bpc : n - bpc * (numChecksums - 1);
-      Assert.assertEquals(expectedRemaining, b.remaining());
+      Assertions.assertEquals(expectedRemaining, b.remaining());
 
       final int offset = j * bpc;
       for (int k = 0; k < expectedRemaining; k++) {
-        Assert.assertEquals(expected[offset + k], b.get());
+        Assertions.assertEquals(expected[offset + k], b.get());
         count++;
       }
     }
-    Assert.assertEquals(n, count);
-    Assert.assertFalse(i.hasNext());
+    Assertions.assertEquals(n, count);
+    Assertions.assertFalse(i.hasNext());
     Assertions.assertThrows(NoSuchElementException.class, i::next);
   }
 
   private static void assertToByteString(
       byte[] expected, int offset, int length, ChunkBuffer impl) {
     final ChunkBuffer duplicated = impl.duplicate(offset, offset + length);
-    Assert.assertEquals(offset, duplicated.position());
-    Assert.assertEquals(length, duplicated.remaining());
+    Assertions.assertEquals(offset, duplicated.position());
+    Assertions.assertEquals(length, duplicated.remaining());
     final ByteString computed = duplicated.toByteString(buffer -> {
       buffer.mark();
       final ByteString string = ByteString.copyFrom(buffer);
       buffer.reset();
       return string;
     });
-    Assert.assertEquals(offset, duplicated.position());
-    Assert.assertEquals(length, duplicated.remaining());
+    Assertions.assertEquals(offset, duplicated.position());
+    Assertions.assertEquals(length, duplicated.remaining());
     assertEquals("offset=" + offset + ", length=" + length,
         ByteString.copyFrom(expected, offset, length), computed);
   }
 
   private static void assertWrite(byte[] expected, ChunkBuffer impl) {
     impl.rewind();
-    Assert.assertEquals(0, impl.position());
+    Assertions.assertEquals(0, impl.position());
 
     ByteArrayOutputStream output = new ByteArrayOutputStream(expected.length);
 
     try {
       impl.writeTo(new MockGatheringChannel(Channels.newChannel(output)));
     } catch (IOException e) {
-      Assert.fail("Unexpected error: " + e);
+      Assertions.fail("Unexpected error: " + e);
     }
 
-    Assert.assertArrayEquals(expected, output.toByteArray());
-    Assert.assertFalse(impl.hasRemaining());
+    Assertions.assertArrayEquals(expected, output.toByteArray());
+    Assertions.assertFalse(impl.hasRemaining());
   }
 
   private static void assertEquals(String message,
       ByteString expected, ByteString actual) {
-    Assert.assertEquals(message,
+    Assertions.assertEquals(message,
         toString(expected.toByteArray()),
         toString(actual.toByteArray()));
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBuffer.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.hdds.utils.MockGatheringChannel;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test {@link ChunkBuffer} implementations.
@@ -42,7 +42,8 @@ public class TestChunkBuffer {
     return ThreadLocalRandom.current().nextInt(n);
   }
 
-  @Test(timeout = 1_000)
+  @Test
+  @Timeout(1)
   public void testImplWithByteBuffer() {
     runTestImplWithByteBuffer(1);
     runTestImplWithByteBuffer(1 << 10);
@@ -57,7 +58,8 @@ public class TestChunkBuffer {
     runTestImpl(expected, 0, ChunkBuffer.allocate(n));
   }
 
-  @Test(timeout = 1_000)
+  @Test
+  @Timeout(1)
   public void testIncrementalChunkBuffer() {
     runTestIncrementalChunkBuffer(1, 1);
     runTestIncrementalChunkBuffer(4, 8);
@@ -76,7 +78,8 @@ public class TestChunkBuffer {
         new IncrementalChunkBuffer(n, increment, false));
   }
 
-  @Test(timeout = 1_000)
+  @Test
+  @Timeout(1)
   public void testImplWithList() {
     runTestImplWithList(4, 8);
     runTestImplWithList(16, 1 << 10);
@@ -217,9 +220,10 @@ public class TestChunkBuffer {
 
   private static void assertEquals(String message,
       ByteString expected, ByteString actual) {
-    Assertions.assertEquals(message,
+    Assertions.assertEquals(
         toString(expected.toByteArray()),
-        toString(actual.toByteArray()));
+        toString(actual.toByteArray()),
+        message);
   }
 
   private static String toString(byte[] arr) {

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.ozone.common;
 
 import com.google.common.collect.ImmutableList;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.BufferOverflowException;
 import java.nio.ByteBuffer;

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/ha/TestOzoneNetUtils.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/ha/TestOzoneNetUtils.java
@@ -18,8 +18,8 @@ package org.apache.hadoop.ozone.ha;
 
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.util.OzoneNetUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.net.InetSocketAddress;
 
@@ -35,7 +35,7 @@ public class TestOzoneNetUtils {
     InetSocketAddress addr0 = NetUtils.createSocketAddr(fqdn, port);
     InetSocketAddress addr1 = OzoneNetUtils.getAddressWithHostNameLocal(
             addr0);
-    Assert.assertEquals("pod0", addr1.getHostName());
-    Assert.assertEquals(port, addr1.getPort());
+    Assertions.assertEquals("pod0", addr1.getHostName());
+    Assertions.assertEquals(port, addr1.getPort());
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
@@ -22,6 +22,7 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Daemon;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,7 +32,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class TestLockManager {
 
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(1)
   public void testWriteLockWithDifferentResource() {
     final LockManager<String> manager =
         new LockManager<>(new OzoneConfiguration());
@@ -67,7 +69,8 @@ public class TestLockManager {
     Assertions.assertTrue(gotLock.get());
   }
 
-  @Test(timeout = 1000)
+  @Test
+  @Timeout(1)
   public void testReadLockWithDifferentResource() {
     final LockManager<String> manager =
         new LockManager<>(new OzoneConfiguration());

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lock/TestLockManager.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.ozone.lock;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.Daemon;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -40,7 +40,7 @@ public class TestLockManager {
     manager.writeLock("/resourceTwo");
     manager.writeUnlock("/resourceOne");
     manager.writeUnlock("/resourceTwo");
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -58,13 +58,13 @@ public class TestLockManager {
     Thread.sleep(100);
     // Since the other thread is trying to get write lock on same object,
     // it will wait.
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     manager.writeUnlock("/resourceOne");
     // Since we have released the write lock, the other thread should have
     // the lock now
     // Let's give some time for the other thread to run
     Thread.sleep(100);
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
   }
 
   @Test(timeout = 1000)
@@ -75,7 +75,7 @@ public class TestLockManager {
     manager.readLock("/resourceTwo");
     manager.readUnlock("/resourceOne");
     manager.readUnlock("/resourceTwo");
-    Assert.assertTrue(true);
+    Assertions.assertTrue(true);
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TestLockManager {
     // Let's give some time for the other thread to run
     Thread.sleep(100);
     // Since the new thread is trying to get read lock, it should work.
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
     manager.readUnlock("/resourceOne");
   }
 
@@ -111,13 +111,13 @@ public class TestLockManager {
     Thread.sleep(100);
     // Since the other thread is trying to get read lock on same object,
     // it will wait.
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     manager.writeUnlock("/resourceOne");
     // Since we have released the write lock, the other thread should have
     // the lock now
     // Let's give some time for the other thread to run
     Thread.sleep(100);
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
   }
 
   @Test
@@ -135,13 +135,13 @@ public class TestLockManager {
     Thread.sleep(100);
     // Since the other thread is trying to get write lock on same object,
     // it will wait.
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     manager.readUnlock("/resourceOne");
     // Since we have released the read lock, the other thread should have
     // the lock now
     // Let's give some time for the other thread to run
     Thread.sleep(100);
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
   }
 
   @Test
@@ -160,17 +160,17 @@ public class TestLockManager {
     Thread.sleep(100);
     // Since the other thread is trying to get write lock on same object,
     // it will wait.
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     manager.readUnlock("/resourceOne");
     //We have only released one read lock, we still hold another read lock.
     Thread.sleep(100);
-    Assert.assertFalse(gotLock.get());
+    Assertions.assertFalse(gotLock.get());
     manager.readUnlock("/resourceOne");
     // Since we have released the read lock, the other thread should have
     // the lock now
     // Let's give some time for the other thread to run
     Thread.sleep(100);
-    Assert.assertTrue(gotLock.get());
+    Assertions.assertTrue(gotLock.get());
   }
 
   @Test
@@ -198,6 +198,6 @@ public class TestLockManager {
     }
     GenericTestUtils.waitFor(() -> done.get() == count, 100,
         10 * count * sleep);
-    Assert.assertEquals(count, done.get());
+    Assertions.assertEquals(count, done.get());
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestBasicUpgradeFinalizer.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestBasicUpgradeFinalizer.java
@@ -22,9 +22,9 @@ import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLa
 import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutFeature.VERSION_3;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.ALREADY_FINALIZED;
 import static org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.Status.FINALIZATION_DONE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.inOrder;
@@ -36,7 +36,7 @@ import java.io.IOException;
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutVersionManager;
 import org.apache.hadoop.ozone.upgrade.UpgradeFinalizer.StatusAndMessages;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.InOrder;
 

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestDefaultUpgradeFinalizationExecutor.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestDefaultUpgradeFinalizationExecutor.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for DefaultUpgradeFinalizationExecutor.

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestLayoutVersionInstanceFactory.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestLayoutVersionInstanceFactory.java
@@ -18,15 +18,15 @@
 
 package org.apache.hadoop.ozone.upgrade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.function.Supplier;
 
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test out APIs of VersionSpecificInstanceFactory.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate simple tests in hdds-common to JUnit5.
Here "simple" means without `@Parameterized` or `@Rule`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6874

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/2480261148
