### PR TITLE
HDDS-6882. Correct exit code for invalid arguments passed to command-line tools.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -31,7 +31,6 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.ExecutionException;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
-import picocli.CommandLine.RunLast;
 
 /**
  * This is a generic parent class for all the ozone related cli tools.
@@ -83,17 +82,22 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
   }
 
   public void run(String[] argv) {
+    int exitCode;
     try {
-      execute(argv);
+      exitCode = execute(argv);
     } catch (ExecutionException ex) {
       printError(ex.getCause() == null ? ex : ex.getCause());
-      System.exit(-1);
+      exitCode = -1;
+    }
+
+    if (exitCode != CommandLine.ExitCode.OK) {
+      System.exit(exitCode);
     }
   }
 
   @VisibleForTesting
-  public void execute(String[] argv) {
-    cmd.parseWithHandler(new RunLast(), argv);
+  public int execute(String[] argv) {
+    return cmd.execute(argv);
   }
 
   protected void printError(Throwable error) {

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -51,6 +51,10 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
 
   public GenericCli() {
     cmd = new CommandLine(this);
+    cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
+      printError(ex);
+      return -1;
+    });
   }
 
   public GenericCli(Class<?> type) {
@@ -82,13 +86,7 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
   }
 
   public void run(String[] argv) {
-    int exitCode;
-    try {
-      exitCode = execute(argv);
-    } catch (ExecutionException ex) {
-      printError(ex.getCause() == null ? ex : ex.getCause());
-      exitCode = -1;
-    }
+    int exitCode = execute(argv);
 
     if (exitCode != CommandLine.ExitCode.OK) {
       System.exit(exitCode);

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/cli/GenericCli.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
-import picocli.CommandLine.ExecutionException;
+import picocli.CommandLine.ExitCode;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Option;
 
@@ -36,6 +36,8 @@ import picocli.CommandLine.Option;
  * This is a generic parent class for all the ozone related cli tools.
  */
 public class GenericCli implements Callable<Void>, GenericParentCommand {
+
+  public static final int EXECUTION_ERROR_EXIT_CODE = -1;
 
   @Option(names = {"--verbose"},
       description = "More verbose output. Show the stack trace of the errors.")
@@ -53,7 +55,7 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
     cmd = new CommandLine(this);
     cmd.setExecutionExceptionHandler((ex, commandLine, parseResult) -> {
       printError(ex);
-      return -1;
+      return EXECUTION_ERROR_EXIT_CODE;
     });
   }
 
