### PR TITLE
HDDS-6807. Remove tcnative.version property

### DIFF
--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -55,11 +55,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <scope>runtime</scope>
       </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/hadoop-ozone/common/pom.xml
+++ b/hadoop-ozone/common/pom.xml
@@ -52,13 +52,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${tcnative.version}</version>
         <scope>runtime</scope>
       </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>${tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -191,7 +191,7 @@ share/ozone/lib/netty-handler-proxy.Final.jar
 share/ozone/lib/netty-resolver.Final.jar
 share/ozone/lib/netty-tcnative-boringssl-static.Final.jar
 share/ozone/lib/netty-tcnative-classes.Final.jar
-share/ozone/lib/netty-tcnative.Final.jar
+share/ozone/lib/netty-tcnative.Final-linux-x86_64.jar
 share/ozone/lib/netty-transport.Final.jar
 share/ozone/lib/netty-transport-classes-epoll.Final.jar
 share/ozone/lib/netty-transport-native-epoll.Final-linux-x86_64.jar

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -191,7 +191,6 @@ share/ozone/lib/netty-handler-proxy.Final.jar
 share/ozone/lib/netty-resolver.Final.jar
 share/ozone/lib/netty-tcnative-boringssl-static.Final.jar
 share/ozone/lib/netty-tcnative-classes.Final.jar
-share/ozone/lib/netty-tcnative.Final-linux-x86_64.jar
 share/ozone/lib/netty-transport.Final.jar
 share/ozone/lib/netty-transport-classes-epoll.Final.jar
 share/ozone/lib/netty-transport-native-epoll.Final-linux-x86_64.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -87,11 +87,6 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative</artifactId>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -90,12 +90,11 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative</artifactId>
-      <version>${tcnative.version}</version>
+      <classifier>linux-x86_64</classifier>
     </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-tcnative-boringssl-static</artifactId>
-        <version>${tcnative.version}</version>
         <scope>runtime</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -203,9 +203,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <netty.version>4.1.74.Final</netty.version>
     <io.grpc.version>1.44.0</io.grpc.version>
-    <tcnative.version>2.0.48.Final</tcnative.version> <!-- See table for correct version -->
-    <!-- Table for netty, grpc & tcnative version combinations  -->
-    <!-- https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty -->
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed the tcnative property from dependencies at it is already included in netty.

## What is the link to the Apache JIRA

Here is the link: [HDDS-6807](https://issues.apache.org/jira/browse/HDDS-6807)

## How was this patch tested?

All unit/integration tests were run in the forked repository's pipeline as well as local deployment to see if the application still runs.