### PR TITLE
HDDS-6456. Update RocksDB Version to 7.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1630,7 +1630,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>7.2.2</version>
+        <version>7.4.5</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1630,7 +1630,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>7.0.4</version>
+        <version>7.2.2</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1630,7 +1630,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>6.29.5</version>
+        <version>7.0.4</version>
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change was reverted by [HDDS-6828](https://issues.apache.org/jira/browse/HDDS-6828).
I'm checking it back in as memory leak has been fixed as per HDDS-6722

https://issues.apache.org/jira/browse/HDDS-6456

## How was this patch tested?

Standard CI. https://github.com/duongnguyen0/ozone/actions/runs/2879138807

Also ran different workloads on my local cluster and verify no leaks were generated.