### PR TITLE
HDDS-6957. EC: ReplicationManager - priortise under replicated containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -48,6 +48,7 @@ import java.io.IOException;
 import java.time.Clock;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -362,24 +363,10 @@ public class ReplicationManager implements SCMService {
    */
   protected PriorityQueue<ContainerHealthResult.UnderReplicatedHealthResult>
       createUnderReplicatedQueue() {
-    return new PriorityQueue<>(
-        (o1, o2) -> {
-          if (o1.getWeightedRedundancy() < o2.getWeightedRedundancy()) {
-            return -1;
-          } else if (o1.getWeightedRedundancy() > o2.getWeightedRedundancy()) {
-            return 1;
-          } else {
-            // Equal weighted redundancy. Put the one with the lesser retries
-            // first
-            if (o1.getRequeueCount() < o2.getRequeueCount()) {
-              return -1;
-            } else if (o1.getRequeueCount() > o2.getRequeueCount()) {
-              return 1;
-            } else {
-              return 0;
-            }
-          }
-        });
+    return new PriorityQueue<>(Comparator.comparing(ContainerHealthResult
+            .UnderReplicatedHealthResult::getWeightedRedundancy)
+        .thenComparing(ContainerHealthResult
+            .UnderReplicatedHealthResult::getRequeueCount));
   }
 
   public ReplicationManagerReport getContainerReport() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -50,6 +50,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.PriorityQueue;
+import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -130,6 +132,9 @@ public class ReplicationManager implements SCMService {
   private final ContainerReplicaPendingOps containerReplicaPendingOps;
   private final ContainerHealthCheck ecContainerHealthCheck;
   private final EventPublisher eventPublisher;
+  private final ReentrantLock lock = new ReentrantLock();
+  private Queue<ContainerHealthResult.UnderReplicatedHealthResult>
+      underRepQueue;
 
   /**
    * Constructs ReplicationManager instance with the given configuration.
@@ -166,6 +171,7 @@ public class ReplicationManager implements SCMService {
     this.legacyReplicationManager = legacyReplicationManager;
     this.ecContainerHealthCheck = new ECContainerHealthCheck();
     this.nodeManager = nodeManager;
+    this.underRepQueue = createUnderReplicatedQueue();
     start();
   }
 
@@ -232,8 +238,8 @@ public class ReplicationManager implements SCMService {
     final List<ContainerInfo> containers =
         containerManager.getContainers();
     ReplicationManagerReport report = new ReplicationManagerReport();
-    List<ContainerHealthResult.UnderReplicatedHealthResult> underReplicated =
-        new ArrayList<>();
+    Queue<ContainerHealthResult.UnderReplicatedHealthResult>
+        underReplicated = createUnderReplicatedQueue();
     List<ContainerHealthResult.OverReplicatedHealthResult> overReplicated =
         new ArrayList<>();
 
@@ -254,16 +260,61 @@ public class ReplicationManager implements SCMService {
       }
     }
     report.setComplete();
-    // TODO - Sort the pending lists by priority and assign to the main queue,
-    //        which is yet to be defined.
+    lock.lock();
+    try {
+      underRepQueue = underReplicated;
+    } finally {
+      lock.unlock();
+    }
     this.containerReport = report;
     LOG.info("Replication Monitor Thread took {} milliseconds for" +
             " processing {} containers.", clock.millis() - start,
         containers.size());
   }
 
+  /**
+   * Retrieve the new highest priority container to be replicated from the
+   * under replicated queue.
+   * @return The new underReplicated container to be processed, or null if the
+   *         queue is empty.
+   */
+  public ContainerHealthResult.UnderReplicatedHealthResult
+      dequeueUnderReplicatedContainer() {
+    lock.lock();
+    try {
+      return underRepQueue.poll();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Add an under replicated container back to the queue if it was unable to
+   * be processed. Its retry count will be incremented before it is re-queued,
+   * reducing its priority.
+   * Note that the queue could have been rebuilt and replaced after this
+   * message was removed but before it is added back. This will result in a
+   * duplicate entry on the queue. However, when it is processed again, the
+   * result of the processing will end up with pending replicas scheduled. If
+   * instance 1 is processed and creates the pending replicas, when instance 2
+   * is processed, it will find the pending containers and know it has no work
+   * to do, and be discarded. Additionally, the queue will be refreshed
+   * periodically removing any duplicates.
+   * @param underReplicatedHealthResult
+   */
+  public void requeueUnderReplicatedContainer(ContainerHealthResult
+      .UnderReplicatedHealthResult underReplicatedHealthResult) {
+    underReplicatedHealthResult.incrementRequeueCount();
+    lock.lock();
+    try {
+      underRepQueue.add(underReplicatedHealthResult);
+    } finally {
+      lock.unlock();
+    }
+  }
+
   protected ContainerHealthResult processContainer(ContainerInfo containerInfo,
-      List<ContainerHealthResult.UnderReplicatedHealthResult> underRep,
+      Queue<ContainerHealthResult.UnderReplicatedHealthResult> underRep,
       List<ContainerHealthResult.OverReplicatedHealthResult> overRep,
       ReplicationManagerReport report) throws ContainerNotFoundException {
     Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
@@ -300,6 +351,35 @@ public class ReplicationManager implements SCMService {
       }
     }
     return health;
+  }
+
+  /**
+   * Creates a priority queue of UnderReplicatedHealthResult, where the elements
+   * are ordered by the weighted redundancy of the container. This means that
+   * containers with the least remaining redundancy are at the front of the
+   * queue, and will be processed first.
+   * @return An empty instance of a PriorityQueue.
+   */
+  protected PriorityQueue<ContainerHealthResult.UnderReplicatedHealthResult>
+      createUnderReplicatedQueue() {
+    return new PriorityQueue<>(
+        (o1, o2) -> {
+          if (o1.getWeightedRedundancy() < o2.getWeightedRedundancy()) {
+            return -1;
+          } else if (o1.getWeightedRedundancy() > o2.getWeightedRedundancy()) {
+            return 1;
+          } else {
+            // Equal weighted redundancy. Put the one with the lesser retries
+            // first
+            if (o1.getRequeueCount() < o2.getRequeueCount()) {
+              return -1;
+            } else if (o1.getRequeueCount() > o2.getRequeueCount()) {
+              return 1;
+            } else {
+              return 0;
+            }
+          }
+        });
   }
 
   public ReplicationManagerReport getContainerReport() {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -263,39 +263,6 @@ public class TestReplicationManager {
   }
 
   @Test
-  public void testUnderReplicatedOrderingInQueue()
-      throws ContainerNotFoundException {
-    ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
-        HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(decomContainer, Pair.of(DECOMMISSIONING, 1),
-        Pair.of(DECOMMISSIONING, 2), Pair.of(DECOMMISSIONING, 3),
-        Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
-
-    ContainerInfo underRep1 = createContainerInfo(repConfig, 2,
-        HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(underRep1, 1, 2, 3, 4);
-    ContainerInfo underRep0 = createContainerInfo(repConfig, 3,
-        HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(underRep0, 1, 2, 3);
-
-    replicationManager.processContainer(decomContainer, underRep, overRep,
-        repReport);
-    replicationManager.processContainer(underRep1, underRep, overRep,
-        repReport);
-    replicationManager.processContainer(underRep0, underRep, overRep,
-        repReport);
-    // We expect 3 messages on the queue. They should be in the reverse order
-    // to which they were added, putting the lowest remaining redundancy first.
-    Assert.assertEquals(3, underRep.size());
-    ContainerHealthResult.UnderReplicatedHealthResult res = underRep.poll();
-    Assert.assertEquals(underRep0, res.getContainerInfo());
-    res = underRep.poll();
-    Assert.assertEquals(underRep1, res.getContainerInfo());
-    res = underRep.poll();
-    Assert.assertEquals(decomContainer, res.getContainerInfo());
-  }
-
-  @Test
   public void testUnderReplicationQueuePopulated() {
     ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
@@ -321,7 +288,7 @@ public class TestReplicationManager {
     replicationManager.requeueUnderReplicatedContainer(res);
 
     // Now get the next message. It should be underRep1, as it has remaining
-    // redundancy 1 + zero retries. UnderRep1 will have remaining redundancy 0
+    // redundancy 1 + zero retries. UnderRep0 will have remaining redundancy 0
     // and 1 retry. They will have the same weighted redundancy so lesser
     // retries should come first
     res = replicationManager.dequeueUnderReplicatedContainer();

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hdds.scm.container.replication;
 
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
+import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.ozone.test.TestClock;
@@ -43,11 +45,14 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONING;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createContainerInfo;
 import static org.apache.hadoop.hdds.scm.container.replication.ReplicationTestUtil.createReplicas;
 
@@ -68,9 +73,10 @@ public class TestReplicationManager {
   private ContainerReplicaPendingOps containerReplicaPendingOps;
 
   private Map<ContainerID, Set<ContainerReplica>> containerReplicaMap;
+  private Set<ContainerInfo> containerInfoSet;
   private ReplicationConfig repConfig;
   private ReplicationManagerReport repReport;
-  private List<ContainerHealthResult.UnderReplicatedHealthResult> underRep;
+  private Queue<ContainerHealthResult.UnderReplicatedHealthResult> underRep;
   private List<ContainerHealthResult.OverReplicatedHealthResult> overRep;
 
   @Before
@@ -94,6 +100,9 @@ public class TestReplicationManager {
             return containerReplicaMap.get(cid);
           });
 
+    Mockito.when(containerManager.getContainers()).thenAnswer(
+        invocation -> new ArrayList<>(containerInfoSet));
+
     replicationManager = new ReplicationManager(
         configuration,
         containerManager,
@@ -105,10 +114,18 @@ public class TestReplicationManager {
         legacyReplicationManager,
         containerReplicaPendingOps);
     containerReplicaMap = new HashMap<>();
+    containerInfoSet = new HashSet<>();
     repConfig = new ECReplicationConfig(3, 2);
     repReport = new ReplicationManagerReport();
-    underRep = new ArrayList<>();
+    underRep = replicationManager.createUnderReplicatedQueue();
     overRep = new ArrayList<>();
+
+    // Ensure that RM will run when asked.
+    Mockito.when(scmContext.isLeaderReady()).thenReturn(true);
+    Mockito.when(scmContext.isInSafeMode()).thenReturn(false);
+    SCMServiceManager serviceManager = new SCMServiceManager();
+    serviceManager.register(replicationManager);
+    serviceManager.notifyStatusChanged();
   }
 
   @Test
@@ -245,12 +262,111 @@ public class TestReplicationManager {
         ReplicationManagerReport.HealthState.OVER_REPLICATED));
   }
 
+  @Test
+  public void testUnderReplicatedOrderingInQueue()
+      throws ContainerNotFoundException {
+    ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(decomContainer, Pair.of(DECOMMISSIONING, 1),
+        Pair.of(DECOMMISSIONING, 2), Pair.of(DECOMMISSIONING, 3),
+        Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
+
+    ContainerInfo underRep1 = createContainerInfo(repConfig, 2,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(underRep1, 1, 2, 3, 4);
+    ContainerInfo underRep0 = createContainerInfo(repConfig, 3,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(underRep0, 1, 2, 3);
+
+    replicationManager.processContainer(decomContainer, underRep, overRep,
+        repReport);
+    replicationManager.processContainer(underRep1, underRep, overRep,
+        repReport);
+    replicationManager.processContainer(underRep0, underRep, overRep,
+        repReport);
+    // We expect 3 messages on the queue. They should be in the reverse order
+    // to which they were added, putting the lowest remaining redundancy first.
+    Assert.assertEquals(3, underRep.size());
+    ContainerHealthResult.UnderReplicatedHealthResult res = underRep.poll();
+    Assert.assertEquals(underRep0, res.getContainerInfo());
+    res = underRep.poll();
+    Assert.assertEquals(underRep1, res.getContainerInfo());
+    res = underRep.poll();
+    Assert.assertEquals(decomContainer, res.getContainerInfo());
+  }
+
+  @Test
+  public void testUnderReplicationQueuePopulated() {
+    ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(decomContainer, Pair.of(DECOMMISSIONING, 1),
+        Pair.of(DECOMMISSIONING, 2), Pair.of(DECOMMISSIONING, 3),
+        Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
+
+    ContainerInfo underRep1 = createContainerInfo(repConfig, 2,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(underRep1, 1, 2, 3, 4);
+    ContainerInfo underRep0 = createContainerInfo(repConfig, 3,
+        HddsProtos.LifeCycleState.CLOSED);
+    addReplicas(underRep0, 1, 2, 3);
+
+    replicationManager.processAll();
+
+    // Get the first message off the queue - it should be underRep0.
+    ContainerHealthResult.UnderReplicatedHealthResult res
+        = replicationManager.dequeueUnderReplicatedContainer();
+    Assert.assertEquals(underRep0, res.getContainerInfo());
+
+    // Now requeue it
+    replicationManager.requeueUnderReplicatedContainer(res);
+
+    // Now get the next message. It should be underRep1, as it has remaining
+    // redundancy 1 + zero retries. UnderRep1 will have remaining redundancy 0
+    // and 1 retry. They will have the same weighted redundancy so lesser
+    // retries should come first
+    res = replicationManager.dequeueUnderReplicatedContainer();
+    Assert.assertEquals(underRep1, res.getContainerInfo());
+
+    // Next message is underRep0. It starts with a weighted redundancy of 0 + 1
+    // retry. The other message on the queue is a decommission only with a
+    // weighted redundancy of 5 + 0. So lets dequeue and requeue the message 4
+    // times. Then the weighted redundancy will be equal and the decommission
+    // one will be next due to having less retries.
+    for (int i = 0; i < 4; i++) {
+      res = replicationManager.dequeueUnderReplicatedContainer();
+      Assert.assertEquals(underRep0, res.getContainerInfo());
+      replicationManager.requeueUnderReplicatedContainer(res);
+    }
+    res = replicationManager.dequeueUnderReplicatedContainer();
+    Assert.assertEquals(decomContainer, res.getContainerInfo());
+
+    res = replicationManager.dequeueUnderReplicatedContainer();
+    Assert.assertEquals(underRep0, res.getContainerInfo());
+
+    res = replicationManager.dequeueUnderReplicatedContainer();
+    Assert.assertNull(res);
+  }
+
+  private Set<ContainerReplica>  addReplicas(ContainerInfo container,
+      Pair<HddsProtos.NodeOperationalState, Integer>... nodes) {
+    final Set<ContainerReplica> replicas =
+        createReplicas(container.containerID(), nodes);
+    storeContainerAndReplicas(container, replicas);
+    return replicas;
+  }
+
   private Set<ContainerReplica> addReplicas(ContainerInfo container,
       int... indexes) {
     final Set<ContainerReplica> replicas =
         createReplicas(container.containerID(), indexes);
-    containerReplicaMap.put(container.containerID(), replicas);
+    storeContainerAndReplicas(container, replicas);
     return replicas;
+  }
+
+  private void storeContainerAndReplicas(ContainerInfo container,
+      Set<ContainerReplica> replicas) {
+    containerReplicaMap.put(container.containerID(), replicas);
+    containerInfoSet.add(container);
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

After the under / over replicated containers are collect in [HDDS-6699](https://issues.apache.org/jira/browse/HDDS-6699), they need to be priortised and placed on a queue for the next stage of RM to pick up and process.

This change adds a priority queue for the under replicated containers, where they are priortised by the remaining redundancy and made available for processing by the next stage of the replication process.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6957

## How was this patch tested?

New unit tests