### PR TITLE
HDDS-6725. Close Rocks objects properly in StorageContainerManager

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManager.java
@@ -1934,19 +1934,20 @@ public class LegacyReplicationManager {
     }
 
     private void initialize() throws IOException {
-      TableIterator<ContainerID,
-          ? extends Table.KeyValue<ContainerID, MoveDataNodePair>>
-          iterator = moveTable.iterator();
+      try (TableIterator<ContainerID,
+          ? extends Table.KeyValue<ContainerID, MoveDataNodePair>> iterator =
+               moveTable.iterator()) {
 
-      while (iterator.hasNext()) {
-        Table.KeyValue<ContainerID, MoveDataNodePair> kv = iterator.next();
-        final ContainerID cid = kv.getKey();
-        final MoveDataNodePair mp = kv.getValue();
-        Preconditions.assertNotNull(cid,
-            "moved container id should not be null");
-        Preconditions.assertNotNull(mp,
-            "MoveDataNodePair container id should not be null");
-        inflightMove.put(cid, mp);
+        while (iterator.hasNext()) {
+          Table.KeyValue<ContainerID, MoveDataNodePair> kv = iterator.next();
+          final ContainerID cid = kv.getKey();
+          final MoveDataNodePair mp = kv.getValue();
+          Preconditions.assertNotNull(cid,
+              "moved container id should not be null");
+          Preconditions.assertNotNull(mp,
+              "MoveDataNodePair container id should not be null");
+          inflightMove.put(cid, mp);
+        }
       }
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SequenceIdGenerator.java
@@ -262,19 +262,19 @@ public class SequenceIdGenerator {
     }
 
     private void initialize() throws IOException {
-      TableIterator<String,
-          ? extends Table.KeyValue<String, Long>>
-          iterator = sequenceIdTable.iterator();
+      try (TableIterator<String, ? extends Table.KeyValue<String, Long>>
+          iterator = sequenceIdTable.iterator()) {
 
-      while (iterator.hasNext()) {
-        Table.KeyValue<String, Long> kv = iterator.next();
-        final String sequenceIdName = kv.getKey();
-        final Long lastId = kv.getValue();
-        Preconditions.checkNotNull(sequenceIdName,
-            "sequenceIdName should not be null");
-        Preconditions.checkNotNull(lastId,
-            "lastId should not be null");
-        sequenceIdToLastIdMap.put(sequenceIdName, lastId);
+        while (iterator.hasNext()) {
+          Table.KeyValue<String, Long> kv = iterator.next();
+          final String sequenceIdName = kv.getKey();
+          final Long lastId = kv.getValue();
+          Preconditions.checkNotNull(sequenceIdName,
+              "sequenceIdName should not be null");
+          Preconditions.checkNotNull(lastId,
+              "lastId should not be null");
+          sequenceIdToLastIdMap.put(sequenceIdName, lastId);
+        }
       }
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelineStateManagerImpl.java
@@ -78,12 +78,14 @@ public class PipelineStateManagerImpl implements PipelineStateManager {
       LOG.info("No pipeline exists in current db");
       return;
     }
-    TableIterator<PipelineID, ? extends Table.KeyValue<PipelineID, Pipeline>>
-        iterator = pipelineStore.iterator();
-    while (iterator.hasNext()) {
-      Pipeline pipeline = iterator.next().getValue();
-      pipelineStateMap.addPipeline(pipeline);
-      nodeManager.addPipeline(pipeline);
+    try (TableIterator<PipelineID,
+        ? extends Table.KeyValue<PipelineID, Pipeline>> iterator =
+             pipelineStore.iterator()) {
+      while (iterator.hasNext()) {
+        Pipeline pipeline = iterator.next().getValue();
+        pipelineStateMap.addPipeline(pipeline);
+        nodeManager.addPipeline(pipeline);
+      }
     }
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Found and fixed some `TableIterator` objects in `hdds-server-scm` that were not closed after use.

https://issues.apache.org/jira/browse/HDDS-6725

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2557552003