### PR TITLE
HDDS-6889. EC: put key command with EC replication can use ReplicationConfig validator

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.hdds.conf.ConfigGroup;
 import org.apache.hadoop.hdds.conf.ConfigTag;
 import org.apache.hadoop.hdds.conf.ConfigType;
 import org.apache.hadoop.hdds.conf.PostConstruct;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 
 import java.util.regex.Pattern;
 
@@ -53,7 +54,8 @@ public class ReplicationConfigValidator {
       if (!validationRegexp.matcher(
           replicationConfig.configFormat()).matches()) {
         String replication = replicationConfig.getReplication();
-        if (replicationConfig instanceof ECReplicationConfig) {
+        if (HddsProtos.ReplicationType.EC.equals(
+                replicationConfig.getReplicationType())) {
           ECReplicationConfig ecConfig =
               (ECReplicationConfig) replicationConfig;
           replication =  ecConfig.getCodec() + "-" + ecConfig.getData() +

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
@@ -54,8 +54,8 @@ public class ReplicationConfigValidator {
       if (!validationRegexp.matcher(
           replicationConfig.configFormat()).matches()) {
         String replication = replicationConfig.getReplication();
-        if (HddsProtos.ReplicationType.EC.equals(
-                replicationConfig.getReplicationType())) {
+        if (HddsProtos.ReplicationType.EC ==
+                replicationConfig.getReplicationType()) {
           ECReplicationConfig ecConfig =
               (ECReplicationConfig) replicationConfig;
           replication =  ecConfig.getCodec() + "-" + ecConfig.getData() +

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
+import org.apache.hadoop.hdds.client.ReplicationConfigValidator;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
@@ -1152,6 +1153,12 @@ public class RpcClient implements ClientProtocol {
             + " Erasure Coded replication, as OzoneManager does not support"
             + " Erasure Coded replication.");
       }
+    }
+
+    if (replicationConfig != null) {
+      ReplicationConfigValidator validator =
+              this.conf.getObject(ReplicationConfigValidator.class);
+      validator.validate(replicationConfig);
     }
     String requestId = UUID.randomUUID().toString();
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -899,8 +899,6 @@ public abstract class TestOzoneRpcClientAbstract {
               () -> bucket.createKey(keyName, "dummy".getBytes(UTF_8).length,
                       replicationConfig, new HashMap<>()));
     }
-
-
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -149,11 +149,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.slf4j.event.Level.DEBUG;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This is an abstract class to test all the public facing APIs of Ozone
@@ -863,6 +865,27 @@ public abstract class TestOzoneRpcClientAbstract {
     }
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"rs-3-3-1024k", "xor-3-5-2048k"})
+  public void testPutKeyWithInvalidReplicationConfig(
+          String replicationValue) throws IOException {
+    String volumeName = UUID.randomUUID().toString();
+    String bucketName = UUID.randomUUID().toString();
+
+    String value = "dummy";
+    store.createVolume(volumeName);
+    OzoneVolume volume = store.getVolume(volumeName);
+    volume.createBucket(bucketName);
+    OzoneBucket bucket = volume.getBucket(bucketName);
+
+    String keyName = UUID.randomUUID().toString();
+    ReplicationConfig replicationConfig =
+            new ECReplicationConfig(replicationValue);
+    Assertions.assertThrows(IllegalArgumentException.class,
+            () -> bucket.createKey(keyName,
+            value.getBytes(UTF_8).length, replicationConfig, new HashMap<>()));
+  }
+
   @Test
   public void testPutKey() throws IOException {
     String volumeName = UUID.randomUUID().toString();
@@ -870,6 +893,7 @@ public abstract class TestOzoneRpcClientAbstract {
     Instant testStartTime = Instant.now();
 
     String value = "sample value";
+
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
     volume.createBucket(bucketName);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestSecureOzoneRpcClient.java
@@ -113,7 +113,7 @@ public class TestSecureOzoneRpcClient extends TestOzoneRpcClient {
     CertificateClientTestImpl certificateClientTest =
         new CertificateClientTestImpl(conf);
     cluster = MiniOzoneCluster.newBuilder(conf)
-        .setNumDatanodes(10)
+        .setNumDatanodes(14)
         .setScmId(SCM_ID)
         .setClusterId(CLUSTER_ID)
         .setCertificateClient(certificateClientTest)


### PR DESCRIPTION


## What changes were proposed in this pull request?

Validate keys while putting a key 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6889

## How was this patch tested?
Unit test, Integration Test
