### PR TITLE
HDDS-7092. EC Offline Recovery with simultaneous Over Replication

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthCheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ContainerHealthCheck.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -28,8 +29,14 @@ import java.util.Set;
  */
 public interface ContainerHealthCheck {
 
-  ContainerHealthResult checkHealth(
+  Optional<ContainerHealthResult> checkHealth(
       ContainerInfo container, Set<ContainerReplica> replicas,
       List<ContainerReplicaOp> replicaPendingOps,
-      int remainingRedundancyForMaintenance);
+      int remainingRedundancyForMaintenance,
+      Optional<ContainerHealthResult.HealthState> healthStateFilter);
+
+  List<ContainerHealthResult> checkHealth(
+          ContainerInfo container, Set<ContainerReplica> replicas,
+          List<ContainerReplicaOp> replicaPendingOps,
+          int remainingRedundancyForMaintenance);
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerHealthCheck.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerHealthCheck.java
@@ -97,7 +97,7 @@ public class ECContainerHealthCheck implements ContainerHealthCheck {
           !replicaCount.isOverReplicated(true)));
     }
 
-    // If No issues detected, return healthy.
+    // If no issues detected, return healthy.
     return containerHealthResults.size() > 0 ? containerHealthResults :
             Collections
             .singletonList(new ContainerHealthResult.HealthyResult(container));

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -342,8 +342,8 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     return indexes;
   }
 
