### PR TITLE
HDDS-6863. Add Group-Id & Ratis-Roles Information for OM UI.

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.Comparator;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.Path;
@@ -795,8 +797,13 @@ public final class OmUtils {
   public static String format(List<ServiceInfo> nodes, int port,
                               String leaderId) {
     StringBuilder sb = new StringBuilder();
+    // Ensuring OM's are printed in correct order
+    List<ServiceInfo> omNodes = nodes.stream()
+        .filter(node -> node.getNodeType() == HddsProtos.NodeType.OM)
+        .sorted(Comparator.comparing(ServiceInfo::getHostname))
+        .collect(Collectors.toList());
     int count = 0;
-    for (ServiceInfo info : nodes) {
+    for (ServiceInfo info : omNodes) {
       // Printing only the OM's running
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
         String role =

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -815,7 +815,7 @@ public final class OmUtils {
     }
     // Print Stand-alone if only one OM exists
     if (count == 1) {
-      return "Not Applicable";
+      return "STANDALONE";
     } else {
       return sb.toString();
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -269,6 +269,11 @@ public final class OmUtils {
     case ListTenant:
     case TenantGetUserInfo:
     case TenantListUser:
+    case RangerBGSync:
+      // RangerBGSync is a read operation in the sense that it doesn't directly
+      // write to OM DB. And therefore it doesn't need a OMClientRequest.
+      // Although indirectly the Ranger sync service task could invoke write
+      // operation SetRangerServiceVersion.
       return true;
     case CreateVolume:
     case SetVolumeProperty:
@@ -305,6 +310,7 @@ public final class OmUtils {
     case SetS3Secret:
     case RevokeS3Secret:
     case PurgeDirectories:
+    case PurgePaths:
     case CreateTenant:
     case DeleteTenant:
     case TenantAssignUserAccessId:

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -305,7 +305,6 @@ public final class OmUtils {
     case SetS3Secret:
     case RevokeS3Secret:
     case PurgeDirectories:
-    case PurgePaths:
     case CreateTenant:
     case DeleteTenant:
     case TenantAssignUserAccessId:
@@ -800,11 +799,10 @@ public final class OmUtils {
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
         sb.append(
             String.format(
-                "{ HostName: %s | Node-Id: %s | Ratis-Port : %d | Role: %s } ",
+                " { HostName: %s | Node-Id: %s | Ratis-Port : %d } ",
                 info.getHostname(),
                 info.getOmRoleInfo().getNodeId(),
-                port,
-                info.getOmRoleInfo().getServerRole()
+                port
             ));
         count++;
       }
@@ -816,5 +814,4 @@ public final class OmUtils {
       return sb.toString();
     }
   }
-
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -798,8 +798,10 @@ public final class OmUtils {
     int count = 0;
     for (ServiceInfo info : nodes) {
       // Printing only the OM's running
-      String role = info.getHostname().equals(leaderId) ? "LEADER" : "FOLLOWER";
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
+        String role =
+            info.getOmRoleInfo().getNodeId().equals(leaderId) ? "LEADER" :
+                "FOLLOWER";
         sb.append(
             String.format(
                 " { HostName: %s | Node-Id: %s | Ratis-Port : %d | Role: %s} ",
@@ -813,7 +815,7 @@ public final class OmUtils {
     }
     // Print Stand-alone if only one OM exists
     if (count == 1) {
-      return "STANDALONE";
+      return "Not Applicable";
     } else {
       return sb.toString();
     }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -269,11 +269,6 @@ public final class OmUtils {
     case ListTenant:
     case TenantGetUserInfo:
     case TenantListUser:
-    case RangerBGSync:
-      // RangerBGSync is a read operation in the sense that it doesn't directly
-      // write to OM DB. And therefore it doesn't need a OMClientRequest.
-      // Although indirectly the Ranger sync service task could invoke write
-      // operation SetRangerServiceVersion.
       return true;
     case CreateVolume:
     case SetVolumeProperty:
@@ -797,18 +792,21 @@ public final class OmUtils {
     return printString.toString();
   }
 
-  public static String format(List<ServiceInfo> nodes, int port) {
+  public static String format(List<ServiceInfo> nodes, int port,
+                              String leaderId) {
     StringBuilder sb = new StringBuilder();
     int count = 0;
     for (ServiceInfo info : nodes) {
       // Printing only the OM's running
+      String role = info.getHostname().equals(leaderId) ? "LEADER" : "FOLLOWER";
       if (info.getNodeType() == HddsProtos.NodeType.OM) {
         sb.append(
             String.format(
-                " { HostName: %s | Node-Id: %s | Ratis-Port : %d } ",
+                " { HostName: %s | Node-Id: %s | Ratis-Port : %d | Role: %s} ",
                 info.getHostname(),
                 info.getOmRoleInfo().getNodeId(),
-                port
+                port,
+                role
             ));
         count++;
       }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -41,6 +41,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
 import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.ozone.conf.OMClientConfig;
@@ -791,21 +792,29 @@ public final class OmUtils {
     return printString.toString();
   }
 
-  public static String format(List<ServiceInfo> nodes) {
+  public static String format(List<ServiceInfo> nodes, int port) {
     StringBuilder sb = new StringBuilder();
+    int count = 0;
     for (ServiceInfo info : nodes) {
-      if (info.getOmRoleInfo() != null) {
+      // Printing only the OM's running
+      if (info.getNodeType() == HddsProtos.NodeType.OM) {
         sb.append(
             String.format(
-                "{ HostName: %s, Ratis Port: %s, Node-Id: %s, Role: %s } ",
+                "{ HostName: %s | Node-Id: %s | Ratis-Port : %d | Role: %s } ",
                 info.getHostname(),
-                info.getPort(OzoneManagerProtocolProtos.ServicePort.Type.RATIS),
                 info.getOmRoleInfo().getNodeId(),
+                port,
                 info.getOmRoleInfo().getServerRole()
             ));
+        count++;
       }
     }
-    return sb.toString();
+    // Print Stand-alone if only one OM exists
+    if (count == 1) {
+      return "STANDALONE";
+    } else {
+      return sb.toString();
+    }
   }
 
 }

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/OmUtils.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.ozone.om.helpers.OMNodeDetails;
 import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.ServiceInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 
 import org.apache.commons.lang3.StringUtils;
@@ -789,4 +790,22 @@ public final class OmUtils {
     printString.append("]");
     return printString.toString();
   }
+
+  public static String format(List<ServiceInfo> nodes) {
+    StringBuilder sb = new StringBuilder();
+    for (ServiceInfo info : nodes) {
+      if (info.getOmRoleInfo() != null) {
+        sb.append(
+            String.format(
+                "{ HostName: %s, Ratis Port: %s, Node-Id: %s, Role: %s } ",
+                info.getHostname(),
+                info.getPort(OzoneManagerProtocolProtos.ServicePort.Type.RATIS),
+                info.getOmRoleInfo().getNodeId(),
+                info.getOmRoleInfo().getServerRole()
+            ));
+      }
+    }
+    return sb.toString();
+  }
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -29,7 +29,7 @@ public interface OMMXBean extends ServiceRuntimeInfo {
 
   String getRpcPort();
 
-  String getOmRatisRoles();
+  String getRatisRoles();
 
   String getRatisLogDirectory();
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -30,9 +30,7 @@ public interface OMMXBean extends ServiceRuntimeInfo {
   String getRpcPort();
 
   String getOmRatisRoles();
-  
-  String getCurrentHost();
-  
+
   String getRatisLogDirectory();
 
   String getRocksDbDirectory();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -28,4 +28,9 @@ import org.apache.hadoop.hdds.server.ServiceRuntimeInfo;
 public interface OMMXBean extends ServiceRuntimeInfo {
 
   String getRpcPort();
+
+  String getOmRatisRoles();
+  
+  String getCurrentHost();
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -35,4 +35,6 @@ public interface OMMXBean extends ServiceRuntimeInfo {
 
   String getRocksDbDirectory();
 
+  String getRatisLeader();
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -34,7 +34,4 @@ public interface OMMXBean extends ServiceRuntimeInfo {
   String getRatisLogDirectory();
 
   String getRocksDbDirectory();
-
-  String getRatisLeader();
-
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMMXBean.java
@@ -34,4 +34,5 @@ public interface OMMXBean extends ServiceRuntimeInfo {
   String getRatisLogDirectory();
 
   String getRocksDbDirectory();
+
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2997,6 +2997,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     } catch (Exception e) {
     }
     return name;
+  }
+
   public String getRatisLogDirectory() {
     return  OzoneManagerRatisUtils.getOMRatisDirectory(configuration);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -277,6 +277,7 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.PrepareStatusResponse.PrepareStatus;
 import org.apache.ratis.proto.RaftProtos.RaftPeerRole;
 import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
 import org.apache.ratis.protocol.RaftPeerId;
 import org.apache.ratis.server.protocol.TermIndex;
 import org.apache.ratis.util.ExitUtils;
@@ -2966,7 +2967,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-
   public String getOmRatisRoles() {
     List<ServiceInfo> serviceList = null;
     int port = omNodeDetails.getRatisPort();
@@ -2977,6 +2977,16 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
       return "Exception: " + e.toString();
     }
     return OmUtils.format(serviceList, port);
+  }
+
+  @Override
+  public String getRatisLeader() {
+    RaftPeer leaderId = null;
+    try {
+      leaderId = omRatisServer.getLeader();
+    } catch (IOException e) {
+    }
+    return leaderId.getId().toString();
   }
 
   public String getRatisLogDirectory() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2969,7 +2969,6 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   public String getOmRatisRoles() {
     List<ServiceInfo> serviceList = null;
-    StringBuilder sb = new StringBuilder();
     try {
       serviceList = getServiceList();
     } catch (IOException e) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -210,7 +210,6 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERV
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
-import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
@@ -2974,31 +2973,10 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       serviceList = getServiceList();
     } catch (IOException e) {
+      LOG.error("IO-Exception Occurred");
       return "";
     }
-    for (ServiceInfo info : serviceList) {
-      if (info.getOmRoleInfo() != null) {
-        sb.append(
-            String.format(
-                "{ HostName: %s, Ratis Port: %s, Node-Id: %s, Role: %s } ",
-                info.getHostname(),
-                info.getPort(ServicePort.Type.RATIS),
-                info.getOmRoleInfo().getNodeId(),
-                info.getOmRoleInfo().getServerRole()
-            ));
-      }
-    }
-    return sb.toString();
-  }
-
-  @Override
-  public String getCurrentHost() {
-    String name = null;
-    try {
-      name = getHostName(configuration);
-    } catch (Exception e) {
-    }
-    return name;
+    return OmUtils.format(serviceList);
   }
 
   public String getRatisLogDirectory() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2970,23 +2970,15 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   public String getOmRatisRoles() {
     List<ServiceInfo> serviceList = null;
     int port = omNodeDetails.getRatisPort();
+    RaftPeer leaderId;
     try {
+      leaderId = omRatisServer.getLeader();
       serviceList = getServiceList();
     } catch (IOException e) {
       LOG.error("IO-Exception Occurred", e);
       return "Exception: " + e.toString();
     }
-    return OmUtils.format(serviceList, port);
-  }
-
-  @Override
-  public String getRatisLeader() throws NullPointerException {
-    RaftPeer leaderId = null;
-    try {
-      leaderId = omRatisServer.getLeader();
-    } catch (IOException e) {
-    }
-    return leaderId.getId().toString();
+    return OmUtils.format(serviceList, port, leaderId.getId().toString());
   }
 
   public String getRatisLogDirectory() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2980,7 +2980,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public String getRatisLeader() throws NullPointerException{
+  public String getRatisLeader() throws NullPointerException {
     RaftPeer leaderId = null;
     try {
       leaderId = omRatisServer.getLeader();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2980,7 +2980,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public String getRatisLeader() {
+  public String getRatisLeader() throws NullPointerException{
     RaftPeer leaderId = null;
     try {
       leaderId = omRatisServer.getLeader();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2973,8 +2973,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       serviceList = getServiceList();
     } catch (IOException e) {
-      LOG.error("IO-Exception Occurred");
-      return "Null values found";
+      LOG.error("IO-Exception Occurred", e);
+      return "Exception: " + e.toString();
     }
     return OmUtils.format(serviceList, port);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2967,18 +2967,22 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   }
 
   @Override
-  public String getOmRatisRoles() {
+  public String getRatisRoles() {
     List<ServiceInfo> serviceList = null;
     int port = omNodeDetails.getRatisPort();
     RaftPeer leaderId;
-    try {
-      leaderId = omRatisServer.getLeader();
-      serviceList = getServiceList();
-    } catch (IOException e) {
-      LOG.error("IO-Exception Occurred", e);
-      return "Exception: " + e.toString();
+    if (isRatisEnabled) {
+      try {
+        leaderId = omRatisServer.getLeader();
+        serviceList = getServiceList();
+      } catch (IOException e) {
+        LOG.error("IO-Exception Occurred", e);
+        return "Exception: " + e.toString();
+      }
+      return OmUtils.format(serviceList, port, leaderId.getId().toString());
+    } else {
+      return "Ratis-Disabled";
     }
-    return OmUtils.format(serviceList, port, leaderId.getId().toString());
   }
 
   public String getRatisLogDirectory() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2969,13 +2969,14 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
 
   public String getOmRatisRoles() {
     List<ServiceInfo> serviceList = null;
+    int port = omNodeDetails.getRatisPort();
     try {
       serviceList = getServiceList();
     } catch (IOException e) {
       LOG.error("IO-Exception Occurred");
-      return "";
+      return "Null values found";
     }
-    return OmUtils.format(serviceList);
+    return OmUtils.format(serviceList, port);
   }
 
   public String getRatisLogDirectory() {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2974,6 +2974,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
     try {
       serviceList = getServiceList();
     } catch (IOException e) {
+      return "";
     }
     for (ServiceInfo info : serviceList) {
       if (info.getOmRoleInfo() != null) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -2985,7 +2985,8 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
                 info.getOmRoleInfo().getNodeId(),
                 info.getOmRoleInfo().getServerRole()
             ));
-      }}
+      }
+    }
     return sb.toString();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -210,6 +210,7 @@ import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERV
 import static org.apache.hadoop.fs.CommonConfigurationKeysPublic.FS_TRASH_INTERVAL_KEY;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED_DEFAULT;
+import static org.apache.hadoop.hdds.HddsUtils.getHostName;
 import static org.apache.hadoop.hdds.HddsUtils.getScmAddressForClients;
 import static org.apache.hadoop.hdds.security.x509.certificates.utils.CertificateSignRequest.getEncodedString;
 import static org.apache.hadoop.hdds.server.ServerUtils.getRemoteUserName;
@@ -2958,6 +2959,38 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   @Override
   public String getRpcPort() {
     return "" + omRpcAddress.getPort();
+  }
+
+  @Override
+  public String getOmRatisRoles() {
+    List<ServiceInfo> serviceList = null;
+    StringBuilder sb = new StringBuilder();
+    try {
+      serviceList = getServiceList();
+    } catch (IOException e) {
+    }
+    for (ServiceInfo info : serviceList) {
+      if (info.getOmRoleInfo() != null) {
+        sb.append(
+            String.format(
+                "{ HostName: %s, Ratis Port: %s, Node-Id: %s, Role: %s } ",
+                info.getHostname(),
+                info.getPort(ServicePort.Type.RATIS),
+                info.getOmRoleInfo().getNodeId(),
+                info.getOmRoleInfo().getServerRole()
+            ));
+      }}
+    return sb.toString();
+  }
+
+  @Override
+  public String getCurrentHost() {
+    String name = null;
+    try {
+      name = getHostName(configuration);
+    } catch (Exception e) {
+    }
+    return name;
   }
 
   @VisibleForTesting

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerRatisServer.java
@@ -82,6 +82,7 @@ import org.apache.ratis.rpc.SupportedRpcType;
 import org.apache.ratis.server.RaftServer;
 import org.apache.ratis.server.RaftServerConfigKeys;
 import org.apache.ratis.server.protocol.TermIndex;
+import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
 import org.apache.ratis.util.LifeCycle;
 import org.apache.ratis.util.SizeInBytes;
 import org.apache.ratis.util.StringUtils;
@@ -726,6 +727,18 @@ public final class OzoneManagerRatisServer {
       ConfigurationSource configuration) {
     return configuration
         .getPropsMatchPrefixAndTrimPrefix(OZONE_OM_HA_PREFIX + ".");
+  }
+
+  public RaftPeer getLeader() throws IOException {
+    RaftServer.Division division = server.getDivision(raftGroupId);
+    if (division.getInfo().isLeader()) {
+      return division.getPeer();
+    } else {
+      ByteString leaderId = division.getInfo().getRoleInfoProto()
+          .getFollowerInfo().getLeaderInfo().getId().getId();
+      return leaderId.isEmpty() ? null :
+          division.getRaftConf().getPeer(RaftPeerId.valueOf(leaderId));
+    }
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -34,11 +34,11 @@
         <td>Group-Id</td>
         <td>{{$ctrl.role.GroupId}}</td>
     </tr>
-    <tr ng-hide="!$ctrl.electionCount.Count">
+    <tr ng-hide="!$ctrl.electionCount.Count || $ctrl.electionCount.Count==-1">
         <td>Election-Count</td>
         <td>{{$ctrl.electionCount.Count}}</td>
     </tr>
-    <tr ng-hide="!$ctrl.elapsedTime.Value">
+    <tr ng-hide="!$ctrl.elapsedTime.Value || $ctrl.elapsedTime.Value==-1">
         <td>Last Election Elapsed Time</td>
         <td>{{$ctrl.elapsedTime.Value}}</td>
     </tr>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -24,7 +24,7 @@
     </tr>
     <tr>
         <td>OM Roles (HA)	</td>
-        <td>{{$ctrl.overview.jmx.OmRatisRoles}}</td>
+        <td>{{$ctrl.overview.jmx.RatisRoles}}</td>
     </tr>
     <tr>
         <td>Current-Role</td>
@@ -33,6 +33,14 @@
     <tr>
         <td>Group-Id</td>
         <td>{{$ctrl.role.GroupId}}</td>
+    </tr>
+    <tr ng-hide="!$ctrl.electionCount.Count">
+        <td>Election-Count</td>
+        <td>{{$ctrl.electionCount.Count}}</td>
+    </tr>
+    <tr ng-hide="!$ctrl.elapsedTime.Value">
+        <td>Last Election Elapsed Time</td>
+        <td>{{$ctrl.elapsedTime.Value}}</td>
     </tr>
     </tbody>
 </table>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -22,10 +22,6 @@
         <td>Rpc port</td>
         <td>{{$ctrl.overview.jmx.RpcPort}}</td>
     </tr>
-    <tr ng-hide="!$ctrl.overview.jmx.RatisLeader">
-        <td>Leader-Id</td>
-        <td>{{$ctrl.overview.jmx.RatisLeader}}</td>
-    </tr>
     <tr>
         <td>OM Roles (HA)	</td>
         <td>{{$ctrl.overview.jmx.OmRatisRoles}}</td>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -22,6 +22,10 @@
         <td>Rpc port</td>
         <td>{{$ctrl.overview.jmx.RpcPort}}</td>
     </tr>
+    <tr ng-hide="!$ctrl.overview.jmx.RatisLeader">
+        <td>Leader-Id</td>
+        <td>{{$ctrl.overview.jmx.RatisLeader}}</td>
+    </tr>
     <tr>
         <td>OM Roles (HA)	</td>
         <td>{{$ctrl.overview.jmx.OmRatisRoles}}</td>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -27,8 +27,8 @@
         <td>{{$ctrl.overview.jmx.OmRatisRoles}}</td>
     </tr>
     <tr>
-        <td>Current-Host</td>
-        <td>{{$ctrl.overview.jmx.CurrentHost}}</td>
+        <td>Current-Role</td>
+        <td>{{$ctrl.role.Role}}</td>
     </tr>
     <tr>
         <td>Group-Id</td>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/om-overview.html
@@ -22,5 +22,17 @@
         <td>Rpc port</td>
         <td>{{$ctrl.overview.jmx.RpcPort}}</td>
     </tr>
+    <tr>
+        <td>OM Roles (HA)	</td>
+        <td>{{$ctrl.overview.jmx.OmRatisRoles}}</td>
+    </tr>
+    <tr>
+        <td>Current-Host</td>
+        <td>{{$ctrl.overview.jmx.CurrentHost}}</td>
+    </tr>
+    <tr>
+        <td>Group-Id</td>
+        <td>{{$ctrl.role.GroupId}}</td>
+    </tr>
     </tbody>
 </table>

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -119,6 +119,30 @@
                 .then(function (result) {
                     ctrl.role = result.data.beans[0];
                 });
+
+            $http.get("jmx?qry=ratis:name=ratis.leader_election.*electionCount")
+                .then(function (result) {
+                    ctrl.electionCount = result.data.beans[0];
+                });
+
+            $http.get("jmx?qry=ratis:name=ratis.leader_election.*lastLeaderElectionElapsedTime")
+                .then(function (result) {
+                    ctrl.elapsedTime = result.data.beans[0];
+                    ctrl.elapsedTime.Value = convertMsToTime(ctrl.elapsedTime.Value);
+                });
         }
     });
+        function convertMsToTime(ms) {
+          if(ms == -1){
+            return "";
+          }
+          let seconds = (ms / 1000).toFixed(1);
+          let minutes = (ms / (1000 * 60)).toFixed(1);
+          let hours = (ms / (1000 * 60 * 60)).toFixed(1);
+          let days = (ms / (1000 * 60 * 60 * 24)).toFixed(1);
+          if (seconds < 60) return seconds + " Seconds";
+          else if (minutes < 60) return minutes + " Minutes";
+          else if (hours < 24) return hours + " Hours";
+          else return days + " Days"
+        }
 })();

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -113,5 +113,12 @@
         require: {
             overview: "^overview"
         },
+        controller: function ($http) {
+            var ctrl = this;
+            $http.get("http://localhost:9874/jmx?qry=Ratis:service=RaftServer,group=*,id=*")
+                .then(function (result) {
+                    ctrl.role = result.data.beans[0];
+                });
+        }
     });
 })();

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -128,14 +128,13 @@
             $http.get("jmx?qry=ratis:name=ratis.leader_election.*lastLeaderElectionElapsedTime")
                 .then(function (result) {
                     ctrl.elapsedTime = result.data.beans[0];
-                    ctrl.elapsedTime.Value = convertMsToTime(ctrl.elapsedTime.Value);
+                    if(ctrl.elapsedTime.Value != -1){
+                        ctrl.elapsedTime.Value = convertMsToTime(ctrl.elapsedTime.Value);
+                    }
                 });
         }
     });
         function convertMsToTime(ms) {
-          if(ms == -1){
-            return "";
-          }
           let seconds = (ms / 1000).toFixed(1);
           let minutes = (ms / (1000 * 60)).toFixed(1);
           let hours = (ms / (1000 * 60 * 60)).toFixed(1);

--- a/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
+++ b/hadoop-ozone/ozone-manager/src/main/resources/webapps/ozoneManager/ozoneManager.js
@@ -115,7 +115,7 @@
         },
         controller: function ($http) {
             var ctrl = this;
-            $http.get("http://localhost:9874/jmx?qry=Ratis:service=RaftServer,group=*,id=*")
+            $http.get("jmx?qry=Ratis:service=RaftServer,group=*,id=*")
                 .then(function (result) {
                     ctrl.role = result.data.beans[0];
                 });


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Group-Id, Current-Node Role, Election Count, Leader Election Elapsed time & the Ratis-Ring information for OM UI.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6863?filter=-1

## How was this patch tested?

Tested on docker OM ha env
<img width="1717" alt="image" src="https://user-images.githubusercontent.com/98023601/190072181-f02b13e9-5bb3-4e49-9372-649176d13792.png">


For a single node cluster it will print STANDALONE 
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/98023601/179665128-e7b4724e-8308-4787-b79a-4875b9f40bf5.png">