### PR TITLE
HDDS-6867.  [Ozone-Streaming] PutKeyHandler should not use streaming to put EC key.

### DIFF
--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -105,6 +105,8 @@ public class TestDatanodeUpgradeToSchemaV3 {
     conf = new OzoneConfiguration();
     conf.setBoolean(DatanodeConfiguration.CONTAINER_SCHEMA_V3_ENABLED,
         this.schemaV3Enabled);
+    conf.setBoolean(
+        OzoneConfigKeys.DFS_CONTAINER_RATIS_DATASTREAM_RANDOM_PORT, true);
   }
 
   @Before


### PR DESCRIPTION
## What changes were proposed in this pull request?

Put EC key should not using streaming.
In the EC write test, writing a small file (less than 4MB) was successful, but writing 100MB failed. Cause 100MB EC key should not be written using Streaming.

![image](https://user-images.githubusercontent.com/13825159/173725250-118063bf-e9d2-4820-8e49-835c3a1c668b.png)


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6867

## How was this patch tested?

Existing test in acceptance-unsecure.
