### PR TITLE
HDDS-7034. File handle leak on datanode in PutBlock

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueHandler.java
@@ -473,9 +473,9 @@ public class KeyValueHandler extends Handler {
 
       boolean endOfBlock = false;
       if (!request.getPutBlock().hasEof() || request.getPutBlock().getEof()) {
-        // in EC, we will be doing empty put block. So, there may not be dat
-        // a available. So, let's flush only when data size is > 0.
-        if (request.getPutBlock().getBlockData().getSize() > 0) {
+        // in EC, we will be doing empty put block.
+        // So, let's flush only when there are any chunks
+        if (!request.getPutBlock().getBlockData().getChunksList().isEmpty()) {
           chunkManager.finishWriteChunks(kvContainer, blockData);
         }
         endOfBlock = true;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Block files are not closed in `PutBlock`, because client does not set `size` in `BlockData` (it is calculated by the DN, so we could use that, though).  Let's use the list of chunks to decide if `finishWriteChunks` should be called or not.

https://issues.apache.org/jira/browse/HDDS-7034

## How was this patch tested?

```
$ sudo yum install -y lsof
...
Installed:
  lsof.x86_64 0:4.87-6.el7

$ ozone freon ockg -n100 -s10
...
Successful executions: 100

$ lsof -u hadoop | grep '/chunks/' | wc -l
0
```

Existing tests cover functionality.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2717806549