### PR TITLE
HDDS-7150. Freon fail-at-end option caused not shutdown

### DIFF
--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/freon/BaseFreonGenerator.java
@@ -210,7 +210,7 @@ public class BaseFreonGenerator {
   }
 
   private void shutdown() {
-    if (failureCounter.get() > 0 && !failAtEnd) {
+    if (failureCounter.get() > 0) {
       progressBar.terminate();
     } else {
       progressBar.shutdown();


### PR DESCRIPTION
## What changes were proposed in this pull request?
Currently if turned on the fail-at-end option and the freon tasks have failures, `shotdown()` will be processed. It waits for the progress bar to be completed, while the progress bar will not naturally finish as there are failures. Thus the freon gets stuck.
```
    if (failureCounter.get() > 0 && !failAtEnd) {
      progressBar.terminate();
    } else {
      progressBar.shutdown();
    }
```
We shall simply remove the flag check here,  when Freon goes into ```shutdown```, it has processed all tasks in     waitForCompletion().

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7150

## How was this patch tested?
Manual test on the cluster