### PR TITLE
HDDS-7041. Avoid ConcurrentModificationException in RepeatedOmKeyInfo

### DIFF
--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -68,7 +68,7 @@ public class RepeatedOmKeyInfo {
    */
   public RepeatedKeyInfo getProto(boolean compact, int clientVersion) {
     List<KeyInfo> list = new ArrayList<>();
-    for (OmKeyInfo k : omKeyInfoList) {
+    for (OmKeyInfo k : new ArrayList<>(omKeyInfoList)) {
       list.add(k.getProtobuf(compact, clientVersion));
     }
 

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/helpers/RepeatedOmKeyInfo.java
@@ -52,6 +52,11 @@ public class RepeatedOmKeyInfo {
     return omKeyInfoList;
   }
 
+  // HDDS-7041. Return a new ArrayList to avoid ConcurrentModifyException
+  public List<OmKeyInfo> cloneOmKeyInfoList() {
+    return new ArrayList<>(omKeyInfoList);
+  }
+
   public static RepeatedOmKeyInfo getFromProto(RepeatedKeyInfo
       repeatedKeyInfo) throws IOException {
     List<OmKeyInfo> list = new ArrayList<>();
@@ -68,7 +73,7 @@ public class RepeatedOmKeyInfo {
    */
   public RepeatedKeyInfo getProto(boolean compact, int clientVersion) {
     List<KeyInfo> list = new ArrayList<>();
-    for (OmKeyInfo k : new ArrayList<>(omKeyInfoList)) {
+    for (OmKeyInfo k : cloneOmKeyInfoList()) {
       list.add(k.getProtobuf(compact, clientVersion));
     }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -1233,7 +1233,7 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
         KeyValue<String, RepeatedOmKeyInfo> kv = keyIter.next();
         if (kv != null) {
           RepeatedOmKeyInfo infoList = kv.getValue();
-          for (OmKeyInfo info : infoList.getOmKeyInfoList()) {
+          for (OmKeyInfo info : infoList.cloneOmKeyInfoList()) {
             // Add all blocks from all versions of the key to the deletion list
             for (OmKeyLocationInfoGroup keyLocations :
                 info.getKeyLocationVersions()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The error is causing OM's crash. Should be caused by concurrent change on RepeatedOmKeyInfo's omKeyInfo list.
```
2022-07-22 15:20:39,215 [OMDoubleBufferFlushThread] ERROR org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer: Terminating with exit status 2: OMDoubleBuffer flush threadOMDoubleBufferFlushThreadencountered Throwable error
java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:909)
        at java.util.ArrayList$Itr.next(ArrayList.java:859)
        at org.apache.hadoop.ozone.om.helpers.RepeatedOmKeyInfo.getProto(RepeatedOmKeyInfo.java:70)
        at org.apache.hadoop.ozone.om.codec.RepeatedOmKeyInfoCodec.toPersistedFormat(RepeatedOmKeyInfoCodec.java:50)
        at org.apache.hadoop.ozone.om.codec.RepeatedOmKeyInfoCodec.toPersistedFormat(RepeatedOmKeyInfoCodec.java:35)
        at org.apache.hadoop.hdds.utils.db.CodecRegistry.asRawData(CodecRegistry.java:85)
        at org.apache.hadoop.hdds.utils.db.TypedTable.putWithBatch(TypedTable.java:130)
        at org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse.updateDeletedTable(OMKeyCommitResponse.java:107)
        at org.apache.hadoop.ozone.om.response.key.OMKeyCommitResponse.addToDBBatch(OMKeyCommitResponse.java:80)
        at org.apache.hadoop.ozone.om.response.OMClientResponse.checkAndUpdateDB(OMClientResponse.java:68)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.lambda$2(OzoneManagerDoubleBuffer.java:256)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.addToBatchWithTrace(OzoneManagerDoubleBuffer.java:201)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.lambda$1(OzoneManagerDoubleBuffer.java:254)
        at java.util.Iterator.forEachRemaining(Iterator.java:116)
        at org.apache.hadoop.ozone.om.ratis.OzoneManagerDoubleBuffer.flushTransactions(OzoneManagerDoubleBuffer.java:250)
        at java.lang.Thread.run(Thread.java:748) 
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7041

## How was this patch tested?

Fixed crash in prod cluster.
