### PR TITLE
HDDS-7033. Include committed space in log for disk out of space

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/AvailableSpaceFilter.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * Filter for selecting volumes with enough space for a new container.
+ * Keeps track of ineligible volumes for logging/debug purposes.
+ */
+class AvailableSpaceFilter implements Predicate<HddsVolume> {
+
+  private final long requiredSpace;
+  private final Map<HddsVolume, AvailableSpace> fullVolumes =
+      new HashMap<>();
+  private long mostAvailableSpace = Long.MIN_VALUE;
+
+  AvailableSpaceFilter(long requiredSpace) {
+    this.requiredSpace = requiredSpace;
+  }
+
+  @Override
+  public boolean test(HddsVolume vol) {
+    long free = vol.getAvailable();
+    long committed = vol.getCommittedBytes();
+    long available = free - committed;
+    boolean hasEnoughSpace = available > requiredSpace;
+
+    mostAvailableSpace = Math.max(available, mostAvailableSpace);
+
+    if (!hasEnoughSpace) {
+      fullVolumes.put(vol, new AvailableSpace(free, committed));
+    }
+
+    return hasEnoughSpace;
+  }
+
+  boolean foundFullVolumes() {
+    return !fullVolumes.isEmpty();
+  }
+
+  long mostAvailableSpace() {
+    return mostAvailableSpace;
+  }
+
+  @Override
+  public String toString() {
+    return "required space: " + requiredSpace +
+        ", volumes: " + fullVolumes;
+  }
+
+  private static class AvailableSpace {
+    private final long free;
+    private final long committed;
+
+    AvailableSpace(long free, long committed) {
+      this.free = free;
+      this.committed = committed;
+    }
+
+    @Override
+    public String toString() {
+      return "free: " + free +
+          ", committed: " + committed;
+    }
+  }
+}

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeChoosingUtil.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeChoosingUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
+import org.slf4j.Logger;
+
+/**
+ * Common methods for VolumeChoosingPolicy implementations.
+ */
+final class VolumeChoosingUtil {
+
+  private VolumeChoosingUtil() {
+    // no instances
+  }
+
+  static void throwDiskOutOfSpace(AvailableSpaceFilter filter, Logger log)
+      throws DiskOutOfSpaceException {
+    String msg = String.format("No volumes have enough space for " +
+        "a new container.  Most available space: %s bytes",
+        filter.mostAvailableSpace());
+    log.info("{}; {}", msg, filter);
+    throw new DiskOutOfSpaceException(msg);
+  }
+
+  static void logIfSomeVolumesOutOfSpace(AvailableSpaceFilter filter,
+      Logger log) {
+    if (log.isDebugEnabled() && filter.foundFullVolumes()) {
+      log.debug("Some volumes do not have enough space for a new container; {}",
+          filter);
+    }
+  }
+
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -80,6 +80,7 @@ public class TestCapacityVolumeChoosingPolicy {
         .conf(CONF)
         .usageCheckFactory(factory3)
         .build();
+    vol3.incCommittedBytes(50);
 
     volumes.add(vol1);
     volumes.add(vol2);
@@ -126,7 +127,7 @@ public class TestCapacityVolumeChoosingPolicy {
     String msg = e.getMessage();
     assertTrue(msg,
         msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 300 bytes"));
+            "Most available space: 250 bytes"));
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestCapacityVolumeChoosingPolicy.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests {@link CapacityVolumeChoosingPolicy}.
@@ -118,17 +119,14 @@ public class TestCapacityVolumeChoosingPolicy {
   }
 
   @Test
-  public void testCapacityPolicyExceptionMessage() throws Exception {
-    int blockSize = 300;
-    try {
-      policy.chooseVolume(volumes, blockSize);
-      Assert.fail("expected to throw DiskOutOfSpaceException");
-    } catch (DiskOutOfSpaceException e) {
-      Assert.assertEquals("Not returning the expected message",
-          "Out of space: All volumes are less than the container size (="
-              + blockSize + " B).",
-          e.getMessage());
-    }
+  public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
+    Exception e = Assert.assertThrows(DiskOutOfSpaceException.class,
+        () -> policy.chooseVolume(volumes, 500));
+
+    String msg = e.getMessage();
+    assertTrue(msg,
+        msg.contains("No volumes have enough space for a new container.  " +
+            "Most available space: 300 bytes"));
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.ozone.container.common.volume;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +31,8 @@ import org.apache.hadoop.hdds.fs.SpaceUsageSource;
 import org.apache.hadoop.util.DiskChecker.DiskOutOfSpaceException;
 
 import static org.apache.ozone.test.GenericTestUtils.getTestDir;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -98,28 +99,17 @@ public class TestRoundRobinVolumeChoosingPolicy {
     // choose the second one in case we ask for more.
     Assert.assertEquals(hddsVolume2,
         policy.chooseVolume(volumes, 150));
-
-    // Fail if no volume has enough space available
-    try {
-      policy.chooseVolume(volumes, Long.MAX_VALUE);
-      Assert.fail();
-    } catch (IOException e) {
-      // Passed.
-    }
   }
 
   @Test
-  public void testRRPolicyExceptionMessage() throws Exception {
-    int blockSize = 300;
-    try {
-      policy.chooseVolume(volumes, blockSize);
-      Assert.fail("expected to throw DiskOutOfSpaceException");
-    } catch (DiskOutOfSpaceException e) {
-      Assert.assertEquals("Not returning the expected message",
-          "Out of space: The volume with the most available space (=" + 200
-              + " B) is less than the container size (=" + blockSize + " B).",
-          e.getMessage());
-    }
+  public void throwsDiskOutOfSpaceIfRequestMoreThanAvailable() {
+    Exception e = Assert.assertThrows(DiskOutOfSpaceException.class,
+        () -> policy.chooseVolume(volumes, 300));
+
+    String msg = e.getMessage();
+    assertTrue(msg,
+        msg.contains("No volumes have enough space for a new container.  " +
+            "Most available space: 200 bytes"));
   }
 
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestRoundRobinVolumeChoosingPolicy.java
@@ -71,6 +71,7 @@ public class TestRoundRobinVolumeChoosingPolicy {
         .conf(CONF)
         .usageCheckFactory(factory2)
         .build();
+    vol2.incCommittedBytes(50);
 
     volumes.add(vol1);
     volumes.add(vol2);
@@ -98,7 +99,7 @@ public class TestRoundRobinVolumeChoosingPolicy {
     // The first volume has only 100L space, so the policy should
     // choose the second one in case we ask for more.
     Assert.assertEquals(hddsVolume2,
-        policy.chooseVolume(volumes, 150));
+        policy.chooseVolume(volumes, 120));
   }
 
   @Test
@@ -109,7 +110,7 @@ public class TestRoundRobinVolumeChoosingPolicy {
     String msg = e.getMessage();
     assertTrue(msg,
         msg.contains("No volumes have enough space for a new container.  " +
-            "Most available space: 200 bytes"));
+            "Most available space: 150 bytes"));
   }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added new log messages:

 * If `VolumeChoosingPolicy` finds no volumes which have enough available space for a new container, it logs an info level message, showing space for all volumes.
 * Otherwise, any volumes with not enough available space are logged at debug level.

Both messages include actual free space and committed space (reserved for existing open containers).

https://issues.apache.org/jira/browse/HDDS-7033

## How was this patch tested?

Verified log messages in updated unit test.

Also tested on docker-compose cluster, by creating empty containers (size set to 10GB in config) until it failed.  Checked datanode log:

```
2022-07-28 10:23:35,663 [ChunkReader-5] INFO volume.RoundRobinVolumeChoosingPolicy: No volumes have enough space for a new container.  Most available space: 5682657280 bytes; required space: 10737418240, volumes: {/data/hdds/hdds=free: 113056829440, committed: 107374172160}
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2752890891