-  public Set<Integer> getAvailableIndexes(boolean includeDelete) {
-    return getHealthyWithDelete(includeDelete).keySet();
+  public int getAvailableIndexSize(boolean includeDelete) {
+    return getHealthyWithDelete(includeDelete).keySet().size();
   }
 
   private Map<Integer, Integer> getHealthyWithDelete(boolean includeDelete) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECContainerReplicaCount.java
@@ -342,6 +342,10 @@ public class ECContainerReplicaCount implements ContainerReplicaCount {
     return indexes;
   }
 
+  public Set<Integer> getAvailableIndexes(boolean includeDelete) {
+    return getHealthyWithDelete(includeDelete).keySet();
+  }
+
   private Map<Integer, Integer> getHealthyWithDelete(boolean includeDelete) {
     final Map<Integer, Integer> availableIndexes;
     if (includeDelete) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -87,8 +87,8 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
                     != ContainerHealthResult.HealthState.OVER_REPLICATED)
             .orElse(true)) {
       LOG.info("The container {} state changed and it's not in over"
-                      + " replication any more. Current state is: {}",
-              container.getContainerID(), currentUnderRepRes);
+              + " replication any more. Current state is: {}",
+          container.getContainerID(), currentUnderRepRes);
       return emptyMap();
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ECOverReplicationHandler.java
@@ -140,7 +140,7 @@ public class ECOverReplicationHandler extends AbstractOverReplicationHandler {
     if (index2replicas.size() > 0) {
       final Map<DatanodeDetails, SCMCommand<?>> commands = new HashMap<>();
       final int replicationFactor = replicaCount
-              .getAvailableIndexes(true).size();
+              .getAvailableIndexSize(true);
       index2replicas.values().forEach(l -> {
         Iterator<ContainerReplica> it = l.iterator();
         Set<ContainerReplica> tempReplicaSet = new HashSet<>(replicas);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerHealthCheck.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestECContainerHealthCheck.java
@@ -32,6 +32,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
@@ -62,9 +63,9 @@ public class TestECContainerHealthCheck {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), 1, 2, 3, 4, 5);
-    ContainerHealthResult result = healthCheck.checkHealth(container, replicas,
-        Collections.emptyList(), 2);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    Optional<ContainerHealthResult> result = healthCheck.checkHealth(container,
+            replicas, Collections.emptyList(), 2, Optional.empty());
+    Assert.assertEquals(HealthState.HEALTHY, result.get().getHealthState());
   }
 
   @Test
@@ -72,10 +73,14 @@ public class TestECContainerHealthCheck {
     ContainerInfo container = createContainerInfo(repConfig);
     Set<ContainerReplica> replicas
         = createReplicas(container.containerID(), 1, 2, 4, 5);
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
-        healthCheck.checkHealth(container, replicas,
-            Collections.emptyList(), 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results =
+            healthCheck.checkHealth(container, replicas,
+                    Collections.emptyList(), 2);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(1, result.getRemainingRedundancy());
     Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
@@ -89,9 +94,13 @@ public class TestECContainerHealthCheck {
     List<ContainerReplicaOp> pending = new ArrayList<>();
     pending.add(ContainerReplicaOp.create(
         ADD, MockDatanodeDetails.randomDatanodeDetails(), 3));
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
-        healthCheck.checkHealth(container, replicas, pending, 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results =
+            healthCheck.checkHealth(container, replicas, pending, 2);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(1, result.getRemainingRedundancy());
     Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
@@ -105,10 +114,14 @@ public class TestECContainerHealthCheck {
         Pair.of(IN_SERVICE, 3), Pair.of(DECOMMISSIONING, 4),
         Pair.of(DECOMMISSIONED, 5));
 
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
-        healthCheck.checkHealth(container, replicas, Collections.emptyList(),
-            2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results =
+            healthCheck.checkHealth(container, replicas,
+                    Collections.emptyList(), 2);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(2, result.getRemainingRedundancy());
     Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
@@ -125,9 +138,14 @@ public class TestECContainerHealthCheck {
     pending.add(ContainerReplicaOp.create(
         ADD, MockDatanodeDetails.randomDatanodeDetails(), 5));
 
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
-        healthCheck.checkHealth(container, replicas, pending, 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results =
+            healthCheck.checkHealth(container, replicas,
+                    pending, 2);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(2, result.getRemainingRedundancy());
     Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
     Assert.assertTrue(result.underReplicatedDueToDecommission());
@@ -143,9 +161,13 @@ public class TestECContainerHealthCheck {
     pending.add(ContainerReplicaOp.create(
         ADD, MockDatanodeDetails.randomDatanodeDetails(), 3));
 
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
-        healthCheck.checkHealth(container, replicas, pending, 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results =
+            healthCheck.checkHealth(container, replicas, pending, 2);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(1, result.getRemainingRedundancy());
     Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
@@ -157,10 +179,14 @@ public class TestECContainerHealthCheck {
     Set<ContainerReplica> replicas = createReplicas(container.containerID(),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2));
 
-    UnderReplicatedHealthResult result = (UnderReplicatedHealthResult)
+    List<ContainerHealthResult> results =
         healthCheck.checkHealth(container, replicas,
             Collections.emptyList(), 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
+    UnderReplicatedHealthResult result =
+            (UnderReplicatedHealthResult) results.get(0);
     Assert.assertEquals(-1, result.getRemainingRedundancy());
     Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
     Assert.assertFalse(result.underReplicatedDueToDecommission());
@@ -182,9 +208,13 @@ public class TestECContainerHealthCheck {
     pending.add(ContainerReplicaOp.create(
         DELETE, MockDatanodeDetails.randomDatanodeDetails(), 2));
 
-    OverReplicatedHealthResult result = (OverReplicatedHealthResult)
+    List<ContainerHealthResult> results =
         healthCheck.checkHealth(container, replicas, pending, 2);
-    Assert.assertEquals(HealthState.OVER_REPLICATED, result.getHealthState());
+    Assert.assertEquals(1, results.size());
+    OverReplicatedHealthResult result =
+            (OverReplicatedHealthResult)results.get(0);
+    Assert.assertEquals(HealthState.OVER_REPLICATED,
+            results.get(0).getHealthState());
     Assert.assertEquals(2, result.getExcessRedundancy());
     Assert.assertTrue(result.isSufficientlyReplicatedAfterPending());
   }
@@ -198,9 +228,9 @@ public class TestECContainerHealthCheck {
         Pair.of(IN_SERVICE, 5),
         Pair.of(IN_MAINTENANCE, 1), Pair.of(IN_MAINTENANCE, 2));
 
-    ContainerHealthResult result = healthCheck.checkHealth(container, replicas,
-        Collections.emptyList(), 2);
-    Assert.assertEquals(HealthState.HEALTHY, result.getHealthState());
+    Optional<ContainerHealthResult> result = healthCheck.checkHealth(container,
+            replicas, Collections.emptyList(), 2, Optional.empty());
+    Assert.assertEquals(HealthState.HEALTHY, result.get().getHealthState());
   }
 
   @Test
@@ -211,11 +241,19 @@ public class TestECContainerHealthCheck {
         Pair.of(IN_SERVICE, 3), Pair.of(IN_SERVICE, 4),
         Pair.of(IN_SERVICE, 1), Pair.of(IN_SERVICE, 2));
 
-    ContainerHealthResult result = healthCheck.checkHealth(container, replicas,
-        Collections.emptyList(), 2);
-    Assert.assertEquals(HealthState.UNDER_REPLICATED, result.getHealthState());
+    List<ContainerHealthResult> results = healthCheck.checkHealth(container,
+            replicas, Collections.emptyList(), 2);
+    Assert.assertEquals(2, results.size());
+    Assert.assertEquals(HealthState.UNDER_REPLICATED,
+            results.get(0).getHealthState());
     Assert.assertEquals(1,
-        ((UnderReplicatedHealthResult)result).getRemainingRedundancy());
+        ((UnderReplicatedHealthResult)results.get(0)).getRemainingRedundancy());
+    Assert.assertEquals(HealthState.OVER_REPLICATED,
+            results.get(1).getHealthState());
+    OverReplicatedHealthResult result =
+            (OverReplicatedHealthResult)results.get(1);
+    Assert.assertEquals(2, result.getExcessRedundancy());
+    Assert.assertFalse(result.isSufficientlyReplicatedAfterPending());
   }
 
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestReplicationManager.java
@@ -220,7 +220,7 @@ public class TestReplicationManager {
     Assert.assertEquals(0, underRep.size());
     Assert.assertEquals(0, overRep.size());
     Assert.assertTrue(((ContainerHealthResult.UnderReplicatedHealthResult)
-        result).isSufficientlyReplicatedAfterPending());
+        result.get(0)).isSufficientlyReplicatedAfterPending());
     // As the container is still under replicated, as the pending have not
     // completed yet, the container is still marked as under-replciated in the
     // report.


### PR DESCRIPTION
…& Under Replication

## What changes were proposed in this pull request?
In case of overreplication & underreplication happening together, it could so happen that all nodes are excluded in case of underreplication. Thus only underreplicationHandler would continuously fail & overreplication will not run. 

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7092

## How was this patch tested?
Unit Tests, Integration Tests