### PR TITLE
HDDS-6928. ozone container balancer CLI went in hung state due to deadlock

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1063,10 +1064,16 @@ public class ContainerBalancer extends StatefulService {
       balancingThread.interrupt();
       try {
         if (lock.isHeldByCurrentThread()) {
+          // warn for possible deadlock
+          String stackTrace =
+              Arrays.toString(Thread.currentThread().getStackTrace())
+                  .replace(',', '\n');
           LOG.warn("Waiting for balancing thread \"{}\" to join while current" +
-                  " thread holds lock. This could result in a deadlock if" +
-                  " balancing thread is also waiting to acquire the lock.",
-              balancingThread.getName());
+                  " thread \"{}\" holds lock. This could result in a deadlock" +
+                  " if balancing thread is also waiting to acquire the lock. " +
+                  "\n{}",
+              balancingThread.getName(), Thread.currentThread().getName(),
+              stackTrace);
         }
         balancingThread.join();
       } catch (InterruptedException exception) {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -739,6 +739,14 @@ public class TestContainerBalancer {
 
   }
 
+  @Test
+  public void testStartAndImmediateStopForDeadlock()
+      throws IllegalContainerBalancerStateException, IOException,
+      InvalidContainerBalancerConfigurationException {
+    startBalancer(balancerConfiguration);
+    stopBalancer();
+  }
+
   /**
    * Determines unBalanced nodes, that is, over and under utilized nodes,
    * according to the generated utilization values for nodes and the threshold.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -745,6 +745,7 @@ public class TestContainerBalancer {
       InvalidContainerBalancerConfigurationException {
     startBalancer(balancerConfiguration);
     stopBalancer();
+    Assertions.assertFalse(containerBalancer.isBalancerRunning());
   }
 
   /**


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerBalancer has `balancingThread.join()` being called in ContainerBalancer#stopBalancingThread. Callers of this method acquire but don't release the only lock in this class when calling this method. If at this time another thread is trying to acquire the lock, we have a deadlock.

For example, SCMClientProtocolServer#stopContainerBalancer() will lead to the calling thread wait for the balancing thread to join in ContainerBalancer#stopBalancingThread. If the balancing thread now checks for `isBalancerRunning()` in ContainerBalancer#balance, the two threads will get into a deadlock. The balancing thread is disabled and waiting to acquire the lock, while the other thread is waiting for balancing thread to finish.

Changes: Release lock in callers of ContainerBalancer#stopBalancingThread before this method is called. Remove locking in `isBalancerRunning()`.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6928

## How was this patch tested?

A basic UT that starts and then immediately stops balancer. In the existing code, this leads to a deadlock.