### PR TITLE
HDDS-7117. Consider reading chunk files using MappedByteBuffer.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfigKeys.java
@@ -141,7 +141,11 @@ public final class ScmConfigKeys {
   public static final String OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_KEY =
       "ozone.chunk.read.buffer.default.size";
   public static final String OZONE_CHUNK_READ_BUFFER_DEFAULT_SIZE_DEFAULT =
-      "64KB";
+      "1MB";
+  public static final String OZONE_CHUNK_READ_MAPPED_BUFFER_THRESHOLD_KEY =
+      "ozone.chunk.read.mapped.buffer.threshold";
+  public static final String OZONE_CHUNK_READ_MAPPED_BUFFER_THRESHOLD_DEFAULT =
+      "32KB";
 
   public static final String OZONE_SCM_CONTAINER_LAYOUT_KEY =
       "ozone.scm.container.layout";

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -58,6 +58,9 @@ public interface ChunkBuffer {
 
   /** Wrap the given list of {@link ByteBuffer}s as a {@link ChunkBuffer}. */
   static ChunkBuffer wrap(List<ByteBuffer> buffers) {
+    if (buffers.size() == 1) {
+      return wrap(buffers.get(0));
+    }
     return new ChunkBufferImplWithByteBufferList(buffers);
   }
 
@@ -91,8 +94,7 @@ public interface ChunkBuffer {
 
   /** Similar to {@link ByteBuffer#put(byte[])}. */
   default ChunkBuffer put(byte b) {
-    byte[] buf = new byte[1];
-    buf[0] = (byte) b;
+    final byte[] buf = {b};
     return put(buf, 0, 1);
   }
 
@@ -116,7 +118,6 @@ public interface ChunkBuffer {
 
   /**
    * Iterate the buffer from the current position to the current limit.
-   *
    * Upon the iteration complete,
    * the buffer's position will be equal to its limit.
    *

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBuffer.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -58,6 +59,7 @@ public interface ChunkBuffer {
 
   /** Wrap the given list of {@link ByteBuffer}s as a {@link ChunkBuffer}. */
   static ChunkBuffer wrap(List<ByteBuffer> buffers) {
+    Objects.requireNonNull(buffers, "buffers == null");
     if (buffers.size() == 1) {
       return wrap(buffers.get(0));
     }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/ChunkBufferImplWithByteBufferList.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -50,8 +51,7 @@ public class ChunkBufferImplWithByteBufferList implements ChunkBuffer {
   private int currentIndex;
 
   ChunkBufferImplWithByteBufferList(List<ByteBuffer> buffers) {
-    Preconditions.checkArgument(buffers != null, "buffer == null");
-
+    Objects.requireNonNull(buffers, "buffers == null");
     this.buffers = !buffers.isEmpty() ? ImmutableList.copyOf(buffers) :
         EMPTY_BUFFER;
     this.limit = buffers.stream().mapToInt(ByteBuffer::limit).sum();

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -829,7 +829,7 @@
   </property>
   <property>
     <name>ozone.chunk.read.buffer.default.size</name>
-    <value>64KB</value>
+    <value>1MB</value>
     <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>
     <description>
       The default read buffer size during read chunk operations when checksum
@@ -838,6 +838,14 @@
       For chunk data with checksum, the read buffer size will be the
       same as the number of bytes per checksum
       (ozone.client.bytes.per.checksum) corresponding to the chunk.
+    </description>
+  </property>
+  <property>
+    <name>ozone.chunk.read.mapped.buffer.threshold</name>
+    <value>32KB</value>
+    <tag>OZONE, SCM, CONTAINER, PERFORMANCE</tag>
+    <description>
+      The default read threshold to use memory mapped buffers.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
+++ b/hadoop-hdds/common/src/test/java/org/apache/hadoop/ozone/common/TestChunkBufferImplWithByteBufferList.java
@@ -36,7 +36,7 @@ public class TestChunkBufferImplWithByteBufferList {
   @Test
   public void rejectsNullList() {
     List<ByteBuffer> list = null;
-    assertThrows(IllegalArgumentException.class, () -> ChunkBuffer.wrap(list));
+    assertThrows(NullPointerException.class, () -> ChunkBuffer.wrap(list));
   }
 
   @Test

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigurationSource.java
@@ -285,6 +285,17 @@ public interface ConfigurationSource {
     }
   }
 
+  default int getBufferSize(String name, String defaultValue) {
+    final double size = getStorageSize(name, defaultValue, StorageUnit.BYTES);
+    if (size <= 0) {
+      throw new IllegalArgumentException(name + " <= 0");
+    } else if (size > Integer.MAX_VALUE) {
+      throw new IllegalArgumentException(
+          name + " > Integer.MAX_VALUE = " + Integer.MAX_VALUE);
+    }
+    return (int) size;
+  }
+
   default double getStorageSize(String name, String defaultValue,
       StorageUnit targetUnit) {
     String vString = get(name);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/helpers/ChunkUtils.java
@@ -192,7 +192,7 @@ public final class ChunkUtils {
       throws StorageContainerException {
     if (len > readMappedBufferThreshold) {
       return readData(file, bufferCapacity, off, len, volume);
-    } if (len == 0) {
+    } else if (len == 0) {
       return ChunkBuffer.wrap(Collections.emptyList());
     }
 

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/impl/FilePerChunkStrategy.java
@@ -20,14 +20,12 @@ package org.apache.hadoop.ozone.container.keyvalue.impl;
 
 import com.google.common.base.Preconditions;
 
-import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.hdds.client.BlockID;
 import org.apache.hadoop.hdds.protocol.datanode.proto.ContainerProtos;
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
-import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.BlockData;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.hadoop.ozone.container.common.transport.server.ratis.DispatcherContext;
@@ -48,7 +46,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
@@ -69,6 +66,7 @@ public class FilePerChunkStrategy implements ChunkManager {
   private final boolean doSyncWrite;
   private final BlockManager blockManager;
   private final int defaultReadBufferCapacity;
+  private final int readMappedBufferThreshold;
   private final VolumeSet volumeSet;
 
   public FilePerChunkStrategy(boolean sync, BlockManager manager,
@@ -77,6 +75,8 @@ public class FilePerChunkStrategy implements ChunkManager {
     blockManager = manager;
     this.defaultReadBufferCapacity = manager == null ? 0 :
         manager.getDefaultReadBufferCapacity();
+    this.readMappedBufferThreshold = manager == null ? 0
+        : manager.getReadMappedBufferThreshold();
     this.volumeSet = volSet;
   }
 
@@ -233,9 +233,6 @@ public class FilePerChunkStrategy implements ChunkManager {
     int bufferCapacity = ChunkManager.getBufferCapacityForChunkRead(info,
         defaultReadBufferCapacity);
 
-    ByteBuffer[] dataBuffers = BufferUtils.assignByteBuffers(len,
-        bufferCapacity);
-
     long chunkFileOffset = 0;
     if (info.getOffset() != 0) {
       try {
@@ -267,8 +264,8 @@ public class FilePerChunkStrategy implements ChunkManager {
         if (file.exists()) {
           long offset = info.getOffset() - chunkFileOffset;
           Preconditions.checkState(offset >= 0);
-          ChunkUtils.readData(file, dataBuffers, offset, len, volume);
-          return ChunkBuffer.wrap(Lists.newArrayList(dataBuffers));
+          return ChunkUtils.readData(len, bufferCapacity, file, offset, volume,
+              readMappedBufferThreshold);
         }
       } catch (StorageContainerException ex) {
         //UNABLE TO FIND chunk is not a problem as we will try with the
@@ -276,7 +273,6 @@ public class FilePerChunkStrategy implements ChunkManager {
         if (ex.getResult() != UNABLE_TO_FIND_CHUNK) {
           throw ex;
         }
-        BufferUtils.clearBuffers(dataBuffers);
       }
     }
     throw new StorageContainerException(

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/interfaces/BlockManager.java
@@ -93,6 +93,9 @@ public interface BlockManager {
 
   int getDefaultReadBufferCapacity();
 
+  /** @return the threshold to read using memory mapped buffers. */
+  int getReadMappedBufferThreshold();
+
   /**
    * Shutdown ContainerManager.
    */

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -17,9 +17,12 @@
  */
 package org.apache.hadoop.ozone.container.keyvalue.helpers;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -27,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -36,7 +40,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.hdds.scm.container.common.helpers.StorageContainerException;
 import org.apache.hadoop.ozone.common.ChunkBuffer;
-import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.hadoop.ozone.container.common.helpers.ChunkInfo;
 import org.apache.ozone.test.GenericTestUtils;
 
@@ -64,6 +67,16 @@ public class TestChunkUtils {
       LoggerFactory.getLogger(TestChunkUtils.class);
 
   private static final String PREFIX = TestChunkUtils.class.getSimpleName();
+  private static final int BUFFER_CAPACITY = 1 << 20;
+  private static final int MAPPED_BUFFER_THRESHOLD = 32 << 10;
+  private static final Random RANDOM = new Random();
+
+  static ChunkBuffer readData(File file, long off, long len)
+      throws StorageContainerException {
+    LOG.info("off={}, len={}", off, len);
+    return ChunkUtils.readData(len, BUFFER_CAPACITY, file, off, null,
+        MAPPED_BUFFER_THRESHOLD);
+  }
 
   @Test
   public void concurrentReadOfSameFile() throws Exception {
@@ -85,12 +98,11 @@ public class TestChunkUtils {
         final int threadNumber = i;
         executor.execute(() -> {
           try {
-            ByteBuffer[] readBuffers = BufferUtils.assignByteBuffers(len, len);
-            ChunkUtils.readData(file, readBuffers, offset, len, null);
-
+            final ChunkBuffer chunk = readData(file, offset, len);
             // There should be only one element in readBuffers
-            Assertions.assertEquals(1, readBuffers.length);
-            ByteBuffer readBuffer = readBuffers[0];
+            final List<ByteBuffer> buffers = chunk.asByteBufferList();
+            Assertions.assertEquals(1, buffers.size());
+            final ByteBuffer readBuffer = buffers.get(0);
 
             LOG.info("Read data ({}): {}", threadNumber,
                 new String(readBuffer.array(), UTF_8));
@@ -172,12 +184,11 @@ public class TestChunkUtils {
       int offset = 0;
       ChunkUtils.writeData(file, data, offset, len, null, true);
 
-      ByteBuffer[] readBuffers = BufferUtils.assignByteBuffers(len, len);
-      ChunkUtils.readData(file, readBuffers, offset, len, null);
-
+      final ChunkBuffer chunk = readData(file, offset, len);
       // There should be only one element in readBuffers
-      Assertions.assertEquals(1, readBuffers.length);
-      ByteBuffer readBuffer = readBuffers[0];
+      final List<ByteBuffer> buffers = chunk.asByteBufferList();
+      Assertions.assertEquals(1, buffers.size());
+      final ByteBuffer readBuffer = buffers.get(0);
 
       assertArrayEquals(array, readBuffer.array());
       assertEquals(len, readBuffer.remaining());
@@ -220,15 +231,90 @@ public class TestChunkUtils {
     int len = 123;
     int offset = 0;
     File nonExistentFile = new File("nosuchfile");
-    ByteBuffer[] bufs = BufferUtils.assignByteBuffers(len, len);
 
     // when
     StorageContainerException e = assertThrows(
         StorageContainerException.class,
-        () -> ChunkUtils.readData(nonExistentFile, bufs, offset, len, null));
+        () -> readData(nonExistentFile, offset, len));
 
     // then
     Assertions.assertEquals(UNABLE_TO_FIND_CHUNK, e.getResult());
   }
 
+  @Test
+  public void testReadData() throws Exception {
+    final File dir = GenericTestUtils.getTestDir("testReadData");
+    try {
+      Assertions.assertTrue(dir.mkdirs());
+
+      // large file
+      final int large = 10 << 20; // 10MB
+      Assertions.assertTrue(large > MAPPED_BUFFER_THRESHOLD);
+      runTestReadFile(large, dir, true);
+
+      // small file
+      final int small = 30 << 10; // 30KB
+      Assertions.assertTrue(small <= MAPPED_BUFFER_THRESHOLD);
+      runTestReadFile(small, dir, false);
+
+      // boundary case
+      runTestReadFile(MAPPED_BUFFER_THRESHOLD, dir, false);
+
+      // empty file
+      runTestReadFile(0, dir, false);
+
+      for(int i = 0; i < 10; i++) {
+        final int length = RANDOM.nextInt(2 * MAPPED_BUFFER_THRESHOLD) + 1;
+        runTestReadFile(length, dir, length > MAPPED_BUFFER_THRESHOLD);
+      }
+    } finally {
+      FileUtils.deleteDirectory(dir);
+    }
+  }
+
+  public void runTestReadFile(int length, File dir, boolean isMapped) throws Exception {
+    final File file;
+    for(int i = length; ; i++) {
+      final File f = new File(dir, "file_" + i);
+      if (!f.exists()) {
+        file = f;
+        break;
+      }
+    }
+    LOG.info("file: {}", file);
+
+    // write a file
+    final byte[] array = new byte[BUFFER_CAPACITY];
+    final long seed = System.nanoTime();
+    LOG.info("seed: {}", seed);
+    RANDOM.setSeed(seed);
+    try(OutputStream out = new BufferedOutputStream(Files.newOutputStream(
+        file.toPath(), StandardOpenOption.CREATE_NEW))) {
+      for (int written = 0; written < length; ) {
+        RANDOM.nextBytes(array);
+        final int remaining = length - written;
+        final int toWrite = Math.min(remaining, array.length);
+        out.write(array, 0, toWrite);
+        written += toWrite;
+      }
+    }
+    Assertions.assertEquals(length, file.length());
+
+    // read the file back
+    final ChunkBuffer chunk = readData(file, 0, length);
+    Assertions.assertEquals(length, chunk.remaining());
+
+    final List<ByteBuffer> buffers = chunk.asByteBufferList();
+    LOG.info("buffers.size(): {}", buffers.size());
+    Assertions.assertEquals((length - 1) / BUFFER_CAPACITY + 1, buffers.size());
+    LOG.info("buffer class: {}", buffers.get(0).getClass());
+    LOG.info("buffer class: MappedByteBuffer? {}", buffers.get(0) instanceof  MappedByteBuffer);
+
+    RANDOM.setSeed(seed);
+    for(ByteBuffer b : buffers) {
+      Assertions.assertEquals(isMapped, b instanceof MappedByteBuffer);
+      RANDOM.nextBytes(array);
+      Assertions.assertEquals(ByteBuffer.wrap(array, 0, b.remaining()), b);
+    }
+  }
 }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/helpers/TestChunkUtils.java
@@ -263,7 +263,7 @@ public class TestChunkUtils {
       // empty file
       runTestReadFile(0, dir, false);
 
-      for(int i = 0; i < 10; i++) {
+      for (int i = 0; i < 10; i++) {
         final int length = RANDOM.nextInt(2 * MAPPED_BUFFER_THRESHOLD) + 1;
         runTestReadFile(length, dir, length > MAPPED_BUFFER_THRESHOLD);
       }
@@ -272,9 +272,10 @@ public class TestChunkUtils {
     }
   }
 
-  public void runTestReadFile(int length, File dir, boolean isMapped) throws Exception {
+  void runTestReadFile(int length, File dir, boolean isMapped)
+      throws Exception {
     final File file;
-    for(int i = length; ; i++) {
+    for (int i = length; ; i++) {
       final File f = new File(dir, "file_" + i);
       if (!f.exists()) {
         file = f;
@@ -288,9 +289,9 @@ public class TestChunkUtils {
     final long seed = System.nanoTime();
     LOG.info("seed: {}", seed);
     RANDOM.setSeed(seed);
-    try(OutputStream out = new BufferedOutputStream(Files.newOutputStream(
+    try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(
         file.toPath(), StandardOpenOption.CREATE_NEW))) {
-      for (int written = 0; written < length; ) {
+      for (int written = 0; written < length;) {
         RANDOM.nextBytes(array);
         final int remaining = length - written;
         final int toWrite = Math.min(remaining, array.length);
@@ -308,10 +309,9 @@ public class TestChunkUtils {
     LOG.info("buffers.size(): {}", buffers.size());
     Assertions.assertEquals((length - 1) / BUFFER_CAPACITY + 1, buffers.size());
     LOG.info("buffer class: {}", buffers.get(0).getClass());
-    LOG.info("buffer class: MappedByteBuffer? {}", buffers.get(0) instanceof  MappedByteBuffer);
 
     RANDOM.setSeed(seed);
-    for(ByteBuffer b : buffers) {
+    for (ByteBuffer b : buffers) {
       Assertions.assertEquals(isMapped, b instanceof MappedByteBuffer);
       RANDOM.nextBytes(array);
       Assertions.assertEquals(ByteBuffer.wrap(array, 0, b.remaining()), b);


### PR DESCRIPTION
## What changes were proposed in this pull request?

From @jojochuang 
> Running Impala TPC-DS which stresses Ozone DN read path.
> BufferUtils#assignByteBuffers stands out as one of the offender.
> We can experiment with MappedByteBuffer and see if it makes performance better.

## What is the link to the Apache JIRA

HDDS-7117

## How was this patch tested?

New unit test.