### PR TITLE
HDDS-7032. RDBStore#getUpdatesSince should throw SequenceNumberNotFou…

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -322,8 +322,16 @@ public class RDBStore implements DBStore {
         }
         transactionLogIterator.next();
       }
+    } catch (SequenceNumberNotFoundException e) {
+      LOG.error("Unable to get delta updates since sequenceNumber {}. "
+              + "This exception will be thrown to the client",
+          sequenceNumber, e);
+      // Throw the exception back to Recon. Expect Recon to fall back to
+      // full snapshot.
+      throw e;
     } catch (RocksDBException | IOException e) {
-      LOG.error("Unable to get delta updates since sequenceNumber {} ",
+      LOG.error("Unable to get delta updates since sequenceNumber {}. "
+              + "This exception will not be thrown to the client ",
           sequenceNumber, e);
     }
     dbUpdatesWrapper.setLatestSequenceNumber(db.getLatestSequenceNumber());

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -323,7 +323,7 @@ public class RDBStore implements DBStore {
         transactionLogIterator.next();
       }
     } catch (SequenceNumberNotFoundException e) {
-      LOG.error("Unable to get delta updates since sequenceNumber {}. "
+      LOG.warn("Unable to get delta updates since sequenceNumber {}. "
               + "This exception will be thrown to the client",
           sequenceNumber, e);
       // Throw the exception back to Recon. Expect Recon to fall back to

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -313,7 +313,7 @@ public class RDBStore implements DBStore {
               currSequenceNumber > 1 + sequenceNumber) {
             throw new SequenceNumberNotFoundException("Unable to read data from"
                 + " RocksDB wal to get delta updates. It may have already been"
-                + "flushed to SSTs.");
+                + " flushed to SSTs.");
           }
           // If the above condition was not satisfied, then it is OK to reset
           // the flag.


### PR DESCRIPTION
…ndException back to the caller in order for Recon to fall back to full snapshot

## What changes were proposed in this pull request?

Recon expects an exception to be thrown in order to fall back to full snapshot when an OM DB delta update cannot be retrieved:

https://github.com/apache/ozone/blob/5ed0e0a9b4c8355f4cde064cc605bc419dacd9c3/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/spi/impl/OzoneManagerServiceProviderImpl.java#L456-L478

However, the current logic implies that `RDBStore#getUpdatesSince` will never throw `SequenceNumberNotFoundException` back to the client (Recon) because it is caught as `IOException` in try-catch. [A patch earlier](https://github.com/apache/ozone/commit/5ed0e0a9b4c8355f4cde064cc605bc419dacd9c3#diff-fee5d70b574d804dcd62230fde7c8456690981673b18a9bc4b48c3fac3e945b8R322) unintentionally caused the regression.

The solution is to restore the intended behavior by explicitly catching `SequenceNumberNotFoundException` and throwing it back to the client.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7032

## How was this patch tested?

- [x] Manual tested on a repro cluster.