### PR TITLE
HDDS-7044. Ignore pr_title_check for selective checks

### DIFF
--- a/dev-support/ci/selective_ci_checks.bats
+++ b/dev-support/ci/selective_ci_checks.bats
@@ -285,6 +285,18 @@ load bats-assert/load.bash
   assert_output -p needs-kubernetes-tests=false
 }
 
+@test "PR-title workflow" {
+  run dev-support/ci/selective_ci_checks.sh 4f0bd4ae3
+
+  assert_output -p 'basic-checks=["rat","bats"]'
+  assert_output -p needs-build=false
+  assert_output -p needs-compile=false
+  assert_output -p needs-compose-tests=false
+  assert_output -p needs-dependency-check=false
+  assert_output -p needs-integration-tests=false
+  assert_output -p needs-kubernetes-tests=false
+}
+
 @test "other README" {
   run dev-support/ci/selective_ci_checks.sh 5532981a7
 

--- a/dev-support/ci/selective_ci_checks.sh
+++ b/dev-support/ci/selective_ci_checks.sh
@@ -163,6 +163,8 @@ function filter_changed_files() {
 }
 
 SOURCES_TRIGGERING_TESTS=(
+    "^.github"
+    "^dev-support"
     "^hadoop-hdds"
     "^hadoop-ozone"
     "^pom.xml"
@@ -190,9 +192,12 @@ function check_if_tests_are_needed_at_all() {
 function run_all_tests_if_environment_files_changed() {
     start_end::group_start "Check if everything should be run"
     local pattern_array=(
-        "^.github/workflows/"
+        "^.github/workflows/post-commit.yml"
         "^dev-support/ci"
         "^hadoop-ozone/dev-support/checks/_lib.sh"
+    )
+    local ignore_array=(
+        "^dev-support/ci/pr_title_check"
     )
     filter_changed_files
 
@@ -451,6 +456,8 @@ function check_needs_unit_test() {
 function get_count_misc_files() {
     start_end::group_start "Count misc. files"
     local pattern_array=(
+        "^dev-support/ci/pr_title_check"
+        "^.github"
         "^hadoop-hdds/dev-support/checkstyle"
         "^hadoop-ozone/dev-support/checks"
         "^hadoop-ozone/dist/src/main/license"
@@ -460,6 +467,7 @@ function get_count_misc_files() {
         "findbugsExcludeFile.xml"
     )
     local ignore_array=(
+        "^.github/workflows/post-commit.yml"
         "^hadoop-ozone/dev-support/checks/_mvn_unit_report.sh"
         "^hadoop-ozone/dev-support/checks/acceptance.sh"
         "^hadoop-ozone/dev-support/checks/integration.sh"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid triggering all tests:
 * for workflows except `post-commit.yml`: they are not exercised by any jobs in the `post-commit.yml` (`build-branch`) workflow, so running those jobs is useless
 * for `pr_title_check.*`: these are covered by specific checks (_rat_ for license, and _bats_ for bash unit tests)

https://issues.apache.org/jira/browse/HDDS-7044

## How was this patch tested?

Added test case in `selective_ci_checks.bats`.  Also checked output for the commit (96009ab20) for HDDS-7043 locally:

```
$ bash dev-support/ci/selective_ci_checks.sh 96009ab20
...

All 2 changed files are known to be handled by specific checks.

needs-basic-checks=true
basic-checks=["rat","bats"]
needs-build=false
needs-compile=false
needs-compose-tests=false
needs-dependency-check=false
needs-integration-tests=false
needs-kubernetes-tests=false
```

and for a commit (1493541d7) that only changed the misc. workflows:

```
$ bash dev-support/ci/selective_ci_checks.sh 1493541d7
...

All 2 changed files are known to be handled by specific checks.

needs-basic-checks=true
basic-checks=["rat"]
needs-build=false
needs-compile=false
needs-compose-tests=false
needs-dependency-check=false
needs-integration-tests=false
needs-kubernetes-tests=false
```

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/runs/7486998639
https://github.com/adoroszlai/hadoop-ozone/runs/7487000326