### PR TITLE
HDDS-6890. EC: Fix potential wrong replica read with over-replicated container.

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -170,9 +170,8 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
           .setId(PipelineID.randomId())
           .setState(Pipeline.PipelineState.CLOSED)
           .build();
-      BlockID blockID = blockInfo.getBlockID();
       BlockLocationInfo blkInfo = new BlockLocationInfo.Builder()
-          .setBlockID(blockID)
+          .setBlockID(blockInfo.getBlockID())
           .setLength(internalBlockLength(locationIndex + 1))
           .setPipeline(blockInfo.getPipeline())
           .setToken(blockInfo.getToken())
@@ -183,29 +182,41 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
               HddsProtos.ReplicationFactor.ONE),
           blkInfo, pipeline,
           blockInfo.getToken(), verifyChecksum, xceiverClientFactory,
-          blkID -> {
-            Pipeline ecPipeline = refreshFunction.apply(blkID);
-            if (ecPipeline == null) {
-              return null;
-            }
-            DatanodeDetails curIndexNode = ecPipeline.getNodes()
-                .stream().filter(dn ->
-                    ecPipeline.getReplicaIndex(dn) == locationIndex + 1)
-                .findAny().orElse(null);
-            if (curIndexNode == null) {
-              return null;
-            }
-            return Pipeline.newBuilder().setReplicationConfig(
-                StandaloneReplicationConfig.getInstance(
-                    HddsProtos.ReplicationFactor.ONE))
-                .setNodes(Collections.singletonList(curIndexNode))
-                .setId(PipelineID.randomId())
-                .setState(Pipeline.PipelineState.CLOSED)
-                .build();
-          });
+          ecPipelineRefreshFunction(locationIndex + 1, refreshFunction));
       blockStreams[locationIndex] = stream;
     }
     return stream;
+  }
+
+  /**
+   * Returns a function that builds a Standalone pipeline corresponding
+   * to the replicaIndex given based on the EC pipeline fetched from SCM.
+   * @param replicaIndex
+   * @param refreshFunc
+   * @return
+   */
+  protected Function<BlockID, Pipeline> ecPipelineRefreshFunction(
+      int replicaIndex, Function<BlockID, Pipeline> refreshFunc) {
+    return (blockID) -> {
+      Pipeline ecPipeline = refreshFunc.apply(blockID);
+      if (ecPipeline == null) {
+        return null;
+      }
+      DatanodeDetails curIndexNode = ecPipeline.getNodes()
+          .stream().filter(dn ->
+              ecPipeline.getReplicaIndex(dn) == replicaIndex)
+          .findAny().orElse(null);
+      if (curIndexNode == null) {
+        return null;
+      }
+      return Pipeline.newBuilder().setReplicationConfig(
+              StandaloneReplicationConfig.getInstance(
+                  HddsProtos.ReplicationFactor.ONE))
+          .setNodes(Collections.singletonList(curIndexNode))
+          .setId(PipelineID.randomId())
+          .setState(Pipeline.PipelineState.CLOSED)
+          .build();
+    };
   }
 
   /**

--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/ozone/client/io/ECBlockInputStream.java
@@ -170,6 +170,7 @@ public class ECBlockInputStream extends BlockExtendedInputStream {
           .setId(PipelineID.randomId())
           .setState(Pipeline.PipelineState.CLOSED)
           .build();
+
       BlockLocationInfo blkInfo = new BlockLocationInfo.Builder()
           .setBlockID(blockInfo.getBlockID())
           .setLength(internalBlockLength(locationIndex + 1))


### PR DESCRIPTION
Co-authored-by: Uma Maheswara Rao G <umagangumalla@cloudera.com>

## What changes were proposed in this pull request?

Fix potential wrong replica read with over-replicated container.
The problem is due to that an EC pipeline with multiple DNs is returned and used with the first DN picked while refreshing pipeline on read error(Read error is due to concurrent redundant EC container replica deletion, e.g. EC 10+4 with 18 replicas),
but the right behavior should be pick the DN with the same replicaIndex and build a standalone pipeline for retry.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6890

## How was this patch tested?

To be verified manually.
