### PR TITLE
HDDS-6948. MultiTenantAccessAuthorizerRangerPlugin#deletePolicyByName should log and exit if getAccessPolicyByName returns null

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerRangerPlugin.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/MultiTenantAccessAuthorizerRangerPlugin.java
@@ -733,9 +733,13 @@ public class MultiTenantAccessAuthorizerRangerPlugin implements
   @Override
   public void deletePolicyByName(String policyName) throws IOException {
     AccessPolicy policy = getAccessPolicyByName(policyName);
-    String policyID = policy.getPolicyID();
-    LOG.debug("policyID is: {}", policyID);
-    deletePolicyById(policyID);
+    if (policy != null) {
+      String policyID = policy.getPolicyID();
+      LOG.debug("policyID is: {}", policyID);
+      deletePolicyById(policyID);
+    } else {
+      LOG.error("No such policy: {} was found!", policyName);
+    }
   }
 
   public void deletePolicyById(String policyId) throws IOException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Check whether return policy is null. If so, we should log and exit instead of still trying to delete the policy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6948

## How was this patch tested?

N/A