### PR TITLE
HDDS-7123. container scan should hold the container read lock

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -823,7 +823,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     long containerId = containerData.getContainerID();
     KeyValueContainerCheck checker =
         new KeyValueContainerCheck(containerData.getMetadataPath(), config,
-            containerId, containerData.getVolume());
+            containerId, containerData.getVolume(), this);
     return checker.fastCheck();
   }
 
@@ -844,7 +844,7 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     long containerId = containerData.getContainerID();
     KeyValueContainerCheck checker =
         new KeyValueContainerCheck(containerData.getMetadataPath(), config,
-            containerId, containerData.getVolume());
+            containerId, containerData.getVolume(), this);
 
     return checker.fullCheck(throttler, canceler);
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/keyvalue/TestKeyValueContainerCheck.java
@@ -70,7 +70,7 @@ public class TestKeyValueContainerCheck
 
     KeyValueContainerCheck kvCheck =
         new KeyValueContainerCheck(containerData.getMetadataPath(), conf,
-            containerID, containerData.getVolume());
+            containerID, containerData.getVolume(), container);
 
     // first run checks on a Open Container
     boolean valid = kvCheck.fastCheck();
@@ -105,7 +105,7 @@ public class TestKeyValueContainerCheck
 
     KeyValueContainerCheck kvCheck =
         new KeyValueContainerCheck(containerData.getMetadataPath(), conf,
-            containerID, containerData.getVolume());
+            containerID, containerData.getVolume(), container);
 
     File dbFile = KeyValueContainerLocationUtil
         .getContainerDBFile(containerData);


### PR DESCRIPTION
## What changes were proposed in this pull request?

now, when scanning container, datanode does not hold a lock. when the blockDeletingService works, it will first deletes the block file in container directory and then delete the metadata in rocksdb. when container scanner works , it will first read the metadata from DB, and then check the block file in container directory.  the two background service runs concurrently for now. there may be a case that when blockDeletingService deletes the block file from container directory but not delete the metadata from rocksdb, container scanner read the metadata from rocksdb and then fail to find the block file in container directory, and then mark the container replica unhealthy

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7123

## How was this patch tested?

no additional test
