### PR TITLE
HDDS-7173. Fix TestReconOmMetadataManagerImpl#testUpdateOmDB

### DIFF
--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/recovery/TestReconOmMetadataManagerImpl.java
@@ -131,10 +131,14 @@ public class TestReconOmMetadataManagerImpl {
     Assert.assertNotNull(reconOMMetadataManager.getKeyTable(getBucketLayout())
         .get("/sampleVol/bucketOne/key_two"));
 
+    //Take a new checkpoint of OM DB.
+    DBCheckpoint newCheckpoint = omMetadataManager.getStore()
+        .getCheckpoint(true);
+    Assert.assertNotNull(newCheckpoint.getCheckpointLocation());
     // Update again with an existing OM DB.
     DBStore current = reconOMMetadataManager.getStore();
     reconOMMetadataManager.updateOmDB(
-        checkpoint.getCheckpointLocation().toFile());
+        newCheckpoint.getCheckpointLocation().toFile());
     // Verify that the existing DB instance is closed.
     Assert.assertTrue(current.isClosed());
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Followup HDDS-7166 (#3713), UT is failling because Exception happened when creating new DBStore, which leads to DBStore not replaced.

```
2022-08-25 15:10:45,751 [main] ERROR recovery.ReconOmMetadataManagerImpl (ReconOmMetadataManagerImpl.java:initializeNewRdbStore(94)) - Unable to initialize Recon OM DB snapshot store.
java.io.IOException: Failed init RocksDB, db path : /var/folders/4k/0pm7c7vs4ds216sc45nft3l40000gn/T/junit4663311154991749567/junit8976120310500205625/db.checkpoints/om.db_checkpoint_1661411444529, exception :org.rocksdb.RocksDBException lock hold by current process, acquire time 1661411445 acquiring thread 13095075840: /var/folders/4k/0pm7c7vs4ds216sc45nft3l40000gn/T/junit4663311154991749567/junit8976120310500205625/db.checkpoints/om.db_checkpoint_1661411444529/LOCK: No locks available
	at org.apache.hadoop.hdds.utils.db.RDBStore.<init>(RDBStore.java:118)
	at org.apache.hadoop.hdds.utils.db.DBStoreBuilder.build(DBStoreBuilder.java:190)
	at org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl.initializeNewRdbStore(ReconOmMetadataManagerImpl.java:89)
	at org.apache.hadoop.ozone.recon.recovery.ReconOmMetadataManagerImpl.updateOmDB(ReconOmMetadataManagerImpl.java:114)
	at org.apache.hadoop.ozone.recon.recovery.TestReconOmMetadataManagerImpl.testUpdateOmDB(TestReconOmMetadataManagerImpl.java:136)
```

See also: https://github.com/apache/ozone/runs/8006144614?check_suite_focus=true#step:6:2255

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7173

## How was this patch tested?

TestReconOmMetadataManagerImpl#testUpdateOmDB
