### PR TITLE
HDDS-6990. AuthorizerLockImpl.java#tryWriteLockInOMRequest: move sani…

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/AuthorizerLockImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/AuthorizerLockImpl.java
@@ -132,11 +132,12 @@ public class AuthorizerLockImpl implements AuthorizerLock {
   @Override
   public void tryWriteLockInOMRequest() throws IOException {
 
+    long stamp = tryWriteLockThrowOnTimeout();
+
     // Sanity check. Must not have held a write lock in a tenant OMRequest.
     Preconditions.checkArgument(omRequestWriteLockStamp == 0L);
     Preconditions.checkArgument(omRequestWriteLockHolderTid == 0L);
 
-    long stamp = tryWriteLockThrowOnTimeout();
     omRequestWriteLockStamp = stamp;
     omRequestWriteLockHolderTid = Thread.currentThread().getId();
     if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
…ty args check to after tryWriteLockThrowOnTimeout().

## What changes were proposed in this pull request?
Move the sanity arguments check to after tryWriteLockThrowOnTimeout(). The original implementation will throw IllegalArgumentException when another tenant write request is in-progress.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6990)

## How was this patch tested?
N/A