### PR TITLE
HDDS-7046. Leader count missing in Recon

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -216,7 +216,7 @@ const COLUMNS = [
       <Icon type='info-circle'/>
     </Tooltip>
   </span>,
-    dataIndex: 'leader Count',
+    dataIndex: 'leaderCount',
     key: 'leaderCount',
     isVisible: true,
     isSearchable: true,


### PR DESCRIPTION
## What changes were proposed in this pull request?

[A patch earlier](https://github.com/apache/ozone/pull/3429) unintentionally changed the leader count's dataIndex from `leaderCount` to `leader Count` in the datanodes.tsx, I changed it back. 

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7046

## How was this patch tested?

I tested it in docker-compose environment and the leader count is visible again.
