### PR TITLE
HDDS-7081. EC: ReplicationManager - UnderRep handler should handle duplicate indexes

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECUnderReplicationHandler.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hdds.scm.container.replication;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.hdds.conf.StorageUnit;
@@ -29,6 +30,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
+import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;
 import org.apache.hadoop.ozone.protocol.commands.ReplicateContainerCommand;
 import org.apache.hadoop.ozone.protocol.commands.SCMCommand;
@@ -45,6 +47,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyMap;
+import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.IN_SERVICE;
 
 /**
  * Handles the EC Under replication processing and forming the respective SCM
@@ -143,17 +146,33 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
       // We got the missing indexes, this is excluded any decommissioning
       // indexes. Find the good source nodes.
       if (missingIndexes.size() > 0) {
-        Map<Integer, ContainerReplica> sources = replicas.stream().filter(r -> r
+        Map<Integer, Pair<ContainerReplica, NodeStatus>> sources =
+            replicas.stream().filter(r -> r
             .getState() == StorageContainerDatanodeProtocolProtos
             .ContainerReplicaProto.State.CLOSED)
             // Exclude stale and dead nodes. This is particularly important for
             // maintenance nodes, as the replicas will remain present in the
             // container manager, even when they go dead.
-            .filter(r -> ReplicationManager
-                .getNodeStatus(r.getDatanodeDetails(), nodeManager).isHealthy())
             .filter(r -> !deletionInFlight.contains(r.getDatanodeDetails()))
-            .collect(
-                Collectors.toMap(ContainerReplica::getReplicaIndex, x -> x));
+            .map(r -> Pair.of(r, ReplicationManager
+                .getNodeStatus(r.getDatanodeDetails(), nodeManager)))
+            .filter(pair -> pair.getRight().isHealthy())
+            // If there are multiple nodes online for a given index, we just
+            // pick any IN_SERVICE one. At the moment, the input streams cannot
+            // handle multiple replicas for the same index, so if we passed them
+            // all through they would not get used anyway.
+            // If neither of the nodes are in service, we just pass one through,
+            // as it will be decommission or maintenance.
+            .collect(Collectors.toMap(
+                pair -> pair.getLeft().getReplicaIndex(),
+                pair -> pair,
+                (p1, p2) -> {
+                  if (p1.getRight().getOperationalState() == IN_SERVICE) {
+                    return p1;
+                  } else {
+                    return p2;
+                  }
+                }));
         LOG.debug("Missing indexes detected for the container {}." +
                 " The missing indexes are {}", id, missingIndexes);
         // We have source nodes.
@@ -164,12 +183,12 @@ public class ECUnderReplicationHandler implements UnhealthyReplicationHandler {
 
           List<ReconstructECContainersCommand.DatanodeDetailsAndReplicaIndex>
               sourceDatanodesWithIndex = new ArrayList<>();
-          for (ContainerReplica srcReplica : sources.values()) {
+          for (Pair<ContainerReplica, NodeStatus> src : sources.values()) {
             sourceDatanodesWithIndex.add(
                 new ReconstructECContainersCommand
                     .DatanodeDetailsAndReplicaIndex(
-                    srcReplica.getDatanodeDetails(),
-                    srcReplica.getReplicaIndex()));
+                    src.getLeft().getDatanodeDetails(),
+                    src.getLeft().getReplicaIndex()));
           }
 
           final ReconstructECContainersCommand reconstructionCommand =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/OverReplicatedProcessor.java
@@ -73,7 +73,7 @@ public class OverReplicatedProcessor {
       try {
         processContainer(overRep);
         processed++;
-      } catch (IOException e) {
+      } catch (Exception e) {
         LOG.error("Error processing over replicated container {}",
             overRep.getContainerInfo(), e);
         failed++;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/UnderReplicatedProcessor.java
@@ -75,7 +75,7 @@ public class UnderReplicatedProcessor {
       try {
         processContainer(underRep);
         processed++;
-      } catch (IOException e) {
+      } catch (Exception e) {
         LOG.error("Error processing under replicated container {}",
             underRep.getContainerInfo(), e);
         failed++;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
@@ -98,7 +98,11 @@ public final class BackgroundSCMService implements SCMService {
     while (running.get()) {
       try {
         if (shouldRun()) {
-          periodicalTask.run();
+          try {
+            periodicalTask.run();
+          } catch (Exception e) {
+            log.error("Unhandled exception in {}.", getServiceName(), e);
+          }
         }
         synchronized (this) {
           if (!runImmediately) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/BackgroundSCMService.java
@@ -100,8 +100,9 @@ public final class BackgroundSCMService implements SCMService {
         if (shouldRun()) {
           try {
             periodicalTask.run();
-          } catch (Exception e) {
-            log.error("Unhandled exception in {}.", getServiceName(), e);
+          } catch (Throwable e) {
+            log.error("Caught Unhandled exception in {}. The task will be " +
+                "re-tried in {}ms", getServiceName(), intervalInMillis, e);
           }
         }
         synchronized (this) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

When there are two replicas online with the same index, eg due to decommission, over-replication or maintenance, and the container is under replicated due to another missing index, an illegal argument exception can be thrown when collecting the source indexes:

```
2022-08-02 10:54:26,939 WARN org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler: Exception while processing for creating the EC reconstruction container commands for #2.
java.lang.IllegalStateException: Duplicate key 3 (attempted merging values ContainerReplica{containerID=#2, state=CLOSED, datanodeDetails=fb63a3c8-2e5b-432e-be63-274c41aab79f{ip: 172.27.124.131, host: quasar-onjdpu-5.quasar-onjdpu.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: IN_SERVICE, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=2ff0ed60-a461-41a4-8fff-9da6cb4e52ad, sequenceId=0, keyCount=1, bytesUsed=34603008,replicaIndex= 3} and ContainerReplica{containerID=#2, state=CLOSED, datanodeDetails=2ff0ed60-a461-41a4-8fff-9da6cb4e52ad{ip: 172.27.193.4, host: quasar-onjdpu-3.quasar-onjdpu.root.hwx.site, ports: [REPLICATION=9886, RATIS=9858, RATIS_ADMIN=9857, RATIS_SERVER=9856, STANDALONE=9859], networkLocation: /default, certSerialId: null, persistedOpState: DECOMMISSIONING, persistedOpStateExpiryEpochSec: 0}, placeOfBirth=2ff0ed60-a461-41a4-8fff-9da6cb4e52ad, sequenceId=0, keyCount=1, bytesUsed=34603008,replicaIndex= 3})
        at java.base/java.util.stream.Collectors.duplicateKeyException(Collectors.java:133)
        at java.base/java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180)
        at java.base/java.util.stream.ReduceOps$3ReducingSink.accept(ReduceOps.java:169)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:177)
        at java.base/java.util.HashMap$KeySpliterator.forEachRemaining(HashMap.java:1603)
        at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)
        at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)
        at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)
        at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
        at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)
        at org.apache.hadoop.hdds.scm.container.replication.ECUnderReplicationHandler.processAndCreateCommands(ECUnderReplicationHandler.java:151)
        at org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.processUnderReplicatedContainer(ReplicationManager.java:366)
        at org.apache.hadoop.hdds.scm.container.replication.UnderReplicatedProcessor.processContainer(UnderReplicatedProcessor.java:92)
        at org.apache.hadoop.hdds.scm.container.replication.UnderReplicatedProcessor.processAll(UnderReplicatedProcessor.java:76)
        at org.apache.hadoop.hdds.scm.ha.BackgroundSCMService.run(BackgroundSCMService.java:101)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

This then goes unhandled and causes the under rep processing thread to exit.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7081

## How was this patch tested?

Unit test to reproduce and ensure the issue is fixed.