### PR TITLE
HDDS-7159. Upgrade ubuntu version from 18.04 to 20.04

### DIFF
--- a/.github/workflows/close-pending.yaml
+++ b/.github/workflows/close-pending.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
   close-pending:
     name: close-pending
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/comments.yaml
+++ b/.github/workflows/comments.yaml
@@ -23,7 +23,7 @@ on:
 jobs:
   process-comment:
     name: check-comment
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 jobs:
   build-info:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       GITHUB_CONTEXT: ${{ toJson(github) }}
     outputs:
@@ -67,7 +67,7 @@ jobs:
   build:
     needs:
       - build-info
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-build == 'true'
     strategy:
@@ -124,7 +124,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: needs.build-info.outputs.needs-compile == 'true'
     strategy:
@@ -162,7 +162,7 @@ jobs:
   basic:
     needs:
       - build-info
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 90
     if: needs.build-info.outputs.needs-basic-checks == 'true'
     strategy:
@@ -188,6 +188,10 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
         if: ${{ !contains('author,bats,docs', matrix.check) }}
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/${{ matrix.check }}.sh
       - name: Summary of failures
@@ -210,7 +214,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 5
     if: needs.build-info.outputs.needs-dependency-check == 'true'
     steps:
@@ -239,7 +243,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-compose-tests == 'true'
     strategy:
@@ -286,7 +290,7 @@ jobs:
     needs:
       - build-info
       - build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     if: needs.build-info.outputs.needs-kubernetes-tests == 'true'
     steps:
@@ -316,7 +320,7 @@ jobs:
   integration:
     needs:
       - build-info
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 150
     if: needs.build-info.outputs.needs-integration-tests == 'true'
     strategy:
@@ -365,7 +369,7 @@ jobs:
           rm -rf ~/.m2/repository/org/apache/ozone/ozone*
         if: always()
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     if: github.repository == 'apache/ozone' && github.event_name != 'pull_request'
     needs:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Github [has deprecated the Ubuntu 18.04 runner image](https://github.com/actions/runner-images/issues/6002).  While 18.04 will be unsupported only after 11/30/2022, there will be periodic "brownout" periods when builds using 18.04 will fail.

This PR upgrades to 20.04.

https://issues.apache.org/jira/browse/HDDS-7159

## How was this patch tested?

`build-branch` workflow:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2904661184

(Not completely finished yet, but each check (integration, acceptance, etc.) has at least one finished run.)

The other two workflows are not tested, but unlikely to have anything version-specific.