### PR TITLE
HDDS-6127. file checksum to support both CRC32 and CRC32C.

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -260,20 +260,22 @@ public abstract class BaseFileChecksumHelper {
     case CRC32C:
       return new MD5MD5CRC32CastagnoliFileChecksum(getBytesPerCRC(),
           crcPerBlock, fileMD5);
+    default:
+      throw new IllegalArgumentException("unexpected checksum type "
+          + getChecksumType());
     }
 
-    throw new IllegalArgumentException("unexpected checksum type "
-        + getChecksumType());
   }
 
   DataChecksum.Type toHadoopChecksumType() {
     switch (checksumType) {
-      case CRC32:
-        return DataChecksum.Type.CRC32;
-      case CRC32C:
-        return DataChecksum.Type.CRC32C;
+    case CRC32:
+      return DataChecksum.Type.CRC32;
+    case CRC32C:
+      return DataChecksum.Type.CRC32C;
+    default:
+      throw new IllegalArgumentException("unsupported checksum type");
     }
-    throw new IllegalArgumentException("unsupported checksum type");
   }
 
   FileChecksum makeCompositeCrcResult() throws IOException {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/BaseFileChecksumHelper.java
@@ -19,9 +19,11 @@ package org.apache.hadoop.ozone.client.checksum;
 
 import org.apache.hadoop.fs.CompositeCrcFileChecksum;
 import org.apache.hadoop.fs.FileChecksum;
+import org.apache.hadoop.fs.MD5MD5CRC32CastagnoliFileChecksum;
 import org.apache.hadoop.fs.MD5MD5CRC32GzipFileChecksum;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
+import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.XceiverClientFactory;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.MD5Hash;
@@ -57,6 +59,7 @@ public abstract class BaseFileChecksumHelper {
 
   private ClientProtocol rpcClient;
   private OzoneClientConfig.ChecksumCombineMode combineMode;
+  private ContainerProtos.ChecksumType checksumType;
 
   private final DataOutputBuffer blockChecksumBuf = new DataOutputBuffer();
   private XceiverClientFactory xceiverClientFactory;
@@ -111,6 +114,10 @@ public abstract class BaseFileChecksumHelper {
     return combineMode;
   }
 
+  protected ContainerProtos.ChecksumType getChecksumType() {
+    return checksumType;
+  }
+
   protected XceiverClientFactory getXceiverClientFactory() {
     return xceiverClientFactory;
   }
@@ -137,6 +144,10 @@ public abstract class BaseFileChecksumHelper {
 
   protected void setBytesPerCRC(int bytesPerCRC) {
     this.bytesPerCRC = bytesPerCRC;
+  }
+
+  protected void setChecksumType(ContainerProtos.ChecksumType type) {
+    checksumType = type;
   }
 
   /**
@@ -242,8 +253,27 @@ public abstract class BaseFileChecksumHelper {
     //compute file MD5
     final MD5Hash fileMD5 = MD5Hash.digest(getBlockChecksumBuf().getData());
     // assume CRC32 for now
-    return new MD5MD5CRC32GzipFileChecksum(getBytesPerCRC(),
-        crcPerBlock, fileMD5);
+    switch (getChecksumType()) {
+    case CRC32:
+      return new MD5MD5CRC32GzipFileChecksum(getBytesPerCRC(),
+          crcPerBlock, fileMD5);
+    case CRC32C:
+      return new MD5MD5CRC32CastagnoliFileChecksum(getBytesPerCRC(),
+          crcPerBlock, fileMD5);
+    }
+
+    throw new IllegalArgumentException("unexpected checksum type "
+        + getChecksumType());
+  }
+
+  DataChecksum.Type toHadoopChecksumType() {
+    switch (checksumType) {
+      case CRC32:
+        return DataChecksum.Type.CRC32;
+      case CRC32C:
+        return DataChecksum.Type.CRC32C;
+    }
+    throw new IllegalArgumentException("unsupported checksum type");
   }
 
   FileChecksum makeCompositeCrcResult() throws IOException {
@@ -252,7 +282,7 @@ public abstract class BaseFileChecksumHelper {
       blockSizeHint = keyLocationInfos.get(0).getLength();
     }
     CrcComposer crcComposer =
-        CrcComposer.newCrcComposer(DataChecksum.Type.CRC32, blockSizeHint);
+        CrcComposer.newCrcComposer(toHadoopChecksumType(), blockSizeHint);
     byte[] blockChecksumBytes = blockChecksumBuf.getData();
 
     for (int i = 0; i < keyLocationInfos.size(); ++i) {
@@ -270,7 +300,7 @@ public abstract class BaseFileChecksumHelper {
 
     int compositeCrc = CrcUtil.readInt(crcComposer.digest(), 0);
     return new CompositeCrcFileChecksum(
-        compositeCrc, DataChecksum.Type.CRC32, bytesPerCRC);
+        compositeCrc, toHadoopChecksumType(), bytesPerCRC);
   }
 
   public FileChecksum getFileChecksum() {

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -71,7 +71,6 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
          blockIdx++) {
       OmKeyLocationInfo keyLocationInfo =
           getKeyLocationInfoList().get(blockIdx);
-      currentLength += keyLocationInfo.getLength();
       if (currentLength > getLength()) {
         return;
       }
@@ -80,6 +79,8 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
         throw new PathIOException(getSrc(),
             "Fail to get block MD5 for " + keyLocationInfo);
       }
+
+      currentLength += keyLocationInfo.getLength();
     }
   }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/checksum/ReplicatedFileChecksumHelper.java
@@ -101,6 +101,7 @@ public class ReplicatedFileChecksumHelper extends BaseFileChecksumHelper {
         getChunkInfos(keyLocationInfo);
     ContainerProtos.ChecksumData checksumData =
         chunkInfos.get(0).getChecksumData();
+    setChecksumType(checksumData.getType());
     int bytesPerChecksum = checksumData.getBytesPerChecksum();
     setBytesPerCRC(bytesPerChecksum);
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/checksum/TestReplicatedFileChecksumHelper.java
@@ -55,7 +55,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.internal.Checks;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support both CRC32 an CRC32C for Ozone to make it possible to replicate files between HDFS and Ozone.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-6127

## How was this patch tested?
Unit tests.
