### PR TITLE
HDDS-7161. Make Checksum.int2ByteString() zero-copy

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/common/Checksum.java
@@ -32,6 +32,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.primitives.Ints;
 import org.apache.hadoop.ozone.common.utils.BufferUtils;
 import org.apache.ratis.thirdparty.com.google.protobuf.ByteString;
+import org.apache.ratis.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +61,7 @@ public class Checksum {
   }
 
   public static ByteString int2ByteString(int n) {
-    return ByteString.copyFrom(Ints.toByteArray(n));
+    return UnsafeByteOperations.unsafeWrap(Ints.toByteArray(n));
   }
 
   private static Function<ByteBuffer, ByteString> newChecksumByteBufferFunction(


### PR DESCRIPTION
## What changes were proposed in this pull request?
Remove expensive heap memory copy; replace with zero copy wrapper.

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7161

## How was this patch tested?

Covered by existing UT.