### PR TITLE
HDDS-7174. Migrate SCM integration tests to JUnit 5

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMDbCheckpointServlet.java
@@ -40,13 +40,11 @@ import org.apache.commons.io.FileUtils;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ACL_ENABLED;
 import static org.apache.hadoop.ozone.OzoneConsts.OZONE_DB_CHECKPOINT_REQUEST_FLUSH;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.mockito.Matchers;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
@@ -56,6 +54,7 @@ import static org.mockito.Mockito.when;
 /**
  * Class used for testing the SCM DB Checkpoint provider servlet.
  */
+@Timeout(240)
 public class TestSCMDbCheckpointServlet {
   private MiniOzoneCluster cluster = null;
   private StorageContainerManager scm;
@@ -65,11 +64,6 @@ public class TestSCMDbCheckpointServlet {
   private String scmId;
   private String omId;
 
-  @Rule
-  public Timeout timeout = Timeout.seconds(240);
-
-  @Rule
-  public TemporaryFolder folder = new TemporaryFolder();
   /**
    * Create a MiniDFSCluster for testing.
    * <p>
@@ -77,7 +71,7 @@ public class TestSCMDbCheckpointServlet {
    *
    * @throws Exception
    */
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     clusterId = UUID.randomUUID().toString();
@@ -97,7 +91,7 @@ public class TestSCMDbCheckpointServlet {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -166,14 +160,14 @@ public class TestSCMDbCheckpointServlet {
 
       scmDbCheckpointServletMock.doGet(requestMock, responseMock);
 
-      Assert.assertTrue(tempFile.length() > 0);
-      Assert.assertTrue(
+      Assertions.assertTrue(tempFile.length() > 0);
+      Assertions.assertTrue(
           scmMetrics.getDBCheckpointMetrics().
               getLastCheckpointCreationTimeTaken() > 0);
-      Assert.assertTrue(
+      Assertions.assertTrue(
           scmMetrics.getDBCheckpointMetrics().
               getLastCheckpointStreamingTimeTaken() > 0);
-      Assert.assertTrue(scmMetrics.getDBCheckpointMetrics().
+      Assertions.assertTrue(scmMetrics.getDBCheckpointMetrics().
           getNumCheckpoints() > initialCheckpointCount);
     } finally {
       FileUtils.deleteQuietly(tempFile);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.utils.TransactionInfo;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
-import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.junit.jupiter.api.AfterAll;
@@ -77,20 +76,18 @@ public class TestSCMSnapshot {
         .getLatestTrxInfo().getTransactionIndex();
 
     Assertions.assertTrue(snapshotInfo2 > snapshotInfo1,
-        String.format("Snapshot index 2 {} should greater than Snapshot " +
-            "index 1 {}", snapshotInfo2, snapshotInfo1));
+        String.format("Snapshot index 2 %d should greater than Snapshot " +
+            "index 1 %d", snapshotInfo2, snapshotInfo1));
 
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo();
     Assertions.assertTrue(
         trxInfoAfterRestart.getTransactionIndex() >= snapshotInfo2);
-    try {
-      pipelineManager.getPipeline(ratisPipeline1.getId());
-      pipelineManager.getPipeline(ratisPipeline2.getId());
-    } catch (PipelineNotFoundException e) {
-      Assertions.fail("Should not see a PipelineNotFoundException");
-    }
+    Assertions.assertDoesNotThrow(() ->
+        pipelineManager.getPipeline(ratisPipeline1.getId()));
+    Assertions.assertDoesNotThrow(() ->
+        pipelineManager.getPipeline(ratisPipeline2.getId()));
   }
 
   @AfterAll

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/TestSCMSnapshot.java
@@ -26,10 +26,10 @@ import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineNotFoundException;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
@@ -43,7 +43,7 @@ public class TestSCMSnapshot {
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.setBoolean(ScmConfigKeys.OZONE_SCM_HA_ENABLE_KEY, true);
@@ -76,25 +76,24 @@ public class TestSCMSnapshot {
     long snapshotInfo2 = scm.getScmHAManager().asSCMHADBTransactionBuffer()
         .getLatestTrxInfo().getTransactionIndex();
 
-    Assert.assertTrue(
+    Assertions.assertTrue(snapshotInfo2 > snapshotInfo1,
         String.format("Snapshot index 2 {} should greater than Snapshot " +
-            "index 1 {}", snapshotInfo2, snapshotInfo1),
-        snapshotInfo2 > snapshotInfo1);
+            "index 1 {}", snapshotInfo2, snapshotInfo1));
 
     cluster.restartStorageContainerManager(false);
     TransactionInfo trxInfoAfterRestart =
         scm.getScmHAManager().asSCMHADBTransactionBuffer().getLatestTrxInfo();
-    Assert.assertTrue(
+    Assertions.assertTrue(
         trxInfoAfterRestart.getTransactionIndex() >= snapshotInfo2);
     try {
       pipelineManager.getPipeline(ratisPipeline1.getId());
       pipelineManager.getPipeline(ratisPipeline2.getId());
     } catch (PipelineNotFoundException e) {
-      Assert.fail("Should not see a PipelineNotFoundException");
+      Assertions.fail("Should not see a PipelineNotFoundException");
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -44,8 +44,7 @@ import java.util.HashMap;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
-import static org.apache.hadoop.hdds.HddsConfigKeys
-    .HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
+import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -33,10 +33,11 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -45,27 +46,20 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys
     .HDDS_SCM_SAFEMODE_PIPELINE_CREATION;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Class used to test {@link SCMContainerManagerMetrics}.
  */
+@Timeout(300)
 public class TestSCMContainerManagerMetrics {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private MiniOzoneCluster cluster;
   private StorageContainerManager scm;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HDDS_CONTAINER_REPORT_INTERVAL, "3000s");
@@ -76,7 +70,7 @@ public class TestSCMContainerManagerMetrics {
   }
 
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.shutdown();
   }
@@ -94,7 +88,7 @@ public class TestSCMContainerManagerMetrics {
             HddsProtos.ReplicationFactor.ONE), OzoneConsts.OZONE);
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assert.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
+    Assertions.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
         metrics), ++numSuccessfulCreateContainers);
 
     try {
@@ -105,9 +99,9 @@ public class TestSCMContainerManagerMetrics {
     } catch (IOException ex) {
       // Here it should fail, so it should have the old metric value.
       metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-      Assert.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
+      Assertions.assertEquals(getLongCounter("NumSuccessfulCreateContainers",
           metrics), numSuccessfulCreateContainers);
-      Assert.assertEquals(getLongCounter("NumFailureCreateContainers",
+      Assertions.assertEquals(getLongCounter("NumFailureCreateContainers",
           metrics), 1);
     }
 
@@ -119,7 +113,7 @@ public class TestSCMContainerManagerMetrics {
         ContainerID.valueOf(containerInfo.getContainerID()));
 
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assert.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
+    Assertions.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
         metrics), numSuccessfulDeleteContainers + 1);
 
     try {
@@ -130,9 +124,9 @@ public class TestSCMContainerManagerMetrics {
     } catch (ContainerNotFoundException ex) {
       // Here it should fail, so it should have the old metric value.
       metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-      Assert.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
+      Assertions.assertEquals(getLongCounter("NumSuccessfulDeleteContainers",
           metrics), numSuccessfulCreateContainers);
-      Assert.assertEquals(getLongCounter("NumFailureDeleteContainers",
+      Assertions.assertEquals(getLongCounter("NumFailureDeleteContainers",
           metrics), 1);
     }
 
@@ -140,7 +134,7 @@ public class TestSCMContainerManagerMetrics {
     containerManager.getContainers(
         ContainerID.valueOf(containerInfo.getContainerID()), 1);
     metrics = getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assert.assertEquals(currentValue + 1,
+    Assertions.assertEquals(currentValue + 1,
         getLongCounter("NumListContainerOps", metrics));
 
   }
@@ -153,7 +147,7 @@ public class TestSCMContainerManagerMetrics {
 
     MetricsRecordBuilder metrics =
         getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assert.assertEquals(getLongCounter("NumContainerReportsProcessedSuccessful",
+    Assertions.assertEquals(getLongCounter("NumContainerReportsProcessedSuccessful",
         metrics), 1);
 
     // Create key should create container on DN.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/container/metrics/TestSCMContainerManagerMetrics.java
@@ -138,8 +138,8 @@ public class TestSCMContainerManagerMetrics {
 
     MetricsRecordBuilder metrics =
         getMetrics(SCMContainerManagerMetrics.class.getSimpleName());
-    Assertions.assertEquals(getLongCounter("NumContainerReportsProcessedSuccessful",
-        metrics), 1);
+    Assertions.assertEquals(1L,
+        getLongCounter("NumContainerReportsProcessedSuccessful", metrics));
 
     // Create key should create container on DN.
     cluster.getRpcClient().getObjectStore().getClientProxy()

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -103,11 +103,8 @@ public class  TestMultiRaftSetup {
     // datanode pipeline limit is set to 2, but only one set of 3 pipelines
     // will be created. Further pipeline creation should fail
     Assertions.assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
-    try {
-      pipelineManager.createPipeline(RATIS_THREE);
-      Assertions.fail();
-    } catch (IOException ex) {
-    }
+    Assertions.assertThrows(IOException.class, () ->
+        pipelineManager.createPipeline(RATIS_THREE));
     shutdown();
   }
 
@@ -128,11 +125,8 @@ public class  TestMultiRaftSetup {
         .filter((dn) -> nodeManager.getPipelinesCount(dn) > 2).collect(
             Collectors.toList());
     Assertions.assertEquals(1, dns.size());
-    try {
-      pipelineManager.createPipeline(RATIS_THREE);
-      Assertions.fail();
-    } catch (IOException ex) {
-    }
+    Assertions.assertThrows(IOException.class, () ->
+        pipelineManager.createPipeline(RATIS_THREE));
     Collection<PipelineID> pipelineIds = nodeManager.getPipelines(dns.get(0));
     // Only one dataode should have 3 pipelines in total, 1 RATIS ONE pipeline
     // and 2 RATIS 3 pipeline

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -102,7 +102,8 @@ public class  TestMultiRaftSetup {
     waitForPipelineCreated(1);
     // datanode pipeline limit is set to 2, but only one set of 3 pipelines
     // will be created. Further pipeline creation should fail
-    Assertions.assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
+    Assertions.assertEquals(1,
+        pipelineManager.getPipelines(RATIS_THREE).size());
     Assertions.assertThrows(IOException.class, () ->
         pipelineManager.createPipeline(RATIS_THREE));
     shutdown();
@@ -120,7 +121,8 @@ public class  TestMultiRaftSetup {
     // For example, with d1,d2, d3, d4, d5, only d1 d2 d3 and d1 d4 d5 can form
     // pipeline as the none of peers from any of existing pipelines will be
     // repeated
-    Assertions.assertEquals(2, pipelineManager.getPipelines(RATIS_THREE).size());
+    Assertions.assertEquals(2,
+        pipelineManager.getPipelines(RATIS_THREE).size());
     List<DatanodeDetails> dns = nodeManager.getAllNodes().stream()
         .filter((dn) -> nodeManager.getPipelinesCount(dn) > 2).collect(
             Collectors.toList());

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestMultiRaftSetup.java
@@ -30,8 +30,8 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
 import org.apache.ozone.test.LambdaTestUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.List;
@@ -86,7 +86,7 @@ public class  TestMultiRaftSetup {
         false);
     init(3, conf);
     waitForPipelineCreated(2);
-    Assert.assertEquals(2, pipelineManager.getPipelines(ReplicationConfig
+    Assertions.assertEquals(2, pipelineManager.getPipelines(ReplicationConfig
         .fromProtoTypeAndFactor(HddsProtos.ReplicationType.RATIS,
             ReplicationFactor.THREE)).size());
     assertNotSamePeers();
@@ -102,10 +102,10 @@ public class  TestMultiRaftSetup {
     waitForPipelineCreated(1);
     // datanode pipeline limit is set to 2, but only one set of 3 pipelines
     // will be created. Further pipeline creation should fail
-    Assert.assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
+    Assertions.assertEquals(1, pipelineManager.getPipelines(RATIS_THREE).size());
     try {
       pipelineManager.createPipeline(RATIS_THREE);
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     }
     shutdown();
@@ -123,20 +123,20 @@ public class  TestMultiRaftSetup {
     // For example, with d1,d2, d3, d4, d5, only d1 d2 d3 and d1 d4 d5 can form
     // pipeline as the none of peers from any of existing pipelines will be
     // repeated
-    Assert.assertEquals(2, pipelineManager.getPipelines(RATIS_THREE).size());
+    Assertions.assertEquals(2, pipelineManager.getPipelines(RATIS_THREE).size());
     List<DatanodeDetails> dns = nodeManager.getAllNodes().stream()
         .filter((dn) -> nodeManager.getPipelinesCount(dn) > 2).collect(
             Collectors.toList());
-    Assert.assertEquals(1, dns.size());
+    Assertions.assertEquals(1, dns.size());
     try {
       pipelineManager.createPipeline(RATIS_THREE);
-      Assert.fail();
+      Assertions.fail();
     } catch (IOException ex) {
     }
     Collection<PipelineID> pipelineIds = nodeManager.getPipelines(dns.get(0));
     // Only one dataode should have 3 pipelines in total, 1 RATIS ONE pipeline
     // and 2 RATIS 3 pipeline
-    Assert.assertEquals(3, pipelineIds.size());
+    Assertions.assertEquals(3, pipelineIds.size());
     List<Pipeline> pipelines = new ArrayList<>();
     pipelineIds.forEach((id) -> {
       try {
@@ -144,21 +144,21 @@ public class  TestMultiRaftSetup {
       } catch (PipelineNotFoundException pnfe) {
       }
     });
-    Assert.assertEquals(1, pipelines.stream()
+    Assertions.assertEquals(1, pipelines.stream()
         .filter((p) -> (p.getReplicationConfig().getRequiredNodes() == 1))
-        .collect(Collectors.toList()).size());
-    Assert.assertEquals(2, pipelines.stream()
+        .count());
+    Assertions.assertEquals(2, pipelines.stream()
         .filter((p) -> (p.getReplicationConfig().getRequiredNodes() == 3))
-        .collect(Collectors.toList()).size());
+        .count());
     shutdown();
   }
   private void assertNotSamePeers() {
     nodeManager.getAllNodes().forEach((dn) -> {
       Collection<DatanodeDetails> peers = nodeManager.getPeerList(dn);
-      Assert.assertFalse(peers.contains(dn));
+      Assertions.assertFalse(peers.contains(dn));
       List<DatanodeDetails> trimList = nodeManager.getAllNodes();
       trimList.remove(dn);
-      Assert.assertTrue(peers.containsAll(trimList));
+      Assertions.assertTrue(peers.containsAll(trimList));
     });
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -30,29 +30,23 @@ import org.apache.hadoop.hdds.scm.container.common.helpers
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
 /**
  * Test for the Node2Pipeline map.
  */
+@Timeout(300)
 public class TestNode2PipelineMap {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
@@ -66,7 +60,7 @@ public class TestNode2PipelineMap {
    *
    * @throws IOException
    */
-  @Before
+  @BeforeEach
   public void init() throws Exception {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(5).build();
@@ -85,7 +79,7 @@ public class TestNode2PipelineMap {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @After
+  @AfterEach
   public void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -100,17 +94,17 @@ public class TestNode2PipelineMap {
         .getContainersInPipeline(ratisContainer.getPipeline().getId());
 
     ContainerID cId = ratisContainer.getContainerInfo().containerID();
-    Assert.assertEquals(1, set.size());
+    Assertions.assertEquals(1, set.size());
     set.forEach(containerID ->
-        Assert.assertEquals(containerID, cId));
+        Assertions.assertEquals(containerID, cId));
 
     List<DatanodeDetails> dns = ratisContainer.getPipeline().getNodes();
-    Assert.assertEquals(3, dns.size());
+    Assertions.assertEquals(3, dns.size());
 
     // get pipeline details by dnid
     Set<PipelineID> pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
-    Assert.assertTrue(pipelines.contains(ratisContainer.getPipeline().getId()));
+    Assertions.assertTrue(pipelines.contains(ratisContainer.getPipeline().getId()));
 
     // Now close the container and it should not show up while fetching
     // containers by pipeline
@@ -120,13 +114,13 @@ public class TestNode2PipelineMap {
         .updateContainerState(cId, HddsProtos.LifeCycleEvent.CLOSE);
     Set<ContainerID> set2 = pipelineManager.getContainersInPipeline(
         ratisContainer.getPipeline().getId());
-    Assert.assertEquals(0, set2.size());
+    Assertions.assertEquals(0, set2.size());
 
     pipelineManager
         .closePipeline(ratisContainer.getPipeline(), false);
     pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
-    Assert
-        .assertFalse(pipelines.contains(ratisContainer.getPipeline().getId()));
+    Assertions.assertFalse(
+        pipelines.contains(ratisContainer.getPipeline().getId()));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -25,8 +25,7 @@ import org.apache.hadoop.hdds.protocol.proto.HddsProtos.ReplicationFactor;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.container.common.helpers
-    .ContainerWithPipeline;
+import org.apache.hadoop.hdds.scm.container.common.helpers.ContainerWithPipeline;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.common.statemachine.InvalidStateTransitionException;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNode2PipelineMap.java
@@ -103,7 +103,8 @@ public class TestNode2PipelineMap {
     // get pipeline details by dnid
     Set<PipelineID> pipelines = scm.getScmNodeManager()
         .getPipelines(dns.get(0));
-    Assertions.assertTrue(pipelines.contains(ratisContainer.getPipeline().getId()));
+    Assertions.assertTrue(
+        pipelines.contains(ratisContainer.getPipeline().getId()));
 
     // Now close the container and it should not show up while fetching
     // containers by pipeline

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestNodeFailure.java
@@ -27,27 +27,19 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.DatanodeRatisServerConfig;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
 /**
  * Test Node failure detection and handling in Ratis.
  */
 public class TestNodeFailure {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private static MiniOzoneCluster cluster;
   private static List<Pipeline> ratisPipelines;
@@ -59,7 +51,7 @@ public class TestNodeFailure {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     final OzoneConfiguration conf = new OzoneConfiguration();
     DatanodeRatisServerConfig ratisServerConfig =
@@ -90,7 +82,7 @@ public class TestNodeFailure {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -112,7 +104,7 @@ public class TestNodeFailure {
           }
         }, timeForFailure / 2, timeForFailure * 3);
       } catch (Exception e) {
-        Assert.fail("Test Failed: " + e.getMessage());
+        Assertions.fail("Test Failed: " + e.getMessage());
       }
     });
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -26,29 +26,23 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
 /**
  * Test SCM restart and recovery wrt pipelines.
  */
+@Timeout(300)
 public class TestSCMRestart {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
@@ -63,7 +57,7 @@ public class TestSCMRestart {
    *
    * @throws IOException
    */
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     conf.setTimeDuration(HDDS_PIPELINE_REPORT_INTERVAL, 1000,
@@ -103,7 +97,7 @@ public class TestSCMRestart {
   /**
    * Shutdown MiniDFSCluster.
    */
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -118,16 +112,16 @@ public class TestSCMRestart {
         pipelineManager.getPipeline(ratisPipeline1.getId());
     Pipeline ratisPipeline2AfterRestart =
         pipelineManager.getPipeline(ratisPipeline2.getId());
-    Assert.assertNotSame(ratisPipeline1AfterRestart, ratisPipeline1);
-    Assert.assertNotSame(ratisPipeline2AfterRestart, ratisPipeline2);
-    Assert.assertEquals(ratisPipeline1AfterRestart, ratisPipeline1);
-    Assert.assertEquals(ratisPipeline2AfterRestart, ratisPipeline2);
+    Assertions.assertNotSame(ratisPipeline1AfterRestart, ratisPipeline1);
+    Assertions.assertNotSame(ratisPipeline2AfterRestart, ratisPipeline2);
+    Assertions.assertEquals(ratisPipeline1AfterRestart, ratisPipeline1);
+    Assertions.assertEquals(ratisPipeline2AfterRestart, ratisPipeline2);
 
     // Try creating a new container, it should be from the same pipeline
     // as was before restart
     ContainerInfo containerInfo = newContainerManager
         .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "Owner1");
-    Assert.assertEquals(containerInfo.getPipelineID(), ratisPipeline1.getId());
+    Assertions.assertEquals(containerInfo.getPipelineID(), ratisPipeline1.getId());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/pipeline/TestSCMRestart.java
@@ -122,6 +122,7 @@ public class TestSCMRestart {
     ContainerInfo containerInfo = newContainerManager
         .allocateContainer(RatisReplicationConfig.getInstance(
             ReplicationFactor.THREE), "Owner1");
-    Assertions.assertEquals(containerInfo.getPipelineID(), ratisPipeline1.getId());
+    Assertions.assertEquals(ratisPipeline1.getId(),
+        containerInfo.getPipelineID());
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestAllocateContainer.java
@@ -25,34 +25,25 @@ import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.OzoneConsts;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test allocate container calls.
  */
+@Timeout(300)
 public class TestAllocateContainer {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private static MiniOzoneCluster cluster;
   private static OzoneConfiguration conf;
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
   private static XceiverClientManager xceiverClientManager;
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     conf = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(conf).setNumDatanodes(3).build();
@@ -62,7 +53,7 @@ public class TestAllocateContainer {
     xceiverClientManager = new XceiverClientManager(conf);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws InterruptedException {
     if (cluster != null) {
       cluster.shutdown();
@@ -77,16 +68,16 @@ public class TestAllocateContainer {
             SCMTestUtils.getReplicationType(conf),
             SCMTestUtils.getReplicationFactor(conf),
             OzoneConsts.OZONE);
-    Assert.assertNotNull(container);
-    Assert.assertNotNull(container.getPipeline().getFirstNode());
+    Assertions.assertNotNull(container);
+    Assertions.assertNotNull(container.getPipeline().getFirstNode());
 
   }
 
   @Test
-  public void testAllocateNull() throws Exception {
-    thrown.expect(NullPointerException.class);
-    storageContainerLocationClient.allocateContainer(
-        SCMTestUtils.getReplicationType(conf),
-        SCMTestUtils.getReplicationFactor(conf), null);
+  public void testAllocateNull() {
+    Assertions.assertThrows(NullPointerException.class, () ->
+        storageContainerLocationClient.allocateContainer(
+            SCMTestUtils.getReplicationType(conf),
+            SCMTestUtils.getReplicationFactor(conf), null));
   }
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
@@ -40,7 +39,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
@@ -49,7 +47,8 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Integration test to ensure a container can be closed and its replicas
@@ -143,14 +142,9 @@ public class TestCloseContainer {
    * @return
    */
   private Set<ContainerReplica> getContainerReplicas(ContainerInfo c) {
-    Set<ContainerReplica> replicas = null;
-    try {
-      replicas = cluster.getStorageContainerManager()
-          .getContainerManager().getContainerReplicas(c.containerID());
-    } catch (ContainerNotFoundException e) {
-      fail("Unexpected ContainerNotFoundException");
-    }
-    return replicas;
+    return assertDoesNotThrow(() -> cluster.getStorageContainerManager()
+        .getContainerManager().getContainerReplicas(c.containerID()),
+        "Unexpected exception while retrieving container replicas");
   }
 
 }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -31,16 +31,16 @@ import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.TestDataUtil;
 import org.apache.hadoop.ozone.client.OzoneBucket;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
@@ -49,7 +49,7 @@ import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVA
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Integration test to ensure a container can be closed and its replicas
@@ -63,7 +63,7 @@ public class TestCloseContainer {
   private OzoneBucket bucket;
   private MiniOzoneCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     final int interval = 100;
@@ -91,7 +91,7 @@ public class TestCloseContainer {
     bucket = TestDataUtil.createVolumeAndBucket(cluster, volName, bucketName);
   }
 
-  @After
+  @AfterEach
   public void cleanup() {
     if (cluster != null) {
       cluster.shutdown();

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMMXBean.java
@@ -30,9 +30,10 @@ import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.container.placement.metrics.ContainerStat;
-import org.junit.BeforeClass;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.io.IOException;
@@ -48,23 +49,16 @@ import java.util.concurrent.TimeoutException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.TabularData;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  *
  * This class is to test JMX management interface for scm information.
  */
+@Timeout(300)
 public class TestSCMMXBean {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
   private static int numOfDatanodes = 3;
@@ -73,7 +67,7 @@ public class TestSCMMXBean {
   private static StorageContainerManager scm;
   private static MBeanServer mbs;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws IOException, TimeoutException,
       InterruptedException {
     conf = new OzoneConfiguration();
@@ -85,7 +79,7 @@ public class TestSCMMXBean {
     mbs = ManagementFactory.getPlatformMBeanServer();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     if (cluster != null) {
       cluster.shutdown();
@@ -205,9 +199,8 @@ public class TestSCMMXBean {
    */
   private void verifyEquals(TabularData actualData,
       Map<String, Integer> expectedData) {
-    if (actualData == null || expectedData == null) {
-      fail("Data should not be null.");
-    }
+    assertNotNull(actualData);
+    assertNotNull(expectedData);
     for (Object obj : actualData.values()) {
       // Each TabularData is a set of CompositeData
       assertTrue(obj instanceof CompositeData);

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestSCMNodeManagerMXBean.java
@@ -23,9 +23,10 @@ import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -38,23 +39,17 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Class which tests the SCMNodeManagerInfo Bean.
  */
+@Timeout(300)
 public class TestSCMNodeManagerMXBean {
 
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
   public static final Logger LOG = LoggerFactory.getLogger(TestSCMMXBean.class);
   private static int numOfDatanodes = 3;
   private static MiniOzoneCluster cluster;
@@ -62,7 +57,7 @@ public class TestSCMNodeManagerMXBean {
   private static StorageContainerManager scm;
   private static MBeanServer mbs;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws IOException, TimeoutException,
       InterruptedException {
     conf = new OzoneConfiguration();
@@ -75,7 +70,7 @@ public class TestSCMNodeManagerMXBean {
     mbs = ManagementFactory.getPlatformMBeanServer();
   }
 
-  @AfterClass
+  @AfterAll
   public static void cleanup() {
     if (cluster != null) {
       cluster.shutdown();
@@ -130,9 +125,8 @@ public class TestSCMNodeManagerMXBean {
 
   private void verifyEquals(TabularData actualData, Map<String, Long>
       expectedData) {
-    if (actualData == null || expectedData == null) {
-      fail("Data should not be null.");
-    }
+    assertNotNull(actualData);
+    assertNotNull(expectedData);
     for (Object obj : actualData.values()) {
       assertTrue(obj instanceof CompositeData);
       CompositeData cds = (CompositeData) obj;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientGrpc.java
@@ -31,9 +31,10 @@ import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.hdds.scm.storage.ContainerProtocolCalls;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -53,7 +54,7 @@ public class TestXceiverClientGrpc {
   private List<DatanodeDetails> dnsInOrder;
   private OzoneConfiguration conf = new OzoneConfiguration();
 
-  @Before
+  @BeforeEach
   public void setup() {
     dns = new ArrayList<>();
     dns.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -77,12 +78,13 @@ public class TestXceiverClientGrpc {
 
   @Test
   public void testCorrectDnsReturnedFromPipeline() throws IOException {
-    Assert.assertEquals(dnsInOrder.get(0), pipeline.getClosestNode());
-    Assert.assertEquals(dns.get(0), pipeline.getFirstNode());
-    Assert.assertNotEquals(dns.get(0), dnsInOrder.get(0));
+    Assertions.assertEquals(dnsInOrder.get(0), pipeline.getClosestNode());
+    Assertions.assertEquals(dns.get(0), pipeline.getFirstNode());
+    Assertions.assertNotEquals(dns.get(0), dnsInOrder.get(0));
   }
 
-  @Test(timeout = 5000)
+  @Test
+  @Timeout(5)
   public void testRandomFirstNodeIsCommandTarget() throws IOException {
     final ArrayList<DatanodeDetails> allDNs = new ArrayList<>(dns);
     // Using a new Xceiver Client, call it repeatedly until all DNs in the
@@ -124,7 +126,7 @@ public class TestXceiverClientGrpc {
       };
       invokeXceiverClientGetBlock(client);
     }
-    Assert.assertEquals(1, seenDNs.size());
+    Assertions.assertEquals(1, seenDNs.size());
   }
 
   @Test
@@ -146,7 +148,7 @@ public class TestXceiverClientGrpc {
       invokeXceiverClientGetBlock(client);
       invokeXceiverClientReadChunk(client);
       invokeXceiverClientReadSmallFile(client);
-      Assert.assertEquals(1, seenDNs.size());
+      Assertions.assertEquals(1, seenDNs.size());
     }
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestXceiverClientMetrics.java
@@ -46,22 +46,17 @@ import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.protocolPB.StorageContainerLocationProtocolClientSideTranslatorPB;
 import org.apache.hadoop.ozone.container.common.SCMTestUtils;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.Timeout;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * This class tests the metrics of XceiverClient.
  */
+@Timeout(300)
 public class TestXceiverClientMetrics {
 
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
   // only for testing
   private volatile boolean breakFlag;
   private CountDownLatch latch;
@@ -71,7 +66,7 @@ public class TestXceiverClientMetrics {
   private static StorageContainerLocationProtocolClientSideTranslatorPB
       storageContainerLocationClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void init() throws Exception {
     config = new OzoneConfiguration();
     cluster = MiniOzoneCluster.newBuilder(config).build();
@@ -80,7 +75,7 @@ public class TestXceiverClientMetrics {
         .getStorageContainerLocationClient();
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() {
     cluster.shutdown();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -62,8 +62,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
@@ -80,7 +80,7 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test from the scmclient for decommission and maintenance.

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -26,13 +26,11 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
-import org.apache.hadoop.hdds.scm.container.ContainerNotFoundException;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaCount;
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
-import org.apache.hadoop.hdds.scm.node.states.NodeNotFoundException;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineManager;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
@@ -62,6 +60,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
@@ -80,7 +79,6 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DATANODE_ADMIN_
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_DEADNODE_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys.OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test from the scmclient for decommission and maintenance.
@@ -567,13 +565,8 @@ public class TestDecommissionAndMaintenance {
    * @return
    */
   private NodeStatus getNodeStatus(DatanodeDetails dn) {
-    NodeStatus status = null;
-    try {
-      status = nm.getNodeStatus(dn);
-    } catch (NodeNotFoundException e) {
-      fail("Unexpected exception getting the nodeState");
-    }
-    return status;
+    return assertDoesNotThrow(() -> nm.getNodeStatus(dn),
+        "Unexpected exception getting the nodeState");
   }
 
   /**
@@ -584,13 +577,8 @@ public class TestDecommissionAndMaintenance {
    * @return
    */
   private Set<ContainerReplica> getContainerReplicas(ContainerInfo c) {
-    Set<ContainerReplica> replicas = null;
-    try {
-      replicas = cm.getContainerReplicas(c.containerID());
-    } catch (ContainerNotFoundException e) {
-      fail("Unexpected ContainerNotFoundException");
-    }
-    return replicas;
+    return assertDoesNotThrow(() -> cm.getContainerReplicas(c.containerID()),
+        "Unexpected exception getting the container replicas");
   }
 
   /**

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
@@ -110,7 +110,7 @@ public class TestQueryNode {
   public void testHealthyNodesCount() throws Exception {
     List<HddsProtos.Node> nodes = scmClient.queryNode(null, HEALTHY,
         HddsProtos.QueryScope.CLUSTER, "");
-    assertEquals(numOfDatanodes, nodes.size(), "Expected  live nodes");
+    assertEquals(numOfDatanodes, nodes.size(), "Expected live nodes");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestQueryNode.java
@@ -25,10 +25,11 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.cli.ContainerOperationClient;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -62,19 +63,19 @@ import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_HEARTBEAT_PROCESS_INTERVAL;
 import static org.apache.hadoop.hdds.scm.ScmConfigKeys
     .OZONE_SCM_STALENODE_INTERVAL;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Test Query Node Operation.
  */
-@Ignore
+@Disabled
 public class TestQueryNode {
   private static int numOfDatanodes = 5;
   private MiniOzoneCluster cluster;
 
   private ContainerOperationClient scmClient;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     final int interval = 100;
@@ -98,7 +99,7 @@ public class TestQueryNode {
     scmClient = new ContainerOperationClient(conf);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     if (cluster != null) {
       cluster.shutdown();
@@ -109,11 +110,11 @@ public class TestQueryNode {
   public void testHealthyNodesCount() throws Exception {
     List<HddsProtos.Node> nodes = scmClient.queryNode(null, HEALTHY,
         HddsProtos.QueryScope.CLUSTER, "");
-    assertEquals("Expected  live nodes", numOfDatanodes,
-        nodes.size());
+    assertEquals(numOfDatanodes, nodes.size(), "Expected  live nodes");
   }
 
-  @Test(timeout = 10 * 1000L)
+  @Test
+  @Timeout(10)
   public void testStaleNodesCount() throws Exception {
     cluster.shutdownHddsDatanode(0);
     cluster.shutdownHddsDatanode(1);
@@ -124,7 +125,7 @@ public class TestQueryNode {
 
     int nodeCount = scmClient.queryNode(null, STALE,
         HddsProtos.QueryScope.CLUSTER, "").size();
-    assertEquals("Mismatch of expected nodes count", 2, nodeCount);
+    assertEquals(2, nodeCount, "Mismatch of expected nodes count");
 
     GenericTestUtils.waitFor(() ->
             cluster.getStorageContainerManager().getNodeCount(DEAD) == 2,
@@ -133,12 +134,12 @@ public class TestQueryNode {
     // Assert that we don't find any stale nodes.
     nodeCount = scmClient.queryNode(null, STALE,
         HddsProtos.QueryScope.CLUSTER, "").size();
-    assertEquals("Mismatch of expected nodes count", 0, nodeCount);
+    assertEquals(0, nodeCount, "Mismatch of expected nodes count");
 
     // Assert that we find the expected number of dead nodes.
     nodeCount = scmClient.queryNode(null, DEAD,
         HddsProtos.QueryScope.CLUSTER, "").size();
-    assertEquals("Mismatch of expected nodes count", 2, nodeCount);
+    assertEquals(2, nodeCount, "Mismatch of expected nodes count");
   }
 
   @Test

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestPipelineManagerMXBean.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestPipelineManagerMXBean.java
@@ -20,9 +20,10 @@ package org.apache.hadoop.ozone.scm.pipeline;
 
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -34,27 +35,20 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager via MXBean.
  */
+@Timeout(300)
 public class TestPipelineManagerMXBean {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private MiniOzoneCluster cluster;
   private MBeanServer mbs;
 
-  @Before
+  @BeforeEach
   public void init()
       throws IOException, TimeoutException, InterruptedException {
     OzoneConfiguration conf = new OzoneConfiguration();
@@ -79,11 +73,10 @@ public class TestPipelineManagerMXBean {
     verifyEquals(data, datanodeInfo);
   }
 
-  private void verifyEquals(TabularData actualData, Map<String, Integer>
-      expectedData) {
-    if (actualData == null || expectedData == null) {
-      fail("Data should not be null.");
-    }
+  private void verifyEquals(TabularData actualData,
+      Map<String, Integer> expectedData) {
+    assertNotNull(actualData);
+    assertNotNull(expectedData);
     for (Object obj : actualData.values()) {
       assertTrue(obj instanceof CompositeData);
       CompositeData cds = (CompositeData) obj;
@@ -98,7 +91,7 @@ public class TestPipelineManagerMXBean {
     assertTrue(expectedData.isEmpty());
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.shutdown();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineBytesWrittenMetrics.java
@@ -35,18 +35,17 @@ import org.apache.hadoop.ozone.client.OzoneVolume;
 import org.apache.hadoop.ozone.client.io.OzoneOutputStream;
 import org.apache.hadoop.ozone.om.helpers.OmKeyArgs;
 import org.apache.ozone.test.GenericTestUtils;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_PIPELINE_REPORT_INTERVAL;
@@ -58,18 +57,13 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 /**
  * Test cases to verify the SCM pipeline bytesWritten metrics.
  */
+@Timeout(300)
 public class TestSCMPipelineBytesWrittenMetrics {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private MiniOzoneCluster cluster;
   private OzoneConfiguration conf;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK,
@@ -109,8 +103,8 @@ public class TestSCMPipelineBytesWrittenMetrics {
         .setKeyName(keyName).setRefreshPipeline(true);
 
     OzoneKeyDetails keyDetails = bucket.getKey(keyName);
-    Assert.assertEquals(keyName, keyDetails.getName());
-    Assert.assertEquals(value.getBytes(UTF_8).length, keyDetails
+    Assertions.assertEquals(keyName, keyDetails.getName());
+    Assertions.assertEquals(value.getBytes(UTF_8).length, keyDetails
         .getOzoneKeyLocations().get(0).getLength());
   }
 
@@ -129,7 +123,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
     List<Pipeline> pipelines = cluster.getStorageContainerManager()
         .getPipelineManager().getPipelines();
 
-    Assert.assertEquals(1, pipelines.size());
+    Assertions.assertEquals(1, pipelines.size());
     Pipeline pipeline = pipelines.get(0);
 
     final String metricName =
@@ -141,7 +135,7 @@ public class TestSCMPipelineBytesWrittenMetrics {
     }, 500, 300000);
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.shutdown();
   }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/pipeline/TestSCMPipelineMetrics.java
@@ -30,17 +30,16 @@ import org.apache.hadoop.hdds.scm.pipeline.SCMPipelineMetrics;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 
-import org.junit.Rule;
-import org.junit.rules.Timeout;
 import static org.apache.hadoop.test.MetricsAsserts.assertCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getLongCounter;
 import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
@@ -48,17 +47,12 @@ import static org.apache.hadoop.test.MetricsAsserts.getMetrics;
 /**
  * Test cases to verify the metrics exposed by SCMPipelineManager.
  */
+@Timeout(300)
 public class TestSCMPipelineMetrics {
-
-  /**
-    * Set a timeout for each test.
-    */
-  @Rule
-  public Timeout timeout = Timeout.seconds(300);
 
   private MiniOzoneCluster cluster;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     OzoneConfiguration conf = new OzoneConfiguration();
     conf.set(HddsConfigKeys.HDDS_SCM_SAFEMODE_PIPELINE_AVAILABILITY_CHECK,
@@ -79,7 +73,7 @@ public class TestSCMPipelineMetrics {
     long numPipelineCreated =
         getLongCounter("NumPipelineCreated", metrics);
     // Pipelines are created in background when the cluster starts.
-    Assert.assertTrue(numPipelineCreated > 0);
+    Assertions.assertTrue(numPipelineCreated > 0);
   }
 
   /**
@@ -91,14 +85,14 @@ public class TestSCMPipelineMetrics {
         .getStorageContainerManager().getPipelineManager();
     Optional<Pipeline> pipeline = pipelineManager
         .getPipelines().stream().findFirst();
-    Assert.assertTrue(pipeline.isPresent());
+    Assertions.assertTrue(pipeline.isPresent());
     try {
       cluster.getStorageContainerManager()
           .getPipelineManager()
           .closePipeline(pipeline.get(), false);
     } catch (IOException | TimeoutException e) {
       e.printStackTrace();
-      Assert.fail();
+      Assertions.fail();
     }
     MetricsRecordBuilder metrics = getMetrics(
         SCMPipelineMetrics.class.getSimpleName());
@@ -117,7 +111,7 @@ public class TestSCMPipelineMetrics {
     Pipeline pipeline = block.getPipeline();
     long numBlocksAllocated = getLongCounter(
         SCMPipelineMetrics.getBlockAllocationMetricName(pipeline), metrics);
-    Assert.assertEquals(numBlocksAllocated, 1);
+    Assertions.assertEquals(numBlocksAllocated, 1);
 
     // destroy the pipeline
     try {
@@ -125,21 +119,21 @@ public class TestSCMPipelineMetrics {
           .closePipeline(pipeline.getId().getProtobuf());
     } catch (IOException e) {
       e.printStackTrace();
-      Assert.fail();
+      Assertions.fail();
     }
     metrics = getMetrics(SCMPipelineMetrics.class.getSimpleName());
     try {
       getLongCounter(SCMPipelineMetrics.getBlockAllocationMetricName(pipeline),
           metrics);
-      Assert.fail("Metric should not be present for closed pipeline.");
+      Assertions.fail("Metric should not be present for closed pipeline.");
     } catch (AssertionError e) {
-      Assert.assertTrue(e.getMessage().contains(
+      Assertions.assertTrue(e.getMessage().contains(
           "Expected exactly one metric for name " + SCMPipelineMetrics
               .getBlockAllocationMetricName(block.getPipeline())));
     }
   }
 
-  @After
+  @AfterEach
   public void teardown() {
     cluster.shutdown();
   }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Migrate tests under following directories to JUnit 5.

* `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/`
* `hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/hdds/scm/`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7174

## How was this patch tested?

https://github.com/kaijchen/ozone/actions/runs/2932207457
