### PR TITLE
HDDS-6998. Ignore keys with higher updateID in OpenKeyDeleteRequest

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/key/OMOpenKeysDeleteRequest.java
@@ -159,6 +159,14 @@ public class OMOpenKeysDeleteRequest extends OMKeyRequest {
             omMetadataManager.getOpenKeyTable(getBucketLayout())
                 .get(fullKeyName);
         if (omKeyInfo != null) {
+          if (ozoneManager.isRatisEnabled() &&
+              trxnLogIndex < omKeyInfo.getUpdateID()) {
+            LOG.warn("Transaction log index {} is smaller than " +
+                "the current updateID {} of key {}, skipping deletion.",
+                trxnLogIndex, omKeyInfo.getUpdateID(), fullKeyName);
+            continue;
+          }
+
           // Set the UpdateID to current transactionLogIndex
           omKeyInfo.setUpdateID(trxnLogIndex, ozoneManager.isRatisEnabled());
           deletedOpenKeys.put(fullKeyName, omKeyInfo);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Ignore keys with higher updateID in OpenKeyDeleteRequest, see:

https://issues.apache.org/jira/browse/HDDS-6998

## How was this patch tested?

`TestOMOpenKeysDeleteRequest#testDeleteKeyWithHigherUpdateID()`