### PR TITLE
HDDS-6895. EC: ReplicationManager - Logic to process the under replicated queue and assign work to DNs

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.google.protobuf.ByteString;
+import org.apache.hadoop.hdds.HddsIdFactory;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
@@ -47,13 +48,8 @@ public class ReconstructECContainersCommand
       List<DatanodeDetailsAndReplicaIndex> sources,
       List<DatanodeDetails> targetDatanodes, byte[] missingContainerIndexes,
       ECReplicationConfig ecReplicationConfig) {
-    super();
-    this.containerID = containerID;
-    this.sources = sources;
-    this.targetDatanodes = targetDatanodes;
-    this.missingContainerIndexes =
-        Arrays.copyOf(missingContainerIndexes, missingContainerIndexes.length);
-    this.ecReplicationConfig = ecReplicationConfig;
+    this(containerID, sources, targetDatanodes, missingContainerIndexes,
+        ecReplicationConfig, HddsIdFactory.getLongId());
   }
 
   // Should be called only for protobuf conversion
@@ -68,6 +64,10 @@ public class ReconstructECContainersCommand
     this.missingContainerIndexes =
         Arrays.copyOf(missingContainerIndexes, missingContainerIndexes.length);
     this.ecReplicationConfig = ecReplicationConfig;
+    if (targetDatanodes.size() != missingContainerIndexes.length) {
+      throw new IllegalArgumentException("Number of target datanodes and " +
+          "container indexes should be same");
+    }
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReconstructECContainersCommand.java
@@ -52,7 +52,6 @@ public class ReconstructECContainersCommand
         ecReplicationConfig, HddsIdFactory.getLongId());
   }
 
