### PR TITLE
HDDS-7136. Memory leak due to ChunkInputStream.close() not releasing buffer

### DIFF
--- a/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
+++ b/hadoop-hdds/client/src/main/java/org/apache/hadoop/hdds/scm/storage/ChunkInputStream.java
@@ -282,6 +282,7 @@ public class ChunkInputStream extends InputStream
 
   @Override
   public synchronized void close() {
+    releaseBuffers();
     releaseClient();
   }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Release buffers when ChunkInputStream is closed.

https://issues.apache.org/jira/browse/HDDS-7136

## How was this patch tested?

Added unit test.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2880737539