### PR TITLE
HDDS-7076. Log container file path when container cannot be written.

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -260,8 +260,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } catch (IOException ex) {
       onFailure(containerData.getVolume());
       throw new StorageContainerException("Error while creating/ updating " +
-          ".container file. ContainerID: " + containerId + " Container path: " +
-          containerFile.getAbsolutePath(), ex,
+          " container file. ContainerID: " + containerId +
+          " ,container path: " + containerFile.getAbsolutePath(), ex,
           CONTAINER_FILES_CREATE_ERROR);
     } finally {
       if (tempContainerFile != null && tempContainerFile.exists()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -259,9 +259,13 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
 
     } catch (IOException ex) {
       onFailure(containerData.getVolume());
-      throw new StorageContainerException("Error while creating/ updating " +
-          " container file. ContainerID: " + containerId +
-          " ,container path: " + containerFile.getAbsolutePath(), ex,
+      String containerExceptionMessage = "Error while creating/updating" +
+            " container file. ContainerID: " + containerId +
+            ", container path: " + containerFile.getAbsolutePath();
+      if (tempContainerFile == null) {
+        containerExceptionMessage += " Temporary file could not be created.";
+      }
+      throw new StorageContainerException(containerExceptionMessage, ex,
           CONTAINER_FILES_CREATE_ERROR);
     } finally {
       if (tempContainerFile != null && tempContainerFile.exists()) {

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainer.java
@@ -260,7 +260,8 @@ public class KeyValueContainer implements Container<KeyValueContainerData> {
     } catch (IOException ex) {
       onFailure(containerData.getVolume());
       throw new StorageContainerException("Error while creating/ updating " +
-          ".container file. ContainerID: " + containerId, ex,
+          ".container file. ContainerID: " + containerId + " Container path: " +
+          containerFile.getAbsolutePath(), ex,
           CONTAINER_FILES_CREATE_ERROR);
     } finally {
       if (tempContainerFile != null && tempContainerFile.exists()) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add container file path to error message when writing to container encounters an error

## What is the link to the Apache JIRA

[HDDS-7076](https://issues.apache.org/jira/browse/HDDS-7076)

## How was this patch tested?

Reproduce the error on a local cluster via taking away the write permission on container data by making its folder read only.