### PR TITLE
HDDS-7105. Introduce multipleExecutors and related configurations in OzoneManagerStateMachine

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -241,6 +241,10 @@ public final class OzoneConfigKeys {
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT
       = ScmConfigKeys.
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT;
+  public static final String
+      OM_NUM_CONCURRENT_WRITE_THREADS_KEY
+      = "om.num.concurrent.write.threads";
+  public static final int OM_NUM_CONCURRENT_WRITE_THREADS_DEFAULT = 10;
   public static final String DFS_CONTAINER_RATIS_REPLICATION_LEVEL_KEY
       = ScmConfigKeys.DFS_CONTAINER_RATIS_REPLICATION_LEVEL_KEY;
   public static final ReplicationLevel

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -258,6 +258,14 @@
     </description>
   </property>
   <property>
+    <name>om.num.concurrent.write.threads</name>
+    <value>10</value>
+    <tag>OZONE, OM</tag>
+    <description>Maximum number of threads in the thread pool used for
+      execution of write operations based on the hashing mechanism.
+    </description>
+  </property>
+  <property>
     <name>dfs.container.ratis.leader.pending.bytes.limit</name>
     <value>1GB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -92,6 +93,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   private OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
   private final RatisSnapshotInfo snapshotInfo;
   private final ExecutorService executorService;
+  private final List<ThreadPoolExecutor> multipleExecutors;
   private final ExecutorService installSnapshotExecutor;
   private final boolean isTracingEnabled;
   private final AtomicInteger statePausedCount = new AtomicInteger(0);
@@ -108,7 +110,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
 
   public OzoneManagerStateMachine(OzoneManagerRatisServer ratisServer,
-      boolean isTracingEnabled) throws IOException {
+                                  boolean isTracingEnabled,
+                                  List<ThreadPoolExecutor> multipleExecutors)
+      throws IOException {
     this.omRatisServer = ratisServer;
     this.isTracingEnabled = isTracingEnabled;
     this.ozoneManager = omRatisServer.getOzoneManager();
@@ -125,6 +129,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
         .setNameFormat("OM StateMachine ApplyTransaction Thread - %d").build();
     this.executorService = HadoopExecutors.newSingleThreadExecutor(build);
+    this.multipleExecutors = multipleExecutors;
     this.installSnapshotExecutor = HadoopExecutors.newSingleThreadExecutor();
   }
 

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ public class TestOzoneManagerStateMachine {
 
   private OzoneManagerStateMachine ozoneManagerStateMachine;
   private OzoneManagerPrepareState prepareState;
+  private List<ThreadPoolExecutor> multipleExecutors;
 
   @Before
   public void setup() throws Exception {
@@ -85,8 +87,10 @@ public class TestOzoneManagerStateMachine {
     when(ozoneManager.getSnapshotInfo()).thenReturn(
         Mockito.mock(RatisSnapshotInfo.class));
     when(ozoneManager.getConfiguration()).thenReturn(conf);
+    multipleExecutors = ozoneManagerRatisServer.createMultipleExecutors();
     ozoneManagerStateMachine =
-        new OzoneManagerStateMachine(ozoneManagerRatisServer, false);
+        new OzoneManagerStateMachine(ozoneManagerRatisServer, false,
+            multipleExecutors);
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 0);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

To expand the current functionality of a single-threaded global executor service for executing a single write operation at a time by introducing multiple executors - a list of `ThreadPoolExecutors` of size equal to the configuration: `om.num.concurrent.write.threads` _(= 10 by default)_ for allowing multiple concurrent write operations to be executed when they are each operating on `OBJECT_STORE` `(“OBS”)` bucket layout disjoint key paths.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7105

## How was this patch tested?

Existing UTs
