### PR TITLE
HDDS-7135. ofs file input stream should support StreamCapabilities interface

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -54,7 +54,6 @@ public abstract class AbstractContractUnbufferTest
   public void testUnbufferAfterRead() throws IOException {
     describe("unbuffer a file after a single read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
-      assertTrue(stream.hasCapability("in:unbuffer"));
       validateFullFileContents(stream);
       unbuffer(stream);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/contract/AbstractContractUnbufferTest.java
@@ -54,6 +54,7 @@ public abstract class AbstractContractUnbufferTest
   public void testUnbufferAfterRead() throws IOException {
     describe("unbuffer a file after a single read");
     try (FSDataInputStream stream = getFileSystem().open(file)) {
+      assertTrue(stream.hasCapability("in:unbuffer"));
       validateFullFileContents(stream);
       unbuffer(stream);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -21,12 +21,14 @@ package org.apache.hadoop.fs.ozone;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.InvalidPathException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathIsNotEmptyDirectoryException;
+import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.TrashPolicy;
 import org.apache.hadoop.fs.contract.ContractTestUtils;
@@ -1719,6 +1721,21 @@ public class TestRootedOzoneFileSystem {
     final OzoneKeyDetails key = bucket.getKey(ofsPath.getKeyName());
     Assert.assertEquals(ReplicationType.EC.name(),
         key.getReplicationConfig().getReplicationType().name());
+  }
+
+  @Test
+  public void testUnbufferBeforeRead() throws IOException {
+    String testKeyName = "testKey2";
+    Path path = new Path(bucketPath, testKeyName);
+    try (FSDataOutputStream stream = fs.create(path)) {
+      stream.write(1);
+    }
+
+    try (FSDataInputStream stream = fs.open(path)) {
+      assertTrue(stream.hasCapability(StreamCapabilities.UNBUFFER));
+      stream.unbuffer();
+    }
+
   }
 
   public void testNonPrivilegedUserMkdirCreateBucket() throws IOException {

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/fs/ozone/TestRootedOzoneFileSystem.java
@@ -1724,7 +1724,7 @@ public class TestRootedOzoneFileSystem {
   }
 
   @Test
-  public void testUnbufferBeforeRead() throws IOException {
+  public void testUnbuffer() throws IOException {
     String testKeyName = "testKey2";
     Path path = new Path(bucketPath, testKeyName);
     try (FSDataOutputStream stream = fs.create(path)) {

--- a/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-common/src/main/java/org/apache/hadoop/fs/ozone/BasicRootedOzoneFileSystem.java
@@ -54,6 +54,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
@@ -194,8 +195,11 @@ public class BasicRootedOzoneFileSystem extends FileSystem {
     statistics.incrementReadOps(1);
     LOG.trace("open() path: {}", path);
     final String key = pathToKey(path);
-    return new FSDataInputStream(
-        new OzoneFSInputStream(adapter.readFile(key), statistics));
+    return new FSDataInputStream(createFSInputStream(adapter.readFile(key)));
+  }
+
+  protected InputStream createFSInputStream(InputStream inputStream) {
+    return new OzoneFSInputStream(inputStream, statistics);
   }
 
   protected void incrementCounter(Statistic statistic) {

--- a/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs-hadoop3/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 
 /**
@@ -91,5 +92,10 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
       String omHost, int omPort) throws IOException {
     return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
         storageStatistics);
+  }
+
+  @Override
+  protected InputStream createFSInputStream(InputStream inputStream) {
+    return new CapableOzoneFSInputStream(inputStream, statistics);
   }
 }

--- a/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
+++ b/hadoop-ozone/ozonefs/src/main/java/org/apache/hadoop/fs/ozone/RootedOzoneFileSystem.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.StorageStatistics;
 import org.apache.hadoop.security.token.DelegationTokenIssuer;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 
 /**
@@ -91,5 +92,10 @@ public class RootedOzoneFileSystem extends BasicRootedOzoneFileSystem
       String omHost, int omPort) throws IOException {
     return new RootedOzoneClientAdapterImpl(omHost, omPort, conf,
         storageStatistics);
+  }
+
+  @Override
+  protected InputStream createFSInputStream(InputStream inputStream) {
+    return new CapableOzoneFSInputStream(inputStream, statistics);
   }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

https://issues.apache.org/jira/browse/HDDS-7135

Make sure that OFS returns an input stream that is wrapped by CapableOzoneFSInputStream when it is shaded with Hadoop3 dependency. CapableOzoneFSInputStream support StreamCapabilities API.

The StreamCapabilities API is added only in Hadoop3, so the Hadoop2-based filesystem jar returns the input stream wrapped by OzoneFSInputStream.

## How was this patch tested?
A simple assertion is added to validate the StreamCapabilities in the file system contrast test.
(Please explain how this patch was tested. Ex: unit tests, manual tests)
(If this patch involves UI changes, please attach a screen-shot; otherwise, remove this)
