### PR TITLE
HDDS-7024. Add queue size metric for OM double buffer

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerDoubleBuffer.java
@@ -438,7 +438,7 @@ public final class OzoneManagerDoubleBuffer {
    * @param flushedTransactionsSize
    */
   private void updateMetrics(
-      long flushedTransactionsSize) {
+      int flushedTransactionsSize) {
     ozoneManagerDoubleBufferMetrics.incrTotalNumOfFlushOperations();
     ozoneManagerDoubleBufferMetrics.incrTotalSizeOfFlushedTransactions(
         flushedTransactionsSize);
@@ -452,6 +452,7 @@ public final class OzoneManagerDoubleBuffer {
           .setMaxNumberOfTransactionsFlushedInOneIteration(
               flushedTransactionsSize);
     }
+    ozoneManagerDoubleBufferMetrics.updateQueueSize(flushedTransactionsSize);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/metrics/OzoneManagerDoubleBufferMetrics.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
 import org.apache.hadoop.metrics2.lib.MutableCounterLong;
 import org.apache.hadoop.metrics2.lib.MutableGaugeFloat;
 import org.apache.hadoop.metrics2.lib.MutableRate;
+import org.apache.hadoop.metrics2.lib.MutableStat;
 
 /**
  * Class which maintains metrics related to OzoneManager DoubleBuffer.
@@ -57,6 +58,9 @@ public class OzoneManagerDoubleBufferMetrics {
   @Metric(about = "Average number of transactions flushed in a single " +
       "iteration")
   private MutableGaugeFloat avgFlushTransactionsInOneIteration;
+
+  @Metric(about = "DoubleBuffer queue size.", valueName = "Size")
+  private MutableStat queueSize;
 
   public static synchronized OzoneManagerDoubleBufferMetrics create() {
     if (instance != null) {
@@ -117,6 +121,15 @@ public class OzoneManagerDoubleBufferMetrics {
 
   public void setAvgFlushTransactionsInOneIteration(float count) {
     this.avgFlushTransactionsInOneIteration.set(count);
+  }
+
+  public void updateQueueSize(long size) {
+    queueSize.add(size);
+  }
+
+  @VisibleForTesting
+  public MutableStat getQueueSize() {
+    return queueSize;
   }
 
   public void unRegister() {

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerDoubleBufferWithDummyResponse.java
@@ -125,6 +125,8 @@ public class TestOzoneManagerDoubleBufferWithDummyResponse {
     assertTrue(doubleBuffer.getFlushIterations() > 0);
     assertTrue(metrics.getFlushTime().lastStat().numSamples() > 0);
     assertTrue(metrics.getAvgFlushTransactionsInOneIteration() > 0);
+    assertEquals(bucketCount, (long) metrics.getQueueSize().lastStat().total());
+    assertTrue(metrics.getQueueSize().lastStat().numSamples() > 0);
 
     // Assert there is only instance of OM Double Metrics.
     OzoneManagerDoubleBufferMetrics metricsCopy =


### PR DESCRIPTION
## What changes were proposed in this pull request?

Though there're already metrics for double buffer in OM, none of them capture the current queue size.

This PR adds the metrics.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7024

## How was this patch tested?

Unit test, and also manual test to verify that the expected metric can be seen in Prometheus. 