### PR TITLE
HDDS-6945. EC: EC Reconstruction Command count queues should be included in DN heartbeat

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CloseContainerCommandHandler.java
@@ -186,4 +186,9 @@ public class CloseContainerCommandHandler implements CommandHandler {
     }
     return 0;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ClosePipelineCommandHandler.java
@@ -121,4 +121,9 @@ public class ClosePipelineCommandHandler implements CommandHandler {
     }
     return 0;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandDispatcher.java
@@ -112,10 +112,9 @@ public final class CommandDispatcher {
 
   /**
    * For each registered handler, call its getQueuedCount method to retrieve the
-   * number of queued commands. Any handlers which do not implement an internal
-   * queue will have a count of 0 from the default interface implementation.
-   * The returned map will contain an entry for every registered command in the
-   * dispatcher, with a value of zero if there are no queued commands.
+   * number of queued commands. The returned map will contain an entry for every
+   * registered command in the dispatcher, with a value of zero if there are no
+   * queued commands.
    * @return A Map of CommandType where the value is the queued command count.
    */
   public Map<Type, Integer> getQueuedCommandCount() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CommandHandler.java
@@ -82,12 +82,8 @@ public interface CommandHandler {
   }
 
   /**
-   * Returns the queued command count for this handler. Some handlers do not
-   * have an internal queue and hence commands are executed immediately. For
-   * those, the default implementation will return 0.
+   * Returns the queued command count for this handler.
    * @return The number of queued commands inside this handler.
    */
-  default int getQueuedCount() {
-    return 0;
-  }
+  int getQueuedCount();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/CreatePipelineCommandHandler.java
@@ -160,4 +160,9 @@ public class CreatePipelineCommandHandler implements CommandHandler {
     }
     return 0;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/FinalizeNewLayoutVersionCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/FinalizeNewLayoutVersionCommandHandler.java
@@ -118,4 +118,9 @@ public class FinalizeNewLayoutVersionCommandHandler implements CommandHandler {
     }
     return 0;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/ReconstructECContainersCommandHandler.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolPro
 import org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCommandInfo;
-import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinatorTask;
 import org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionSupervisor;
 import org.apache.hadoop.ozone.container.ozoneimpl.OzoneContainer;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
@@ -53,9 +52,7 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
             ecContainersCommand.getMissingContainerIndexes(),
             ecContainersCommand.getSources(),
             ecContainersCommand.getTargetDatanodes());
-    this.supervisor.addTask(new ECReconstructionCoordinatorTask(
-        this.supervisor.getReconstructionCoordinator(),
-        reconstructionCommandInfo));
+    this.supervisor.addTask(reconstructionCommandInfo);
   }
 
   @Override
@@ -71,6 +68,11 @@ public class ReconstructECContainersCommandHandler implements CommandHandler {
   @Override
   public long getAverageRunTime() {
     return 0;
+  }
+
+  @Override
+  public int getQueuedCount() {
+    return supervisor.getInFlightReplications();
   }
 
   public ConfigurationSource getConf() {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/RefreshVolumeUsageCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/RefreshVolumeUsageCommandHandler.java
@@ -70,4 +70,9 @@ public class RefreshVolumeUsageCommandHandler implements CommandHandler {
     return invocations == 0 ?
         0 : totalTime.get() / invocations;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/SetNodeOperationalStateCommandHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/SetNodeOperationalStateCommandHandler.java
@@ -143,4 +143,9 @@ public class SetNodeOperationalStateCommandHandler implements CommandHandler {
     return invocations == 0 ?
         0 : totalTime.get() / invocations;
   }
+
+  @Override
+  public int getQueuedCount() {
+    return 0;
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/ec/reconstruction/TestECReconstructionSupervisor.java
@@ -17,9 +17,16 @@
  */
 package org.apache.hadoop.ozone.container.ec.reconstruction;
 
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.ozone.test.GenericTestUtils;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.SortedMap;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -27,27 +34,40 @@ import java.util.concurrent.TimeoutException;
  */
 public class TestECReconstructionSupervisor {
 
-  private final ECReconstructionSupervisor supervisor =
-      new ECReconstructionSupervisor(null, null, 5, null);
-
   @Test
   public void testAddTaskShouldExecuteTheGivenTask()
-      throws InterruptedException, TimeoutException {
-    FakeTask task = new FakeTask(null);
-    supervisor.addTask(task);
-    GenericTestUtils.waitFor(() -> task.isExecuted, 100, 15000);
-  }
-
-  static class FakeTask extends ECReconstructionCoordinatorTask {
-    private boolean isExecuted = false;
-
-    FakeTask(ECReconstructionCommandInfo reconstructionCommandInfo) {
-      super(null, reconstructionCommandInfo);
-    }
-
-    @Override
-    public void run() {
-      isExecuted = true;
-    }
+      throws InterruptedException, TimeoutException, IOException {
+    final boolean[] reconstructInvoked = {false};
+    final boolean[] holdOn = {true};
+    ECReconstructionSupervisor supervisor =
+        new ECReconstructionSupervisor(null, null, 5,
+            new ECReconstructionCoordinator(new OzoneConfiguration(), null) {
+              @Override
+              public void reconstructECContainerGroup(long containerID,
+                  ECReplicationConfig repConfig,
+                  SortedMap<Integer, DatanodeDetails> sourceNodeMap,
+                  SortedMap<Integer, DatanodeDetails> targetNodeMap)
+                  throws IOException {
+                reconstructInvoked[0] = true;
+                try {
+                  GenericTestUtils.waitFor(() -> !holdOn[0], 100, 15000);
+                } catch (TimeoutException e) {
+                } catch (InterruptedException e) {
+                }
+                super.reconstructECContainerGroup(containerID, repConfig,
+                    sourceNodeMap, targetNodeMap);
+              }
+            }) {
+        };
+    supervisor.addTask(
+        new ECReconstructionCommandInfo(1, new ECReplicationConfig(3, 2),
+            new byte[0], ImmutableList.of(), ImmutableList.of()));
+    GenericTestUtils.waitFor(() -> reconstructInvoked[0], 100, 15000);
+    Assert.assertEquals(1, supervisor.getInFlightReplications());
+    holdOn[0] = false;
+    // After task execution, this counter should be removed. so, total count
+    // should be 0.
+    GenericTestUtils
+        .waitFor(() -> supervisor.getInFlightReplications() == 0, 100, 15000);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

This JIRA addresses the issue regarding DN reconstruction command queues reporting. Now with this changes, when reconstruction command received by DN, while executing the task, counter will be incremented and after execution of the coordinator task counter will be reduced. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6945

## How was this patch tested?

added test.