### PR TITLE
HDDS-7069. EC: ReplicationManager - Track nodes already used when handing under replication

### DIFF
--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -166,6 +166,35 @@ public final class ReplicationTestUtil {
     };
   }
 
+  public static PlacementPolicy getSameNodeTestPlacementPolicy(
+      final NodeManager nodeManager, final OzoneConfiguration conf,
+      DatanodeDetails nodeToReturn) {
+    return new SCMCommonPlacementPolicy(nodeManager, conf) {
+      @Override
+      protected List<DatanodeDetails> chooseDatanodesInternal(
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+          long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
+        if (nodesRequiredToChoose > 1) {
+          throw new IllegalArgumentException("Only one node is allowed");
+        }
+        if (excludedNodes.contains(nodeToReturn)) {
+          throw new SCMException("Insufficient Nodes available to choose",
+              SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
+        }
+        List<DatanodeDetails> dns = new ArrayList<>();
+        dns.add(nodeToReturn);
+        return dns;
+      }
+
+      @Override
+      public DatanodeDetails chooseNode(List<DatanodeDetails> healthyNodes) {
+        return null;
+      }
+    };
+  }
+
   public static PlacementPolicy getNoNodesTestPlacementPolicy(
       final NodeManager nodeManager, final OzoneConfiguration conf) {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

If a container has a missing replica, and some decommission replicas, then it will have both a reconstruction and replication command scheduled when it is processed for under replication.

However, the target node picked for the reconstruction is not excluded when picking nodes for the replication, so it would be possible for both commands to target the same node with different indexes.

We need to track all nodes selected when processing under replication to ensure they are not used twice.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7069

## How was this patch tested?

New unit test
