### PR TITLE
HDDS-6899. [EC] Remove warnings and errors from console during online reconstruction of data.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -280,7 +280,10 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       // Re-interrupt the thread while catching InterruptedException
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {
-      LOG.error("Failed to execute command {}", processForDebug(request), e);
+      LOG.error("Failed to execute command {}." +
+                      "Exception Class: {}, Exception Message: {}",
+              request.getCmdType(), e.getClass().getName(), e.getMessage());
+      LOG.debug("{}", processForDebug(request), e);
     }
     return responseProtoHashMap;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -280,11 +280,11 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       // Re-interrupt the thread while catching InterruptedException
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {
+      String message = "Failed to execute command {}.";
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Failed to execute command {}", processForDebug(request), e);
+        LOG.debug(message, processForDebug(request), e);
       } else {
-        LOG.error("Failed to execute command {}." +
-                        "Exception Class: {}, Exception Message: {}",
+        LOG.error(message + "Exception Class: {}, Exception Message: {}",
                 request.getCmdType(), e.getClass().getName(), e.getMessage());
       }
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -280,10 +280,13 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       // Re-interrupt the thread while catching InterruptedException
       Thread.currentThread().interrupt();
     } catch (ExecutionException e) {
-      LOG.error("Failed to execute command {}." +
-                      "Exception Class: {}, Exception Message: {}",
-              request.getCmdType(), e.getClass().getName(), e.getMessage());
-      LOG.debug("{}", processForDebug(request), e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Failed to execute command {}", processForDebug(request), e);
+      } else {
+        LOG.error("Failed to execute command {}." +
+                        "Exception Class: {}, Exception Message: {}",
+                request.getCmdType(), e.getClass().getName(), e.getMessage());
+      }
     }
     return responseProtoHashMap;
   }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/XceiverClientGrpc.java
@@ -284,7 +284,7 @@ public class XceiverClientGrpc extends XceiverClientSpi {
       if (LOG.isDebugEnabled()) {
         LOG.debug(message, processForDebug(request), e);
       } else {
-        LOG.error(message + "Exception Class: {}, Exception Message: {}",
+        LOG.error(message + " Exception Class: {}, Exception Message: {}",
                 request.getCmdType(), e.getClass().getName(), e.getMessage());
       }
     }

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -165,12 +165,13 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         throw e;
       }
       if (e instanceof BadDataLocationException) {
-        if(LOG.isDebugEnabled()){
+        if(LOG.isDebugEnabled()) {
           LOG.debug("Failing over to reconstruction read due to an error in " +
                           "ECBlockReader.", e);
-        }else {
+        } else {
           LOG.warn("Failing over to reconstruction read due to an error in " +
-                          "ECBlockReader. Exception Class: {}, Exception Message: {}",
+                          "ECBlockReader. Exception Class: {}, " +
+                          "Exception Message: {}",
                   e.getClass().getName(), e.getMessage());
         }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -165,10 +165,15 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         throw e;
       }
       if (e instanceof BadDataLocationException) {
-        LOG.warn("Failing over to reconstruction read due to an error in " +
-            "ECBlockReader. Exception Class: {}, Exception Message: {}",
-                e.getClass().getName(), e.getMessage());
-        LOG.debug("Exception: ", e);
+        if(LOG.isDebugEnabled()){
+          LOG.debug("Failing over to reconstruction read due to an error in " +
+                          "ECBlockReader.", e);
+        }else {
+          LOG.warn("Failing over to reconstruction read due to an error in " +
+                          "ECBlockReader. Exception Class: {}, Exception Message: {}",
+                  e.getClass().getName(), e.getMessage());
+        }
+
         failoverToReconstructionRead(
             ((BadDataLocationException) e).getFailedLocation(), lastPosition);
         buf.reset();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -167,7 +167,7 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
       if (e instanceof BadDataLocationException) {
         String message = "Failing over to reconstruction read due" +
                 " to an error in ECBlockReader.";
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
           LOG.debug(message, e);
         } else {
           LOG.warn("{} Exception Class: {}, Exception Message: {}",

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -170,7 +170,7 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         if (LOG.isDebugEnabled()) {
           LOG.debug(message, e);
         } else {
-          LOG.warn("{} Exception Class: {}, Exception Message: {}",
+          LOG.warn("{} Exception Class: {} , Exception Message: {}",
                   message, e.getClass().getName(), e.getMessage());
         }
 

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -166,7 +166,9 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
       }
       if (e instanceof BadDataLocationException) {
         LOG.warn("Failing over to reconstruction read due to an error in " +
-            "ECBlockReader", e);
+            "ECBlockReader. Exception Class: {}, Exception Message: {}",
+                e.getClass().getName(), e.getMessage());
+        LOG.debug("Exception: ", e);
         failoverToReconstructionRead(
             ((BadDataLocationException) e).getFailedLocation(), lastPosition);
         buf.reset();

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStreamProxy.java
@@ -165,14 +165,13 @@ public class ECBlockInputStreamProxy extends BlockExtendedInputStream {
         throw e;
       }
       if (e instanceof BadDataLocationException) {
+        String message = "Failing over to reconstruction read due" +
+                " to an error in ECBlockReader.";
         if(LOG.isDebugEnabled()) {
-          LOG.debug("Failing over to reconstruction read due to an error in " +
-                          "ECBlockReader.", e);
+          LOG.debug(message, e);
         } else {
-          LOG.warn("Failing over to reconstruction read due to an error in " +
-                          "ECBlockReader. Exception Class: {}, " +
-                          "Exception Message: {}",
-                  e.getClass().getName(), e.getMessage());
+          LOG.warn("{} Exception Class: {}, Exception Message: {}",
+                  message, e.getClass().getName(), e.getMessage());
         }
 
         failoverToReconstructionRead(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exception stacktrace put in debug level instead of warn or error level. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6899
## How was this patch tested?
Logging Changes, no change in logic.