### PR TITLE
HDDS-7157. Log the error msg explicitly in BlockDeletingService

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/keyvalue/statemachine/background/BlockDeletingService.java
@@ -168,9 +168,7 @@ public class BlockDeletingService extends BackgroundService {
           + "Retry in next interval. ", e);
     } catch (Exception e) {
       // In case listContainer call throws any uncaught RuntimeException.
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Unexpected error occurs during deleting blocks.", e);
-      }
+      LOG.error("Unexpected error occurs during deleting blocks.", e);
     }
     return queue;
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Currently, if a runtime error happened and `LOG.isDebugEnabled() == false`, there are no logs recorded in the DN,  which lead to inconvenience when checking certain error.
So, log the error msg explicitly in BlockDeletingService

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7157

## How was this patch tested?
/
