### PR TITLE
HDDS-6830. EC: SCMContainerPlacementRackScatter may choose fewer nodes than required

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -140,7 +140,7 @@ public final class SCMContainerPlacementRackScatter
       racks = sortRackWithExcludedNodes(racks, excludedNodes);
     }
 
-    List<Node> toChooseRacks = new LinkedList<>(racks);
+    List<Node> toChooseRacks = new LinkedList<>();
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>();
     List<Node> unavailableNodes = new ArrayList<>();
     Set<Node> skippedRacks = new HashSet<>();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -167,7 +167,7 @@ public final class SCMContainerPlacementRackScatter
       }
 
       if (mutableFavoredNodes.size() > 0) {
-        List<Node> chosenFavoredNodesInForLoop = new ArrayList<>();
+        List<DatanodeDetails> chosenFavoredNodesInForLoop = new ArrayList<>();
         for (DatanodeDetails favoredNode : mutableFavoredNodes) {
           Node curRack = getRackOfDatanodeDetails(favoredNode);
           if (toChooseRacks.contains(curRack)) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
@@ -140,7 +141,7 @@ public final class SCMContainerPlacementRackScatter
     }
 
     List<Node> toChooseRacks = new LinkedList<>(racks);
-    List<DatanodeDetails> chosenNodes = new ArrayList<>();
+    Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>();
     List<Node> unavailableNodes = new ArrayList<>();
     Set<Node> skippedRacks = new HashSet<>();
     if (excludedNodes != null) {
@@ -219,8 +220,9 @@ public final class SCMContainerPlacementRackScatter
         retryCount = 0;
       }
     }
+    List<DatanodeDetails> result = new ArrayList<>(chosenNodes);
     ContainerPlacementStatus placementStatus =
-        validateContainerPlacement(chosenNodes, nodesRequiredToChoose);
+        validateContainerPlacement(result, nodesRequiredToChoose);
     if (!placementStatus.isPolicySatisfied()) {
       String errorMsg = "ContainerPlacementPolicy not met, currentRacks is" +
           placementStatus.actualPlacementCount() + "desired racks is" +
@@ -237,7 +239,7 @@ public final class SCMContainerPlacementRackScatter
       throw new SCMException(reason,
           SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
     }
-    return chosenNodes;
+    return result;
   }
 
   @Override


### PR DESCRIPTION
## What changes were proposed in this pull request?

Attempt to fix mismatch in count of nodes selected by `SCMContainerPlacementRackScatter`:

```
SCMException: Nodes size= 5, replication factor= 6 do not match
	at org.apache.hadoop.hdds.scm.pipeline.PipelineFactory.checkPipeline(PipelineFactory.java:106)
	at org.apache.hadoop.hdds.scm.pipeline.PipelineFactory.create(PipelineFactory.java:90)
	at org.apache.hadoop.hdds.scm.pipeline.PipelineManagerImpl.createPipeline(PipelineManagerImpl.java:195)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.allocateContainer(WritableECContainerProvider.java:172)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:155)
	at org.apache.hadoop.hdds.scm.pipeline.WritableECContainerProvider.getContainer(WritableECContainerProvider.java:51)
	at org.apache.hadoop.hdds.scm.pipeline.WritableContainerFactory.getContainer(WritableContainerFactory.java:59)
	at org.apache.hadoop.hdds.scm.block.BlockManagerImpl.allocateBlock(BlockManagerImpl.java:176)
```

The exception comes from `PipelineFactory.checkPipeline`, which implies that the placement policy itself did not find any problem with the number of nodes selected:

https://github.com/apache/ozone/blob/3d623a8dd337b507558d5b8fab745f3b420d7b87/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java#L230-L240

Placement policy returns a list, which allows duplicates, but the pipeline stores nodes as keys in a map, thus discarding duplicates.  Hence node count in the two places may be different.

https://github.com/apache/ozone/blob/3d623a8dd337b507558d5b8fab745f3b420d7b87/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/pipeline/Pipeline.java#L508-L510

This PR changes `SCMContainerPlacementRackScatter` to use a set for collecting selected nodes, only at the last step is it converted to list.  This way the algorithm exits only when required number of distinct nodes are found, or throws exception if that's not possible.

https://issues.apache.org/jira/browse/HDDS-6830

## How was this patch tested?

Existing tests pass.  I couldn't reproduce the duplicate node scenario, so no new test added.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2488488385