### PR TITLE
HDDS-7175. Timed out tests missing from bundle

### DIFF
--- a/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
+++ b/hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
@@ -48,7 +48,7 @@ grep -A1 'Crashed tests' "${REPORT_DIR}/output.log" \
   | tee -a "${REPORT_DIR}/summary.txt"
 
 # Check for tests that started but were not finished
-if grep -q 'There was a timeout or other error in the fork' "${REPORT_DIR}/output.log"; then
+if grep -q 'There was a timeout.*in the fork' "${REPORT_DIR}/output.log"; then
   diff -uw \
     <(grep -e 'Running org' "${REPORT_DIR}/output.log" \
       | sed -e 's/.* \(org[^ ]*\)/\1/' \


### PR DESCRIPTION
## What changes were proposed in this pull request?

Timed out tests are now missing from CI bundles:

 * HDDS-3078 added timed out tests to CI check bundles
 * SUREFIRE-1728 [changed the output](https://github.com/apache/maven-surefire/commit/706346f0b293a2ab834fcb71ff09e70d24799251#diff-bf7f174589af8f08638da17d6aefbe897133b7b77ff363a1e12439c37ea8683eL283) of Surefire plugin
 * Ozone upgraded to the version with changed output in HDDS-6095

Example [timeout](https://github.com/apache/ozone/runs/8006028747?check_suite_focus=true#step:6:3118) missing from [summary](https://github.com/apache/ozone/runs/8006028747?check_suite_focus=true#step:7:1).

This PR tweaks the search string used to check for timeouts in output.

https://issues.apache.org/jira/browse/HDDS-7175

## How was this patch tested?

Old Surefire version:

```
$ curl -LOSs https://raw.githubusercontent.com/adoroszlai/ozone-build-results/master/2022/01/14/12529/it-ozone/output.log

$ grep 'in the fork' output.log
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M1:test (default-test) on project ozone-integration-test: There was a timeout or other error in the fork -> [Help 1]

$ bash hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
org.apache.hadoop.ozone.om.TestAddRemoveOzoneManager
```

New Surefire version:

```
$ curl -LOSs https://raw.githubusercontent.com/adoroszlai/ozone-build-results/master/2022/08/22/16839/it-hdds/output.log

$ grep 'in the fork' output.log
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M5:test (default-test) on project ozone-integration-test: There was a timeout in the fork -> [Help 1]

$ bash hadoop-ozone/dev-support/checks/_mvn_unit_report.sh
org.apache.hadoop.hdds.upgrade.TestScmHAFinalization
```