-  // Should be called only for protobuf conversion
   public ReconstructECContainersCommand(long containerID,
       List<DatanodeDetailsAndReplicaIndex> sourceDatanodes,
       List<DatanodeDetails> targetDatanodes, byte[] missingContainerIndexes,

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/protocol/commands/ReplicateContainerCommand.java
@@ -41,6 +41,7 @@ public class ReplicateContainerCommand
 
   private final long containerID;
   private final List<DatanodeDetails> sourceDatanodes;
+  private int replicaIndex = 0;
 
   public ReplicateContainerCommand(long containerID,
       List<DatanodeDetails> sourceDatanodes) {
@@ -57,6 +58,10 @@ public class ReplicateContainerCommand
     this.sourceDatanodes = sourceDatanodes;
   }
 
+  public void setReplicaIndex(int index) {
+    replicaIndex = index;
+  }
+
   @Override
   public Type getType() {
     return SCMCommandProto.Type.replicateContainerCommand;
@@ -70,6 +75,7 @@ public class ReplicateContainerCommand
     for (DatanodeDetails dd : sourceDatanodes) {
       builder.addSources(dd.getProtoBufMessage());
     }
+    builder.setReplicaIndex(replicaIndex);
     return builder.build();
   }
 
@@ -83,9 +89,13 @@ public class ReplicateContainerCommand
             .map(DatanodeDetails::getFromProtoBuf)
             .collect(Collectors.toList());
 
-    return new ReplicateContainerCommand(protoMessage.getContainerID(),
-        datanodeDetails, protoMessage.getCmdId());
-
+    ReplicateContainerCommand cmd =
+        new ReplicateContainerCommand(protoMessage.getContainerID(),
+            datanodeDetails, protoMessage.getCmdId());
+    if (protoMessage.hasReplicaIndex()) {
+      cmd.setReplicaIndex(protoMessage.getReplicaIndex());
+    }
+    return cmd;
   }
 
   public long getContainerID() {
@@ -94,5 +104,9 @@ public class ReplicateContainerCommand
 
   public List<DatanodeDetails> getSourceDatanodes() {
     return sourceDatanodes;
+  }
+
+  public int getReplicaIndex() {
+    return replicaIndex;
   }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/endpoint/TestHeartbeatEndpointTask.java
@@ -24,7 +24,9 @@ import static org.apache.hadoop.hdds.upgrade.HDDSLayoutVersionManager.maxLayoutV
 import static org.mockito.ArgumentMatchers.any;
 
 import java.net.InetSocketAddress;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,6 +35,7 @@ import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.SCMCommandProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandQueueReportProto;
 import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.CommandStatusReportsProto;
@@ -68,8 +71,11 @@ public class TestHeartbeatEndpointTask {
         Mockito.mock(
             StorageContainerDatanodeProtocolClientSideTranslatorPB.class);
 
+    List<DatanodeDetails> targetDns = new ArrayList<>();
+    targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
+    targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
     ReconstructECContainersCommand cmd = new ReconstructECContainersCommand(
-        1, emptyList(), emptyList(), new byte[]{2, 5},
+        1, emptyList(), targetDns, new byte[]{2, 5},
         new ECReplicationConfig(3, 2));
 
     Mockito.when(scm.sendHeartbeat(any()))

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/protocol/commands/TestReconstructionECContainersCommands.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -32,6 +33,19 @@ import java.util.stream.Collectors;
  * Test ECReconstructionContainersCommand.
  */
 public class TestReconstructionECContainersCommands {
+
+  @Test
+  public void testExceptionIfSourceAndMissingNotSameLength() {
+    ECReplicationConfig ecReplicationConfig = new ECReplicationConfig(3, 2);
+    byte[] missingContainerIndexes = {1, 2};
+
+    List<DatanodeDetails> targetDns = new ArrayList<>();
+    targetDns.add(MockDatanodeDetails.randomDatanodeDetails());
+
+    Assert.assertThrows(IllegalArgumentException.class,
+        () -> new ReconstructECContainersCommand(1L, Collections.emptyList(),
+        targetDns, missingContainerIndexes, ecReplicationConfig));
+  }
 
   @Test
   public void protobufConversion() {
@@ -48,7 +62,7 @@ public class TestReconstructionECContainersCommands {
           a -> new ReconstructECContainersCommand
               .DatanodeDetailsAndReplicaIndex(a, dnDetails.indexOf(a)))
         .collect(Collectors.toList());
-    List<DatanodeDetails> targets = getDNDetails(5);
+    List<DatanodeDetails> targets = getDNDetails(2);
     ReconstructECContainersCommand reconstructECContainersCommand =
         new ReconstructECContainersCommand(1L, sources, targets,
             missingContainerIndexes, ecReplicationConfig);

--- a/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
+++ b/hadoop-hdds/interface-server/src/main/proto/ScmServerDatanodeHeartbeatProtocol.proto
@@ -409,6 +409,7 @@ message ReplicateContainerCommandProto {
   required int64 containerID = 1;
   repeated DatanodeDetailsProto sources = 2;
   required int64 cmdId = 3;
+  optional int32 replicaIndex = 4;
 }
 
 /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -202,6 +202,9 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
             final ReplicateContainerCommand replicateCommand =
                 new ReplicateContainerCommand(id.getProtobuf().getId(),
                     ImmutableList.of(decommissioningSrcNode));
+            // For EC containers, we need to track the replica index which is
+            // to be replicated, so add it to the command.
+            replicateCommand.setReplicaIndex(replica.getReplicaIndex());
             DatanodeDetails target = iterator.next();
             commands.put(target, replicateCommand);
           }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -81,14 +81,17 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
    * @param remainingMaintenanceRedundancy - represents that how many nodes go
    *                                      into maintenance.
    * @return Returns the key value pair of destination dn where the command gets
-   * executed and the command itself.
+   * executed and the command itself. If an empty list if returned, it indicates
+   * the container is no longer unhealthy and can be removed from the unhealthy
+   * queue. Any exception indicates that the container is still unhealthy and
+   * should be retried later.
    */
   @Override
   public Map<DatanodeDetails, SCMCommand<?>> processAndCreateCommands(
       final Set<ContainerReplica> replicas,
       final List<ContainerReplicaOp> pendingOps,
       final ContainerHealthResult result,
-      final int remainingMaintenanceRedundancy) {
+      final int remainingMaintenanceRedundancy) throws IOException {
     ContainerInfo container = result.getContainerInfo();
     ECReplicationConfig repConfig =
         (ECReplicationConfig) container.getReplicationConfig();
@@ -208,6 +211,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
       LOG.warn("Exception while processing for creating the EC reconstruction" +
               " container commands for {}.",
           id, ex);
+      throw ex;
     }
     return commands;
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -81,7 +81,7 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
    * @param remainingMaintenanceRedundancy - represents that how many nodes go
    *                                      into maintenance.
    * @return Returns the key value pair of destination dn where the command gets
-   * executed and the command itself. If an empty list if returned, it indicates
+   * executed and the command itself. If an empty list is returned, it indicates
    * the container is no longer unhealthy and can be removed from the unhealthy
    * queue. Any exception indicates that the container is still unhealthy and
    * should be retried later.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -139,7 +139,7 @@ public class ReplicationManager implements SCMService {
   private final ReentrantLock lock = new ReentrantLock();
   private Queue<ContainerHealthResult.UnderReplicatedHealthResult>
       underRepQueue;
-  private ECUnderReplicationHandler ecUnderReplicationHandler;
+  private final ECUnderReplicationHandler ecUnderReplicationHandler;
 
   /**
    * Constructs ReplicationManager instance with the given configuration.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.ExitUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -137,6 +138,7 @@ public class ReplicationManager implements SCMService {
   private final ReentrantLock lock = new ReentrantLock();
   private Queue<ContainerHealthResult.UnderReplicatedHealthResult>
       underRepQueue;
+  private ECUnderReplicationHandler ecUnderReplicationHandler;
 
   /**
    * Constructs ReplicationManager instance with the given configuration.
@@ -174,6 +176,8 @@ public class ReplicationManager implements SCMService {
     this.ecContainerHealthCheck = new ECContainerHealthCheck();
     this.nodeManager = nodeManager;
     this.underRepQueue = createUnderReplicatedQueue();
+    ecUnderReplicationHandler = new ECUnderReplicationHandler(
+        containerPlacement, conf, nodeManager);
     start();
   }
 
@@ -315,6 +319,17 @@ public class ReplicationManager implements SCMService {
     }
   }
 
+  public Map<DatanodeDetails, SCMCommand<?>> processUnderReplicatedContainer(
+      final ContainerHealthResult result) throws IOException {
+    ContainerID containerID = result.getContainerInfo().containerID();
+    Set<ContainerReplica> replicas = containerManager.getContainerReplicas(
+        containerID);
+    List<ContainerReplicaOp> pendingOps =
+        containerReplicaPendingOps.getPendingOps(containerID);
+    return ecUnderReplicationHandler.processAndCreateCommands(replicas,
+        pendingOps, result, 0);
+  }
+
   protected ContainerHealthResult processContainer(ContainerInfo containerInfo,
       Queue<ContainerHealthResult.UnderReplicatedHealthResult> underRep,
       List<ContainerHealthResult.OverReplicatedHealthResult> overRep,
@@ -432,6 +447,18 @@ public class ReplicationManager implements SCMService {
     private long interval = Duration.ofSeconds(300).toMillis();
 
     /**
+     * The frequency in which the Under Replicated queue is processed.
+     */
+    @Config(key = "under.replicated.interval",
+        type = ConfigType.TIME,
+        defaultValue = "30s",
+        tags = {SCM, OZONE},
+        description = "Hpw frequently to check if there are work to process " +
+            " on the under replicated queue"
+    )
+    private long underReplicatedInterval = Duration.ofSeconds(30).toMillis();
+
+    /**
      * Timeout for container replication & deletion command issued by
      * ReplicationManager.
      */
@@ -472,6 +499,10 @@ public class ReplicationManager implements SCMService {
 
     public long getInterval() {
       return interval;
+    }
+
+    public long getUnderReplicatedInterval() {
+      return underReplicatedInterval;
     }
 
     public long getEventTimeout() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.apache.hadoop.util.ExitUtil;
+import org.apache.ratis.protocol.exceptions.NotLeaderException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -328,6 +329,10 @@ public class ReplicationManager implements SCMService {
         containerReplicaPendingOps.getPendingOps(containerID);
     return ecUnderReplicationHandler.processAndCreateCommands(replicas,
         pendingOps, result, 0);
+  }
+
+  public long getScmTerm() throws NotLeaderException {
+    return scmContext.getTermOfLeader();
   }
 
   protected ContainerHealthResult processContainer(ContainerInfo containerInfo,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -453,7 +453,7 @@ public class ReplicationManager implements SCMService {
         type = ConfigType.TIME,
         defaultValue = "30s",
         tags = {SCM, OZONE},
-        description = "Hpw frequently to check if there are work to process " +
+        description = "How frequently to check if there are work to process " +
             " on the under replicated queue"
     )
     private long underReplicatedInterval = Duration.ofSeconds(30).toMillis();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -64,6 +64,8 @@ public class UnderReplicatedProcessor {
    * datanode, so they are not assigned too much work.
    */
   public void processAll() {
+    int processed = 0;
+    int failed = 0;
     while (true) {
       ContainerHealthResult.UnderReplicatedHealthResult underRep =
           replicationManager.dequeueUnderReplicatedContainer();
@@ -72,12 +74,16 @@ public class UnderReplicatedProcessor {
       }
       try {
         processContainer(underRep);
+        processed++;
       } catch (IOException e) {
         LOG.error("Error processing under replicated container {}",
             underRep.getContainerInfo(), e);
+        failed++;
         replicationManager.requeueUnderReplicatedContainer(underRep);
       }
     }
+    LOG.info("Processed {} under replicated containers, failed processing {}",
+        processed, failed);
   }
 
   protected void processContainer(ContainerHealthResult

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ *  with the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerID;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.CommandForDatanode;
+import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Class used to pick messages from the ReplicationManager under replicated
+ * queue, calculate the reconstruction commands and assign to the datanodes
+ * via the eventQueue.
+ */
+public class UnderReplicatedProcessor {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(UnderReplicatedProcessor.class);
+  private final ReplicationManager replicationManager;
+  private final ContainerReplicaPendingOps pendingOps;
+  private final EventPublisher eventPublisher;
+
+  public UnderReplicatedProcessor(ReplicationManager replicationManager,
+      ContainerReplicaPendingOps pendingOps,
+      EventPublisher eventPublisher) {
+    this.replicationManager = replicationManager;
+    this.pendingOps = pendingOps;
+    this.eventPublisher = eventPublisher;
+  }
+
+  /**
+   * Read messages from the ReplicationManager under replicated queue and,
+   * form commands to correct the under replication. The commands are added
+   * to the event queue and the PendingReplicaOps are adjusted.
+   *
+   * Note: this is a temporary implementation of this feature. A future
+   * version will need to limit the amount of messages assigned to each
+   * datanode, so they are not assigned too much work.
+   */
+  public void processAll() {
+    while (true) {
+      ContainerHealthResult.UnderReplicatedHealthResult underRep =
+          replicationManager.dequeueUnderReplicatedContainer();
+      if (underRep == null) {
+        break;
+      }
+      try {
+        processContainer(underRep);
+      } catch (IOException e) {
+        LOG.error("Error processing under replicated container {}",
+            underRep.getContainerInfo(), e);
+        replicationManager.requeueUnderReplicatedContainer(underRep);
+      }
+    }
+  }
+
+  protected void processContainer(ContainerHealthResult
+      .UnderReplicatedHealthResult underRep) throws IOException {
+    Map<DatanodeDetails, SCMCommand<?>> cmds = replicationManager
+        .processUnderReplicatedContainer(underRep);
+    for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds.entrySet()) {
+      final CommandForDatanode<?> datanodeCommand =
+          new CommandForDatanode<>(cmd.getKey().getUuid(), cmd.getValue());
+      eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
+      adjustPendingOps(underRep.getContainerInfo().containerID(),
+          cmd.getValue(), cmd.getKey());
+    }
+  }
+
+  private void adjustPendingOps(ContainerID containerID, SCMCommand<?> cmd,
+      DatanodeDetails targetDatanode)
+      throws IOException {
+    if (cmd.getType() == StorageContainerDatanodeProtocolProtos
+        .SCMCommandProto.Type.reconstructECContainersCommand) {
+      ReconstructECContainersCommand rcc = (ReconstructECContainersCommand) cmd;
+      List<DatanodeDetails> targets = rcc.getTargetDatanodes();
+      byte[] targetIndexes = rcc.getMissingContainerIndexes();
+      for (int i = 0; i < targetIndexes.length; i++) {
+        pendingOps.scheduleAddReplica(containerID, targets.get(i),
+            targetIndexes[i]);
+      }
+    } else if (cmd.getType() == StorageContainerDatanodeProtocolProtos
+        .SCMCommandProto.Type.replicateContainerCommand) {
+      ReplicateContainerCommand rcc = (ReplicateContainerCommand) cmd;
+      pendingOps.scheduleAddReplica(containerID, targetDatanode, 0);
+    } else {
+      throw new IOException("Unexpected command type " + cmd.getType());
+    }
+  }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -114,7 +114,8 @@ public class UnderReplicatedProcessor {
     } else if (cmd.getType() == StorageContainerDatanodeProtocolProtos
         .SCMCommandProto.Type.replicateContainerCommand) {
       ReplicateContainerCommand rcc = (ReplicateContainerCommand) cmd;
-      pendingOps.scheduleAddReplica(containerID, targetDatanode, 0);
+      pendingOps.scheduleAddReplica(
+          containerID, targetDatanode, rcc.getReplicaIndex());
     } else {
       throw new IOException("Unexpected command type " + cmd.getType());
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -91,11 +91,13 @@ public class UnderReplicatedProcessor {
     Map<DatanodeDetails, SCMCommand<?>> cmds = replicationManager
         .processUnderReplicatedContainer(underRep);
     for (Map.Entry<DatanodeDetails, SCMCommand<?>> cmd : cmds.entrySet()) {
+      SCMCommand<?> scmCmd = cmd.getValue();
+      scmCmd.setTerm(replicationManager.getScmTerm());
       final CommandForDatanode<?> datanodeCommand =
-          new CommandForDatanode<>(cmd.getKey().getUuid(), cmd.getValue());
+          new CommandForDatanode<>(cmd.getKey().getUuid(), scmCmd);
       eventPublisher.fireEvent(SCMEvents.DATANODE_COMMAND, datanodeCommand);
       adjustPendingOps(underRep.getContainerInfo().containerID(),
-          cmd.getValue(), cmd.getKey());
+          scmCmd, cmd.getKey());
     }
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
@@ -42,7 +42,7 @@ public interface UnhealthyReplicationHandler {
    * @param remainingMaintenanceRedundancy - represents that how many nodes go
    *                                      into maintenance.
    * @return Returns the key value pair of destination dn where the command gets
-   * executed and the command itself. If an empty list if returned, it indicates
+   * executed and the command itself. If an empty list is returned, it indicates
    * the container is no longer unhealthy and can be removed from the unhealthy
    * queue. Any exception indicates that the container is still unhealthy and
    * should be retried later.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnhealthyReplicationHandler.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -41,9 +42,13 @@ public interface UnhealthyReplicationHandler {
    * @param remainingMaintenanceRedundancy - represents that how many nodes go
    *                                      into maintenance.
    * @return Returns the key value pair of destination dn where the command gets
-   * executed and the command itself.
+   * executed and the command itself. If an empty list if returned, it indicates
+   * the container is no longer unhealthy and can be removed from the unhealthy
+   * queue. Any exception indicates that the container is still unhealthy and
+   * should be retried later.
    */
   Map<DatanodeDetails, SCMCommand<?>> processAndCreateCommands(
       Set<ContainerReplica> replicas, List<ContainerReplicaOp> pendingOps,
-      ContainerHealthResult result, int remainingMaintenanceRedundancy);
+      ContainerHealthResult result, int remainingMaintenanceRedundancy)
+      throws IOException;
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
+import static org.apache.hadoop.hdds.scm.exceptions.SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE;
 
 /**
  * Helper class to provide common methods used to test ReplicationManager.
@@ -134,6 +135,26 @@ public final class ReplicationTestUtil {
           dns.add(MockDatanodeDetails.randomDatanodeDetails());
         }
         return dns;
+      }
+
+      @Override
+      public DatanodeDetails chooseNode(List<DatanodeDetails> healthyNodes) {
+        return null;
+      }
+    };
+  }
+
+  public static PlacementPolicy getNoNodesTestPlacementPolicy(
+      final NodeManager nodeManager, final OzoneConfiguration conf) {
+    return new SCMCommonPlacementPolicy(nodeManager, conf) {
+      @Override
+      public List<DatanodeDetails> chooseDatanodes(
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+          long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
+        throw new SCMException("No nodes available",
+            FAILED_TO_FIND_SUITABLE_NODE);
       }
 
       @Override

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -125,8 +125,15 @@ public class TestECUnderReplicationHandler {
         .createReplicas(Pair.of(DECOMMISSIONING, 1), Pair.of(IN_SERVICE, 2),
             Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
             Pair.of(IN_SERVICE, 5));
-    testUnderReplicationWithMissingIndexes(Lists.emptyList(), availableReplicas,
-        1, policy);
+    Map<DatanodeDetails, SCMCommand<?>> cmds =
+        testUnderReplicationWithMissingIndexes(
+            Lists.emptyList(), availableReplicas, 1, policy);
+    Assert.assertEquals(1, cmds.size());
+    // Check the replicate command has index 1 set
+    ReplicateContainerCommand cmd = (ReplicateContainerCommand) cmds.values()
+        .iterator().next();
+    Assert.assertEquals(1, cmd.getReplicaIndex());
+
   }
 
   @Test
@@ -164,7 +171,8 @@ public class TestECUnderReplicationHandler {
 
   }
 
-  public void testUnderReplicationWithMissingIndexes(
+  public Map<DatanodeDetails, SCMCommand<?>>
+      testUnderReplicationWithMissingIndexes(
       List<Integer> missingIndexes, Set<ContainerReplica> availableReplicas,
       int decomIndexes, PlacementPolicy placementPolicy) throws IOException {
     ECUnderReplicationHandler ecURH =
@@ -204,5 +212,6 @@ public class TestECUnderReplicationHandler {
     Assert.assertEquals(decomIndexes, replicateCommand);
     Assert.assertEquals(shouldReconstructCommandExist ? 1 : 0,
         reconstructCommand);
+    return datanodeDetailsSCMCommandMap;
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -1,0 +1,179 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
+import org.apache.hadoop.hdds.conf.ConfigurationSource;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.protocol.DatanodeDetails;
+import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
+import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.scm.container.ContainerInfo;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
+import org.apache.hadoop.hdds.server.events.EventPublisher;
+import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
+import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
+import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
+import org.apache.ozone.test.TestClock;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.eq;
+
+/**
+ * Tests for the UnderReplicatedProcessor class.
+ */
+public class TestUnderReplicatedProcessor {
+
+  private ConfigurationSource conf;
+  private TestClock clock;
+  private ContainerReplicaPendingOps pendingOps;
+  private ReplicationManager replicationManager;
+  private EventPublisher eventPublisher;
+  private ECReplicationConfig repConfig;
+  private UnderReplicatedProcessor underReplicatedProcessor;
+
+  @Before
+  public void setup() {
+    conf = new OzoneConfiguration();
+    clock = new TestClock(Instant.now(), ZoneId.systemDefault());
+    pendingOps = new ContainerReplicaPendingOps(conf, clock);
+    replicationManager = Mockito.mock(ReplicationManager.class);
+    eventPublisher = Mockito.mock(EventPublisher.class);
+    repConfig = new ECReplicationConfig(3, 2);
+    underReplicatedProcessor = new UnderReplicatedProcessor(
+        replicationManager, pendingOps, eventPublisher);
+  }
+
+  @Test
+  public void testEcReconstructionCommand() throws IOException {
+    ContainerInfo container = ReplicationTestUtil
+        .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
+        .thenReturn(new ContainerHealthResult
+                .UnderReplicatedHealthResult(container, 3, false, false, false),
+            null);
+    List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
+        sourceNodes = new ArrayList<>();
+    for (int i = 1; i <= 3; i++) {
+      sourceNodes.add(
+          new ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex(
+              MockDatanodeDetails.randomDatanodeDetails(), i));
+    }
+    List<DatanodeDetails> targetNodes = new ArrayList<>();
+    targetNodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    targetNodes.add(MockDatanodeDetails.randomDatanodeDetails());
+    byte[] missingIndexes = {4, 5};
+
+    Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
+    commands.put(MockDatanodeDetails.randomDatanodeDetails(),
+        new ReconstructECContainersCommand(container.getContainerID(),
+            sourceNodes, targetNodes, missingIndexes, repConfig));
+
+    Mockito.when(replicationManager
+            .processUnderReplicatedContainer(Mockito.any()))
+        .thenReturn(commands);
+    underReplicatedProcessor.processAll();
+
+    Mockito.verify(eventPublisher, Mockito.times(1))
+        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(0))
+        .requeueUnderReplicatedContainer(Mockito.any());
+
+    // Ensure pending ops is updated for the target DNs in the command and the
+    // correct indexes.
+    List<ContainerReplicaOp> ops = pendingOps
+        .getPendingOps(container.containerID());
+    Assert.assertEquals(2, ops.size());
+    for (ContainerReplicaOp op : ops) {
+      int ind = targetNodes.indexOf(op.getTarget());
+      Assert.assertEquals(missingIndexes[ind], op.getReplicaIndex());
+    }
+  }
+
+  @Test
+  public void testEcReplicationCommand() throws IOException {
+    ContainerInfo container = ReplicationTestUtil
+        .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
+        .thenReturn(new ContainerHealthResult
+                .UnderReplicatedHealthResult(container, 3, true, false, false),
+            null);
+    List<DatanodeDetails> sourceDns = new ArrayList<>();
+    sourceDns.add(MockDatanodeDetails.randomDatanodeDetails());
+    DatanodeDetails targetDn = MockDatanodeDetails.randomDatanodeDetails();
+    ReplicateContainerCommand rcc = new ReplicateContainerCommand(
+        container.getContainerID(), sourceDns);
+    rcc.setReplicaIndex(3);
+
+    Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
+    commands.put(targetDn, rcc);
+
+    Mockito.when(replicationManager
+            .processUnderReplicatedContainer(Mockito.any()))
+        .thenReturn(commands);
+    underReplicatedProcessor.processAll();
+
+    Mockito.verify(eventPublisher, Mockito.times(1))
+        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(0))
+        .requeueUnderReplicatedContainer(Mockito.any());
+
+    // Ensure pending ops is updated for the target DNs in the command and the
+    // correct indexes.
+    List<ContainerReplicaOp> ops = pendingOps
+        .getPendingOps(container.containerID());
+    Assert.assertEquals(1, ops.size());
+    Assert.assertEquals(3, ops.get(0).getReplicaIndex());
+  }
+
+  @Test
+  public void testMessageRequeuedOnException() throws IOException {
+    ContainerInfo container = ReplicationTestUtil
+        .createContainer(HddsProtos.LifeCycleState.CLOSED, repConfig);
+    Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
+        .thenReturn(new ContainerHealthResult
+                .UnderReplicatedHealthResult(container, 3, false, false, false),
+            null);
+
+    Mockito.when(replicationManager
+            .processUnderReplicatedContainer(Mockito.any()))
+        .thenThrow(new IOException("Test Exception"));
+    underReplicatedProcessor.processAll();
+
+    Mockito.verify(eventPublisher, Mockito.times(0))
+        .fireEvent(eq(SCMEvents.DATANODE_COMMAND), Mockito.any());
+    Mockito.verify(replicationManager, Mockito.times(1))
+        .requeueUnderReplicatedContainer(Mockito.any());
+
+    // Ensure pending ops has nothing for this container.
+    List<ContainerReplicaOp> ops = pendingOps
+        .getPendingOps(container.containerID());
+    Assert.assertEquals(0, ops.size());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

We need some sort of thread which picks work from the under / over replicated queue and assigns the work to DNs with capacity. The DNs will pick the work up on each heartbeat.

This initial change does not consider DN capacity or any limits. It will process all under replicated EC containers and assign them to the DN.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6895

## How was this patch tested?

New unit tests added