### PR TITLE
HDDS-7059. S3G should not call lookup twice for Get Object

### DIFF
--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.ozone.client;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
@@ -109,6 +109,7 @@ public class OzoneKeyDetails extends OzoneKey {
    * @return OzoneInputStream
    * @throws IOException
    */
+  @JsonIgnore
   public OzoneInputStream getContent() throws IOException {
     return this.contentSupplier.get();
   }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/OzoneKeyDetails.java
@@ -21,7 +21,10 @@ package org.apache.hadoop.ozone.client;
 import org.apache.hadoop.fs.FileEncryptionInfo;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.function.SupplierWithIOException;
+import org.apache.hadoop.ozone.client.io.OzoneInputStream;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
@@ -38,6 +41,8 @@ public class OzoneKeyDetails extends OzoneKey {
   private Map<String, String> metadata;
 
   private FileEncryptionInfo feInfo;
+
+  private SupplierWithIOException<OzoneInputStream> contentSupplier;
 
   /**
    * Constructs OzoneKeyDetails from OmKeyInfo.
@@ -66,12 +71,14 @@ public class OzoneKeyDetails extends OzoneKey {
       List<OzoneKeyLocation> ozoneKeyLocations,
       ReplicationConfig replicationConfig,
       Map<String, String> metadata,
-      FileEncryptionInfo feInfo) {
+      FileEncryptionInfo feInfo,
+      SupplierWithIOException<OzoneInputStream> contentSupplier) {
     super(volumeName, bucketName, keyName, size, creationTime,
             modificationTime, replicationConfig);
     this.ozoneKeyLocations = ozoneKeyLocations;
     this.metadata = metadata;
     this.feInfo = feInfo;
+    this.contentSupplier = contentSupplier;
   }
 
   /**
@@ -94,5 +101,14 @@ public class OzoneKeyDetails extends OzoneKey {
    */
   public void setOzoneKeyLocations(List<OzoneKeyLocation> ozoneKeyLocations) {
     this.ozoneKeyLocations = ozoneKeyLocations;
+  }
+
+  /**
+   * Get OzoneInputStream to read the content of the key.
+   * @return OzoneInputStream
+   * @throws IOException
+   */
+  public OzoneInputStream getContent() throws IOException {
+    return this.contentSupplier.get();
   }
 }

--- a/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
+++ b/hadoop-ozone/client/src/main/java/org/apache/hadoop/ozone/client/rpc/RpcClient.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
+import org.apache.hadoop.hdds.function.SupplierWithIOException;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.StorageType;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
@@ -1424,11 +1425,16 @@ public class RpcClient implements ClientProtocol {
           lastKeyOffset));
       lastKeyOffset += info.getLength();
     }
+
+    SupplierWithIOException<OzoneInputStream> getInputStream =
+        () -> getInputStreamWithRetryFunction(keyInfo);
+
     return new OzoneKeyDetails(keyInfo.getVolumeName(), keyInfo.getBucketName(),
         keyInfo.getKeyName(), keyInfo.getDataSize(), keyInfo.getCreationTime(),
         keyInfo.getModificationTime(), ozoneKeyLocations,
         keyInfo.getReplicationConfig(), keyInfo.getMetadata(),
-        keyInfo.getFileEncryptionInfo());
+        keyInfo.getFileEncryptionInfo(),
+        getInputStream);
   }
 
   @Override

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOzoneRpcClientAbstract.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.client.rpc;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.PrivilegedExceptionAction;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1616,10 +1617,6 @@ public abstract class TestOzoneRpcClientAbstract {
     out.write(keyValue.getBytes(UTF_8));
     out.close();
 
-    OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[32];
-    is.read(fileContent);
-
     // First, confirm the key info from the client matches the info in OM.
     OmKeyArgs.Builder builder = new OmKeyArgs.Builder();
     builder.setVolumeName(volumeName).setBucketName(bucketName)
@@ -1678,6 +1675,15 @@ public abstract class TestOzoneRpcClientAbstract {
         }
       }
     }
