### PR TITLE
HDDS-7111. SCMHADBTransactionBuffer not flushed in time

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -575,6 +575,24 @@ public final class ScmConfigKeys {
   public static final boolean
       OZONE_SCM_HA_RATIS_SERVER_ELECTION_PRE_VOTE_DEFAULT = false;
 
+  // SCMHADBTransactionBufferFlushMonitorService related
+  public static final String OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL =
+      "ozone.scm.ha.dbtransactionbuffer.flush.interval";
+  public static final long
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_FLUSH_INTERVAL_DEFAULT = 60 * 1000L;
+  public static final String
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_MONITOR_SERVICE_TIMEOUT =
+      "ozone.scm.ha.dbtransactionbuffer.monitor.service.timeout";
+  public static final long
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_MONITOR_SERVICE_TIMEOUT_DEFAULT =
+      300 * 1000L;
+  public static final String
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_MONITOR_SERVICE_INTERVAL =
+      "ozone.scm.ha.dbtransactionbuffer.monitor.service.interval";
+  public static final long
+      OZONE_SCM_HA_DBTRANSACTIONBUFFER_MONITOR_SERVICE_INTERVAL_DEFAULT =
+      30 * 1000L;
+
   public static final String OZONE_AUDIT_LOG_DEBUG_CMD_LIST_SCMAUDIT =
       "ozone.audit.log.debug.cmd.list.scmaudit";
   /**

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -3145,6 +3145,39 @@
     <description>Deadline for SCM DB checkpoint interval.</description>
   </property>
 
+  <property>
+    <name>ozone.scm.ha.dbtransactionbuffer.flush.interval</name>
+    <value>60s</value>
+    <tag>SCM, OZONE, HA</tag>
+    <description>
+      SCMHADBTransactionbuffer flush interval, if elapses more than
+      this time since the last flush, the background monitor will trigger flush
+      the non-empty buffer into DB.
+      Unit could be defined with postfix (ns,ms,s,m,h,d).
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.ha.dbtransactionbuffer.monitor.service.timeout</name>
+    <value>300s</value>
+    <tag>SCM, OZONE, HA</tag>
+    <description>
+      A timeout value of SCMHADBTransactionBufferMonitorService. If this is set
+      greater than 0, the service will stop waiting for the flush after
+      this time.
+      Unit could be defined with postfix (ns,ms,s,m,h,d).
+    </description>
+  </property>
+  <property>
+    <name>ozone.scm.ha.dbtransactionbuffer.monitor.service.interval</name>
+    <value>30s</value>
+    <tag>SCM, OZONE, HA</tag>
+    <description>
+      Time interval of the SCMHADBTransactionBufferMonitorService.
+      The service runs on each SCM periodically (if ratis enabled), checks
+      the pending transaction buffer and then flushes it.
+      Unit could be defined with postfix (ns,ms,s,m,h,d).
+    </description>
+  </property>
 
   <property>
     <name>ozone.s3g.kerberos.keytab.file</name>

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferMonitorService.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/ha/SCMHADBTransactionBufferMonitorService.java
@@ -1,0 +1,69 @@
+package org.apache.hadoop.hdds.scm.ha;
+
+import org.apache.hadoop.hdds.utils.BackgroundService;
+import org.apache.hadoop.hdds.utils.BackgroundTask;
+import org.apache.hadoop.hdds.utils.BackgroundTaskQueue;
+import org.apache.hadoop.hdds.utils.BackgroundTaskResult;
+import org.apache.hadoop.util.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This service monitors the flush time and SCMHADBTransactionBuffer, triggers
+ * flush when last flush time elapsed too long and buffer size is not 0.
+ * This provides the short-term visibility of SCMHADBTransactionBuffer where
+ * flush opportunity is quantitative and not periodic.
+ */
+class SCMHADBTransactionBufferMonitorService extends BackgroundService {
+  private static final Logger LOG = LoggerFactory.
+      getLogger(SCMHADBTransactionBufferMonitorService.class);
+
+  private final SCMHADBTransactionBufferImpl dbBuffer;
+  private final long flushInterval;
+  private static final int BUFFER_FLUSH_WORKER_POOL_SIZE = 1;
+
+
+  SCMHADBTransactionBufferMonitorService(
+      SCMHADBTransactionBufferImpl buffer,
+      long serviceInterval,
+      long serviceTimeout,
+      TimeUnit unit,
+      long flushTimeout) {
+    super("SCMHADBTransactionBufferMonitorService",
+        serviceInterval, unit, BUFFER_FLUSH_WORKER_POOL_SIZE, serviceTimeout);
+    this.dbBuffer = buffer;
+    this.flushInterval = flushTimeout;
+  }
+
+  @Override
+  public BackgroundTaskQueue getTasks() {
+    BackgroundTaskQueue queue = new BackgroundTaskQueue();
+    queue.add(new SCMHADBTransactionBufferFlushTask());
+    return queue;
+  }
+
+  private class SCMHADBTransactionBufferFlushTask implements BackgroundTask {
+
+    @Override
+    public BackgroundTaskResult.EmptyTaskResult call() throws Exception {
+      long elapsedTime = Time.monotonicNow() - dbBuffer.getLastFlushTime();
+      long size = dbBuffer.getBufferSize();
+      if (elapsedTime > flushInterval && size > 0) {
+        dbBuffer.flush();
+        LOG.info("Last flush elapsed {} ms > timeout {} ms, and buffer size" +
+            " is {}, trigger SCMHADBTransactionBuffer flush ",
+            elapsedTime, flushInterval, size);
+      }
+      return BackgroundTaskResult.EmptyTaskResult.newResult();
+    }
+
+    @Override
+    public int getPriority() {
+      return 0;
+    }
+  }
+}
+
+


### PR DESCRIPTION
## What changes were proposed in this pull request?

We recently found that after we deleted all the keys, the cluster will remain with some data. One of the reasons is due to this:

SCM will add deleted blocks into transactions when receiving the request from OM. When HA is enabled,  DBTransactionbuffer is implemented as the SCMHADBTransactionbufferImpl. Inside this, the buffer will not be flushed immediately. Normally, it will be flushed when SCM takes a snapshot. The snapshot gap threshold is default 1000. If the user has little load pressure on the cluster (no writing more ratis logs), the buffer will be always pending in the memory. Real deletion happened in SCMBlockDeletingService, which will scan the DB and get the transactions, for those txns in-memory buffer, it won't find them. This is why DN has not yet received these deleted block info.

This PR adds a flush monitor checking regularly to trigger the non-empty flush, overall, this could be a common mechanism if some other cases like the deleted blocks appear in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7111

## How was this patch tested?
UT
