### PR TITLE
HDDS-6588. Recon shows zero datanodes with `./compose/upgrade/compose/ha/`

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
+++ b/hadoop-ozone/dist/src/main/compose/upgrade/compose/ha/docker-config
@@ -51,6 +51,7 @@ OZONE-SITE.XML_ozone.scm.pipeline.allocated.timeout=2m
 
 OZONE-SITE.XML_ozone.recon.db.dir=/data/metadata/recon
 OZONE-SITE.XML_ozone.recon.om.snapshot.task.interval.delay=1m
+OZONE-SITE.XML_ozone.recon.address=recon:9891
 
 no_proxy=om1,om2,om3,scm,s3g,kdc,localhost,127.0.0.1
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Recon previously showed zero datanodes at the Overview and Datanodes pages in the `./compose/upgrade/compose/ha/` environment. I added the recon address (recon:9891) in the docker-config file, which fixed it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6588

## How was this patch tested?

I created a cluster in the `./compose/upgrade/compose/ha/` directory, checked the Recon page at http://localhost:9888/ and the datanode number was correct, I was able to see each datanode.
