### PR TITLE
HDDS-7172. Intermittent failure in Close pipeline smoketest

### DIFF
--- a/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/admincli/pipeline.robot
@@ -52,8 +52,9 @@ Activate pipeline
 
 Close pipeline
                         Execute          ozone admin pipeline close "${PIPELINE}"
-    ${output} =         Execute          ozone admin pipeline list | grep "${PIPELINE}"
-                        Should contain   ${output}   CLOSED
+    ${output} =         Execute          ozone admin pipeline list
+                        Pass Execution If     '${PIPELINE}' not in '''${output}'''    Pipeline already scrubbed
+                        Should Match Regexp   ${output}   ${PIPELINE}.*CLOSED
 
 Incomplete command
     ${output} =         Execute And Ignore Error     ozone admin pipeline


### PR DESCRIPTION
## What changes were proposed in this pull request?

`Close pipeline` test case fails intermittently like this:

```
INFO Running command 'ozone admin pipeline close "028eec27-0d46-45d5-b682-74c543a13bcd"
INFO ${rc} = 0
...
INFO Running command 'ozone admin pipeline list | grep "028eec27-0d46-45d5-b682-74c543a13bcd"
INFO ${rc} = 1
```

The problem is that the pipeline may be removed between the `close` and `list` commands by the background `BackgroundPipelineScrubber` thread:

```
scm1.org_1   | 2022-08-24 10:46:49,350 [IPC Server handler 0 on default port 9860] INFO pipeline.PipelineManagerImpl: Pipeline Pipeline[ Id: 028eec27-0d46-45d5-b682-74c543a13bcd, ...] moved to CLOSED state
scm1.org_1   | 2022-08-24 10:46:50,353 [BackgroundPipelineScrubberThread] INFO pipeline.PipelineManagerImpl: Scrubbing pipeline: id: PipelineID=028eec27-0d46-45d5-b682-74c543a13bcd since it stays at CLOSED stage.
```

Examples:
https://github.com/adoroszlai/ozone-build-results/tree/master/2022/08/04/16552/acceptance-unsecure
https://github.com/adoroszlai/ozone-build-results/tree/master/2022/08/22/16859/acceptance-HA
https://github.com/adoroszlai/ozone-build-results/tree/master/2022/08/23/16883/acceptance-HA

This PR changes the test to also pass if the pipeline no longer exists after it was closed.

https://issues.apache.org/jira/browse/HDDS-7172

## How was this patch tested?

The test passed locally in the regular case (when pipeline is present and in CLOSED state).

Temporarily changed the `'${PIPELINE}' not in '''${output}'''` condition to look for unknown pipeline, to verify that the non-existent case also passes.

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/2920042156