### PR TITLE
HDDS-7102. Exclude unnecessary RangerClient dependencies

### DIFF
--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -444,7 +444,6 @@ angular-nvd3-1.0.9.min.js
 angular-1.8.0.min.js
 jquery-3.5.1.min.js
 
-
 --------------------------------------------------------------------------------
 recon server uses a huge number of javascript and css dependencies. See the
 licenses/LICENSE-ozone-recon.txt for the detailed list of the dependencies and licenses.

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -209,6 +209,7 @@ See licenses/ for text of these licenses.
 EPL
 =====================
 
+   org.eclipse.jetty:jetty-client
    org.eclipse.jetty:jetty-http
    org.eclipse.jetty:jetty-io
    org.eclipse.jetty:jetty-security
@@ -231,6 +232,7 @@ CDDL
 =====================
 
    com.sun.istack:istack-commons-runtime
+   com.sun.jersey:jersey-client
    com.sun.jersey:jersey-core
    com.sun.jersey:jersey-json
    com.sun.jersey:jersey-server
@@ -265,6 +267,7 @@ CDDL
 Apache License
 =====================
 
+   com.carrotsearch:hppc
    com.fasterxml.jackson.core:jackson-annotations
    com.fasterxml.jackson.core:jackson-core
    com.fasterxml.jackson.core:jackson-databind
@@ -354,6 +357,7 @@ Apache License
 MIT
 =====================
 
+   com.kstruct:gethostname4j
    net.sf.jopt-simple:jopt-simple
    org.codehaus.mojo:animal-sniffer-annotations
    org.slf4j:slf4j-api
@@ -437,6 +441,13 @@ angular-route-1.8.0.min.js
 angular-nvd3-1.0.9.min.js
 angular-1.8.0.min.js
 jquery-3.5.1.min.js
+
+
+LGPL 2.1
+=====================
+
+   net.java.dev.jna:jna
+   net.java.dev.jna:jna-platform
 
 --------------------------------------------------------------------------------
 recon server uses a huge number of javascript and css dependencies. See the

--- a/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
+++ b/hadoop-ozone/dist/src/main/license/bin/LICENSE.txt
@@ -330,6 +330,8 @@ Apache License
    log4j:log4j
    net.minidev:accessors-smart
    net.minidev:json-smart
+   net.java.dev.jna:jna
+   net.java.dev.jna:jna-platform
    org.bouncycastle:bcpkix-jdk15on
    org.bouncycastle:bcprov-jdk15on
    org.codehaus.jackson:jackson-core-asl
@@ -442,12 +444,6 @@ angular-nvd3-1.0.9.min.js
 angular-1.8.0.min.js
 jquery-3.5.1.min.js
 
-
-LGPL 2.1
-=====================
-
-   net.java.dev.jna:jna
-   net.java.dev.jna:jna-platform
 
 --------------------------------------------------------------------------------
 recon server uses a huge number of javascript and css dependencies. See the

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -118,7 +118,6 @@ share/ozone/lib/jaxb-api.jar
 share/ozone/lib/jaxb-core.jar
 share/ozone/lib/jaxb-runtime.jar
 share/ozone/lib/jcip-annotations.jar
-share/ozone/lib/jcl-over-slf4j.jar
 share/ozone/lib/jersey-cdi1x.jar
 share/ozone/lib/jersey-client.jar
 share/ozone/lib/jersey-client.jar

--- a/hadoop-ozone/dist/src/main/license/jar-report.txt
+++ b/hadoop-ozone/dist/src/main/license/jar-report.txt
@@ -8,7 +8,6 @@ share/ozone/lib/aopalliance-repackaged.jar
 share/ozone/lib/asm.jar
 share/ozone/lib/aspectjrt.jar
 share/ozone/lib/aspectjweaver.jar
-share/ozone/lib/aws-java-sdk-bundle.jar
 share/ozone/lib/aws-java-sdk-core.jar
 share/ozone/lib/aws-java-sdk-kms.jar
 share/ozone/lib/aws-java-sdk-s3.jar
@@ -76,7 +75,6 @@ share/ozone/lib/hdds-interface-server.jar
 share/ozone/lib/hdds-server-framework.jar
 share/ozone/lib/hdds-server-scm.jar
 share/ozone/lib/hdds-tools.jar
-share/ozone/lib/hive-storage-api.jar
 share/ozone/lib/hk2-api.jar
 share/ozone/lib/hk2-locator.jar
 share/ozone/lib/hk2-utils.jar
@@ -157,7 +155,6 @@ share/ozone/lib/json-smart.jar
 share/ozone/lib/jsp-api.jar
 share/ozone/lib/jsr305.jar
 share/ozone/lib/jsr311-api.jar
-share/ozone/lib/kafka-clients.jar
 share/ozone/lib/kerb-admin.jar
 share/ozone/lib/kerb-client.jar
 share/ozone/lib/kerb-common.jar
@@ -258,7 +255,6 @@ share/ozone/lib/slf4j-api.jar
 share/ozone/lib/slf4j-log4j12.jar
 share/ozone/lib/snakeyaml.jar
 share/ozone/lib/snappy-java.jar
-share/ozone/lib/solr-solrj.jar
 share/ozone/lib/spring-beans.RELEASE.jar
 share/ozone/lib/spring-core.RELEASE.jar
 share/ozone/lib/spring-jcl.RELEASE.jar
@@ -271,4 +267,3 @@ share/ozone/lib/token-provider.jar
 share/ozone/lib/txw2.jar
 share/ozone/lib/weld-servlet.Final.jar
 share/ozone/lib/woodstox-core.jar
-share/ozone/lib/zstd-jni.jar

--- a/hadoop-ozone/ozone-manager/pom.xml
+++ b/hadoop-ozone/ozone-manager/pom.xml
@@ -186,6 +186,22 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
           <groupId>org.elasticsearch.plugin</groupId>
           <artifactId>*</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.amazonaws</groupId>
+          <artifactId>aws-java-sdk-bundle</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-storage-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.kafka</groupId>
+          <artifactId>kafka-clients</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.solr</groupId>
+          <artifactId>solr-solrj</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Exclude:

```
com.amazonaws:aws-java-sdk-bundle
org.apache.hive:hive-storage-api
org.apache.kafka:kafka-clients
org.apache.solr:solr-solrj
```

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7102

## How was this patch tested?

- [x] Check new licenses, if any.
- [x] All existing tests should pass.
- [ ] Ensure `RangerClient` would still function as expected.