### PR TITLE
HDDS-6968. [Multi-Tenant] Fix USER_MISMATCH error even on correct user.

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/security/ozone-secure-tenant.robot
@@ -101,7 +101,7 @@ Create Tenant Failure with Regular User
 
 SetSecret Failure with Regular User
     ${rc}  ${output} =  Run And Return Rc And Output  ozone tenant user set-secret 'tenantone$testuser' --secret=somesecret2
-                        Should contain   ${output}         USER_MISMATCH Requested accessId 'tenantone$testuser' doesn't belong to current user 'testuser2/scm@EXAMPLE.COM', nor does current user have Ozone or tenant administrator privilege
+                        Should contain   ${output}         USER_MISMATCH Requested accessId 'tenantone$testuser' doesn't belong to current user 'testuser2', nor does current user have Ozone or tenant administrator privilege
 
 Create Bucket 2 Success with somesecret1 via S3 API
     ${output} =         Execute          aws s3api --endpoint-url ${S3G_ENDPOINT_URL} create-bucket --bucket bucket-test2

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
@@ -49,7 +49,7 @@ public final class S3SecretRequestHelper {
       OzoneManager ozoneManager, UserGroupInformation ugi, String accessId)
       throws IOException {
 
-    final String username = ugi.getUserName();
+    final String username = ugi.getShortUserName();
 
     // Flag indicating whether the accessId is assigned to a tenant
     // (under S3 Multi-Tenancy feature) or not.

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -90,10 +90,11 @@ public class TestS3GetSecretRequest {
 
   // Multi-tenant related vars
   private static final String USER_ALICE = "alice@EXAMPLE.COM";
+  private static final String USER_ALICE_SHORT = "alice";
   private static final String TENANT_ID = "finance";
-  private static final String USER_BOB = "bob@EXAMPLE.COM";
+  private static final String USER_BOB_SHORT = "bob";
   private static final String ACCESS_ID_BOB =
-      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB);
+      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB_SHORT);
 
   private UserGroupInformation ugiAlice;
 
@@ -246,7 +247,7 @@ public class TestS3GetSecretRequest {
     S3GetSecretRequest s3GetSecretRequest1 =
         new S3GetSecretRequest(
             new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE)
+                s3GetSecretRequest(USER_ALICE_SHORT)
             ).preExecute(ozoneManager)
         );
 
@@ -262,7 +263,7 @@ public class TestS3GetSecretRequest {
 
     // Check response
     final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
-    Assert.assertEquals(USER_ALICE, s3SecretValue.getKerberosID());
+    Assert.assertEquals(USER_ALICE_SHORT, s3SecretValue.getKerberosID());
     final String awsSecret1 = s3SecretValue.getAwsSecret();
     Assert.assertNotNull(awsSecret1);
 
@@ -270,7 +271,7 @@ public class TestS3GetSecretRequest {
         s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
     // The secret inside should be the same.
     final S3Secret s3Secret1 = getS3SecretResponse.getS3Secret();
-    Assert.assertEquals(USER_ALICE, s3Secret1.getKerberosID());
+    Assert.assertEquals(USER_ALICE_SHORT, s3Secret1.getKerberosID());
     Assert.assertEquals(awsSecret1, s3Secret1.getAwsSecret());
 
 
@@ -281,7 +282,7 @@ public class TestS3GetSecretRequest {
     S3GetSecretRequest s3GetSecretRequest2 =
         new S3GetSecretRequest(
             new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE)
+                s3GetSecretRequest(USER_ALICE_SHORT)
             ).preExecute(ozoneManager)
         );
 
@@ -302,7 +303,7 @@ public class TestS3GetSecretRequest {
         s3GetSecretResponse2.getOMResponse().getGetS3SecretResponse();
     // The secret inside should be the same.
     final S3Secret s3Secret2 = getS3SecretResponse2.getS3Secret();
-    Assert.assertEquals(USER_ALICE, s3Secret2.getKerberosID());
+    Assert.assertEquals(USER_ALICE_SHORT, s3Secret2.getKerberosID());
 
     // Should get the same secret as the first request's.
     Assert.assertEquals(awsSecret1, s3Secret2.getAwsSecret());
@@ -376,7 +377,8 @@ public class TestS3GetSecretRequest {
     OMTenantAssignUserAccessIdRequest omTenantAssignUserAccessIdRequest =
         new OMTenantAssignUserAccessIdRequest(
             new OMTenantAssignUserAccessIdRequest(
-                assignUserToTenantRequest(TENANT_ID, USER_BOB, ACCESS_ID_BOB)
+                assignUserToTenantRequest(TENANT_ID,
+                    USER_BOB_SHORT, ACCESS_ID_BOB)
             ).preExecute(ozoneManager)
         );
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

We are unable to get secret even though we kinit with the same user for which we want to retrieve the secret. This PR aims to fix this by getting short user principal and not the full prinicipal.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6968

## How was this patch tested?

The patch was tested manually in a cluster and also using CI tests.

```
bash-4.2$ klist
Ticket cache: FILE:/tmp/krb5cc_0
Default principal: systest@ROOT.HWX.SITE

bash-4.2$ ozone tenant user getsecret 'tenant$systest' --om-service-id=ozone1
export AWS_ACCESS_KEY_ID='tenant$systest'
export AWS_SECRET_ACCESS_KEY='e264d0460c146624d381d058677b4102f8deaaa7302ad589d85adc1c3fdd7d16'
```
