### PR TITLE
HDDS-7015. Ensure excluded nodes have network location when used in placement policies

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/net/NetworkTopologyImpl.java
@@ -601,6 +601,10 @@ public class NetworkTopologyImpl implements NetworkTopology {
       ancestorGen = 0;
     }
     Node scopeNode = getNode(finalScope);
+    if (scopeNode == null) {
+      throw new IllegalArgumentException(String.format("No nodes with Scope: " +
+              "%s exists", finalScope));
+    }
 
     // check overlap of excludedScopes and finalScope
     List<String> mutableExcludedScopes = null;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -132,7 +133,8 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
           int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
           throws SCMException {
     return chooseDatanodesInternal(
-            excludedNodes.stream()
+            Objects.isNull(excludedNodes)
+                    ? excludedNodes : excludedNodes.stream()
                     .map(node -> nodeManager
                             .getNodeByUuid(node.getUuidString()))
                     .collect(Collectors.toList()),

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -105,7 +105,6 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   public ConfigurationSource getConf() {
     return conf;
   }
-
   /**
    * Given size required, return set of datanodes
    * that satisfy the nodes and size requirement.
@@ -127,6 +126,28 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    */
   @Override
   public List<DatanodeDetails> chooseDatanodes(
+          List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+          int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
+    return chooseDatanodesInternal(
+            excludedNodes.stream()
+                    .map(node->nodeManager.getNodeByUuid(node.getUuidString()))
+                    .collect(Collectors.toList()),
+            favoredNodes, nodesRequired, metadataSizeRequired, dataSizeRequired);
+  }
+
+  /**
+   * Pipeline placement choose datanodes to join the pipeline.
+   *
+   * @param excludedNodes - excluded nodes
+   * @param favoredNodes  - list of nodes preferred.
+   * @param nodesRequired - number of datanodes required.
+   * @param dataSizeRequired - size required for the container.
+   * @param metadataSizeRequired - size required for Ratis metadata.
+   * @return a list of chosen datanodeDetails
+   * @throws SCMException when chosen nodes are not enough in numbers
+   */
+  protected List<DatanodeDetails> chooseDatanodesInternal(
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
       throws SCMException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -105,6 +105,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   public ConfigurationSource getConf() {
     return conf;
   }
+
   /**
    * Given size required, return set of datanodes
    * that satisfy the nodes and size requirement.
@@ -126,14 +127,17 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    */
   @Override
   public List<DatanodeDetails> chooseDatanodes(
-          List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes,
           int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
           throws SCMException {
     return chooseDatanodesInternal(
             excludedNodes.stream()
-                    .map(node->nodeManager.getNodeByUuid(node.getUuidString()))
+                    .map(node -> nodeManager
+                            .getNodeByUuid(node.getUuidString()))
                     .collect(Collectors.toList()),
-            favoredNodes, nodesRequired, metadataSizeRequired, dataSizeRequired);
+            favoredNodes, nodesRequired,
+            metadataSizeRequired, dataSizeRequired);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -127,11 +127,14 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    * @throws SCMException SCM exception.
    */
   @Override
-  public List<DatanodeDetails> chooseDatanodes(
+  public final List<DatanodeDetails> chooseDatanodes(
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes,
           int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
           throws SCMException {
+//    This method calls the chooseDatanodeInternal after fixing
+//    the excludeList to get the DatanodeDetails from the node manager.
+//    Network Topology requires this info to choose a random node.
     return chooseDatanodesInternal(
             Objects.isNull(excludedNodes)
                     ? excludedNodes : excludedNodes.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -148,9 +148,11 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
     return chooseDatanodesInternal(
             Objects.isNull(excludedNodes)
                     ? excludedNodes : excludedNodes.stream()
-                    .map(node -> nodeManager
-                            .getNodeByUuid(node.getUuidString()))
-                    .collect(Collectors.toList()),
+                    .map(node -> {
+                      DatanodeDetails datanodeDetails =
+                              nodeManager.getNodeByUuid(node.getUuidString());
+                      return datanodeDetails != null ? datanodeDetails : node;
+                    }).collect(Collectors.toList()),
             favoredNodes, nodesRequired,
             metadataSizeRequired, dataSizeRequired);
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -132,9 +132,19 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
           List<DatanodeDetails> favoredNodes,
           int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
           throws SCMException {
-//    This method calls the chooseDatanodeInternal after fixing
-//    the excludeList to get the DatanodeDetails from the node manager.
-//    Network Topology requires this info to choose a random node.
+/*
+  This method calls the chooseDatanodeInternal after fixing
+  the excludeList to get the DatanodeDetails from the node manager.
+  When the object of the Class DataNodeDetails is built from protobuf
+  only UUID of the datanode is added which is used for the hashcode.
+  Thus not passing any information about the topology. While excluding
+  datanodes the object is built from protobuf @Link {ExcludeList.java}.
+  NetworkTopology removes all nodes from the list which does not fall under
+  the scope while selecting a random node. Default scope value is
+  "/default-rack/" which won't match the required scope. Thus passing the proper
+  object of DatanodeDetails(with Topology Information) while trying to get the
+  random node from NetworkTopology should fix this. Check HDDS-7015
+ */
     return chooseDatanodesInternal(
             Objects.isNull(excludedNodes)
                     ? excludedNodes : excludedNodes.stream()

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -102,8 +102,9 @@ public final class SCMContainerPlacementCapacity
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {
-    List<DatanodeDetails> healthyNodes = super.chooseDatanodesInternal(excludedNodes,
-        favoredNodes, nodesRequired, metadataSizeRequired, dataSizeRequired);
+    List<DatanodeDetails> healthyNodes = super.chooseDatanodesInternal(
+            excludedNodes, favoredNodes, nodesRequired,
+            metadataSizeRequired, dataSizeRequired);
     if (healthyNodes.size() == nodesRequired) {
       return healthyNodes;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -98,7 +98,7 @@ public final class SCMContainerPlacementCapacity
    * @throws SCMException  SCMException
    */
   @Override
-  public List<DatanodeDetails> chooseDatanodes(
+  protected List<DatanodeDetails> chooseDatanodesInternal(
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -102,7 +102,7 @@ public final class SCMContainerPlacementCapacity
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {
-    List<DatanodeDetails> healthyNodes = super.chooseDatanodes(excludedNodes,
+    List<DatanodeDetails> healthyNodes = super.chooseDatanodesInternal(excludedNodes,
         favoredNodes, nodesRequired, metadataSizeRequired, dataSizeRequired);
     if (healthyNodes.size() == nodesRequired) {
       return healthyNodes;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -97,7 +97,7 @@ public final class SCMContainerPlacementRackAware
    * @throws SCMException  SCMException
    */
   @Override
-  public List<DatanodeDetails> chooseDatanodes(
+  protected List<DatanodeDetails> chooseDatanodesInternal(
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
       throws SCMException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -123,7 +123,6 @@ public final class SCMContainerPlacementRackScatter
           " ExcludedNode = " + excludedNodesCount,
           SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
     }
-
     List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();
     if (favoredNodes != null) {
       // Generate mutableFavoredNodes, only stores valid favoredNodes
@@ -151,7 +150,7 @@ public final class SCMContainerPlacementRackScatter
     if (excludedNodes != null) {
       unavailableNodes.addAll(
               excludedNodes.stream()
-                      .filter(node->!unavailableNodes.contains(node))
+                      .filter(node -> !unavailableNodes.contains(node))
                       .collect(Collectors.toList()));
     }
 
@@ -195,7 +194,6 @@ public final class SCMContainerPlacementRackScatter
       if (nodesRequired == 0) {
         break;
       }
-
       for (Node rack : toChooseRacks) {
         if (rack == null) {
           // TODO: need to recheck why null coming here.

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -269,11 +269,11 @@ public final class SCMContainerPlacementRackScatter
       try {
         node = networkTopology.chooseRandom(scope, excludedNodes);
       } catch (Exception e) {
-        if(LOG.isDebugEnabled()) {
+        if (LOG.isDebugEnabled()) {
           LOG.debug("Error while choosing Node: Scope: {}, Excluded Nodes: " +
                           "{}, MetaDataSizeRequired: {}, DataSizeRequired: " +
                   "{}", scope, excludedNodes, metadataSizeRequired,
-                  dataSizeRequired,e);
+                  dataSizeRequired, e);
         }
       }
       if (node != null) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -107,8 +107,12 @@ public final class SCMContainerPlacementRackScatter
     int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
     List<Node> availableNodes = networkTopology.getNodes(
         networkTopology.getMaxLevel());
+    List<Node> unavailableNodes = new ArrayList<>();
     int totalNodesCount = availableNodes.size();
     if (excludedNodes != null) {
+      unavailableNodes.addAll(
+              availableNodes.stream().filter(excludedNodes::contains)
+                      .collect(Collectors.toList()));
       availableNodes.removeAll(excludedNodes);
     }
     if (availableNodes.size() < nodesRequired) {
@@ -143,10 +147,12 @@ public final class SCMContainerPlacementRackScatter
 
     List<Node> toChooseRacks = new LinkedList<>();
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>();
-    List<Node> unavailableNodes = new ArrayList<>();
     Set<Node> skippedRacks = new HashSet<>();
     if (excludedNodes != null) {
-      unavailableNodes.addAll(excludedNodes);
+      unavailableNodes.addAll(
+              excludedNodes.stream()
+                      .filter(node->!unavailableNodes.contains(node))
+                      .collect(Collectors.toList()));
     }
 
     // If the result doesn't change after retryCount, we return with exception

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -225,7 +225,7 @@ public final class SCMContainerPlacementRackScatter
     ContainerPlacementStatus placementStatus =
         validateContainerPlacement(result, nodesRequiredToChoose);
     if (!placementStatus.isPolicySatisfied()) {
-      String errorMsg = "ContainerPlacementPolicy not met, currentRacks is" +
+      String errorMsg = "ContainerPlacementPolicy not met, currentRacks is " +
           placementStatus.actualPlacementCount() + "desired racks is" +
           placementStatus.expectedPlacementCount();
       throw new SCMException(errorMsg, null);
@@ -265,7 +265,17 @@ public final class SCMContainerPlacementRackScatter
     int maxRetry = INNER_LOOP_MAX_RETRY;
     while (true) {
       metrics.incrDatanodeChooseAttemptCount();
-      Node node = networkTopology.chooseRandom(scope, excludedNodes);
+      Node node = null;
+      try {
+        node = networkTopology.chooseRandom(scope, excludedNodes);
+      } catch (Exception e) {
+        if(LOG.isDebugEnabled()) {
+          LOG.debug("Error while choosing Node: Scope: {}, Excluded Nodes: " +
+                          "{}, MetaDataSizeRequired: {}, DataSizeRequired: " +
+                  "{}", scope, excludedNodes, metadataSizeRequired,
+                  dataSizeRequired,e);
+        }
+      }
       if (node != null) {
         DatanodeDetails datanodeDetails = (DatanodeDetails) node;
         if (isValidNode(datanodeDetails, metadataSizeRequired,

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -70,7 +70,7 @@ public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
    * @throws SCMException  SCMException
    */
   @Override
-  public List<DatanodeDetails> chooseDatanodes(
+  protected List<DatanodeDetails> chooseDatanodesInternal(
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -75,8 +75,8 @@ public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {
     List<DatanodeDetails> healthyNodes =
-        super.chooseDatanodesInternal(excludedNodes, favoredNodes, nodesRequired,
-            metadataSizeRequired, dataSizeRequired);
+        super.chooseDatanodesInternal(excludedNodes, favoredNodes,
+                nodesRequired, metadataSizeRequired, dataSizeRequired);
 
     if (healthyNodes.size() == nodesRequired) {
       return healthyNodes;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -75,7 +75,7 @@ public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
       final int nodesRequired,
       long metadataSizeRequired, long dataSizeRequired) throws SCMException {
     List<DatanodeDetails> healthyNodes =
-        super.chooseDatanodes(excludedNodes, favoredNodes, nodesRequired,
+        super.chooseDatanodesInternal(excludedNodes, favoredNodes, nodesRequired,
             metadataSizeRequired, dataSizeRequired);
 
     if (healthyNodes.size() == nodesRequired) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -214,7 +214,7 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
    * @throws SCMException when chosen nodes are not enough in numbers
    */
   @Override
-  public List<DatanodeDetails> chooseDatanodes(
+  protected List<DatanodeDetails> chooseDatanodesInternal(
       List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
       int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
       throws SCMException {

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -137,7 +137,7 @@ public class TestSCMContainerPlacementCapacity {
 
       //when
       List<DatanodeDetails> datanodeDetails = scmContainerPlacementRandom
-          .chooseDatanodesInternal(existingNodes, null, 1, 15, 15);
+          .chooseDatanodes(existingNodes, null, 1, 15, 15);
 
       //then
       Assertions.assertEquals(1, datanodeDetails.size());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_DATANODE_RATIS_VOLUME_FREE_SPACE_MIN;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Matchers.anyObject;
 import org.mockito.Mockito;
 import static org.mockito.Mockito.when;
@@ -109,6 +110,13 @@ public class TestSCMContainerPlacementCapacity {
         .thenReturn(new SCMNodeMetric(100L, 80L, 20L));
     when(mockNodeManager.getNodeStat(datanodes.get(4)))
         .thenReturn(new SCMNodeMetric(100L, 70L, 30L));
+    when(mockNodeManager.getNodeByUuid(anyString())).thenAnswer(
+            invocation -> {
+              String uuid = invocation.getArgument(0);
+              return datanodes.stream().filter(
+                              datanode -> datanode.getUuid().toString().equals(uuid)).findFirst()
+                      .orElse(null);
+            });
 
     SCMContainerPlacementCapacity scmContainerPlacementRandom =
         new SCMContainerPlacementCapacity(mockNodeManager, conf, null, true,
@@ -127,7 +135,7 @@ public class TestSCMContainerPlacementCapacity {
 
       //when
       List<DatanodeDetails> datanodeDetails = scmContainerPlacementRandom
-          .chooseDatanodes(existingNodes, null, 1, 15, 15);
+          .chooseDatanodesInternal(existingNodes, null, 1, 15, 15);
 
       //then
       Assertions.assertEquals(1, datanodeDetails.size());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementCapacity.java
@@ -114,7 +114,9 @@ public class TestSCMContainerPlacementCapacity {
             invocation -> {
               String uuid = invocation.getArgument(0);
               return datanodes.stream().filter(
-                              datanode -> datanode.getUuid().toString().equals(uuid)).findFirst()
+                              datanode ->
+                                      datanode.getUuid().toString()
+                                              .equals(uuid)).findFirst()
                       .orElse(null);
             });
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -107,24 +107,23 @@ public class TestSCMContainerPlacementRackAware {
       DatanodeDetails datanodeDetails =
           MockDatanodeDetails.createDatanodeDetails(
           hostname + i, rack + (i / NODE_PER_RACK));
-      DatanodeInfo datanodeInfo = new DatanodeInfo(
-          datanodeDetails, NodeStatus.inServiceHealthy(),
-          UpgradeUtils.defaultLayoutVersionProto());
-
-      StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      MetadataStorageReportProto metaStorage1 =
-          HddsTestUtils.createMetadataStorageReport(
-          "/metadata1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      datanodeInfo.updateStorageReports(
-          new ArrayList<>(Arrays.asList(storage1)));
-      datanodeInfo.updateMetaDataStorageReports(
-          new ArrayList<>(Arrays.asList(metaStorage1)));
-
       datanodes.add(datanodeDetails);
       cluster.add(datanodeDetails);
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+              datanodeDetails, NodeStatus.inServiceHealthy(),
+              UpgradeUtils.defaultLayoutVersionProto());
+
+      StorageReportProto storage1 = HddsTestUtils.createStorageReport(
+              datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+              STORAGE_CAPACITY, 0, 100L, null);
+      MetadataStorageReportProto metaStorage1 =
+              HddsTestUtils.createMetadataStorageReport(
+                      "/metadata1-" + datanodeInfo.getUuidString(),
+                      STORAGE_CAPACITY, 0, 100L, null);
+      datanodeInfo.updateStorageReports(
+              new ArrayList<>(Arrays.asList(storage1)));
+      datanodeInfo.updateMetaDataStorageReports(
+              new ArrayList<>(Arrays.asList(metaStorage1)));
       dnInfos.add(datanodeInfo);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackAware.java
@@ -110,20 +110,20 @@ public class TestSCMContainerPlacementRackAware {
       datanodes.add(datanodeDetails);
       cluster.add(datanodeDetails);
       DatanodeInfo datanodeInfo = new DatanodeInfo(
-              datanodeDetails, NodeStatus.inServiceHealthy(),
-              UpgradeUtils.defaultLayoutVersionProto());
+          datanodeDetails, NodeStatus.inServiceHealthy(),
+          UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-              datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
-              STORAGE_CAPACITY, 0, 100L, null);
+          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
-              HddsTestUtils.createMetadataStorageReport(
-                      "/metadata1-" + datanodeInfo.getUuidString(),
-                      STORAGE_CAPACITY, 0, 100L, null);
+          HddsTestUtils.createMetadataStorageReport(
+          "/metadata1-" + datanodeInfo.getUuidString(),
+          STORAGE_CAPACITY, 0, 100L, null);
       datanodeInfo.updateStorageReports(
-              new ArrayList<>(Arrays.asList(storage1)));
+          new ArrayList<>(Arrays.asList(storage1)));
       datanodeInfo.updateMetaDataStorageReports(
-              new ArrayList<>(Arrays.asList(metaStorage1)));
+          new ArrayList<>(Arrays.asList(metaStorage1)));
       dnInfos.add(datanodeInfo);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -106,24 +106,24 @@ public class TestSCMContainerPlacementRackScatter {
       DatanodeDetails datanodeDetails =
           MockDatanodeDetails.createDatanodeDetails(
           hostname + i, rack + (i / NODE_PER_RACK));
-      DatanodeInfo datanodeInfo = new DatanodeInfo(
-          datanodeDetails, NodeStatus.inServiceHealthy(),
-          UpgradeUtils.defaultLayoutVersionProto());
-
-      StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      MetadataStorageReportProto metaStorage1 =
-          HddsTestUtils.createMetadataStorageReport(
-          "/metadata1-" + datanodeInfo.getUuidString(),
-          STORAGE_CAPACITY, 0, 100L, null);
-      datanodeInfo.updateStorageReports(
-          new ArrayList<>(Arrays.asList(storage1)));
-      datanodeInfo.updateMetaDataStorageReports(
-          new ArrayList<>(Arrays.asList(metaStorage1)));
 
       datanodes.add(datanodeDetails);
       cluster.add(datanodeDetails);
+      DatanodeInfo datanodeInfo = new DatanodeInfo(
+              datanodeDetails, NodeStatus.inServiceHealthy(),
+              UpgradeUtils.defaultLayoutVersionProto());
+
+      StorageReportProto storage1 = HddsTestUtils.createStorageReport(
+              datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+              STORAGE_CAPACITY, 0, 100L, null);
+      MetadataStorageReportProto metaStorage1 =
+              HddsTestUtils.createMetadataStorageReport(
+                      "/metadata1-" + datanodeInfo.getUuidString(),
+                      STORAGE_CAPACITY, 0, 100L, null);
+      datanodeInfo.updateStorageReports(
+              new ArrayList<>(Arrays.asList(storage1)));
+      datanodeInfo.updateMetaDataStorageReports(
+              new ArrayList<>(Arrays.asList(metaStorage1)));
       dnInfos.add(datanodeInfo);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -110,20 +110,20 @@ public class TestSCMContainerPlacementRackScatter {
       datanodes.add(datanodeDetails);
       cluster.add(datanodeDetails);
       DatanodeInfo datanodeInfo = new DatanodeInfo(
-              datanodeDetails, NodeStatus.inServiceHealthy(),
-              UpgradeUtils.defaultLayoutVersionProto());
+          datanodeDetails, NodeStatus.inServiceHealthy(),
+          UpgradeUtils.defaultLayoutVersionProto());
 
       StorageReportProto storage1 = HddsTestUtils.createStorageReport(
-              datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
-              STORAGE_CAPACITY, 0, 100L, null);
+          datanodeInfo.getUuid(), "/data1-" + datanodeInfo.getUuidString(),
+          STORAGE_CAPACITY, 0, 100L, null);
       MetadataStorageReportProto metaStorage1 =
-              HddsTestUtils.createMetadataStorageReport(
-                      "/metadata1-" + datanodeInfo.getUuidString(),
-                      STORAGE_CAPACITY, 0, 100L, null);
+          HddsTestUtils.createMetadataStorageReport(
+          "/metadata1-" + datanodeInfo.getUuidString(),
+          STORAGE_CAPACITY, 0, 100L, null);
       datanodeInfo.updateStorageReports(
-              new ArrayList<>(Arrays.asList(storage1)));
+          new ArrayList<>(Arrays.asList(storage1)));
       datanodeInfo.updateMetaDataStorageReports(
-              new ArrayList<>(Arrays.asList(metaStorage1)));
+          new ArrayList<>(Arrays.asList(metaStorage1)));
       dnInfos.add(datanodeInfo);
     }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -125,7 +125,7 @@ public final class ReplicationTestUtil {
       final NodeManager nodeManager, final OzoneConfiguration conf) {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {
       @Override
-      public List<DatanodeDetails> chooseDatanodes(
+      protected List<DatanodeDetails> chooseDatanodesInternal(
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
           long metadataSizeRequired, long dataSizeRequired)
@@ -148,7 +148,7 @@ public final class ReplicationTestUtil {
       final NodeManager nodeManager, final OzoneConfiguration conf) {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {
       @Override
-      public List<DatanodeDetails> chooseDatanodes(
+      protected List<DatanodeDetails> chooseDatanodesInternal(
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
           long metadataSizeRequired, long dataSizeRequired)


### PR DESCRIPTION
## What changes were proposed in this pull request?
When the object of the Class DataNodeDetails is built from protobuf only UUID of the datanode is added which is used for the hashcode. Thus not passing any information about the topology. While excluding datanodes the object is built from protobuf. NetworkTopology removes all nodes from the list which does not fall under the scope while selecting a random node. Default scope value is "/default-rack/" which won't match the required scope. Thus pass the proper object of DatanodeDetails while trying to get the random node from NetworkTopology should fix this.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7015

## How was this patch tested?
Stage Test. Writing a unit test would be flaky.