### PR TITLE
HDDS-7127. Fix Transparent Data Encryption documentation

### DIFF
--- a/hadoop-hdds/docs/content/security/SecuringTDE.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.md
@@ -33,7 +33,7 @@ when a bucket is created.
 
 To use TDE, admin must setup a Key Management Server and provide that URI to
 Ozone/HDFS. Since Ozone and HDFS can use the same Key Management Server, this
- configuration can be provided via *hdfs-site.xml*.
+ configuration can be provided via *core-site.xml*.
 
 Property| Value
 -----------------------------------|-----------------------------------------
@@ -49,7 +49,7 @@ To create an encrypted bucket, client need to:
   how you would use HDFS encryption zones.
 
   ```bash
-  hadoop key create encKey
+  hadoop key create enckey
   ```
   The above command creates an encryption key for the bucket you want to protect.
   Once the key is created, you can tell Ozone to use that key when you are
@@ -58,11 +58,11 @@ To create an encrypted bucket, client need to:
    * Assign the encryption key to a bucket.
 
   ```bash
-  ozone sh bucket create -k encKey /vol/encryptedbucket
+  ozone sh bucket create -k enckey /vol/encryptedbucket
   ```
 
 After this command, all data written to the _encryptedbucket_ will be encrypted
-via the encKey and while reading the clients will talk to Key Management
+via the enckey and while reading the clients will talk to Key Management
 Server and read the key and decrypt it. In other words, the data stored
 inside Ozone is always encrypted. The fact that data is encrypted at rest
 will be completely transparent to the clients and end users.
@@ -74,13 +74,13 @@ There are two ways to create an encrypted bucket that can be accessed via S3 Gat
 #### Option 1. Create a bucket using shell under "/s3v" volume
 
   ```bash
-  ozone sh bucket create -k encKey --layout=OBJECT_STORE /s3v/encryptedbucket
+  ozone sh bucket create -k enckey --layout=OBJECT_STORE /s3v/encryptedbucket
   ```
 
 #### Option 2. Create a link to an encrypted bucket under "/s3v" volume
 
   ```bash
-  ozone sh bucket create -k encKey --layout=OBJECT_STORE /vol/encryptedbucket
+  ozone sh bucket create -k enckey --layout=OBJECT_STORE /vol/encryptedbucket
   ozone sh bucket link /vol/encryptedbucket /s3v/linkencryptedbucket
   ```
 

--- a/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
@@ -52,4 +52,4 @@ hadoop.security.key.provider.path  | KMS uri. <br> 比如 kms://http@kms-host:96
   ozone sh bucket create -k enckey /vol/encryptedbucket
   ```
 
-这条命令执行后，所以写往 _encryptedbucket_ 的数据都会用 encKey 进行加密，当读取里面的数据时，客户端通过 KMS 获取密钥进行解密。换句话说，Ozone 中存储的数据一直是加密的，但用户和客户端对此完全无感知。
+这条命令执行后，所以写往 _encryptedbucket_ 的数据都会用 enckey 进行加密，当读取里面的数据时，客户端通过 KMS 获取密钥进行解密。换句话说，Ozone 中存储的数据一直是加密的，但用户和客户端对此完全无感知。

--- a/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
+++ b/hadoop-hdds/docs/content/security/SecuringTDE.zh.md
@@ -42,14 +42,14 @@ hadoop.security.key.provider.path  | KMS uri. <br> 比如 kms://http@kms-host:96
    * 使用 hadoop key 命令创建桶加密密钥，和 HDFS 加密区域的使用方法类似。
 
   ```bash
-  hadoop key create encKey
+  hadoop key create enckey
   ```
   上面这个命令会创建一个用于保护桶数据的密钥。创建完成之后，你可以告诉 Ozone 在读写某个桶中的数据时使用这个密钥。
 
    * 将加密密钥分配给桶
 
   ```bash
-  ozone sh bucket create -k encKey /vol/encryptedbucket
+  ozone sh bucket create -k enckey /vol/encryptedbucket
   ```
 
 这条命令执行后，所以写往 _encryptedbucket_ 的数据都会用 encKey 进行加密，当读取里面的数据时，客户端通过 KMS 获取密钥进行解密。换句话说，Ozone 中存储的数据一直是加密的，但用户和客户端对此完全无感知。


### PR DESCRIPTION
## What changes were proposed in this pull request?

The following docs issues are fixed:
* hadoop.security.key.provider.path must be set up via core-site.xml, not hdfs-site.xml
* encKey" is invalid name for hadoop kms key. Uppercase characters are not supported for keys

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7127

## How was this patch tested?

Unit tests are passed. No additional testing needed for documentation change.
