### PR TITLE
HDDS-7156. Clean container's inconsistent pendingDeletingBlockCount

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/KeyValueContainerData.java
@@ -234,6 +234,13 @@ public class KeyValueContainerData extends ContainerData {
   }
 
   /**
+   * Reset the number of pending deletion blocks.
+   */
+  public void resetNumPendingDeletionBlocks() {
+    this.numPendingDeletionBlocks.set(0L);
+  }
+
+  /**
    * Get the number of pending deletion blocks.
    */
   public long getNumPendingDeletionBlocks() {


### PR DESCRIPTION
## What changes were proposed in this pull request?

The metadata of "pendingDeleteBlockCount" can be inconsistent in some cases, this ticket is to clean this inconsistency.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7156

## How was this patch tested?

Not a normal case, works fine in the prod cluster.
