### PR TITLE
HDDS-7036. Enable RocksDB stats in monitoring sample config

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
+++ b/hadoop-ozone/dist/src/main/compose/ozone/monitoring.conf
@@ -16,6 +16,7 @@
 
 OZONE-SITE.XML_hdds.prometheus.endpoint.enabled=true
 OZONE-SITE.XML_hdds.tracing.enabled=true
+OZONE-SITE.XML_ozone.metastore.rocksdb.statistics=ALL
 HDFS-SITE.XML_rpc.metrics.quantile.enable=true
 HDFS-SITE.XML_rpc.metrics.percentiles.intervals=60,300
 JAEGER_SAMPLER_PARAM=1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Enable RocksDB statistics in the sample `ozone` docker-compose environment's [monitoring extension](https://github.com/apache/ozone/blob/master/hadoop-ozone/dist/src/main/compose/ozone/README.md#monitoring).

https://issues.apache.org/jira/browse/HDDS-7036

## How was this patch tested?

```
cd hadoop-ozone/dist/target/ozone-1.3.0-SNAPSHOT/compose/ozone
export COMPOSE_FILE=docker-compose.yaml:monitoring.yaml
OZONE_REPLICATION_FACTOR=3 ./run.sh -d
sleep 60
docker-compose exec -T scm ozone freon ockg -n1 -t1
```

Verified that JMX endpoint shows RocksDB stats:

```
$ curl -LSs http://localhost:9874/jmx
...
  }, {
    "name" : "Hadoop:service=Ozone,name=RocksDbStore,dbName=om.db",
    ...
    "NUMBER_KEYS_WRITTEN" : 14,
    "NUMBER_KEYS_READ" : 7,
    ...
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2719241954