### PR TITLE
HDDS-7119. Specify endpoint type for datanode

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachine.java
@@ -51,6 +51,7 @@ public class EndpointStateMachine
   private final Lock lock;
   private final ConfigurationSource conf;
   private EndPointStates state;
+  private EndPointType type;
   private VersionResponse version;
   private ZonedDateTime lastSuccessfulHeartbeat;
   private boolean isPassive;
@@ -62,8 +63,8 @@ public class EndpointStateMachine
    * @param endPoint - RPC endPoint.
    */
   public EndpointStateMachine(InetSocketAddress address,
-      StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
-      ConfigurationSource conf) {
+        StorageContainerDatanodeProtocolClientSideTranslatorPB endPoint,
+        ConfigurationSource conf, EndPointType type) {
     this.endPoint = endPoint;
     this.missedCount = new AtomicLong(0);
     this.address = address;
@@ -75,6 +76,7 @@ public class EndpointStateMachine
             .setNameFormat("EndpointStateMachine task thread for "
                 + this.address + " - %d ")
             .build());
+    this.type = type;
   }
 
   /**
@@ -328,6 +330,42 @@ public class EndpointStateMachine
       }
       return getLastState();
     }
+  }
+
+  /**
+   * Service type of the Endpoint.
+   */
+  public enum EndPointType {
+    SCM(1),
+    RECON(2);
+    private final int value;
+
+    /**
+     * Constructs endPointType.
+     *
+     * @param value  state.
+     */
+    EndPointType(int value) {
+      this.value = value;
+    }
+
+    /**
+     * returns the numeric value associated with the endPoint.
+     *
+     * @return int.
+     */
+    public int getValue() {
+      return value;
+    }
+  }
+
+  public void setType(EndPointType type) {
+    this.type = type;
+  }
+
+  @Override
+  public EndPointType getType() {
+    return this.type;
   }
 
   @Override

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/EndpointStateMachineMBean.java
@@ -31,4 +31,6 @@ public interface EndpointStateMachineMBean {
   int getVersionNumber();
 
   long getLastSuccessfulHeartbeat();
+
+  EndpointStateMachine.EndPointType getType();
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/statemachine/SCMConnectionManager.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.ipc.ProtobufRpcEngine;
 import org.apache.hadoop.ipc.RPC;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hadoop.net.NetUtils;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointType;
 import org.apache.hadoop.ozone.protocolPB.ReconDatanodeProtocolPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.protocolPB.StorageContainerDatanodeProtocolPB;
@@ -166,7 +167,8 @@ public class SCMConnectionManager
           rpcProxy);
 
       EndpointStateMachine endPoint =
-          new EndpointStateMachine(address, rpcClient, this.conf);
+          new EndpointStateMachine(address, rpcClient, this.conf,
+              EndPointType.SCM);
       endPoint.setPassive(false);
       scmMachines.put(address, endPoint);
     } finally {
@@ -209,7 +211,8 @@ public class SCMConnectionManager
           new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
 
       EndpointStateMachine endPoint =
-          new EndpointStateMachine(address, rpcClient, conf);
+          new EndpointStateMachine(address, rpcClient, conf,
+              EndPointType.RECON);
       endPoint.setPassive(true);
       scmMachines.put(address, endPoint);
     } finally {

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/ContainerTestUtils.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.container.common.impl.ContainerLayoutVersion;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointType;
 import org.apache.hadoop.ozone.container.common.statemachine.StateContext;
 import org.apache.hadoop.ozone.container.common.utils.StorageVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.HddsVolume;
@@ -68,7 +69,8 @@ public final class ContainerTestUtils {
    * @throws Exception
    */
   public static EndpointStateMachine createEndpoint(Configuration conf,
-      InetSocketAddress address, int rpcTimeout) throws Exception {
+      InetSocketAddress address, int rpcTimeout, EndPointType type)
+      throws Exception {
     RPC.setProtocolEngine(conf, StorageContainerDatanodeProtocolPB.class,
         ProtobufRpcEngine.class);
     long version =
@@ -83,7 +85,7 @@ public final class ContainerTestUtils {
     StorageContainerDatanodeProtocolClientSideTranslatorPB rpcClient =
         new StorageContainerDatanodeProtocolClientSideTranslatorPB(rpcProxy);
     return new EndpointStateMachine(address, rpcClient,
-        new LegacyHadoopConfigurationSource(conf));
+        new LegacyHadoopConfigurationSource(conf), type);
   }
 
   public static OzoneContainer getOzoneContainer(

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/states/datanode/TestRunningDatanodeState.java
@@ -57,7 +57,7 @@ public class TestRunningDatanodeState {
     state.setExecutorCompletionService(ecs);
 
     for (int i = 0; i < threadPoolSize; i++) {
-      stateMachines.add(new EndpointStateMachine(null, null, null));
+      stateMachines.add(new EndpointStateMachine(null, null, null, null));
     }
 
     CompletableFuture<EndpointStateMachine.EndPointStates> futureOne =

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToSchemaV3.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.ozone.container.common.ScmTestMock;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeConfiguration;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointType;
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.common.volume.DbVolume;
@@ -623,7 +624,7 @@ public class TestDatanodeUpgradeToSchemaV3 {
    */
   public void callVersionEndpointTask() throws Exception {
     try (EndpointStateMachine esm = ContainerTestUtils.createEndpoint(conf,
-        address, 1000)) {
+        address, 1000, EndPointType.SCM)) {
       VersionEndpointTask vet = new VersionEndpointTask(esm, conf,
           dsm.getContainer());
       esm.setState(EndpointStateMachine.EndPointStates.GETVERSION);

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/upgrade/TestDatanodeUpgradeToScmHA.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.hadoop.ozone.container.common.ScmTestMock;
 import org.apache.hadoop.ozone.container.common.statemachine.DatanodeStateMachine;
 import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine;
+import org.apache.hadoop.ozone.container.common.statemachine.EndpointStateMachine.EndPointType;
 import org.apache.hadoop.ozone.container.common.states.endpoint.VersionEndpointTask;
 import org.apache.hadoop.ozone.container.common.utils.HddsVolumeUtil;
 import org.apache.hadoop.ozone.container.keyvalue.KeyValueContainerData;
@@ -552,7 +553,7 @@ public class TestDatanodeUpgradeToScmHA {
    */
   public void callVersionEndpointTask() throws Exception {
     try (EndpointStateMachine esm = ContainerTestUtils.createEndpoint(conf,
-        address, 1000)) {
+        address, 1000, EndPointType.SCM)) {
       VersionEndpointTask vet = new VersionEndpointTask(esm, conf,
           dsm.getContainer());
       esm.setState(EndpointStateMachine.EndPointStates.GETVERSION);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently SCM and Recon can not be distinguished in metrics of SCMConnectionManager.

This ticket is to add a new field to indicate the type of the endpoint.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7119

## How was this patch tested?

unit test.