### PR TITLE
HDDS-7068. EC: Prematurely re-throwed the exception in reconstruction cleanup loop.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinator.java
@@ -179,8 +179,8 @@ public class ECReconstructionCoordinator implements Closeable {
           LOG.error("Exception while deleting the container {} at target: {}",
               containerID, dn, ioe);
         }
-        throw e;
       }
+      throw e;
     }
 
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/ec/reconstruction/ECReconstructionCoordinatorTask.java
@@ -64,6 +64,10 @@ public class ECReconstructionCoordinatorTask implements Runnable {
     // respective container. HDDS-6582
     // 5. Close/finalize the recovered containers.
     long containerID = this.reconstructionCommandInfo.getContainerID();
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Starting the EC reconstruction of the container {}",
+          containerID);
+    }
     try {
       SortedMap<Integer, DatanodeDetails> sourceNodeMap =
           reconstructionCommandInfo.getSources().stream().collect(Collectors


### PR DESCRIPTION
## What changes were proposed in this pull request?

Wrongly re throwing the exception before fully finishing the cleanup loop.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7068

## How was this patch tested
Depending existing tests.
