### PR TITLE
HDDS-7055. NPE in ec.reconstruction.TokenHelper

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/TokenHelper.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/TokenHelper.java
@@ -58,7 +58,11 @@ class TokenHelper {
     boolean blockTokenEnabled = securityConfig.isBlockTokenEnabled();
     boolean containerTokenEnabled = securityConfig.isContainerTokenEnabled();
 
-    if (blockTokenEnabled || containerTokenEnabled) {
+    // checking certClient != null instead of securityConfig.isSecurityEnabled()
+    // to allow integration test without full kerberos etc. setup
+    boolean securityEnabled = certClient != null;
+
+    if (securityEnabled && (blockTokenEnabled || containerTokenEnabled)) {
       user = UserGroupInformation.getCurrentUser().getShortUserName();
 
       long expiryTime = conf.getTimeDuration(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -28,6 +28,10 @@ import org.apache.ozone.test.GenericTestUtils;
 import org.apache.hadoop.util.ServicePlugin;
 
 import org.junit.After;
+
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_BLOCK_TOKEN_ENABLED;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_TOKEN_ENABLED;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_SECURITY_ENABLED_KEY;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -50,6 +54,9 @@ public class TestHddsDatanodeService {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getPath());
     conf.setClass(OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY, MockService.class,
         ServicePlugin.class);
+    conf.setBoolean(OZONE_SECURITY_ENABLED_KEY, false);
+    conf.setBoolean(HDDS_BLOCK_TOKEN_ENABLED, true);
+    conf.setBoolean(HDDS_CONTAINER_TOKEN_ENABLED, true);
 
     String volumeDir = testDir + "/disk1";
     conf.set(DFSConfigKeysLegacy.DFS_DATANODE_DATA_DIR_KEY, volumeDir);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/TestHddsDatanodeService.java
@@ -54,6 +54,10 @@ public class TestHddsDatanodeService {
     conf.set(HddsConfigKeys.OZONE_METADATA_DIRS, testDir.getPath());
     conf.setClass(OzoneConfigKeys.HDDS_DATANODE_PLUGINS_KEY, MockService.class,
         ServicePlugin.class);
+
+    // Tokens only work if security is enabled.  Here we're testing that a
+    // misconfig in unsecure cluster does not prevent datanode from starting up.
+    // see HDDS-7055
     conf.setBoolean(OZONE_SECURITY_ENABLED_KEY, false);
     conf.setBoolean(HDDS_BLOCK_TOKEN_ENABLED, true);
     conf.setBoolean(HDDS_CONTAINER_TOKEN_ENABLED, true);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the exception:

```
ERROR org.apache.hadoop.ozone.HddsDatanodeService: Exception in HddsDatanodeService.
java.lang.NullPointerException
	at org.apache.hadoop.ozone.container.ec.reconstruction.TokenHelper.<init>(TokenHelper.java:68)
	at org.apache.hadoop.ozone.container.ec.reconstruction.ECReconstructionCoordinator.<init>(ECReconstructionCoordinator.java:119)
	at org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine.<init>(DatanodeStateMachine.java:185)
	at org.apache.hadoop.ozone.HddsDatanodeService.start(HddsDatanodeService.java:279)
```

triggered by such config:

```xml
  <property>
    <name>hdds.block.token.enabled</name>
    <value>true</value>
  </property>
  <property>
    <name>hdds.container.token.enabled</name>
    <value>true</value>
  </property>
  <property>
    <name>ozone.security.enabled</name>
    <value>false</value>
  </property>
```

`TokenHelper` still allows this config (as required for `TestContainerCommandsEC` integration test), but checks if certificate client is present or not.

https://issues.apache.org/jira/browse/HDDS-7055

## How was this patch tested?

Updated `TestHddsDatanodeService` with configuration as above to verify `HddsDatanodeService` can be started successfully.

`TestContainerCommandsEC` covers functionality of `TokenHelper` with tokens enabled.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2745224823