### PR TITLE
HDDS-7147. DirectoryDeletingService doesn't run in the expected interval for FSO

### DIFF
--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/KeyManagerImpl.java
@@ -257,7 +257,7 @@ public class KeyManagerImpl implements KeyManager {
           OZONE_BLOCK_DELETING_SERVICE_TIMEOUT_DEFAULT,
           TimeUnit.MILLISECONDS);
       dirDeletingService = new DirectoryDeletingService(dirDeleteInterval,
-          TimeUnit.SECONDS, serviceTimeout, ozoneManager, configuration);
+          TimeUnit.MILLISECONDS, serviceTimeout, ozoneManager, configuration);
       dirDeletingService.start();
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DirectoryDeletingService` is supposed to run every 60s by default for FSO buckets. Due to a wrong conversion, Instead of 60s it runs every 60000s~=16hours.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7147

## How was this patch tested?

The patch was tested manually on a real cluster. 
