### PR TITLE
HDDS-7051. Fix offset Condition in ECKeyOutputStream

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -212,9 +212,6 @@ public final class ECKeyOutputStream extends KeyOutputStream {
         streamEntry.streamsWithWriteFailure();
     if (!failedStreams.isEmpty()) {
       excludePipelineAndFailedDN(streamEntry.getPipeline(), failedStreams);
-      if(LOG.isDebugEnabled()) {
-
-      }
       return StripeWriteStatus.FAILED;
     }
 

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/io/ECKeyOutputStream.java
@@ -154,7 +154,7 @@ public final class ECKeyOutputStream extends KeyOutputStream {
     }
     try {
       int writtenLen = 0;
-      while (off + writtenLen < len) {
+      while (writtenLen < len) {
         writtenLen += handleWrite(b, off + writtenLen, len - writtenLen);
       }
     } catch (Exception e) {
@@ -212,6 +212,9 @@ public final class ECKeyOutputStream extends KeyOutputStream {
         streamEntry.streamsWithWriteFailure();
     if (!failedStreams.isEmpty()) {
       excludePipelineAndFailedDN(streamEntry.getPipeline(), failedStreams);
+      if(LOG.isDebugEnabled()) {
+
+      }
       return StripeWriteStatus.FAILED;
     }
 

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -263,7 +263,7 @@ public class TestOzoneECClient {
 
   @Test
   public void testChunksInSingleWriteOpWithOffset() throws IOException {
-    testMultipleChunksInSingleWriteOp(100 ,12, 11);
+    testMultipleChunksInSingleWriteOp(100, 12, 11);
   }
 
   @Test
@@ -286,8 +286,8 @@ public class TestOzoneECClient {
     }
     final OzoneBucket bucket = writeIntoECKey(offset, numChunks * chunkSize,
             inputData, keyName, new DefaultReplicationConfig(ReplicationType.EC,
-            new ECReplicationConfig(dataBlocks, parityBlocks,
-                ECReplicationConfig.EcCodec.RS, chunkSize)));
+                    new ECReplicationConfig(dataBlocks, parityBlocks,
+                            ECReplicationConfig.EcCodec.RS, chunkSize)));
     OzoneKey key = bucket.getKey(keyName);
     validateContent(offset, numChunks * chunkSize, inputData, bucket, key);
   }
@@ -1157,7 +1157,7 @@ public class TestOzoneECClient {
   }
 
   private OzoneBucket writeIntoECKey(byte[] data, String key,
-     DefaultReplicationConfig defaultReplicationConfig) throws IOException {
+      DefaultReplicationConfig defaultReplicationConfig) throws IOException {
     return writeIntoECKey(0, data.length, data, key, defaultReplicationConfig);
   }
   private OzoneBucket writeIntoECKey(int offset, int length, byte[] data,
@@ -1168,12 +1168,13 @@ public class TestOzoneECClient {
   }
 
   private OzoneBucket writeIntoECKey(byte[][] chunks, String key,
-     DefaultReplicationConfig defaultReplicationConfig) throws IOException {
+      DefaultReplicationConfig defaultReplicationConfig) throws IOException {
     int[] offsets = new int[chunks.length];
     Arrays.fill(offsets, 0);
     int[] lengths = Arrays.stream(chunks)
             .mapToInt(chunk -> chunk.length).toArray();
-    return writeIntoECKey(offsets, lengths, chunks, key, defaultReplicationConfig);
+    return writeIntoECKey(offsets, lengths, chunks,
+            key, defaultReplicationConfig);
   }
 
   private OzoneBucket writeIntoECKey(int[] offsets, int[] lengths,

--- a/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
+++ b/hadoop-ozone/client/src/test/java/org/apache/hadoop/ozone/client/TestOzoneECClient.java
@@ -262,33 +262,52 @@ public class TestOzoneECClient {
   }
 
   @Test
+  public void testChunksInSingleWriteOpWithOffset() throws IOException {
+    testMultipleChunksInSingleWriteOp(100 ,12, 11);
+  }
+
+  @Test
   public void test12ChunksInSingleWriteOp() throws IOException {
     testMultipleChunksInSingleWriteOp(12);
   }
 
-  public void testMultipleChunksInSingleWriteOp(int numChunks)
+  private void testMultipleChunksInSingleWriteOp(int numChunks)
+          throws IOException {
+    testMultipleChunksInSingleWriteOp(0, numChunks, numChunks);
+  }
+  private void testMultipleChunksInSingleWriteOp(int offset, int bufferChunks,
+                                                 int numChunks)
       throws IOException {
-    byte[] inputData = new byte[numChunks * chunkSize];
+    byte[] inputData = new byte[offset + bufferChunks * chunkSize];
     for (int i = 0; i < numChunks; i++) {
-      int start = (i * chunkSize);
+      int start = offset + (i * chunkSize);
       Arrays.fill(inputData, start, start + chunkSize - 1,
           String.valueOf(i % 9).getBytes(UTF_8)[0]);
     }
-    final OzoneBucket bucket = writeIntoECKey(inputData, keyName,
-        new DefaultReplicationConfig(ReplicationType.EC,
+    final OzoneBucket bucket = writeIntoECKey(offset, numChunks * chunkSize,
+            inputData, keyName, new DefaultReplicationConfig(ReplicationType.EC,
             new ECReplicationConfig(dataBlocks, parityBlocks,
                 ECReplicationConfig.EcCodec.RS, chunkSize)));
     OzoneKey key = bucket.getKey(keyName);
-    validateContent(inputData, bucket, key);
+    validateContent(offset, numChunks * chunkSize, inputData, bucket, key);
   }
 
-  private void validateContent(byte[] inputData, OzoneBucket bucket,
+  private void validateContent(byte[] inputData,
+                               OzoneBucket bucket,
+                               OzoneKey key) throws IOException {
+    validateContent(0, inputData.length, inputData, bucket, key);
+  }
+
+  private void validateContent(int offset, int length, byte[] inputData,
+                               OzoneBucket bucket,
       OzoneKey key) throws IOException {
     Assert.assertEquals(keyName, key.getName());
     try (OzoneInputStream is = bucket.readKey(keyName)) {
-      byte[] fileContent = new byte[inputData.length];
-      Assert.assertEquals(inputData.length, is.read(fileContent));
-      Assert.assertEquals(new String(inputData, UTF_8),
+      byte[] fileContent = new byte[length];
+      Assert.assertEquals(length, is.read(fileContent));
+      Assert.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
+                      offset + length),
+                      UTF_8),
           new String(fileContent, UTF_8));
     }
   }
@@ -1138,11 +1157,28 @@ public class TestOzoneECClient {
   }
 
   private OzoneBucket writeIntoECKey(byte[] data, String key,
-      DefaultReplicationConfig defaultReplicationConfig) throws IOException {
-    return writeIntoECKey(new byte[][] {data}, key, defaultReplicationConfig);
+     DefaultReplicationConfig defaultReplicationConfig) throws IOException {
+    return writeIntoECKey(0, data.length, data, key, defaultReplicationConfig);
+  }
+  private OzoneBucket writeIntoECKey(int offset, int length, byte[] data,
+      String key, DefaultReplicationConfig defaultReplicationConfig)
+      throws IOException {
+    return writeIntoECKey(new int[]{offset}, new int[]{length},
+            new byte[][] {data}, key, defaultReplicationConfig);
   }
 
   private OzoneBucket writeIntoECKey(byte[][] chunks, String key,
+     DefaultReplicationConfig defaultReplicationConfig) throws IOException {
+    int[] offsets = new int[chunks.length];
+    Arrays.fill(offsets, 0);
+    int[] lengths = Arrays.stream(chunks)
+            .mapToInt(chunk -> chunk.length).toArray();
+    return writeIntoECKey(offsets, lengths, chunks, key, defaultReplicationConfig);
+  }
+
+  private OzoneBucket writeIntoECKey(int[] offsets, int[] lengths,
+                                     byte[][] chunks,
+                                     String key,
       DefaultReplicationConfig defaultReplicationConfig) throws IOException {
     store.createVolume(volumeName);
     OzoneVolume volume = store.getVolume(volumeName);
@@ -1160,7 +1196,7 @@ public class TestOzoneECClient {
         new ECReplicationConfig(dataBlocks, parityBlocks,
             ECReplicationConfig.EcCodec.RS, chunkSize), new HashMap<>())) {
       for (int i = 0; i < chunks.length; i++) {
-        out.write(chunks[i]);
+        out.write(chunks[i], offsets[i], lengths[i]);
       }
     }
     return bucket;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -282,7 +282,7 @@ public class TestECKeyOutputStream {
     testMultipleChunksInSingleWriteOp(21);
   }
 
-  public void testMultipleChunksInSingleWriteOp(int offset,
+  private void testMultipleChunksInSingleWriteOp(int offset,
                                                 int bufferChunks, int numChunks)
           throws IOException {
     byte[] inputData = getInputBytes(offset, bufferChunks, numChunks);
@@ -301,7 +301,7 @@ public class TestECKeyOutputStream {
             bucket.getKey(keyName));
   }
 
-  public void testMultipleChunksInSingleWriteOp(int numChunks)
+  private void testMultipleChunksInSingleWriteOp(int numChunks)
       throws IOException {
     testMultipleChunksInSingleWriteOp(0, numChunks, numChunks);
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -263,6 +263,11 @@ public class TestECKeyOutputStream {
   }
 
   @Test
+  public void testChunksInSingleWriteOpWithOffset() throws IOException {
+    testMultipleChunksInSingleWriteOp(11, 25, 19);
+  }
+
+  @Test
   public void test15ChunksInSingleWriteOp() throws IOException {
     testMultipleChunksInSingleWriteOp(15);
   }
@@ -277,18 +282,27 @@ public class TestECKeyOutputStream {
     testMultipleChunksInSingleWriteOp(21);
   }
 
-  public void testMultipleChunksInSingleWriteOp(int numChunks)
-      throws IOException {
-    byte[] inputData = getInputBytes(numChunks);
+  public void testMultipleChunksInSingleWriteOp(int offset,
+                                                int bufferChunks, int numChunks)
+          throws IOException {
+    byte[] inputData = getInputBytes(offset, bufferChunks, numChunks);
     final OzoneBucket bucket = getOzoneBucket();
-    String keyName = "testMultipleChunksInSingleWriteOp" + numChunks;
+    String keyName =
+            String.format("testMultipleChunksInSingleWriteOpOffset" +
+                    "%dBufferChunks%dNumChunks", offset, bufferChunks, numChunks);
     try (OzoneOutputStream out = bucket.createKey(keyName, 4096,
-        new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
-            chunkSize), new HashMap<>())) {
-      out.write(inputData);
+            new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
+                    chunkSize), new HashMap<>())) {
+      out.write(inputData, offset, numChunks * chunkSize);
     }
 
-    validateContent(inputData, bucket, bucket.getKey(keyName));
+    validateContent(offset, numChunks * chunkSize, inputData, bucket,
+            bucket.getKey(keyName));
+  }
+
+  public void testMultipleChunksInSingleWriteOp(int numChunks)
+      throws IOException {
+    testMultipleChunksInSingleWriteOp(0, numChunks, numChunks);
   }
 
   @Test
@@ -332,11 +346,18 @@ public class TestECKeyOutputStream {
   }
 
   private void validateContent(byte[] inputData, OzoneBucket bucket,
+                               OzoneKey key) throws IOException {
+    validateContent(0, inputData.length, inputData, bucket, key);
+  }
+
+  private void validateContent(int offset, int length, byte[] inputData,
+                               OzoneBucket bucket,
       OzoneKey key) throws IOException {
     try (OzoneInputStream is = bucket.readKey(key.getName())) {
-      byte[] fileContent = new byte[inputData.length];
-      Assert.assertEquals(inputData.length, is.read(fileContent));
-      Assert.assertEquals(new String(inputData, UTF_8),
+      byte[] fileContent = new byte[length];
+      Assert.assertEquals(length, is.read(fileContent));
+      Assert.assertEquals(new String(Arrays.copyOfRange(inputData, offset,
+                      offset + length), UTF_8),
           new String(fileContent, UTF_8));
     }
   }
@@ -410,9 +431,13 @@ public class TestECKeyOutputStream {
   }
 
   private byte[] getInputBytes(int numChunks) {
-    byte[] inputData = new byte[numChunks * chunkSize];
+    return getInputBytes(0, numChunks, numChunks);
+  }
+
+  private byte[] getInputBytes(int offset, int bufferChunks, int numChunks) {
+    byte[] inputData = new byte[offset + bufferChunks * chunkSize];
     for (int i = 0; i < numChunks; i++) {
-      int start = (i * chunkSize);
+      int start = offset + (i * chunkSize);
       Arrays.fill(inputData, start, start + chunkSize - 1,
           String.valueOf(i % 9).getBytes(UTF_8)[0]);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestECKeyOutputStream.java
@@ -289,10 +289,11 @@ public class TestECKeyOutputStream {
     final OzoneBucket bucket = getOzoneBucket();
     String keyName =
             String.format("testMultipleChunksInSingleWriteOpOffset" +
-                    "%dBufferChunks%dNumChunks", offset, bufferChunks, numChunks);
+                    "%dBufferChunks%dNumChunks", offset, bufferChunks,
+                    numChunks);
     try (OzoneOutputStream out = bucket.createKey(keyName, 4096,
-            new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
-                    chunkSize), new HashMap<>())) {
+        new ECReplicationConfig(3, 2, ECReplicationConfig.EcCodec.RS,
+            chunkSize), new HashMap<>())) {
       out.write(inputData, offset, numChunks * chunkSize);
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?
Fix offset Condition in ECKeyOutputStream
Condition checking with offset+writtenLen !< length if offset is not zero.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7051

## How was this patch tested?

Current flows all have offset =0.