### PR TITLE
HDDS-7043. Disallow trailing ellipsis in PR title

### DIFF
--- a/dev-support/ci/pr_title_check.bats
+++ b/dev-support/ci/pr_title_check.bats
@@ -97,6 +97,14 @@ load bats-assert/load.bash
   run dev-support/ci/pr_title_check.sh 'HDDS-1234. Hello World '
   assert_output 'Fail: trailing space'
 
+  # trailing ellipsis
+  run dev-support/ci/pr_title_check.sh 'HDDS-1234. Hello World...'
+  assert_output 'Fail: trailing ellipsis indicates title is cut'
+
+  # trailing ellipsis
+  run dev-support/ci/pr_title_check.sh 'HDDS-1234. Hello World…'
+  assert_output 'Fail: trailing ellipsis indicates title is cut'
+
   # double spaces after Jira
   run dev-support/ci/pr_title_check.sh 'HDDS-1234.  Hello World'
   assert_output 'Fail: two consecutive spaces'

--- a/dev-support/ci/pr_title_check.sh
+++ b/dev-support/ci/pr_title_check.sh
@@ -42,6 +42,8 @@ assertMatch    '^HDDS-[1-9][0-9]{0,4}[^0-9]'       'Fail: Jira must be 1 to 5 di
 assertMatch    '^HDDS-[1-9][0-9]{0,4}\.'           'Fail: missing dot after Jira'
 assertMatch    '^HDDS-[1-9][0-9]{0,4}\. '          'Fail: missing space after Jira'
 assertNotMatch '[[:space:]]$'                      'Fail: trailing space'
+assertNotMatch '\.{3,}$'                           'Fail: trailing ellipsis indicates title is cut'
+assertNotMatch '…$'                                'Fail: trailing ellipsis indicates title is cut'
 assertNotMatch '[[:space:]]{2}'                    'Fail: two consecutive spaces'
 assertMatch    '^HDDS-[1-9][0-9]{0,4}\. .*[^ ]$'   'Fail: not match "^HDDS-[1-9][0-9]{0,4}\. .*[^ ]$"'
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

When opening a PR on Github, title is filled from commit message. If it is too long, an ellipsis (…) is added, and the rest of the message is moved to the PR description. The partial PR title could then end up in the final commit message if not corrected during merge. We should avoid such titles.

https://issues.apache.org/jira/browse/HDDS-7043

## How was this patch tested?

Added test case in `pr_title_check.bats`.

https://github.com/adoroszlai/hadoop-ozone/runs/7651057967?check_suite_focus=true#step:5:41