### PR TITLE
HDDS-7108. Make ReplicationConfig validation error message type-specific

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
@@ -62,12 +62,15 @@ public class ReplicationConfigValidator {
               (ECReplicationConfig) replicationConfig;
         replication =  ecConfig.getCodec() + "-" + ecConfig.getData() +
                 "-" + ecConfig.getParity() + "-{CHUNK_SIZE}";
-      }
-      throw new IllegalArgumentException(
+        throw new IllegalArgumentException(
                 "Invalid data-parity replication config " +
                         "for type " + replicationConfig.getReplicationType() +
                         " and replication " + replication + "." +
                         " Supported data-parity are 3-2,6-3,10-4");
+      }
+      throw new IllegalArgumentException("Invalid replication config " +
+              "for type " + replicationConfig.getReplicationType() +
+              " and replication " + replication);
     }
     return replicationConfig;
   }

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/client/ReplicationConfigValidator.java
@@ -62,12 +62,14 @@ public class ReplicationConfigValidator {
               (ECReplicationConfig) replicationConfig;
         replication =  ecConfig.getCodec() + "-" + ecConfig.getData() +
                 "-" + ecConfig.getParity() + "-{CHUNK_SIZE}";
+        //EC type checks data-parity
         throw new IllegalArgumentException(
                 "Invalid data-parity replication config " +
                         "for type " + replicationConfig.getReplicationType() +
                         " and replication " + replication + "." +
                         " Supported data-parity are 3-2,6-3,10-4");
       }
+      //Non-EC type
       throw new IllegalArgumentException("Invalid replication config " +
               "for type " + replicationConfig.getReplicationType() +
               " and replication " + replication);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Based on replication type, ReplicationConfigValidator returns different error messages

## What is the link to the Apache JIRA

This is a patch for jira https://issues.apache.org/jira/browse/HDDS-7108

## How was this patch tested?

CI tests