### PR TITLE
HDDS-6699. EC: ReplicationManager - collect under and over replicated containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthCheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthCheck.java
@@ -16,8 +16,6 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
@@ -32,7 +30,6 @@ public interface ContainerHealthCheck {
 
   ContainerHealthResult checkHealth(
       ContainerInfo container, Set<ContainerReplica> replicas,
-      List<Pair<Integer, DatanodeDetails>> indexesPendingAdd,
-      List<Pair<Integer, DatanodeDetails>> indexesPendingDelete,
+      List<ContainerReplicaOp> replicaPendingOps,
       int remainingRedundancyForMaintenance);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerReplicaOp.java
@@ -36,6 +36,12 @@ public class ContainerReplicaOp {
   private int replicaIndex;
   private long scheduledEpochMillis;
 
+  public static ContainerReplicaOp create(PendingOpType opType,
+      DatanodeDetails target, int replicaIndex) {
+    return new ContainerReplicaOp(opType, target, replicaIndex,
+        System.currentTimeMillis());
+  }
+
   public ContainerReplicaOp(PendingOpType opType,
       DatanodeDetails target, int replicaIndex, long scheduledTime) {
     this.opType = opType;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -404,7 +404,6 @@ public class LegacyReplicationManager {
         final Set<ContainerReplica> replicas = containerManager
             .getContainerReplicas(id);
         final LifeCycleState state = container.getState();
-        report.increment(state);
 
         /*
          * We don't take any action if the container is in OPEN state and

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -39,7 +38,6 @@ import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMHAManager;
 import org.apache.hadoop.hdds.scm.ha.SCMService;
-import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
@@ -150,7 +148,6 @@ public class ReplicationManager implements SCMService {
              final PlacementPolicy containerPlacement,
              final EventPublisher eventPublisher,
              final SCMContext scmContext,
-             final SCMServiceManager serviceManager,
              final NodeManager nodeManager,
              final Clock clock,
              final SCMHAManager scmhaManager,
@@ -174,11 +171,6 @@ public class ReplicationManager implements SCMService {
         conf, containerManager, containerPlacement, eventPublisher,
         scmContext, nodeManager, scmhaManager, clock, moveTable);
     this.ecContainerHealthCheck = new ECContainerHealthCheck();
-
-    // register ReplicationManager to SCMServiceManager.
-    serviceManager.register(this);
-
-    // start ReplicationManager.
     start();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -150,8 +150,7 @@ public class ReplicationManager implements SCMService {
              final SCMContext scmContext,
              final NodeManager nodeManager,
              final Clock clock,
-             final SCMHAManager scmhaManager,
-             final Table<ContainerID, MoveDataNodePair> moveTable,
+             final LegacyReplicationManager legacyReplicationManager,
              final ContainerReplicaPendingOps replicaPendingOps)
              throws IOException {
     this.containerManager = containerManager;
@@ -167,9 +166,7 @@ public class ReplicationManager implements SCMService {
         HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT_DEFAULT,
         TimeUnit.MILLISECONDS);
     this.containerReplicaPendingOps = replicaPendingOps;
-    this.legacyReplicationManager = new LegacyReplicationManager(
-        conf, containerManager, containerPlacement, eventPublisher,
-        scmContext, nodeManager, scmhaManager, clock, moveTable);
+    this.legacyReplicationManager = legacyReplicationManager;
     this.ecContainerHealthCheck = new ECContainerHealthCheck();
     start();
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -714,13 +714,13 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           containerPlacementPolicy,
           eventQueue,
           scmContext,
-          serviceManager,
           scmNodeManager,
           clock,
           scmHAManager,
           getScmMetadataStore().getMoveTable(),
           containerReplicaPendingOps);
     }
+    serviceManager.register(replicationManager);
     if (configurator.getScmSafeModeManager() != null) {
       scmSafeModeManager = configurator.getScmSafeModeManager();
     } else {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/StorageContainerManager.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaPendingOps;
+import org.apache.hadoop.hdds.scm.container.replication.LegacyReplicationManager;
 import org.apache.hadoop.hdds.scm.crl.CRLStatusReportHandler;
 import org.apache.hadoop.hdds.scm.ha.BackgroundSCMService;
 import org.apache.hadoop.hdds.scm.ha.HASecurityUtils;
@@ -708,6 +709,10 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
     if (configurator.getReplicationManager() != null) {
       replicationManager = configurator.getReplicationManager();
     }  else {
+      LegacyReplicationManager legacyRM = new LegacyReplicationManager(
+          conf, containerManager, containerPlacementPolicy, eventQueue,
+          scmContext, scmNodeManager, scmHAManager, clock,
+          getScmMetadataStore().getMoveTable());
       replicationManager = new ReplicationManager(
           conf,
           containerManager,
@@ -716,8 +721,7 @@ public final class StorageContainerManager extends ServiceRuntimeInfoImpl
           scmContext,
           scmNodeManager,
           clock,
-          scmHAManager,
-          getScmMetadataStore().getMoveTable(),
+          legacyRM,
           containerReplicaPendingOps);
     }
     serviceManager.register(replicationManager);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+
+/**
+ * Helper class to provide common methods used to test ReplicationManager.
+ */
+public final class ReplicationTestUtil {
+
+  private ReplicationTestUtil() {
+  }
+
+  public static Set<ContainerReplica> createReplicas(ContainerID containerID,
+      Pair<HddsProtos.NodeOperationalState, Integer>... nodes) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (Pair<HddsProtos.NodeOperationalState, Integer> p : nodes) {
+      replicas.add(
+          createContainerReplica(containerID, p.getRight(), p.getLeft()));
+    }
+    return replicas;
+  }
+
+  public static Set<ContainerReplica> createReplicas(ContainerID containerID,
+      int... indexes) {
+    Set<ContainerReplica> replicas = new HashSet<>();
+    for (int i : indexes) {
+      replicas.add(createContainerReplica(
+          containerID, i, IN_SERVICE));
+    }
+    return replicas;
+  }
+
+  public static ContainerReplica createContainerReplica(ContainerID containerID,
+      int replicaIndex, HddsProtos.NodeOperationalState opState) {
+    ContainerReplica.ContainerReplicaBuilder builder
+        = ContainerReplica.newBuilder();
+    DatanodeDetails datanodeDetails
+        = MockDatanodeDetails.randomDatanodeDetails();
+    datanodeDetails.setPersistedOpState(opState);
+    builder.setContainerID(containerID);
+    builder.setReplicaIndex(replicaIndex);
+    builder.setKeyCount(123);
+    builder.setBytesUsed(1234);
+    builder.setContainerState(StorageContainerDatanodeProtocolProtos
+        .ContainerReplicaProto.State.CLOSED);
+    builder.setDatanodeDetails(datanodeDetails);
+    builder.setSequenceId(0);
+    builder.setOriginNodeId(datanodeDetails.getUuid());
+    return builder.build();
+  }
+
+  public static ContainerInfo createContainerInfo(ReplicationConfig repConfig) {
+    return createContainerInfo(repConfig, 1, HddsProtos.LifeCycleState.CLOSED);
+  }
+
+  public static ContainerInfo createContainerInfo(
+      ReplicationConfig replicationConfig, long containerID,
+      HddsProtos.LifeCycleState containerState) {
+    ContainerInfo.Builder builder = new ContainerInfo.Builder();
+    builder.setContainerID(containerID);
+    builder.setOwner("Ozone");
+    builder.setPipelineID(PipelineID.randomId());
+    builder.setReplicationConfig(replicationConfig);
+    builder.setState(containerState);
+    return builder.build();
+  }
+
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerHealthCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerHealthCheck.java
@@ -18,18 +18,12 @@ package org.apache.hadoop.hdds.scm.container.replication;
 
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
-import org.apache.hadoop.hdds.client.ReplicationConfig;
-import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
-import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
-import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
-import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.OverReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.UnderReplicatedHealthResult;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerHealthResult.HealthState;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -37,7 +31,6 @@ import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -47,6 +40,8 @@ import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalSt
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.ADD;
 import static org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaOp.PendingOpType.DELETE;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 
 /**
  * Tests for the ECContainerHealthCheck class.
@@ -223,54 +218,4 @@ public class TestECContainerHealthCheck {
         ((UnderReplicatedHealthResult)result).getRemainingRedundancy());
   }
 
-
-  private Set<ContainerReplica> createReplicas(ContainerID containerID,
-      Pair<HddsProtos.NodeOperationalState, Integer>... nodes) {
-    Set<ContainerReplica> replicas = new HashSet<>();
-    for (Pair<HddsProtos.NodeOperationalState, Integer> p : nodes) {
-      replicas.add(
-          createContainerReplica(containerID, p.getRight(), p.getLeft()));
-    }
-    return replicas;
-  }
-
-  private Set<ContainerReplica> createReplicas(ContainerID containerID,
-      int... indexes) {
-    Set<ContainerReplica> replicas = new HashSet<>();
-    for (int i : indexes) {
-      replicas.add(createContainerReplica(
-          containerID, i, IN_SERVICE));
-    }
-    return replicas;
-  }
-
-  private ContainerReplica createContainerReplica(ContainerID containerID,
-      int replicaIndex, HddsProtos.NodeOperationalState opState) {
-    ContainerReplica.ContainerReplicaBuilder builder
-        = ContainerReplica.newBuilder();
-    DatanodeDetails datanodeDetails
-        = MockDatanodeDetails.randomDatanodeDetails();
-    datanodeDetails.setPersistedOpState(opState);
-    builder.setContainerID(containerID);
-    builder.setReplicaIndex(replicaIndex);
-    builder.setKeyCount(123);
-    builder.setBytesUsed(1234);
-    builder.setContainerState(StorageContainerDatanodeProtocolProtos
-        .ContainerReplicaProto.State.CLOSED);
-    builder.setDatanodeDetails(datanodeDetails);
-    builder.setSequenceId(0);
-    builder.setOriginNodeId(datanodeDetails.getUuid());
-    return builder.build();
-  }
-
-  private ContainerInfo createContainerInfo(
-      ReplicationConfig replicationConfig) {
-    ContainerInfo.Builder builder = new ContainerInfo.Builder();
-    builder.setContainerID(1);
-    builder.setOwner("Ozone");
-    builder.setPipelineID(PipelineID.randomId());
-    builder.setReplicationConfig(replicationConfig);
-    builder.setState(HddsProtos.LifeCycleState.CLOSED);
-    return builder.build();
-  }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -213,6 +213,7 @@ public class TestLegacyReplicationManager {
     clock = new TestClock(Instant.now(), ZoneId.of("UTC"));
     containerReplicaPendingOps = new ContainerReplicaPendingOps(conf, clock);
     createReplicationManager(new ReplicationManagerConfiguration());
+    serviceManager.register(replicationManager);
   }
 
   void createReplicationManager(int replicationLimit, int deletionLimit)
@@ -256,17 +257,20 @@ public class TestLegacyReplicationManager {
     dbStore = DBStoreBuilder.createDBStore(
       config, new SCMDBDefinition());
 
+    LegacyReplicationManager legacyRM = new LegacyReplicationManager(
+        config, containerManager, containerPlacementPolicy, eventQueue,
+        SCMContext.emptyContext(), nodeManager, scmHAManager, clock,
+        SCMDBDefinition.MOVE.getTable(dbStore));
+
     replicationManager = new ReplicationManager(
         config,
         containerManager,
         containerPlacementPolicy,
         eventQueue,
         SCMContext.emptyContext(),
-        serviceManager,
         nodeManager,
         clock,
-        scmHAManager,
-        SCMDBDefinition.MOVE.getTable(dbStore),
+        legacyRM,
         containerReplicaPendingOps);
 
     serviceManager.notifyStatusChanged();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -113,7 +113,7 @@ import static org.mockito.Mockito.when;
 /**
  * Test cases to verify the functionality of ReplicationManager.
  */
-public class TestReplicationManager {
+public class TestLegacyReplicationManager {
 
   private ReplicationManager replicationManager;
   private ContainerStateManager containerStateManager;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -1,0 +1,265 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.PlacementPolicy;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.container.ContainerManager;
+import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
+import org.apache.hadoop.hdds.scm.container.ContainerReplica;
+import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.ozone.test.TestClock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
+import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
+
+/**
+ * Tests for the ReplicationManager.
+ */
+public class TestReplicationManager {
+
+  private OzoneConfiguration configuration;
+  private ReplicationManager replicationManager;
+  private LegacyReplicationManager legacyReplicationManager;
+  private ContainerManager containerManager;
+  private PlacementPolicy placementPolicy;
+  private EventPublisher eventPublisher;
+  private SCMContext scmContext;
+  private NodeManager nodeManager;
+  private TestClock clock;
+  private ContainerReplicaPendingOps containerReplicaPendingOps;
+
+  private Map<ContainerID, Set<ContainerReplica>> containerReplicaMap;
+  private ReplicationConfig repConfig;
+  private ReplicationManagerReport repReport;
+  private List<ContainerHealthResult.UnderReplicatedHealthResult> underRep;
+  private List<ContainerHealthResult.OverReplicatedHealthResult> overRep;
+
+  @Before
+  public void setup() throws IOException {
+    configuration = new OzoneConfiguration();
+    configuration.set(HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT, "0s");
+    containerManager = Mockito.mock(ContainerManager.class);
+    placementPolicy = Mockito.mock(PlacementPolicy.class);
+    eventPublisher = Mockito.mock(EventPublisher.class);
+    scmContext = Mockito.mock(SCMContext.class);
+    nodeManager = Mockito.mock(NodeManager.class);
+    legacyReplicationManager = Mockito.mock(LegacyReplicationManager.class);
+    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    containerReplicaPendingOps =
+        new ContainerReplicaPendingOps(configuration, clock);
+
+    Mockito.when(containerManager
+        .getContainerReplicas(Mockito.any(ContainerID.class))).thenAnswer(
+          invocation -> {
+            ContainerID cid = invocation.getArgument(0);
+            return containerReplicaMap.get(cid);
+          });
+
+    replicationManager = new ReplicationManager(
+        configuration,
+        containerManager,
+        placementPolicy,
+        eventPublisher,
+        scmContext,
+        nodeManager,
+        clock,
+        legacyReplicationManager,
+        containerReplicaPendingOps);
+    containerReplicaMap = new HashMap<>();
+    repConfig = new ECReplicationConfig(3, 2);
+    repReport = new ReplicationManagerReport();
+    underRep = new ArrayList<>();
+    overRep = new ArrayList<>();
+  }
+
+  @Test
+  public void testHealthyContainer() throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 4, 5);
+
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.HEALTHY,
+        result.getHealthState());
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+  }
+
+  @Test
+  public void testUnderReplicatedContainer() throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 4);
+
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  @Test
+  public void testUnderReplicatedContainerFixedByPending()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 4);
+    containerReplicaPendingOps.scheduleAddReplica(container.containerID(),
+        MockDatanodeDetails.randomDatanodeDetails(), 5);
+
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    // As the pending replication fixes the under replication, nothing is added
+    // to the under replication list.
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+    Assert.assertTrue(((ContainerHealthResult.UnderReplicatedHealthResult)
+        result).isSufficientlyReplicatedAfterPending());
+    // As the container is still under replicated, as the pending have not
+    // completed yet, the container is still marked as under-replciated in the
+    // report.
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+  }
+
+  @Test
+  public void testUnderReplicatedAndUnrecoverable()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2);
+
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    // If it is unrecoverable, there is no point in putting it into the under
+    // replication list. It will be checked again on the next RM run.
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.MISSING));
+  }
+
+  @Test
+  public void testUnderAndOverReplicated()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 5, 5);
+
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    // If it is both under and over replicated, we set it to the most important
+    // state, which is under-replicated. When that is fixed, over replication
+    // will be handled.
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNDER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(1, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.UNDER_REPLICATED));
+    Assert.assertEquals(0, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+  }
+
+  @Test
+  public void testOverReplicated() throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 4, 5, 5);
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(1, overRep.size());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+  }
+
+  @Test
+  public void testOverReplicatedFixByPending()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(container, 1, 2, 3, 4, 5, 5);
+    containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(),
+        MockDatanodeDetails.randomDatanodeDetails(), 5);
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
+        result.getHealthState());
+    Assert.assertEquals(0, underRep.size());
+    // If the pending replication fixes the over-replication, nothing is added
+    // to the over replication list.
+    Assert.assertEquals(0, overRep.size());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OVER_REPLICATED));
+  }
+
+  private Set<ContainerReplica> addReplicas(ContainerInfo container,
+      Pair<HddsProtos.NodeOperationalState, Integer>... nodes) {
+    final Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), nodes);
+    containerReplicaMap.put(container.containerID(), replicas);
+    return replicas;
+  }
+
+  private Set<ContainerReplica> addReplicas(ContainerInfo container,
+      int... indexes) {
+    final Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), indexes);
+    containerReplicaMap.put(container.containerID(), replicas);
+    return replicas;
+  }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Scan all containers in Replication Manager. For the EC containers, pass them to the EcContainerHealthCheck class to allow their health to be check. For any under or over replicated containers add them a list which later will be sorted by priority and turned into a queue for subsequent stages of the RM processing.

## What is the link to the Apache JIRA

[ec-HDDS-6699](https://issues.apache.org/jira/browse/HDDS-6699)

## How was this patch tested?

New unit tests
