### PR TITLE
HDDS-6947. Bump gson version to 2.9.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <guava.version>31.1-jre</guava.version>
     <guice.version>4.0</guice.version>
-    <gson.version>2.8.9</gson.version>
+    <gson.version>2.9.0</gson.version>
 
     <!-- Required for testing LDAP integration -->
     <apacheds.version>2.0.0-M21</apacheds.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?
Bump gson version to a more secure one.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6947

## How was this patch tested?
Clean build and tests.