@@ -82,13 +84,13 @@ public class GenericCli implements Callable<Void>, GenericParentCommand {
   public static void missingSubcommand(CommandSpec spec) {
     System.err.println("Incomplete command");
     spec.commandLine().usage(System.err);
-    System.exit(-1);
+    System.exit(EXECUTION_ERROR_EXIT_CODE);
   }
 
   public void run(String[] argv) {
     int exitCode = execute(argv);
 
-    if (exitCode != CommandLine.ExitCode.OK) {
+    if (exitCode != ExitCode.OK) {
       System.exit(exitCode);
     }
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/server/TestStorageContainerManagerStarter.java
@@ -17,10 +17,13 @@
  */
 package org.apache.hadoop.hdds.scm.server;
 
+import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import picocli.CommandLine.ExitCode;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
@@ -32,7 +35,6 @@ import java.util.regex.Pattern;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 
 /**
@@ -64,102 +66,91 @@ public class TestStorageContainerManagerStarter {
 
   @Test
   public void testCallsStartWhenServerStarted() throws Exception {
-    executeCommand();
+    assertEquals(ExitCode.OK, executeCommand());
     assertTrue(mock.startCalled);
   }
 
   @Test
   public void testExceptionThrownWhenStartFails() throws Exception {
     mock.throwOnStart = true;
-    try {
-      executeCommand();
-      fail("Exception show have been thrown");
-    } catch (Exception e) {
-      assertTrue(true);
-    }
+    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE, executeCommand());
   }
 
   @Test
   public void testStartNotCalledWithInvalidParam() throws Exception {
-    executeCommand("--invalid");
+    assertEquals(ExitCode.USAGE, executeCommand("--invalid"));
     assertFalse(mock.startCalled);
   }
 
   @Test
   public void testPassingInitSwitchCallsInit() {
-    executeCommand("--init");
+    assertEquals(ExitCode.OK, executeCommand("--init"));
     assertTrue(mock.initCalled);
   }
 
   @Test
   public void testPassingBootStrapSwitchCallsBootStrap() {
-    executeCommand("--bootstrap");
+    assertEquals(ExitCode.OK, executeCommand("--bootstrap"));
     assertTrue(mock.bootStrapCalled);
   }
 
   @Test
   public void testInitSwitchAcceptsClusterIdSSwitch() {
-    executeCommand("--init", "--clusterid=abcdefg");
+    assertEquals(ExitCode.OK, executeCommand("--init", "--clusterid=abcdefg"));
     assertEquals("abcdefg", mock.clusterId);
   }
 
   @Test
   public void testInitSwitchWithInvalidParamDoesNotRun() {
-    executeCommand("--init", "--clusterid=abcdefg", "--invalid");
+    assertEquals(ExitCode.USAGE,
+            executeCommand("--init", "--clusterid=abcdefg", "--invalid"));
     assertFalse(mock.initCalled);
   }
 
   @Test
   public void testBootStrapSwitchWithInvalidParamDoesNotRun() {
-    executeCommand("--bootstrap", "--clusterid=abcdefg", "--invalid");
+    assertEquals(ExitCode.USAGE,
+            executeCommand("--bootstrap", "--clusterid=abcdefg", "--invalid"));
     assertFalse(mock.bootStrapCalled);
   }
 
   @Test
   public void testUnSuccessfulInitThrowsException() {
     mock.throwOnInit = true;
-    try {
-      executeCommand("--init");
-      fail("Exception show have been thrown");
-    } catch (Exception e) {
-      assertTrue(true);
-    }
+    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE,
+            executeCommand("--init"));
   }
 
   @Test
   public void testUnSuccessfulBootStrapThrowsException() {
     mock.throwOnBootstrap = true;
-    try {
-      executeCommand("--bootstrap");
-      fail("Exception show have been thrown");
-    } catch (Exception e) {
-      assertTrue(true);
-    }
+    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE,
+            executeCommand("--bootstrap"));
   }
 
   @Test
   public void testGenClusterIdRunsGenerate() {
-    executeCommand("--genclusterid");
+    assertEquals(ExitCode.OK, executeCommand("--genclusterid"));
     assertTrue(mock.generateCalled);
   }
 
   @Test
   public void testGenClusterIdWithInvalidParamDoesNotRun() {
-    executeCommand("--genclusterid", "--invalid");
+    assertEquals(ExitCode.USAGE, executeCommand("--genclusterid", "--invalid"));
     assertFalse(mock.generateCalled);
   }
 
   @Test
   public void testUsagePrintedOnInvalidInput()
       throws UnsupportedEncodingException {
-    executeCommand("--invalid");
+    assertEquals(ExitCode.USAGE, executeCommand("--invalid"));
     Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
     Matcher m = p.matcher(errContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());
   }
 
-  private void executeCommand(String... args) {
-    new StorageContainerManagerStarter(mock).execute(args);
+  private int executeCommand(String... args) {
+    return new StorageContainerManagerStarter(mock).execute(args);
   }
 
   static class MockSCMStarter implements SCMStarterInterface {

--- a/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
+++ b/hadoop-hdds/tools/src/main/java/org/apache/hadoop/hdds/cli/OzoneAdmin.java
@@ -87,12 +87,9 @@ public class OzoneAdmin extends GenericCli {
   }
 
   @Override
-  public void execute(String[] argv) {
+  public int execute(String[] argv) {
     TracingUtil.initTracing("shell", createOzoneConfiguration());
-    TracingUtil.executeInNewSpan("main",
-        (Supplier<Void>) () -> {
-          super.execute(argv);
-          return null;
-        });
+    return TracingUtil.executeInNewSpan("main",
+        (Supplier<Integer>) () -> super.execute(argv));
   }
 }

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell-lib.robot
@@ -30,7 +30,7 @@ Generate prefix
 
 Test ozone shell
     [arguments]     ${protocol}         ${server}       ${volume}
-    ${result} =     Execute And Ignore Error    ozone sh volume info ${protocol}${server}/${volume}
+    ${result} =     Execute and checkrc    ozone sh volume info ${protocol}${server}/${volume}      255
                     Should contain      ${result}       VOLUME_NOT_FOUND
     ${result} =     Execute             ozone sh volume create ${protocol}${server}/${volume} --space-quota 100TB --namespace-quota 100
                     Should not contain  ${result}       Failed
@@ -85,6 +85,24 @@ Test ozone shell
                     Should Be Equal     ${result}       -1
                     Execute             ozone sh bucket delete ${protocol}${server}/${volume}/bb1
                     Execute             ozone sh volume delete ${protocol}${server}/${volume}
+
+Test ozone shell errors
+    [arguments]     ${protocol}         ${server}       ${volume}
+    ${result} =     Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume} --space-quota invalid      255
+                    Should contain      ${result}       Invalid
+                    Execute and checkrc    ozone sh volume create ${protocol}${server}/${volume}                            0
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket_1                   255
+                    Should contain      ${result}       INVALID_BUCKET_NAME
+    ${result} =     Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1 --layout Invalid   2
+                    Should contain      ${result}       Usage
+                    Execute and checkrc    ozone sh bucket create ${protocol}${server}/${volume}/bucket1                    0
+    ${result} =     Execute and checkrc    ozone sh key info ${protocol}${server}/${volume}/bucket1/non-existing           255
+                    Should contain      ${result}       KEY_NOT_FOUND
+    ${result} =     Execute and checkrc    ozone sh key put ${protocol}${server}/${volume}/bucket1/key1 unexisting --type invalid    2
+                    Execute and checkrc    ozone sh bucket delete ${protocol}${server}/${volume}/bucket1                    0
+                    Execute and checkrc    ozone sh volume delete ${protocol}${server}/${volume}                            0
+
+
 
 Test Volume Acls
     [arguments]     ${protocol}         ${server}       ${volume}

--- a/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/ozone-shell.robot
@@ -26,6 +26,9 @@ Suite Setup         Generate prefix
 RpcClient with port
    Test ozone shell       o3://            om:9862     ${prefix}-with-host
 
+RpcClient with execution errors
+   Test ozone shell errors    o3://        om:9862     ${prefix}-with-errors
+
 RpcClient volume acls
    Test Volume Acls       o3://            om:9862     ${prefix}-acls
 

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/OzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/OzoneChaosCluster.java
@@ -37,11 +37,6 @@ import picocli.CommandLine;
     versionProvider = HddsVersionProvider.class,
     mixinStandardHelpOptions = true)
 public class OzoneChaosCluster extends GenericCli {
-  @Override
-  public void execute(String[] argv) {
-    super.execute(argv);
-  }
-
   public static void main(String[] args) {
     new OzoneChaosCluster().run(args);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -17,7 +17,6 @@
 
 package org.apache.hadoop.ozone.om;
 
-import org.apache.hadoop.hdds.cli.GenericCli;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.After;
@@ -33,9 +32,11 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hdds.cli.GenericCli.EXECUTION_ERROR_EXIT_CODE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static picocli.CommandLine.ExitCode.USAGE;
 
 /**
  * This class is used to test the CLI provided by OzoneManagerStarter, which is
@@ -75,12 +76,12 @@ public class TestOzoneManagerStarter {
   @Test
   public void testExceptionThrownWhenStartFails() throws Exception {
     mock.throwOnStart = true;
-    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE, executeCommand());
+    assertEquals(EXECUTION_ERROR_EXIT_CODE, executeCommand());
   }
 
   @Test
   public void testStartNotCalledWithInvalidParam() throws Exception {
-    assertEquals(ExitCode.USAGE, executeCommand("--invalid"));
+    assertEquals(USAGE, executeCommand("--invalid"));
     assertFalse(mock.startCalled);
   }
 
@@ -92,21 +93,20 @@ public class TestOzoneManagerStarter {
 
   @Test
   public void testInitSwitchWithInvalidParamDoesNotRun() {
-    assertEquals(ExitCode.USAGE, executeCommand("--init", "--invalid"));
+    assertEquals(USAGE, executeCommand("--init", "--invalid"));
     assertFalse(mock.initCalled);
   }
 
   @Test
   public void testUnSuccessfulInitThrowsException() {
     mock.throwOnInit = true;
-    assertEquals(ExitCode.USAGE, executeCommand("--init"));
+    assertEquals(EXECUTION_ERROR_EXIT_CODE, executeCommand("--init"));
   }
 
   @Test
   public void testInitThatReturnsFalseThrowsException() {
     mock.initStatus = false;
-    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE,
-            executeCommand("--init"));
+    assertEquals(EXECUTION_ERROR_EXIT_CODE, executeCommand("--init"));
   }
 
   @Test
@@ -118,14 +118,13 @@ public class TestOzoneManagerStarter {
   @Test
   public void testUnsuccessfulUpgradeThrowsException() {
     mock.throwOnStartAndCancelPrepare = true;
-    assertEquals(GenericCli.EXECUTION_ERROR_EXIT_CODE,
-            executeCommand("--upgrade"));
+    assertEquals(EXECUTION_ERROR_EXIT_CODE, executeCommand("--upgrade"));
   }
 
   @Test
   public void testUsagePrintedOnInvalidInput()
       throws UnsupportedEncodingException {
-    assertEquals(ExitCode.USAGE, executeCommand("--invalid"));
+    assertEquals(USAGE, executeCommand("--invalid"));
     Pattern p = Pattern.compile("^Unknown option:.*--invalid.*\nUsage");
     Matcher m = p.matcher(errContent.toString(DEFAULT_ENCODING));
     assertTrue(m.find());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneManagerStarter.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import picocli.CommandLine.ExitCode;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -36,6 +35,7 @@ import static org.apache.hadoop.hdds.cli.GenericCli.EXECUTION_ERROR_EXIT_CODE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static picocli.CommandLine.ExitCode.OK;
 import static picocli.CommandLine.ExitCode.USAGE;
 
 /**
@@ -69,7 +69,7 @@ public class TestOzoneManagerStarter {
 
   @Test
   public void testCallsStartWhenServerStarted() throws Exception {
-    assertEquals(ExitCode.OK, executeCommand());
+    assertEquals(OK, executeCommand());
     assertTrue(mock.startCalled);
   }
 
@@ -87,7 +87,7 @@ public class TestOzoneManagerStarter {
 
   @Test
   public void testPassingInitSwitchCallsInit() {
-    assertEquals(ExitCode.OK, executeCommand("--init"));
+    assertEquals(OK, executeCommand("--init"));
     assertTrue(mock.initCalled);
   }
 
@@ -111,7 +111,7 @@ public class TestOzoneManagerStarter {
 
   @Test
   public void testCallsStartAndCancelPrepareWithUpgradeFlag() {
-    assertEquals(ExitCode.OK, executeCommand("--upgrade"));
+    assertEquals(OK, executeCommand("--upgrade"));
     assertTrue(mock.startAndCancelPrepareCalled);
   }
 

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/Freon.java
@@ -87,11 +87,11 @@ public class Freon extends GenericCli {
   private OzoneConfiguration conf;
 
   @Override
-  public void execute(String[] argv) {
+  public int execute(String[] argv) {
     conf = createOzoneConfiguration();
     HddsServerUtil.initializeMetrics(conf, "ozone-freon");
     TracingUtil.initTracing("freon", conf);
-    super.execute(argv);
+    return super.execute(argv);
   }
 
   public void stopHttpServer() {

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/RatisLogParser.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/segmentparser/RatisLogParser.java
@@ -42,11 +42,6 @@ import picocli.CommandLine;
 @MetaInfServices(SubcommandWithParent.class)
 public class RatisLogParser extends GenericCli implements SubcommandWithParent {
 
-  @Override
-  public void execute(String[] argv) {
-    super.execute(argv);
-  }
-
   public static void main(String[] args) {
     new RatisLogParser().run(args);
   }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/OzoneShell.java
@@ -48,13 +48,10 @@ public class OzoneShell extends Shell {
   }
 
   @Override
-  public void execute(String[] argv) {
+  public int execute(String[] argv) {
     TracingUtil.initTracing("shell", createOzoneConfiguration());
-    TracingUtil.executeInNewSpan("main",
-        (Supplier<Void>) () -> {
-          super.execute(argv);
-          return null;
-        });
+    return TracingUtil.executeInNewSpan("main",
+        (Supplier<Integer>) () -> super.execute(argv));
   }
 
 }

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/s3/S3Shell.java
@@ -37,13 +37,10 @@ import picocli.CommandLine.Command;
 public class S3Shell extends Shell {
 
   @Override
-  public void execute(String[] argv) {
+  public int execute(String[] argv) {
     TracingUtil.initTracing("s3shell", createOzoneConfiguration());
-    TracingUtil.executeInNewSpan("s3shell",
-        (Supplier<Void>) () -> {
-          super.execute(argv);
-          return null;
-        });
+    return TracingUtil.executeInNewSpan("s3shell",
+        (Supplier<Integer>) () -> super.execute(argv));
   }
 
   /**

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/tenant/TenantShell.java
@@ -38,13 +38,10 @@ import java.util.function.Supplier;
 public class TenantShell extends Shell {
 
   @Override
-  public void execute(String[] argv) {
+  public int execute(String[] argv) {
     TracingUtil.initTracing("tenant-shell", createOzoneConfiguration());
-    TracingUtil.executeInNewSpan("tenant-shell",
-        (Supplier<Void>) () -> {
-          super.execute(argv);
-          return null;
-        });
+    return TracingUtil.executeInNewSpan("tenant-shell",
+        (Supplier<Integer>) () -> super.execute(argv));
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?
Command-line tools don't take exit-code from `picocli` and set the exit-code accordingly. That makes exit-codes for cases like invalid argument be always 0.

This change fixes that by replacing the use of the deprecated `parseWithHandler` method with the `execute` method that returns correct exit-code for parsing/invalid input cases. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6882

## How was this patch tested?
Regression is checked by unit test.

Manually tests to verify the expected status code for error-cases.

```
ozone sh bucket create /vol1/bucket1 -l 123
Invalid value for option '--layout': expected one of [FILE_SYSTEM_OPTIMIZED, OBJECT_STORE, LEGACY] (case-sensitive) but was '123'
Usage: ozone sh bucket create [-ghV] [-k=<bekName>] [-l=<allowedBucketLayout>]
                              [--namespace-quota=<quotaInNamespace>]
                              [--quota=<quotaInBytes>] [-r=<replication>]
                              [-t=<type>] [-u=<ownerName>] <value>
creates a bucket in a given volume
      <value>              URI of the volume/bucket.
                           Ozone URI could start with o3:// or without prefix.
                             URI may contain the host/serviceId and port of the
                             OM server. Both are optional. If they are not
                             specified it will be identified from the config
                             files.
  -g, --enforcegdpr        if true, indicates GDPR enforced bucket,
                             false/unspecified indicates otherwise
  -h, --help               Show this help message and exit.
  -k, --bucketkey=<bekName>
                           bucket encryption key name
  -l, --layout=<allowedBucketLayout>
                           Allowed Bucket Layouts: FILE_SYSTEM_OPTIMIZED,
                             OBJECT_STORE, LEGACY
      --namespace-quota=<quotaInNamespace>
                           For volume this parameter represents the number of
                             buckets, and for buckets represents the number of
                             keys (eg. 5)
      --quota, --space-quota=<quotaInBytes>
                           The maximum space quota can be used (eg. 1GB)
  -r, --replication=<replication>
                           Replication definition. Valid values are replication
                             type-specific.  For RATIS: ONE or THREE. In case
                             of EC, pass CODEC-DATA-PARITY-CHUNKSIZE,  e.g.
                             rs-3-2-1024k, rs-6-3-1024k, rs-10-4-1024k
  -t, --type, --replication-type=<type>
                           Replication type. Supported types are: RATIS, EC
  -u, --user=<ownerName>   Owner of the bucket. Defaults to current user if not
                             specified
  -V, --version            Print version information and exit.
sh-4.2$ echo $?
2

sh-4.2$ ozone sh bucket create /vol1/bucket_1
INVALID_BUCKET_NAME Bucket or Volume name has an unsupported character : _
sh-4.2$ echo $?
255

sh-4.2$ ozone sh bucket create /vol1/bucket1
2022-06-14 23:06:01,060 INFO  rpc.RpcClient (RpcClient.java:createVolume(466)) - Creating Volume: vol1, with duong as owner and space quota set to -1 bytes, counts quota set to -1
sh-4.2$ echo $?
0

```
