### PR TITLE
HDDS-7120. Fix Prometheus reporting only 1 VolumeIOStat

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -108,7 +108,8 @@ public class HddsVolume extends StorageVolume {
 
     if (!b.getFailedVolume()) {
       this.setState(VolumeState.NOT_INITIALIZED);
-      this.volumeIOStats = new VolumeIOStats(b.getVolumeRootStr());
+      this.volumeIOStats = new VolumeIOStats(b.getVolumeRootStr(),
+          this.getStorageDir().toString());
       this.volumeInfoMetrics =
           new VolumeInfoMetrics(b.getVolumeRootStr(), this);
       this.committedBytes = new AtomicLong(0);

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.metrics2.lib.MutableCounterLong;
  */
 public class VolumeIOStats {
   private String metricsSourceName = VolumeIOStats.class.getSimpleName();
-
+  private String storageDirectory;
   private @Metric MutableCounterLong readBytes;
   private @Metric MutableCounterLong readOpCount;
   private @Metric MutableCounterLong writeBytes;
@@ -44,8 +44,9 @@ public class VolumeIOStats {
   /**
    * @param identifier Typically, path to volume root. e.g. /data/hdds
    */
-  public VolumeIOStats(String identifier) {
+  public VolumeIOStats(String identifier, String storageDirectory) {
     this.metricsSourceName += '-' + identifier;
+    this.storageDirectory = storageDirectory;
     init();
   }
 
@@ -156,6 +157,8 @@ public class VolumeIOStats {
   public long getWriteTime() {
     return writeTime.value();
   }
-
-
+  @Metric(value = "Returns the storage directory name for the volume")
+  public String getStorageDirectory() {
+    return storageDirectory;
+  }
 }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeIOStats.java
@@ -157,7 +157,8 @@ public class VolumeIOStats {
   public long getWriteTime() {
     return writeTime.value();
   }
-  @Metric(value = "Returns the storage directory name for the volume")
+
+  @Metric
   public String getStorageDirectory() {
     return storageDirectory;
   }

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.ozone.container.common.volume;
+
+import org.apache.hadoop.hdds.server.http.PrometheusMetricsSink;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Test PrometheusMetricSink regarding VolumeIOStats.
+ */
+public class TestVolumeIOStatsWithPrometheusSink {
+  private MetricsSystem metrics;
+  private PrometheusMetricsSink sink;
+
+  @BeforeEach
+  public void init() {
+    metrics = DefaultMetricsSystem.instance();
+    metrics.init("test");
+    sink = new PrometheusMetricsSink();
+    metrics.register("Prometheus", "Prometheus", sink);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    metrics.stop();
+    metrics.shutdown();
+  }
+
+  @Test
+  public void testMultipleVolumeIOMetricsExist() throws IOException {
+    //GIVEN
+    VolumeIOStats volumeIOStats1 = new VolumeIOStats("VolumeIOStat1",
+        "vol1/dir");
+    VolumeIOStats volumeIOStat2 = new VolumeIOStats("VolumeIOStat2",
+        "vol2/dir");
+
+    //WHEN
+    String writtenMetrics = publishMetricsAndGetOutput();
+
+    //THEN
+    Assertions.assertTrue(
+        writtenMetrics.contains("storagedirectory=\"" +
+            volumeIOStats1.getStorageDirectory() + "\""),
+        "The expected metric line is missing from prometheus" +
+            " metrics output"
+    );
+    Assertions.assertTrue(
+        writtenMetrics.contains("storagedirectory=\"" +
+            volumeIOStat2.getStorageDirectory() + "\""),
+        "The expected metric line is missing from prometheus" +
+            " metrics output"
+    );
+  }
+  private String publishMetricsAndGetOutput() throws IOException {
+    metrics.publishMetricsNow();
+
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    OutputStreamWriter writer = new OutputStreamWriter(stream, UTF_8);
+
+    sink.writeMetrics(writer);
+    writer.flush();
+
+    return stream.toString(UTF_8.name());
+  }
+}

--- a/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
+++ b/hadoop-hdds/container-service/src/test/java/org/apache/hadoop/ozone/container/common/volume/TestVolumeIOStatsWithPrometheusSink.java
@@ -77,6 +77,7 @@ public class TestVolumeIOStatsWithPrometheusSink {
             " metrics output"
     );
   }
+
   private String publishMetricsAndGetOutput() throws IOException {
     metrics.publishMetricsNow();
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Prometheus can't distinguish between different volumes when getting data about VolumeIOStats. It's due to a MetricTag missing that would separate the volumes. Adding an additional tag fixes this issue.

## What is the link to the Apache JIRA

[HDDS-7120](https://issues.apache.org/jira/browse/HDDS-7120)

## How was this patch tested?

Added unit test for multiple VolumeIOStats.
Also deployed locally via a local docker container, different VolumeIOStats did show up.
