### PR TITLE
HDDS-6877. MiniOzoneCluster should keep replication port when restarting datanode

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/MiniOzoneClusterImpl.java
@@ -79,6 +79,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.RATIS;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.RATIS_ADMIN;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.RATIS_SERVER;
+import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.REPLICATION;
 import static org.apache.hadoop.hdds.protocol.DatanodeDetails.Port.Name.STANDALONE;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
 import static org.apache.hadoop.hdds.recon.ReconConfigKeys.OZONE_RECON_ADDRESS_KEY;
@@ -414,6 +415,8 @@ public class MiniOzoneClusterImpl implements MiniOzoneCluster {
         dn.getPort(RATIS_ADMIN).getValue());
     config.setInt(DFS_CONTAINER_RATIS_SERVER_PORT,
         dn.getPort(RATIS_SERVER).getValue());
+    config.setFromObject(new ReplicationConfig()
+        .setPort(dn.getPort(REPLICATION).getValue()));
     hddsDatanodes.remove(i);
     if (waitForDatanode) {
       // wait for node to be removed from SCM healthy node list.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestMiniOzoneCluster.java
@@ -281,6 +281,22 @@ public class TestMiniOzoneCluster {
     }
   }
 
+  @Test
+  public void testKeepPortsWhenRestartDN() throws Exception {
+    cluster = MiniOzoneCluster.newBuilder(conf)
+        .setNumDatanodes(1)
+        .build();
+    cluster.waitForClusterToBeReady();
+    DatanodeDetails before =
+        cluster.getHddsDatanodes().get(0).getDatanodeDetails();
+    cluster.restartHddsDatanode(0, true);
+    DatanodeDetails after =
+        cluster.getHddsDatanodes().get(0).getDatanodeDetails();
+    for (Port.Name name : Port.Name.ALL_PORTS) {
+      assertEquals(before.getPort(name), after.getPort(name));
+    }
+  }
+
   private void createMalformedIDFile(File malformedFile)
       throws IOException {
     malformedFile.delete();


### PR DESCRIPTION
## What changes were proposed in this pull request?

When restarting a datanode in MiniOzoneCluster, the replication port is not supposed to change.

This bug was discovered when developing integration tests for in-house EC offline recovery branch,
which relies on the replication port to transfer the data.

Although this bug is not affecting the tests in master, it's better to have it fixed in advance.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6877

## How was this patch tested?

New test `TestMiniOzoneCluster#testKeepPortsWhenRestartDN`.

https://github.com/kaijchen/ozone/runs/6860775365?check_suite_focus=true#step:4:3076