### PR TITLE
HDDS-7125. Inaccurate numBlocksDeletion when getTransactions

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -79,7 +79,7 @@ public class ScmConfig {
 
   @Config(key = "block.deletion.per-interval.max",
       type = ConfigType.INT,
-      defaultValue = "20000",
+      defaultValue = "100000",
       tags = { ConfigTag.SCM, ConfigTag.DELETION},
       description =
           "Maximum number of blocks which SCM processes during an interval. "

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/ScmConfig.java
@@ -83,6 +83,7 @@ public class ScmConfig {
       tags = { ConfigTag.SCM, ConfigTag.DELETION},
       description =
           "Maximum number of blocks which SCM processes during an interval. "
+              + "The block num is counted at the replica level."
               + "If SCM has 100000 blocks which need to be deleted and the "
               + "configuration is 5000 then it would only send 5000 blocks "
               + "for deletion to the datanodes."

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogImpl.java
@@ -419,6 +419,9 @@ public class DeletedBlockLogImpl
           ? extends Table.KeyValue<Long, DeletedBlocksTransaction>> iter =
                deletedBlockLogStateManager.getReadOnlyIterator()) {
         ArrayList<Long> txIDs = new ArrayList<>();
+        // Here takes block replica count as the threshold to avoid the case
+        // that part of replicas committed the TXN and recorded in the
+        // transactionToDNsCommitMap, while they are counted in the threshold.
         while (iter.hasNext() &&
             transactions.getBlocksDeleted() < blockDeletionLimit) {
           Table.KeyValue<Long, DeletedBlocksTransaction> keyValue = iter.next();

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/block/DeletedBlockLogStateManagerImpl.java
@@ -43,9 +43,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
-import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT;
-
 /**
  * {@link DeletedBlockLogStateManager} implementation
  * based on {@link DeletedBlocksTransaction}.
@@ -59,15 +56,12 @@ public class DeletedBlockLogStateManagerImpl
   private Table<Long, DeletedBlocksTransaction> deletedTable;
   private ContainerManager containerManager;
   private final DBTransactionBuffer transactionBuffer;
-  private final int maxRetry;
   private final Set<Long> deletingTxIDs;
   private final Set<Long> skippingRetryTxIDs;
 
   public DeletedBlockLogStateManagerImpl(ConfigurationSource conf,
              Table<Long, DeletedBlocksTransaction> deletedTable,
              ContainerManager containerManager, DBTransactionBuffer txBuffer) {
-    this.maxRetry = conf.getInt(OZONE_SCM_BLOCK_DELETION_MAX_RETRY,
-        OZONE_SCM_BLOCK_DELETION_MAX_RETRY_DEFAULT);
     this.deletedTable = deletedTable;
     this.containerManager = containerManager;
     this.transactionBuffer = txBuffer;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/block/TestDeletedBlockLog.java
@@ -69,7 +69,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor.THREE;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_BLOCK_DELETION_MAX_RETRY;
 import static org.mockito.Matchers.anyObject;
@@ -93,6 +92,8 @@ public class TestDeletedBlockLog {
   private Map<Long, ContainerInfo> containers = new HashMap<>();
   private Map<Long, Set<ContainerReplica>> replicas = new HashMap<>();
   private ScmBlockDeletingServiceMetrics metrics;
+  private static final int THREE = ReplicationFactor.THREE_VALUE;
+  private static final int ONE = ReplicationFactor.ONE_VALUE;
 
   @BeforeEach
   public void setup() throws Exception {
@@ -165,7 +166,8 @@ public class TestDeletedBlockLog {
     final ContainerInfo container =
         new ContainerInfo.Builder()
             .setContainerID(cid)
-            .setReplicationConfig(RatisReplicationConfig.getInstance(THREE))
+            .setReplicationConfig(RatisReplicationConfig.getInstance(
+                ReplicationFactor.THREE))
             .setState(HddsProtos.LifeCycleState.CLOSED)
             .setOwner("TestDeletedBlockLog")
             .setPipelineID(PipelineID.randomId())
@@ -265,6 +267,15 @@ public class TestDeletedBlockLog {
         .collect(Collectors.toList()));
   }
 
+  private void commitTransactions(DatanodeDeletedBlockTransactions
+      transactions) {
+    transactions.getDatanodeTransactionMap().forEach((uuid,
+        deletedBlocksTransactions) -> deletedBlockLog
+        .commitTransactions(deletedBlocksTransactions.stream()
+            .map(this::createDeleteBlockTransactionResult)
+            .collect(Collectors.toList()), uuid));
+  }
+
   private DeleteBlockTransactionResult createDeleteBlockTransactionResult(
       DeletedBlocksTransaction transaction) {
     return DeleteBlockTransactionResult.newBuilder()
@@ -282,7 +293,7 @@ public class TestDeletedBlockLog {
           transactions.getDatanodeTransactionMap().get(dn.getUuid()))
           .orElseGet(LinkedList::new));
     }
-    return txns.stream().distinct().collect(Collectors.toList());
+    return txns;
   }
 
   @Test
@@ -304,7 +315,7 @@ public class TestDeletedBlockLog {
     scmHADBTransactionBuffer.flush();
     // After flush there should be 30 transactions in deleteTable
     // All containers should have positive deleteTransactionId
-    Assertions.assertEquals(30, getTransactions(1000).size());
+    Assertions.assertEquals(90, getTransactions(1000).size());
     for (ContainerInfo containerInfo : containerManager.getContainers()) {
       Assertions.assertTrue(containerInfo.getDeleteTransactionId() > 0);
     }
@@ -319,7 +330,7 @@ public class TestDeletedBlockLog {
 
     // This will return all TXs, total num 30.
     List<DeletedBlocksTransaction> blocks =
-        getTransactions(40 * BLOCKS_PER_TXN);
+        getTransactions(40 * BLOCKS_PER_TXN * THREE);
     List<Long> txIDs = blocks.stream().map(DeletedBlocksTransaction::getTxID)
         .collect(Collectors.toList());
 
@@ -330,13 +341,13 @@ public class TestDeletedBlockLog {
     // Increment another time so it exceed the maxRetry.
     // On this call, count will be set to -1 which means TX eventually fails.
     incrementCount(txIDs);
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
+    blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
     for (DeletedBlocksTransaction block : blocks) {
       Assertions.assertEquals(-1, block.getCount());
     }
 
     // If all TXs are failed, getTransactions call will always return nothing.
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
+    blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
     Assertions.assertEquals(blocks.size(), 0);
   }
 
@@ -349,7 +360,7 @@ public class TestDeletedBlockLog {
 
     // This will return all TXs, total num 30.
     List<DeletedBlocksTransaction> blocks =
-        getTransactions(40 * BLOCKS_PER_TXN);
+        getTransactions(40 * BLOCKS_PER_TXN * THREE);
     List<Long> txIDs = blocks.stream().map(DeletedBlocksTransaction::getTxID)
         .collect(Collectors.toList());
 
@@ -360,48 +371,76 @@ public class TestDeletedBlockLog {
     // Increment another time so it exceed the maxRetry.
     // On this call, count will be set to -1 which means TX eventually fails.
     incrementCount(txIDs);
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
+    blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
     for (DeletedBlocksTransaction block : blocks) {
       Assertions.assertEquals(-1, block.getCount());
     }
 
     // If all TXs are failed, getTransactions call will always return nothing.
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
+    blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
     Assertions.assertEquals(0, blocks.size());
 
     // Reset the retry count, these transactions should be accessible.
     resetCount(txIDs);
-    blocks = getTransactions(40 * BLOCKS_PER_TXN);
+    blocks = getTransactions(40 * BLOCKS_PER_TXN * THREE);
     for (DeletedBlocksTransaction block : blocks) {
       Assertions.assertEquals(0, block.getCount());
     }
-    Assertions.assertEquals(30, blocks.size());
+    Assertions.assertEquals(90, blocks.size());
   }
 
   @Test
   public void testCommitTransactions() throws Exception {
     addTransactions(generateData(50), true);
     List<DeletedBlocksTransaction> blocks =
-        getTransactions(20 * BLOCKS_PER_TXN);
+        getTransactions(20 * BLOCKS_PER_TXN * THREE);
     // Add an invalid txn.
     blocks.add(
         DeletedBlocksTransaction.newBuilder().setContainerID(1).setTxID(70)
             .setCount(0).addLocalID(0).build());
     commitTransactions(blocks);
-    blocks.remove(blocks.size() - 1);
 
-    blocks = getTransactions(50 * BLOCKS_PER_TXN);
-    Assertions.assertEquals(30, blocks.size());
+    blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
+    Assertions.assertEquals(30 * 3, blocks.size());
     commitTransactions(blocks, dnList.get(1), dnList.get(2),
         DatanodeDetails.newBuilder().setUuid(UUID.randomUUID())
             .build());
 
-    blocks = getTransactions(50 * BLOCKS_PER_TXN);
+    blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
+    // only uncommitted dn have transactions
     Assertions.assertEquals(30, blocks.size());
     commitTransactions(blocks, dnList.get(0));
 
-    blocks = getTransactions(50 * BLOCKS_PER_TXN);
+    blocks = getTransactions(50 * BLOCKS_PER_TXN * THREE);
     Assertions.assertEquals(0, blocks.size());
+  }
+
+  @Test
+  public void testInadequateReplicaCommit() throws Exception {
+    Map<Long, List<Long>> deletedBlocks = generateData(50);
+    addTransactions(deletedBlocks, true);
+    long containerID;
+    // let the first 30 container only consisting of only two unhealthy replicas
+    int count = 30;
+    for (Map.Entry<Long, List<Long>> entry :deletedBlocks.entrySet()) {
+      if (count <= 0) {
+        break;
+      }
+      containerID = entry.getKey();
+      mockInadequateReplicaUnhealthyContainerInfo(containerID);
+      count -= 1;
+    }
+    // getTransactions will get existing container replicas then add transaction
+    // to DN.
+    // For the first 30 txn, deletedBlockLog only has the txn from dn1 and dn2
+    // For the rest txn, txn will be got from all dns.
+    // Committed txn will be: 1-40. 1-40. 31-40
+    commitTransactions(deletedBlockLog.getTransactions(
+        30 * BLOCKS_PER_TXN * THREE));
+
+    // The rest txn shall be: 41-50. 41-50. 41-50
+    List<DeletedBlocksTransaction> blocks = getTransactions(1000);
+    Assertions.assertEquals(30, blocks.size());
   }
 
   @Test
@@ -417,7 +456,7 @@ public class TestDeletedBlockLog {
         addTransactions(generateData(10), true);
         added += 10;
       } else if (state == 1) {
-        blocks = getTransactions(20);
+        blocks = getTransactions(20 * THREE);
         txIDs = new ArrayList<>();
         for (DeletedBlocksTransaction block : blocks) {
           txIDs.add(block.getTxID());
@@ -425,7 +464,7 @@ public class TestDeletedBlockLog {
         incrementCount(txIDs);
       } else if (state == 2) {
         commitTransactions(blocks);
-        committed += blocks.size();
+        committed += blocks.size() / THREE;
         blocks = new ArrayList<>();
       } else {
         // verify the number of added and committed.
@@ -457,11 +496,11 @@ public class TestDeletedBlockLog {
         scm.getSequenceIdGen(),
         metrics);
     List<DeletedBlocksTransaction> blocks =
-        getTransactions(BLOCKS_PER_TXN * 10);
-    Assertions.assertEquals(10, blocks.size());
+        getTransactions(BLOCKS_PER_TXN * 10 * THREE);
+    Assertions.assertEquals(10 * 3, blocks.size());
     commitTransactions(blocks);
-    blocks = getTransactions(BLOCKS_PER_TXN * 40);
-    Assertions.assertEquals(40, blocks.size());
+    blocks = getTransactions(BLOCKS_PER_TXN * 40 * THREE);
+    Assertions.assertEquals(40 * 3, blocks.size());
     commitTransactions(blocks);
 
     // close db and reopen it again to make sure
@@ -475,7 +514,7 @@ public class TestDeletedBlockLog {
         scm.getScmContext(),
         scm.getSequenceIdGen(),
         metrics);
-    blocks = getTransactions(BLOCKS_PER_TXN * 40);
+    blocks = getTransactions(BLOCKS_PER_TXN * 40 * THREE);
     Assertions.assertEquals(0, blocks.size());
     //Assertions.assertEquals((long)deletedBlockLog.getCurrentTXID(), 50L);
   }
@@ -496,38 +535,33 @@ public class TestDeletedBlockLog {
     for (Map.Entry<Long, List<Long>> entry :deletedBlocks.entrySet()) {
       count++;
       containerID = entry.getKey();
-
+      // let the container replication factor to be ONE
       if (count % 2 == 0) {
-        mockContainerInfo(containerID, dnId1);
+        mockStandAloneContainerInfo(containerID, dnId1);
       } else {
-        mockContainerInfo(containerID, dnId2);
+        mockStandAloneContainerInfo(containerID, dnId2);
       }
     }
 
     // fetch and delete 1 less txn Id
     commitTransactions(getTransactions((txNum - 1) * BLOCKS_PER_TXN));
 
-    blocks = getTransactions(txNum * BLOCKS_PER_TXN);
+    blocks = getTransactions(txNum * BLOCKS_PER_TXN * ONE);
     // There should be one txn remaining
     Assertions.assertEquals(1, blocks.size());
 
     // add two transactions for same container
     containerID = blocks.get(0).getContainerID();
-    DeletedBlocksTransaction.Builder builder =
-        DeletedBlocksTransaction.newBuilder();
-    builder.setTxID(11);
-    builder.setContainerID(containerID);
-    builder.setCount(0);
     Map<Long, List<Long>> deletedBlocksMap = new HashMap<>();
     deletedBlocksMap.put(containerID, new LinkedList<>());
     addTransactions(deletedBlocksMap, true);
 
     // get should return two transactions for the same container
-    blocks = getTransactions(txNum);
+    blocks = getTransactions(txNum * ONE);
     Assertions.assertEquals(2, blocks.size());
   }
 
-  private void mockContainerInfo(long containerID, DatanodeDetails dd)
+  private void mockStandAloneContainerInfo(long containerID, DatanodeDetails dd)
       throws IOException {
     List<DatanodeDetails> dns = Collections.singletonList(dd);
     Pipeline pipeline = Pipeline.newBuilder()
@@ -551,6 +585,38 @@ public class TestDeletedBlockLog {
         .map(datanodeDetails -> ContainerReplica.newBuilder()
             .setContainerID(containerInfo.containerID())
             .setContainerState(ContainerReplicaProto.State.OPEN)
+            .setDatanodeDetails(datanodeDetails)
+            .build())
+        .collect(Collectors.toSet());
+    when(containerManager.getContainerReplicas(
+        ContainerID.valueOf(containerID)))
+        .thenReturn(replicaSet);
+  }
+
+  private void mockInadequateReplicaUnhealthyContainerInfo(long containerID)
+      throws IOException {
+    List<DatanodeDetails> dns = dnList.subList(0, 2);
+    Pipeline pipeline = Pipeline.newBuilder()
+        .setReplicationConfig(
+            RatisReplicationConfig.getInstance(ReplicationFactor.THREE))
+        .setState(Pipeline.PipelineState.OPEN)
+        .setId(PipelineID.randomId())
+        .setNodes(dnList)
+        .build();
+
+    ContainerInfo.Builder builder = new ContainerInfo.Builder();
+    builder.setContainerID(containerID)
+        .setPipelineID(pipeline.getId())
+        .setReplicationConfig(pipeline.getReplicationConfig());
+
+    ContainerInfo containerInfo = builder.build();
+    Mockito.doReturn(containerInfo).when(containerManager)
+        .getContainer(ContainerID.valueOf(containerID));
+
+    final Set<ContainerReplica> replicaSet = dns.stream()
+        .map(datanodeDetails -> ContainerReplica.newBuilder()
+            .setContainerID(containerInfo.containerID())
+            .setContainerState(ContainerReplicaProto.State.CLOSED)
             .setDatanodeDetails(datanodeDetails)
             .build())
         .collect(Collectors.toSet());


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, we find that the deleted block txns in SCM RDB are not updated anymore.

For the unhealthy container(no healthy replica and not enough replicas), SCM will not commit the txn and remove it from RDB until all desired replicas commit it. SCM will add the committed replica to the map `dnsWithTransactionCommitted` before all replicas commit the txn.

In the process of `getTransactions`, SCM will read the txn out from RDB and try to add it to the result, but if the txn existed in the `dnsWithTransactionCommitted`, SCM will ignore it. No matter whether ignoring the txn, the numBlocksDeletion is still counting this, which will lead to nonsense running, and actually returning empty txns when the cluster has a certain amount of unhealthy containers.

1. use the real num of blocks as the criterion 
2. increase the block.deletion.per-interval.max (originally it will be multiplied with the Replication Factor)
3. Fix UT and add the scenario of this case.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7125


## How was this patch tested?

UT
