### PR TITLE
HDDS-7139. INVALID_TOKEN is handled as internal error in S3G

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -47,7 +47,7 @@ Get object from s3
 
 #This test depends on the previous test case. Can't be executed alone
 Get object with wrong signature
-    Return From Keyword if    '${SECURITY_ENABLED}' == 'false'
+    Pass Execution If          '${SECURITY_ENABLED}' == 'false'    Skip in unsecure cluster
     ${result} =                 Execute and Ignore Error   curl -i -H 'Authorization: AWS scm/scm@EXAMPLE.COM:asdfqwerty' ${ENDPOINT_URL}/${BUCKET}/${PREFIX}/putobject/key=value/f1
                                 Should contain             ${result}        403 Forbidden
 

--- a/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/objectputget.robot
@@ -45,6 +45,12 @@ Get object from s3
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/f1 /tmp/testfile.result
     Compare files               /tmp/testfile              /tmp/testfile.result
 
+#This test depends on the previous test case. Can't be executed alone
+Get object with wrong signature
+    Return From Keyword if    '${SECURITY_ENABLED}' == 'false'
+    ${result} =                 Execute and Ignore Error   curl -i -H 'Authorization: AWS scm/scm@EXAMPLE.COM:asdfqwerty' ${ENDPOINT_URL}/${BUCKET}/${PREFIX}/putobject/key=value/f1
+                                Should contain             ${result}        403 Forbidden
+
 Get Partial object from s3 with both start and endoffset
     ${result} =                 Execute AWSS3ApiCli        get-object --bucket ${BUCKET} --key ${PREFIX}/putobject/key=value/f1 --range bytes=0-4 /tmp/testfile1.result
                                 Should contain             ${result}        ContentRange

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/BucketEndpoint.java
@@ -146,7 +146,7 @@ public class BucketEndpoint extends EndpointBase {
       AUDIT.logReadFailure(
           buildAuditMessageForFailure(s3GAction, getAuditParameters(), ex));
       getMetrics().incGetBucketFailure();
-      if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw ex;
@@ -300,7 +300,7 @@ public class BucketEndpoint extends EndpointBase {
           buildAuditMessageForFailure(s3GAction, getAuditParameters(),
               exception));
       getMetrics().incListMultipartUploadsFailure();
-      if (exception.getResult() == ResultCodes.PERMISSION_DENIED) {
+      if (isAccessDenied(exception)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, prefix, exception);
       }
       throw exception;
@@ -355,7 +355,7 @@ public class BucketEndpoint extends EndpointBase {
         throw newError(S3ErrorTable.BUCKET_NOT_EMPTY, bucketName, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw ex;
@@ -400,7 +400,7 @@ public class BucketEndpoint extends EndpointBase {
             result.addDeleted(new DeletedObject(keyToDelete.getKey()));
           }
         } catch (OMException ex) {
-          if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+          if (isAccessDenied(ex)) {
             result.addError(
                 new Error(keyToDelete.getKey(), "PermissionDenied",
                     ex.getMessage()));
@@ -463,7 +463,7 @@ public class BucketEndpoint extends EndpointBase {
       auditReadFailure(S3GAction.GET_ACL, ex);
       if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, ex);
       } else {
         throw newError(S3ErrorTable.INTERNAL_ERROR, bucketName, ex);
@@ -565,7 +565,7 @@ public class BucketEndpoint extends EndpointBase {
       auditWriteFailure(S3GAction.PUT_ACL, exception);
       if (exception.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, exception);
-      } else if (exception.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(exception)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucketName, exception);
       }
       throw exception;

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/EndpointBase.java
@@ -305,4 +305,11 @@ public abstract class EndpointBase implements Auditor {
     AUDIT.logReadFailure(
         buildAuditMessageForFailure(action, getAuditParameters(), ex));
   }
+
+  protected boolean isAccessDenied(OMException ex) {
+    ResultCodes result = ex.getResult();
+    return result == ResultCodes.PERMISSION_DENIED
+        || result == ResultCodes.INVALID_TOKEN;
+  }
+
 }

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -230,7 +230,7 @@ public class ObjectEndpoint extends EndpointBase {
             " considered as Unix Paths. Path has Violated FS Semantics " +
             "which caused put operation to fail.");
         throw os3Exception;
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
@@ -367,7 +367,7 @@ public class ObjectEndpoint extends EndpointBase {
       }
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_KEY, keyPath, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
@@ -426,7 +426,7 @@ public class ObjectEndpoint extends EndpointBase {
       if (ex.getResult() == ResultCodes.KEY_NOT_FOUND) {
         // Just return 404 with no content
         return Response.status(Status.NOT_FOUND).build();
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, bucketName, ex);
@@ -524,7 +524,7 @@ public class ObjectEndpoint extends EndpointBase {
         // to true will throw DIRECTORY_NOT_EMPTY error for a non-empty dir.
         // NOT_FOUND is not a problem, AWS doesn't throw exception for missing
         // keys. Just return 204
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, keyPath, ex);
       } else {
         throw ex;
@@ -587,7 +587,7 @@ public class ObjectEndpoint extends EndpointBase {
     } catch (OMException ex) {
       auditWriteFailure(s3GAction, ex);
       getMetrics().incInitMultiPartUploadFailure();
-      if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, key, ex);
       }
       throw ex;
@@ -777,7 +777,7 @@ public class ObjectEndpoint extends EndpointBase {
       getMetrics().incCreateMultipartKeyFailure();
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED, bucket + "/" + key, ex);
       }
       throw ex;
@@ -834,7 +834,7 @@ public class ObjectEndpoint extends EndpointBase {
       getMetrics().incListPartsFailure();
       if (ex.getResult() == ResultCodes.NO_SUCH_MULTIPART_UPLOAD_ERROR) {
         throw newError(NO_SUCH_UPLOAD, uploadID, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED,
             bucket + "/" + key + "/" + uploadID, ex);
       }
@@ -921,7 +921,7 @@ public class ObjectEndpoint extends EndpointBase {
         throw newError(S3ErrorTable.NO_SUCH_KEY, sourceKey, ex);
       } else if (ex.getResult() == ResultCodes.BUCKET_NOT_FOUND) {
         throw newError(S3ErrorTable.NO_SUCH_BUCKET, sourceBucket, ex);
-      } else if (ex.getResult() == ResultCodes.PERMISSION_DENIED) {
+      } else if (isAccessDenied(ex)) {
         throw newError(S3ErrorTable.ACCESS_DENIED,
             destBucket + "/" + destkey, ex);
       }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Providing wrong signature (authentication) for S3 request should result in access denied (403), but currently it results in server error (500) instead:

```
$ kinit -kt /etc/security/keytabs/scm.keytab scm/scm@EXAMPLE.COM
$ ozone sh bucket create /s3v/bucket
$ ozone sh key put /s3v/bucket/passwd /etc/passwd
$ curl -i -X GET 'http://s3g:9878/bucket/passwd' -H 'Authorization: AWS scm/scm@EXAMPLE.COM:asdfqwerty'
HTTP/1.1 500 Server Error
...
```

Server-side log:

```
s3g_1       | 2022-08-18 17:58:41,466 [qtp1178587240-20] WARN server.HttpChannelState: unhandled due to prior sendError
s3g_1       | javax.servlet.ServletException: javax.servlet.ServletException: org.glassfish.jersey.server.ContainerException: INVALID_TOKEN org.apache.hadoop.ozone.om.exceptions.OMException: User scm/scm@EXAMPLE.COM request authorization failure: signatures do NOT match
...
s3g_1       | Caused by: INVALID_TOKEN org.apache.hadoop.ozone.om.exceptions.OMException: User scm/scm@EXAMPLE.COM request authorization failure: signatures do NOT match
s3g_1       | 	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.handleError(OzoneManagerProtocolClientSideTranslatorPB.java:696)
s3g_1       | 	at org.apache.hadoop.ozone.om.protocolPB.OzoneManagerProtocolClientSideTranslatorPB.getS3VolumeContext(OzoneManagerProtocolClientSideTranslatorPB.java:1205)
s3g_1       | 	at org.apache.hadoop.ozone.client.rpc.RpcClient.getS3VolumeContext(RpcClient.java:510)
s3g_1       | 	at org.apache.hadoop.ozone.client.ObjectStore.getS3Volume(ObjectStore.java:167)
s3g_1       | 	at org.apache.hadoop.ozone.s3.endpoint.EndpointBase.getVolume(EndpointBase.java:133)
s3g_1       | 	at org.apache.hadoop.ozone.s3.endpoint.ObjectEndpoint.get(ObjectEndpoint.java:289)
```

This patch makes S3G handle `INVALID_TOKEN` as permission problem.

https://issues.apache.org/jira/browse/HDDS-7139

## How was this patch tested?

Added Robot test case.

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2887470108