### PR TITLE
HDDS-6979. Remove unused plexus dependency declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -895,17 +895,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       </dependency>
 
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>2.0.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-annotations</artifactId>
-        <version>1.5.5</version>
-      </dependency>
-
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>5.0.4</version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Dependencies from `org.codehaus.plexus` are defined in `dependencyManagement`, but never actually used, so can be removed.

https://issues.apache.org/jira/browse/HDDS-6979

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2600537869