### PR TITLE
HDDS-7020. EC: ReplicationManager - skip processing open containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthResult.java
@@ -32,6 +32,7 @@ public class ContainerHealthResult {
    */
   public enum HealthState {
     HEALTHY,
+    UNHEALTHY,
     UNDER_REPLICATED,
     OVER_REPLICATED
   }
@@ -68,6 +69,17 @@ public class ContainerHealthResult {
 
     HealthyResult(ContainerInfo containerInfo) {
       super(containerInfo, HealthState.HEALTHY);
+    }
+  }
+
+  /**
+   * Class for Unhealthy container check results, where the container has some
+   * issue other than over or under replication.
+   */
+  public static class UnHealthyResult extends ContainerHealthResult {
+
+    UnHealthyResult(ContainerInfo containerInfo) {
+      super(containerInfo, HealthState.UNHEALTHY);
     }
   }
 

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECUnderReplicationHandler.java
@@ -32,13 +32,12 @@ import org.apache.hadoop.hdds.scm.net.NodeSchema;
 import org.apache.hadoop.hdds.scm.net.NodeSchemaManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
-import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.assertj.core.util.Lists;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -70,8 +69,7 @@ public class TestECUnderReplicationHandler {
   public void setup() {
     nodeManager = new MockNodeManager(true, 10) {
       @Override
-      public NodeStatus getNodeStatus(DatanodeDetails dd)
-          throws NodeNotFoundException {
+      public NodeStatus getNodeStatus(DatanodeDetails dd) {
         return NodeStatus.inServiceHealthy();
       }
     };
@@ -128,11 +126,11 @@ public class TestECUnderReplicationHandler {
     Map<DatanodeDetails, SCMCommand<?>> cmds =
         testUnderReplicationWithMissingIndexes(
             Lists.emptyList(), availableReplicas, 1, policy);
-    Assert.assertEquals(1, cmds.size());
+    Assertions.assertEquals(1, cmds.size());
     // Check the replicate command has index 1 set
     ReplicateContainerCommand cmd = (ReplicateContainerCommand) cmds.values()
         .iterator().next();
-    Assert.assertEquals(1, cmd.getReplicaIndex());
+    Assertions.assertEquals(1, cmd.getReplicaIndex());
 
   }
 
@@ -158,7 +156,7 @@ public class TestECUnderReplicationHandler {
   }
 
   @Test
-  public void testExceptionIfNoNodesFound() throws IOException {
+  public void testExceptionIfNoNodesFound() {
     PlacementPolicy noNodesPolicy = ReplicationTestUtil
         .getNoNodesTestPlacementPolicy(nodeManager, conf);
     Set<ContainerReplica> availableReplicas = ReplicationTestUtil
@@ -202,15 +200,15 @@ public class TestECUnderReplicationHandler {
       } else if (dnCommand
           .getValue() instanceof ReconstructECContainersCommand) {
         if (shouldReconstructCommandExist) {
-          Assert.assertArrayEquals(missingIndexesByteArr,
+          Assertions.assertArrayEquals(missingIndexesByteArr,
               ((ReconstructECContainersCommand) dnCommand.getValue())
-                  .getMissingContainerIndexes());
+              .getMissingContainerIndexes());
         }
         reconstructCommand++;
       }
     }
-    Assert.assertEquals(decomIndexes, replicateCommand);
-    Assert.assertEquals(shouldReconstructCommandExist ? 1 : 0,
+    Assertions.assertEquals(decomIndexes, replicateCommand);
+    Assertions.assertEquals(shouldReconstructCommandExist ? 1 : 0,
         reconstructCommand);
     return datanodeDetailsSCMCommandMap;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -125,6 +125,9 @@ public class TestReplicationManager {
     // Ensure that RM will run when asked.
     Mockito.when(scmContext.isLeaderReady()).thenReturn(true);
     Mockito.when(scmContext.isInSafeMode()).thenReturn(false);
+  }
+
+  private void enableProcessAll() {
     SCMServiceManager serviceManager = new SCMServiceManager();
     serviceManager.register(replicationManager);
     serviceManager.notifyStatusChanged();
@@ -315,6 +318,7 @@ public class TestReplicationManager {
         HddsProtos.LifeCycleState.CLOSED);
     addReplicas(underRep0, ContainerReplicaProto.State.CLOSED, 1, 2, 3);
 
+    enableProcessAll();
     replicationManager.processAll();
 
     // Get the first message off the queue - it should be underRep0.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.protocol.proto.StorageContainerDatanodeProtocolProtos.ContainerReplicaProto;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
+import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.scm.ha.SCMContext;
 import org.apache.hadoop.hdds.scm.ha.SCMServiceManager;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
@@ -129,10 +131,43 @@ public class TestReplicationManager {
   }
 
   @Test
+  public void testOpenContainerSkipped() throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.OPEN);
+    // It is under replicated, but as its still open it is seen as healthy.
+    addReplicas(container, ContainerReplicaProto.State.OPEN, 1, 2, 3, 4);
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.HEALTHY,
+        result.getHealthState());
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+  }
+
+  @Test
+  public void testUnhealthyOpenContainerClosed()
+      throws ContainerNotFoundException {
+    ContainerInfo container = createContainerInfo(repConfig, 1,
+        HddsProtos.LifeCycleState.OPEN);
+    // Container is open but replicas are closed, so it is open but unhealthy.
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
+    ContainerHealthResult result = replicationManager.processContainer(
+        container, underRep, overRep, repReport);
+    Assert.assertEquals(ContainerHealthResult.HealthState.UNHEALTHY,
+        result.getHealthState());
+    Mockito.verify(eventPublisher, Mockito.times(1))
+        .fireEvent(SCMEvents.CLOSE_CONTAINER, container.containerID());
+    Assert.assertEquals(1, repReport.getStat(
+        ReplicationManagerReport.HealthState.OPEN_UNHEALTHY));
+    Assert.assertEquals(0, underRep.size());
+    Assert.assertEquals(0, overRep.size());
+  }
+
+  @Test
   public void testHealthyContainer() throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 4, 5);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4, 5);
 
     ContainerHealthResult result = replicationManager.processContainer(
         container, underRep, overRep, repReport);
@@ -146,7 +181,7 @@ public class TestReplicationManager {
   public void testUnderReplicatedContainer() throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 4);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
 
     ContainerHealthResult result = replicationManager.processContainer(
         container, underRep, overRep, repReport);
@@ -163,7 +198,7 @@ public class TestReplicationManager {
       throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 4);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
     containerReplicaPendingOps.scheduleAddReplica(container.containerID(),
         MockDatanodeDetails.randomDatanodeDetails(), 5);
 
@@ -189,7 +224,7 @@ public class TestReplicationManager {
       throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2);
 
     ContainerHealthResult result = replicationManager.processContainer(
         container, underRep, overRep, repReport);
@@ -210,7 +245,7 @@ public class TestReplicationManager {
       throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 5, 5);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 5, 5);
 
     ContainerHealthResult result = replicationManager.processContainer(
         container, underRep, overRep, repReport);
@@ -231,7 +266,8 @@ public class TestReplicationManager {
   public void testOverReplicated() throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 4, 5, 5);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED,
+        1, 2, 3, 4, 5, 5);
     ContainerHealthResult result = replicationManager.processContainer(
         container, underRep, overRep, repReport);
     Assert.assertEquals(ContainerHealthResult.HealthState.OVER_REPLICATED,
@@ -247,7 +283,8 @@ public class TestReplicationManager {
       throws ContainerNotFoundException {
     ContainerInfo container = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(container, 1, 2, 3, 4, 5, 5);
+    addReplicas(container, ContainerReplicaProto.State.CLOSED,
+        1, 2, 3, 4, 5, 5);
     containerReplicaPendingOps.scheduleDeleteReplica(container.containerID(),
         MockDatanodeDetails.randomDatanodeDetails(), 5);
     ContainerHealthResult result = replicationManager.processContainer(
@@ -266,16 +303,17 @@ public class TestReplicationManager {
   public void testUnderReplicationQueuePopulated() {
     ContainerInfo decomContainer = createContainerInfo(repConfig, 1,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(decomContainer, Pair.of(DECOMMISSIONING, 1),
+    addReplicas(decomContainer, ContainerReplicaProto.State.CLOSED,
+        Pair.of(DECOMMISSIONING, 1),
         Pair.of(DECOMMISSIONING, 2), Pair.of(DECOMMISSIONING, 3),
         Pair.of(DECOMMISSIONING, 4), Pair.of(DECOMMISSIONING, 5));
 
     ContainerInfo underRep1 = createContainerInfo(repConfig, 2,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(underRep1, 1, 2, 3, 4);
+    addReplicas(underRep1, ContainerReplicaProto.State.CLOSED, 1, 2, 3, 4);
     ContainerInfo underRep0 = createContainerInfo(repConfig, 3,
         HddsProtos.LifeCycleState.CLOSED);
-    addReplicas(underRep0, 1, 2, 3);
+    addReplicas(underRep0, ContainerReplicaProto.State.CLOSED, 1, 2, 3);
 
     replicationManager.processAll();
 
@@ -314,18 +352,20 @@ public class TestReplicationManager {
     Assert.assertNull(res);
   }
 
-  private Set<ContainerReplica>  addReplicas(ContainerInfo container,
+  @SafeVarargs
+  private final Set<ContainerReplica>  addReplicas(ContainerInfo container,
+      ContainerReplicaProto.State replicaState,
       Pair<HddsProtos.NodeOperationalState, Integer>... nodes) {
     final Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), nodes);
+        createReplicas(container.containerID(), replicaState, nodes);
     storeContainerAndReplicas(container, replicas);
     return replicas;
   }
 
   private Set<ContainerReplica> addReplicas(ContainerInfo container,
-      int... indexes) {
+      ContainerReplicaProto.State replicaState, int... indexes) {
     final Set<ContainerReplica> replicas =
-        createReplicas(container.containerID(), indexes);
+        createReplicas(container.containerID(), replicaState, indexes);
     storeContainerAndReplicas(container, replicas);
     return replicas;
   }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -77,7 +77,7 @@ public class TestUnderReplicatedProcessor {
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
                 .UnderReplicatedHealthResult(container, 3, false, false, false),
-            null);
+            (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
         sourceNodes = new ArrayList<>();
     for (int i = 1; i <= 3; i++) {
@@ -123,7 +123,7 @@ public class TestUnderReplicatedProcessor {
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
                 .UnderReplicatedHealthResult(container, 3, true, false, false),
-            null);
+            (ContainerHealthResult.UnderReplicatedHealthResult) null);
     List<DatanodeDetails> sourceDns = new ArrayList<>();
     sourceDns.add(MockDatanodeDetails.randomDatanodeDetails());
     DatanodeDetails targetDn = MockDatanodeDetails.randomDatanodeDetails();
@@ -159,7 +159,7 @@ public class TestUnderReplicatedProcessor {
     Mockito.when(replicationManager.dequeueUnderReplicatedContainer())
         .thenReturn(new ContainerHealthResult
                 .UnderReplicatedHealthResult(container, 3, false, false, false),
-            null);
+            (ContainerHealthResult.UnderReplicatedHealthResult) null);
 
     Mockito.when(replicationManager
             .processUnderReplicatedContainer(Mockito.any()))


### PR DESCRIPTION
## What changes were proposed in this pull request?

When processing containers, we should skip the open containers until they are closed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7020

## How was this patch tested?

New unit tests
