### PR TITLE
HDDS-6968. Addendum: [Multi-Tenant] Fix USER_MISMATCH error even on correct user.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
@@ -49,8 +49,6 @@ public final class S3SecretRequestHelper {
       OzoneManager ozoneManager, UserGroupInformation ugi, String accessId)
       throws IOException {
 
-    final String username = ugi.getShortUserName();
-
     // Flag indicating whether the accessId is assigned to a tenant
     // (under S3 Multi-Tenancy feature) or not.
     boolean isAccessIdAssignedToTenant = false;
@@ -74,12 +72,15 @@ public final class S3SecretRequestHelper {
             multiTenantManager.getUserNameGivenAccessId(accessId);
         final String tenantId = optionalTenantId.get();
 
+        // Access ID owner is short name
+        final String shortName = ugi.getShortUserName();
+
         // HDDS-6691: ugi should either own the access ID, or be an Ozone/tenant
         // admin to pass the check.
-        if (!username.equals(accessIdOwnerUsername) &&
+        if (!shortName.equals(accessIdOwnerUsername) &&
             !multiTenantManager.isTenantAdmin(ugi, tenantId, false)) {
           throw new OMException("Requested accessId '" + accessId + "' doesn't"
-              + " belong to current user '" + username + "', nor does"
+              + " belong to current user '" + shortName + "', nor does"
               + " current user have Ozone or tenant administrator privilege",
               ResultCodes.USER_MISMATCH);
           // Note: A more fitting result code could be PERMISSION_DENIED,
@@ -95,11 +96,12 @@ public final class S3SecretRequestHelper {
 
     // 2. If S3 multi-tenancy is disabled (or the access ID is not assigned
     // to a tenant), fall back to the old permission check.
+    final String fullPrincipal = ugi.getUserName();
     if (!isAccessIdAssignedToTenant &&
-        !username.equals(accessId) && !ozoneManager.isAdmin(ugi)) {
+        !fullPrincipal.equals(accessId) && !ozoneManager.isAdmin(ugi)) {
 
       throw new OMException("Requested accessId '" + accessId +
-          "' doesn't match current user '" + username +
+          "' doesn't match current user '" + fullPrincipal +
           "', nor does current user has administrator privilege.",
           OMException.ResultCodes.USER_MISMATCH);
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -90,11 +90,10 @@ public class TestS3GetSecretRequest {
 
   // Multi-tenant related vars
   private static final String USER_ALICE = "alice@EXAMPLE.COM";
-  private static final String USER_ALICE_SHORT = "alice";
   private static final String TENANT_ID = "finance";
-  private static final String USER_BOB_SHORT = "bob";
+  private static final String USER_BOB = "bob@EXAMPLE.COM";
   private static final String ACCESS_ID_BOB =
-      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB_SHORT);
+      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB);
 
   private UserGroupInformation ugiAlice;
 
@@ -247,7 +246,7 @@ public class TestS3GetSecretRequest {
     S3GetSecretRequest s3GetSecretRequest1 =
         new S3GetSecretRequest(
             new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE_SHORT)
+                s3GetSecretRequest(USER_ALICE)
             ).preExecute(ozoneManager)
         );
 
@@ -263,7 +262,7 @@ public class TestS3GetSecretRequest {
 
     // Check response
     final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
-    Assert.assertEquals(USER_ALICE_SHORT, s3SecretValue.getKerberosID());
+    Assert.assertEquals(USER_ALICE, s3SecretValue.getKerberosID());
     final String awsSecret1 = s3SecretValue.getAwsSecret();
     Assert.assertNotNull(awsSecret1);
 
@@ -271,7 +270,7 @@ public class TestS3GetSecretRequest {
         s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
     // The secret inside should be the same.
     final S3Secret s3Secret1 = getS3SecretResponse.getS3Secret();
-    Assert.assertEquals(USER_ALICE_SHORT, s3Secret1.getKerberosID());
+    Assert.assertEquals(USER_ALICE, s3Secret1.getKerberosID());
     Assert.assertEquals(awsSecret1, s3Secret1.getAwsSecret());
 
 
@@ -282,7 +281,7 @@ public class TestS3GetSecretRequest {
     S3GetSecretRequest s3GetSecretRequest2 =
         new S3GetSecretRequest(
             new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE_SHORT)
+                s3GetSecretRequest(USER_ALICE)
             ).preExecute(ozoneManager)
         );
 
@@ -303,7 +302,7 @@ public class TestS3GetSecretRequest {
         s3GetSecretResponse2.getOMResponse().getGetS3SecretResponse();
     // The secret inside should be the same.
     final S3Secret s3Secret2 = getS3SecretResponse2.getS3Secret();
-    Assert.assertEquals(USER_ALICE_SHORT, s3Secret2.getKerberosID());
+    Assert.assertEquals(USER_ALICE, s3Secret2.getKerberosID());
 
     // Should get the same secret as the first request's.
     Assert.assertEquals(awsSecret1, s3Secret2.getAwsSecret());
@@ -378,7 +377,7 @@ public class TestS3GetSecretRequest {
         new OMTenantAssignUserAccessIdRequest(
             new OMTenantAssignUserAccessIdRequest(
                 assignUserToTenantRequest(TENANT_ID,
-                    USER_BOB_SHORT, ACCESS_ID_BOB)
+                    USER_BOB, ACCESS_ID_BOB)
             ).preExecute(ozoneManager)
         );
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -91,9 +91,9 @@ public class TestS3GetSecretRequest {
   // Multi-tenant related vars
   private static final String USER_ALICE = "alice@EXAMPLE.COM";
   private static final String TENANT_ID = "finance";
-  private static final String USER_BOB = "bob@EXAMPLE.COM";
+  private static final String USER_BOB_SHORT = "bob";
   private static final String ACCESS_ID_BOB =
-      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB);
+      OMMultiTenantManager.getDefaultAccessId(TENANT_ID, USER_BOB_SHORT);
 
   private UserGroupInformation ugiAlice;
 
@@ -377,7 +377,7 @@ public class TestS3GetSecretRequest {
         new OMTenantAssignUserAccessIdRequest(
             new OMTenantAssignUserAccessIdRequest(
                 assignUserToTenantRequest(TENANT_ID,
-                    USER_BOB, ACCESS_ID_BOB)
+                    USER_BOB_SHORT, ACCESS_ID_BOB)
             ).preExecute(ozoneManager)
         );
 


### PR DESCRIPTION
This is an addendum to #3566

Fix the Short Principle and Full Principle check for `GetS3SecretHandler` and `TenantGetSecretHandler`

CI run: https://github.com/aswinshakil/ozone/actions/runs/2599527648