### PR TITLE
HDDS-7074. DN EndpointStateMachineMBean to add getType()

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.ozone.container.common.statemachine;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.hadoop.hdds.conf.ConfigurationSource;
 import org.apache.hadoop.ozone.protocol.VersionResponse;
+import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
 import org.apache.hadoop.ozone.protocolPB
     .StorageContainerDatanodeProtocolClientSideTranslatorPB;
 import org.slf4j.Logger;
@@ -55,6 +56,10 @@ public class EndpointStateMachine
   private ZonedDateTime lastSuccessfulHeartbeat;
   private boolean isPassive;
   private final ExecutorService executorService;
+
+  private static final String RECONN_TYPE = "Reconn";
+
+  private static final String SCM_TYPE = "SCM";
 
   /**
    * Constructs RPC Endpoints.
@@ -340,5 +345,14 @@ public class EndpointStateMachine
   public void setLastSuccessfulHeartbeat(
       ZonedDateTime lastSuccessfulHeartbeat) {
     this.lastSuccessfulHeartbeat = lastSuccessfulHeartbeat;
+  }
+
+  @Override
+  public String getType() {
+    if (endPoint.getUnderlyingProxyObject()
+            instanceof ReconDatanodeProtocolPB) {
+      return RECONN_TYPE;
+    }
+    return SCM_TYPE;
   }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -57,7 +57,7 @@ public class EndpointStateMachine
   private boolean isPassive;
   private final ExecutorService executorService;
 
-  private static final String RECONN_TYPE = "Reconn";
+  private static final String RECON_TYPE = "Recon";
 
   private static final String SCM_TYPE = "SCM";
 
@@ -351,7 +351,7 @@ public class EndpointStateMachine
   public String getType() {
     if (endPoint.getUnderlyingProxyObject()
             instanceof ReconDatanodeProtocolPB) {
-      return RECONN_TYPE;
+      return RECON_TYPE;
     }
     return SCM_TYPE;
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
@@ -31,4 +31,6 @@ public interface EndpointStateMachineMBean {
   int getVersionNumber();
 
   long getLastSuccessfulHeartbeat();
+
+  String getType();
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a new MBean interface to export the type of end point.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7074

## How was this patch tested?

This is the new EndpointStateMachineMBean output:
```
{
"name": "Hadoop:service=HddsDatanode,name=SCMConnectionManager",
"modelerType": "org.apache.hadoop.ozone.container.common.statemachine.SCMConnectionManager",
"SCMServers": [
{
"addressString": "localhost/127.0.0.1:9891",
"lastSuccessfulHeartbeat": 1659536391,
"missedCount": 0,
"state": "HEARTBEAT",
"type": "Reconn",
"versionNumber": 0
},
{
"addressString": "localhost/127.0.0.1:9861",
"lastSuccessfulHeartbeat": 0,
"missedCount": 0,
"state": "REGISTER",
"type": "SCM",
"versionNumber": 1
}
]
}
```


