### PR TITLE
HDDS-7057. EC: ReplicationManager - Over replication handler should set repIndex on delete cmds

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -151,6 +151,7 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
               tempReplicaSet, r, replicationFactor)) {
             DeleteContainerCommand deleteCommand =
                 new DeleteContainerCommand(container.getContainerID(), true);
+            deleteCommand.setReplicaIndex(r.getReplicaIndex());
             commands.put(r.getDatanodeDetails(), deleteCommand);
             it.remove();
             tempReplicaSet.remove(r);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECOverReplicationHandler.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
+import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,6 +140,10 @@ public class TestECOverReplicationHandler {
     int totalDeleteCommandNum =
         index2excessNum.values().stream().reduce(0, Integer::sum);
     Assert.assertEquals(totalDeleteCommandNum, commands.size());
+
+    // Each command should have a non-zero replica index
+    commands.forEach((datanode, command) -> Assert.assertNotEquals(0,
+        ((DeleteContainerCommand)command).getReplicaIndex()));
 
     // command num of each index should be equal to the excess num
     // of this index


### PR DESCRIPTION
## What changes were proposed in this pull request?

ContainerReplicaPendingOps needs to track the replica index of any pending replicas. In ECOverReplicationHandler we missed setting the repIndex of the replica in the delete command.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7057

## How was this patch tested?

Modified a unit test
