### PR TITLE
HDDS-6975. EC: Define the value of Maintenance Redundancy for EC containers

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/ContainerReplica.java
@@ -173,7 +173,7 @@ public final class ContainerReplica implements Comparable<ContainerReplica> {
         ", sequenceId=" + sequenceId +
         ", keyCount=" + keyCount +
         ", bytesUsed=" + bytesUsed + ((replicaIndex > 0) ?
-        ",replicaIndex= " + replicaIndex :
+        ",replicaIndex=" + replicaIndex :
         "") +
         '}';
   }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -701,14 +701,14 @@ public class ReplicationManager implements SCMService {
         description = "The number of redundant containers in a group which" +
             " must be available for a node to enter maintenance. If putting" +
             " a node into maintenance reduces the redundancy below this value" +
-            " , the node will remain in the entering maintenance state until" +
+            " , the node will remain in the ENTERING_MAINTENANCE state until" +
             " a new replica is created. For Ratis containers, the default" +
             " value of 1 ensures at least two replicas are online, meaning 1" +
             " more can be lost without data becoming unavailable. For any EC" +
             " container it will have at least dataNum + 1 online, allowing" +
             " the loss of 1 more replica before data becomes unavailable." +
             " Currently only EC containers use this setting. Ratis containers" +
-            " use maintenance.replica.minimum."
+            " use hdds.scm.replication.maintenance.replica.minimum."
     )
     private int maintenanceRemainingRedundancy = 1;
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -690,7 +690,9 @@ public class ReplicationManager implements SCMService {
 
     /**
      * Defines how many redundant replicas of a container must be online for a
-     * node to enter maintenance.
+     * node to enter maintenance. Currently, only used for EC containers. We
+     * need to consider removing the "maintenance.replica.minimum" setting
+     * and having both Ratis and EC use this new one.
      */
     @Config(key = "maintenance.remaining.redundancy",
         type = ConfigType.INT,
@@ -704,7 +706,9 @@ public class ReplicationManager implements SCMService {
             " value of 1 ensures at least two replicas are online, meaning 1" +
             " more can be lost without data becoming unavailable. For any EC" +
             " container it will have at least dataNum + 1 online, allowing" +
-            " the loss of 1 more replica before data becomes unavailable."
+            " the loss of 1 more replica before data becomes unavailable." +
+            " Currently only EC containers use this setting. Ratis containers" +
+            " use maintenance.replica.minimum."
     )
     private int maintenanceRemainingRedundancy = 1;
 
@@ -724,12 +728,12 @@ public class ReplicationManager implements SCMService {
       return underReplicatedInterval;
     }
 
-    public void setUnderReplicatedInterval(Duration interval) {
-      this.underReplicatedInterval = interval.toMillis();
+    public void setUnderReplicatedInterval(Duration duration) {
+      this.underReplicatedInterval = duration.toMillis();
     }
 
-    public void setOverReplicatedInterval(Duration interval) {
-      this.overReplicatedInterval = interval.toMillis();
+    public void setOverReplicatedInterval(Duration duration) {
+      this.overReplicatedInterval = duration.toMillis();
     }
 
     public long getOverReplicatedInterval() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -706,7 +706,7 @@ public class ReplicationManager implements SCMService {
             " container it will have at least dataNum + 1 online, allowing" +
             " the loss of 1 more replica before data becomes unavailable."
     )
-    private int maintenanceRemainingRedundancy = 2;
+    private int maintenanceRemainingRedundancy = 1;
 
     public void setMaintenanceRemainingRedundancy(int redundancy) {
       this.maintenanceRemainingRedundancy = redundancy;
@@ -722,6 +722,14 @@ public class ReplicationManager implements SCMService {
 
     public long getUnderReplicatedInterval() {
       return underReplicatedInterval;
+    }
+
+    public void setUnderReplicatedInterval(Duration interval) {
+      this.underReplicatedInterval = interval.toMillis();
+    }
+
+    public void setOverReplicatedInterval(Duration interval) {
+      this.overReplicatedInterval = interval.toMillis();
     }
 
     public long getOverReplicatedInterval() {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -152,6 +152,7 @@ public class ReplicationManager implements SCMService {
       overRepQueue;
   private final ECUnderReplicationHandler ecUnderReplicationHandler;
   private final ECOverReplicationHandler ecOverReplicationHandler;
+  private final int maintenanceRedundancy;
 
   /**
    * Constructs ReplicationManager instance with the given configuration.
@@ -190,6 +191,7 @@ public class ReplicationManager implements SCMService {
     this.nodeManager = nodeManager;
     this.underRepQueue = createUnderReplicatedQueue();
     this.overRepQueue = new LinkedList<>();
+    this.maintenanceRedundancy = rmConf.maintenanceRemainingRedundancy;
     ecUnderReplicationHandler = new ECUnderReplicationHandler(
         containerPlacement, conf, nodeManager);
     ecOverReplicationHandler =
@@ -370,7 +372,7 @@ public class ReplicationManager implements SCMService {
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
     return ecUnderReplicationHandler.processAndCreateCommands(replicas,
-        pendingOps, result, 0);
+        pendingOps, result, maintenanceRedundancy);
   }
 
   public Map<DatanodeDetails, SCMCommand<?>> processOverReplicatedContainer(
@@ -381,7 +383,7 @@ public class ReplicationManager implements SCMService {
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
     return ecOverReplicationHandler.processAndCreateCommands(replicas,
-        pendingOps, result, 0);
+        pendingOps, result, maintenanceRedundancy);
   }
 
   public long getScmTerm() throws NotLeaderException {
@@ -419,8 +421,8 @@ public class ReplicationManager implements SCMService {
 
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerID);
-    ContainerHealthResult health = ecContainerHealthCheck
-        .checkHealth(containerInfo, replicas, pendingOps, 0);
+    ContainerHealthResult health = ecContainerHealthCheck.checkHealth(
+        containerInfo, replicas, pendingOps, maintenanceRedundancy);
       // TODO - should the report have a HEALTHY state, rather than just bad
       //        states? It would need to be added to legacy RM too.
     if (health.getHealthState()
@@ -686,6 +688,34 @@ public class ReplicationManager implements SCMService {
       this.maintenanceReplicaMinimum = replicaCount;
     }
 
+    /**
+     * Defines how many redundant replicas of a container must be online for a
+     * node to enter maintenance.
+     */
+    @Config(key = "maintenance.remaining.redundancy",
+        type = ConfigType.INT,
+        defaultValue = "1",
+        tags = {SCM, OZONE},
+        description = "The number of redundant containers in a group which" +
+            " must be available for a node to enter maintenance. If putting" +
+            " a node into maintenance reduces the redundancy below this value" +
+            " , the node will remain in the entering maintenance state until" +
+            " a new replica is created. For Ratis containers, the default" +
+            " value of 1 ensures at least two replicas are online, meaning 1" +
+            " more can be lost without data becoming unavailable. For any EC" +
+            " container it will have at least dataNum + 1 online, allowing" +
+            " the loss of 1 more replica before data becomes unavailable."
+    )
+    private int maintenanceRemainingRedundancy = 2;
+
+    public void setMaintenanceRemainingRedundancy(int redundancy) {
+      this.maintenanceRemainingRedundancy = redundancy;
+    }
+
+    public int getMaintenanceRemainingRedundancy() {
+      return maintenanceRemainingRedundancy;
+    }
+
     public long getInterval() {
       return interval;
     }
@@ -796,8 +826,8 @@ public class ReplicationManager implements SCMService {
         containerInfo.containerID());
     List<ContainerReplicaOp> pendingOps =
         containerReplicaPendingOps.getPendingOps(containerInfo.containerID());
-    // TODO: define maintenance redundancy for EC (HDDS-6975)
-    return new ECContainerReplicaCount(containerInfo, replicas, pendingOps, 0);
+    return new ECContainerReplicaCount(
+        containerInfo, replicas, pendingOps, maintenanceRedundancy);
   }
 
   /**

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManager.java
@@ -708,7 +708,10 @@ public class ReplicationManager implements SCMService {
             " container it will have at least dataNum + 1 online, allowing" +
             " the loss of 1 more replica before data becomes unavailable." +
             " Currently only EC containers use this setting. Ratis containers" +
-            " use hdds.scm.replication.maintenance.replica.minimum."
+            " use hdds.scm.replication.maintenance.replica.minimum. For EC," +
+            " if nodes are in maintenance, it is likely reconstruction reads" +
+            " will be required if some of the data replicas are offline. This" +
+            " is seamless to the client, but will affect read performance."
     )
     private int maintenanceRemainingRedundancy = 1;
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/TestDataUtil.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Scanner;
 
+import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
 import org.apache.hadoop.hdds.protocol.StorageType;
@@ -99,8 +100,16 @@ public final class TestDataUtil {
   public static void createKey(OzoneBucket bucket, String keyName,
       ReplicationFactor repFactor, ReplicationType repType, String content)
       throws IOException {
+    ReplicationConfig repConfig = ReplicationConfig
+        .fromTypeAndFactor(repType, repFactor);
+    createKey(bucket, keyName, repConfig, content);
+  }
+
+  public static void createKey(OzoneBucket bucket, String keyName,
+      ReplicationConfig repConfig, String content)
+      throws IOException {
     try (OutputStream stream = bucket
-        .createKey(keyName, content.length(), repType, repFactor,
+        .createKey(keyName, content.length(), repConfig,
             new HashMap<>())) {
       stream.write(content.getBytes(UTF_8));
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.ozone.scm.node;
 
+import org.apache.hadoop.hdds.HddsConfigKeys;
+import org.apache.hadoop.hdds.client.ECReplicationConfig;
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
@@ -57,13 +59,14 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_COMMAND_STATUS_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_CONTAINER_REPORT_INTERVAL;
 import static org.apache.hadoop.hdds.HddsConfigKeys.HDDS_HEARTBEAT_INTERVAL;
@@ -90,11 +93,13 @@ public class TestDecommissionAndMaintenance {
   private static final Logger LOG =
       LoggerFactory.getLogger(TestDecommissionAndMaintenance.class);
 
-  private static int numOfDatanodes = 6;
+  private static int numOfDatanodes = 7;
   private static String bucketName = "bucket1";
   private static String volName = "vol1";
   private static RatisReplicationConfig ratisRepConfig =
       RatisReplicationConfig.getInstance(HddsProtos.ReplicationFactor.THREE);
+  private static ECReplicationConfig ecRepConfig =
+      new ECReplicationConfig(3, 2);
   private OzoneBucket bucket;
   private MiniOzoneCluster cluster;
   private NodeManager nm;
@@ -123,16 +128,25 @@ public class TestDecommissionAndMaintenance {
     conf.setTimeDuration(OZONE_SCM_DEADNODE_INTERVAL, 6, SECONDS);
     conf.setTimeDuration(OZONE_SCM_DATANODE_ADMIN_MONITOR_INTERVAL,
         1, SECONDS);
+    conf.setTimeDuration(ScmConfigKeys.OZONE_SCM_CONTAINER_REPLICA_OP_TIME_OUT,
+        10, SECONDS);
+    conf.setTimeDuration(
+        ScmConfigKeys.OZONE_SCM_EXPIRED_CONTAINER_REPLICA_OP_SCRUB_INTERVAL,
+        1, SECONDS);
+    conf.setTimeDuration(HddsConfigKeys.HDDS_SCM_WAIT_TIME_AFTER_SAFE_MODE_EXIT,
+        0, SECONDS);
 
     ReplicationManagerConfiguration replicationConf =
         conf.getObject(ReplicationManagerConfiguration.class);
     replicationConf.setInterval(Duration.ofSeconds(1));
+    replicationConf.setUnderReplicatedInterval(Duration.ofSeconds(1));
+    replicationConf.setOverReplicatedInterval(Duration.ofSeconds(1));
     conf.setFromObject(replicationConf);
 
     MiniOzoneCluster.Builder builder = MiniOzoneCluster.newBuilder(conf)
         .setNumDatanodes(numOfDatanodes);
 
-    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 8);
+    clusterProvider = new MiniOzoneClusterProvider(conf, builder, 7);
   }
 
   @AfterAll
@@ -166,14 +180,27 @@ public class TestDecommissionAndMaintenance {
       throws Exception {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
+    generateData(20, "ecKey", ecRepConfig);
 
     // Locate any container and find its open pipeline
-    final ContainerInfo container = waitForAndReturnContainer();
+    final ContainerInfo container =
+        waitForAndReturnContainer(ratisRepConfig, 3);
+    final ContainerInfo ecContainer = waitForAndReturnContainer(ecRepConfig, 5);
     Pipeline pipeline = pm.getPipeline(container.getPipelineID());
+    Pipeline ecPipeline = pm.getPipeline(ecContainer.getPipelineID());
     assertEquals(Pipeline.PipelineState.OPEN, pipeline.getPipelineState());
-    Set<ContainerReplica> replicas = getContainerReplicas(container);
+    assertEquals(Pipeline.PipelineState.OPEN, ecPipeline.getPipelineState());
+    // Find a DN to decommission that is in both the EC and Ratis pipeline.
+    // There are 7 DNs. The EC pipeline must have 5 and the Ratis must have 3
+    // so there must be an intersecting DN in both lists.
+    // Once we have a DN id, look it up in the NM, as the datanodeDetails
+    // instance in the pipeline may not be the same as the one stored in the
+    // NM.
+    final UUID dnID = pipeline.getNodes().stream()
+        .filter(node -> ecPipeline.getNodes().contains(node))
+        .findFirst().get().getUuid();
+    final DatanodeDetails toDecommission = nm.getNodeByUuid(dnID.toString());
 
-    final DatanodeDetails toDecommission = getOneDNHostingReplica(replicas);
     scmClient.decommissionNodes(Arrays.asList(
         getDNHostAndPort(toDecommission)));
 
@@ -187,6 +214,8 @@ public class TestDecommissionAndMaintenance {
     // Should now be 4 replicas online as the DN is still alive but
     // in the DECOMMISSIONED state.
     waitForContainerReplicas(container, 4);
+    // In the EC case, there should be 6 online
+    waitForContainerReplicas(ecContainer, 6);
 
     // Stop the decommissioned DN
     int dnIndex = cluster.getHddsDatanodeIndex(toDecommission);
@@ -196,6 +225,8 @@ public class TestDecommissionAndMaintenance {
     // Now the decommissioned node is dead, we should have
     // 3 replicas for the tracked container.
     waitForContainerReplicas(container, 3);
+    // In the EC case, there should be 5 online
+    waitForContainerReplicas(ecContainer, 5);
 
     cluster.restartHddsDatanode(dnIndex, true);
     scmClient.recommissionNodes(Arrays.asList(
@@ -209,6 +240,8 @@ public class TestDecommissionAndMaintenance {
   // when it re-registers it should re-enter the decommission workflow and
   // complete decommissioning. If SCM is restarted after decommssion is complete
   // then SCM should learn of the decommissioned DN when it registers.
+  // If the DN is then stopped and recommissioned, when its state should
+  // move to IN_SERVICE when it is restarted.
   public void testDecommissioningNodesCompleteDecommissionOnSCMRestart()
       throws Exception {
     // First stop the replicationManager so nodes marked for decommission cannot
@@ -218,7 +251,9 @@ public class TestDecommissionAndMaintenance {
     // container. This ensures it will not decommission immediately due to
     // having no containers.
     generateData(20, "key", ratisRepConfig);
-    final ContainerInfo container = waitForAndReturnContainer();
+    generateData(20, "ecKey", ecRepConfig);
+    final ContainerInfo container =
+        waitForAndReturnContainer(ratisRepConfig, 3);
     final DatanodeDetails dn
         = getOneDNHostingReplica(getContainerReplicas(container));
     scmClient.decommissionNodes(Arrays.asList(getDNHostAndPort(dn)));
@@ -246,40 +281,24 @@ public class TestDecommissionAndMaintenance {
     // Also confirm the datanodeDetails correctly reflect the operational
     // state.
     waitForDnToReachPersistedOpState(newDn, DECOMMISSIONED);
-  }
 
-  @Test
-  // If a node was decommissioned, and then stopped so it is dead. Then it is
-  // recommissioned in SCM and restarted, the SCM state should be taken as the
-  // source of truth and the node will go to the IN_SERVICE state and the state
-  // should be updated on the DN.
-  public void testStoppedDecommissionedNodeTakesSCMStateOnRestart()
-      throws Exception {
-    // Decommission node and wait for it to be DECOMMISSIONED
-    generateData(20, "key", ratisRepConfig);
-
-    DatanodeDetails dn = nm.getAllNodes().get(0);
-    scmClient.decommissionNodes(Arrays.asList(getDNHostAndPort(dn)));
-    waitForDnToReachOpState(dn, DECOMMISSIONED);
-    waitForDnToReachPersistedOpState(dn, DECOMMISSIONED);
-
+    // Now stop the DN and recommission it in SCM. When it restarts, it should
+    // reflect the state of in SCM, in IN_SERVICE.
     int dnIndex = cluster.getHddsDatanodeIndex(dn);
     cluster.shutdownHddsDatanode(dnIndex);
     waitForDnToReachHealthState(dn, DEAD);
-
     // Datanode is shutdown and dead. Now recommission it in SCM
     scmClient.recommissionNodes(Arrays.asList(getDNHostAndPort(dn)));
-
     // Now restart it and ensure it remains IN_SERVICE
     cluster.restartHddsDatanode(dnIndex, true);
-    DatanodeDetails newDn = nm.getNodeByUuid(dn.getUuid().toString());
+    newDn = nm.getNodeByUuid(dn.getUuid().toString());
 
     // As this is not an initial registration since SCM was started, the DN
     // should report its operational state and if it differs from what SCM
     // has, then the SCM state should be used and the DN state updated.
     waitForDnToReachHealthState(newDn, HEALTHY);
     waitForDnToReachOpState(newDn, IN_SERVICE);
-    waitForDnToReachPersistedOpState(dn, IN_SERVICE);
+    waitForDnToReachPersistedOpState(newDn, IN_SERVICE);
   }
 
   @Test
@@ -293,14 +312,28 @@ public class TestDecommissionAndMaintenance {
       throws Exception {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
+    generateData(20, "ecKey", ecRepConfig);
 
     // Locate any container and find its open pipeline
-    final ContainerInfo container = waitForAndReturnContainer();
+    final ContainerInfo container =
+        waitForAndReturnContainer(ratisRepConfig, 3);
+    final ContainerInfo ecContainer =
+        waitForAndReturnContainer(ecRepConfig, 5);
     Pipeline pipeline = pm.getPipeline(container.getPipelineID());
+    Pipeline ecPipeline = pm.getPipeline(ecContainer.getPipelineID());
     assertEquals(Pipeline.PipelineState.OPEN, pipeline.getPipelineState());
-    Set<ContainerReplica> replicas = getContainerReplicas(container);
+    assertEquals(Pipeline.PipelineState.OPEN, ecPipeline.getPipelineState());
+    // Find a DN to decommission that is in both the EC and Ratis pipeline.
+    // There are 7 DNs. The EC pipeline must have 5 and the Ratis must have 3
+    // so there must be an intersecting DN in both lists.
+    // Once we have a DN id, look it up in the NM, as the datanodeDetails
+    // instance in the pipeline may not be the same as the one stored in the
+    // NM.
+    final UUID dnID = pipeline.getNodes().stream()
+        .filter(node -> ecPipeline.getNodes().contains(node))
+        .findFirst().get().getUuid();
+    final DatanodeDetails dn = nm.getNodeByUuid(dnID.toString());
 
-    final DatanodeDetails dn = getOneDNHostingReplica(replicas);
     scmClient.startMaintenanceNodes(Arrays.asList(
         getDNHostAndPort(dn)), 0);
 
@@ -311,7 +344,10 @@ public class TestDecommissionAndMaintenance {
     // maintenance
     Set<ContainerReplica> newReplicas =
         cm.getContainerReplicas(container.containerID());
+    Set<ContainerReplica> ecReplicas =
+        cm.getContainerReplicas(ecContainer.containerID());
     assertEquals(3, newReplicas.size());
+    assertEquals(5, ecReplicas.size());
 
     // Stop the maintenance DN
     cluster.shutdownHddsDatanode(dn);
@@ -320,7 +356,9 @@ public class TestDecommissionAndMaintenance {
     // Now the maintenance node is dead, we should still have
     // 3 replicas as we don't purge the replicas for a dead maintenance node
     newReplicas = cm.getContainerReplicas(container.containerID());
+    ecReplicas = cm.getContainerReplicas(ecContainer.containerID());
     assertEquals(3, newReplicas.size());
+    assertEquals(5, ecReplicas.size());
 
     // Restart the DN and it should keep the IN_MAINTENANCE state
     cluster.restartHddsDatanode(dn, true);
@@ -349,8 +387,8 @@ public class TestDecommissionAndMaintenance {
   }
 
   @Test
-  // By default a node can enter maintenance if there are two replicas left
-  // available when the maintenance nodes are stopped. Therefore putting all
+  // By default, a node can enter maintenance if there are two replicas left
+  // available when the maintenance nodes are stopped. Therefore, putting all
   // nodes hosting a replica to maintenance should cause new replicas to get
   // created before the nodes can enter maintenance. When the maintenance nodes
   // return, the excess replicas should be removed.
@@ -359,14 +397,14 @@ public class TestDecommissionAndMaintenance {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
     // Locate any container and find its open pipeline
-    final ContainerInfo container = waitForAndReturnContainer();
+    final ContainerInfo container = waitForAndReturnContainer(ratisRepConfig, 3);
     Set<ContainerReplica> replicas = getContainerReplicas(container);
 
     List<DatanodeDetails> forMaintenance = new ArrayList<>();
     replicas.forEach(r -> forMaintenance.add(r.getDatanodeDetails()));
 
     scmClient.startMaintenanceNodes(forMaintenance.stream()
-        .map(d -> getDNHostAndPort(d))
+        .map(this::getDNHostAndPort)
         .collect(Collectors.toList()), 0);
 
     // Ensure all 3 DNs go to maintenance
@@ -387,8 +425,32 @@ public class TestDecommissionAndMaintenance {
     for (DatanodeDetails dn : forMaintenance) {
       waitForDnToReachOpState(dn, IN_SERVICE);
     }
-
     waitForContainerReplicas(container, 3);
+
+    // Now write some EC data and put two nodes into maintenance. This should
+    // result in at least 1 extra replica getting created.
+    generateData(20, "eckey", ecRepConfig);
+    final ContainerInfo ecContainer =
+        waitForAndReturnContainer(ecRepConfig, 5);
+    List<DatanodeDetails> ecMaintenance = replicas.stream()
+        .map(ContainerReplica::getDatanodeDetails)
+        .limit(2)
+        .collect(Collectors.toList());
+    scmClient.startMaintenanceNodes(ecMaintenance.stream()
+        .map(this::getDNHostAndPort)
+        .collect(Collectors.toList()), 0);
+    for (DatanodeDetails dn : ecMaintenance) {
+      waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
+    }
+    assertTrue(cm.getContainerReplicas(ecContainer.containerID()).size() >= 6);
+    scmClient.recommissionNodes(forMaintenance.stream()
+        .map(this::getDNHostAndPort)
+        .collect(Collectors.toList()));
+    // Ensure the 2 DNs go to maintenance
+    for (DatanodeDetails dn : ecMaintenance) {
+      waitForDnToReachOpState(dn, IN_SERVICE);
+    }
+    waitForContainerReplicas(ecContainer, 5);
   }
 
   @Test
@@ -401,14 +463,15 @@ public class TestDecommissionAndMaintenance {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
     // Locate any container and find its open pipeline
-    final ContainerInfo container = waitForAndReturnContainer();
+    final ContainerInfo container =
+        waitForAndReturnContainer(ratisRepConfig, 3);
     Set<ContainerReplica> replicas = getContainerReplicas(container);
 
     List<DatanodeDetails> forMaintenance = new ArrayList<>();
     replicas.forEach(r -> forMaintenance.add(r.getDatanodeDetails()));
 
     scmClient.startMaintenanceNodes(forMaintenance.stream()
-        .map(d -> getDNHostAndPort(d))
+        .map(this::getDNHostAndPort)
         .collect(Collectors.toList()), 0);
 
     // Ensure all 3 DNs go to entering_maintenance
@@ -443,7 +506,7 @@ public class TestDecommissionAndMaintenance {
       throws Exception {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
-    ContainerInfo container = waitForAndReturnContainer();
+    ContainerInfo container = waitForAndReturnContainer(ratisRepConfig, 3);
     DatanodeDetails dn =
         getOneDNHostingReplica(getContainerReplicas(container));
 
@@ -485,7 +548,7 @@ public class TestDecommissionAndMaintenance {
       throws Exception {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
-    ContainerInfo container = waitForAndReturnContainer();
+    ContainerInfo container = waitForAndReturnContainer(ratisRepConfig, 3);
     DatanodeDetails dn =
         getOneDNHostingReplica(getContainerReplicas(container));
 
@@ -668,10 +731,18 @@ public class TestDecommissionAndMaintenance {
    * @return A single container present on the cluster
    * @throws Exception
    */
-  private ContainerInfo waitForAndReturnContainer() throws Exception {
-    final ContainerInfo container = cm.getContainers().get(0);
-    // Ensure all 3 replicas of the container have been reported via ICR
-    waitForContainerReplicas(container, 3);
+  private ContainerInfo waitForAndReturnContainer(ReplicationConfig repConfig,
+      int expectedReplicas) throws Exception {
+    List<ContainerInfo> containers = cm.getContainers();
+    ContainerInfo container = null;
+    for (ContainerInfo c : containers) {
+      if (c.getReplicationConfig().equals(repConfig)) {
+        container = c;
+        break;
+      }
+    }
+    // Ensure expected replicas of the container have been reported via ICR
+    waitForContainerReplicas(container, expectedReplicas);
     return container;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -447,7 +447,7 @@ public class TestDecommissionAndMaintenance {
     scmClient.recommissionNodes(forMaintenance.stream()
         .map(this::getDNHostAndPort)
         .collect(Collectors.toList()));
-    // Ensure the 2 DNs go to maintenance
+    // Ensure the 2 DNs go to IN_SERVICE
     for (DatanodeDetails dn : ecMaintenance) {
       waitForDnToReachOpState(dn, IN_SERVICE);
     }

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -397,7 +397,8 @@ public class TestDecommissionAndMaintenance {
     // Generate some data on the empty cluster to create some containers
     generateData(20, "key", ratisRepConfig);
     // Locate any container and find its open pipeline
-    final ContainerInfo container = waitForAndReturnContainer(ratisRepConfig, 3);
+    final ContainerInfo container =
+        waitForAndReturnContainer(ratisRepConfig, 3);
     Set<ContainerReplica> replicas = getContainerReplicas(container);
 
     List<DatanodeDetails> forMaintenance = new ArrayList<>();


### PR DESCRIPTION
## What changes were proposed in this pull request?

For Ratis, the number of replicas which must be available when a node goes into maintenance is a simple integer defaulting to 2 in hdds.scm.replication.maintenance.replica.minimum.

This means that for a Ratis container, one out of the 3 nodes can be offline without any replication happening. This can be set to 1, letting two go offline or 3 ensuring full redundancy and hence replication when any node is taken offline.

It could be argued that 1 would be a better default here. With the default placement of 2 replicas on one rack and 1 on another rack, that should allow for a full rack to be taken offline without replication.

For EC, its a little more tricky. Aside from Ratis 1 containers, which are rarely used in practice, EC can tolerate 2 offline (for 3-2), 3 (for 6-3) or 4 (for 10-4).

If we use the same default of 2, that means replication will always be required for 3-2 containers. Also the "number of replicas online" doesn't make as much sense for EC, as each replica is not identical.

EC is also slightly more tricky - when any of the data copies are offline, online reconctruction must be used to read the data, causing a performance penalty, but that cannot be avoided.

If we take the Ratis default of 2 - when there are two replicas out of 3 online, then we have a remaining redundancy of 1 - ie we can afford to lose one more copy and still read data.

If we change the Ratis setting to 1, there is a remaining redundancy of 0, because the loss of another replica renders the data unreadable.

For EC, if we default the setting to a "remaining redundancy" of 1, this would mean we can tolerate a loss of 1 more replicas and still read the data.

This would allow for 3-2 to have 1 replica offline, 6-3 could have 2 and 10-4 could have 3 without any replicaion. In all cases the data redundancy is the same as with Ratis having 2 containers offline.

Additionally, its highly likely online recovery will be needed to read the data, eg if 1 container is offline in 10-4 there is a 10 in 14 (5 in 7) chance its a data container, so trying to keep more containers online for larger EC groups is probably not going to help performance much.

In a large cluster, ideally EC containers will be spread across racks such that there is only 1 replia per rack, so taking a full rack offline would only reduce the redundancy by 1 meaning even 3-2 containers could tolerate a rack going into maintenance.

In summary, I believe the simplest solution, is to have an EC setting hdds.scm.replication.maintenance.ec.remaining.redundancy = 1 which we use for maintenance of EC containers and is basically equivalent to the Ratis default of 2. It may make sense to call the new parameter hdds.scm.replication.maintenance.remaining.redundancy and use the same value for both Ratis and EC, deprecating the old value.

For now in this change I have added "hdds.scm.replication.maintenance.remaining.redundancy" and noted in the comments / docs this is for EC only. We should consider how to deprecate the old parameter and bring the two together in another Jira. I am reluctant to call this one `hdds.scm.replication.ec.maintenance.remaining.redundancy` as then we will have to deprecate two parameters in the future.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6975

## How was this patch tested?

Existing tests cover the maintenance counts in the new RM related classes. I also modified the decommission and maintenance tests to include some EC data, and hence fully test the decommission and maintenance flows with EC data in place.