### PR TITLE
HDDS-7091. Filter containers with pending deletion blocks before checking policy

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/RandomContainerDeletionChoosingPolicy.java
@@ -61,19 +61,17 @@ public class RandomContainerDeletionChoosingPolicy
     // blocks don't exceed the number of blocks to be deleted in an interval.
 
     for (ContainerData entry : shuffled) {
-      if (((KeyValueContainerData) entry).getNumPendingDeletionBlocks() > 0) {
-        long numBlocksToDelete = Math.min(blockCount,
+      long numBlocksToDelete = Math.min(blockCount,
+          ((KeyValueContainerData) entry).getNumPendingDeletionBlocks());
+      blockCount -= numBlocksToDelete;
+      result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Select container {} for block deletion, "
+                + "pending deletion blocks num: {}.", entry.getContainerID(),
             ((KeyValueContainerData) entry).getNumPendingDeletionBlocks());
-        blockCount -= numBlocksToDelete;
-        result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Select container {} for block deletion, "
-                  + "pending deletion blocks num: {}.", entry.getContainerID(),
-              ((KeyValueContainerData) entry).getNumPendingDeletionBlocks());
-        }
-        if (blockCount == 0) {
-          break;
-        }
+      }
+      if (blockCount == 0) {
+        break;
       }
     }
     return result;

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/impl/TopNOrderedContainerDeletionChoosingPolicy.java
@@ -74,22 +74,16 @@ public class TopNOrderedContainerDeletionChoosingPolicy
     // blocks don't exceed the number of blocks to be deleted in an interval.
 
     for (KeyValueContainerData entry : orderedList) {
-      if (entry.getNumPendingDeletionBlocks() > 0) {
-        long numBlocksToDelete =
-            Math.min(totalBlocks, entry.getNumPendingDeletionBlocks());
-        totalBlocks -= numBlocksToDelete;
-        result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Select container {} for block deletion, "
-                  + "pending deletion blocks num: {}.", entry.getContainerID(),
-              entry.getNumPendingDeletionBlocks());
-        }
-        if (totalBlocks == 0) {
-          break;
-        }
-      } else {
-        LOG.debug("Stop looking for next container, there is no"
-            + " pending deletion block contained in remaining containers.");
+      long numBlocksToDelete =
+          Math.min(totalBlocks, entry.getNumPendingDeletionBlocks());
+      totalBlocks -= numBlocksToDelete;
+      result.add(new ContainerBlockInfo(entry, numBlocksToDelete));
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Select container {} for block deletion, "
+                + "pending deletion blocks num: {}.", entry.getContainerID(),
+            entry.getNumPendingDeletionBlocks());
+      }
+      if (totalBlocks == 0) {
         break;
       }
     }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -177,6 +177,8 @@ public class BlockDeletingService extends BackgroundService {
       throws StorageContainerException {
     Map<Long, ContainerData> containerDataMap =
         ozoneContainer.getContainerSet().getContainerMap().entrySet().stream()
+            .filter(e -> ((KeyValueContainerData) e.getValue()
+                .getContainerData()).getNumPendingDeletionBlocks() > 0)
             .filter(e -> isDeletionAllowed(e.getValue().getContainerData(),
                 deletionPolicy)).collect(Collectors
             .toMap(Map.Entry::getKey, e -> e.getValue().getContainerData()));


### PR DESCRIPTION
## What changes were proposed in this pull request?

Previously, containers with zero pending deletion blocks will also be sent to check container chosing policy, which is unnecessary. We can filter them out before passing to any policy.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7091

## How was this patch tested?

Manual tested with debug log added.

Before:

```
2022-08-04 14:14:23,725 [BlockDeletingService#8] INFO org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService: Found 57 candidates for bl
ock deletion
2022-08-04 14:14:23,725 [BlockDeletingService#8] INFO org.apache.hadoop.ozone.container.common.impl.TopNOrderedContainerDeletionChoosingPolicy: Container 128 has 0 pendi
ng deletion blocks
2022-08-04 14:14:23,725 [BlockDeletingService#8] INFO org.apache.hadoop.ozone.container.common.impl.TopNOrderedContainerDeletionChoosingPolicy: Stop looking for next con
tainer, there is no pending deletion block contained in remaining containers.
2022-08-04 14:14:23,725 [BlockDeletingService#8] INFO org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService: Found 0 containers for blo
ck deletion
```

After:

```
2022-08-04 20:07:55,288 [BlockDeletingService#2] INFO org.apache.hadoop.ozone.container.keyvalue.statemachine.background.BlockDeletingService: Found 0 containers with pending deletion blocks and allowed for deletion
```
