### PR TITLE
HDDS-7085. Update gRPC to 1.48.1 to address OOM bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
     <os-maven-plugin.version>1.5.0.Final</os-maven-plugin.version>
 
     <netty.version>4.1.79.Final</netty.version>
-    <io.grpc.version>1.44.0</io.grpc.version>
+    <io.grpc.version>1.48.1</io.grpc.version>
 
     <!-- define the Java language version used by the compiler -->
     <javac.version>1.8</javac.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade gRPC dependency used for S3-OM gRPC communication to 1.48.1.

Datanode-side gRPC will be upgraded later via new Ratis release.

https://issues.apache.org/jira/browse/HDDS-7085

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2808890973