### PR TITLE
HDDS-6999. Correct volume parameter description for freon test tools

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketGenerator.java
@@ -42,7 +42,7 @@ public class OmBucketGenerator extends BaseFreonGenerator
     implements Callable<Void> {
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketRemover.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmBucketRemover.java
@@ -38,7 +38,7 @@ public class OmBucketRemover extends BaseFreonGenerator
     implements Callable<Void> {
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OmKeyGenerator.java
@@ -50,7 +50,7 @@ public class OmKeyGenerator extends BaseFreonGenerator
     implements Callable<Void> {
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyGenerator.java
@@ -45,7 +45,7 @@ public class OzoneClientKeyGenerator extends BaseFreonGenerator
     implements Callable<Void> {
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyRemover.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyRemover.java
@@ -39,7 +39,7 @@ public class OzoneClientKeyRemover extends BaseFreonGenerator
     implements Callable<Void> {
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyValidator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/OzoneClientKeyValidator.java
@@ -49,7 +49,7 @@ public class OzoneClientKeyValidator extends BaseFreonGenerator
       LoggerFactory.getLogger(OzoneClientKeyValidator.class);
 
   @Option(names = {"-v", "--volume"},
-      description = "Name of the bucket which contains the test data. Will be"
+      description = "Name of the volume which contains the test data. Will be"
           + " created if missing.",
       defaultValue = "vol1")
   private String volumeName;


### PR DESCRIPTION
## What changes were proposed in this pull request?

While executing any of the following `ozone freon` commands:

```
ozone freon ockg --help
ozone freon ockv --help
ozone freon ockr --help
ozone freon ombg --help
ozone freon omkg --help
ozone freon ombr --help
```

the `-v, --volume` description reads “Name of the `bucket`…” instead of `volume`:
```
-v, --volume=<volumeName>
                          Name of the bucket which contains the test data. Will
                          be created if missing.
                          Default: vol1
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6999

## How was this patch tested?

NA
