### PR TITLE
HDDS-7134. NPE when Ranger client throws RangerServiceException without Status.

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
+import com.sun.jersey.api.client.ClientResponse;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.OmUtils;
 import org.apache.hadoop.ozone.OzoneConsts;
@@ -148,17 +149,21 @@ public class RangerClientMultiTenantAccessController implements
    * @param rse RangerServiceException
    */
   private void decodeRSEStatusCodes(RangerServiceException rse) {
-
-    switch (rse.getStatus().getStatusCode()) {
-    case HTTP_STATUS_CODE_UNAUTHORIZED:
-      LOG.error("Auth failure. Please double check Ranger-related configs");
-      break;
-    case HTTP_STATUS_CODE_BAD_REQUEST:
-      LOG.error("Request failure. If this is an assign-user operation, "
-          + "check if the user name exists in Ranger.");
-      break;
-    default:
-      LOG.error("Other request failure: {}", rse.getStatus());
+    ClientResponse.Status status = rse.getStatus();
+    if (status == null) {
+      LOG.error("Request failure with no status provided.", rse);
+    } else {
+      switch (status.getStatusCode()) {
+        case HTTP_STATUS_CODE_UNAUTHORIZED:
+          LOG.error("Auth failure. Please double check Ranger-related configs");
+          break;
+        case HTTP_STATUS_CODE_BAD_REQUEST:
+          LOG.error("Request failure. If this is an assign-user operation, "
+                  + "check if the user name exists in Ranger.");
+          break;
+        default:
+          LOG.error("Other request failure. Status: {}", status);
+      }
     }
   }
 

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/multitenant/RangerClientMultiTenantAccessController.java
@@ -154,15 +154,15 @@ public class RangerClientMultiTenantAccessController implements
       LOG.error("Request failure with no status provided.", rse);
     } else {
       switch (status.getStatusCode()) {
-        case HTTP_STATUS_CODE_UNAUTHORIZED:
-          LOG.error("Auth failure. Please double check Ranger-related configs");
-          break;
-        case HTTP_STATUS_CODE_BAD_REQUEST:
-          LOG.error("Request failure. If this is an assign-user operation, "
-                  + "check if the user name exists in Ranger.");
-          break;
-        default:
-          LOG.error("Other request failure. Status: {}", status);
+      case HTTP_STATUS_CODE_UNAUTHORIZED:
+        LOG.error("Auth failure. Please double check Ranger-related configs");
+        break;
+      case HTTP_STATUS_CODE_BAD_REQUEST:
+        LOG.error("Request failure. If this is an assign-user operation, "
+            + "check if the user name exists in Ranger.");
+        break;
+      default:
+        LOG.error("Other request failure. Status: {}", status);
       }
     }
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

`RangerClientMultiTenantAccessController#decodeRSEStatusCodes` assumes the provided RangerServiceException will have a non-null status. However, Looking at the [constructors for the class](https://github.com/apache/ranger/blob/master/intg/src/main/java/org/apache/ranger/RangerServiceException.java) this may not always be true, and we have seen exceptions will null statuses during testing.

## What is the link to the Apache JIRA

HDDS-7134

## How was this patch tested?

N/A
