### PR TITLE
HDDS-2954. Support admin groups

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/recon/ReconConfigKeys.java
@@ -65,4 +65,7 @@ public final class ReconConfigKeys {
    */
   public static final String OZONE_RECON_ADMINISTRATORS =
       "ozone.recon.administrators";
+
+  public static final String OZONE_RECON_ADMINISTRATORS_GROUPS =
+      "ozone.recon.administrators.groups";
 }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -129,6 +129,9 @@ public final class OzoneConfigKeys {
    * */
   public static final String OZONE_ADMINISTRATORS =
       "ozone.administrators";
+
+  public static final String OZONE_ADMINISTRATORS_GROUPS =
+      "ozone.administrators.groups";
   /**
    * Used only for testing purpose. Results in making every user an admin.
    * */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -376,6 +376,17 @@
     </description>
   </property>
   <property>
+    <name>ozone.administrators.groups</name>
+    <value/>
+    <tag>OZONE, SECURITY</tag>
+    <description>Ozone administrator groups delimited by the comma.
+      This is the list of groups who can access admin only information
+      from ozone.
+      It is enough to either have the name defined in ozone.administrators
+      or be directly or indirectly in a group defined in this property.
+    </description>
+  </property>
+  <property>
     <name>ozone.block.deleting.container.limit.per.interval</name>
     <value>10</value>
     <tag>OZONE, PERFORMANCE, SCM</tag>
@@ -2543,6 +2554,18 @@
       This is the list of users who can access admin only information from recon.
       Users defined in ozone.administrators will always be able to access all
       recon information regardless of this setting.
+    </description>
+  </property>
+  <property>
+    <name>ozone.recon.administrators.groups</name>
+    <value/>
+    <tag>RECON, SECURITY</tag>
+    <description>
+      Recon administrator groups delimited by a comma.
+      This is the list of groups who can access admin only information
+      from recon.
+      It is enough to either have the name defined in ozone.recon.administrators
+      or be directly or indirectly in a group defined in this property.
     </description>
   </property>
   <property>

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.server;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+
+import org.apache.hadoop.security.UserGroupInformation;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
+
+/**
+ * This class contains ozone admin user information, username and group,
+ * and is able to check whether the provided {@link UserGroupInformation}
+ * has admin permissions.
+ */
+public class OzoneAdmins {
+
+  /**
+   * Ozone super user / admin username list.
+   */
+  private final Set<String> adminUsernames;
+  /**
+   * Ozone super user / admin group list.
+   */
+  private final Set<String> adminGroups;
+
+  public OzoneAdmins(Collection<String> adminUsernames) {
+    this(adminUsernames, null);
+  }
+
+  public OzoneAdmins(Collection<String> adminUsernames,
+      Collection<String> adminGroups) {
+    this.adminUsernames = adminUsernames != null ?
+            new LinkedHashSet<>(adminUsernames) : Collections.emptySet();
+    this.adminGroups = adminGroups != null ?
+            new LinkedHashSet<>(adminGroups) : Collections.emptySet();
+  }
+
+  private boolean hasAdminGroup(Collection<String> userGroups) {
+    return !Sets.intersection(adminGroups,
+            new LinkedHashSet<>(userGroups)).isEmpty();
+  }
+
+  /**
+   * Check whether the provided {@link UserGroupInformation user}
+   * has admin permissions.
+   *
+   * @param user
+   *
+   * @return
+   */
+  public boolean isAdmin(UserGroupInformation user) {
+    return adminUsernames.contains(OZONE_ADMINISTRATORS_WILDCARD)
+        || adminUsernames.contains(user.getShortUserName())
+        || adminUsernames.contains(user.getUserName())
+        || hasAdminGroup(user.getGroups());
+  }
+
+  public Collection<String> getAdminGroups() {
+    return Collections.unmodifiableSet(adminGroups);
+  }
+
+  public Set<String> getAdminUsernames() {
+    return Collections.unmodifiableSet(adminUsernames);
+  }
+}

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/OzoneAdmins.java
@@ -51,14 +51,16 @@ public class OzoneAdmins {
   public OzoneAdmins(Collection<String> adminUsernames,
       Collection<String> adminGroups) {
     this.adminUsernames = adminUsernames != null ?
-            new LinkedHashSet<>(adminUsernames) : Collections.emptySet();
+        Collections.unmodifiableSet(new LinkedHashSet<>(adminUsernames)) :
+        Collections.emptySet();
     this.adminGroups = adminGroups != null ?
-            new LinkedHashSet<>(adminGroups) : Collections.emptySet();
+        Collections.unmodifiableSet(new LinkedHashSet<>(adminGroups)) :
+        Collections.emptySet();
   }
 
   private boolean hasAdminGroup(Collection<String> userGroups) {
     return !Sets.intersection(adminGroups,
-            new LinkedHashSet<>(userGroups)).isEmpty();
+        new LinkedHashSet<>(userGroups)).isEmpty();
   }
 
   /**
@@ -66,7 +68,6 @@ public class OzoneAdmins {
    * has admin permissions.
    *
    * @param user
-   *
    * @return
    */
   public boolean isAdmin(UserGroupInformation user) {
@@ -77,10 +78,10 @@ public class OzoneAdmins {
   }
 
   public Collection<String> getAdminGroups() {
-    return Collections.unmodifiableSet(adminGroups);
+    return adminGroups;
   }
 
   public Set<String> getAdminUsernames() {
-    return Collections.unmodifiableSet(adminUsernames);
+    return adminUsernames;
   }
 }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -195,18 +195,12 @@ public abstract class BaseHttpServer {
       final InetSocketAddress httpsAddr, String name) throws IOException {
     HttpConfig.Policy policy = getHttpPolicy(conf);
 
-    String userString = conf.get(OZONE_ADMINISTRATORS, " ");
+    String userString = conf.get(OZONE_ADMINISTRATORS, "");
     String groupString = conf.get(OZONE_ADMINISTRATORS_GROUPS, "");
-    String userGroupString;
-    if (!groupString.trim().isEmpty()) {
-      userGroupString = userString.trim() + " " + groupString.trim();
-    } else {
-      userGroupString = userString;
-    }
 
     HttpServer2.Builder builder = new HttpServer2.Builder().setName(name)
         .setConf(conf)
-        .setACL(new AccessControlList(userGroupString));
+        .setACL(new AccessControlList(userString, groupString));
 
     // initialize the webserver for uploading/downloading files.
     if (policy.isHttpEnabled()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/server/http/BaseHttpServer.java
@@ -45,6 +45,7 @@ import static org.apache.hadoop.hdds.HddsUtils.getPortNumberFromConfigKeys;
 import static org.apache.hadoop.hdds.HddsUtils.createDir;
 import static org.apache.hadoop.hdds.server.http.HttpConfig.getHttpPolicy;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_HTTPS_NEED_AUTH_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_CLIENT_HTTPS_NEED_AUTH_KEY;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_HTTP_SECURITY_ENABLED_DEFAULT;
@@ -194,9 +195,18 @@ public abstract class BaseHttpServer {
       final InetSocketAddress httpsAddr, String name) throws IOException {
     HttpConfig.Policy policy = getHttpPolicy(conf);
 
+    String userString = conf.get(OZONE_ADMINISTRATORS, " ");
+    String groupString = conf.get(OZONE_ADMINISTRATORS_GROUPS, "");
+    String userGroupString;
+    if (!groupString.trim().isEmpty()) {
+      userGroupString = userString.trim() + " " + groupString.trim();
+    } else {
+      userGroupString = userString;
+    }
+
     HttpServer2.Builder builder = new HttpServer2.Builder().setName(name)
-        .setConf(conf).setACL(new AccessControlList(conf.get(
-            OZONE_ADMINISTRATORS, " ")));
+        .setConf(conf)
+        .setACL(new AccessControlList(userGroupString));
 
     // initialize the webserver for uploading/downloading files.
     if (policy.isHttpEnabled()) {

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/DBCheckpointServlet.java
@@ -66,7 +66,7 @@ public class DBCheckpointServlet extends HttpServlet {
 
   private boolean aclEnabled;
   private boolean isSpnegoEnabled;
-  private transient OzoneAdmins allowedUsers;
+  private transient OzoneAdmins admins;
 
   public void initialize(DBStore store, DBCheckpointMetrics metrics,
                          boolean omAclEnabled,
@@ -83,7 +83,7 @@ public class DBCheckpointServlet extends HttpServlet {
     }
 
     this.aclEnabled = omAclEnabled;
-    this.allowedUsers = new OzoneAdmins(allowedAdminUsers, allowedAdminGroups);
+    this.admins = new OzoneAdmins(allowedAdminUsers, allowedAdminGroups);
     this.isSpnegoEnabled = isSpnegoAuthEnabled;
   }
 
@@ -91,7 +91,7 @@ public class DBCheckpointServlet extends HttpServlet {
     // Check ACL for dbCheckpoint only when global Ozone ACL and SPNEGO is
     // enabled
     if (aclEnabled && isSpnegoEnabled) {
-      return allowedUsers.isAdmin(user);
+      return admins.isAdmin(user);
     } else {
       return true;
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/server/SCMDBCheckpointServlet.java
@@ -60,6 +60,7 @@ public class SCMDBCheckpointServlet extends DBCheckpointServlet {
         scm.getMetrics().getDBCheckpointMetrics(),
         false,
         Collections.emptyList(),
+        Collections.emptyList(),
         false);
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -118,6 +118,7 @@ public class TestSCMDbCheckpointServlet {
           scmMetrics.getDBCheckpointMetrics(),
           false,
           Collections.emptyList(),
+          Collections.emptyList(),
           false);
 
       HttpServletRequest requestMock = mock(HttpServletRequest.class);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -33,6 +33,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.Collection;
+import java.util.Collections;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
@@ -176,6 +177,7 @@ public class TestOMDbCheckpointServlet {
         om.getMetrics().getDBCheckpointMetrics(),
         om.getAclsEnabled(),
         om.getOmAdminUsernames(),
+        om.getOmAdminGroups(),
         om.isSpnegoEnabled());
 
     doNothing().when(responseMock).setContentType("application/x-tgz");
@@ -219,6 +221,7 @@ public class TestOMDbCheckpointServlet {
         om.getMetrics().getDBCheckpointMetrics(),
         om.getAclsEnabled(),
         allowedUsers,
+        Collections.emptyList(),
         om.isSpnegoEnabled());
 
     omDbCheckpointServletMock.init();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -223,7 +223,7 @@ public class TestOMDbCheckpointServlet {
         om.getMetrics().getDBCheckpointMetrics(),
         om.getAclsEnabled(),
         allowedUsers,
-        Collections.emptyList(),
+        Collections.emptySet(),
         om.isSpnegoEnabled());
 
     omDbCheckpointServletMock.init();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/om/TestOMDbCheckpointServlet.java
@@ -34,6 +34,7 @@ import java.nio.file.Paths;
 import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.utils.db.DBCheckpoint;
@@ -213,7 +214,8 @@ public class TestOMDbCheckpointServlet {
     setupCluster();
 
     final OzoneManager om = cluster.getOzoneManager();
-    Collection<String> allowedUsers = om.getOmAdminUsernames();
+    Collection<String> allowedUsers =
+            new LinkedHashSet<>(om.getOmAdminUsernames());
     allowedUsers.add("recon");
 
     doCallRealMethod().when(omDbCheckpointServletMock).initialize(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -30,6 +30,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
 
 /**
  * Provides the current checkpoint Snapshot of the OM DB. (tar.gz)
@@ -63,7 +64,8 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
 
     OzoneConfiguration conf = om.getConfiguration();
     // Only Ozone Admins and Recon are allowed
-    Collection<String> allowedUsers = om.getOmAdminUsernames();
+    Collection<String> allowedUsers =
+            new LinkedHashSet<>(om.getOmAdminUsernames());
     Collection<String> allowedGroups = om.getOmAdminGroups();
     ReconConfig reconConfig = conf.getObject(ReconConfig.class);
     String reconPrincipal = reconConfig.getKerberosPrincipal();

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OMDBCheckpointServlet.java
@@ -64,6 +64,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
     OzoneConfiguration conf = om.getConfiguration();
     // Only Ozone Admins and Recon are allowed
     Collection<String> allowedUsers = om.getOmAdminUsernames();
+    Collection<String> allowedGroups = om.getOmAdminGroups();
     ReconConfig reconConfig = conf.getObject(ReconConfig.class);
     String reconPrincipal = reconConfig.getKerberosPrincipal();
     if (!reconPrincipal.isEmpty()) {
@@ -76,6 +77,7 @@ public class OMDBCheckpointServlet extends DBCheckpointServlet {
         om.getMetrics().getDBCheckpointMetrics(),
         om.getAclsEnabled(),
         allowedUsers,
+        allowedGroups,
         om.isSpnegoEnabled());
   }
 }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneManager.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hdds.protocol.proto.SCMSecurityProtocolProtos.SCMGetCer
 import org.apache.hadoop.hdds.protocolPB.SCMSecurityProtocolClientSideTranslatorPB;
 import org.apache.hadoop.hdds.scm.ScmInfo;
 import org.apache.hadoop.hdds.scm.client.HddsClientUtils;
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.hdds.utils.db.Table;
 import org.apache.hadoop.hdds.utils.db.Table.KeyValue;
 import org.apache.hadoop.hdds.utils.db.TableIterator;
@@ -226,7 +227,6 @@ import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_FLEXIBLE_FQDN_RESOLUTION_ENABLED_DEFAULT;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_KEY_PREALLOCATION_BLOCKS_MAX;
@@ -334,8 +334,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
   /**
    * OM super user / admin list.
    */
-  private final Collection<String> omAdminUsernames;
-  private final Collection<String> omAdminGroups;
+  private final OzoneAdmins omAdmins;
 
   private final OMMetrics metrics;
   private final ProtocolMessageMetrics<ProtocolMessageEnum>
@@ -574,8 +573,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         OMMultiTenantManager.checkAndEnableMultiTenancy(this, conf);
 
     // Get admin list
-    omAdminUsernames = getOzoneAdminsFromConfig(configuration);
-    omAdminGroups = getOzoneAdminsGroupsFromConfig(configuration);
+    Collection<String> omAdminUsernames =
+        getOzoneAdminsFromConfig(configuration);
+    Collection<String> omAdminGroups =
+        getOzoneAdminsGroupsFromConfig(configuration);
+    omAdmins = new OzoneAdmins(omAdminUsernames, omAdminGroups);
     instantiateServices(false);
 
     // Create special volume s3v which is required for S3G.
@@ -751,8 +753,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
         authorizer.setBucketManager(bucketManager);
         authorizer.setKeyManager(keyManager);
         authorizer.setPrefixManager(prefixManager);
-        authorizer.setOzoneAdmins(omAdminUsernames);
-        authorizer.setOzoneAdminGroups(omAdminGroups);
+        authorizer.setOzoneAdmins(omAdmins);
         authorizer.setAllowListAllVolumes(allowListAllVolumes);
       }
     } else {
@@ -4081,11 +4082,11 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * Return the list of Ozone administrators in effect.
    */
   Collection<String> getOmAdminUsernames() {
-    return omAdminUsernames;
+    return omAdmins.getAdminUsernames();
   }
 
   public Collection<String> getOmAdminGroups() {
-    return omAdminGroups;
+    return omAdmins.getAdminGroups();
   }
 
   /**
@@ -4093,31 +4094,7 @@ public final class OzoneManager extends ServiceRuntimeInfoImpl
    * @param callerUgi Caller UserGroupInformation
    */
   public boolean isAdmin(UserGroupInformation callerUgi) {
-    if (callerUgi == null) {
-      return false;
-    } else {
-      return isAdmin(callerUgi.getShortUserName())
-          || isAdmin(callerUgi.getUserName())
-          || callerUgi.getGroups().stream().anyMatch(this::isAdminGroup);
-    }
-  }
-
-  @VisibleForTesting
-  private boolean isAdmin(String username) {
-    if (omAdminUsernames == null) {
-      return false;
-    } else {
-      return omAdminUsernames.contains(OZONE_ADMINISTRATORS_WILDCARD) ||
-          omAdminUsernames.contains(username);
-    }
-  }
-
-  public boolean isAdminGroup(String groupName) {
-    if (omAdminGroups == null) {
-      return false;
-    } else {
-      return omAdminGroups.contains(groupName);
-    }
+    return callerUgi != null && omAdmins.isAdmin(callerUgi);
   }
 
   /**

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneAdministrators.java
@@ -18,13 +18,13 @@
 
 package org.apache.hadoop.ozone.security.acl;
 
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.ozone.om.exceptions.OMException;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import static java.util.Arrays.asList;
@@ -44,7 +44,8 @@ public class TestOzoneAdministrators {
 
   @Test
   public void testCreateVolume() throws Exception {
-    UserGroupInformation.createUserForTesting("testuser", new String[]{"testgroup"});
+    UserGroupInformation.createUserForTesting("testuser",
+        new String[]{"testgroup"});
     try {
       OzoneObj obj = getTestVolumeobj("testvolume");
       RequestContext context = getUserRequestContext("testuser",
@@ -58,7 +59,8 @@ public class TestOzoneAdministrators {
 
   @Test
   public void testListAllVolume() throws Exception {
-    UserGroupInformation.createUserForTesting("testuser", new String[]{"testgroup"});
+    UserGroupInformation.createUserForTesting("testuser",
+        new String[]{"testgroup"});
     try {
       OzoneObj obj = getTestVolumeobj("/");
       RequestContext context = getUserRequestContext("testuser",
@@ -72,40 +74,44 @@ public class TestOzoneAdministrators {
 
   private void testAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
-    nativeAuthorizer.setOzoneAdmins(Collections.emptyList());
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(Collections.emptyList()));
     Assert.assertFalse("empty admin list disallow anyone to perform " +
             "admin operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(
-        Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD));
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+        Collections.singletonList(OZONE_ADMINISTRATORS_WILDCARD)));
     Assert.assertTrue("wildcard admin allows everyone to perform admin" +
         " operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(
-        Collections.singletonList("testuser"));
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+        Collections.singletonList("testuser")));
     Assert.assertTrue("matching admins are allowed to perform admin " +
             "operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(
-        asList(new String[]{"testuser2", "testuser"}));
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+        asList(new String[]{"testuser2", "testuser"})));
     Assert.assertTrue("matching admins are allowed to perform admin " +
             "operations", nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdmins(
-        asList(new String[]{"testuser2", "testuser3"}));
+    nativeAuthorizer.setOzoneAdmins(new OzoneAdmins(
+        asList(new String[]{"testuser2", "testuser3"})));
     Assert.assertFalse("mismatching admins are not allowed perform " +
         "admin operations", nativeAuthorizer.checkAccess(obj, context));
   }
 
   private void testGroupAdminOperations(OzoneObj obj, RequestContext context)
       throws OMException {
-    nativeAuthorizer.setOzoneAdminGroups(asList("testgroup", "anothergroup"));
+    nativeAuthorizer.setOzoneAdmins(
+        new OzoneAdmins(null, asList("testgroup", "anothergroup")));
     Assert.assertTrue("Users from matching admin groups " +
-        "are allowed to perform admin operations", nativeAuthorizer.checkAccess(obj, context));
+        "are allowed to perform admin operations",
+            nativeAuthorizer.checkAccess(obj, context));
 
-    nativeAuthorizer.setOzoneAdminGroups(asList("wronggroup"));
+    nativeAuthorizer.setOzoneAdmins(
+            new OzoneAdmins(null, asList("wronggroup")));
     Assert.assertFalse("Users from mismatching admin groups " +
-        "are allowed to perform admin operations", nativeAuthorizer.checkAccess(obj, context));
+        "are allowed to perform admin operations",
+            nativeAuthorizer.checkAccess(obj, context));
   }
 
   private RequestContext getUserRequestContext(String username,

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestOzoneNativeAuthorizer.java
@@ -21,6 +21,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -159,7 +160,7 @@ public class TestOzoneNativeAuthorizer {
     writeClient = omTestManagers.getWriteClient();
     nativeAuthorizer = new OzoneNativeAuthorizer(volumeManager, bucketManager,
         keyManager, prefixManager,
-        Collections.singletonList("om"));
+        new OzoneAdmins(Collections.singletonList("om")));
     adminUgi = UserGroupInformation.createUserForTesting("om",
         new String[]{"ozone"});
     testUgi = UserGroupInformation.createUserForTesting("testuser",
@@ -400,7 +401,8 @@ public class TestOzoneNativeAuthorizer {
       String msg = "Acl to check:" + a1 + " accessType:" +
           accessType + " path:" + obj.getPath();
       if (a1.equals(CREATE) && obj.getResourceType().equals(VOLUME)) {
-        assertEquals(msg, nativeAuthorizer.getOzoneAdmins().contains(user),
+        assertEquals(msg, nativeAuthorizer.getOzoneAdmins()
+                         .getAdminUsernames().contains(user),
             nativeAuthorizer.checkAccess(obj,
                 builder.setAclRights(a1).build()));
       } else {
@@ -521,7 +523,7 @@ public class TestOzoneNativeAuthorizer {
     allAcls.remove(NONE);
     RequestContext ctx = builder.build();
     boolean expectedResult = expectedAclResult;
-    if (nativeAuthorizer.getOzoneAdmins().contains(
+    if (nativeAuthorizer.getOzoneAdmins().getAdminUsernames().contains(
         ctx.getClientUgi().getUserName())) {
       expectedResult = true;
     }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestParentAcl.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.hdds.utils.db.cache.CacheKey;
 import org.apache.hadoop.hdds.utils.db.cache.CacheValue;
 import org.apache.hadoop.ozone.OzoneAcl;
@@ -109,7 +110,7 @@ public class TestParentAcl {
     writeClient = omTestManagers.getWriteClient();
     nativeAuthorizer = new OzoneNativeAuthorizer(volumeManager, bucketManager,
         keyManager, prefixManager,
-        Collections.singletonList("om"));
+        new OzoneAdmins(Collections.singletonList("om")));
     adminUgi = UserGroupInformation.createUserForTesting("om",
         new String[]{"ozone"});
     testUgi = UserGroupInformation.createUserForTesting("testuser",

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/security/acl/TestVolumeOwner.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.ozone.security.acl;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.ozone.om.BucketManager;
 import org.apache.hadoop.ozone.om.KeyManager;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
@@ -89,7 +90,7 @@ public class TestVolumeOwner {
     writeClient = omTestManagers.getWriteClient();
     nativeAuthorizer = new OzoneNativeAuthorizer(volumeManager, bucketManager,
         keyManager, prefixManager,
-        Collections.singletonList("om"));
+        new OzoneAdmins(Collections.singletonList("om")));
 
     testUgi = UserGroupInformation.createUserForTesting("testuser",
         new String[]{"test"});

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAdminFilter.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAdminFilter.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.ozone.recon.api.filters;
 
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.recon.ReconConfigKeys;
+import org.apache.hadoop.hdds.server.OzoneAdmins;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
@@ -38,10 +38,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 
 /**
  * Filter that can be applied to paths to only allow access by configured
@@ -109,14 +105,11 @@ public class ReconAdminFilter implements Filter {
         conf.getStringCollection(OzoneConfigKeys.OZONE_ADMINISTRATORS);
     admins.addAll(
         conf.getStringCollection(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS));
-    Set<String> adminGroups =
-        new HashSet<>(conf.getStringCollection(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS));
+    Collection<String> adminGroups =
+        conf.getStringCollection(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS);
     adminGroups.addAll(
-        conf.getStringCollection(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS));
-
-    return admins.contains(OZONE_ADMINISTRATORS_WILDCARD)
-        || admins.contains(user.getShortUserName())
-        || admins.contains(user.getUserName())
-        || !Sets.intersection(adminGroups, new HashSet<>(user.getGroups())).isEmpty();
+        conf.getStringCollection(
+            ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS));
+    return new OzoneAdmins(admins, adminGroups).isAdmin(user);
   }
 }

--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAdminFilter.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/api/filters/ReconAdminFilter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.ozone.recon.api.filters;
 
+import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -37,6 +38,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.security.Principal;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
 
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD;
 
@@ -106,8 +109,14 @@ public class ReconAdminFilter implements Filter {
         conf.getStringCollection(OzoneConfigKeys.OZONE_ADMINISTRATORS);
     admins.addAll(
         conf.getStringCollection(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS));
+    Set<String> adminGroups =
+        new HashSet<>(conf.getStringCollection(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS));
+    adminGroups.addAll(
+        conf.getStringCollection(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS));
+
     return admins.contains(OZONE_ADMINISTRATORS_WILDCARD)
         || admins.contains(user.getShortUserName())
-        || admins.contains(user.getUserName());
+        || admins.contains(user.getUserName())
+        || !Sets.intersection(adminGroups, new HashSet<>(user.getGroups())).isEmpty();
   }
 }

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
@@ -104,10 +104,12 @@ public class TestAdminFilter {
         OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD);
     testAdminFilterWithPrincipal(conf, "other", true);
 
-    UserGroupInformation.createUserForTesting("user1", new String[]{"admingroup"});
+    UserGroupInformation.createUserForTesting("user1",
+        new String[]{"admingroup"});
     try {
       conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS, "ozone");
-      conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS, "admingroup");
+      conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS,
+          "admingroup");
       testAdminFilterWithPrincipal(conf, "user1", true);
     } finally {
       UserGroupInformation.reset();
@@ -125,10 +127,12 @@ public class TestAdminFilter {
         OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD);
     testAdminFilterWithPrincipal(conf, "other", true);
 
-    UserGroupInformation.createUserForTesting("user1", new String[]{"reconadmingroup"});
+    UserGroupInformation.createUserForTesting("user1",
+        new String[]{"reconadmingroup"});
     try {
       conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS, "recon");
-      conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS, "reconadmingroup");
+      conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS,
+          "reconadmingroup");
       testAdminFilterWithPrincipal(conf, "user1", true);
     } finally {
       UserGroupInformation.reset();

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/api/filters/TestAdminFilter.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.ozone.recon.api.NodeEndpoint;
 import org.apache.hadoop.ozone.recon.api.PipelineEndpoint;
 import org.apache.hadoop.ozone.recon.api.TaskStatusService;
 import org.apache.hadoop.ozone.recon.api.UtilizationEndpoint;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -102,6 +103,15 @@ public class TestAdminFilter {
     conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS,
         OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD);
     testAdminFilterWithPrincipal(conf, "other", true);
+
+    UserGroupInformation.createUserForTesting("user1", new String[]{"admingroup"});
+    try {
+      conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS, "ozone");
+      conf.setStrings(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS, "admingroup");
+      testAdminFilterWithPrincipal(conf, "user1", true);
+    } finally {
+      UserGroupInformation.reset();
+    }
   }
 
   @Test
@@ -114,6 +124,15 @@ public class TestAdminFilter {
     conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS,
         OzoneConfigKeys.OZONE_ADMINISTRATORS_WILDCARD);
     testAdminFilterWithPrincipal(conf, "other", true);
+
+    UserGroupInformation.createUserForTesting("user1", new String[]{"reconadmingroup"});
+    try {
+      conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS, "recon");
+      conf.setStrings(ReconConfigKeys.OZONE_RECON_ADMINISTRATORS_GROUPS, "reconadmingroup");
+      testAdminFilterWithPrincipal(conf, "user1", true);
+    } finally {
+      UserGroupInformation.reset();
+    }
   }
 
   @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

Two new properties have been added to support admin groups:
- "ozone.administrators.groups" 
- "ozone.recon.administrators.groups"

These properties are somewhat similar to existing "ozone.administrators" and  "ozone.recon.administrators" (hence the naming) but specify groups the user is directly or indirectly a part of.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-2954


## How was this patch tested?

unit tests and manual testing
