### PR TITLE
HDDS-6955. [Ozone-streaming] Add explicit stream flag in ozone shell

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfig.java
@@ -76,6 +76,17 @@ public interface ReplicationConfig {
     return parse(null, replication, config);
   }
 
+  static ReplicationConfig resolve(ReplicationConfig replicationConfig,
+      ReplicationConfig bucketReplicationConfig, ConfigurationSource conf) {
+    if (replicationConfig == null) {
+      replicationConfig = bucketReplicationConfig;
+    }
+    if (replicationConfig == null) {
+      replicationConfig = getDefault(conf);
+    }
+    return replicationConfig;
+  }
+
   /**
    * Helper method to serialize from proto.
    * <p>

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/shell/keys/PutKeyHandler.java
@@ -29,6 +29,7 @@ import java.nio.channels.FileChannel;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.StorageUnit;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
@@ -42,13 +43,13 @@ import org.apache.hadoop.ozone.client.io.OzoneDataStreamOutput;
 import org.apache.hadoop.ozone.shell.OzoneAddress;
 
 import org.apache.commons.codec.digest.DigestUtils;
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationType.EC;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_DEFAULT;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_CHUNK_SIZE_KEY;
 
 import org.apache.hadoop.ozone.shell.ShellReplicationOptions;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Mixin;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 /**
@@ -60,6 +61,9 @@ public class PutKeyHandler extends KeyHandler {
 
   @Parameters(index = "1", arity = "1..1", description = "File to upload")
   private String fileName;
+
+  @Option(names = "--stream")
+  private boolean stream;
 
   @Mixin
   private ShellReplicationOptions replication;
@@ -96,26 +100,21 @@ public class PutKeyHandler extends KeyHandler {
     int chunkSize = (int) getConf().getStorageSize(OZONE_SCM_CHUNK_SIZE_KEY,
         OZONE_SCM_CHUNK_SIZE_DEFAULT, StorageUnit.BYTES);
 
-    Boolean useAsync = false;
-    if (dataFile.length() <= chunkSize ||
-        (replicationConfig != null &&
-        replicationConfig.getReplicationType()  == EC) ||
-        bucket.getReplicationConfig() instanceof ECReplicationConfig) {
-      useAsync = true;
-    }
-    if (useAsync) {
-      if (isVerbose()) {
-        out().println("API: async");
-      }
-      try (InputStream input = new FileInputStream(dataFile);
-           OutputStream output = bucket.createKey(keyName, dataFile.length(),
-               replicationConfig, keyMetadata)) {
-        IOUtils.copyBytes(input, output, chunkSize);
-      }
-    } else {
+    if (stream) {
       if (isVerbose()) {
         out().println("API: streaming");
       }
+      // In streaming mode, always resolve replication config at client side,
+      // because streaming is not compatible for writing EC keys.
+      if (replicationConfig == null) {
+        replicationConfig = bucket.getReplicationConfig();
+      }
+      if (replicationConfig == null) {
+        replicationConfig = ReplicationConfig.parse(null, null, getConf());
+      }
+      Preconditions.checkArgument(
+          !(replicationConfig instanceof ECReplicationConfig),
+          "Can not put EC key by streaming");
       try (RandomAccessFile raf = new RandomAccessFile(dataFile, "r");
            OzoneDataStreamOutput out = bucket.createStreamKey(keyName,
                dataFile.length(), replicationConfig, keyMetadata)) {
@@ -129,6 +128,15 @@ public class PutKeyHandler extends KeyHandler {
           off += writeLen;
           len -= writeLen;
         }
+      }
+    } else {
+      if (isVerbose()) {
+        out().println("API: async");
+      }
+      try (InputStream input = new FileInputStream(dataFile);
+           OutputStream output = bucket.createKey(keyName, dataFile.length(),
+               replicationConfig, keyMetadata)) {
+        IOUtils.copyBytes(input, output, chunkSize);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Cluster-level replication for EC was introduced in HDDS-6294.
When client side and bucket level replication config are both missing,
client will pass `null` as replication config to let OM decide.

The first problem is NPE in createStreamKey() if replication config is `null`.
The second problem is, since streaming is not compatible for writing EC keys,
we cannot determine when to use streaming just by key size and client side replication config.

In this PR, I have added a explicit `--stream` flag in ozone shell key handler.
In stream mode, replication config will fallback to client side defaults when missing.
And it will be checked to ensure not using streaming to write an EC key.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6955

## How was this patch tested?

Manual test

```bash
ozone sh --verbose key put --stream /vol1/bucket1/key1 data
```