### PR TITLE
HDDS-4970. Significant overhead when DataNode is over-subscribed

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.container.keyvalue.helpers;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -125,7 +126,9 @@ public final class ChunkUtils {
     try {
       bytesWritten = writer.applyAsLong(data);
     } catch (UncheckedIOException e) {
-      onFailure(volume);
+      if (!(e.getCause() instanceof InterruptedIOException)) {
+        onFailure(volume);
+      }
       throw wrapInStorageContainerException(e.getCause());
     }
 
@@ -146,20 +149,25 @@ public final class ChunkUtils {
   private static long writeDataToFile(File file, ChunkBuffer data,
       long offset, boolean sync) {
     final Path path = file.toPath();
-    return processFileExclusively(path, () -> {
-      FileChannel channel = null;
-      try {
-        channel = open(path, WRITE_OPTIONS, NO_ATTRIBUTES);
+    try {
+      return processFileExclusively(path, () -> {
+        FileChannel channel = null;
+        try {
+          channel = open(path, WRITE_OPTIONS, NO_ATTRIBUTES);
 
-        try (FileLock ignored = channel.lock()) {
-          return writeDataToChannel(channel, data, offset);
+          try (FileLock ignored = channel.lock()) {
+            return writeDataToChannel(channel, data, offset);
+          }
+        } catch (IOException e) {
+          throw new UncheckedIOException(e);
+        } finally {
+          closeFile(channel, sync);
         }
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      } finally {
-        closeFile(channel, sync);
-      }
-    });
+      });
+    } catch (InterruptedException e) {
+      throw new UncheckedIOException(new InterruptedIOException(
+          "Interrupted while waiting to write file " + path));
+    }
   }
 
   private static long writeDataToChannel(FileChannel channel, ChunkBuffer data,
@@ -203,6 +211,8 @@ public final class ChunkUtils {
     } catch (UncheckedIOException e) {
       onFailure(volume);
       throw wrapInStorageContainerException(e.getCause());
+    } catch (InterruptedException e) {
+      throw wrapInStorageContainerException(e);
     }
 
     // Increment volumeIO stats here.
@@ -291,10 +301,18 @@ public final class ChunkUtils {
   }
 
   @VisibleForTesting
-  static <T> T processFileExclusively(Path path, Supplier<T> op) {
+  static <T> T processFileExclusively(Path path, Supplier<T> op)
+      throws InterruptedException {
+    long period = 1;
     for (;;) {
       if (LOCKS.add(path)) {
         break;
+      } else {
+        Thread.sleep(period);
+        // exponentially backoff until the sleep time is over 1 second.
+        if (period < 1000) {
+          period *= 2;
+        }
       }
     }
 
@@ -357,7 +375,7 @@ public final class ChunkUtils {
   }
 
   public static StorageContainerException wrapInStorageContainerException(
-      IOException e) {
+      Exception e) {
     ContainerProtos.Result result = translate(e);
     return new StorageContainerException(e, result);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -129,15 +129,19 @@ public class TestChunkUtils {
         Path path = Files.createTempFile(PREFIX, String.valueOf(i));
         paths.add(path);
         executor.execute(() -> {
-          ChunkUtils.processFileExclusively(path, () -> {
-            try {
-              Thread.sleep(perThreadWait);
-            } catch (InterruptedException e) {
-              e.printStackTrace();
-            }
-            processed.incrementAndGet();
-            return null;
-          });
+          try {
+            ChunkUtils.processFileExclusively(path, () -> {
+              try {
+                Thread.sleep(perThreadWait);
+              } catch (InterruptedException e) {
+                e.printStackTrace();
+              }
+              processed.incrementAndGet();
+              return null;
+            });
+          } catch (InterruptedException e) {
+            e.printStackTrace();
+          }
         });
       }
       try {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Replace the spinlock in ChunkUtils with exponentially backoff timed wait.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-4970

## How was this patch tested?
The patch is applied and verified to work in a 20-node test cluster running Impala TPC-DS workload.