### PR TITLE
HDDS-7077. EC: Fix block deletion not allowed due to missing pipelineID

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -198,8 +198,15 @@ public class BlockDeletingService extends BackgroundService {
       if (ozoneContainer.getWriteChannel() instanceof XceiverServerRatis) {
         XceiverServerRatis ratisServer =
             (XceiverServerRatis) ozoneContainer.getWriteChannel();
-        PipelineID pipelineID = PipelineID
-            .valueOf(UUID.fromString(containerData.getOriginPipelineId()));
+        PipelineID pipelineID;
+        try {
+          pipelineID = PipelineID.valueOf(
+              UUID.fromString(containerData.getOriginPipelineId()));
+        } catch (IllegalArgumentException e) {
+          // If the pipeline id is not a valid uuid, just mark for deletion.
+          // TODO: This is a workaround for EC containers.
+          return true;
+        }
         // in case te ratis group does not exist, just mark it for deletion.
         if (!ratisServer.isExist(pipelineID.getProtobuf())) {
           return true;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -194,20 +194,17 @@ public class BlockDeletingService extends BackgroundService {
       return false;
     } else if (!containerData.isClosed()) {
       return false;
+    } else if (containerData.getOriginPipelineId() == null
+        || containerData.getOriginPipelineId().isEmpty()) {
+      // in case the pipelineID is empty, just mark it for deletion.
+      return true;
     } else {
       if (ozoneContainer.getWriteChannel() instanceof XceiverServerRatis) {
         XceiverServerRatis ratisServer =
             (XceiverServerRatis) ozoneContainer.getWriteChannel();
-        PipelineID pipelineID;
-        try {
-          pipelineID = PipelineID.valueOf(
-              UUID.fromString(containerData.getOriginPipelineId()));
-        } catch (IllegalArgumentException e) {
-          // If the pipeline id is not a valid uuid, just mark for deletion.
-          // TODO: This is a workaround for EC containers.
-          return true;
-        }
-        // in case te ratis group does not exist, just mark it for deletion.
+        PipelineID pipelineID = PipelineID
+            .valueOf(UUID.fromString(containerData.getOriginPipelineId()));
+        // in case the ratis group does not exist, just mark it for deletion.
         if (!ratisServer.isExist(pipelineID.getProtobuf())) {
           return true;
         }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -194,17 +194,20 @@ public class BlockDeletingService extends BackgroundService {
       return false;
     } else if (!containerData.isClosed()) {
       return false;
-    } else if (containerData.getOriginPipelineId() == null
-        || containerData.getOriginPipelineId().isEmpty()) {
-      // in case the pipelineID is empty, just mark it for deletion.
-      return true;
     } else {
       if (ozoneContainer.getWriteChannel() instanceof XceiverServerRatis) {
         XceiverServerRatis ratisServer =
             (XceiverServerRatis) ozoneContainer.getWriteChannel();
-        PipelineID pipelineID = PipelineID
-            .valueOf(UUID.fromString(containerData.getOriginPipelineId()));
-        // in case the ratis group does not exist, just mark it for deletion.
+        PipelineID pipelineID;
+        try {
+          pipelineID = PipelineID.valueOf(
+              UUID.fromString(containerData.getOriginPipelineId()));
+        } catch (IllegalArgumentException e) {
+          // If the pipeline id is not a valid uuid, just mark for deletion.
+          // TODO: This is a workaround for EC containers.
+          return true;
+        }
+        // in case te ratis group does not exist, just mark it for deletion.
         if (!ratisServer.isExist(pipelineID.getProtobuf())) {
           return true;
         }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -60,7 +60,7 @@ import org.apache.hadoop.ozone.om.protocol.OzoneManagerProtocol;
 import org.apache.ozone.test.GenericTestUtils;
 import org.apache.ozone.test.GenericTestUtils.LogCapturer;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -215,25 +215,23 @@ public class TestBlockDeletion {
       }
     }, 1000, 10000);
     // No containers with deleted blocks
-    Assert.assertTrue(containerIdsWithDeletedBlocks.isEmpty());
+    Assertions.assertTrue(containerIdsWithDeletedBlocks.isEmpty());
     // Delete transactionIds for the containers should be 0.
     // NOTE: this test assumes that all the container is KetValueContainer. If
     // other container types is going to be added, this test should be checked.
     matchContainerTransactionIds();
 
-    Assert.assertEquals(0L, metrics.getNumBlockDeletionTransactionCreated());
+    Assertions.assertEquals(0L,
+        metrics.getNumBlockDeletionTransactionCreated());
     writeClient.deleteKey(keyArgs);
     Thread.sleep(5000);
     // The blocks should not be deleted in the DN as the container is open
-    try {
+    Throwable e = Assertions.assertThrows(AssertionError.class, () -> {
       verifyBlocksDeleted(omKeyLocationInfoGroupList);
-      Assert.fail("Blocks should not have been deleted");
-    } catch (Throwable e) {
-      Assert.assertTrue(e.getMessage().contains("expected null, but was"));
-      Assert.assertEquals(e.getClass(), AssertionError.class);
-    }
+    });
+    Assertions.assertTrue(e.getMessage().startsWith("expected: <null> but was:"));
 
-    Assert.assertEquals(0L, metrics.getNumBlockDeletionTransactionSent());
+    Assertions.assertEquals(0L, metrics.getNumBlockDeletionTransactionSent());
     // close the containers which hold the blocks for the key
     OzoneTestUtils.closeAllContainers(scm.getEventQueue(), scm);
     Thread.sleep(2000);
@@ -259,7 +257,7 @@ public class TestBlockDeletion {
     }, 2000, 30000);
 
     // Few containers with deleted blocks
-    Assert.assertTrue(!containerIdsWithDeletedBlocks.isEmpty());
+    Assertions.assertTrue(!containerIdsWithDeletedBlocks.isEmpty());
     // Containers in the DN and SCM should have same delete transactionIds
     matchContainerTransactionIds();
     // Containers in the DN and SCM should have same delete transactionIds
@@ -278,12 +276,12 @@ public class TestBlockDeletion {
         return false;
       }
     }, 500, 10000);
-    Assert.assertTrue(metrics.getNumBlockDeletionTransactionCreated() ==
+    Assertions.assertTrue(metrics.getNumBlockDeletionTransactionCreated() ==
             metrics.getNumBlockDeletionTransactionCompleted());
-    Assert.assertTrue(metrics.getNumBlockDeletionCommandSent() >=
+    Assertions.assertTrue(metrics.getNumBlockDeletionCommandSent() >=
         metrics.getNumBlockDeletionCommandSuccess() +
             metrics.getBNumBlockDeletionCommandFailure());
-    Assert.assertTrue(metrics.getNumBlockDeletionTransactionSent() >=
+    Assertions.assertTrue(metrics.getNumBlockDeletionTransactionSent() >=
         metrics.getNumBlockDeletionTransactionFailure() +
             metrics.getNumBlockDeletionTransactionSuccess());
     LOG.info(metrics.toString());
@@ -322,8 +320,8 @@ public class TestBlockDeletion {
     final int valueSize = value.getBytes(UTF_8).length;
     final int keyCount = 1;
     containerInfos.stream().forEach(container -> {
-      Assert.assertEquals(valueSize, container.getUsedBytes());
-      Assert.assertEquals(keyCount, container.getNumberOfKeys());
+      Assertions.assertEquals(valueSize, container.getUsedBytes());
+      Assertions.assertEquals(keyCount, container.getNumberOfKeys());
     });
 
     OzoneTestUtils.closeAllContainers(scm.getEventQueue(), scm);
@@ -344,8 +342,8 @@ public class TestBlockDeletion {
     Thread.sleep(5000);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container -> {
-      Assert.assertEquals(0, container.getUsedBytes());
-      Assert.assertEquals(0, container.getNumberOfKeys());
+      Assertions.assertEquals(0, container.getUsedBytes());
+      Assertions.assertEquals(0, container.getNumberOfKeys());
     });
     // Verify that pending block delete num are as expected with resent cmds
     cluster.getHddsDatanodes().forEach(dn -> {
@@ -354,7 +352,7 @@ public class TestBlockDeletion {
       containerMap.values().forEach(container -> {
         KeyValueContainerData containerData =
             (KeyValueContainerData)container.getContainerData();
-        Assert.assertEquals(0, containerData.getNumPendingDeletionBlocks());
+        Assertions.assertEquals(0, containerData.getNumPendingDeletionBlocks());
       });
     });
 
@@ -363,7 +361,7 @@ public class TestBlockDeletion {
     ((EventQueue)scm.getEventQueue()).processAll(1000);
     containerInfos = scm.getContainerManager().getContainers();
     containerInfos.stream().forEach(container ->
-        Assert.assertEquals(HddsProtos.LifeCycleState.DELETING,
+        Assertions.assertEquals(HddsProtos.LifeCycleState.DELETING,
             container.getState()));
     LogCapturer logCapturer =
         LogCapturer.captureLogs(LegacyReplicationManager.LOG);
@@ -382,14 +380,15 @@ public class TestBlockDeletion {
       List<ContainerInfo> infos = scm.getContainerManager().getContainers();
       try {
         infos.stream().forEach(container -> {
-          Assert.assertEquals(HddsProtos.LifeCycleState.DELETED,
+          Assertions.assertEquals(HddsProtos.LifeCycleState.DELETED,
               container.getState());
           try {
-            Assert.assertTrue(scm.getScmMetadataStore().getContainerTable()
+            Assertions.assertTrue(scm.getScmMetadataStore().getContainerTable()
                 .get(container.containerID()).getState() ==
                 HddsProtos.LifeCycleState.DELETED);
           } catch (IOException e) {
-            Assert.fail("Container from SCM DB should be marked as DELETED");
+            Assertions.fail(
+                "Container from SCM DB should be marked as DELETED");
           }
         });
       } catch (Throwable e) {
@@ -403,7 +402,7 @@ public class TestBlockDeletion {
   private void verifyTransactionsCommitted() throws IOException {
     scm.getScmBlockManager().getDeletedBlockLog();
     for (long txnID = 1; txnID <= maxTransactionId; txnID++) {
-      Assert.assertNull(
+      Assertions.assertNull(
           scm.getScmMetadataStore().getDeletedBlocksTXTable().get(txnID));
     }
   }
@@ -417,15 +416,15 @@ public class TestBlockDeletion {
       for (ContainerData containerData : containerDataList) {
         long containerId = containerData.getContainerID();
         if (containerIdsWithDeletedBlocks.contains(containerId)) {
-          Assert.assertTrue(
+          Assertions.assertTrue(
               scm.getContainerInfo(containerId).getDeleteTransactionId() > 0);
           maxTransactionId = max(maxTransactionId,
               scm.getContainerInfo(containerId).getDeleteTransactionId());
         } else {
-          Assert.assertEquals(
+          Assertions.assertEquals(
               scm.getContainerInfo(containerId).getDeleteTransactionId(), 0);
         }
-        Assert.assertEquals(
+        Assertions.assertEquals(
             ((KeyValueContainerData) dnContainerSet.getContainer(containerId)
                 .getContainerData()).getDeleteTransactionId(),
             scm.getContainerInfo(containerId).getDeleteTransactionId());
@@ -442,7 +441,7 @@ public class TestBlockDeletion {
         KeyValueContainerData cData = (KeyValueContainerData) dnContainerSet
             .getContainer(blockID.getContainerID()).getContainerData();
         try (DBHandle db = BlockUtils.getDB(cData, conf)) {
-          Assert.assertNotNull(db.getStore().getBlockDataTable()
+          Assertions.assertNotNull(db.getStore().getBlockDataTable()
               .get(cData.blockKey(blockID.getLocalID())));
         }
       }, omKeyLocationInfoGroups);
@@ -464,10 +463,10 @@ public class TestBlockDeletion {
           String blockKey = cData.blockKey(blockID.getLocalID());
 
           BlockData blockData = blockDataTable.get(blockKey);
-          Assert.assertNull(blockData);
+          Assertions.assertNull(blockData);
 
           String deletingKey = cData.deletingBlockKey(blockID.getLocalID());
-          Assert.assertNull(blockDataTable.get(deletingKey));
+          Assertions.assertNull(blockDataTable.get(deletingKey));
         }
         containerIdsWithDeletedBlocks.add(blockID.getContainerID());
       }, omKeyLocationInfoGroups);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -40,7 +40,6 @@ import org.apache.hadoop.hdds.server.events.EventQueue;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.ozone.HddsDatanodeService;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.OzoneTestUtils;
 import org.apache.hadoop.ozone.client.ObjectStore;
 import org.apache.hadoop.ozone.client.OzoneBucket;
@@ -66,14 +65,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
@@ -115,13 +112,12 @@ public class TestBlockDeletion {
   private ScmBlockDeletingServiceMetrics metrics;
 
   @BeforeEach
-  public void init(@TempDir File baseDir) throws Exception {
+  public void init() throws Exception {
     conf = new OzoneConfiguration();
     GenericTestUtils.setLogLevel(DeletedBlockLogImpl.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(SCMBlockDeletingService.LOG, Level.DEBUG);
     GenericTestUtils.setLogLevel(LegacyReplicationManager.LOG, Level.DEBUG);
 
-    conf.set(OzoneConfigKeys.OZONE_METADATA_DIRS, baseDir.getAbsolutePath());
     conf.set("ozone.replication.allowed-configs", "^(RATIS/THREE)|(EC/2-1)$");
     conf.setTimeDuration(OZONE_BLOCK_DELETING_SERVICE_INTERVAL, 100,
         TimeUnit.MILLISECONDS);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/common/statemachine/commandhandler/TestBlockDeletion.java
@@ -259,7 +259,7 @@ public class TestBlockDeletion {
     }, 2000, 30000);
 
     // Few containers with deleted blocks
-    Assertions.assertTrue(!containerIdsWithDeletedBlocks.isEmpty());
+    Assertions.assertFalse(containerIdsWithDeletedBlocks.isEmpty());
     // Containers in the DN and SCM should have same delete transactionIds
     matchContainerTransactionIds();
     // Containers in the DN and SCM should have same delete transactionIds
@@ -278,8 +278,8 @@ public class TestBlockDeletion {
         return false;
       }
     }, 500, 10000);
-    Assertions.assertTrue(metrics.getNumBlockDeletionTransactionCreated() ==
-            metrics.getNumBlockDeletionTransactionCompleted());
+    Assertions.assertEquals(metrics.getNumBlockDeletionTransactionCreated(),
+        metrics.getNumBlockDeletionTransactionCompleted());
     Assertions.assertTrue(metrics.getNumBlockDeletionCommandSent() >=
         metrics.getNumBlockDeletionCommandSuccess() +
             metrics.getBNumBlockDeletionCommandFailure());
@@ -385,9 +385,9 @@ public class TestBlockDeletion {
           Assertions.assertEquals(HddsProtos.LifeCycleState.DELETED,
               container.getState());
           try {
-            Assertions.assertTrue(scm.getScmMetadataStore().getContainerTable()
-                .get(container.containerID()).getState() ==
-                HddsProtos.LifeCycleState.DELETED);
+            Assertions.assertEquals(HddsProtos.LifeCycleState.DELETED,
+                scm.getScmMetadataStore().getContainerTable()
+                    .get(container.containerID()).getState());
           } catch (IOException e) {
             Assertions.fail(
                 "Container from SCM DB should be marked as DELETED");


### PR DESCRIPTION
## What changes were proposed in this pull request?

EC Block is never deleted due to BlockDeletingService#isDeletionAllowed() throwing Exception.

```
2022-08-02 10:53:47,890 [BlockDeletingService#3] WARN  background.BlockDeletingService (BlockDeletingService.java:getTasks(171)) - Unexpected error occurs during deleting blocks.
java.lang.IllegalArgumentException: Invalid UUID string: 
	at java.util.UUID.fromString(UUID.java:194)
	at org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService.isDeletionAllowed(BlockDeletingService.java:200)
```

This patch is a workaround for now, and requires redesign in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7077

## How was this patch tested?

Integration test `TestBlockDeletion#testBlockDeletion()`.
