### PR TITLE
HDDS-7159. Run integration tests on Java 8

### DIFF
--- a/.github/workflows/post-commit.yml
+++ b/.github/workflows/post-commit.yml
@@ -346,6 +346,10 @@ jobs:
             maven-repo-${{ hashFiles('**/pom.xml') }}-8
             maven-repo-${{ hashFiles('**/pom.xml') }}
             maven-repo-
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
       - name: Execute tests
         run: hadoop-ozone/dev-support/checks/integration.sh -P${{ matrix.profile }}
         if: matrix.profile != 'flaky'


### PR DESCRIPTION
## What changes were proposed in this pull request?

Follow-up to #3707: run integration tests on Java 8.  `TestSecureOzoneCluster` is failing on Java 11.

https://issues.apache.org/jira/browse/HDDS-7159

## How was this patch tested?

https://github.com/adoroszlai/hadoop-ozone/runs/7957021440?check_suite_focus=true