### PR TITLE
HDDS-6876. Migrate test with rules in hdds-common to JUnit5

### DIFF
--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
@@ -29,11 +29,10 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Test class for OzoneConfiguration.
@@ -42,10 +41,7 @@ public class TestOzoneConfiguration {
 
   private OzoneConfiguration conf;
 
-  @Rule
-  public TemporaryFolder tempConfigs = new TemporaryFolder();
-
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     conf = new OzoneConfiguration();
   }
@@ -62,9 +58,10 @@ public class TestOzoneConfiguration {
   }
 
   @Test
-  public void testGetAllPropertiesByTags() throws Exception {
-    File coreDefault = tempConfigs.newFile("core-default-test.xml");
-    File coreSite = tempConfigs.newFile("core-site-test.xml");
+  public void testGetAllPropertiesByTags(@TempDir File tempDir)
+      throws Exception {
+    File coreDefault = new File(tempDir, "core-default-test.xml");
+    File coreSite = new File(tempDir, "core-site-test.xml");
     FileOutputStream coreDefaultStream = new FileOutputStream(coreDefault);
     try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
         coreDefaultStream, StandardCharsets.UTF_8))) {
@@ -80,7 +77,7 @@ public class TestOzoneConfiguration {
 
       Path fileResource = new Path(coreDefault.getAbsolutePath());
       conf.addResource(fileResource);
-      Assert.assertEquals("XYZ", conf.getAllPropertiesByTag("MYCUSTOMTAG")
+      Assertions.assertEquals("XYZ", conf.getAllPropertiesByTag("MYCUSTOMTAG")
           .getProperty("dfs.random.key"));
     }
 
@@ -98,11 +95,11 @@ public class TestOzoneConfiguration {
     }
 
     // Test if values are getting overridden even without tags being present
-    Assert.assertEquals("3", conf.getAllPropertiesByTag("HDFS")
+    Assertions.assertEquals("3", conf.getAllPropertiesByTag("HDFS")
         .getProperty("dfs.replication"));
-    Assert.assertEquals("ABC", conf.getAllPropertiesByTag("MYCUSTOMTAG")
+    Assertions.assertEquals("ABC", conf.getAllPropertiesByTag("MYCUSTOMTAG")
         .getProperty("dfs.random.key"));
-    Assert.assertEquals("true", conf.getAllPropertiesByTag("YARN")
+    Assertions.assertEquals("true", conf.getAllPropertiesByTag("YARN")
         .getProperty("dfs.cblock.trace.io"));
   }
 
@@ -119,12 +116,12 @@ public class TestOzoneConfiguration {
     SimpleConfiguration configuration =
         ozoneConfig.getObject(SimpleConfiguration.class);
 
-    Assert.assertEquals("host", configuration.getBindHost());
-    Assert.assertEquals("address", configuration.getClientAddress());
-    Assert.assertTrue(configuration.isEnabled());
-    Assert.assertEquals(5555, configuration.getPort());
-    Assert.assertEquals(600, configuration.getWaitTime());
-    Assert.assertEquals(Integer.class, configuration.getMyClass());
+    Assertions.assertEquals("host", configuration.getBindHost());
+    Assertions.assertEquals("address", configuration.getClientAddress());
+    Assertions.assertTrue(configuration.isEnabled());
+    Assertions.assertEquals(5555, configuration.getPort());
+    Assertions.assertEquals(600, configuration.getWaitTime());
+    Assertions.assertSame(Integer.class, configuration.getMyClass());
   }
 
   @Test
@@ -134,9 +131,9 @@ public class TestOzoneConfiguration {
     SimpleConfiguration configuration =
         ozoneConfiguration.getObject(SimpleConfiguration.class);
 
-    Assert.assertTrue(configuration.isEnabled());
-    Assert.assertEquals(9878, configuration.getPort());
-    Assert.assertEquals(Object.class, configuration.getMyClass());
+    Assertions.assertTrue(configuration.isEnabled());
+    Assertions.assertEquals(9878, configuration.getPort());
+    Assertions.assertSame(Object.class, configuration.getMyClass());
   }
 
   @Test
@@ -156,17 +153,17 @@ public class TestOzoneConfiguration {
     subject.setFromObject(object);
 
     // THEN
-    Assert.assertEquals(object.getBindHost(),
+    Assertions.assertEquals(object.getBindHost(),
         subject.get("test.scm.client.bind.host"));
-    Assert.assertEquals(object.getClientAddress(),
+    Assertions.assertEquals(object.getClientAddress(),
         subject.get("test.scm.client.address"));
-    Assert.assertEquals(object.isEnabled(),
+    Assertions.assertEquals(object.isEnabled(),
         subject.getBoolean("test.scm.client.enabled", false));
-    Assert.assertEquals(object.getPort(),
+    Assertions.assertEquals(object.getPort(),
         subject.getInt("test.scm.client.port", 0));
-    Assert.assertEquals(TimeUnit.SECONDS.toMinutes(object.getWaitTime()),
+    Assertions.assertEquals(TimeUnit.SECONDS.toMinutes(object.getWaitTime()),
         subject.getTimeDuration("test.scm.client.wait", 0, TimeUnit.MINUTES));
-    Assert.assertEquals(this.getClass(),
+    Assertions.assertSame(this.getClass(),
         subject.getClass("test.scm.client.class", null));
   }
 
@@ -180,25 +177,26 @@ public class TestOzoneConfiguration {
     subject.setFromObject(object);
 
     // THEN
-    Assert.assertEquals("0.0.0.0",
+    Assertions.assertEquals("0.0.0.0",
         subject.get("test.scm.client.bind.host"));
-    Assert.assertEquals("localhost",
+    Assertions.assertEquals("localhost",
         subject.get("test.scm.client.address"));
-    Assert.assertTrue(
+    Assertions.assertTrue(
         subject.getBoolean("test.scm.client.enabled", false));
-    Assert.assertEquals(9878,
+    Assertions.assertEquals(9878,
         subject.getInt("test.scm.client.port", 123));
-    Assert.assertEquals(TimeUnit.MINUTES.toSeconds(30),
+    Assertions.assertEquals(TimeUnit.MINUTES.toSeconds(30),
         subject.getTimeDuration("test.scm.client.wait", 555, TimeUnit.SECONDS));
   }
 
   @Test
-  public void testInstantiationWithInputConfiguration() throws IOException {
+  public void testInstantiationWithInputConfiguration(@TempDir File tempDir)
+      throws IOException {
     String key = "hdds.scm.init.default.layout.version";
     String val = "Test1";
     Configuration configuration = new Configuration(true);
 
-    File ozoneSite = tempConfigs.newFile("ozone-site.xml");
+    File ozoneSite = new File(tempDir, "ozone-site.xml");
     FileOutputStream ozoneSiteStream = new FileOutputStream(ozoneSite);
     try (BufferedWriter out = new BufferedWriter(new OutputStreamWriter(
         ozoneSiteStream, StandardCharsets.UTF_8))) {
@@ -212,10 +210,10 @@ public class TestOzoneConfiguration {
     OzoneConfiguration ozoneConfiguration =
         new OzoneConfiguration(configuration);
     // ozoneConfig value matches input config value for the corresponding key
-    Assert.assertEquals(val, ozoneConfiguration.get(key));
-    Assert.assertEquals(val, configuration.get(key));
+    Assertions.assertEquals(val, ozoneConfiguration.get(key));
+    Assertions.assertEquals(val, configuration.get(key));
 
-    Assert.assertNotEquals(val, new OzoneConfiguration().get(key));
+    Assertions.assertNotEquals(val, new OzoneConfiguration().get(key));
   }
 
   @Test
@@ -228,24 +226,25 @@ public class TestOzoneConfiguration {
     subject.setFromObject(object);
 
     // THEN
-    Assert.assertEquals("0.0.0.0",
+    Assertions.assertEquals("0.0.0.0",
         subject.get("test.scm.client.bind.host"));
-    Assert.assertEquals("localhost",
+    Assertions.assertEquals("localhost",
         subject.get("test.scm.client.address"));
-    Assert.assertFalse(
+    Assertions.assertFalse(
         subject.getBoolean("test.scm.client.enabled", false));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         subject.getInt("test.scm.client.port", 123));
-    Assert.assertEquals(0,
+    Assertions.assertEquals(0,
         subject.getTimeDuration("test.scm.client.wait", 555, TimeUnit.SECONDS));
   }
 
-  @Test(expected = NumberFormatException.class)
+  @Test
   public void postConstructValidation() {
     OzoneConfiguration ozoneConfiguration = new OzoneConfiguration();
     ozoneConfiguration.setInt("test.scm.client.port", -3);
 
-    ozoneConfiguration.getObject(SimpleConfiguration.class);
+    Assertions.assertThrows(NumberFormatException.class,
+        () -> ozoneConfiguration.getObject(SimpleConfiguration.class));
   }
 
   private void appendProperty(BufferedWriter out, String name, String val)

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNodeSchemaManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNodeSchemaManager.java
@@ -22,16 +22,18 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 
 import static org.apache.hadoop.hdds.scm.net.NetConstants.DEFAULT_NODEGROUP;
 import static org.apache.hadoop.hdds.scm.net.NetConstants.DEFAULT_RACK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Test the node schema loader. */
+@Timeout(30)
 public class TestNodeSchemaManager {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestNodeSchemaManager.class);
@@ -49,17 +51,16 @@ public class TestNodeSchemaManager {
     manager.init(conf);
   }
 
-  @Rule
-  public Timeout testTimeout = Timeout.seconds(30);
-
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFailure1() {
-    manager.getCost(0);
+    assertThrows(IllegalArgumentException.class,
+        () -> manager.getCost(0));
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test
   public void testFailure2() {
-    manager.getCost(manager.getMaxLevel() + 1);
+    assertThrows(IllegalArgumentException.class,
+        () -> manager.getCost(manager.getMaxLevel() + 1));
   }
 
   @Test
@@ -75,13 +76,10 @@ public class TestNodeSchemaManager {
     String filePath = classLoader.getResource(
         "./networkTopologyTestFiles/good.xml").getPath() + ".backup";
     conf.set(ScmConfigKeys.OZONE_SCM_NETWORK_TOPOLOGY_SCHEMA_FILE, filePath);
-    try {
-      manager.init(conf);
-      fail("should fail");
-    } catch (Throwable e) {
-      assertTrue(e.getMessage().contains("Failed to load schema file:" +
-          filePath));
-    }
+    Throwable e = assertThrows(RuntimeException.class,
+        () -> manager.init(conf));
+    assertTrue(e.getMessage().contains("Failed to load schema file:" +
+        filePath));
   }
 
   @Test
@@ -96,6 +94,6 @@ public class TestNodeSchemaManager {
         manager.complete("/nodegroup" + path));
 
     // failed complete action
-    assertEquals(null, manager.complete("/dc" + path));
+    assertNull(manager.complete("/dc" + path));
   }
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestStateMachine.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestStateMachine.java
@@ -21,10 +21,8 @@ import org.apache.commons.collections.SetUtils;
 import org.apache.hadoop.ozone.common.statemachine
     .InvalidStateTransitionException;
 import org.apache.hadoop.ozone.common.statemachine.StateMachine;
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -45,15 +43,12 @@ public class TestStateMachine {
   /**
    * STATES used by the test state machine.
    */
-  public enum STATES { INIT, CREATING, OPERATIONAL, CLOSED, CLEANUP, FINAL };
+  public enum STATES { INIT, CREATING, OPERATIONAL, CLOSED, CLEANUP, FINAL }
 
   /**
    * EVENTS used by the test state machine.
    */
-  public enum EVENTS { ALLOCATE, CREATE, UPDATE, CLOSE, DELETE, TIMEOUT };
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
+  public enum EVENTS { ALLOCATE, CREATE, UPDATE, CLOSE, DELETE, TIMEOUT }
 
   @Test
   public void testStateMachineStates() throws InvalidStateTransitionException {
@@ -71,36 +66,29 @@ public class TestStateMachine {
     stateMachine.addTransition(CREATING, CLEANUP, EVENTS.TIMEOUT);
 
     // Initial and Final states
-    Assert.assertEquals("Initial State", INIT, stateMachine.getInitialState());
-    Assert.assertTrue("Final States", SetUtils.isEqualSet(finals,
-        stateMachine.getFinalStates()));
+    Assertions.assertEquals(INIT, stateMachine.getInitialState(),
+        "Initial State");
+    Assertions.assertTrue(SetUtils.isEqualSet(finals,
+        stateMachine.getFinalStates()), "Final States");
 
     // Valid state transitions
-    Assert.assertEquals("STATE should be OPERATIONAL after being created",
-        OPERATIONAL, stateMachine.getNextState(CREATING, EVENTS.CREATE));
-    Assert.assertEquals("STATE should be OPERATIONAL after being updated",
-        OPERATIONAL, stateMachine.getNextState(OPERATIONAL, EVENTS.UPDATE));
-    Assert.assertEquals("STATE should be CLEANUP after being deleted",
-        CLEANUP, stateMachine.getNextState(OPERATIONAL, EVENTS.DELETE));
-    Assert.assertEquals("STATE should be CLEANUP after being timeout",
-        CLEANUP, stateMachine.getNextState(CREATING, EVENTS.TIMEOUT));
-    Assert.assertEquals("STATE should be CLOSED after being closed",
-        CLOSED, stateMachine.getNextState(OPERATIONAL, EVENTS.CLOSE));
+    Assertions.assertEquals(OPERATIONAL, stateMachine.getNextState(CREATING,
+        EVENTS.CREATE), "STATE should be OPERATIONAL after being created");
+    Assertions.assertEquals(OPERATIONAL, stateMachine.getNextState(OPERATIONAL,
+        EVENTS.UPDATE), "STATE should be OPERATIONAL after being updated");
+    Assertions.assertEquals(CLEANUP, stateMachine.getNextState(OPERATIONAL,
+        EVENTS.DELETE), "STATE should be CLEANUP after being deleted");
+    Assertions.assertEquals(CLEANUP, stateMachine.getNextState(CREATING,
+        EVENTS.TIMEOUT), "STATE should be CLEANUP after being timeout");
+    Assertions.assertEquals(CLOSED, stateMachine.getNextState(OPERATIONAL,
+        EVENTS.CLOSE), "STATE should be CLOSED after being closed");
 
     // Negative cases: invalid transition
-    expectException();
-    stateMachine.getNextState(OPERATIONAL, EVENTS.CREATE);
+    Assertions.assertThrowsExactly(InvalidStateTransitionException.class, () ->
+        stateMachine.getNextState(OPERATIONAL, EVENTS.CREATE), "Invalid event");
 
-    expectException();
-    stateMachine.getNextState(CREATING, EVENTS.CLOSE);
-  }
-
-  /**
-   * We expect an InvalidStateTransitionException.
-   */
-  private void expectException() {
-    exception.expect(InvalidStateTransitionException.class);
-    exception.expectMessage("Invalid event");
+    Assertions.assertThrowsExactly(InvalidStateTransitionException.class, () ->
+        stateMachine.getNextState(CREATING, EVENTS.CLOSE), "Invalid event");
   }
 
 }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lease/TestLeaseManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lease/TestLeaseManager.java
@@ -17,10 +17,8 @@
 
 package org.apache.hadoop.ozone.lease;
 
-import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,9 +27,6 @@ import java.util.Map;
  * Test class to check functionality and consistency of LeaseManager.
  */
 public class TestLeaseManager {
-
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
 
   /**
    * Dummy resource on which leases can be acquired.
@@ -85,19 +80,19 @@ public class TestLeaseManager {
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
     Lease<DummyResource> leaseTwo = manager.acquire(resourceTwo);
     Lease<DummyResource> leaseThree = manager.acquire(resourceThree);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertEquals(leaseTwo, manager.get(resourceTwo));
-    Assert.assertEquals(leaseThree, manager.get(resourceThree));
-    Assert.assertFalse(leaseOne.hasExpired());
-    Assert.assertFalse(leaseTwo.hasExpired());
-    Assert.assertFalse(leaseThree.hasExpired());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertEquals(leaseTwo, manager.get(resourceTwo));
+    Assertions.assertEquals(leaseThree, manager.get(resourceThree));
+    Assertions.assertFalse(leaseOne.hasExpired());
+    Assertions.assertFalse(leaseTwo.hasExpired());
+    Assertions.assertFalse(leaseThree.hasExpired());
     //The below releases should not throw LeaseNotFoundException.
     manager.release(resourceOne);
     manager.release(resourceTwo);
     manager.release(resourceThree);
-    Assert.assertTrue(leaseOne.hasExpired());
-    Assert.assertTrue(leaseTwo.hasExpired());
-    Assert.assertTrue(leaseThree.hasExpired());
+    Assertions.assertTrue(leaseOne.hasExpired());
+    Assertions.assertTrue(leaseTwo.hasExpired());
+    Assertions.assertTrue(leaseThree.hasExpired());
     manager.shutdown();
   }
 
@@ -109,12 +104,11 @@ public class TestLeaseManager {
     DummyResource resourceTwo = new DummyResource("two");
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
     Lease<DummyResource> leaseTwo = manager.acquire(resourceTwo);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertEquals(leaseTwo, manager.get(resourceTwo));
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertEquals(leaseTwo, manager.get(resourceTwo));
 
-    exception.expect(LeaseAlreadyExistException.class);
-    exception.expectMessage("Resource: " + resourceOne);
-    manager.acquire(resourceOne);
+    Assertions.assertThrowsExactly(LeaseAlreadyExistException.class,
+        () -> manager.acquire(resourceOne), "Resource: " + resourceOne);
 
     manager.release(resourceOne);
     manager.release(resourceTwo);
@@ -130,24 +124,22 @@ public class TestLeaseManager {
     DummyResource resourceThree = new DummyResource("three");
 
     //Case 1: lease was never acquired.
-    exception.expect(LeaseNotFoundException.class);
-    exception.expectMessage("Resource: " + resourceOne);
-    manager.get(resourceOne);
+    Assertions.assertThrowsExactly(LeaseNotFoundException.class,
+        () -> manager.get(resourceOne), "Resource: " + resourceOne);
 
     //Case 2: lease is acquired and released.
     Lease<DummyResource> leaseTwo = manager.acquire(resourceTwo);
-    Assert.assertEquals(leaseTwo, manager.get(resourceTwo));
-    Assert.assertFalse(leaseTwo.hasExpired());
+    Assertions.assertEquals(leaseTwo, manager.get(resourceTwo));
+    Assertions.assertFalse(leaseTwo.hasExpired());
     manager.release(resourceTwo);
-    Assert.assertTrue(leaseTwo.hasExpired());
-    exception.expect(LeaseNotFoundException.class);
-    exception.expectMessage("Resource: " + resourceTwo);
-    manager.get(resourceTwo);
+    Assertions.assertTrue(leaseTwo.hasExpired());
+    Assertions.assertThrowsExactly(LeaseNotFoundException.class,
+        () -> manager.get(resourceTwo), "Resource: " + resourceTwo);
 
     //Case 3: lease acquired and timed out.
     Lease<DummyResource> leaseThree = manager.acquire(resourceThree);
-    Assert.assertEquals(leaseThree, manager.get(resourceThree));
-    Assert.assertFalse(leaseThree.hasExpired());
+    Assertions.assertEquals(leaseThree, manager.get(resourceThree));
+    Assertions.assertFalse(leaseThree.hasExpired());
     long sleepTime = leaseThree.getRemainingTime() + 1000;
     try {
       Thread.sleep(sleepTime);
@@ -155,10 +147,9 @@ public class TestLeaseManager {
       //even in case of interrupt we have to wait till lease times out.
       Thread.sleep(sleepTime);
     }
-    Assert.assertTrue(leaseThree.hasExpired());
-    exception.expect(LeaseNotFoundException.class);
-    exception.expectMessage("Resource: " + resourceThree);
-    manager.get(resourceThree);
+    Assertions.assertTrue(leaseThree.hasExpired());
+    Assertions.assertThrowsExactly(LeaseNotFoundException.class,
+        () -> manager.get(resourceThree), "Resource: " + resourceThree);
     manager.shutdown();
   }
 
@@ -172,15 +163,15 @@ public class TestLeaseManager {
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
     Lease<DummyResource> leaseTwo = manager.acquire(resourceTwo, 10000);
     Lease<DummyResource> leaseThree = manager.acquire(resourceThree, 50000);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertEquals(leaseTwo, manager.get(resourceTwo));
-    Assert.assertEquals(leaseThree, manager.get(resourceThree));
-    Assert.assertFalse(leaseOne.hasExpired());
-    Assert.assertFalse(leaseTwo.hasExpired());
-    Assert.assertFalse(leaseThree.hasExpired());
-    Assert.assertEquals(5000, leaseOne.getLeaseLifeTime());
-    Assert.assertEquals(10000, leaseTwo.getLeaseLifeTime());
-    Assert.assertEquals(50000, leaseThree.getLeaseLifeTime());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertEquals(leaseTwo, manager.get(resourceTwo));
+    Assertions.assertEquals(leaseThree, manager.get(resourceThree));
+    Assertions.assertFalse(leaseOne.hasExpired());
+    Assertions.assertFalse(leaseTwo.hasExpired());
+    Assertions.assertFalse(leaseThree.hasExpired());
+    Assertions.assertEquals(5000, leaseOne.getLeaseLifeTime());
+    Assertions.assertEquals(10000, leaseTwo.getLeaseLifeTime());
+    Assertions.assertEquals(50000, leaseThree.getLeaseLifeTime());
     // Releasing of leases is done in shutdown, so don't have to worry about
     // lease release
     manager.shutdown();
@@ -206,12 +197,11 @@ public class TestLeaseManager {
       //even in case of interrupt we have to wait till lease times out.
       Thread.sleep(sleepTime);
     }
-    Assert.assertTrue(leaseOne.hasExpired());
-    exception.expect(LeaseNotFoundException.class);
-    exception.expectMessage("Resource: " + resourceOne);
-    manager.get(resourceOne);
+    Assertions.assertTrue(leaseOne.hasExpired());
+    Assertions.assertThrowsExactly(LeaseNotFoundException.class,
+        () -> manager.get(resourceOne), "Resource: " + resourceOne);
     // check if callback has been executed
-    Assert.assertEquals("lease expired", leaseStatus.get(resourceOne));
+    Assertions.assertEquals("lease expired", leaseStatus.get(resourceOne));
   }
 
   @Test
@@ -230,11 +220,10 @@ public class TestLeaseManager {
     });
     leaseStatus.put(resourceOne, "lease released");
     manager.release(resourceOne);
-    Assert.assertTrue(leaseOne.hasExpired());
-    exception.expect(LeaseNotFoundException.class);
-    exception.expectMessage("Resource: " + resourceOne);
-    manager.get(resourceOne);
-    Assert.assertEquals("lease released", leaseStatus.get(resourceOne));
+    Assertions.assertTrue(leaseOne.hasExpired());
+    Assertions.assertThrowsExactly(LeaseNotFoundException.class,
+        () -> manager.get(resourceOne), "Resource: " + resourceOne);
+    Assertions.assertEquals("lease released", leaseStatus.get(resourceOne));
   }
 
   @Test
@@ -296,17 +285,17 @@ public class TestLeaseManager {
       //even in case of interrupt we have to wait till lease times out.
       Thread.sleep(sleepTime);
     }
-    Assert.assertTrue(leaseOne.hasExpired());
-    Assert.assertTrue(leaseTwo.hasExpired());
-    Assert.assertTrue(leaseThree.hasExpired());
-    Assert.assertTrue(leaseFour.hasExpired());
-    Assert.assertTrue(leaseFive.hasExpired());
+    Assertions.assertTrue(leaseOne.hasExpired());
+    Assertions.assertTrue(leaseTwo.hasExpired());
+    Assertions.assertTrue(leaseThree.hasExpired());
+    Assertions.assertTrue(leaseFour.hasExpired());
+    Assertions.assertTrue(leaseFive.hasExpired());
 
-    Assert.assertEquals("lease released", leaseStatus.get(resourceOne));
-    Assert.assertEquals("lease released", leaseStatus.get(resourceTwo));
-    Assert.assertEquals("lease released", leaseStatus.get(resourceThree));
-    Assert.assertEquals("lease expired", leaseStatus.get(resourceFour));
-    Assert.assertEquals("lease expired", leaseStatus.get(resourceFive));
+    Assertions.assertEquals("lease released", leaseStatus.get(resourceOne));
+    Assertions.assertEquals("lease released", leaseStatus.get(resourceTwo));
+    Assertions.assertEquals("lease released", leaseStatus.get(resourceThree));
+    Assertions.assertEquals("lease expired", leaseStatus.get(resourceFour));
+    Assertions.assertEquals("lease expired", leaseStatus.get(resourceFive));
     manager.shutdown();
   }
 
@@ -316,18 +305,18 @@ public class TestLeaseManager {
     manager.start();
     DummyResource resourceOne = new DummyResource("one");
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertFalse(leaseOne.hasExpired());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertFalse(leaseOne.hasExpired());
 
     manager.release(resourceOne);
-    Assert.assertTrue(leaseOne.hasExpired());
+    Assertions.assertTrue(leaseOne.hasExpired());
 
     Lease<DummyResource> sameResourceLease = manager.acquire(resourceOne);
-    Assert.assertEquals(sameResourceLease, manager.get(resourceOne));
-    Assert.assertFalse(sameResourceLease.hasExpired());
+    Assertions.assertEquals(sameResourceLease, manager.get(resourceOne));
+    Assertions.assertFalse(sameResourceLease.hasExpired());
 
     manager.release(resourceOne);
-    Assert.assertTrue(sameResourceLease.hasExpired());
+    Assertions.assertTrue(sameResourceLease.hasExpired());
     manager.shutdown();
   }
 
@@ -338,8 +327,8 @@ public class TestLeaseManager {
     manager.start();
     DummyResource resourceOne = new DummyResource("one");
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertFalse(leaseOne.hasExpired());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertFalse(leaseOne.hasExpired());
     // wait for lease to expire
     long sleepTime = leaseOne.getRemainingTime() + 1000;
     try {
@@ -348,14 +337,14 @@ public class TestLeaseManager {
       //even in case of interrupt we have to wait till lease times out.
       Thread.sleep(sleepTime);
     }
-    Assert.assertTrue(leaseOne.hasExpired());
+    Assertions.assertTrue(leaseOne.hasExpired());
 
     Lease<DummyResource> sameResourceLease = manager.acquire(resourceOne);
-    Assert.assertEquals(sameResourceLease, manager.get(resourceOne));
-    Assert.assertFalse(sameResourceLease.hasExpired());
+    Assertions.assertEquals(sameResourceLease, manager.get(resourceOne));
+    Assertions.assertFalse(sameResourceLease.hasExpired());
 
     manager.release(resourceOne);
-    Assert.assertTrue(sameResourceLease.hasExpired());
+    Assertions.assertTrue(sameResourceLease.hasExpired());
     manager.shutdown();
   }
 
@@ -365,8 +354,8 @@ public class TestLeaseManager {
     manager.start();
     DummyResource resourceOne = new DummyResource("one");
     Lease<DummyResource> leaseOne = manager.acquire(resourceOne);
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertFalse(leaseOne.hasExpired());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertFalse(leaseOne.hasExpired());
 
     // add 5 more seconds to the lease
     leaseOne.renew(5000);
@@ -374,8 +363,8 @@ public class TestLeaseManager {
     Thread.sleep(5000);
 
     // lease should still be active
-    Assert.assertEquals(leaseOne, manager.get(resourceOne));
-    Assert.assertFalse(leaseOne.hasExpired());
+    Assertions.assertEquals(leaseOne, manager.get(resourceOne));
+    Assertions.assertFalse(leaseOne.hasExpired());
     manager.release(resourceOne);
     manager.shutdown();
   }

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
@@ -18,21 +18,21 @@
 
 package org.apache.hadoop.ozone.upgrade;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.Iterator;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -40,14 +40,15 @@ import javax.management.ObjectName;
 /**
  * Test generic layout management init and APIs.
  */
-@RunWith(MockitoJUnitRunner.class)
 public class TestAbstractLayoutVersionManager {
 
   @Spy
   private AbstractLayoutVersionManager<LayoutFeature> versionManager;
 
-  @Rule
-  public ExpectedException exception = ExpectedException.none();
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
 
   @Test
   public void testInitializationWithFeaturesToBeFinalized() throws  Exception {
@@ -82,12 +83,11 @@ public class TestAbstractLayoutVersionManager {
   }
 
   @Test
-  public void testInitFailsIfNotEnoughLayoutFeaturesForVersion()
-      throws Exception {
-    exception.expect(IOException.class);
-    exception.expectMessage("Cannot initialize VersionManager.");
+  public void testInitFailsIfNotEnoughLayoutFeaturesForVersion() {
 
-    versionManager.init(3, getTestLayoutFeatures(2));
+    assertThrowsExactly(IOException.class,
+        () -> versionManager.init(3, getTestLayoutFeatures(2)),
+        "Cannot initialize VersionManager.");
   }
 
   @Test
@@ -114,23 +114,21 @@ public class TestAbstractLayoutVersionManager {
   @Test
   public void testFeatureFinalizationFailsIfTheFinalizedFeatureIsNotTheNext()
       throws IOException {
-    exception.expect(IllegalArgumentException.class);
-
     LayoutFeature[] lfs = getTestLayoutFeatures(3);
     versionManager.init(1, lfs);
 
-    versionManager.finalized(lfs[2]);
+    assertThrows(IllegalArgumentException.class,
+        () -> versionManager.finalized(lfs[2]));
   }
 
   @Test
   public void testFeatureFinalizationFailsIfFeatureIsAlreadyFinalized()
       throws IOException {
-    exception.expect(IllegalArgumentException.class);
-
     LayoutFeature[] lfs = getTestLayoutFeatures(3);
     versionManager.init(1, lfs);
 
-    versionManager.finalized(lfs[0]);
+    assertThrows(IllegalArgumentException.class,
+        () -> versionManager.finalized(lfs[0]));
   }
 
   @Test

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestUpgradeFinalizerActions.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestUpgradeFinalizerActions.java
@@ -23,7 +23,7 @@ import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.ON
 import static org.apache.hadoop.ozone.upgrade.LayoutFeature.UpgradeActionType.VALIDATE_IN_PREFINALIZE;
 import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutFeature.VERSION_2;
 import static org.apache.hadoop.ozone.upgrade.TestUpgradeFinalizerActions.MockLayoutFeature.VERSION_3;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -41,20 +41,17 @@ import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockDnUpgradeAction;
 import org.apache.hadoop.hdds.upgrade.test.MockComponent.MockScmUpgradeAction;
 import org.apache.hadoop.ozone.common.Storage;
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * Class to test upgrade related actions.
  */
 public class TestUpgradeFinalizerActions {
 
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
-
   @Test
-  public void testRunPrefinalizeStateActions() throws IOException {
+  public void testRunPrefinalizeStateActions(@TempDir File file)
+      throws IOException {
 
     VERSION_2.addAction(VALIDATE_IN_PREFINALIZE,
         new MockScmUpgradeAction());
@@ -64,7 +61,6 @@ public class TestUpgradeFinalizerActions {
 
     MockComponent mockObj = mock(MockComponent.class);
 
-    File file = folder.newFolder();
     File scmCurrent = Paths.get(file.toString(), "scm", "current")
         .toFile();
     assertTrue(scmCurrent.mkdirs());
@@ -88,7 +84,7 @@ public class TestUpgradeFinalizerActions {
   }
 
   @Test
-  public void testValidationFailureWorks() throws Exception {
+  public void testValidationFailureWorks(@TempDir File file) throws Exception {
     VERSION_2.addAction(VALIDATE_IN_PREFINALIZE,
         new MockFailingUpgradeAction());
     MockLayoutVersionManager lvm = new MockLayoutVersionManager(1);
@@ -96,7 +92,6 @@ public class TestUpgradeFinalizerActions {
 
     MockComponent mockObj = mock(MockComponent.class);
 
-    File file = folder.newFolder();
     File scmCurrent = Paths.get(file.toString(), "scm", "current")
         .toFile();
     assertTrue(scmCurrent.mkdirs());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate following tests to JUnit 5:

```
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/conf/TestOzoneConfiguration.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/hdds/scm/net/TestNodeSchemaManager.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestStateMachine.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/lease/TestLeaseManager.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestAbstractLayoutVersionManager.java
hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/upgrade/TestUpgradeFinalizerActions.java
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6876

## How was this patch tested?

Full CI: https://github.com/kaijchen/ozone/actions/runs/2539608584
