### PR TITLE
HDDS-6898. [SCM HA finalization] Modify acceptance test configuration to speed up test finalization

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -47,7 +47,7 @@ OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=5s
 # If datanodes take too long to close pipelines during finalization, let the
 # scrubber force close them to move the test forward.
 OZONE-SITE.XML_ozone.scm.pipeline.scrub.interval=1m
-OZONE-SITE.XML_ozone.scm.pipeline.allocated.timeout=1m
+OZONE-SITE.XML_ozone.scm.pipeline.allocated.timeout=2m
 
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m

--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -34,6 +34,21 @@ OZONE-SITE.XML_ozone.scm.client.address=scm
 
 OZONE-SITE.XML_hdds.datanode.dir=/data/hdds
 
+# If SCM sends container close commands as part of upgrade finalization while
+# datanodes are doing a leader election, all 3 replicas may end up in the
+# CLOSING state. The replication manager must be running to later move them to
+# a CLOSED state so the datanodes can progress with finalization.
+#
+# This config sets the amount of time SCM will wait after safemode exit to
+# start the replication manager and pipeline scrubber. The default of 5 minutes
+# is fine in real clusters to prevent unnecessary over-replication,
+# but it is too long for this test.
+OZONE-SITE.XML_hdds.scm.wait.time.after.safemode.exit=5s
+# If datanodes take too long to close pipelines during finalization, let the
+# scrubber force close them to move the test forward.
+OZONE-SITE.XML_ozone.scm.pipeline.scrub.interval=1m
+OZONE-SITE.XML_ozone.scm.pipeline.allocated.timeout=1m
+
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
 

--- a/hadoop-ozone/dist/src/main/smoketest/upgrade/finalize.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/upgrade/finalize.robot
@@ -16,7 +16,7 @@
 *** Settings ***
 Documentation       Finalize Upgrade of OMs and SCM
 Resource            ../commonlib.robot
-Test Timeout        5 minutes
+Test Timeout        10 minutes
 Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit test user     testuser     testuser.keytab
 
 *** Test Cases ***


### PR DESCRIPTION
## What changes were proposed in this pull request?

After HDDS-6760, SCM finalization was intermittently timing out during the acceptance test. This happened because containers were put in a CLOSING state since finalization happened before datanode leader election, but the replication manager was not running to close the containers until 5 minutes after safemode exit. The pipeline scrubber also had a large wait time and pipeline timeout that prevented it from force closing these pipelines during the duration of the test.

This Jira modifies the acceptance test configurations to speed up moving containers to a CLOSED state so finalization can proceed. It also increases the test timeout.

## What is the link to the Apache JIRA

HDDS-6898

## How was this patch tested?

50 successful runs on my fork: https://github.com/errose28/hadoop-ozone/runs/6905140700?check_suite_focus=true