### PR TITLE
HDDS-6936. Mark TestContainerStateMachineFailures#testApplyTransactionFailure as flaky.

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerStateMachineFailures.java
@@ -386,6 +386,7 @@ public class TestContainerStateMachineFailures {
   }
 
   @Test
+  @Flaky("HDDS-6935")
   public void testApplyTransactionFailure() throws Exception {
     OzoneOutputStream key =
             objectStore.getVolume(volumeName).getBucket(bucketName)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `@Flaky` annotation to this test due to unrelated failures described in HDDS-6935.

## What is the link to the Apache JIRA

HDDS-6936

## How was this patch tested?

N/A, this patch is only skipping a test.
