### PR TITLE
HDDS-6812. Fix INTERNAL_ERROR message on failed write.

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -115,7 +115,8 @@ public final class SCMContainerPlacementRackScatter
           "TotalNode = " + totalNodesCount +
           " AvailableNode = " + availableNodes.size() +
           " RequiredNode = " + nodesRequired +
-          " ExcludedNode = " + excludedNodesCount, null);
+          " ExcludedNode = " + excludedNodesCount,
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
 
     List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/WritableECContainerProvider.java
@@ -157,7 +157,7 @@ public class WritableECContainerProvider
     } catch (IOException e) {
       LOG.error("Unable to allocate a container for {} after trying all "
           + "existing containers", repConfig, e);
-      return null;
+      throw e;
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/protocol/ScmBlockLocationProtocolServerSideTranslatorPB.java
@@ -178,7 +178,7 @@ public final class ScmBlockLocationProtocolServerSideTranslatorPB
   }
 
   private Status exceptionToResponseStatus(IOException ex) {
-    if (ex instanceof SCMException) {
+    if (ex instanceof SCMException && ((SCMException) ex).getResult() != null) {
       return Status.values()[((SCMException) ex).getResult().ordinal()];
     } else {
       return Status.INTERNAL_ERROR;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -66,7 +66,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
 
@@ -221,7 +220,8 @@ public class TestWritableECContainerProvider {
   }
 
   @Test
-  public void testUnableToCreateAnyPipelinesReturnsNull() throws IOException {
+  public void testUnableToCreateAnyPipelinesThrowsException()
+      throws IOException {
     pipelineManager = new MockPipelineManager(
         dbStore, scmhaManager, nodeManager) {
       @Override
@@ -234,9 +234,12 @@ public class TestWritableECContainerProvider {
     provider = new WritableECContainerProvider(
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
-    ContainerInfo container =
-        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-    assertNull(container);
+    try {
+      ContainerInfo container =
+          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
+    }
   }
 
   @Test
@@ -261,12 +264,20 @@ public class TestWritableECContainerProvider {
     provider = new WritableECContainerProvider(
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
-    ContainerInfo container =
-        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-    for (int i = 0; i < 5; i++) {
-      ContainerInfo nextContainer =
+    try {
+      ContainerInfo container =
           provider.getContainer(1, repConfig, OWNER, new ExcludeList());
-      assertEquals(container, nextContainer);
+    } catch (IOException ex) {
+      GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
+    }
+
+    for (int i = 0; i < 5; i++) {
+      try {
+        ContainerInfo nextContainer =
+            provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      } catch (IOException ex) {
+        GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
+      }
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -235,8 +235,7 @@ public class TestWritableECContainerProvider {
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
     try {
-      ContainerInfo container =
-          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
     }
@@ -265,16 +264,14 @@ public class TestWritableECContainerProvider {
         conf, pipelineManager, containerManager, pipelineChoosingPolicy);
 
     try {
-      ContainerInfo container =
-          provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      provider.getContainer(1, repConfig, OWNER, new ExcludeList());
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
     }
 
     for (int i = 0; i < 5; i++) {
       try {
-        ContainerInfo nextContainer =
-            provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+        provider.getContainer(1, repConfig, OWNER, new ExcludeList());
       } catch (IOException ex) {
         GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
       }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestWritableECContainerProvider.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.scm.pipeline.choose.algorithms.HealthyPipelineChoo
 import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.hdds.utils.db.DBStoreBuilder;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Matchers;
@@ -236,6 +237,7 @@ public class TestWritableECContainerProvider {
 
     try {
       provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      Assert.fail();
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
     }
@@ -265,6 +267,7 @@ public class TestWritableECContainerProvider {
 
     try {
       provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+      Assert.fail();
     } catch (IOException ex) {
       GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
     }
@@ -272,6 +275,7 @@ public class TestWritableECContainerProvider {
     for (int i = 0; i < 5; i++) {
       try {
         provider.getContainer(1, repConfig, OWNER, new ExcludeList());
+        Assert.fail();
       } catch (IOException ex) {
         GenericTestUtils.assertExceptionContains("Cannot create pipelines", ex);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When `allocateBlock()` fails, It throws a generic SCMException `Allocated 0 blocks. Requested 1 blocks`. Here the block allocation failed because there weren't enough DataNodes for EC replication. Proposing to throw an exception when `allocateContainer()` fails and propagate back the actual Exception. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6812

## How was this patch tested?

This patch was tested manually with docker and Unit test. Now the error message is,
```
INTERNAL_ERROR No enough datanodes to choose. TotalNode = 3 AvailableNode = 3 RequiredNode = 5 ExcludedNode = 0
```