+
+    assertInputStreamContent(keyValue, keyDetails.getContent());
+  }
+
+  private void assertInputStreamContent(String expected, InputStream is)
+      throws IOException {
+    byte[] fileContent = new byte[expected.getBytes(UTF_8).length];
+    is.read(fileContent);
+    assertEquals(expected, new String(fileContent, UTF_8));
   }
 
   /**
@@ -3698,11 +3704,9 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertNotNull(key.getMetadata().get(OzoneConsts.GDPR_SECRET));
 
     OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[text.getBytes(UTF_8).length];
-    is.read(fileContent);
+    assertInputStreamContent(text, is);
     verifyReplication(volumeName, bucketName, keyName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
-    Assert.assertEquals(text, new String(fileContent, UTF_8));
 
     //Step 4
     OMMetadataManager omMetadataManager = ozoneManager.getMetadataManager();
@@ -3720,7 +3724,7 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertEquals(keyName, key.getName());
     Assert.assertNull(key.getMetadata().get(OzoneConsts.GDPR_FLAG));
     is = bucket.readKey(keyName);
-    fileContent = new byte[text.getBytes(UTF_8).length];
+    byte[] fileContent = new byte[text.getBytes(UTF_8).length];
     is.read(fileContent);
 
     //Step 6
@@ -3777,11 +3781,9 @@ public abstract class TestOzoneRpcClientAbstract {
     Assert.assertTrue(key.getMetadata().get(OzoneConsts.GDPR_SECRET) != null);
 
     OzoneInputStream is = bucket.readKey(keyName);
-    byte[] fileContent = new byte[text.getBytes(UTF_8).length];
-    is.read(fileContent);
+    assertInputStreamContent(text, is);
     verifyReplication(volumeName, bucketName, keyName,
         RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.ONE));
-    Assert.assertEquals(text, new String(fileContent, UTF_8));
 
     //Step 4
     bucket.deleteKey(keyName);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -717,8 +717,9 @@ public class ObjectEndpoint extends EndpointBase {
           String sourceBucket = result.getLeft();
           String sourceKey = result.getRight();
 
-          Long sourceKeyModificationTime = getClientProtocol().getKeyDetails(
-              volume.getName(), sourceBucket, sourceKey)
+          OzoneKeyDetails sourceKeyDetails = getClientProtocol().getKeyDetails(
+              volume.getName(), sourceBucket, sourceKey);
+          Long sourceKeyModificationTime = sourceKeyDetails
               .getModificationTime().toEpochMilli();
           String copySourceIfModifiedSince =
               headers.getHeaderString(COPY_SOURCE_IF_MODIFIED_SINCE);
@@ -729,8 +730,7 @@ public class ObjectEndpoint extends EndpointBase {
             throw newError(PRECOND_FAILED, sourceBucket + "/" + sourceKey);
           }
 
-          try (OzoneInputStream sourceObject = getClientProtocol().getKey(
-              volume.getName(), sourceBucket, sourceKey)) {
+          try (OzoneInputStream sourceObject = sourceKeyDetails.getContent()) {
 
             String range =
                 headers.getHeaderString(COPY_SOURCE_HEADER_RANGE);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -312,8 +312,7 @@ public class ObjectEndpoint extends EndpointBase {
 
       if (rangeHeaderVal == null || rangeHeader.isReadFull()) {
         StreamingOutput output = dest -> {
-          try (OzoneInputStream key = getClientProtocol().getKey(
-              volume.getName(), bucketName, keyPath)) {
+          try (OzoneInputStream key = keyDetails.getContent()) {
             IOUtils.copy(key, dest);
           }
         };
@@ -329,8 +328,7 @@ public class ObjectEndpoint extends EndpointBase {
         // byte from start offset
         long copyLength = endOffset - startOffset + 1;
         StreamingOutput output = dest -> {
-          try (OzoneInputStream ozoneInputStream = getClientProtocol().getKey(
-              volume.getName(), bucketName, keyPath)) {
+          try (OzoneInputStream ozoneInputStream = keyDetails.getContent()) {
             ozoneInputStream.seek(startOffset);
             IOUtils.copyLarge(ozoneInputStream, dest, 0,
                 copyLength, new byte[bufferSize]);

--- a/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
+++ b/hadoop-ozone/s3gateway/src/test/java/org/apache/hadoop/ozone/client/OzoneBucketStub.java
@@ -112,7 +112,8 @@ public class OzoneBucketStub extends OzoneBucket {
                 size,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                new ArrayList<>(), replicationConfig, metadata, null
+                new ArrayList<>(), replicationConfig, metadata, null,
+                () -> readKey(key)
             ));
             super.close();
           }
@@ -143,7 +144,8 @@ public class OzoneBucketStub extends OzoneBucket {
                 size,
                 System.currentTimeMillis(),
                 System.currentTimeMillis(),
-                new ArrayList<>(), finalReplicationCon, metadata, null
+                new ArrayList<>(), finalReplicationCon, metadata, null,
+                () -> readKey(key)
             ));
             super.close();
           }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove the additional lookupKeys calls in getObject API.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7059

## How was this patch tested?

Unit, rotbot.