### PR TITLE
HDDS-6969. [Docs] Add link to compose directory in smoketest README

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/README.md
+++ b/hadoop-ozone/dist/src/main/smoketest/README.md
@@ -29,14 +29,14 @@ The current configuration in the robot files (hostnames, ports) are adjusted for
 
 # Run tests in docker environment
 
-In the ./compose folder there are additional test scripts to make it easy to run all tests or run a specific test in a docker environment.
+In the [compose](../compose) folder there are additional test scripts to make it easy to run all tests or run a specific test in a docker environment.
 
 ## Test one environment
 
 Go to the compose directory and execute the test.sh directly from there:
 
 ```
-cd compose/ozone
+cd ../compose/ozone
 ./test.sh
 ```
 
@@ -45,7 +45,7 @@ The results will be saved to the `compose/ozone/results`
 ## Run all the tests
 
 ```
-cd compose
+cd ../compose
 ./test-all.sh
 ```
 
@@ -56,7 +56,7 @@ The results will be combined to the `compose/results` folder.
 Start the compose environment and execute test:
 
 ```
-cd compose/ozone
+cd ../compose/ozone
 docker-compose up -d
 #wait....
 ../test-single.sh scm basic/basic.robot

--- a/hadoop-ozone/dist/src/main/smoketest/README.md
+++ b/hadoop-ozone/dist/src/main/smoketest/README.md
@@ -36,7 +36,7 @@ In the [compose](../compose) folder there are additional test scripts to make it
 Go to the compose directory and execute the test.sh directly from there:
 
 ```
-cd ../compose/ozone
+cd compose/ozone
 ./test.sh
 ```
 
@@ -45,7 +45,7 @@ The results will be saved to the `compose/ozone/results`
 ## Run all the tests
 
 ```
-cd ../compose
+cd compose
 ./test-all.sh
 ```
 
@@ -56,7 +56,7 @@ The results will be combined to the `compose/results` folder.
 Start the compose environment and execute test:
 
 ```
-cd ../compose/ozone
+cd compose/ozone
 docker-compose up -d
 #wait....
 ../test-single.sh scm basic/basic.robot


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current README in smoketest reference compose directory like a sub-directory.
It was quite confusing at first glance.

This patch adds link to compose directory, and changes the path in the command example.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6969

## How was this patch tested?

Rendered version: https://github.com/kaijchen/ozone/blob/HDDS-6969/hadoop-ozone/dist/src/main/smoketest/README.md
