### PR TITLE
HDDS-6983. Snapshot Chain - list of snapshots per snapshottable bucket

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OmMetadataManagerImpl.java
@@ -171,6 +171,13 @@ public class OmMetadataManagerImpl implements OMMetadataManager {
    * |----------------------------------------------------------------------|
    * |  deletedDirTable | /volumeId/bucketId/parentId/dirName -> KeyInfo    |
    * |----------------------------------------------------------------------|
+   *
+   * Snapshot Tables:
+   * |----------------------------------------------------------------------|
+   * |  Column Family     |        VALUE                                    |
+   * |----------------------------------------------------------------------|
+   * |  snapshotInfoTable | /volume/bucket/snapshotName -> SnapshotInfo     |
+   * |----------------------------------------------------------------------|
    */
 
   public static final String USER_TABLE = "userTable";

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainInfo.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainInfo.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+/**
+ * SnapshotChain supporting SnapshotInfo class.
+ *
+ * Defines and provides the interface to the SnapshotChainInfo
+ * entry that comprises a SnapshotChain.
+ * Getters / setters for current, prev, next element in snapshot chain.
+ */
+public class SnapshotChainInfo {
+  private String snapshotID;
+  private String previousSnapshotID;
+  private String nextSnapshotID;
+
+  public SnapshotChainInfo(String snapshotID, String prev, String next) {
+    this.snapshotID = snapshotID;
+    previousSnapshotID = prev;
+    nextSnapshotID = next;
+  }
+
+  public void setNextSnapshotID(String snapsID) {
+    nextSnapshotID = snapsID;
+  }
+
+  public void setPreviousSnapshotID(String snapsID) {
+    previousSnapshotID = snapsID;
+  }
+
+  public String getSnapshotID() {
+    return snapshotID;
+  }
+
+  public String getNextSnapshotID() {
+    return nextSnapshotID;
+  }
+
+  public String getPreviousSnapshotID() {
+    return previousSnapshotID;
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/SnapshotChainManager.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.hdds.utils.db.TableIterator;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.LinkedHashMap;
+import java.util.TreeMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class is used for creating and accessing Snapshot Chains.
+ *
+ * The snapshot chain maintains the in-memory sequence of snapshots
+ * created in chronological order.  There are two such snapshots maintained
+ * i.) Path based snapshot chain, sequence of snapshots created for a
+ * given /volume/bucket
+ * ii.) Global snapshot chain, sequence of all snapshots created in order
+ *
+ * On start, the snapshot chains are initialized from the on disk
+ * SnapshotInfoTable from the om RocksDB.
+ */
+public class SnapshotChainManager {
+  private LinkedHashMap<String, SnapshotChainInfo>  snapshotChainGlobal;
+  private Map<String, LinkedHashMap<String, SnapshotChainInfo>>
+      snapshotChainPath;
+  private Map<String, String> latestPathSnapshotID;
+  private String latestGlobalSnapshotID;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(SnapshotChainManager.class);
+
+  public SnapshotChainManager(OMMetadataManager metadataManager)
+          throws IOException {
+    snapshotChainGlobal = new LinkedHashMap<>();
+    snapshotChainPath = new HashMap<>();
+    latestPathSnapshotID = new HashMap<>();
+    latestGlobalSnapshotID = null;
+    loadFromSnapshotInfoTable(metadataManager);
+  }
+
+  private void addSnapshotGlobal(String snapshotID,
+                            String prevGlobalID) throws IOException {
+    // set previous snapshotID to null if it is "" for
+    // internal in-mem structure
+    if (prevGlobalID != null && prevGlobalID.equals("")) {
+      prevGlobalID = null;
+    }
+    // on add snapshot; set previous snapshot entry nextSnapshotID =
+    // snapshotID
+    if (prevGlobalID != null &&
+        snapshotChainGlobal.containsKey(prevGlobalID)) {
+      snapshotChainGlobal
+          .get(prevGlobalID)
+          .setNextSnapshotID(snapshotID);
+    }
+    if (prevGlobalID != null &&
+        !snapshotChainGlobal.containsKey(prevGlobalID)) {
+      throw new IOException("Snapshot Chain corruption: "
+          + " previous snapshotID given but no associated snapshot "
+      + "found in snapshot chain: SnapshotID "
+      + prevGlobalID);
+    }
+    snapshotChainGlobal.put(snapshotID,
+            new SnapshotChainInfo(snapshotID, prevGlobalID, null));
+
+    // set state variable latestGlobal snapshot entry to this snapshotID
+    latestGlobalSnapshotID = snapshotID;
+  };
+
+  private void addSnapshotPath(String snapshotPath,
+                               String snapshotID,
+                                String prevPathID) throws IOException {
+    // set previous snapshotID to null if it is "" for
+    // internal in-mem structure
+    if (prevPathID != null && prevPathID.equals("")) {
+      prevPathID = null;
+    }
+
+    // on add snapshot; set previous snapshot entry nextSnapshotID =
+    // snapshotID
+    if (prevPathID != null &&
+        ((!snapshotChainPath
+            .containsKey(snapshotPath)) ||
+        (!snapshotChainPath
+            .get(snapshotPath)
+            .containsKey(prevPathID)))) {
+      throw new IOException("Snapshot Chain corruption: "
+          + "previous snapshotID given but no associated snapshot "
+          + "found in snapshot chain: SnapshotID "
+          + prevPathID);
+    }
+
+    if (prevPathID != null &&
+            snapshotChainPath.containsKey(snapshotPath)) {
+      snapshotChainPath
+              .get(snapshotPath)
+              .get(prevPathID)
+              .setNextSnapshotID(snapshotID);
+    }
+
+    if (!snapshotChainPath.containsKey(snapshotPath)) {
+      snapshotChainPath.put(snapshotPath, new LinkedHashMap<>());
+    }
+
+    snapshotChainPath
+        .get(snapshotPath)
+        .put(snapshotID,
+                new SnapshotChainInfo(snapshotID, prevPathID, null));
+
+    // set state variable latestPath snapshot entry to this snapshotID
+    latestPathSnapshotID.put(snapshotPath, snapshotID);
+  };
+
+  private boolean deleteSnapshotGlobal(String snapshotID) throws IOException {
+    boolean status = true;
+    if (snapshotChainGlobal.containsKey(snapshotID)) {
+      // reset prev and next snapshot entries in chain ordered list
+      // for node removal
+      String next = snapshotChainGlobal.get(snapshotID).getNextSnapshotID();
+      String prev = snapshotChainGlobal.get(snapshotID).getPreviousSnapshotID();
+
+      if (prev != null && !snapshotChainGlobal.containsKey(prev)) {
+        throw new IOException("Snapshot chain corruption: snapshot node to be "
+                + "deleted has prev node element not found in snapshot chain: "
+                + "SnapshotID " + prev);
+      }
+      if (next != null && !snapshotChainGlobal.containsKey(next)) {
+        throw new IOException("Snapshot chain corruption: snapshot node to be "
+                + "deleted has next node element not found in snapshot chain: "
+                + "SnapshotID " + next);
+      }
+      snapshotChainGlobal.remove(snapshotID);
+      if (next != null) {
+        snapshotChainGlobal.get(next).setPreviousSnapshotID(prev);
+      }
+      if (prev != null) {
+        snapshotChainGlobal.get(prev).setNextSnapshotID(next);
+      }
+      // remove from latest list if necessary
+      if (latestGlobalSnapshotID.equals(snapshotID)) {
+        latestGlobalSnapshotID = prev;
+      }
+    } else {
+      // snapshotID not found in snapshot chain, log warning and return
+      LOG.warn("Snapshot chain: snapshotID not found: SnapshotID {}",
+          snapshotID);
+    }
+
+    return status;
+  }
+
+  private boolean deleteSnapshotPath(String snapshotPath,
+                                     String snapshotID) throws IOException {
+    boolean status = true;
+    if (snapshotChainPath.containsKey(snapshotPath) &&
+            snapshotChainPath
+                    .get(snapshotPath)
+                    .containsKey(snapshotID)) {
+      // reset prev and next snapshot entries in chain ordered list
+      // for node removal
+      String next = snapshotChainPath
+          .get(snapshotPath)
+          .get(snapshotID)
+          .getNextSnapshotID();
+      String prev = snapshotChainPath
+          .get(snapshotPath)
+          .get(snapshotID)
+          .getPreviousSnapshotID();
+
+      if (prev != null &&
+          !snapshotChainPath
+              .get(snapshotPath)
+              .containsKey(prev)) {
+        throw new IOException("Snapshot chain corruption: snapshot node to "
+                + "be deleted has prev node element not found in snapshot "
+                + "chain: Snapshot path " + snapshotPath + ", SnapshotID "
+                + prev);
+      }
+      if (next != null && !snapshotChainPath
+          .get(snapshotPath)
+          .containsKey(next)) {
+        throw new IOException("Snapshot chain corruption: snapshot node to "
+                + "be deleted has next node element not found in snapshot "
+                + "chain:  Snapshot path " + snapshotPath + ", SnapshotID "
+                + next);
+      }
+      snapshotChainPath
+          .get(snapshotPath)
+          .remove(snapshotID);
+      if (next != null) {
+        snapshotChainPath
+            .get(snapshotPath)
+            .get(next)
+            .setPreviousSnapshotID(prev);
+      }
+      if (prev != null) {
+        snapshotChainPath
+            .get(snapshotPath)
+            .get(prev)
+            .setNextSnapshotID(next);
+      }
+      // remove from latest list if necessary
+      if (latestPathSnapshotID.get(snapshotPath).equals(snapshotID)) {
+        latestPathSnapshotID.remove(snapshotPath);
+        if (prev != null) {
+          latestPathSnapshotID.put(snapshotPath, prev);
+        }
+      }
+
+    } else {
+      // snapshotID not found in snapshot chain, log warning and return
+      LOG.warn("Snapshot chain: snapshotID not found: Snapshot path {}," +
+              " SnapshotID {}",
+          snapshotPath, snapshotID);
+    }
+
+    return status;
+  }
+
+  private void loadFromSnapshotInfoTable(OMMetadataManager metadataManager)
+          throws IOException {
+    // read from snapshotInfo table to populate
+    // snapshot chains - both global and local path
+    TableIterator<String, ? extends Table.KeyValue<String, SnapshotInfo>>
+            keyIter = metadataManager.getSnapshotInfoTable().iterator();
+    Map<Long, SnapshotInfo> snaps = new TreeMap<>();
+    Table.KeyValue< String, SnapshotInfo > kv;
+    snapshotChainGlobal.clear();
+    snapshotChainPath.clear();
+
+    while (keyIter.hasNext()) {
+      kv = keyIter.next();
+      snaps.put(kv.getValue().getCreationTime(), kv.getValue());
+    }
+    for (SnapshotInfo sinfo : snaps.values()) {
+      addSnapshot(sinfo);
+    }
+  }
+
+  public void addSnapshot(SnapshotInfo sinfo) throws IOException {
+    addSnapshotGlobal(sinfo.getSnapshotID(),
+        sinfo.getGlobalPreviousSnapshotID());
+    addSnapshotPath(sinfo.getSnapshotPath(),
+        sinfo.getSnapshotID(),
+        sinfo.getPathPreviousSnapshotID());
+  }
+
+  public boolean deleteSnapshot(SnapshotInfo sinfo) throws IOException {
+    boolean status;
+
+    status = deleteSnapshotGlobal(sinfo.getSnapshotID());
+    return status && deleteSnapshotPath(sinfo.getSnapshotPath(),
+        sinfo.getSnapshotID());
+  }
+
+  public String getLatestGlobalSnapshot() {
+    return latestGlobalSnapshotID;
+  }
+
+  public String getLatestPathSnapshot(String snapshotPath) {
+    return latestPathSnapshotID.get(snapshotPath);
+  }
+
+  public boolean hasNextGlobalSnapshot(String snapshotID)
+          throws NoSuchElementException {
+    boolean hasNext = false;
+    if (!snapshotChainGlobal.containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotID {}", snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID);
+    }
+    if (snapshotChainGlobal
+            .get(snapshotID)
+            .getNextSnapshotID() != null) {
+      hasNext = true;
+    }
+    return hasNext;
+  }
+
+  public String nextGlobalSnapshot(String snapshotID)
+          throws NoSuchElementException {
+    if (!snapshotChainGlobal.containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotID {}", snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID);
+    }
+    if (snapshotChainGlobal
+            .get(snapshotID)
+            .getNextSnapshotID() == null) {
+      LOG.error("no following snapshot for provided snapshotID {}", snapshotID);
+      throw new NoSuchElementException("no following snapshot from: "
+              + snapshotID);
+    }
+    return snapshotChainGlobal
+            .get(snapshotID)
+            .getNextSnapshotID();
+  }
+
+  public boolean hasPreviousGlobalSnapshot(String snapshotID)
+          throws NoSuchElementException {
+    boolean hasPrevious = false;
+    if (!snapshotChainGlobal.containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotID {}", snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID);
+    }
+    if (snapshotChainGlobal
+            .get(snapshotID)
+            .getPreviousSnapshotID() != null) {
+      hasPrevious = true;
+    }
+    return hasPrevious;
+  }
+
+  public String previousGlobalSnapshot(String snapshotID)
+          throws NoSuchElementException {
+    if (!snapshotChainGlobal.containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotID {}", snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID);
+    }
+    if (snapshotChainGlobal
+            .get(snapshotID)
+            .getPreviousSnapshotID() == null) {
+      LOG.error("no preceeding snapshot for provided snapshotID {}",
+              snapshotID);
+      throw new NoSuchElementException("No preceeding snapshot from: "
+      + snapshotID);
+    }
+    return snapshotChainGlobal
+            .get(snapshotID)
+            .getPreviousSnapshotID();
+  }
+
+  public boolean hasNextPathSnapshot(String snapshotMask, String snapshotID)
+          throws NoSuchElementException {
+    boolean hasNext = false;
+    if (!snapshotChainPath.containsKey(snapshotMask) ||
+            !snapshotChainPath.get(snapshotMask).containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotMask {} and "
+              + " snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("No such snapshot: "
+      + snapshotID + "for path: " + snapshotMask);
+    }
+    if (snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getNextSnapshotID() != null) {
+      hasNext = true;
+    }
+    return hasNext;
+  }
+
+  public boolean hasPreviousPathSnapshot(String snapshotMask, String snapshotID)
+          throws NoSuchElementException {
+    boolean hasPrevious = false;
+    if (!snapshotChainPath.containsKey(snapshotMask) ||
+            !snapshotChainPath.get(snapshotMask).containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotMask {} and "
+              + " snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID
+      + " for snapshot path: " + snapshotMask);
+    }
+    if (snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getPreviousSnapshotID() != null) {
+      hasPrevious = true;
+    }
+    return hasPrevious;
+  }
+
+  public String nextPathSnapshot(String snapshotMask, String snapshotID)
+          throws NoSuchElementException {
+    if (!snapshotChainPath.containsKey(snapshotMask) ||
+            !snapshotChainPath.get(snapshotMask).containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotMask {} and "
+              + " snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID
+      + " for snapshot path:" + snapshotMask);
+    }
+    if (snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getNextSnapshotID() == null) {
+      LOG.error("no following snapshot for provided snapshotMask {}, "
+              + "snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("no following snapshot from: "
+              + snapshotID + "for snapshot path:" + snapshotMask);
+    }
+    return snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getNextSnapshotID();
+  }
+
+  public String previousPathSnapshot(String snapshotMask, String snapshotID)
+          throws NoSuchElementException {
+    if (!snapshotChainPath.containsKey(snapshotMask) ||
+            !snapshotChainPath.get(snapshotMask).containsKey(snapshotID)) {
+      LOG.error("no snapshot for provided snapshotMask {} and "
+              + " snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("No snapshot: " + snapshotID
+              + " for snapshot path:" + snapshotMask);
+    }
+    if (snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getPreviousSnapshotID() == null) {
+      LOG.error("no preceeding snapshot for provided snapshotMask {}, "
+              + "snapshotID {}", snapshotMask, snapshotID);
+      throw new NoSuchElementException("no preceeding snapshot from: "
+              + snapshotID + "for snapshot path:" + snapshotMask);
+    }
+    return snapshotChainPath
+            .get(snapshotMask)
+            .get(snapshotID)
+            .getPreviousSnapshotID();
+  }
+
+  @VisibleForTesting
+  public void loadSnapshotInfo(OMMetadataManager metadataManager)
+          throws IOException {
+    loadFromSnapshotInfoTable(metadataManager);
+  }
+
+}

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestSnapshotChain.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.om;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.hdds.utils.db.Table;
+import org.apache.hadoop.ozone.om.helpers.SnapshotInfo;
+import org.apache.hadoop.util.Time;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import static org.apache.hadoop.ozone.om.OMConfigKeys.OZONE_OM_DB_DIRS;
+
+/**
+ * Tests SnapshotChain that stores in chronological order
+ * Ozone object storage snapshots.  There exist two types
+ * of chains provided by the SnapshotChainManager
+ * i.) path based snapshots - a list of snapshots taken for a given bucket
+ * ii.) global snapshots - a list of every snapshot taken in chrono order
+ */
+public class TestSnapshotChain {
+  private OMMetadataManager omMetadataManager;
+  private Map<String, SnapshotInfo> sinfos;
+  private SnapshotChainManager chainManager;
+
+  @Rule
+  public TemporaryFolder folder = new TemporaryFolder();
+
+  @Before
+  public void setup() throws Exception {
+    OzoneConfiguration conf = new OzoneConfiguration();
+    conf.set(OZONE_OM_DB_DIRS,
+        folder.getRoot().getAbsolutePath());
+    omMetadataManager = new OmMetadataManagerImpl(conf);
+    sinfos = new HashMap<>();
+    chainManager = new SnapshotChainManager(omMetadataManager);
+  }
+
+  private SnapshotInfo createSnapshotInfo(String volName,
+                                          String bucketName,
+                                          String snapshotName,
+                                          String snapshotID,
+                                          String pathPrevID,
+                                          String globalPrevID) {
+    return new SnapshotInfo.Builder()
+        .setSnapshotID(snapshotID)
+        .setName(snapshotName)
+        .setVolumeName(volName)
+        .setBucketName(bucketName)
+        .setSnapshotStatus(SnapshotInfo.SnapshotStatus.SNAPSHOT_ACTIVE)
+        .setCreationTime(Time.now())
+        .setDeletionTime(-1L)
+        .setPathPreviousSnapshotID(pathPrevID)
+        .setGlobalPreviousSnapshotID(globalPrevID)
+        .setSnapshotPath(String.join("/", volName, bucketName))
+        .setCheckpointDir("checkpoint.testdir")
+        .build();
+  }
+
+  private void deleteSnapshot(String snapshotID) throws IOException {
+    SnapshotInfo sinfo = null;
+    final String snapshotPath = "vol1/bucket1";
+    // reset the next snapshotInfo.globalPreviousSnapshotID
+    // to the previous in the entry to be deleted.
+    if (chainManager.hasNextGlobalSnapshot(snapshotID)) {
+      sinfo = sinfos
+              .get(chainManager.nextGlobalSnapshot(snapshotID));
+      if (chainManager.hasPreviousGlobalSnapshot(snapshotID)) {
+        sinfo.setGlobalPreviousSnapshotID(chainManager
+                .previousGlobalSnapshot(snapshotID));
+      } else {
+        sinfo.setGlobalPreviousSnapshotID(null);
+      }
+      sinfos.put(sinfo.getSnapshotID(), sinfo);
+    }
+    // reset the next snapshotInfo.pathPreviousSnapshotID
+    // to the previous in the entry to be deleted.
+    if (chainManager.hasNextPathSnapshot(snapshotPath,
+            snapshotID)) {
+      sinfo = sinfos.get(chainManager
+              .nextPathSnapshot(snapshotPath,
+                      snapshotID));
+      if (chainManager.hasPreviousPathSnapshot(snapshotPath,
+              snapshotID)) {
+        sinfo.setPathPreviousSnapshotID(chainManager
+                .previousPathSnapshot(snapshotPath,
+                        snapshotID));
+      } else {
+        sinfo.setPathPreviousSnapshotID(null);
+      }
+      sinfos.put(sinfo.getSnapshotID(), sinfo);
+    }
+    chainManager.deleteSnapshot(sinfos.get(snapshotID));
+  }
+
+  @Test
+  public void testAddSnapshot() throws Exception {
+    final String snapshotPath = "vol1/bucket1";
+    // add three snapshots
+    String snapshotID1 = UUID.randomUUID().toString();
+    String snapshotID2 = UUID.randomUUID().toString();
+    String snapshotID3 = UUID.randomUUID().toString();
+
+    ArrayList<String> snapshotIDs = new ArrayList<>();
+    snapshotIDs.add(snapshotID1);
+    snapshotIDs.add(snapshotID2);
+    snapshotIDs.add(snapshotID3);
+
+    String prevSnapshotID = null;
+
+    // add 3 snapshots
+    for (String snapshotID : snapshotIDs) {
+      chainManager.addSnapshot(createSnapshotInfo("vol1",
+          "bucket1",
+          "test",
+          snapshotID,
+          prevSnapshotID,
+          prevSnapshotID));
+      prevSnapshotID = snapshotID;
+    }
+
+    Assert.assertEquals(snapshotID3,
+        chainManager
+            .getLatestGlobalSnapshot());
+    Assert.assertEquals(snapshotID3,
+        chainManager
+            .getLatestPathSnapshot(String
+                .join("/", "vol1", "bucket1")));
+
+    int i = 0;
+    String curID = snapshotIDs.get(i);
+    while (chainManager.hasNextGlobalSnapshot(curID)) {
+      i++;
+      Assert.assertEquals(snapshotIDs.get(i),
+              chainManager.nextGlobalSnapshot(curID));
+      curID = snapshotIDs.get(i);
+    }
+
+    curID = snapshotIDs.get(i);
+    while (chainManager.hasPreviousGlobalSnapshot(curID)) {
+      i--;
+      Assert.assertEquals(snapshotIDs.get(i),
+              chainManager.previousGlobalSnapshot(curID));
+      curID = snapshotIDs.get(i);
+    }
+
+    i = 0;
+    curID = snapshotIDs.get(i);
+    while (chainManager.hasNextPathSnapshot(snapshotPath,
+            curID)) {
+      i++;
+      Assert.assertEquals(snapshotIDs.get(i),
+              chainManager.nextPathSnapshot(snapshotPath,
+                      curID));
+      curID = snapshotIDs.get(i);
+    }
+
+    curID = snapshotIDs.get(i);
+    while (chainManager.hasPreviousPathSnapshot(snapshotPath,
+            curID)) {
+      i--;
+      Assert.assertEquals(snapshotIDs.get(i),
+              chainManager.previousPathSnapshot(snapshotPath,
+                      curID));
+      curID = snapshotIDs.get(i);
+    }
+  }
+
+  @Test
+  public void testDeleteSnapshot() throws Exception {
+    // add three snapshots
+    String snapshotID1 = UUID.randomUUID().toString();
+    String snapshotID2 = UUID.randomUUID().toString();
+    String snapshotID3 = UUID.randomUUID().toString();
+
+    ArrayList<String> snapshotIDs = new ArrayList<>();
+    snapshotIDs.add(snapshotID1);
+    snapshotIDs.add(snapshotID2);
+    snapshotIDs.add(snapshotID3);
+
+    String prevSnapshotID = null;
+
+    // add 3 snapshots
+    for (String snapshotID : snapshotIDs) {
+      sinfos.put(snapshotID,
+          createSnapshotInfo("vol1",
+              "bucket1",
+              "test",
+              snapshotID,
+              prevSnapshotID,
+              prevSnapshotID));
+
+      chainManager
+          .addSnapshot(sinfos.get(snapshotID));
+      prevSnapshotID = snapshotID;
+    }
+
+    // delete snapshotID2
+    // should have snapshots ID1 and ID3 in chain
+
+    deleteSnapshot(snapshotID2);
+    // start with first snapshot in snapshot chain
+    Assert.assertEquals(false, chainManager
+            .hasPreviousGlobalSnapshot(snapshotID1));
+    Assert.assertEquals(true, chainManager
+            .hasNextGlobalSnapshot(snapshotID1));
+    Assert.assertEquals(snapshotID3, chainManager
+            .nextGlobalSnapshot(snapshotID1));
+    Assert.assertEquals(false, chainManager
+            .hasNextGlobalSnapshot(snapshotID3));
+
+    // add snapshotID2 and delete snapshotID1
+    // should have snapshotID3 and snapshotID2
+    deleteSnapshot(snapshotID1);
+    // start with latest snapshot in chain
+    SnapshotInfo sinfo = sinfos
+            .get(snapshotID2);
+    // update previous snapshots for adding new snapshotID2
+    sinfo.setPathPreviousSnapshotID(chainManager
+        .getLatestPathSnapshot(String
+            .join("/", "vol1", "bucket1")));
+    sinfo.setGlobalPreviousSnapshotID(chainManager
+        .getLatestGlobalSnapshot());
+    sinfos.put(snapshotID2, sinfo);
+
+    chainManager
+        .addSnapshot(sinfos.get(snapshotID2));
+
+    Assert.assertEquals(false,
+            chainManager.hasPreviousGlobalSnapshot(snapshotID3));
+    Assert.assertEquals(true,
+            chainManager.hasNextGlobalSnapshot(snapshotID3));
+    Assert.assertEquals(snapshotID2,
+            chainManager.nextGlobalSnapshot(snapshotID3));
+    Assert.assertEquals(false,
+            chainManager.hasNextGlobalSnapshot(snapshotID2));
+  }
+
+  @Test
+  public void testChainFromLoadFromTable() throws Exception {
+    Table<String, SnapshotInfo> snapshotInfo =
+            omMetadataManager.getSnapshotInfoTable();
+
+    // add two snapshots to the snapshotInfo
+    String snapshotID1 = UUID.randomUUID().toString();
+    String snapshotID2 = UUID.randomUUID().toString();
+
+    ArrayList<String> snapshotIDs = new ArrayList<>();
+    snapshotIDs.add(snapshotID1);
+    snapshotIDs.add(snapshotID2);
+
+    String prevSnapshotID = "";
+
+    // add 3 snapshots
+    for (String snapshotID : snapshotIDs) {
+      snapshotInfo.put(snapshotID,
+              createSnapshotInfo("vol1",
+                      "bucket1",
+                      "test",
+                      snapshotID,
+                      prevSnapshotID,
+                      prevSnapshotID));
+
+      prevSnapshotID = snapshotID;
+    }
+
+    chainManager.loadSnapshotInfo(omMetadataManager);
+    // check if snapshots loaded correctly from snapshotInfoTable
+    Assert.assertEquals(snapshotID2, chainManager.getLatestGlobalSnapshot());
+    Assert.assertEquals(snapshotID2, chainManager
+            .nextGlobalSnapshot(snapshotID1));
+    Assert.assertEquals(snapshotID1, chainManager.previousPathSnapshot(String
+            .join("/", "vol1", "bucket1"), snapshotID2));
+    Assert.assertThrows(NoSuchElementException.class,
+            () -> chainManager.nextGlobalSnapshot(snapshotID2));
+    Assert.assertThrows(NoSuchElementException.class,
+            () -> chainManager.previousPathSnapshot(String
+                    .join("/", "vol1", "bucket1"), snapshotID1));
+  }
+}


### PR DESCRIPTION
…t of snapshots.   Iniitializes in-memory snapshot chains on start/restart from snapshotInfoTable.  Provides interface to add/delete snapshot and for getting next/previous snapshots in snapshot chain.

## What changes were proposed in this pull request?
This PR implements the in-memory snapshot chain for ozone object store snapshots.  The snapshot chain provides the sequence of snapshots created in chronological order.  Two snapshot chains are provided, the sequence of snapshots created per bucket path and the total global sequence of snapshots created.  The snapshot chain will be maintained by the Snapshot Metadata manager and the creation sequence chains are intended to be used for efficient deletion and reclamation of keys. 

The snapshot chains are initialized from the on-disk `snapshotInfoTable` when instantiated on start/restart.  Provided are interfaces to add / delete snapshots from the snapshot chain and getters for the previous and next snapshots in a snapshot sequence given a snapshot.     

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6983

## How was this patch tested?
Units tests : `TestSnapshotChain`

`hadoop-ozone/ozone-manager$ mvn -Dtest=TestSnapshotChain test`

[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.hadoop.ozone.om.TestSnapshotChain
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.091 s - in org.apache.hadoop.ozone.om.TestSnapshotChain
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0


CI workflow


