### PR TITLE
HDDS-6943. Linked bucket layout types changes on setQuota

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/basic/links.robot
@@ -157,3 +157,10 @@ Source bucket not affected by deleting link
                         Should Not Contain          ${bucket_list}    link1
     ${source_list} =    Execute                     ozone sh key list ${source}/bucket1 | jq -r '.[].name'
                         Should Contain              ${source_list}    key1
+
+Setting bucket property on link not allowed
+                        Execute                     ozone sh bucket link ${source}/bucket1 ${target}/link4
+    ${result} =         Execute And Ignore Error    ozone sh bucket setquota ${target}/link4 --quota 1GB
+                        Should Contain              ${result}    NOT_SUPPORTED_OPERATION
+    ${result} =         Execute                     ozone sh bucket info ${target}/link4
+                        Should Contain              ${result}            sourceBucket

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/bucket/OMBucketSetPropertyRequest.java
@@ -143,6 +143,11 @@ public class OMBucketSetPropertyRequest extends OMClientRequest {
             OMException.ResultCodes.BUCKET_NOT_FOUND);
       }
 
+      if (dbBucketInfo.isLink()) {
+        throw new OMException("Cannot set property on link",
+            OMException.ResultCodes.NOT_SUPPORTED_OPERATION);
+      }
+
       OmBucketInfo.Builder bucketInfoBuilder = OmBucketInfo.newBuilder();
       bucketInfoBuilder.setVolumeName(dbBucketInfo.getVolumeName())
           .setBucketName(dbBucketInfo.getBucketName())

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/OMRequestTestUtils.java
@@ -483,13 +483,23 @@ public final class OMRequestTestUtils {
   public static void addBucketToDB(String volumeName, String bucketName,
       OMMetadataManager omMetadataManager, BucketLayout bucketLayout)
       throws Exception {
-
-    OmBucketInfo omBucketInfo =
+    addBucketToDB(omMetadataManager,
         OmBucketInfo.newBuilder().setVolumeName(volumeName)
-                .setBucketName(bucketName)
-                .setObjectID(System.currentTimeMillis())
-                .setCreationTime(Time.now())
-                .setBucketLayout(bucketLayout).build();
+            .setBucketName(bucketName)
+            .setBucketLayout(bucketLayout)
+    );
+  }
+
+  public static void addBucketToDB(OMMetadataManager omMetadataManager,
+      OmBucketInfo.Builder builder) throws Exception {
+
+    OmBucketInfo omBucketInfo = builder
+        .setObjectID(System.currentTimeMillis())
+        .setCreationTime(Time.now())
+        .build();
+
+    String volumeName = omBucketInfo.getVolumeName();
+    String bucketName = omBucketInfo.getBucketName();
 
     // Add to cache.
     omMetadataManager.getBucketTable().addCacheEntry(


### PR DESCRIPTION
## What changes were proposed in this pull request?

Reject property change requests on link buckets, as quota, layout, etc. are not applicable.

https://issues.apache.org/jira/browse/HDDS-6943

## How was this patch tested?

Added unit test:
https://github.com/adoroszlai/hadoop-ozone/runs/7040743390#step:5:1962

and acceptance test:
https://github.com/adoroszlai/hadoop-ozone/runs/7041017030#step:5:138