### PR TITLE
HDDS-7056. EC: Ensure replica index is maintained when replicating a container

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -122,6 +122,7 @@ public class KeyValueContainerData extends ContainerData {
     this.numPendingDeletionBlocks = new AtomicLong(0);
     this.deleteTransactionId = 0;
     this.schemaVersion = source.getSchemaVersion();
+    this.replicaIndex = source.getReplicaIndex();
   }
 
   /**

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/TestKeyValueContainerData.java
@@ -97,6 +97,7 @@ public class TestKeyValueContainerData {
     kvData.setContainerDBType(containerDBType);
     kvData.setChunksPath(path);
     kvData.setMetadataPath(path);
+    kvData.setReplicaIndex(4);
     kvData.incrReadBytes(10);
     kvData.incrWriteBytes(10);
     kvData.incrReadCount();
@@ -121,6 +122,12 @@ public class TestKeyValueContainerData {
     assertEquals(datanodeId.toString(), kvData.getOriginNodeId());
     assertEquals(VersionedDatanodeFeatures.SchemaV3.chooseSchemaVersion(conf),
         kvData.getSchemaVersion());
+
+    KeyValueContainerData newKvData = new KeyValueContainerData(kvData);
+    assertEquals(kvData.getReplicaIndex(), newKvData.getReplicaIndex());
+    assertEquals(0, newKvData.getNumPendingDeletionBlocks());
+    assertEquals(0, newKvData.getDeleteTransactionId());
+    assertEquals(kvData.getSchemaVersion(), newKvData.getSchemaVersion());
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

When an EC container is replicated (not reconstructed) the replica index gets lost when it is imported. We need to ensure the index is copied from the source container data to the new container data.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7056

## How was this patch tested?

New unit test added and manually verified.
