### PR TITLE
HDDS-6934. OM crashed with OzoneManagerDoubleBuffer

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -58,7 +58,7 @@ import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
  */
 public class TestRecursiveAclWithFSO {
 
-  @Rule public Timeout timeout = Timeout.seconds(500);
+  @Rule public Timeout timeout = Timeout.seconds(120);
 
   private MiniOzoneCluster cluster;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestRecursiveAclWithFSO.java
@@ -58,7 +58,7 @@ import static org.apache.hadoop.ozone.security.acl.OzoneObj.StoreType.OZONE;
  */
 public class TestRecursiveAclWithFSO {
 
-  @Rule public Timeout timeout = Timeout.seconds(120);
+  @Rule public Timeout timeout = Timeout.seconds(500);
 
   private MiniOzoneCluster cluster;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -92,6 +92,8 @@ import org.apache.commons.lang3.StringUtils;
 import static org.apache.hadoop.ozone.OzoneConsts.DB_TRANSIENT_MARKER;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_DB_NAME;
 import static org.apache.hadoop.ozone.OzoneConsts.OM_KEY_PREFIX;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.BUCKET_NOT_FOUND;
+import static org.apache.hadoop.ozone.om.exceptions.OMException.ResultCodes.VOLUME_NOT_FOUND;
 
 import org.apache.ratis.util.ExitUtils;
 import org.eclipse.jetty.util.StringUtil;
@@ -1474,11 +1476,23 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
 
   @Override
   public long getVolumeId(String volume) throws IOException {
-    return getVolumeTable().get(getVolumeKey(volume)).getObjectID();
+    OmVolumeArgs omVolumeArgs = getVolumeTable().get(getVolumeKey(volume));
+    if (omVolumeArgs == null) {
+      throw new OMException("Volume not found " + volume,
+          VOLUME_NOT_FOUND);
+    }
+    return omVolumeArgs.getObjectID();
   }
 
   @Override
   public long getBucketId(String volume, String bucket) throws IOException {
-    return getBucketTable().get(getBucketKey(volume, bucket)).getObjectID();
+    OmBucketInfo omBucketInfo =
+        getBucketTable().get(getBucketKey(volume, bucket));
+    if (omBucketInfo == null) {
+      throw new OMException(
+          "Bucket not found " + bucket + ", volume name: " + volume,
+          BUCKET_NOT_FOUND);
+    }
+    return omBucketInfo.getObjectID();
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMDirectoryCreateRequestWithFSO.java
@@ -176,8 +176,8 @@ public class OMDirectoryCreateRequestWithFSO extends OMDirectoryCreateRequest {
         result = OMDirectoryCreateRequest.Result.SUCCESS;
         omClientResponse =
             new OMDirectoryCreateResponseWithFSO(omResponse.build(),
-                    volumeName, bucketName, dirInfo,
-                missingParentInfos, result, getBucketLayout());
+                volumeId, bucketId, dirInfo, missingParentInfos, result,
+                getBucketLayout());
       } else {
         result = Result.DIRECTORY_ALREADY_EXISTS;
         omResponse.setStatus(Status.DIRECTORY_ALREADY_EXISTS);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileCreateRequestWithFSO.java
@@ -226,7 +226,7 @@ public class OMFileCreateRequestWithFSO extends OMFileCreateRequest {
           .setCmdType(Type.CreateFile);
       omClientResponse = new OMFileCreateResponseWithFSO(omResponse.build(),
               omFileInfo, missingParentInfos, clientID,
-              omBucketInfo.copyObject());
+              omBucketInfo.copyObject(), volumeId);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -574,13 +574,8 @@ public final class OMFileRequest {
    * @throws IOException DB failure
    */
   public static String addToOpenFileTable(OMMetadataManager omMetadataMgr,
-      BatchOperation batchOp, OmKeyInfo omFileInfo, String uploadID)
-          throws IOException {
-
-    final long volumeId = omMetadataMgr.getVolumeId(
-            omFileInfo.getVolumeName());
-    final long bucketId = omMetadataMgr.getBucketId(
-            omFileInfo.getVolumeName(), omFileInfo.getBucketName());
+      BatchOperation batchOp, OmKeyInfo omFileInfo, String uploadID,
+      long volumeId, long bucketId) throws IOException {
 
     String multipartFileKey = omMetadataMgr.getMultipartKey(volumeId,
             bucketId, omFileInfo.getParentObjectID(),
@@ -602,13 +597,9 @@ public final class OMFileRequest {
    * @throws IOException
    */
   public static String addToFileTable(OMMetadataManager omMetadataMgr,
-                                    BatchOperation batchOp,
-                                    OmKeyInfo omFileInfo)
-          throws IOException {
-    final long volumeId = omMetadataMgr.getVolumeId(
-            omFileInfo.getVolumeName());
-    final long bucketId = omMetadataMgr.getBucketId(
-            omFileInfo.getVolumeName(), omFileInfo.getBucketName());
+      BatchOperation batchOp, OmKeyInfo omFileInfo, long volumeId,
+      long bucketId) throws IOException {
+
     String dbFileKey = omMetadataMgr.getOzonePathKey(volumeId, bucketId,
             omFileInfo.getParentObjectID(), omFileInfo.getFileName());
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/file/OMFileRequest.java
@@ -546,15 +546,9 @@ public final class OMFileRequest {
    * @throws IOException DB failure
    */
   public static void addToOpenFileTable(OMMetadataManager omMetadataMgr,
-                                        BatchOperation batchOp,
-                                        OmKeyInfo omFileInfo,
-                                        long openKeySessionID)
-          throws IOException {
+      BatchOperation batchOp, OmKeyInfo omFileInfo, long openKeySessionID,
+      long volumeId, long bucketId) throws IOException {
 
-    final long volumeId = omMetadataMgr.getVolumeId(
-            omFileInfo.getVolumeName());
-    final long bucketId = omMetadataMgr.getBucketId(
-            omFileInfo.getVolumeName(), omFileInfo.getBucketName());
     String dbOpenFileKey = omMetadataMgr.getOpenFileName(volumeId, bucketId,
             omFileInfo.getParentObjectID(), omFileInfo.getFileName(),
             openKeySessionID);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMAllocateBlockRequestWithFSO.java
@@ -168,8 +168,9 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
 
       omResponse.setAllocateBlockResponse(AllocateBlockResponse.newBuilder()
               .setKeyLocation(blockLocation).build());
+      long volumeId = omMetadataManager.getVolumeId(volumeName);
       omClientResponse = getOmClientResponse(clientID, omResponse,
-              openKeyInfo, omBucketInfo.copyObject());
+              openKeyInfo, omBucketInfo.copyObject(), volumeId);
       LOG.debug("Allocated block for Volume:{}, Bucket:{}, OpenKey:{}",
               volumeName, bucketName, openKeyName);
     } catch (IOException ex) {
@@ -227,8 +228,8 @@ public class OMAllocateBlockRequestWithFSO extends OMAllocateBlockRequest {
   @NotNull
   private OMClientResponse getOmClientResponse(long clientID,
       OMResponse.Builder omResponse, OmKeyInfo openKeyInfo,
-      OmBucketInfo omBucketInfo) {
+      OmBucketInfo omBucketInfo, long volumeId) {
     return new OMAllocateBlockResponseWithFSO(omResponse.build(), openKeyInfo,
-            clientID, getBucketLayout());
+            clientID, getBucketLayout(), volumeId, omBucketInfo.getObjectID());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCommitRequestWithFSO.java
@@ -192,7 +192,7 @@ public class OMKeyCommitRequestWithFSO extends OMKeyCommitRequest {
 
       omClientResponse = new OMKeyCommitResponseWithFSO(omResponse.build(),
               omKeyInfo, dbFileKey, dbOpenFileKey, omBucketInfo.copyObject(),
-              oldKeyVersionsToDelete);
+              oldKeyVersionsToDelete, volumeId);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyCreateRequestWithFSO.java
@@ -212,7 +212,7 @@ public class OMKeyCreateRequestWithFSO extends OMKeyCreateRequest {
               .setCmdType(Type.CreateKey);
       omClientResponse = new OMKeyCreateResponseWithFSO(omResponse.build(),
               omFileInfo, missingParentInfos, clientID,
-              omBucketInfo.copyObject());
+              omBucketInfo.copyObject(), volumeId);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeyDeleteRequestWithFSO.java
@@ -168,7 +168,7 @@ public class OMKeyDeleteRequestWithFSO extends OMKeyDeleteRequest {
       omClientResponse = new OMKeyDeleteResponseWithFSO(omResponse
           .setDeleteKeyResponse(DeleteKeyResponse.newBuilder()).build(),
           keyName, omKeyInfo, ozoneManager.isRatisEnabled(),
-          omBucketInfo.copyObject(), keyStatus.isDirectory());
+          omBucketInfo.copyObject(), keyStatus.isDirectory(), volumeId);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMKeysDeleteRequest.java
@@ -177,9 +177,10 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
       omBucketInfo.incrUsedBytes(-quotaReleased);
       omBucketInfo.incrUsedNamespace(-1L * omKeyInfoList.size());
 
+      final long volumeId = omMetadataManager.getVolumeId(volumeName);
       omClientResponse =
           getOmClientResponse(ozoneManager, omKeyInfoList, dirList, omResponse,
-              unDeletedKeys, deleteStatus, omBucketInfo);
+              unDeletedKeys, deleteStatus, omBucketInfo, volumeId);
 
       result = Result.SUCCESS;
 
@@ -248,11 +249,12 @@ public class OMKeysDeleteRequest extends OMKeyRequest {
   }
 
   @NotNull
+  @SuppressWarnings("parameternumber")
   protected OMClientResponse getOmClientResponse(OzoneManager ozoneManager,
       List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
       OMResponse.Builder omResponse,
       OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
-      boolean deleteStatus, OmBucketInfo omBucketInfo) {
+      boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId) {
     OMClientResponse omClientResponse;
     omClientResponse = new OMKeysDeleteResponse(omResponse
         .setDeleteKeysResponse(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OmKeysDeleteRequestWithFSO.java
@@ -137,7 +137,7 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
       List<OmKeyInfo> omKeyInfoList, List<OmKeyInfo> dirList,
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
       OzoneManagerProtocolProtos.DeleteKeyArgs.Builder unDeletedKeys,
-      boolean deleteStatus, OmBucketInfo omBucketInfo) {
+      boolean deleteStatus, OmBucketInfo omBucketInfo, long volumeId) {
     OMClientResponse omClientResponse;
     omClientResponse = new OMKeysDeleteResponseWithFSO(omResponse
         .setDeleteKeysResponse(
@@ -145,7 +145,7 @@ public class OmKeysDeleteRequestWithFSO extends OMKeysDeleteRequest {
                 .setStatus(deleteStatus).setUnDeletedKeys(unDeletedKeys))
         .setStatus(deleteStatus ? OK : PARTIAL_DELETE).setSuccess(deleteStatus)
         .build(), omKeyInfoList, dirList, ozoneManager.isRatisEnabled(),
-        omBucketInfo.copyObject());
+        omBucketInfo.copyObject(), volumeId);
     return omClientResponse;
 
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAclRequestWithFSO.java
@@ -128,8 +128,8 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
             .addCacheEntry(new CacheKey<>(dbKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
-      omClientResponse =
-          onSuccess(omResponse, omKeyInfo, operationResult, isDirectory);
+      omClientResponse = onSuccess(omResponse, omKeyInfo, operationResult,
+          isDirectory, volumeId, bucketId);
       result = Result.SUCCESS;
     } catch (IOException ex) {
       result = Result.FAILURE;
@@ -169,6 +169,7 @@ public abstract class OMKeyAclRequestWithFSO extends OMKeyAclRequest {
 
   abstract OMClientResponse onSuccess(
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDirectory);
+      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDirectory,
+      long volumeId, long bucketId);
 
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyAddAclRequestWithFSO.java
@@ -140,14 +140,16 @@ public class OMKeyAddAclRequestWithFSO extends OMKeyAclRequestWithFSO {
         omDoubleBufferHelper);
   }
 
-  @Override OMClientResponse onSuccess(
+  @Override
+  OMClientResponse onSuccess(
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir) {
+      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir,
+      long volumeId, long bucketId) {
     omResponse.setSuccess(operationResult);
     omResponse.setAddAclResponse(
         OzoneManagerProtocolProtos.AddAclResponse.newBuilder()
             .setResponse(operationResult));
     return new OMKeyAclResponseWithFSO(omResponse.build(), omKeyInfo, isDir,
-        getBucketLayout());
+        getBucketLayout(), volumeId, bucketId);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeyRemoveAclRequestWithFSO.java
@@ -153,12 +153,13 @@ public class OMKeyRemoveAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   @Override
   OMClientResponse onSuccess(
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir) {
+      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir,
+      long volumeId, long bucketId) {
     omResponse.setSuccess(operationResult);
     omResponse.setRemoveAclResponse(
         OzoneManagerProtocolProtos.RemoveAclResponse.newBuilder()
             .setResponse(operationResult));
     return new OMKeyAclResponseWithFSO(omResponse.build(), omKeyInfo, isDir,
-        getBucketLayout());
+        getBucketLayout(), volumeId, bucketId);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/acl/OMKeySetAclRequestWithFSO.java
@@ -146,12 +146,13 @@ public class OMKeySetAclRequestWithFSO extends OMKeyAclRequestWithFSO {
   @Override
   OMClientResponse onSuccess(
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
-      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir) {
+      OmKeyInfo omKeyInfo, boolean operationResult, boolean isDir,
+      long volumeId, long bucketId) {
     omResponse.setSuccess(operationResult);
     omResponse.setSetAclResponse(
         OzoneManagerProtocolProtos.SetAclResponse.newBuilder()
             .setResponse(operationResult));
     return new OMKeyAclResponseWithFSO(omResponse.build(), omKeyInfo, isDir,
-        getBucketLayout());
+        getBucketLayout(), volumeId, bucketId);
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3InitiateMultipartUploadRequestWithFSO.java
@@ -218,7 +218,7 @@ public class S3InitiateMultipartUploadRequestWithFSO
                       .setKeyName(keyName)
                       .setMultipartUploadID(keyArgs.getMultipartUploadID()))
                   .build(), multipartKeyInfo, omKeyInfo, multipartKey,
-              missingParentInfos, getBucketLayout());
+              missingParentInfos, getBucketLayout(), volumeId, bucketId);
 
       result = Result.SUCCESS;
     } catch (IOException ex) {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequest.java
@@ -262,9 +262,11 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
                 .setKey(keyName)
                 .setHash(DigestUtils.sha256Hex(keyName)));
 
+        long volumeId = omMetadataManager.getVolumeId(volumeName);
         omClientResponse =
             getOmClientResponse(multipartKey, omResponse, dbMultipartOpenKey,
-                omKeyInfo, unUsedParts, omBucketInfo, oldKeyVersionsToDelete);
+                omKeyInfo, unUsedParts, omBucketInfo, oldKeyVersionsToDelete,
+                volumeId);
 
         result = Result.SUCCESS;
       } else {
@@ -299,10 +301,12 @@ public class S3MultipartUploadCompleteRequest extends OMKeyRequest {
         createErrorOMResponse(omResponse, exception), getBucketLayout());
   }
 
+  @SuppressWarnings("parameternumber")
   protected OMClientResponse getOmClientResponse(String multipartKey,
       OMResponse.Builder omResponse, String dbMultipartOpenKey,
       OmKeyInfo omKeyInfo,  List<OmKeyInfo> unUsedParts,
-      OmBucketInfo omBucketInfo, RepeatedOmKeyInfo oldKeyVersionsToDelete) {
+      OmBucketInfo omBucketInfo, RepeatedOmKeyInfo oldKeyVersionsToDelete,
+      long volumeId) {
 
     return new S3MultipartUploadCompleteResponse(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/multipart/S3MultipartUploadCompleteRequestWithFSO.java
@@ -163,11 +163,11 @@ public class S3MultipartUploadCompleteRequestWithFSO
       OzoneManagerProtocolProtos.OMResponse.Builder omResponse,
       String dbMultipartOpenKey, OmKeyInfo omKeyInfo,
       List<OmKeyInfo> unUsedParts, OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo oldKeyVersionsToDelete) {
+      RepeatedOmKeyInfo oldKeyVersionsToDelete, long volumeId) {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse.build(),
         multipartKey, dbMultipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete);
+        getBucketLayout(), omBucketInfo, oldKeyVersionsToDelete, volumeId);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
@@ -47,23 +47,19 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
   private OmDirectoryInfo dirInfo;
   private List<OmDirectoryInfo> parentDirInfos;
   private Result result;
-  private String volume;
-  private String bucket;
+  private long volumeId;
+  private long bucketId;
 
   public OMDirectoryCreateResponseWithFSO(@Nonnull OMResponse omResponse,
-                                          @Nonnull String volume,
-                                          @Nonnull String bucket,
-                                          @Nonnull OmDirectoryInfo dirInfo,
-                                          @Nonnull
-                                              List<OmDirectoryInfo> pDirInfos,
-                                          @Nonnull Result result, @Nonnull
-                                          BucketLayout bucketLayout) {
+      long volumeId, long bucketId, @Nonnull OmDirectoryInfo dirInfo,
+      @Nonnull List<OmDirectoryInfo> pDirInfos, @Nonnull Result result,
+      @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);
     this.dirInfo = dirInfo;
     this.parentDirInfos = pDirInfos;
     this.result = result;
-    this.volume = volume;
-    this.bucket = bucket;
+    this.volumeId = volumeId;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -86,8 +82,6 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
                                 BatchOperation batchOperation)
           throws IOException {
     if (dirInfo != null) {
-      final long volumeId = omMetadataManager.getVolumeId(volume);
-      final long bucketId = omMetadataManager.getBucketId(volume, bucket);
       if (parentDirInfos != null) {
         for (OmDirectoryInfo parentDirInfo : parentDirInfos) {
           String parentKey = omMetadataManager

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMDirectoryCreateResponseWithFSO.java
@@ -51,7 +51,8 @@ public class OMDirectoryCreateResponseWithFSO extends OmKeyResponse {
   private long bucketId;
 
   public OMDirectoryCreateResponseWithFSO(@Nonnull OMResponse omResponse,
-      long volumeId, long bucketId, @Nonnull OmDirectoryInfo dirInfo,
+      @Nonnull long volumeId, @Nonnull long bucketId,
+      @Nonnull OmDirectoryInfo dirInfo,
       @Nonnull List<OmDirectoryInfo> pDirInfos, @Nonnull Result result,
       @Nonnull BucketLayout bucketLayout) {
     super(omResponse, bucketLayout);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
@@ -50,7 +50,7 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
   public OMFileCreateResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmDirectoryInfo> parentDirInfos, long openKeySessionID,
-      @Nonnull OmBucketInfo omBucketInfo, long volumeId) {
+      @Nonnull OmBucketInfo omBucketInfo, @Nonnull long volumeId) {
     super(omResponse, omKeyInfo, new ArrayList<>(), openKeySessionID,
         omBucketInfo);
     this.parentDirInfos = parentDirInfos;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
@@ -90,7 +90,7 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
     }
 
     OMFileRequest.addToOpenFileTable(omMetadataMgr, batchOp, getOmKeyInfo(),
-            getOpenKeySessionID());
+        getOpenKeySessionID(), volumeId, getOmBucketInfo().getObjectID());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/file/OMFileCreateResponseWithFSO.java
@@ -45,15 +45,16 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
 
   private List<OmDirectoryInfo> parentDirInfos;
+  private long volumeId;
 
   public OMFileCreateResponseWithFSO(@Nonnull OMResponse omResponse,
-                                @Nonnull OmKeyInfo omKeyInfo,
-                                @Nonnull List<OmDirectoryInfo> parentDirInfos,
-                                long openKeySessionID,
-                                @Nonnull OmBucketInfo omBucketInfo) {
+      @Nonnull OmKeyInfo omKeyInfo,
+      @Nonnull List<OmDirectoryInfo> parentDirInfos, long openKeySessionID,
+      @Nonnull OmBucketInfo omBucketInfo, long volumeId) {
     super(omResponse, omKeyInfo, new ArrayList<>(), openKeySessionID,
         omBucketInfo);
     this.parentDirInfos = parentDirInfos;
+    this.volumeId = volumeId;
   }
 
   /**
@@ -75,13 +76,10 @@ public class OMFileCreateResponseWithFSO extends OMFileCreateResponse {
      * XXX handle stale directory entries.
      */
     if (parentDirInfos != null) {
-      final long volumeId = omMetadataMgr.getVolumeId(
-              getOmKeyInfo().getVolumeName());
-      final long bucketId = omMetadataMgr.getBucketId(
-              getOmKeyInfo().getVolumeName(), getOmKeyInfo().getBucketName());
       for (OmDirectoryInfo parentDirInfo : parentDirInfos) {
-        String parentKey = omMetadataMgr.getOzonePathKey(volumeId, bucketId,
-                parentDirInfo.getParentObjectID(), parentDirInfo.getName());
+        String parentKey = omMetadataMgr.getOzonePathKey(volumeId,
+            getOmBucketInfo().getObjectID(), parentDirInfo.getParentObjectID(),
+            parentDirInfo.getName());
         if (LOG.isDebugEnabled()) {
           LOG.debug("putWithBatch adding parent : key {} info : {}", parentKey,
                   parentDirInfo);

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMAllocateBlockResponseWithFSO.java
@@ -38,10 +38,16 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 @CleanupTableInfo(cleanupTables = {OPEN_FILE_TABLE, BUCKET_TABLE})
 public class OMAllocateBlockResponseWithFSO extends OMAllocateBlockResponse {
 
+  private long volumeId;
+  private long bucketId;
+
   public OMAllocateBlockResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull OmKeyInfo omKeyInfo, long clientID,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull BucketLayout bucketLayout, @Nonnull long volumeId,
+      @Nonnull long bucketId) {
     super(omResponse, omKeyInfo, clientID, bucketLayout);
+    this.volumeId = volumeId;
+    this.bucketId = bucketId;
   }
 
   /**
@@ -58,7 +64,7 @@ public class OMAllocateBlockResponseWithFSO extends OMAllocateBlockResponse {
       BatchOperation batchOperation) throws IOException {
 
     OMFileRequest.addToOpenFileTable(omMetadataManager, batchOperation,
-            getOmKeyInfo(), getClientID());
+            getOmKeyInfo(), getClientID(), volumeId, bucketId);
   }
 }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCommitResponseWithFSO.java
@@ -44,13 +44,16 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.DELETED_TABLE;
     BUCKET_TABLE})
 public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
 
+  private long volumeId;
+
   public OMKeyCommitResponseWithFSO(@Nonnull OMResponse omResponse,
                                @Nonnull OmKeyInfo omKeyInfo,
                                String ozoneKeyName, String openKeyName,
                                @Nonnull OmBucketInfo omBucketInfo,
-                               RepeatedOmKeyInfo deleteKeys) {
+                               RepeatedOmKeyInfo deleteKeys, long volumeId) {
     super(omResponse, omKeyInfo, ozoneKeyName, openKeyName,
             omBucketInfo, deleteKeys);
+    this.volumeId = volumeId;
   }
 
   /**
@@ -72,7 +75,7 @@ public class OMKeyCommitResponseWithFSO extends OMKeyCommitResponse {
         .deleteWithBatch(batchOperation, getOpenKeyName());
 
     OMFileRequest.addToFileTable(omMetadataManager, batchOperation,
-            getOmKeyInfo());
+            getOmKeyInfo(), volumeId, getOmBucketInfo().getObjectID());
 
     updateDeletedTable(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponseWithFSO.java
@@ -41,12 +41,12 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 public class OMKeyCreateResponseWithFSO extends OMFileCreateResponseWithFSO {
 
   public OMKeyCreateResponseWithFSO(@Nonnull OMResponse omResponse,
-                               @Nonnull OmKeyInfo omKeyInfo,
-                               @Nonnull List<OmDirectoryInfo> parentDirInfos,
-                               long openKeySessionID,
-                               @Nonnull OmBucketInfo omBucketInfo) {
+      @Nonnull OmKeyInfo omKeyInfo,
+      @Nonnull List<OmDirectoryInfo> parentDirInfos,
+      long openKeySessionID, @Nonnull OmBucketInfo omBucketInfo,
+      long volumeId) {
     super(omResponse, omKeyInfo, parentDirInfos, openKeySessionID,
-            omBucketInfo);
+        omBucketInfo, volumeId);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyCreateResponseWithFSO.java
@@ -44,7 +44,7 @@ public class OMKeyCreateResponseWithFSO extends OMFileCreateResponseWithFSO {
       @Nonnull OmKeyInfo omKeyInfo,
       @Nonnull List<OmDirectoryInfo> parentDirInfos,
       long openKeySessionID, @Nonnull OmBucketInfo omBucketInfo,
-      long volumeId) {
+      @Nonnull long volumeId) {
     super(omResponse, omKeyInfo, parentDirInfos, openKeySessionID,
         omBucketInfo, volumeId);
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -45,14 +45,17 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
 
   private boolean isDeleteDirectory;
   private String keyName;
+  private long volumeId;
 
+  @SuppressWarnings("parameternumber")
   public OMKeyDeleteResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull String keyName, @Nonnull OmKeyInfo omKeyInfo,
       boolean isRatisEnabled, @Nonnull OmBucketInfo omBucketInfo,
-      @Nonnull boolean isDeleteDirectory) {
+      @Nonnull boolean isDeleteDirectory, long volumeId) {
     super(omResponse, omKeyInfo, isRatisEnabled, omBucketInfo);
     this.keyName = keyName;
     this.isDeleteDirectory = isDeleteDirectory;
+    this.volumeId = volumeId;
   }
 
   /**
@@ -68,17 +71,11 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
   public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    final long volumeId = omMetadataManager.getVolumeId(
-            getOmKeyInfo().getVolumeName());
-    final long bucketId = omMetadataManager.getBucketId(
-            getOmKeyInfo().getVolumeName(),
-            getOmKeyInfo().getBucketName());
-
     // For OmResponse with failure, this should do nothing. This method is
     // not called in failure scenario in OM code.
     String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId,
-            bucketId, getOmKeyInfo().getParentObjectID(),
-            getOmKeyInfo().getFileName());
+        getOmBucketInfo().getObjectID(), getOmKeyInfo().getParentObjectID(),
+        getOmKeyInfo().getFileName());
 
     if (isDeleteDirectory) {
       omMetadataManager.getDirectoryTable().deleteWithBatch(batchOperation,

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeyDeleteResponseWithFSO.java
@@ -51,7 +51,7 @@ public class OMKeyDeleteResponseWithFSO extends OMKeyDeleteResponse {
   public OMKeyDeleteResponseWithFSO(@Nonnull OMResponse omResponse,
       @Nonnull String keyName, @Nonnull OmKeyInfo omKeyInfo,
       boolean isRatisEnabled, @Nonnull OmBucketInfo omBucketInfo,
-      @Nonnull boolean isDeleteDirectory, long volumeId) {
+      @Nonnull boolean isDeleteDirectory, @Nonnull long volumeId) {
     super(omResponse, omKeyInfo, isRatisEnabled, omBucketInfo);
     this.keyName = keyName;
     this.isDeleteDirectory = isDeleteDirectory;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/OMKeysDeleteResponseWithFSO.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.ozone.om.response.CleanupTableInfo;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
@@ -50,7 +51,7 @@ public class OMKeysDeleteResponseWithFSO extends OMKeysDeleteResponse {
       @NotNull OzoneManagerProtocolProtos.OMResponse omResponse,
       @NotNull List<OmKeyInfo> keyDeleteList,
       @NotNull List<OmKeyInfo> dirDeleteList, boolean isRatisEnabled,
-      @NotNull OmBucketInfo omBucketInfo, long volId) {
+      @NotNull OmBucketInfo omBucketInfo, @Nonnull long volId) {
     super(omResponse, keyDeleteList, isRatisEnabled, omBucketInfo);
     this.dirsList = dirDeleteList;
     this.volumeId = volId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponseWithFSO.java
@@ -40,11 +40,13 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.FILE_TABLE;
 public class OMKeyAclResponseWithFSO extends OMKeyAclResponse {
 
   private boolean isDirectory;
+  private long volumeId;
+  private long bucketId;
 
   public OMKeyAclResponseWithFSO(
       @NotNull OzoneManagerProtocolProtos.OMResponse omResponse,
       @NotNull OmKeyInfo omKeyInfo, boolean isDirectory,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull BucketLayout bucketLayout, long volumeId, long bucketId) {
     super(omResponse, omKeyInfo, bucketLayout);
     this.isDirectory = isDirectory;
   }
@@ -64,14 +66,8 @@ public class OMKeyAclResponseWithFSO extends OMKeyAclResponse {
   @Override public void addToDBBatch(OMMetadataManager omMetadataManager,
       BatchOperation batchOperation) throws IOException {
 
-    final long volumeId = omMetadataManager.getVolumeId(
-            getOmKeyInfo().getVolumeName());
-    final long bucketId = omMetadataManager.getBucketId(
-            getOmKeyInfo().getVolumeName(), getOmKeyInfo().getBucketName());
-    String ozoneDbKey = omMetadataManager
-        .getOzonePathKey(volumeId, bucketId,
-                getOmKeyInfo().getParentObjectID(),
-                getOmKeyInfo().getFileName());
+    String ozoneDbKey = omMetadataManager.getOzonePathKey(volumeId, bucketId,
+        getOmKeyInfo().getParentObjectID(), getOmKeyInfo().getFileName());
     if (isDirectory) {
       OmDirectoryInfo dirInfo = OMFileRequest.getDirectoryInfo(getOmKeyInfo());
       omMetadataManager.getDirectoryTable()

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/key/acl/OMKeyAclResponseWithFSO.java
@@ -46,9 +46,12 @@ public class OMKeyAclResponseWithFSO extends OMKeyAclResponse {
   public OMKeyAclResponseWithFSO(
       @NotNull OzoneManagerProtocolProtos.OMResponse omResponse,
       @NotNull OmKeyInfo omKeyInfo, boolean isDirectory,
-      @Nonnull BucketLayout bucketLayout, long volumeId, long bucketId) {
+      @Nonnull BucketLayout bucketLayout, @Nonnull long volumeId,
+      @Nonnull long bucketId) {
     super(omResponse, omKeyInfo, bucketLayout);
     this.isDirectory = isDirectory;
+    this.volumeId = volumeId;
+    this.bucketId = bucketId;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
@@ -49,15 +49,19 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
   private long volumeId;
   private long bucketId;
 
+  @SuppressWarnings("parameternumber")
   public S3InitiateMultipartUploadResponseWithFSO(
       @Nonnull OMResponse omResponse,
       @Nonnull OmMultipartKeyInfo omMultipartKeyInfo,
       @Nonnull OmKeyInfo omKeyInfo, @Nonnull String mpuDBKey,
       @Nonnull List<OmDirectoryInfo> parentDirInfos,
-      @Nonnull BucketLayout bucketLayout) {
+      @Nonnull BucketLayout bucketLayout, @Nonnull long volumeId,
+      @Nonnull long bucketId) {
     super(omResponse, omMultipartKeyInfo, omKeyInfo, bucketLayout);
     this.parentDirInfos = parentDirInfos;
     this.mpuDBKey = mpuDBKey;
+    this.volumeId = volumeId;
+    this.bucketId = bucketId;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3InitiateMultipartUploadResponseWithFSO.java
@@ -46,6 +46,8 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
         S3InitiateMultipartUploadResponse {
   private List<OmDirectoryInfo> parentDirInfos;
   private String mpuDBKey;
+  private long volumeId;
+  private long bucketId;
 
   public S3InitiateMultipartUploadResponseWithFSO(
       @Nonnull OMResponse omResponse,
@@ -76,11 +78,6 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
      * wait for File Commit request.
      */
     if (parentDirInfos != null) {
-      final OmKeyInfo keyInfo = getOmKeyInfo();
-      final long volumeId = omMetadataManager.getVolumeId(
-              keyInfo.getVolumeName());
-      final long bucketId = omMetadataManager.getBucketId(
-              keyInfo.getVolumeName(), keyInfo.getBucketName());
       for (OmDirectoryInfo parentDirInfo : parentDirInfos) {
         final String parentKey = omMetadataManager.getOzonePathKey(
                 volumeId, bucketId, parentDirInfo.getParentObjectID(),
@@ -91,7 +88,8 @@ public class S3InitiateMultipartUploadResponseWithFSO extends
     }
 
     OMFileRequest.addToOpenFileTable(omMetadataManager, batchOperation,
-        getOmKeyInfo(), getOmMultipartKeyInfo().getUploadID());
+        getOmKeyInfo(), getOmMultipartKeyInfo().getUploadID(), volumeId,
+        bucketId);
 
     omMetadataManager.getMultipartInfoTable().putWithBatch(batchOperation,
         mpuDBKey, getOmMultipartKeyInfo());

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponse.java
@@ -147,4 +147,7 @@ public class S3MultipartUploadCompleteResponse extends OmKeyResponse {
     return partsUnusedList;
   }
 
+  public OmBucketInfo getOmBucketInfo() {
+    return omBucketInfo;
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -61,7 +61,7 @@ public class S3MultipartUploadCompleteResponseWithFSO
       @Nonnull List<OmKeyInfo> unUsedParts,
       @Nonnull BucketLayout bucketLayout,
       @Nonnull OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo keysToDelete, long volumeId) {
+      RepeatedOmKeyInfo keysToDelete, @Nonnull long volumeId) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
         bucketLayout, omBucketInfo, keysToDelete);
     this.volumeId = volumeId;

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -51,7 +51,6 @@ public class S3MultipartUploadCompleteResponseWithFSO
         extends S3MultipartUploadCompleteResponse {
 
   private long volumeId;
-  private long bucketId;
 
   @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadCompleteResponseWithFSO(
@@ -62,9 +61,10 @@ public class S3MultipartUploadCompleteResponseWithFSO
       @Nonnull List<OmKeyInfo> unUsedParts,
       @Nonnull BucketLayout bucketLayout,
       @Nonnull OmBucketInfo omBucketInfo,
-      RepeatedOmKeyInfo keysToDelete) {
+      RepeatedOmKeyInfo keysToDelete, long volumeId) {
     super(omResponse, multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
         bucketLayout, omBucketInfo, keysToDelete);
+    this.volumeId = volumeId;
   }
 
   /**
@@ -87,7 +87,7 @@ public class S3MultipartUploadCompleteResponseWithFSO
 
     OMFileRequest
         .addToFileTable(omMetadataManager, batchOperation, getOmKeyInfo(),
-            volumeId, bucketId);
+            volumeId, getOmBucketInfo().getObjectID());
 
     return ozoneKey;
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/response/s3/multipart/S3MultipartUploadCompleteResponseWithFSO.java
@@ -50,6 +50,9 @@ import static org.apache.hadoop.ozone.om.OmMetadataManagerImpl.OPEN_FILE_TABLE;
 public class S3MultipartUploadCompleteResponseWithFSO
         extends S3MultipartUploadCompleteResponse {
 
+  private long volumeId;
+  private long bucketId;
+
   @SuppressWarnings("checkstyle:ParameterNumber")
   public S3MultipartUploadCompleteResponseWithFSO(
       @Nonnull OMResponse omResponse,
@@ -83,7 +86,8 @@ public class S3MultipartUploadCompleteResponseWithFSO
             getOmKeyInfo().getBucketName(), getOmKeyInfo().getKeyName());
 
     OMFileRequest
-        .addToFileTable(omMetadataManager, batchOperation, getOmKeyInfo());
+        .addToFileTable(omMetadataManager, batchOperation, getOmKeyInfo(),
+            volumeId, bucketId);
 
     return ozoneKey;
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -1149,41 +1149,43 @@ public final class OMRequestTestUtils {
    *
    * @throws Exception DB failure
    */
-  public static void addFileToKeyTable(boolean openKeyTable,
+  public static String addFileToKeyTable(boolean openKeyTable,
                                        boolean addToCache, String fileName,
                                        OmKeyInfo omKeyInfo,
                                        long clientID, long trxnLogIndex,
                                        OMMetadataManager omMetadataManager)
           throws Exception {
+    String ozoneDBKey;
     if (openKeyTable) {
       final long volumeId = omMetadataManager.getVolumeId(
               omKeyInfo.getVolumeName());
       final long bucketId = omMetadataManager.getBucketId(
               omKeyInfo.getVolumeName(), omKeyInfo.getBucketName());
-      final String ozoneKey = omMetadataManager.getOpenFileName(
+      ozoneDBKey = omMetadataManager.getOpenFileName(
               volumeId, bucketId, omKeyInfo.getParentObjectID(),
               fileName, clientID);
       if (addToCache) {
         omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-            .addCacheEntry(new CacheKey<>(ozoneKey),
+            .addCacheEntry(new CacheKey<>(ozoneDBKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
       omMetadataManager.getOpenKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-          .put(ozoneKey, omKeyInfo);
+          .put(ozoneDBKey, omKeyInfo);
     } else {
-      String ozoneKey = omMetadataManager.getOzonePathKey(
+      ozoneDBKey = omMetadataManager.getOzonePathKey(
               omMetadataManager.getVolumeId(omKeyInfo.getVolumeName()),
               omMetadataManager.getBucketId(omKeyInfo.getVolumeName(),
                       omKeyInfo.getBucketName()),
               omKeyInfo.getParentObjectID(), fileName);
       if (addToCache) {
         omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-            .addCacheEntry(new CacheKey<>(ozoneKey),
+            .addCacheEntry(new CacheKey<>(ozoneDBKey),
                 new CacheValue<>(Optional.of(omKeyInfo), trxnLogIndex));
       }
       omMetadataManager.getKeyTable(BucketLayout.FILE_SYSTEM_OPTIMIZED)
-          .put(ozoneKey, omKeyInfo);
+          .put(ozoneDBKey, omKeyInfo);
     }
+    return ozoneDBKey;
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMDirectoryCreateResponseWithFSO.java
@@ -86,7 +86,7 @@ public class TestOMDirectoryCreateResponseWithFSO {
             .build();
 
     OMDirectoryCreateResponseWithFSO omDirectoryCreateResponseWithFSO =
-        new OMDirectoryCreateResponseWithFSO(omResponse, volume, bucket,
+        new OMDirectoryCreateResponseWithFSO(omResponse, volumeId, bucketId,
                 omDirInfo, new ArrayList<>(),
                 OMDirectoryCreateRequestWithFSO.Result.SUCCESS,
                 BucketLayout.FILE_SYSTEM_OPTIMIZED);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
@@ -62,7 +62,7 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected OMKeyCreateResponse getOmKeyCreateResponse(OmKeyInfo keyInfo,
-      OmBucketInfo bucketInfo, OMResponse response) {
+      OmBucketInfo bucketInfo, OMResponse response) throws IOException {
 
     return new OMFileCreateResponseWithFSO(response, keyInfo,
         new ArrayList<>(), clientID, bucketInfo, getVolumeId());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/file/TestOMFileCreateResponseWithFSO.java
@@ -65,7 +65,7 @@ public class TestOMFileCreateResponseWithFSO extends TestOMKeyCreateResponse {
       OmBucketInfo bucketInfo, OMResponse response) {
 
     return new OMFileCreateResponseWithFSO(response, keyInfo,
-        new ArrayList<>(), clientID, bucketInfo);
+        new ArrayList<>(), clientID, bucketInfo, getVolumeId());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponse.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -30,6 +29,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.AllocateBlockResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
 
+import java.io.IOException;
+
 /**
  * Tests OMAllocateBlockResponse.
  */
@@ -39,9 +40,6 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
   public void testAddToDBBatch() throws Exception {
 
     OmKeyInfo omKeyInfo = createOmKeyInfo();
-    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder()
         .setAllocateBlockResponse(
@@ -69,9 +67,6 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
   @Test
   public void testAddToDBBatchWithErrorResponse() throws Exception {
     OmKeyInfo omKeyInfo = createOmKeyInfo();
-    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OMResponse omResponse = OMResponse.newBuilder()
         .setAllocateBlockResponse(
@@ -111,7 +106,7 @@ public class TestOMAllocateBlockResponse extends TestOMKeyResponse {
   @NotNull
   protected OMAllocateBlockResponse getOmAllocateBlockResponse(
           OmKeyInfo omKeyInfo, OmBucketInfo omBucketInfo,
-          OMResponse omResponse) {
+          OMResponse omResponse) throws IOException {
     return new OMAllocateBlockResponse(omResponse, omKeyInfo, clientID,
         getBucketLayout());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMAllocateBlockResponseWithFSO.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMRespo
 import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.IOException;
+
 /**
  * Tests OMAllocateBlockResponse - prefix layout.
  */
@@ -67,10 +69,11 @@ public class TestOMAllocateBlockResponseWithFSO
   @NotNull
   @Override
   protected OMAllocateBlockResponse getOmAllocateBlockResponse(
-          OmKeyInfo omKeyInfo, OmBucketInfo omBucketInfo,
-          OMResponse omResponse) {
+      OmKeyInfo omKeyInfo, OmBucketInfo omBucketInfo,
+      OMResponse omResponse) throws IOException {
     return new OMAllocateBlockResponseWithFSO(omResponse, omKeyInfo, clientID,
-            getBucketLayout());
+        getBucketLayout(), omMetadataManager.getVolumeId(volumeName),
+        omBucketInfo.getObjectID());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -38,7 +38,7 @@ import java.io.IOException;
 @SuppressWarnings("visibilitymodifier")
 public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
-  private final long volumeId = 1000;
+  private long volumeId = 1000;
 
   protected long getVolumeId() {
     return volumeId;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -38,18 +38,8 @@ import java.io.IOException;
 @SuppressWarnings("visibilitymodifier")
 public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
-  private long volumeId = 1000;
-
-  protected long getVolumeId() {
-    return volumeId;
-  }
-
   @Test
   public void testAddToDBBatch() throws Exception {
-
-    omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OmKeyInfo omKeyInfo = getOmKeyInfo();
 
@@ -129,9 +119,6 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatchOnOverwrite() throws Exception {
-    omBucketInfo = OmBucketInfo.newBuilder()
-            .setVolumeName(volumeName).setBucketName(bucketName)
-            .setCreationTime(Time.now()).build();
     OmKeyInfo omKeyInfo = getOmKeyInfo();
     keysToDelete =
             OmUtils.prepareKeyForDelete(omKeyInfo, null, 100, false);
@@ -161,7 +148,7 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
   @NotNull
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
           OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-          String ozoneKey, RepeatedOmKeyInfo deleteKeys) {
+          String ozoneKey, RepeatedOmKeyInfo deleteKeys) throws IOException {
     Assert.assertNotNull(omBucketInfo);
     return new OMKeyCommitResponse(omResponse, omKeyInfo, ozoneKey, openKey,
             omBucketInfo, deleteKeys);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -38,6 +38,12 @@ import java.io.IOException;
 @SuppressWarnings("visibilitymodifier")
 public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
+  private final long volumeId = 1000;
+
+  protected long getVolumeId() {
+    return volumeId;
+  }
+
   @Test
   public void testAddToDBBatch() throws Exception {
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponse.java
@@ -19,9 +19,7 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.OmUtils;
-import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
-import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -79,9 +77,6 @@ public class TestOMKeyCommitResponse extends TestOMKeyResponse {
 
     OmKeyInfo omKeyInfo = OMRequestTestUtils.createOmKeyInfo(volumeName,
         bucketName, keyName, replicationType, replicationFactor);
-    omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =
         OzoneManagerProtocolProtos.OMResponse.newBuilder().setCommitKeyResponse(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -40,10 +40,11 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
   @Override
   protected OMKeyCommitResponse getOmKeyCommitResponse(OmKeyInfo omKeyInfo,
       OzoneManagerProtocolProtos.OMResponse omResponse, String openKey,
-      String ozoneKey, RepeatedOmKeyInfo deleteKeys) {
+      String ozoneKey, RepeatedOmKeyInfo deleteKeys) throws IOException {
     Assert.assertNotNull(omBucketInfo);
+    long volumeId = omMetadataManager.getVolumeId(omKeyInfo.getVolumeName());
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
-        openKey, omBucketInfo, deleteKeys, getVolumeId());
+        openKey, omBucketInfo, deleteKeys, volumeId);
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCommitResponseWithFSO.java
@@ -43,7 +43,7 @@ public class TestOMKeyCommitResponseWithFSO extends TestOMKeyCommitResponse {
       String ozoneKey, RepeatedOmKeyInfo deleteKeys) {
     Assert.assertNotNull(omBucketInfo);
     return new OMKeyCommitResponseWithFSO(omResponse, omKeyInfo, ozoneKey,
-        openKey, omBucketInfo, deleteKeys);
+        openKey, omBucketInfo, deleteKeys, getVolumeId());
   }
 
   @NotNull

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -37,6 +37,12 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
  */
 public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
+  private final long volumeId = 1000;
+
+  protected long getVolumeId() {
+    return volumeId;
+  }
+
   @Test
   public void testAddToDBBatch() throws Exception {
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.ozone.om.response.key;
 
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
-import org.apache.hadoop.util.Time;
 import org.jetbrains.annotations.NotNull;
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,10 +44,6 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatch() throws Exception {
-
-    omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OmKeyInfo omKeyInfo = getOmKeyInfo();
 
@@ -77,10 +72,6 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatchWithErrorResponse() throws Exception {
-
-    omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
 
     OmKeyInfo omKeyInfo = getOmKeyInfo();
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -37,7 +37,7 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
  */
 public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
-  private final long volumeId = 1000;
+  private long volumeId = 1000;
 
   protected long getVolumeId() {
     return volumeId;

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponse.java
@@ -31,16 +31,16 @@ import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos
     .OMResponse;
 
+import java.io.IOException;
+
 
 /**
  * Tests MKeyCreateResponse.
  */
 public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
-  private long volumeId = 1000;
-
-  protected long getVolumeId() {
-    return volumeId;
+  protected long getVolumeId() throws IOException {
+    return omMetadataManager.getVolumeId(volumeName);
   }
 
   @Test
@@ -112,7 +112,7 @@ public class TestOMKeyCreateResponse extends TestOMKeyResponse {
 
   @NotNull
   protected OMKeyCreateResponse getOmKeyCreateResponse(OmKeyInfo keyInfo,
-      OmBucketInfo bucketInfo, OMResponse response) {
+      OmBucketInfo bucketInfo, OMResponse response) throws IOException {
 
     return new OMKeyCreateResponse(response, keyInfo, null, clientID,
             bucketInfo);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
@@ -60,7 +60,7 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
   @NotNull
   @Override
   protected OMKeyCreateResponse getOmKeyCreateResponse(OmKeyInfo keyInfo,
-      OmBucketInfo bucketInfo, OMResponse response) {
+      OmBucketInfo bucketInfo, OMResponse response) throws IOException {
 
     return new OMKeyCreateResponseWithFSO(response, keyInfo, new ArrayList<>(),
         clientID, bucketInfo, getVolumeId());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyCreateResponseWithFSO.java
@@ -63,7 +63,7 @@ public class TestOMKeyCreateResponseWithFSO extends TestOMKeyCreateResponse {
       OmBucketInfo bucketInfo, OMResponse response) {
 
     return new OMKeyCreateResponseWithFSO(response, keyInfo, new ArrayList<>(),
-        clientID, bucketInfo);
+        clientID, bucketInfo, getVolumeId());
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -188,7 +188,7 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
   }
 
   protected OMKeyDeleteResponse getOmKeyDeleteResponse(OmKeyInfo omKeyInfo,
-      OzoneManagerProtocolProtos.OMResponse omResponse) {
+      OzoneManagerProtocolProtos.OMResponse omResponse) throws Exception {
     return new OMKeyDeleteResponse(omResponse, omKeyInfo, true, omBucketInfo);
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponse.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.ozone.om.helpers.BucketLayout;
 import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
 import org.apache.hadoop.ozone.om.helpers.OmKeyLocationInfo;
 import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
-import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -41,15 +40,8 @@ import java.util.List;
  */
 public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
-  private OmBucketInfo omBucketInfo;
-
   @Test
   public void testAddToDBBatch() throws Exception {
-    omBucketInfo = OmBucketInfo.newBuilder()
-            .setVolumeName(volumeName).setBucketName(bucketName)
-            .setObjectID(System.currentTimeMillis())
-            .setCreationTime(Time.now()).build();
-
     String ozoneKey = addKeyToTable();
     OmKeyInfo omKeyInfo = omMetadataManager
             .getKeyTable(getBucketLayout()).get(ozoneKey);
@@ -85,11 +77,6 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatchWithNonEmptyBlocks() throws Exception {
-    omBucketInfo = OmBucketInfo.newBuilder()
-            .setVolumeName(volumeName).setBucketName(bucketName)
-            .setObjectID(System.currentTimeMillis())
-            .setCreationTime(Time.now()).build();
-
     final String ozoneKey = addKeyToTable();
     final OmKeyInfo omKeyInfo = omMetadataManager
             .getKeyTable(getBucketLayout())
@@ -146,9 +133,6 @@ public class TestOMKeyDeleteResponse extends TestOMKeyResponse {
 
   @Test
   public void testAddToDBBatchWithErrorResponse() throws Exception {
-    omBucketInfo = OmBucketInfo.newBuilder()
-            .setVolumeName(volumeName).setBucketName(bucketName)
-            .setCreationTime(Time.now()).build();
     OmKeyInfo omKeyInfo = getOmKeyInfo();
 
     OzoneManagerProtocolProtos.OMResponse omResponse =

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeyDeleteResponseWithFSO.java
@@ -33,9 +33,10 @@ public class TestOMKeyDeleteResponseWithFSO extends TestOMKeyDeleteResponse {
 
   @Override
   protected OMKeyDeleteResponse getOmKeyDeleteResponse(OmKeyInfo omKeyInfo,
-      OzoneManagerProtocolProtos.OMResponse omResponse) {
+      OzoneManagerProtocolProtos.OMResponse omResponse) throws Exception {
     return new OMKeyDeleteResponseWithFSO(omResponse, omKeyInfo.getKeyName(),
-        omKeyInfo, true, getOmBucketInfo(), false);
+        omKeyInfo, true, getOmBucketInfo(), false,
+        omMetadataManager.getVolumeId(volumeName));
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponse.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
 import org.apache.hadoop.ozone.om.response.OMClientResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
 import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
-import org.apache.hadoop.util.Time;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,16 +43,21 @@ import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.
 public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
 
 
-  private List<OmKeyInfo> omKeyInfoList;
-  private List<String> ozoneKeys;
+  private List<OmKeyInfo> omKeyInfoList = new ArrayList<>();
+  private List<String> ozoneKeys = new ArrayList<>();
 
+  protected List<OmKeyInfo> getOmKeyInfoList() {
+    return omKeyInfoList;
+  }
 
-  private void createPreRequisities() throws Exception {
+  protected List<String> getOzoneKeys() {
+    return ozoneKeys;
+  }
+
+  protected void createPreRequisities() throws Exception {
     String parent = "/user";
     String key = "key";
 
-    omKeyInfoList = new ArrayList<>();
-    ozoneKeys = new ArrayList<>();
     String ozoneKey = "";
     for (int i = 0; i < 10; i++) {
       keyName = parent.concat(key + i);
@@ -77,12 +81,8 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
             .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
                 .setStatus(true)).build();
 
-    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
-
-    OMClientResponse omKeysDeleteResponse = new OMKeysDeleteResponse(
-        omResponse, omKeyInfoList, true, omBucketInfo);
+    OMClientResponse omKeysDeleteResponse =
+        getOmKeysDeleteResponse(omResponse, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 
@@ -100,6 +100,12 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
 
   }
 
+  protected OMClientResponse getOmKeysDeleteResponse(OMResponse omResponse,
+      OmBucketInfo omBucketInfo) {
+    return new OMKeysDeleteResponse(
+        omResponse, omKeyInfoList, true, omBucketInfo);
+  }
+
   @Test
   public void testKeysDeleteResponseFail() throws Exception {
     createPreRequisities();
@@ -110,12 +116,8 @@ public class TestOMKeysDeleteResponse extends TestOMKeyResponse {
             .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
                 .setStatus(false)).build();
 
-    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
-
-    OMClientResponse omKeysDeleteResponse = new OMKeysDeleteResponse(
-        omResponse, omKeyInfoList, true, omBucketInfo);
+    OMClientResponse omKeysDeleteResponse
+        = getOmKeysDeleteResponse(omResponse, omBucketInfo);
 
     omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/key/TestOMKeysDeleteResponseWithFSO.java
@@ -1,0 +1,180 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.ozone.om.response.key;
+
+import com.google.common.base.Optional;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
+import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
+import org.apache.hadoop.ozone.om.helpers.BucketLayout;
+import org.apache.hadoop.ozone.om.helpers.OmBucketInfo;
+import org.apache.hadoop.ozone.om.helpers.OmDirectoryInfo;
+import org.apache.hadoop.ozone.om.helpers.OmKeyInfo;
+import org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo;
+import org.apache.hadoop.ozone.om.request.OMRequestTestUtils;
+import org.apache.hadoop.ozone.om.request.file.OMFileRequest;
+import org.apache.hadoop.ozone.om.response.OMClientResponse;
+import org.apache.hadoop.ozone.om.response.bucket.OMBucketDeleteResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.DeleteKeysResponse;
+import org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.OMResponse;
+import org.apache.hadoop.util.Time;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Status.OK;
+import static org.apache.hadoop.ozone.protocol.proto.OzoneManagerProtocolProtos.Type.DeleteKeys;
+
+/**
+ * Class to test OMKeysDeleteResponse with FSO bucket layout.
+ */
+public class TestOMKeysDeleteResponseWithFSO
+    extends TestOMKeysDeleteResponse {
+
+  private List<OmKeyInfo> dirDeleteList = new ArrayList<>();
+  private List<String> dirDBKeys = new ArrayList<>();
+  private long volId;
+
+  @Override
+  public BucketLayout getBucketLayout() {
+    return BucketLayout.FILE_SYSTEM_OPTIMIZED;
+  }
+
+  protected void createPreRequisities() throws Exception {
+    volId = omMetadataManager.getVolumeId(volumeName);
+    long buckId = omMetadataManager.getBucketId(volumeName, bucketName);
+
+    // Create some dir under the bucket
+    String dir = "dir1";
+    OmDirectoryInfo omDirInfo =
+        OMRequestTestUtils.createOmDirectoryInfo(dir, 5000,
+            buckId);
+    OMRequestTestUtils.addDirKeyToDirTable(false, omDirInfo,
+        volumeName, bucketName, 6001, omMetadataManager);
+    long dirId = omDirInfo.getObjectID();
+
+    String dirOzoneDBKey =
+        omMetadataManager.getOzonePathKey(volId, buckId, buckId, dir);
+    OmDirectoryInfo dirInfo =
+        omMetadataManager.getDirectoryTable().get(dirOzoneDBKey);
+
+    OmKeyInfo dirKeyInfo = OMFileRequest.getOmKeyInfo(volumeName,
+        bucketName, dirInfo, dir);
+    dirDeleteList.add(dirKeyInfo);
+    dirDBKeys.add(dirOzoneDBKey);
+
+    // create set of keys directly under the bucket
+    String ozoneDBKey = "";
+    String keyPrefix = "key";
+    for (int i = 0; i < 10; i++) {
+      keyName = keyPrefix + i;
+
+      OmKeyInfo omKeyInfo =
+          OMRequestTestUtils.createOmKeyInfo(volumeName, bucketName, keyName,
+              HddsProtos.ReplicationType.RATIS,
+              HddsProtos.ReplicationFactor.ONE, dirId + 1, buckId,
+              dirId + 1, Time.now());
+      ozoneDBKey = OMRequestTestUtils.addFileToKeyTable(false, false,
+          keyName, omKeyInfo, -1, 50, omMetadataManager);
+
+      getOmKeyInfoList().add(omKeyInfo);
+      getOzoneKeys().add(ozoneDBKey);
+    }
+  }
+
+  @Override
+  protected OMClientResponse getOmKeysDeleteResponse(OMResponse omResponse,
+      OmBucketInfo omBucketInfo) {
+    return new OMKeysDeleteResponseWithFSO(
+        omResponse, getOmKeyInfoList(), dirDeleteList, true, omBucketInfo,
+        volId);
+  }
+
+  @Test
+  public void testKeysDeleteResponseWithNoBucketExists() throws Exception {
+
+    createPreRequisities();
+
+    OMResponse omResponse =
+        OMResponse.newBuilder().setCmdType(DeleteKeys).setStatus(OK)
+            .setSuccess(true)
+            .setDeleteKeysResponse(DeleteKeysResponse.newBuilder()
+                .setStatus(true)).build();
+
+    // Simulates associated bucket deletion.
+    // Updates both table cache and DB.
+    deleteBucket();
+
+    OMClientResponse omKeysDeleteResponse =
+        getOmKeysDeleteResponse(omResponse, omBucketInfo);
+
+    omKeysDeleteResponse.checkAndUpdateDB(omMetadataManager, batchOperation);
+
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+    for (String ozKey : getOzoneKeys()) {
+      Assert.assertNull(
+          omMetadataManager.getKeyTable(getBucketLayout()).get(ozKey));
+
+      // ozKey had no block information associated with it, so it should have
+      // been removed from the file table but not added to the delete table.
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(ozKey);
+      Assert.assertNull(repeatedOmKeyInfo);
+    }
+
+    for (String dirDBKey : dirDBKeys) {
+      Assert.assertNull(
+          omMetadataManager.getDirectoryTable().get(dirDBKey));
+
+      // dir deleted from DirTable
+      RepeatedOmKeyInfo repeatedOmKeyInfo =
+          omMetadataManager.getDeletedTable().get(dirDBKey);
+      Assert.assertNull(repeatedOmKeyInfo);
+
+      // dir added to the deleted dir table, for deep cleanups
+      OmKeyInfo omDirInfo =
+          omMetadataManager.getDeletedDirTable().get(dirDBKey);
+      Assert.assertNotNull(omDirInfo);
+    }
+
+  }
+
+  private void deleteBucket() throws IOException {
+    omMetadataManager.getBucketTable().addCacheEntry(
+        new CacheKey<>(omMetadataManager.getBucketKey(volumeName, bucketName)),
+        new CacheValue<>(Optional.absent(), 10001));
+
+    OMBucketDeleteResponse omBucketDeleteResponse =
+        new OMBucketDeleteResponse(OMResponse.newBuilder()
+            .setCmdType(OzoneManagerProtocolProtos.Type.DeleteBucket)
+            .setStatus(OzoneManagerProtocolProtos.Status.OK)
+            .setDeleteBucketResponse(
+                OzoneManagerProtocolProtos.DeleteBucketResponse
+                    .getDefaultInstance()).build(),
+            volumeName, bucketName);
+
+    omBucketDeleteResponse.addToDBBatch(omMetadataManager, batchOperation);
+    // Do manual commit and see whether addToBatch is successful or not.
+    omMetadataManager.getStore().commitBatchOperation(batchOperation);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3InitiateMultipartUploadResponseWithFSO.java
@@ -56,9 +56,13 @@ public class TestS3InitiateMultipartUploadResponseWithFSO
     long parentID = 1027; // assume objectID of dir path "a/b/c/d" is 1027
     List<OmDirectoryInfo> parentDirInfos = new ArrayList<>();
 
+    final long volumeId = omMetadataManager.getVolumeId(volumeName);
+    final long bucketId = omMetadataManager.getBucketId(volumeName,
+        bucketName);
+
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
-            createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
-                    keyName, multipartUploadID, parentDirInfos);
+        createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
+            keyName, multipartUploadID, parentDirInfos, volumeId, bucketId);
 
     s3InitiateMultipartUploadResponseFSO.addToDBBatch(omMetadataManager,
         batchOperation);
@@ -69,9 +73,7 @@ public class TestS3InitiateMultipartUploadResponseWithFSO
     String multipartKey = omMetadataManager
         .getMultipartKey(volumeName, bucketName, keyName, multipartUploadID);
 
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+
 
     String multipartOpenKey = omMetadataManager
         .getMultipartKey(volumeId, bucketId, parentID,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -317,7 +317,7 @@ public class TestS3MultipartResponse {
 
     return new S3MultipartUploadCompleteResponseWithFSO(omResponse,
         multipartKey, multipartOpenKey, omKeyInfo, unUsedParts,
-        getBucketLayout(), omBucketInfo, keysToDelete);
+        getBucketLayout(), omBucketInfo, keysToDelete, volumeId);
   }
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartResponse.java
@@ -124,8 +124,9 @@ public class TestS3MultipartResponse {
                 .setKeyName(keyName)
                 .setMultipartUploadID(multipartUploadID)).build();
 
+    // some volID and buckID as these values are not used in legacy buckets
     return getS3InitiateMultipartUploadResp(multipartKeyInfo, omKeyInfo,
-        omResponse);
+        omResponse, -1, -1);
   }
 
   public S3MultipartUploadAbortResponse createS3AbortMPUResponse(
@@ -188,9 +189,11 @@ public class TestS3MultipartResponse {
             .setFactor(HddsProtos.ReplicationFactor.ONE).build()).build();
   }
 
+  @SuppressWarnings("parameternumber")
   public S3InitiateMultipartUploadResponse createS3InitiateMPUResponseFSO(
       String volumeName, String bucketName, long parentID, String keyName,
-      String multipartUploadID, List<OmDirectoryInfo> parentDirInfos) {
+      String multipartUploadID, List<OmDirectoryInfo> parentDirInfos,
+      long volumeId, long bucketId) {
     OmMultipartKeyInfo multipartKeyInfo = new OmMultipartKeyInfo.Builder()
             .setUploadID(multipartUploadID)
             .setCreationTime(Time.now())
@@ -230,7 +233,8 @@ public class TestS3MultipartResponse {
         keyName, multipartUploadID);
 
     return new S3InitiateMultipartUploadResponseWithFSO(omResponse,
-        multipartKeyInfo, omKeyInfo, mpuKey, parentDirInfos, getBucketLayout());
+        multipartKeyInfo, omKeyInfo, mpuKey, parentDirInfos, getBucketLayout(),
+        volumeId, bucketId);
   }
 
   @SuppressWarnings("checkstyle:ParameterNumber")
@@ -322,7 +326,7 @@ public class TestS3MultipartResponse {
 
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(
       OmMultipartKeyInfo multipartKeyInfo, OmKeyInfo omKeyInfo,
-      OMResponse omResponse) {
+      OMResponse omResponse, long volumeId, long bucketId) {
     return new S3InitiateMultipartUploadResponse(omResponse, multipartKeyInfo,
         omKeyInfo, getBucketLayout());
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponse.java
@@ -55,12 +55,13 @@ public class TestS3MultipartUploadAbortResponse
     String multipartKey = omMetadataManager.getMultipartKey(volumeName,
         bucketName, keyName, multipartUploadID);
 
-    OmBucketInfo omBucketInfo = OmBucketInfo.newBuilder()
-        .setVolumeName(volumeName).setBucketName(bucketName)
-        .setCreationTime(Time.now()).build();
+    String buckDBKey = omMetadataManager.getBucketKey(volumeName, bucketName);
+    OmBucketInfo omBucketInfo =
+        omMetadataManager.getBucketTable().get(buckDBKey);
+    long volumeId = omMetadataManager.getVolumeId(volumeName);
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponse =
         getS3InitiateMultipartUploadResponse(volumeName, bucketName, keyName,
-            multipartUploadID);
+            multipartUploadID, volumeId, omBucketInfo.getObjectID());
 
     s3InitiateMultipartUploadResponse.addToDBBatch(omMetadataManager,
         batchOperation);
@@ -99,7 +100,7 @@ public class TestS3MultipartUploadAbortResponse
   protected S3InitiateMultipartUploadResponse
         getS3InitiateMultipartUploadResponse(
       String volumeName, String bucketName, String keyName,
-      String multipartUploadID) {
+      String multipartUploadID, long volumeId, long bucketId) {
     return createS3InitiateMPUResponse(volumeName, bucketName, keyName,
         multipartUploadID);
   }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadAbortResponseWithFSO.java
@@ -64,7 +64,8 @@ public class TestS3MultipartUploadAbortResponseWithFSO
   @Override
   protected S3InitiateMultipartUploadResponse getS3InitiateMultipartUploadResp(
       OmMultipartKeyInfo multipartKeyInfo, OmKeyInfo omKeyInfo,
-      OzoneManagerProtocolProtos.OMResponse omResponse) {
+      OzoneManagerProtocolProtos.OMResponse omResponse, long volumeId,
+      long bucketId) {
 
     String mpuDBKey =
         omMetadataManager.getMultipartKey(omKeyInfo.getVolumeName(),
@@ -73,17 +74,17 @@ public class TestS3MultipartUploadAbortResponseWithFSO
 
     return new S3InitiateMultipartUploadResponseWithFSO(omResponse,
         multipartKeyInfo, omKeyInfo, mpuDBKey, new ArrayList<>(),
-        getBucketLayout());
+        getBucketLayout(), volumeId, bucketId);
   }
 
   @Override
   protected S3InitiateMultipartUploadResponse
       getS3InitiateMultipartUploadResponse(
       String volumeName, String bucketName, String keyName,
-      String multipartUploadID) {
+      String multipartUploadID, long volumeId, long bucketId) {
     return createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
         keyName,
-        multipartUploadID, new ArrayList<>());
+        multipartUploadID, new ArrayList<>(), volumeId, bucketId);
   }
 
   @Override

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCommitPartResponseWithFSO.java
@@ -100,10 +100,13 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
     String fileName = OzoneFSUtils.getFileName(keyName);
     String multipartKey = omMetadataManager
         .getMultipartKey(volumeName, bucketName, keyName, multipartUploadID);
+    final long volumeId = omMetadataManager.getVolumeId(volumeName);
+    final long bucketId = omMetadataManager.getBucketId(volumeName,
+        bucketName);
 
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
-            createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
-                    keyName, multipartUploadID, new ArrayList<>());
+        createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
+            keyName, multipartUploadID, new ArrayList<>(), volumeId, bucketId);
 
     s3InitiateMultipartUploadResponseFSO.addToDBBatch(omMetadataManager,
             batchOperation);
@@ -120,9 +123,7 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
     addPart(1, part1, omMultipartKeyInfo);
 
     long clientId = Time.now();
-    final long volumeId = omMetadataManager.getVolumeId(volumeName);
-    final long bucketId = omMetadataManager.getBucketId(volumeName,
-            bucketName);
+
     String openKey = omMetadataManager.getOpenFileName(volumeId, bucketId,
             parentID, fileName, clientId);
 
@@ -181,8 +182,8 @@ public class TestS3MultipartUploadCommitPartResponseWithFSO
             parentID, fileName, multipartUploadID);
 
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
-            createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
-                    keyName, multipartUploadID, new ArrayList<>());
+        createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
+            keyName, multipartUploadID, new ArrayList<>(), volumeId, bucketId);
 
     s3InitiateMultipartUploadResponseFSO.addToDBBatch(omMetadataManager,
             batchOperation);

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/response/s3/multipart/TestS3MultipartUploadCompleteResponseWithFSO.java
@@ -74,7 +74,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
     List<OmDirectoryInfo> parentDirInfos = new ArrayList<>();
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
         createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
-            keyName, multipartUploadID, parentDirInfos);
+            keyName, multipartUploadID, parentDirInfos, volumeId, bucketId);
 
     s3InitiateMultipartUploadResponseFSO.addToDBBatch(omMetadataManager,
         batchOperation);
@@ -206,7 +206,7 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
             addS3InitiateMultipartUpload(volumeName, bucketName, keyName,
-                    multipartUploadID);
+                    multipartUploadID, volumeId, bucketId);
 
     // Add some dummy parts for testing.
     // Not added any key locations, as this just test is to see entries are
@@ -313,11 +313,13 @@ public class TestS3MultipartUploadCompleteResponseWithFSO
 
   private S3InitiateMultipartUploadResponse addS3InitiateMultipartUpload(
           String volumeName, String bucketName, String keyName,
-          String multipartUploadID) throws IOException {
+          String multipartUploadID, long volumeId,
+          long bucketId) throws IOException {
 
     S3InitiateMultipartUploadResponse s3InitiateMultipartUploadResponseFSO =
-            createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
-                    keyName, multipartUploadID, new ArrayList<>());
+        createS3InitiateMPUResponseFSO(volumeName, bucketName, parentID,
+            keyName, multipartUploadID, new ArrayList<>(), volumeId,
+            bucketId);
 
     s3InitiateMultipartUploadResponseFSO.addToDBBatch(omMetadataManager,
             batchOperation);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Race condition between async thread `OzoneManagerDoubleBuffer.flushTransactions()` and BucketDeleteRequest:

**Case:**
While processing `OMKeysDeleteResponseWithFSO` by  the `OzoneManagerDoubleBuffer.flushTransactions()` thread, response logic constructs "buck_Id" by querying BucketTable. Assume during this time, `DELETE_BUCKET`  request for this bucket "buck_Id" has been processed and updated the DB. Now, `OMKeysDeleteResponseWithFSO` will not see the bucket and throws NPE.

**More Details:**
OzoneClient: deleteBucket with recursive flag = true. Now, ozone client will splits this user call to multiple RPC calls to OM.
step-1)List paths and deleteObjects.
step-2)Finally deleteBucket

**Preventive Action:**
Action-1) Revisited all the Response classes. VolumeId and bucketId should be passed to all *Response* objects before sending response back to the client. This will avoid fetch bucketId from DB again and avoids NPE.
Action-2) Validated bucketInfo and volumeInfo for the non-existent case and throws OMException.
long getVolumeId(String volume) throws IOException;
long getBucketId(String volume, String bucket) throws IOException;

```
2022-06-22 11:53:30,901 Deleted all the keys and responded back to the ozone client after adding an OMKeysDeleteResponseWithFSO entry to the OzoneManagerDoubleBuffer
2022-06-22 11:53:30,905  DeleteBucket call came for the  "vol_Id/buck_Id" and responded back to ozone client after adding an OMKeysDeleteResponseWithFSO entry to the OzoneManagerDoubleBuffer
2022-06-22 11:53:30,907 OzoneManagerDoubleBuffer#flushTransactions  kicked in and picks up OMKeysDeleteResponseWithFSO entry. While processing it tries to construct "vol_Id/buck_Id/prefixId" inorder to delete the path from DirTable & FileTable.
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6934

## How was this patch tested?

Added test cases.
