### PR TITLE
HDDS-6878. Only export span if Ozone tracer init

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/tracing/TracingUtil.java
@@ -40,6 +40,8 @@ public final class TracingUtil {
 
   private static final String NULL_SPAN_AS_STRING = "";
 
+  private static volatile boolean isInit = false;
+
   private TracingUtil() {
   }
 
@@ -55,6 +57,7 @@ public final class TracingUtil {
           .registerInjector(StringCodec.FORMAT, new StringCodec())
           .build();
       GlobalTracer.registerIfAbsent(tracer);
+      isInit = true;
     }
   }
 
@@ -73,7 +76,7 @@ public final class TracingUtil {
    * @return encoded tracing context.
    */
   public static String exportSpan(Span span) {
-    if (span != null) {
+    if (span != null && isInit) {
       StringBuilder builder = new StringBuilder();
       GlobalTracer.get().inject(span.context(), StringCodec.FORMAT, builder);
       return builder.toString();

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/tracing/TestTracingUtil.java
@@ -17,14 +17,19 @@
  */
 package org.apache.hadoop.hdds.tracing;
 
+import io.jaegertracing.Configuration;
+import io.jaegertracing.internal.JaegerTracer;
+import io.opentracing.util.GlobalTracer;
 import org.apache.hadoop.hdds.conf.InMemoryConfiguration;
 import org.apache.hadoop.hdds.conf.MutableConfigurationSource;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.Service;
 import org.apache.hadoop.hdds.tracing.TestTraceAllMethod.ServiceImpl;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.apache.hadoop.hdds.tracing.TracingUtil.createProxy;
+import static org.apache.hadoop.hdds.tracing.TracingUtil.exportCurrentSpan;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -38,6 +43,19 @@ public class TestTracingUtil {
         tracingEnabled());
 
     assertEquals("Hello default", subject.defaultMethod());
+  }
+
+  @Test
+  public void testInitTracing() {
+    Configuration config = Configuration.fromEnv("testInitTracing");
+    JaegerTracer tracer = config.getTracerBuilder().build();
+    GlobalTracer.registerIfAbsent(tracer);
+    try (AutoCloseable scope = TracingUtil
+        .createActivatedSpan("initTracing")) {
+      exportCurrentSpan();
+    } catch (Exception e) {
+      Assert.fail("Should not get exception");
+    }
   }
 
   private static MutableConfigurationSource tracingEnabled() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When clients wraps OzoneClient with Tracing.span, Ozone will try to export the context using StringCodec, but the clients' tracer don't know the StringCodec Ozone is using, the exception of UnsupportedFormatException would be thrown.

This ticket is to fix this issue.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6878

## How was this patch tested?

unit test.
