### PR TITLE
HDDS-6682. Validate Bucket ID of bucket associated with in-flight requests.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/exceptions/OMException.java
@@ -257,6 +257,8 @@ public class OMException extends IOException {
     VOLUME_IS_REFERENCED,
     TENANT_NOT_EMPTY,
 
-    FEATURE_NOT_ENABLED
+    FEATURE_NOT_ENABLED,
+
+    BUCKET_ID_MISMATCH
   }
 }

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -228,6 +228,8 @@ message OMRequest {
   optional SetRangerServiceVersionRequest   SetRangerServiceVersionRequest = 107;
   optional RangerBGSyncRequest              RangerBGSyncRequest            = 109;
   optional EchoRPCRequest                   EchoRPCRequest                 = 110;
+
+  optional uint64 associatedBucketId = 111;
 }
 
 message OMResponse {

--- a/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
+++ b/hadoop-ozone/interface-client/src/main/proto/OmClientProtocol.proto
@@ -438,6 +438,8 @@ enum Status {
     TENANT_NOT_EMPTY = 85;
 
     FEATURE_NOT_ENABLED = 86;
+
+    BUCKET_ID_MISMATCH = 87;
 }
 
 /**

--- a/hadoop-ozone/ozone-manager/hs_err_pid37420.log
+++ b/hadoop-ozone/ozone-manager/hs_err_pid37420.log
@@ -1,0 +1,9 @@
+#
+# A fatal error has been detected by the Java Runtime Environment:
+#
+#  SIGSEGV (0xb) at pc=0x0000000129e3d888, pid=37420, tid=9987
+#
+# JRE version: Java(TM) SE Runtime Environment 18.9 (11.0.9+7) (build 11.0.9+7-LTS)
+# Java VM: Java HotSpot(TM) 64-Bit Server VM 18.9 (11.0.9+7-LTS, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
+# Problematic frame:
+# C  [librocksdbjni12109772278608409961.jnilib+0x2cc888]

--- a/hadoop-ozone/ozone-manager/hs_err_pid37420.log
+++ b/hadoop-ozone/ozone-manager/hs_err_pid37420.log
@@ -1,9 +1,0 @@
-#
-# A fatal error has been detected by the Java Runtime Environment:
-#
-#  SIGSEGV (0xb) at pc=0x0000000129e3d888, pid=37420, tid=9987
-#
-# JRE version: Java(TM) SE Runtime Environment 18.9 (11.0.9+7) (build 11.0.9+7-LTS)
-# Java VM: Java HotSpot(TM) 64-Bit Server VM 18.9 (11.0.9+7-LTS, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
-# Problematic frame:
-# C  [librocksdbjni12109772278608409961.jnilib+0x2cc888]

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
@@ -70,7 +70,8 @@ public final class OMClientRequestUtils {
     if (omRequest.hasAssociatedBucketId()) {
       if (bucketId != omRequest.getAssociatedBucketId()) {
         throw new OMException(
-            "Bucket ID mismatch. Associated bucket was modified while this" +
+            "Bucket ID mismatch. Associated bucket was modified concurrently" +
+                " while " + omRequest.getCmdType() +
                 " request was being processed. Please retry the request.",
             OMException.ResultCodes.BUCKET_ID_MISMATCH);
       }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.om.request;
 
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,29 @@ public final class OMClientRequestUtils {
       throw new OMException(
           errMsg,
           OMException.ResultCodes.INTERNAL_ERROR);
+    }
+  }
+
+  /**
+   * Validates the bucket associated with the request - to make sure it did
+   * not change since the request started processing.
+   *
+   * @param bucketId  - bucket ID of the associated bucket when the request
+   *                  is being processed.
+   * @param omRequest - request to be validated, contains the bucket ID of the
+   *                  associated bucket when the request was created.
+   * @throws OMException
+   */
+  public static void validateAssociatedBucketId(long bucketId,
+                                                OMRequest omRequest)
+      throws OMException {
+    if (omRequest.hasAssociatedBucketId()) {
+      if (bucketId != omRequest.getAssociatedBucketId()) {
+        throw new OMException(
+            "Bucket ID mismatch. Associated bucket was modified while this" +
+                " request was being processed. Please retry the request.",
+            OMException.ResultCodes.BUCKET_ID_MISMATCH);
+      }
     }
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/OMClientRequestUtils.java
@@ -17,11 +17,16 @@
 
 package org.apache.hadoop.ozone.om.request;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
 
 /**
  * Utility class for OMClientRequest. Validates that the bucket layout expected
@@ -70,5 +75,28 @@ public final class OMClientRequestUtils {
             OMException.ResultCodes.BUCKET_ID_MISMATCH);
       }
     }
+  }
+
+  /**
+   * Returns bucket ID of the given bucket. In case the given bucket is a link -
+   * returns the bucket ID of the source bucket.
+   *
+   * @param ozoneManager - Ozone Manager instance.
+   * @param volume       - volume name.
+   * @param bucket       - bucket name.
+   * @return bucket ID of the resolved bucket.
+   * @throws IOException
+   */
+  public static long getResolvedBucketId(OzoneManager ozoneManager,
+                                  String volume,
+                                  String bucket) throws IOException {
+    // Fetch the bucket ID for request validation.
+    // We fetch source bucket ID in case of link buckets.
+    ResolvedBucket resolvedBucket =
+        ozoneManager.resolveBucketLink(Pair.of(volume, bucket));
+    long bucketId = ozoneManager.getMetadataManager()
+        .getBucketId(resolvedBucket.realVolume(),
+            resolvedBucket.realBucket());
+    return bucketId;
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -122,11 +123,10 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // with out volume creation. Check if bucket exists
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volumeName, bucketName);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       OmBucketInfo omBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketDeleteRequest.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.VOLUME_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles DeleteBucket Request.
@@ -120,6 +121,12 @@ public class OMBucketDeleteRequest extends OMClientRequest {
       // No need to check volume exists here, as bucket cannot be created
       // with out volume creation. Check if bucket exists
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       OmBucketInfo omBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle set owner request for bucket.
@@ -123,6 +124,13 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
           BUCKET_LOCK, volumeName, bucketName);
 
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       OmBucketInfo omBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);
       //Check if bucket exist

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetOwnerRequest.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -125,11 +126,10 @@ public class OMBucketSetOwnerRequest extends OMClientRequest {
 
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volumeName, bucketName);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       OmBucketInfo omBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -136,11 +137,10 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
 
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volumeName, bucketName);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       OmBucketInfo dbBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle SetBucketProperty Request.
@@ -134,6 +135,13 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
           BUCKET_LOCK, volumeName, bucketName);
 
       String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       OmBucketInfo dbBucketInfo =
           omMetadataManager.getBucketTable().get(bucketKey);
       //Check if bucket exist

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Base class for Bucket acl request.
@@ -104,6 +105,13 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
               bucket);
 
       String dbBucketKey = omMetadataManager.getBucketKey(volume, bucket);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volume, bucket);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       omBucketInfo = omMetadataManager.getBucketTable().get(dbBucketKey);
       if (omBucketInfo == null) {
         throw new OMException(OMException.ResultCodes.BUCKET_NOT_FOUND);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/acl/OMBucketAclRequest.java
@@ -48,6 +48,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -106,11 +107,10 @@ public abstract class OMBucketAclRequest extends OMClientRequest {
 
       String dbBucketKey = omMetadataManager.getBucketKey(volume, bucket);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volume, bucket);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volume, bucket);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       omBucketInfo = omMetadataManager.getBucketTable().get(dbBucketKey);
       if (omBucketInfo == null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -180,7 +180,7 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       Path keyPath = Paths.get(keyName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -79,6 +79,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.NONE;
@@ -181,6 +182,14 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       Path keyPath = Paths.get(keyName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequest.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.NONE;
@@ -182,14 +181,6 @@ public class OMDirectoryCreateRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       Path keyPath = Paths.get(keyName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -129,7 +129,7 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       Path keyPath = Paths.get(keyName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -61,6 +61,7 @@ import java.util.Map;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
@@ -131,6 +132,12 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       Path keyPath = Paths.get(keyName);
 
       // Need to check if any files exist in the given path, if they exist we
@@ -157,8 +164,6 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
                         ozoneManager, keyArgs, omPathInfo, trxnLogIndex);
 
         final long volumeId = omMetadataManager.getVolumeId(volumeName);
-        final long bucketId = omMetadataManager
-                .getBucketId(volumeName, bucketName);
 
         // prepare leafNode dir
         OmDirectoryInfo dirInfo = createDirectoryInfoWithACL(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -61,7 +61,6 @@ import java.util.Map;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.FILE_ALREADY_EXISTS;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.INVALID_KEY_NAME;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
@@ -132,12 +131,6 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       Path keyPath = Paths.get(keyName);
 
       // Need to check if any files exist in the given path, if they exist we
@@ -164,6 +157,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
                         ozoneManager, keyArgs, omPathInfo, trxnLogIndex);
 
         final long volumeId = omMetadataManager.getVolumeId(volumeName);
+        final long bucketId = omMetadataManager
+                .getBucketId(volumeName, bucketName);
 
         // prepare leafNode dir
         OmDirectoryInfo dirInfo = createDirectoryInfoWithACL(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -216,7 +216,7 @@ public class OMFileCreateRequest extends OMKeyRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       if (keyName.length() == 0) {
         // Check if this is the root of the filesystem.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -72,6 +72,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
@@ -217,6 +218,12 @@ public class OMFileCreateRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       if (keyName.length() == 0) {
         // Check if this is the root of the filesystem.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequest.java
@@ -72,7 +72,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS;
@@ -218,12 +217,6 @@ public class OMFileCreateRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       if (keyName.length() == 0) {
         // Check if this is the root of the filesystem.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -54,7 +54,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles create file request layout version1.
@@ -131,13 +130,9 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
+      final long bucketId = omMetadataManager
+              .getBucketId(volumeName, bucketName);
 
       OmKeyInfo dbFileInfo = null;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -128,7 +128,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
       final long bucketId = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles create file request layout version1.
@@ -130,9 +131,13 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
-      final long bucketId = omMetadataManager
-              .getBucketId(volumeName, bucketName);
 
       OmKeyInfo dbFileInfo = null;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequest.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles allocate block request.
@@ -210,7 +211,13 @@ public class OMAllocateBlockRequest extends OMKeyRequest {
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
+
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+      final long bucketId = omBucketInfo.getObjectID();
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       // check bucket and volume quota
       long preAllocatedKeySize = newLocationList.size()
           * ozoneManager.getScmBlockSize();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -59,6 +59,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -122,8 +123,7 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
       checkKeyAclsInOpenKeyTable(ozoneManager, volumeName, bucketName, keyName,
           IAccessAuthorizer.ACLType.WRITE, allocateBlockRequest.getClientID());
 
-      validateBucketAndVolume(omMetadataManager, volumeName,
-          bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       // Here we don't acquire bucket/volume lock because for a single client
       // allocateBlock is called in serial fashion. With this approach, it
@@ -144,10 +144,11 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
               volumeName, bucketName);
 
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-      final long bucketId = omBucketInfo.getObjectID();
 
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volumeName, bucketName);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       // check bucket and volume quota
       long preAllocatedKeySize = newLocationList.size()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -59,6 +59,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles allocate block request - prefix layout.
@@ -141,7 +142,13 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
 
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
+
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+      final long bucketId = omBucketInfo.getObjectID();
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       // check bucket and volume quota
       long preAllocatedKeySize = newLocationList.size()
           * ozoneManager.getScmBlockSize();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -176,7 +176,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       // Check for directory exists with same name, if it exists throw error.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -68,6 +68,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles CommitKey request.
@@ -177,7 +178,12 @@ public class OMKeyCommitRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // Check for directory exists with same name, if it exists throw error.
       if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequest.java
@@ -68,7 +68,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles CommitKey request.
@@ -178,12 +177,7 @@ public class OMKeyCommitRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
 
       // Check for directory exists with same name, if it exists throw error.
       if (LOG.isDebugEnabled()) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -118,7 +118,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
               omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
                       volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       String fileName = OzoneFSUtils.getFileName(keyName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -52,7 +52,6 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles CommitKey request - prefix layout.
@@ -121,15 +120,11 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId = omBucketInfo.getObjectID();
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       String fileName = OzoneFSUtils.getFileName(keyName);
+      omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
+      final long bucketId = omMetadataManager.getBucketId(
+              volumeName, bucketName);
       long parentID = OMFileRequest.getParentID(volumeId, bucketId,
               pathComponents, keyName, omMetadataManager,
               "Cannot create file : " + keyName

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -52,6 +52,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles CommitKey request - prefix layout.
@@ -120,11 +121,15 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      String fileName = OzoneFSUtils.getFileName(keyName);
       omBucketInfo = getBucketInfo(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId = omBucketInfo.getObjectID();
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
+      String fileName = OzoneFSUtils.getFileName(keyName);
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
-      final long bucketId = omMetadataManager.getBucketId(
-              volumeName, bucketName);
       long parentID = OMFileRequest.getParentID(volumeId, bucketId,
               pathComponents, keyName, omMetadataManager,
               "Cannot create file : " + keyName

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -222,7 +222,7 @@ public class OMKeyCreateRequest extends OMKeyRequest {
 
       acquireLock = ozoneLockStrategy.acquireWriteLock(omMetadataManager,
           volumeName, bucketName, keyName);
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
       //TODO: We can optimize this get here, if getKmsProvider is null, then
       // bucket encryptionInfo will be not set. If this assumption holds
       // true, we can avoid get from bucket table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -223,6 +223,13 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       acquireLock = ozoneLockStrategy.acquireWriteLock(omMetadataManager,
           volumeName, bucketName, keyName);
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       //TODO: We can optimize this get here, if getKmsProvider is null, then
       // bucket encryptionInfo will be not set. If this assumption holds
       // true, we can avoid get from bucket table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequest.java
@@ -223,13 +223,6 @@ public class OMKeyCreateRequest extends OMKeyRequest {
       acquireLock = ozoneLockStrategy.acquireWriteLock(omMetadataManager,
           volumeName, bucketName, keyName);
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       //TODO: We can optimize this get here, if getKmsProvider is null, then
       // bucket encryptionInfo will be not set. If this assumption holds
       // true, we can avoid get from bucket table.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -54,7 +54,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentId;
@@ -112,14 +111,11 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               volumeName, bucketName);
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       final long volumeId = omMetadataManager.getVolumeTable()
               .get(omMetadataManager.getVolumeKey(volumeName)).getObjectID();
+      final long bucketId = omMetadataManager.getBucketTable()
+              .get(omMetadataManager.getBucketKey(volumeName, bucketName))
+              .getObjectID();
 
       OmKeyInfo dbFileInfo = null;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -109,7 +109,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
 
       acquireLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       final long volumeId = omMetadataManager.getVolumeTable()
               .get(omMetadataManager.getVolumeKey(volumeName)).getObjectID();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.FILE_EXISTS_IN_GIVENPATH;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.getParentId;
@@ -111,11 +112,14 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               volumeName, bucketName);
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       final long volumeId = omMetadataManager.getVolumeTable()
               .get(omMetadataManager.getVolumeKey(volumeName)).getObjectID();
-      final long bucketId = omMetadataManager.getBucketTable()
-              .get(omMetadataManager.getBucketKey(volumeName, bucketName))
-              .getObjectID();
 
       OmKeyInfo dbFileInfo = null;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -58,7 +58,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles DeleteKey request.
@@ -146,12 +145,6 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       OmKeyInfo omKeyInfo =
           omMetadataManager.getKeyTable(bucketLayout).get(objectKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -144,7 +144,7 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
 
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       OmKeyInfo omKeyInfo =
           omMetadataManager.getKeyTable(bucketLayout).get(objectKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequest.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles DeleteKey request.
@@ -145,6 +146,12 @@ public class OMKeyDeleteRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       OmKeyInfo omKeyInfo =
           omMetadataManager.getKeyTable(bucketLayout).get(objectKey);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -107,7 +107,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
           volumeName, bucketName);
 
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       OzoneFileStatus keyStatus =
               OMFileRequest.getOMKeyInfoIfExists(omMetadataManager, volumeName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -52,6 +52,7 @@ import java.util.Map;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_EMPTY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles DeleteKey request - prefix layout.
@@ -109,6 +110,12 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       OzoneFileStatus keyStatus =
               OMFileRequest.getOMKeyInfoIfExists(omMetadataManager, volumeName,
                       bucketName, keyName, 0);
@@ -128,8 +135,6 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
-      final long bucketId = omMetadataManager.getBucketId(volumeName,
-              bucketName);
       String ozonePathKey = omMetadataManager.getOzonePathKey(volumeId,
               bucketId, omKeyInfo.getParentObjectID(),
               omKeyInfo.getFileName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -52,7 +52,6 @@ import java.util.Map;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.DIRECTORY_NOT_EMPTY;
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles DeleteKey request - prefix layout.
@@ -110,12 +109,6 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       OzoneFileStatus keyStatus =
               OMFileRequest.getOMKeyInfoIfExists(omMetadataManager, volumeName,
                       bucketName, keyName, 0);
@@ -135,6 +128,8 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
+      final long bucketId = omMetadataManager.getBucketId(volumeName,
+              bucketName);
       String ozonePathKey = omMetadataManager.getOzonePathKey(volumeId,
               bucketId, omKeyInfo.getParentObjectID(),
               omKeyInfo.getFileName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -165,7 +165,7 @@ public class OMKeyRenameRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       // Check if toKey exists
       fromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -64,7 +64,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles rename key request.
@@ -167,12 +166,6 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // Check if toKey exists
       fromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequest.java
@@ -64,6 +64,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles rename key request.
@@ -166,6 +167,12 @@ public class OMKeyRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // Check if toKey exists
       fromKey = omMetadataManager.getOzoneKey(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -124,7 +124,7 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
               volumeName, bucketName);
 
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       // Check if fromKey exists
       OzoneFileStatus fromKeyFileStatus =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -57,6 +57,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles rename key request - prefix layout.
@@ -125,6 +126,12 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // Check if fromKey exists
       OzoneFileStatus fromKeyFileStatus =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRenameRequestWithFSO.java
@@ -57,7 +57,6 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles rename key request - prefix layout.
@@ -126,12 +125,6 @@ public class OMKeyRenameRequestWithFSO extends OMKeyRenameRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // Check if fromKey exists
       OzoneFileStatus fromKeyFileStatus =

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyRequest.java
@@ -91,6 +91,7 @@ import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes
     .VOLUME_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.util.Time.monotonicNow;
 
 /**
@@ -204,6 +205,10 @@ public abstract class OMKeyRequest extends OMClientRequest {
       // exception
       throw new OMException("Bucket not found " + bucketName, BUCKET_NOT_FOUND);
     }
+
+    // Bucket ID verification for in-flight requests.
+    validateAssociatedBucketId(
+        omMetadataManager.getBucketId(volumeName, bucketName), getOmRequest());
 
     // Make sure associated bucket's layout matches the one associated with
     // the request.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -65,7 +65,6 @@ import static org.apache.hadoop.ozone.OzoneConsts.UNDELETED_KEYS_LIST;
 import static org.apache.hadoop.ozone.OzoneConsts.VOLUME;
 import static org.apache.hadoop.ozone.audit.OMAction.DELETE_KEYS;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_DELETE;
 
@@ -133,13 +132,6 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -131,7 +131,7 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       acquiredLock = omMetadataManager.getLock()
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -65,6 +65,7 @@ import static org.apache.hadoop.ozone.OzoneConsts.UNDELETED_KEYS_LIST;
 import static org.apache.hadoop.ozone.OzoneConsts.VOLUME;
 import static org.apache.hadoop.ozone.audit.OMAction.DELETE_KEYS;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_DELETE;
 
@@ -132,6 +133,13 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
           .acquireWriteLock(BUCKET_LOCK, volumeName, bucketName);
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
 
       for (indexFailed = 0; indexFailed < length; indexFailed++) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -61,6 +61,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_RENAME;
 import static org.apache.hadoop.ozone.OzoneConsts.RENAMED_KEYS_MAP;
@@ -126,6 +127,13 @@ public class OMKeysRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
       for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -61,7 +61,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.PARTIAL_RENAME;
 import static org.apache.hadoop.ozone.OzoneConsts.RENAMED_KEYS_MAP;
@@ -127,13 +126,6 @@ public class OMKeysRenameRequest extends OMKeyRequest {
 
       // Validate bucket and volume exists or not.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
       for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysRenameRequest.java
@@ -125,7 +125,7 @@ public class OMKeysRenameRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       // Validate bucket and volume exists or not.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
       String volumeOwner = getVolumeOwner(omMetadataManager, volumeName);
       for (RenameKeysMap renameKey : renameKeysArgs.getRenameKeysMapList()) {
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -42,7 +42,6 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles requests to move open keys from the open key table to the delete
@@ -150,12 +149,6 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
     try {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       for (OpenKey key: keysPerBucket.getKeysList()) {
         String fullKeyName = key.getName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles requests to move open keys from the open key table to the delete
@@ -149,6 +150,12 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
     try {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       for (OpenKey key: keysPerBucket.getKeysList()) {
         String fullKeyName = key.getName();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
@@ -101,8 +101,8 @@ public class OMTrashRecoverRequest extends OMKeyRequest {
           .acquireWriteLock(BUCKET_LOCK, volumeName, destinationBucket);
 
       // Validate.
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-      validateBucketAndVolume(omMetadataManager, volumeName, destinationBucket);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, destinationBucket);
 
 
       /** TODO: HDDS-2425. HDDS-2426.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles RecoverTrash request.
@@ -103,6 +104,12 @@ public class OMTrashRecoverRequest extends OMKeyRequest {
       // Validate.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       validateBucketAndVolume(omMetadataManager, volumeName, destinationBucket);
+
+      final long sourceBucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(sourceBucketId, getOmRequest());
 
 
       /** TODO: HDDS-2425. HDDS-2426.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMTrashRecoverRequest.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles RecoverTrash request.
@@ -104,12 +103,6 @@ public class OMTrashRecoverRequest extends OMKeyRequest {
       // Validate.
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       validateBucketAndVolume(omMetadataManager, volumeName, destinationBucket);
-
-      final long sourceBucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(sourceBucketId, getOmRequest());
 
 
       /** TODO: HDDS-2425. HDDS-2426.

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
@@ -105,8 +106,10 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
         throw new OMException(OMException.ResultCodes.KEY_NOT_FOUND);
       }
 
-      long bucketId = omMetadataManager.getBucketId(volume, bucket);
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volume, bucket);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       operationResult = apply(omKeyInfo, trxnLogIndex);
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Base class for Bucket acl request.
@@ -103,6 +104,9 @@ public abstract class OMKeyAclRequest extends OMClientRequest {
       if (omKeyInfo == null) {
         throw new OMException(OMException.ResultCodes.KEY_NOT_FOUND);
       }
+
+      long bucketId = omMetadataManager.getBucketId(volume, bucket);
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       operationResult = apply(omKeyInfo, trxnLogIndex);
       omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 
 /**
@@ -95,6 +96,9 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
       omKeyInfo = keyStatus.getKeyInfo();
       final long volumeId = omMetadataManager.getVolumeId(volume);
       final long bucketId = omMetadataManager.getBucketId(volume, bucket);
+
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       final String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
               omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());
       boolean isDirectory = keyStatus.isDirectory();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -42,6 +42,7 @@ import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 
@@ -97,7 +98,10 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
       final long volumeId = omMetadataManager.getVolumeId(volume);
       final long bucketId = omMetadataManager.getBucketId(volume, bucket);
 
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volume, bucket);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       final String dbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
               omKeyInfo.getParentObjectID(), omKeyInfo.getFileName());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.PREFIX_LOCK;
 import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 
 /**
  * Base class for Prefix acl request.
@@ -95,8 +96,10 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
 
       omPrefixInfo = omMetadataManager.getPrefixTable().get(prefixPath);
 
-      long bucketId = omMetadataManager.getBucketId(volume, bucket);
-      validateAssociatedBucketId(bucketId, getOmRequest());
+      // Bucket ID validation for in-flight requests.
+      long resolvedBucketId =
+          getResolvedBucketId(ozoneManager, volume, bucket);
+      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       try {
         operationResult = apply(prefixManager, omPrefixInfo, trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -43,8 +43,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.PREFIX_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.getResolvedBucketId;
 
 /**
  * Base class for Prefix acl request.
@@ -95,11 +93,6 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
           omMetadataManager.getLock().acquireWriteLock(PREFIX_LOCK, prefixPath);
 
       omPrefixInfo = omMetadataManager.getPrefixTable().get(prefixPath);
-
-      // Bucket ID validation for in-flight requests.
-      long resolvedBucketId =
-          getResolvedBucketId(ozoneManager, volume, bucket);
-      validateAssociatedBucketId(resolvedBucketId, getOmRequest());
 
       try {
         operationResult = apply(prefixManager, omPrefixInfo, trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/prefix/OMPrefixAclRequest.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.PREFIX_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Base class for Prefix acl request.
@@ -93,6 +94,9 @@ public abstract class OMPrefixAclRequest extends OMClientRequest {
           omMetadataManager.getLock().acquireWriteLock(PREFIX_LOCK, prefixPath);
 
       omPrefixInfo = omMetadataManager.getPrefixTable().get(prefixPath);
+
+      long bucketId = omMetadataManager.getBucketId(volume, bucket);
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       try {
         operationResult = apply(prefixManager, omPrefixInfo, trxnLogIndex);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -64,7 +64,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles initiate multipart upload request.
@@ -153,12 +152,6 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // We are adding uploadId to key, because if multiple users try to
       // perform multipart upload on the same key, each will try to upload, who

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -151,7 +151,7 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       // We are adding uploadId to key, because if multiple users try to
       // perform multipart upload on the same key, each will try to upload, who

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequest.java
@@ -64,6 +64,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles initiate multipart upload request.
@@ -152,6 +153,12 @@ public class S3InitiateMultipartUploadRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       // We are adding uploadId to key, because if multiple users try to
       // perform multipart upload on the same key, each will try to upload, who

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -55,6 +55,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 
 /**
@@ -114,6 +115,12 @@ public class S3InitiateMultipartUploadRequestWithFSO
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
+
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO = OMFileRequest
           .verifyDirectoryKeysInPath(omMetadataManager, volumeName, bucketName,
               keyName, Paths.get(keyName));
@@ -146,8 +153,6 @@ public class S3InitiateMultipartUploadRequestWithFSO
           keyArgs.getMultipartUploadID());
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
-      final long bucketId = omMetadataManager.getBucketId(volumeName,
-              bucketName);
 
       String multipartOpenKey = omMetadataManager
           .getMultipartKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -55,7 +55,6 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 import static org.apache.hadoop.ozone.om.request.file.OMFileRequest.OMDirectoryResult.DIRECTORY_EXISTS;
 
 /**
@@ -115,12 +114,6 @@ public class S3InitiateMultipartUploadRequestWithFSO
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
 
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
-
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO = OMFileRequest
           .verifyDirectoryKeysInPath(omMetadataManager, volumeName, bucketName,
               keyName, Paths.get(keyName));
@@ -153,6 +146,8 @@ public class S3InitiateMultipartUploadRequestWithFSO
           keyArgs.getMultipartUploadID());
 
       final long volumeId = omMetadataManager.getVolumeId(volumeName);
+      final long bucketId = omMetadataManager.getBucketId(volumeName,
+              bucketName);
 
       String multipartOpenKey = omMetadataManager
           .getMultipartKey(volumeId, bucketId,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -112,7 +112,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       OMFileRequest.OMPathInfoWithFSO pathInfoFSO = OMFileRequest
           .verifyDirectoryKeysInPath(omMetadataManager, volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -134,7 +134,7 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
           omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
               volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       multipartKey = omMetadataManager.getMultipartKey(
           volumeName, bucketName, keyName, keyArgs.getMultipartUploadID());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -61,7 +61,6 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles Abort of multipart upload request.
@@ -136,12 +135,6 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       multipartKey = omMetadataManager.getMultipartKey(
           volumeName, bucketName, keyName, keyArgs.getMultipartUploadID());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadAbortRequest.java
@@ -61,6 +61,7 @@ import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handles Abort of multipart upload request.
@@ -135,6 +136,12 @@ public class S3MultipartUploadAbortRequest extends OMKeyRequest {
               volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       multipartKey = omMetadataManager.getMultipartKey(
           volumeName, bucketName, keyName, keyArgs.getMultipartUploadID());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -141,7 +141,7 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
 
       String uploadID = keyArgs.getMultipartUploadID();
       multipartKey = getMultipartKey(volumeName, bucketName, keyName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -67,7 +67,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle Multipart upload commit upload part file.
@@ -143,12 +142,6 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
-
-      final long bucketId =
-          omMetadataManager.getBucketId(volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(bucketId, getOmRequest());
 
       String uploadID = keyArgs.getMultipartUploadID();
       multipartKey = getMultipartKey(volumeName, bucketName, keyName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCommitPartRequest.java
@@ -67,6 +67,7 @@ import java.util.stream.Collectors;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.KEY_NOT_FOUND;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle Multipart upload commit upload part file.
@@ -142,6 +143,12 @@ public class S3MultipartUploadCommitPartRequest extends OMKeyRequest {
           volumeName, bucketName);
 
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+
+      final long bucketId =
+          omMetadataManager.getBucketId(volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(bucketId, getOmRequest());
 
       String uploadID = keyArgs.getMultipartUploadID();
       multipartKey = getMultipartKey(volumeName, bucketName, keyName,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -73,6 +73,7 @@ import javax.annotation.Nullable;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
+import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle Multipart upload complete request.
@@ -152,6 +153,9 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
           volumeName, bucketName);
+
+      // Bucket ID verification for in-flight requests.
+      validateAssociatedBucketId(omBucketInfo.getObjectID(), getOmRequest());
 
       String ozoneKey = omMetadataManager.getOzoneKey(
           volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -73,7 +73,6 @@ import javax.annotation.Nullable;
 
 import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.NOT_A_FILE;
 import static org.apache.hadoop.ozone.om.lock.OzoneManagerLock.Resource.BUCKET_LOCK;
-import static org.apache.hadoop.ozone.om.request.OMClientRequestUtils.validateAssociatedBucketId;
 
 /**
  * Handle Multipart upload complete request.
@@ -153,9 +152,6 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
       OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
           volumeName, bucketName);
-
-      // Bucket ID verification for in-flight requests.
-      validateAssociatedBucketId(omBucketInfo.getObjectID(), getOmRequest());
 
       String ozoneKey = omMetadataManager.getOzoneKey(
           volumeName, bucketName, keyName);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -149,7 +149,7 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
       acquiredLock = omMetadataManager.getLock().acquireWriteLock(BUCKET_LOCK,
           volumeName, bucketName);
 
-      validateBucketAndVolume(omMetadataManager, volumeName, bucketName);
+      validateBucketAndVolume(ozoneManager, volumeName, bucketName);
       OmBucketInfo omBucketInfo = getBucketInfo(omMetadataManager,
           volumeName, bucketName);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.OmUtils;
-import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -476,7 +476,13 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       return omRequest;
     }
 
-    long bucketId = metadataManager.getBucketId(volumeName, bucketName);
+    long bucketId;
+    try {
+      bucketId = metadataManager.getBucketId(volumeName, bucketName);
+    } catch (OMException oe) {
+      // Ignore exceptions at this stage, let respective classes handle them.
+      return omRequest;
+    }
 
     return OMRequest.newBuilder(omRequest)
         .setAssociatedBucketId(bucketId)

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -481,6 +481,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       break;
     default:
       // do nothing in case of other requests.
+      LOG.debug(
+          "Bucket ID validation is not enabled for " + omRequest.getCmdType() +
+              ". Bucket ID will not be associated with this request.");
       break;
     }
 
@@ -510,6 +513,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
               bucketName);
     } catch (OMException oe) {
       // Ignore exceptions at this stage, let respective classes handle them.
+      LOG.debug(
+          "There was an error while fetching bucket ID for " + volumeName +
+              "/" + bucketName + ".", oe);
       return omRequest;
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -25,14 +25,12 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.server.OzoneProtocolMessageDispatcher;
 import org.apache.hadoop.hdds.tracing.TracingUtil;
 import org.apache.hadoop.hdds.utils.ProtocolMessageMetrics;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OzoneManager;
-import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.exceptions.OMLeaderNotReadyException;
 import org.apache.hadoop.ozone.om.exceptions.OMNotLeaderException;
@@ -42,6 +40,7 @@ import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer;
 import org.apache.hadoop.ozone.om.ratis.OzoneManagerRatisServer.RaftServerStatus;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerRatisUtils;
 import org.apache.hadoop.ozone.om.request.OMClientRequest;
+import org.apache.hadoop.ozone.om.request.OMClientRequestUtils;
 import org.apache.hadoop.ozone.om.request.util.ObjectParser;
 import org.apache.hadoop.ozone.om.request.validation.RequestValidations;
 import org.apache.hadoop.ozone.om.request.validation.ValidationContext;
@@ -506,10 +505,9 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
       // This is not a problem, since we will anyway be validating this bucket
       // ID inside validateAndUpdateCache method - and it will be caught there.
       // This is a fail-slow approach.
-      ResolvedBucket resolvedBucket =
-          ozoneManager.resolveBucketLink(Pair.of(volumeName, bucketName));
-      bucketId = metadataManager.getBucketId(resolvedBucket.realVolume(),
-          resolvedBucket.realBucket());
+      bucketId =
+          OMClientRequestUtils.getResolvedBucketId(ozoneManager, volumeName,
+              bucketName);
     } catch (OMException oe) {
       // Ignore exceptions at this stage, let respective classes handle them.
       return omRequest;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/protocolPB/OzoneManagerProtocolServerSideTranslatorPB.java
@@ -355,7 +355,6 @@ public class OzoneManagerProtocolServerSideTranslatorPB implements
   @SuppressWarnings("checkstyle:MethodLength")
   private OMRequest associateBucketIdWithRequest(OMRequest omRequest)
       throws IOException {
-    OMMetadataManager metadataManager = ozoneManager.getMetadataManager();
     String volumeName = "";
     String bucketName = "";
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithOMResponse.java
@@ -24,6 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -32,6 +33,7 @@ import org.apache.hadoop.ozone.audit.AuditMessage;
 import org.apache.hadoop.ozone.om.OMConfigKeys;
 import org.apache.hadoop.ozone.om.OMMetrics;
 import org.apache.hadoop.ozone.om.OzoneManager;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.request.bucket.OMBucketCreateRequest;
@@ -115,6 +117,11 @@ public class TestOzoneManagerDoubleBufferWithOMResponse {
         .setIndexToTerm((i) -> term)
         .build();
     ozoneManagerDoubleBufferHelper = doubleBuffer::add;
+
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenAnswer(
+            i -> new ResolvedBucket((Pair<String, String>) i.getArguments()[0],
+                (Pair<String, String>) i.getArguments()[0]));
   }
 
   @After

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestBucketRequest.java
@@ -19,6 +19,8 @@
 
 package org.apache.hadoop.ozone.om.request.bucket;
 
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.ozone.om.ResolvedBucket;
 import org.apache.hadoop.ozone.om.upgrade.OMLayoutVersionManager;
 import org.junit.After;
 import org.junit.Before;
@@ -37,6 +39,8 @@ import org.apache.hadoop.ozone.om.OzoneManager;
 import org.apache.hadoop.ozone.om.ratis.utils.OzoneManagerDoubleBufferHelper;
 
 
+import java.util.UUID;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,6 +57,8 @@ public class TestBucketRequest {
   protected OMMetrics omMetrics;
   protected OMMetadataManager omMetadataManager;
   protected AuditLogger auditLogger;
+  protected String volumeName;
+  protected String bucketName;
 
   // Just setting ozoneManagerDoubleBuffer which does nothing.
   protected OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
@@ -85,5 +91,19 @@ public class TestBucketRequest {
   public void stop() {
     omMetrics.unRegister();
     Mockito.framework().clearInlineMocks();
+  }
+
+  /**
+   * Setups up volume and bucket names, along with related mocks.
+   *
+   * @throws Exception
+   */
+  protected void setupVolumeAndBucketName() throws Exception {
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+
+    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketCreateRequest.java
@@ -59,8 +59,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMBucketCreateRequest omBucketCreateRequest = doPreExecute(volumeName,
         bucketName);
@@ -72,8 +71,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithNoVolume() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMRequest originalRequest = OMRequestTestUtils.createBucketRequest(
         bucketName, volumeName, false, StorageTypeProto.SSD);
@@ -104,8 +102,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
   @Test
   public void testValidateAndUpdateCacheWithBucketAlreadyExists()
       throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMBucketCreateRequest omBucketCreateRequest =
         doPreExecute(volumeName, bucketName);
@@ -126,8 +123,7 @@ public class TestOMBucketCreateRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheVerifyBucketLayout() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
 
     OMBucketCreateRequest omBucketCreateRequest = doPreExecute(volumeName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequest.java
@@ -52,8 +52,7 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     OMRequest omRequest =
         createDeleteBucketRequest(volumeName, bucketName);
 
@@ -73,8 +72,7 @@ public class TestOMBucketDeleteRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheFailure() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMRequest omRequest =
         createDeleteBucketRequest(volumeName, bucketName);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketDeleteRequestWithFSO.java
@@ -39,8 +39,7 @@ public class TestOMBucketDeleteRequestWithFSO
 
   @Test
   public void testValidateAndUpdateCacheWithFSO() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     Assert.assertEquals(0, omMetrics.getNumFSOBucketDeletes());
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -74,9 +74,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true, Long.MAX_VALUE);
@@ -103,9 +101,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
   @Test
   public void testNonDefaultLayout() throws Exception {
-
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
 
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true, Long.MAX_VALUE);
@@ -132,10 +128,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheFails() throws Exception {
-
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-
+    setupVolumeAndBucketName();
     OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
         bucketName, true, Long.MAX_VALUE);
 
@@ -169,10 +162,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithQuota() throws Exception {
-
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
-
+    setupVolumeAndBucketName();
     OMRequestTestUtils.addVolumeToDB(
         volumeName, omMetadataManager, 10 * GB);
     OMRequestTestUtils.addBucketToDB(
@@ -207,8 +197,7 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
   @Test
   public void rejectsSettingQuotaOnLink() throws Exception {
     // GIVEN
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String linkName = UUID.randomUUID().toString();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketAddAclRequest.java
@@ -62,8 +62,7 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheSuccess() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String ownerName = "testUser";
 
     OMRequestTestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
@@ -97,8 +96,7 @@ public class TestOMBucketAddAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
 
     OMRequest originalRequest = OMRequestTestUtils

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketRemoveAclRequest.java
@@ -61,8 +61,7 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheSuccess() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String ownerName = "testUser";
 
     OMRequestTestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
@@ -114,8 +113,7 @@ public class TestOMBucketRemoveAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
 
     OMRequest originalRequest = OMRequestTestUtils

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/acl/TestOMBucketSetAclRequest.java
@@ -63,8 +63,7 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheSuccess() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String ownerName = "owner";
 
     OMRequestTestUtils.addUserToDB(volumeName, ownerName, omMetadataManager);
@@ -102,8 +101,7 @@ public class TestOMBucketSetAclRequest extends TestBucketRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     OzoneAcl acl = OzoneAcl.parseAcl("user:newUser:rw");
 
     OMRequest originalRequest = OMRequestTestUtils

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -76,8 +76,8 @@ public class TestOMDirectoryCreateRequest {
       ((response, transactionIndex) -> {
         return null;
       });
-  private static final String volumeName = "vol1";
-  private static final String bucketName = "bucket1";
+  private static final String VOLUME_NAME = "vol1";
+  private static final String BUCKET_NAME = "bucket1";
 
   @Before
   public void setup() throws Exception {
@@ -96,7 +96,7 @@ public class TestOMDirectoryCreateRequest {
         any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
 
-    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    Pair<String, String> volumeAndBucket = Pair.of(VOLUME_NAME, BUCKET_NAME);
     when(ozoneManager.resolveBucketLink(any(Pair.class)))
         .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
@@ -111,10 +111,10 @@ public class TestOMDirectoryCreateRequest {
   public void testPreExecute() throws Exception {
     String keyName = "a/b/c";
 
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -133,10 +133,10 @@ public class TestOMDirectoryCreateRequest {
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -154,16 +154,16 @@ public class TestOMDirectoryCreateRequest {
     Assert.assertTrue(omClientResponse.getOMResponse().getStatus()
         == OzoneManagerProtocolProtos.Status.OK);
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
+        .get(
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName))
         != null);
-
   }
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
     String keyName = genRandomKeyName();
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -183,7 +183,8 @@ public class TestOMDirectoryCreateRequest {
 
     // Key should not exist in DB
     Assert.assertNull(omMetadataManager.getKeyTable(getBucketLayout()).
-        get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
+        get(omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME,
+            keyName)));
 
   }
 
@@ -191,7 +192,7 @@ public class TestOMDirectoryCreateRequest {
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
     String keyName = genRandomKeyName();
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -201,7 +202,7 @@ public class TestOMDirectoryCreateRequest {
 
     omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(modifiedOmRequest, getBucketLayout());
-    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OMRequestTestUtils.addVolumeToDB(VOLUME_NAME, omMetadataManager);
 
     OMClientResponse omClientResponse =
         omDirectoryCreateRequest.validateAndUpdateCache(ozoneManager, 100L,
@@ -212,7 +213,8 @@ public class TestOMDirectoryCreateRequest {
 
     // Key should not exist in DB
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
+        .get(
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName))
         == null);
   }
 
@@ -222,13 +224,13 @@ public class TestOMDirectoryCreateRequest {
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 
-    OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
+    OMRequestTestUtils.addKeyToTable(false, VOLUME_NAME, BUCKET_NAME,
         keyName.substring(0, 12), 1L, HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, omMetadataManager);
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -248,11 +250,13 @@ public class TestOMDirectoryCreateRequest {
 
     // Key should exist in DB and cache.
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
+        .get(
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName))
         != null);
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .getCacheValue(new CacheKey<>(
-            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)))
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME,
+                keyName)))
         != null);
 
   }
@@ -263,14 +267,14 @@ public class TestOMDirectoryCreateRequest {
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 
-    OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
+    OMRequestTestUtils.addKeyToTable(false, VOLUME_NAME, BUCKET_NAME,
         OzoneFSUtils.addTrailingSlashIfNeeded(keyName), 1L,
         HddsProtos.ReplicationType.RATIS, HddsProtos.ReplicationFactor.ONE,
         omMetadataManager);
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -290,15 +294,16 @@ public class TestOMDirectoryCreateRequest {
 
     // Key should exist in DB
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
+        .get(
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName))
         != null);
 
     // As it already exists, it should not be in cache.
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
         .getCacheValue(new CacheKey<>(
-            omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)))
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME,
+                keyName)))
         == null);
-
   }
 
   @Test
@@ -306,13 +311,13 @@ public class TestOMDirectoryCreateRequest {
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
     // Add a key with first two levels.
-    OMRequestTestUtils.addKeyToTable(false, volumeName, bucketName,
+    OMRequestTestUtils.addKeyToTable(false, VOLUME_NAME, BUCKET_NAME,
         keyName.substring(0, 11), 1L, HddsProtos.ReplicationType.RATIS,
         HddsProtos.ReplicationFactor.ONE, omMetadataManager);
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         keyName);
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -332,7 +337,8 @@ public class TestOMDirectoryCreateRequest {
 
     // Key should not exist in DB
     Assert.assertTrue(omMetadataManager.getKeyTable(getBucketLayout())
-        .get(omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName))
+        .get(
+            omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName))
         == null);
 
   }
@@ -343,10 +349,10 @@ public class TestOMDirectoryCreateRequest {
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
         omMetadataManager);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
         OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequest omDirectoryCreateRequest =
         new OMDirectoryCreateRequest(omRequest, getBucketLayout());
@@ -366,7 +372,7 @@ public class TestOMDirectoryCreateRequest {
         omClientResponse.getOMResponse().getStatus());
 
     Assert.assertNotNull(omMetadataManager.getKeyTable(getBucketLayout()).get(
-        omMetadataManager.getOzoneDirKey(volumeName, bucketName, keyName)));
+        omMetadataManager.getOzoneDirKey(VOLUME_NAME, BUCKET_NAME, keyName)));
 
     Assert.assertEquals(4L, omMetrics.getNumKeys());
   }
@@ -374,18 +380,17 @@ public class TestOMDirectoryCreateRequest {
 
   /**
    * Create OMRequest which encapsulates CreateDirectory request.
-   *
-   * @param volume
-   * @param bucket
+   * @param volumeName
+   * @param bucketName
    * @param keyName
    * @return OMRequest
    */
-  private OMRequest createDirectoryRequest(String volume, String bucket,
+  private OMRequest createDirectoryRequest(String volumeName, String bucketName,
                                            String keyName) {
     return OMRequest.newBuilder().setCreateDirectoryRequest(
-        CreateDirectoryRequest.newBuilder().setKeyArgs(
-            KeyArgs.newBuilder().setVolumeName(volume)
-                .setBucketName(bucket).setKeyName(keyName)))
+            CreateDirectoryRequest.newBuilder().setKeyArgs(
+                KeyArgs.newBuilder().setVolumeName(volumeName)
+                    .setBucketName(bucketName).setKeyName(keyName)))
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
         .setClientId(UUID.randomUUID().toString()).build();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -76,8 +76,8 @@ public class TestOMDirectoryCreateRequest {
       ((response, transactionIndex) -> {
         return null;
       });
-  private final String volumeName = "vol1";
-  private final String bucketName = "bucket1";
+  private static final String volumeName = "vol1";
+  private static final String bucketName = "bucket1";
 
   @Before
   public void setup() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequest.java
@@ -76,6 +76,8 @@ public class TestOMDirectoryCreateRequest {
       ((response, transactionIndex) -> {
         return null;
       });
+  private final String volumeName = "vol1";
+  private final String bucketName = "bucket1";
 
   @Before
   public void setup() throws Exception {
@@ -93,6 +95,10 @@ public class TestOMDirectoryCreateRequest {
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
         any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
+
+    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
 
   @After
@@ -103,9 +109,6 @@ public class TestOMDirectoryCreateRequest {
 
   @Test
   public void testPreExecute() throws Exception {
-
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = "a/b/c";
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -127,8 +130,6 @@ public class TestOMDirectoryCreateRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
@@ -160,8 +161,6 @@ public class TestOMDirectoryCreateRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
@@ -190,8 +189,6 @@ public class TestOMDirectoryCreateRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
@@ -222,8 +219,6 @@ public class TestOMDirectoryCreateRequest {
   @Test
   public void testValidateAndUpdateCacheWithSubDirectoryInPath()
       throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
@@ -265,8 +260,6 @@ public class TestOMDirectoryCreateRequest {
   @Test
   public void testValidateAndUpdateCacheWithDirectoryAlreadyExists()
       throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
@@ -310,8 +303,6 @@ public class TestOMDirectoryCreateRequest {
 
   @Test
   public void testValidateAndUpdateCacheWithFilesInPath() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
@@ -349,8 +340,6 @@ public class TestOMDirectoryCreateRequest {
   @Test
   public void testCreateDirectoryOMMetric()
       throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = genRandomKeyName();
 
     // Add volume and bucket entries to DB.
@@ -385,17 +374,18 @@ public class TestOMDirectoryCreateRequest {
 
   /**
    * Create OMRequest which encapsulates CreateDirectory request.
-   * @param volumeName
-   * @param bucketName
+   *
+   * @param volume
+   * @param bucket
    * @param keyName
    * @return OMRequest
    */
-  private OMRequest createDirectoryRequest(String volumeName, String bucketName,
-      String keyName) {
+  private OMRequest createDirectoryRequest(String volume, String bucket,
+                                           String keyName) {
     return OMRequest.newBuilder().setCreateDirectoryRequest(
         CreateDirectoryRequest.newBuilder().setKeyArgs(
-            KeyArgs.newBuilder().setVolumeName(volumeName)
-                .setBucketName(bucketName).setKeyName(keyName)))
+            KeyArgs.newBuilder().setVolumeName(volume)
+                .setBucketName(bucket).setKeyName(keyName)))
         .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
         .setClientId(UUID.randomUUID().toString()).build();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -82,8 +82,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
           ((response, transactionIndex) -> {
             return null;
           });
-  private final String volumeName = "vol1";
-  private final String bucketName = "bucket1";
+  private static final String volumeName = "vol1";
+  private static final String bucketName = "bucket1";
 
   @Before
   public void setup() throws Exception {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -82,8 +82,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
           ((response, transactionIndex) -> {
             return null;
           });
-  private static final String volumeName = "vol1";
-  private static final String bucketName = "bucket1";
+  private static final String VOLUME_NAME = "vol1";
+  private static final String BUCKET_NAME = "bucket1";
 
   @Before
   public void setup() throws Exception {
@@ -103,7 +103,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
             any(OMClientRequest.class)))
             .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
 
-    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    Pair<String, String> volumeAndBucket = Pair.of(VOLUME_NAME, BUCKET_NAME);
     when(ozoneManager.resolveBucketLink(any(Pair.class)))
         .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
@@ -118,10 +118,10 @@ public class TestOMDirectoryCreateRequestWithFSO {
   public void testPreExecute() throws Exception {
     String keyName = "a/b/c";
 
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirectoryCreateRequestWithFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -140,14 +140,14 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
+    final long bucketId = omMetadataManager.getBucketId(VOLUME_NAME,
+        BUCKET_NAME);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateRequestFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -174,7 +174,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateRequestFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -205,7 +205,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -215,7 +215,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
     omDirCreateReqFSO = new OMDirectoryCreateRequestWithFSO(modifiedOmReq,
         BucketLayout.FILE_SYSTEM_OPTIMIZED);
-    OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
+    OMRequestTestUtils.addVolumeToDB(VOLUME_NAME, omMetadataManager);
 
     OMClientResponse omClientResponse =
             omDirCreateReqFSO.validateAndUpdateCache(ozoneManager, 100L,
@@ -236,12 +236,12 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
+    final long bucketId = omMetadataManager.getBucketId(VOLUME_NAME,
+        BUCKET_NAME);
     int objID = 100;
 
     //1. Create root
@@ -249,16 +249,16 @@ public class TestOMDirectoryCreateRequestWithFSO {
             OMRequestTestUtils.createOmDirectoryInfo(dirs.get(0), objID++,
                     bucketId);
     OMRequestTestUtils.addDirKeyToDirTable(true, omDirInfo,
-            volumeName, bucketName, 5000,
+        VOLUME_NAME, BUCKET_NAME, 5000,
             omMetadataManager);
     //2. Create sub-directory under root
     omDirInfo = OMRequestTestUtils.createOmDirectoryInfo(dirs.get(1), objID++,
             omDirInfo.getObjectID());
     OMRequestTestUtils.addDirKeyToDirTable(true, omDirInfo,
-            volumeName, bucketName, 5000,
+        VOLUME_NAME, BUCKET_NAME, 5000,
             omMetadataManager);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -287,12 +287,12 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
+    final long bucketId = omMetadataManager.getBucketId(VOLUME_NAME,
+        BUCKET_NAME);
 
     // bucketID is the parent
     long parentID = bucketId;
@@ -305,12 +305,12 @@ public class TestOMDirectoryCreateRequestWithFSO {
       OmDirectoryInfo omDirInfo = OMRequestTestUtils.createOmDirectoryInfo(
               dirs.get(indx), objID, parentID);
       OMRequestTestUtils.addDirKeyToDirTable(false, omDirInfo,
-              volumeName, bucketName, txnID, omMetadataManager);
+          VOLUME_NAME, BUCKET_NAME, txnID, omMetadataManager);
 
       parentID = omDirInfo.getObjectID();
     }
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -347,9 +347,9 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    String bucketKey = omMetadataManager.getBucketKey(VOLUME_NAME, BUCKET_NAME);
     OmBucketInfo omBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
     long parentID = omBucketInfo.getObjectID();
@@ -363,7 +363,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
       OmDirectoryInfo omDirInfo = OMRequestTestUtils.createOmDirectoryInfo(
               dirs.get(indx), objID, parentID);
       OMRequestTestUtils.addDirKeyToDirTable(false, omDirInfo,
-              volumeName, bucketName, txnID, omMetadataManager);
+          VOLUME_NAME, BUCKET_NAME, txnID, omMetadataManager);
 
       parentID = omDirInfo.getObjectID();
     }
@@ -372,10 +372,10 @@ public class TestOMDirectoryCreateRequestWithFSO {
     long txnID = 50000;
 
     // Add a file into the FileTable, this is to simulate "file exists" check.
-    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, HddsProtos.ReplicationType.RATIS,
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(VOLUME_NAME,
+        BUCKET_NAME, keyName, HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.THREE, objID++);
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
     final long bucketId = omBucketInfo.getObjectID();
 
     final String ozoneFileName = omMetadataManager.getOzonePathKey(
@@ -387,7 +387,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
     omMetadataManager.getKeyTable(getBucketLayout())
         .put(ozoneFileName, omKeyInfo);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -430,9 +430,9 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
-    String bucketKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    String bucketKey = omMetadataManager.getBucketKey(VOLUME_NAME, BUCKET_NAME);
     OmBucketInfo omBucketInfo =
             omMetadataManager.getBucketTable().get(bucketKey);
     long parentID = omBucketInfo.getObjectID();
@@ -444,15 +444,15 @@ public class TestOMDirectoryCreateRequestWithFSO {
     OmDirectoryInfo omDirInfo = OMRequestTestUtils.createOmDirectoryInfo(
             dirs.get(0), objID++, parentID);
     OMRequestTestUtils.addDirKeyToDirTable(true, omDirInfo,
-            volumeName, bucketName, txnID, omMetadataManager);
+        VOLUME_NAME, BUCKET_NAME, txnID, omMetadataManager);
     parentID = omDirInfo.getObjectID();
 
     // Add a key in second level.
-    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
-            bucketName, keyName, HddsProtos.ReplicationType.RATIS,
+    OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(VOLUME_NAME,
+        BUCKET_NAME, keyName, HddsProtos.ReplicationType.RATIS,
             HddsProtos.ReplicationFactor.THREE, objID);
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
     final long bucketId = omBucketInfo.getObjectID();
 
     final String ozoneKey = omMetadataManager.getOzonePathKey(
@@ -463,7 +463,7 @@ public class TestOMDirectoryCreateRequestWithFSO {
             new CacheValue<>(Optional.of(omKeyInfo), txnID));
     omMetadataManager.getKeyTable(getBucketLayout()).put(ozoneKey, omKeyInfo);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             keyName);
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -501,13 +501,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 255);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
+    final long bucketId = omMetadataManager.getBucketId(VOLUME_NAME,
+        BUCKET_NAME);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -537,10 +537,10 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 256);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -571,13 +571,13 @@ public class TestOMDirectoryCreateRequestWithFSO {
     String keyName = createDirKey(dirs, 3);
 
     // Add volume and bucket entries to DB.
-    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+    OMRequestTestUtils.addVolumeAndBucketToDB(VOLUME_NAME, BUCKET_NAME,
             omMetadataManager, getBucketLayout());
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+    final long volumeId = omMetadataManager.getVolumeId(VOLUME_NAME);
+    final long bucketId = omMetadataManager.getBucketId(VOLUME_NAME,
+        BUCKET_NAME);
 
-    OMRequest omRequest = createDirectoryRequest(volumeName, bucketName,
+    OMRequest omRequest = createDirectoryRequest(VOLUME_NAME, BUCKET_NAME,
             OzoneFSUtils.addTrailingSlashIfNeeded(keyName));
     OMDirectoryCreateRequestWithFSO omDirCreateReqFSO =
         new OMDirectoryCreateRequestWithFSO(omRequest,
@@ -658,19 +658,19 @@ public class TestOMDirectoryCreateRequestWithFSO {
   /**
    * Create OMRequest which encapsulates CreateDirectory request.
    *
-   * @param volume
-   * @param bucket
+   * @param volumeName
+   * @param bucketName
    * @param keyName
    * @return OMRequest
    */
-  private OMRequest createDirectoryRequest(String volume, String bucket,
+  private OMRequest createDirectoryRequest(String volumeName, String bucketName,
                                            String keyName) {
     return OMRequest.newBuilder().setCreateDirectoryRequest(
             CreateDirectoryRequest.newBuilder().setKeyArgs(
-                    KeyArgs.newBuilder().setVolumeName(volume)
-                            .setBucketName(bucket).setKeyName(keyName)))
-            .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
-            .setClientId(UUID.randomUUID().toString()).build();
+                KeyArgs.newBuilder().setVolumeName(volumeName)
+                    .setBucketName(bucketName).setKeyName(keyName)))
+        .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
+        .setClientId(UUID.randomUUID().toString()).build();
   }
 
   private BucketLayout getBucketLayout() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/file/TestOMDirectoryCreateRequestWithFSO.java
@@ -82,6 +82,8 @@ public class TestOMDirectoryCreateRequestWithFSO {
           ((response, transactionIndex) -> {
             return null;
           });
+  private final String volumeName = "vol1";
+  private final String bucketName = "bucket1";
 
   @Before
   public void setup() throws Exception {
@@ -100,6 +102,10 @@ public class TestOMDirectoryCreateRequestWithFSO {
     when(ozoneManager.resolveBucketLink(any(KeyArgs.class),
             any(OMClientRequest.class)))
             .thenReturn(new ResolvedBucket(Pair.of("", ""), Pair.of("", "")));
+
+    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
 
   @After
@@ -110,8 +116,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testPreExecute() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     String keyName = "a/b/c";
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -132,8 +136,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -169,8 +171,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -202,8 +202,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -234,8 +232,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
   @Test
   public void testValidateAndUpdateCacheWithSubDirectoryInPath()
           throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -287,8 +283,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
   @Test
   public void testValidateAndUpdateCacheWithDirectoryAlreadyExists()
           throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -349,8 +343,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
    */
   @Test
   public void testValidateAndUpdateCacheWithFilesInPath() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -434,8 +426,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
   @Test
   public void testValidateAndUpdateCacheWithFileExistsInGivenPath()
           throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -507,8 +497,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testCreateDirectoryUptoLimitOfMaxLevels255() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 255);
 
@@ -545,8 +533,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testCreateDirectoryExceedLimitOfMaxLevels255() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 256);
 
@@ -581,8 +567,6 @@ public class TestOMDirectoryCreateRequestWithFSO {
 
   @Test
   public void testCreateDirectoryOMMetric() throws Exception {
-    String volumeName = "vol1";
-    String bucketName = "bucket1";
     List<String> dirs = new ArrayList<String>();
     String keyName = createDirKey(dirs, 3);
 
@@ -674,17 +658,17 @@ public class TestOMDirectoryCreateRequestWithFSO {
   /**
    * Create OMRequest which encapsulates CreateDirectory request.
    *
-   * @param volumeName
-   * @param bucketName
+   * @param volume
+   * @param bucket
    * @param keyName
    * @return OMRequest
    */
-  private OMRequest createDirectoryRequest(String volumeName, String bucketName,
+  private OMRequest createDirectoryRequest(String volume, String bucket,
                                            String keyName) {
     return OMRequest.newBuilder().setCreateDirectoryRequest(
             CreateDirectoryRequest.newBuilder().setKeyArgs(
-                    KeyArgs.newBuilder().setVolumeName(volumeName)
-                            .setBucketName(bucketName).setKeyName(keyName)))
+                    KeyArgs.newBuilder().setVolumeName(volume)
+                            .setBucketName(bucket).setKeyName(keyName)))
             .setCmdType(OzoneManagerProtocolProtos.Type.CreateDirectory)
             .setClientId(UUID.randomUUID().toString()).build();
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/key/TestOMKeyRequest.java
@@ -201,6 +201,8 @@ public class TestOMKeyRequest {
     when(ozoneManager.resolveBucketLink(any(Pair.class),
         any(OMClientRequest.class)))
         .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequest.java
@@ -44,8 +44,7 @@ public class TestS3InitiateMultipartUploadRequest
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     // Add volume and bucket to DB.
@@ -96,8 +95,7 @@ public class TestS3InitiateMultipartUploadRequest
 
   @Test
   public void testValidateAndUpdateCacheWithBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
@@ -128,8 +126,7 @@ public class TestS3InitiateMultipartUploadRequest
 
   @Test
   public void testValidateAndUpdateCacheWithVolumeNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     OMRequest modifiedRequest = doPreExecuteInitiateMPU(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3InitiateMultipartUploadRequestWithFSO.java
@@ -43,8 +43,7 @@ public class TestS3InitiateMultipartUploadRequestWithFSO
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String prefix = "a/b/c/";
     List<String> dirs = new ArrayList<String>();
     dirs.add("a");

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartRequest.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.om.request.s3.multipart;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;
@@ -64,6 +65,8 @@ public class TestS3MultipartRequest {
   protected OMMetrics omMetrics;
   protected OMMetadataManager omMetadataManager;
   protected AuditLogger auditLogger;
+  protected String volumeName;
+  protected String bucketName;
 
   // Just setting ozoneManagerDoubleBuffer which does nothing.
   protected OzoneManagerDoubleBufferHelper ozoneManagerDoubleBufferHelper =
@@ -107,15 +110,16 @@ public class TestS3MultipartRequest {
   /**
    * Perform preExecute of Initiate Multipart upload request for given
    * volume, bucket and key name.
-   * @param volumeName
-   * @param bucketName
+   *
+   * @param volume
+   * @param bucket
    * @param keyName
    * @return OMRequest - returned from preExecute.
    */
   protected OMRequest doPreExecuteInitiateMPU(
-      String volumeName, String bucketName, String keyName) throws Exception {
+      String volume, String bucket, String keyName) throws Exception {
     OMRequest omRequest =
-        OMRequestTestUtils.createInitiateMPURequest(volumeName, bucketName,
+        OMRequestTestUtils.createInitiateMPURequest(volume, bucket,
             keyName);
 
     S3InitiateMultipartUploadRequest s3InitiateMultipartUploadRequest =
@@ -137,8 +141,9 @@ public class TestS3MultipartRequest {
   /**
    * Perform preExecute of Commit Multipart Upload request for given volume,
    * bucket and keyName.
-   * @param volumeName
-   * @param bucketName
+   *
+   * @param volume
+   * @param bucket
    * @param keyName
    * @param clientID
    * @param multipartUploadID
@@ -146,14 +151,14 @@ public class TestS3MultipartRequest {
    * @return OMRequest - returned from preExecute.
    */
   protected OMRequest doPreExecuteCommitMPU(
-      String volumeName, String bucketName, String keyName,
+      String volume, String bucket, String keyName,
       long clientID, String multipartUploadID, int partNumber)
       throws Exception {
 
     // Just set dummy size
     long dataSize = 100L;
     OMRequest omRequest =
-        OMRequestTestUtils.createCommitPartMPURequest(volumeName, bucketName,
+        OMRequestTestUtils.createCommitPartMPURequest(volume, bucket,
             keyName, clientID, dataSize, multipartUploadID, partNumber);
     S3MultipartUploadCommitPartRequest s3MultipartUploadCommitPartRequest =
             getS3MultipartUploadCommitReq(omRequest);
@@ -170,19 +175,19 @@ public class TestS3MultipartRequest {
   /**
    * Perform preExecute of Abort Multipart Upload request for given volume,
    * bucket and keyName.
-   * @param volumeName
-   * @param bucketName
+   * @param volume
+   * @param bucket
    * @param keyName
    * @param multipartUploadID
    * @return OMRequest - returned from preExecute.
    * @throws IOException
    */
   protected OMRequest doPreExecuteAbortMPU(
-      String volumeName, String bucketName, String keyName,
+      String volume, String bucket, String keyName,
       String multipartUploadID) throws IOException {
 
     OMRequest omRequest =
-        OMRequestTestUtils.createAbortMPURequest(volumeName, bucketName,
+        OMRequestTestUtils.createAbortMPURequest(volume, bucket,
             keyName, multipartUploadID);
 
 
@@ -199,12 +204,14 @@ public class TestS3MultipartRequest {
 
   }
 
-  protected OMRequest doPreExecuteCompleteMPU(String volumeName,
-      String bucketName, String keyName, String multipartUploadID,
-      List<Part> partList) throws IOException {
+  protected OMRequest doPreExecuteCompleteMPU(String volume,
+                                              String bucket, String keyName,
+                                              String multipartUploadID,
+                                              List<Part> partList)
+      throws IOException {
 
     OMRequest omRequest =
-        OMRequestTestUtils.createCompleteMPURequest(volumeName, bucketName,
+        OMRequestTestUtils.createCompleteMPURequest(volume, bucket,
             keyName, multipartUploadID, partList);
 
     S3MultipartUploadCompleteRequest s3MultipartUploadCompleteRequest =
@@ -224,15 +231,16 @@ public class TestS3MultipartRequest {
   /**
    * Perform preExecute of Initiate Multipart upload request for given
    * volume, bucket and key name.
-   * @param volumeName
-   * @param bucketName
+   *
+   * @param volume
+   * @param bucket
    * @param keyName
    * @return OMRequest - returned from preExecute.
    */
   protected OMRequest doPreExecuteInitiateMPUWithFSO(
-      String volumeName, String bucketName, String keyName) throws Exception {
+      String volume, String bucket, String keyName) throws Exception {
     OMRequest omRequest =
-            OMRequestTestUtils.createInitiateMPURequest(volumeName, bucketName,
+            OMRequestTestUtils.createInitiateMPURequest(volume, bucket,
                     keyName);
 
     S3InitiateMultipartUploadRequestWithFSO
@@ -280,4 +288,17 @@ public class TestS3MultipartRequest {
     return BucketLayout.DEFAULT;
   }
 
+  /**
+   * Setups up volume and bucket names, along with related mocks.
+   *
+   * @throws Exception
+   */
+  protected void setupVolumeAndBucketName() throws Exception {
+    volumeName = UUID.randomUUID().toString();
+    bucketName = UUID.randomUUID().toString();
+
+    Pair<String, String> volumeAndBucket = Pair.of(volumeName, bucketName);
+    when(ozoneManager.resolveBucketLink(any(Pair.class)))
+        .thenReturn(new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadAbortRequest.java
@@ -48,8 +48,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
 
   @Test
   public void testValidateAndUpdateCache() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -100,8 +99,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
 
   @Test
   public void testValidateAndUpdateCacheMultipartNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -130,8 +128,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
 
   @Test
   public void testValidateAndUpdateCacheVolumeNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
 
@@ -157,8 +154,7 @@ public class TestS3MultipartUploadAbortRequest extends TestS3MultipartRequest {
 
   @Test
   public void testValidateAndUpdateCacheBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequest.java
@@ -51,8 +51,7 @@ public class TestS3MultipartUploadCommitPartRequest
 
   @Test
   public void testValidateAndUpdateCacheSuccess() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -113,8 +112,7 @@ public class TestS3MultipartUploadCommitPartRequest
 
   @Test
   public void testValidateAndUpdateCacheMultipartNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -152,8 +150,7 @@ public class TestS3MultipartUploadCommitPartRequest
 
   @Test
   public void testValidateAndUpdateCacheKeyNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -190,8 +187,7 @@ public class TestS3MultipartUploadCommitPartRequest
 
   @Test
   public void testValidateAndUpdateCacheBucketFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCommitPartRequestWithFSO.java
@@ -97,10 +97,11 @@ public class TestS3MultipartUploadCommitPartRequestWithFSO
   }
 
   @Override
-  protected OMRequest doPreExecuteInitiateMPU(String volumeName,
-      String bucketName, String keyName) throws Exception {
+  protected OMRequest doPreExecuteInitiateMPU(String volume,
+                                              String bucket, String keyName)
+      throws Exception {
     OMRequest omRequest =
-            OMRequestTestUtils.createInitiateMPURequest(volumeName, bucketName,
+            OMRequestTestUtils.createInitiateMPURequest(volume, bucket,
                     keyName);
 
     S3InitiateMultipartUploadRequest s3InitiateMultipartUploadRequest =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/multipart/TestS3MultipartUploadCompleteRequest.java
@@ -57,8 +57,7 @@ public class TestS3MultipartUploadCompleteRequest
 
   @Test
   public void testValidateAndUpdateCacheSuccess() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
         omMetadataManager, getBucketLayout());
@@ -166,8 +165,7 @@ public class TestS3MultipartUploadCompleteRequest
 
   @Test
   public void testInvalidPartOrderError() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = getKeyName();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
@@ -228,8 +226,7 @@ public class TestS3MultipartUploadCompleteRequest
 
   @Test
   public void testValidateAndUpdateCacheVolumeNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     List<Part> partList = new ArrayList<>();
@@ -251,8 +248,7 @@ public class TestS3MultipartUploadCompleteRequest
 
   @Test
   public void testValidateAndUpdateCacheBucketNotFound() throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     OMRequestTestUtils.addVolumeToDB(volumeName, omMetadataManager);
@@ -276,8 +272,7 @@ public class TestS3MultipartUploadCompleteRequest
   @Test
   public void testValidateAndUpdateCacheNoSuchMultipartUploadError()
       throws Exception {
-    String volumeName = UUID.randomUUID().toString();
-    String bucketName = UUID.randomUUID().toString();
+    setupVolumeAndBucketName();
     String keyName = UUID.randomUUID().toString();
 
     OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/TestCleanupTableInfo.java
@@ -139,6 +139,12 @@ public class TestCleanupTableInfo {
     when(om.getAuditLogger()).thenReturn(mock(AuditLogger.class));
     when(om.getDefaultReplicationConfig()).thenReturn(ReplicationConfig
         .getDefault(new OzoneConfiguration()));
+
+    Pair<String, String> volumeAndBucket =
+        Pair.of(TEST_VOLUME_NAME, TEST_BUCKET_NAME);
+    when(om.resolveBucketLink(any(Pair.class))).thenReturn(
+        new ResolvedBucket(volumeAndBucket, volumeAndBucket));
+
     addVolumeToMetaTable(aVolumeArgs());
     addBucketToMetaTable(aBucketInfo());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

In high concurrency scenarios (which will become more common once we introduced prefix-based locking), there is a possibility of the following race condition:
Take for instance the following scenario and 3 concurrent write requests:
Bucket `vol/buck1` exists with `LEGACY` layout.

**Request 1**: `CreateKey` by an older client (pre- bucket layout) on a bucket `vol/buck1`.
**Request 2**: `DeleteBucket` by a new client on the bucket `vol/buck1`.
**Request 3**: `CreateBucket` by a new client on the bucket `vol/buck1` with layout `FILE_SYSTEM_OPTIMIZED`.

Let's say that these requests are processed in the following order:
1. `Request 1` is picked up by one of the threads, which proceeds to run the `PRE_PROCESS` validations on this request. The validator we are interested in is called `blockCreateKeyWithBucketLayoutFromOldClient`. This validator will make sure that the bucket associated with this request is a `LEGACY` bucket - which is the pre-defined behavior in the case of old client/new cluster interactions since we do not want an old client operating on buckets using a new metadata layout.

One thing to know here is that at this stage, the OM does not hold a bucket lock (which only happens inside the `updateAndValidateCache` method associated with the write request's handler class).

2. While `Request 1` was being processed, another thread was processing `Request 2`. Let's say `Request2' managed to get hold of the bucket lock and successfully completed the bucket deletion.

3. Now before `Request 1` got a chance to acquire the bucket lock, `Request 3` manages to acquire it. It proceeds with the bucket creation and creates a new bucket `vol/buck1` with `FILE_SYSTEM_OPTIMIZED` bucket layout.

4. Finally, `Request 1` is able to acquire the bucket lock and proceeds to enter its `validateAndUpdateCache` method. However, even though it is able to find the bucket it is looking for, this is not the same bucket that was validated in its pre-processing hook. This new bucket has the same name, but a different bucket layout. The request ends up modifying a bucket that it should not be allowed to touch.

This race condition can lead to undefined behavior of the Ozone cluster, where older clients might be modifying information they do not understand.

This PR aims to add bucket ID validation to the request processing flow, which would make sure that the bucket that ends up being processed is the same one that was validated. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6682

## How was this patch tested?

Existing test cases.
