### PR TITLE
HDDS-6879. Bucket layout as null on default layout type

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -202,6 +202,7 @@ public class RpcClient implements ClientProtocol {
   private final BlockInputStreamFactory blockInputStreamFactory;
   private final OzoneManagerVersion omVersion;
   private volatile ExecutorService ecReconstructExecutor;
+  private final String defaultBucketLayout;
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -308,6 +309,9 @@ public class RpcClient implements ClientProtocol {
     getLatestVersionLocation = conf.getBoolean(
         OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION,
         OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION_DEFAULT);
+    defaultBucketLayout = conf.getTrimmed(
+        OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
+        OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT);
 
     long keyProviderCacheExpiryMs = conf.getTimeDuration(
         OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY,
@@ -663,11 +667,20 @@ public class RpcClient implements ClientProtocol {
       builder.setDefaultReplicationConfig(defaultReplicationConfig);
     }
 
-    LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {}, {} as " +
-            "owner, Versioning {}, Storage Type set to {} and Encryption set " +
-            "to {} ",
-        volumeName, bucketName, bucketLayout, owner, isVersionEnabled,
-        storageType, bek != null);
+    if (bucketLayout != null) {
+      LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {}, {} as " +
+              "owner, Versioning {}, Storage Type set to {} and Encryption " +
+              "set to {} ",
+          volumeName, bucketName, bucketLayout, owner, isVersionEnabled,
+          storageType, bek != null);
+    } else {
+      LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {} - set to" +
+              "OM server default using the configuration: " +
+              "ozone.default.bucket.layout, {} as owner, Versioning {}, " +
+              "Storage Type set to {} and Encryption set to {} ",
+          volumeName, bucketName, defaultBucketLayout, owner, isVersionEnabled,
+          storageType, bek != null);
+    }
     ozoneManagerClient.createBucket(builder.build());
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -202,7 +202,6 @@ public class RpcClient implements ClientProtocol {
   private final BlockInputStreamFactory blockInputStreamFactory;
   private final OzoneManagerVersion omVersion;
   private volatile ExecutorService ecReconstructExecutor;
-  private final String defaultBucketLayout;
 
   /**
    * Creates RpcClient instance with the given configuration.
@@ -309,9 +308,6 @@ public class RpcClient implements ClientProtocol {
     getLatestVersionLocation = conf.getBoolean(
         OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION,
         OzoneConfigKeys.OZONE_CLIENT_KEY_LATEST_VERSION_LOCATION_DEFAULT);
-    defaultBucketLayout = conf.getTrimmed(
-        OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT,
-        OMConfigKeys.OZONE_DEFAULT_BUCKET_LAYOUT_DEFAULT);
 
     long keyProviderCacheExpiryMs = conf.getTimeDuration(
         OZONE_CLIENT_KEY_PROVIDER_CACHE_EXPIRY,
@@ -667,20 +663,13 @@ public class RpcClient implements ClientProtocol {
       builder.setDefaultReplicationConfig(defaultReplicationConfig);
     }
 
-    if (bucketLayout != null) {
-      LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {}, {} as " +
-              "owner, Versioning {}, Storage Type set to {} and Encryption " +
-              "set to {} ",
-          volumeName, bucketName, bucketLayout, owner, isVersionEnabled,
-          storageType, bek != null);
-    } else {
-      LOG.info("Creating Bucket: {}/{}, with the Bucket Layout {} - set to" +
-              "OM server default using the configuration: " +
-              "ozone.default.bucket.layout, {} as owner, Versioning {}, " +
-              "Storage Type set to {} and Encryption set to {} ",
-          volumeName, bucketName, defaultBucketLayout, owner, isVersionEnabled,
-          storageType, bek != null);
-    }
+    String layoutMsg = bucketLayout != null
+        ? "with bucket layout " + bucketLayout
+        : "with server-side default bucket layout";
+    LOG.info("Creating Bucket: {}/{}, {}, {} as owner, Versioning {}, " +
+            "Storage Type set to {} and Encryption set to {} ",
+        volumeName, bucketName, layoutMsg, owner, isVersionEnabled,
+        storageType, bek != null);
     ozoneManagerClient.createBucket(builder.build());
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

As per a recent change to add Bucket Layout information while creating bucket: [HDDS-6811](https://issues.apache.org/jira/browse/HDDS-6811) (PR [#3479](https://github.com/apache/ozone/pull/3479)), the information is displayed as expected when we pass a parameter for `--layout` but is displayed as `null` when we don't pass any.
It should rather print the default bucket layout type and should not rely on the user params.

```
root@st-ozone-sq1qpy-p9xm2:/ansible# /opt/cloudera/parcels/CDH/bin/ozone sh bucket create o3://ozone1/vol-1/buck-1
2022-06-13 17:37:30,582 [main] INFO  rpc.RpcClient (RpcClient.java:createBucket(666))       - Creating Bucket: vol-1/buck-1, with the Bucket Layout null, hrt_qa as owner, Versioning false, Storage Type set to DISK and Encryption set to false
22/06/13 17:37:30 INFO rpc.RpcClient: Creating Bucket: vol-1/buck-1, with the Bucket Layout null, hrt_qa as owner, Versioning false, Storage Type set to DISK and Encryption set to false
root@st-ozone-sq1qpy-p9xm2:/ansible# /opt/cloudera/parcels/CDH/bin/ozone sh bucket info o3://ozone1/vol-1/buck-1
{
  "metadata" : { },
  "volumeName" : "vol-1",
  "name" : "buck-1",
  "storageType" : "DISK",
  "versioning" : false,
  "usedBytes" : 0,
  "usedNamespace" : 0,
  "creationTime" : "2022-06-13T17:37:30.596Z",
  "modificationTime" : "2022-06-13T17:37:30.596Z",
  "quotaInBytes" : -1,
  "quotaInNamespace" : -1,
  "bucketLayout" : "LEGACY",
  "owner" : "hrt_qa",
  "link" : false
}
root@st-ozone-sq1qpy-p9xm2:/ansible# /opt/cloudera/parcels/CDH/bin/ozone sh bucket create o3://ozone1/vol-1/buck-2 --layout OBJECT_STORE
2022-06-13 17:42:28,032 [main] INFO  rpc.RpcClient (RpcClient.java:createBucket(666))       - Creating Bucket: vol-1/buck-2, with the Bucket Layout OBJECT_STORE, hrt_qa as owner, Versioning false, Storage Type set to DISK and Encryption set to false
22/06/13 17:42:28 INFO rpc.RpcClient: Creating Bucket: vol-1/buck-2, with the Bucket Layout OBJECT_STORE, hrt_qa as owner, Versioning false, Storage Type set to DISK and Encryption set to false
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6879

## How was this patch tested?

NA
