### PR TITLE
HDDS-7107. Determine OzoneManagerStateMachine multipleExecutors index via hashing

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -241,6 +241,10 @@ public final class OzoneConfigKeys {
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT
       = ScmConfigKeys.
       DFS_CONTAINER_RATIS_NUM_WRITE_CHUNK_THREADS_PER_VOLUME_DEFAULT;
+  public static final String
+      OM_NUM_CONCURRENT_WRITE_THREADS_KEY
+      = "om.num.concurrent.write.threads";
+  public static final int OM_NUM_CONCURRENT_WRITE_THREADS_DEFAULT = 10;
   public static final String DFS_CONTAINER_RATIS_REPLICATION_LEVEL_KEY
       = ScmConfigKeys.DFS_CONTAINER_RATIS_REPLICATION_LEVEL_KEY;
   public static final ReplicationLevel

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -258,6 +258,14 @@
     </description>
   </property>
   <property>
+    <name>om.num.concurrent.write.threads</name>
+    <value>10</value>
+    <tag>OZONE, OM</tag>
+    <description>Maximum number of threads in the thread pool used for
+      execution of write operations based on the hashing mechanism.
+    </description>
+  </property>
+  <property>
     <name>dfs.container.ratis.leader.pending.bytes.limit</name>
     <value>1GB</value>
     <tag>OZONE, RATIS, PERFORMANCE</tag>

--- a/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
+++ b/hadoop-ozone/common/src/main/java/org/apache/hadoop/ozone/om/lock/OzoneManagerLock.java
@@ -250,7 +250,8 @@ public class OzoneManagerLock {
    * @param resource
    * @param resources
    */
-  public String generateResourceName(Resource resource, String... resources) {
+  public static String generateResourceName(Resource resource,
+                                            String... resources) {
     if (resources.length == 1 && resource != Resource.BUCKET_LOCK) {
       return OzoneManagerLockUtil.generateResourceLockName(resource,
           resources[0]);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOMKeyPathLock.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestOMKeyPathLock.java
@@ -1,0 +1,38 @@
+package org.apache.hadoop.ozone.client.rpc;
+
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
+import org.apache.hadoop.ozone.om.OMConfigKeys;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+
+/**
+ * This class is to test Ozone Manager KeyPathLock, multipleExecutors in
+ * OzoneManagerStateMachine.
+ */
+@Timeout(300)
+public class TestOMKeyPathLock extends TestOzoneRpcClientAbstract {
+  private static OzoneConfiguration conf;
+
+  @BeforeAll
+  public static void init() throws Exception {
+    conf = new OzoneConfiguration();
+    conf.setBoolean(OMConfigKeys.OZONE_OM_KEY_PATH_LOCK_ENABLED, true);
+
+    conf.setBoolean(OzoneConfigKeys.OZONE_ACL_ENABLED, true);
+    conf.set(OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS,
+        OzoneConfigKeys.OZONE_ACL_AUTHORIZER_CLASS_NATIVE);
+    startCluster(conf);
+  }
+
+  /**
+   * Close OzoneClient and shutdown MiniOzoneCluster.
+   */
+  @AfterAll
+  public static void shutdown() throws IOException {
+    shutdownCluster();
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/OzoneManagerStateMachine.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.utils.db.Table;
@@ -92,6 +93,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
   private OzoneManagerDoubleBuffer ozoneManagerDoubleBuffer;
   private final RatisSnapshotInfo snapshotInfo;
   private final ExecutorService executorService;
+  private final List<ThreadPoolExecutor> multipleExecutors;
   private final ExecutorService installSnapshotExecutor;
   private final boolean isTracingEnabled;
   private final AtomicInteger statePausedCount = new AtomicInteger(0);
@@ -108,7 +110,9 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
 
 
   public OzoneManagerStateMachine(OzoneManagerRatisServer ratisServer,
-      boolean isTracingEnabled) throws IOException {
+                                  boolean isTracingEnabled,
+                                  List<ThreadPoolExecutor> multipleExecutors)
+      throws IOException {
     this.omRatisServer = ratisServer;
     this.isTracingEnabled = isTracingEnabled;
     this.ozoneManager = omRatisServer.getOzoneManager();
@@ -125,6 +129,7 @@ public class OzoneManagerStateMachine extends BaseStateMachine {
     ThreadFactory build = new ThreadFactoryBuilder().setDaemon(true)
         .setNameFormat("OM StateMachine ApplyTransaction Thread - %d").build();
     this.executorService = HadoopExecutors.newSingleThreadExecutor(build);
+    this.multipleExecutors = multipleExecutors;
     this.installSnapshotExecutor = HadoopExecutors.newSingleThreadExecutor();
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/BasicOMStateMachineThreadIndexerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/BasicOMStateMachineThreadIndexerImpl.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis.utils;
+
+/**
+ * Implementation of OMStateMachineThreadIndexer interface.
+ */
+public class BasicOMStateMachineThreadIndexerImpl
+    implements OMStateMachineThreadIndexer {
+
+  @Override
+  public int getOMStateMachineThreadIndex(long hashCode, int size) {
+    return (int) (((hashCode % size) + size) % size);
+  }
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OMStateMachineThreadIndexer.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OMStateMachineThreadIndexer.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership.  The ASF
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.hadoop.ozone.om.ratis.utils;
+
+/**
+ * Interface for translating the generated hash code to an
+ * OMStateMachineThreadIndex.
+ */
+public interface OMStateMachineThreadIndexer {
+
+  /**
+   * Returns the OMStateMachineThreadIndex for the request to be executed.
+   *
+   * @param hashCode
+   * @param size
+   * @return
+   */
+  int getOMStateMachineThreadIndex(long hashCode, int size);
+}

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/ratis/utils/OzoneManagerRatisUtils.java
@@ -108,6 +108,78 @@ public final class OzoneManagerRatisUtils {
   }
 
   /**
+   * The class stores the volumeName, bucketName and keyName on which the
+   * OMRequest is operating on.
+   */
+  public static class OmKeyPathArgsInfo {
+    private String volName = "";
+    private String buckName = "";
+    private String keyName = "";
+
+    OmKeyPathArgsInfo(String volName, String buckName, String keyName) {
+      this.volName = volName;
+      this.buckName = buckName;
+      this.keyName = keyName;
+    }
+
+    public String getBuckName() {
+      return buckName;
+    }
+
+    public String getVolName() {
+      return volName;
+    }
+
+    public String getKeyName() {
+      return keyName;
+    }
+  }
+
+  public static OmKeyPathArgsInfo getKeyPathInfo(OMRequest omRequest) {
+
+    OzoneManagerProtocolProtos.KeyArgs keyArgs;
+    //  We are only considering the key-level request classes supported for
+    //  OBJECT_STORE bucket layout.
+
+    switch (omRequest.getCmdType()) {
+    case CreateDirectory:
+      keyArgs = omRequest.getCreateDirectoryRequest().getKeyArgs();
+      break;
+    case CreateFile:
+      keyArgs = omRequest.getCreateFileRequest().getKeyArgs();
+      break;
+    case CreateKey:
+      keyArgs = omRequest.getCreateKeyRequest().getKeyArgs();
+      break;
+    case AllocateBlock:
+      keyArgs = omRequest.getAllocateBlockRequest().getKeyArgs();
+      break;
+    case CommitKey:
+      keyArgs = omRequest.getCommitKeyRequest().getKeyArgs();
+      break;
+    case DeleteKey:
+      keyArgs = omRequest.getDeleteKeyRequest().getKeyArgs();
+      break;
+    case InitiateMultiPartUpload:
+      keyArgs = omRequest.getInitiateMultiPartUploadRequest().getKeyArgs();
+      break;
+    case CommitMultiPartUpload:
+      keyArgs = omRequest.getCommitMultiPartUploadRequest().getKeyArgs();
+      break;
+    case AbortMultiPartUpload:
+      keyArgs = omRequest.getAbortMultiPartUploadRequest().getKeyArgs();
+      break;
+    case CompleteMultiPartUpload:
+      keyArgs = omRequest.getCompleteMultiPartUploadRequest().getKeyArgs();
+      break;
+    default:
+      return null;
+    }
+    return new OmKeyPathArgsInfo(keyArgs.getVolumeName(),
+        keyArgs.getBucketName(), keyArgs.getKeyName());
+  }
+
+  /**
    * Create OMClientRequest which encapsulates the OMRequest.
    * @param omRequest
    * @return OMClientRequest

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/ratis/TestOzoneManagerStateMachine.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -60,6 +61,7 @@ public class TestOzoneManagerStateMachine {
 
   private OzoneManagerStateMachine ozoneManagerStateMachine;
   private OzoneManagerPrepareState prepareState;
+  private List<ThreadPoolExecutor> multipleExecutors;
 
   @Before
   public void setup() throws Exception {
@@ -85,8 +87,10 @@ public class TestOzoneManagerStateMachine {
     when(ozoneManager.getSnapshotInfo()).thenReturn(
         Mockito.mock(RatisSnapshotInfo.class));
     when(ozoneManager.getConfiguration()).thenReturn(conf);
+    multipleExecutors = ozoneManagerRatisServer.createMultipleExecutors();
     ozoneManagerStateMachine =
-        new OzoneManagerStateMachine(ozoneManagerRatisServer, false);
+        new OzoneManagerStateMachine(ozoneManagerRatisServer, false,
+            multipleExecutors);
     ozoneManagerStateMachine.notifyTermIndexUpdated(0, 0);
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

[To be merged after [HDDS-7105](https://issues.apache.org/jira/browse/HDDS-7105) PR #[3662](https://github.com/apache/ozone/pull/3662)] Introduce an interface `OMHashCodeGenerator` which translates each of the `OBJECT_STORE "OBS"` bucket layout key path names into a hash code based on the corresponding hash function used. 

The write operations on different key paths now have their corresponding hash codes and are allotted a thread writer (executor) index for execution determined via the modulo (`hashCode % om.num.concurrent.write.threads`) - this enables concurrency for write operations. 

Please refer [link](https://issues.apache.org/jira/secure/attachment/13047873/HDDS%20-%20Allow%20Concurrent%20Writers%20in%20OM%20for%20OBS%20Bucket%20Key%20Paths_8Aug2022.pdf).

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7107

## How was this patch tested?

Added integration tests
