### PR TITLE
HDDS-7166. Memory leak in Recon when replacing DB for new checkpoint

### DIFF
--- a/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/main/java/org/apache/hadoop/ozone/recon/recovery/ReconOmMetadataManagerImpl.java
@@ -109,7 +109,15 @@ public class ReconOmMetadataManagerImpl extends OmMetadataManagerImpl
         FileUtils.deleteDirectory(oldDBLocation);
       }
     }
-    initializeNewRdbStore(newDbLocation);
+    DBStore current = getStore();
+    try {
+      initializeNewRdbStore(newDbLocation);
+    } finally {
+      // Always close DBStore if it's replaced.
+      if (current != null && current != getStore()) {
+        current.close();
+      }
+    }
   }
 
   @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -131,6 +131,12 @@ public class TestReconOmMetadataManagerImpl {
     Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
 
+    // Update again with an existing OM DB.
+    DBStore current = reconOMMetadataManager.getStore();
+    reconOMMetadataManager.updateOmDB(
+        checkpoint.getCheckpointLocation().toFile());
+    // Verify that the existing DB instance is closed.
+    Assert.assertTrue(current.isClosed());
   }
 
   /**

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -28,6 +28,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hdds.client.StandaloneReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.hdds.utils.db.DBStore;
 import org.apache.hadoop.ozone.om.OMMetadataManager;
 import org.apache.hadoop.ozone.om.OmMetadataManagerImpl;
 import org.apache.hadoop.ozone.om.helpers.BucketLayout;


### PR DESCRIPTION
## What changes were proposed in this pull request?
Found this when baking RocksDB changes in our internal test cluster.
When updating the database object for a new checkpoint, the existing DB is replaced without closing. 

https://issues.apache.org/jira/browse/HDDS-7166

## How was this patch tested?
Unit test, standard CI. 