### PR TITLE
HDDS-6941. Setting Bucket Property can corrupt bucket layout.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -147,6 +147,7 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
       bucketInfoBuilder.setVolumeName(dbBucketInfo.getVolumeName())
           .setBucketName(dbBucketInfo.getBucketName())
           .setObjectID(dbBucketInfo.getObjectID())
+          .setBucketLayout(dbBucketInfo.getBucketLayout())
           .setUpdateID(transactionLogIndex);
       bucketInfoBuilder.addAllMetadata(KeyValueUtil
           .getFromProtobuf(bucketArgs.getMetadataList()));

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -22,6 +22,7 @@ package org.apache.hadoop.ozone.om.request.bucket;
 import java.util.UUID;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
 import org.junit.Assert;
@@ -94,6 +95,35 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
             .getIsVersionEnabled());
+
+    Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
+        omClientResponse.getOMResponse().getStatus());
+  }
+
+  @Test
+  public void testNonDefaultLayout() throws Exception {
+
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    OMRequest omRequest = createSetBucketPropertyRequest(volumeName,
+        bucketName, true, Long.MAX_VALUE);
+
+    // Create FSO Bucket
+    OMRequestTestUtils.addVolumeAndBucketToDB(volumeName, bucketName,
+        omMetadataManager, BucketLayout.FILE_SYSTEM_OPTIMIZED);
+
+    OMBucketSetPropertyRequest omBucketSetPropertyRequest =
+        new OMBucketSetPropertyRequest(omRequest);
+
+    OMClientResponse omClientResponse =
+        omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
+            ozoneManagerDoubleBufferHelper);
+
+    Assert.assertEquals(
+        omMetadataManager.getBucketTable().get(
+            omMetadataManager.getBucketKey(volumeName, bucketName))
+            .getBucketLayout(), BucketLayout.FILE_SYSTEM_OPTIMIZED);
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/bucket/TestOMBucketSetPropertyRequest.java
@@ -120,10 +120,10 @@ public class TestOMBucketSetPropertyRequest extends TestBucketRequest {
         omBucketSetPropertyRequest.validateAndUpdateCache(ozoneManager, 1,
             ozoneManagerDoubleBufferHelper);
 
-    Assert.assertEquals(
+    Assert.assertEquals(BucketLayout.FILE_SYSTEM_OPTIMIZED,
         omMetadataManager.getBucketTable().get(
             omMetadataManager.getBucketKey(volumeName, bucketName))
-            .getBucketLayout(), BucketLayout.FILE_SYSTEM_OPTIMIZED);
+            .getBucketLayout());
 
     Assert.assertEquals(OzoneManagerProtocolProtos.Status.OK,
         omClientResponse.getOMResponse().getStatus());


### PR DESCRIPTION
## What changes were proposed in this pull request?



A member of our dev ops team discovered that setting a quota on a non legacy bucket will convert it to a legacy bucket, making the data there inaccessible.

You can reproduce the problem like so:
```
ozone sh volume create testgbj
ozone sh bucket create -l FILE_SYSTEM_OPTIMIZED testgbj/fsobucket4
ozone sh bucket info testgbj/fsobucket4
{
  "metadata" : { },
  "volumeName" : "testgbj",
  "name" : "fsobucket4",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-06-23T21:26:47.091Z",
  "modificationTime" : "2022-06-23T21:26:47.091Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "FILE_SYSTEM_OPTIMIZED",
  "owner" : "root",
  "link" : false
}

ozone sh bucket setquota --namespace-quota=20 testgbj/fsobucket4
ozone sh bucket info testgbj/fsobucket4

{{{}}
  "metadata" : { },
  "volumeName" : "testgbj",
  "name" : "fsobucket4",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-06-23T21:26:47.091Z",
  "modificationTime" : "2022-06-23T21:27:48.255Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : 20,
  "bucketLayout" : "LEGACY",
  "replicationConfig" : {
    "replicationFactor" : "ONE",
    "requiredNodes" : 1,
    "replicationType" : "RATIS"
  },
  "link" : false
}
```
 

The problem is that validateAndUpdateCache() method in OMBucketSetPropertyRequest.java creates a copy of the OmBucketInfo with the new property set, but leaves the bucket layout as the default, instead of copying it over.

Fix appears to be just to set the layout explicitly.


## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6941

## How was this patch tested?

added unit test