### PR TITLE
HDDS-7164. Skip installing awscli if already present

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/s3/commonawslib.robot
@@ -42,6 +42,8 @@ Execute AWSS3Cli
     [return]          ${output}
 
 Install aws cli
+    ${rc}              ${output} =                 Run And Return Rc And Output           which aws
+    Return From Keyword If    '${rc}' == '0'
     ${rc}              ${output} =                 Run And Return Rc And Output           which apt-get
     Run Keyword if     '${rc}' == '0'              Install aws cli s3 debian
     ${rc}              ${output} =                 Run And Return Rc And Output           yum --help


### PR DESCRIPTION
## What changes were proposed in this pull request?

AWS CLI is pre-installed in ozone-runner docker image since HDDS-4881.  The problem is that HDDS-6264 changed it to install `awscli` via `pip`, not `yum`.  Thus `yum` installs another instance of the tool during test setup:

```
Running command 'sudo -E yum install -y awscli'

...

Installing:
 awscli                       noarch 1.23.2-1.el7_9.1             updates 2.3 M
Installing for dependencies:
 PyYAML                       x86_64 3.10-11.el7                  base    153 k
 jbigkit-libs                 x86_64 2.0-11.el7                   base     46 k
 libtiff                      x86_64 4.0.3-35.el7                 base    172 k
 libwebp                      x86_64 0.3.0-10.el7_9               updates 170 k
 libyaml                      x86_64 0.1.4-11.el7_0               base     55 k
 make                         x86_64 1:3.82-24.el7                base    421 k
 openssl                      x86_64 1:1.0.2k-25.el7_9            updates 494 k
 python-backports             x86_64 1.0-8.el7                    base    5.8 k
 python-backports-ssl_match_hostname
                              noarch 3.5.0.1-1.el7                base     13 k
 python-cffi                  x86_64 1.6.0-5.el7                  base    218 k
 python-dateutil              noarch 1.5-7.el7                    base     85 k
 python-docutils              noarch 0.11-0.3.20130715svn7687.el7 base    1.5 M
 python-enum34                noarch 1.0.4-1.el7                  base     52 k
 python-idna                  noarch 2.4-1.el7                    base     94 k
 python-ipaddress             noarch 1.0.16-2.el7                 base     34 k
 python-pillow                x86_64 2.0.0-23.gitd1c6db8.el7_9    updates 439 k
 python-ply                   noarch 3.4-11.el7                   base    123 k
 python-pycparser             noarch 2.14-1.el7                   base    104 k
 python-s3transfer            noarch 0.1.13-1.el7_9.2             updates 6.1 M
 python-setuptools            noarch 0.9.8-7.el7                  base    397 k
 python-six                   noarch 1.9.0-2.el7                  base     29 k
 python2-cryptography         x86_64 1.7.2-2.el7                  base    502 k
 python2-pyasn1               noarch 0.1.9-7.el7                  base    100 k
Updating for dependencies:
 openssl-libs                 x86_64 1:1.0.2k-25.el7_9            updates 1.2 M

...

Installed:
  awscli.noarch 0:1.23.2-1.el7_9.1                                              
```

This patch makes the test skip installation if `aws` is already present.

https://issues.apache.org/jira/browse/HDDS-7164

## How was this patch tested?

Verified that `Install aws cli` step in S3 test setup skips installation (since `aws` is already available), and that S3 tests still pass.

```
INFO  Running command 'which aws 2>&1'.	
INFO	${rc} = 0	
INFO	${output} = /usr/local/bin/aws

INFO  Returning from the enclosing user keyword
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2911350373