### PR TITLE
HDDS-6965. Increase timeout for basic check

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -163,7 +163,7 @@ jobs:
     needs:
       - build-info
     runs-on: ubuntu-18.04
-    timeout-minutes: 60
+    timeout-minutes: 90
     if: needs.build-info.outputs.needs-basic-checks == 'true'
     strategy:
       matrix:


### PR DESCRIPTION
## What changes were proposed in this pull request?

_basic (unit)_ check takes 45+ minutes, and sometimes even times out after 60 minutes.  It looks like Github runners have variable performance.  Since we have more tests now, I think it is reasonable to increase the timeout.

https://issues.apache.org/jira/browse/HDDS-6965

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/7087566467

_basic (unit)_ check succeeded in 1h 1m 44s, so it would have failed prior to this change.