### PR TITLE
HDDS-7171. Add SupportedSourceVersion in annotation processors

### DIFF
--- a/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/ReplicateAnnotationProcessor.java
+++ b/hadoop-hdds/annotations/src/main/java/org/apache/ozone/annotations/ReplicateAnnotationProcessor.java
@@ -20,6 +20,8 @@ package org.apache.ozone.annotations;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -35,6 +37,7 @@ import java.util.concurrent.TimeoutException;
  * TimeoutException.
  */
 @SupportedAnnotationTypes("org.apache.hadoop.hdds.scm.metadata.Replicate")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ReplicateAnnotationProcessor extends AbstractProcessor {
 
   private static final String ANNOTATION_SIMPLE_NAME = "Replicate";

--- a/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
+++ b/hadoop-hdds/config/src/main/java/org/apache/hadoop/hdds/conf/ConfigFileGenerator.java
@@ -21,6 +21,8 @@ import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Filer;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
+import javax.annotation.processing.SupportedSourceVersion;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -42,6 +44,7 @@ import java.util.Set;
  * Annotation processor to generate config fragments from Config annotations.
  */
 @SupportedAnnotationTypes("org.apache.hadoop.hdds.conf.ConfigGroup")
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class ConfigFileGenerator extends AbstractProcessor {
 
   public static final String OUTPUT_FILE_NAME = "ozone-default-generated.xml";


### PR DESCRIPTION
## What changes were proposed in this pull request?

Get rid of the warning:

```
[INFO] --- aspectj-maven-plugin:1.14.0:compile (default) @ ozone-manager ---
[INFO] Showing AJC message detail for messages of types: [error, warning, fail]
[WARNING] No SupportedSourceVersion annotation found on org.apache.hadoop.hdds.conf.ConfigFileGenerator, returning RELEASE_6.
	<unknown source file>:<no line information>

[WARNING] No SupportedSourceVersion annotation found on org.apache.ozone.annotations.ReplicateAnnotationProcessor, returning RELEASE_6.
	<unknown source file>:<no line information>
```

https://issues.apache.org/jira/browse/HDDS-7171

## How was this patch tested?

Built locally, verified no warnings:

```
[INFO] --- aspectj-maven-plugin:1.14.0:compile (default) @ ozone-manager ---
[INFO] Showing AJC message detail for messages of types: [error, warning, fail]
[INFO] 
```

https://github.com/adoroszlai/hadoop-ozone/actions/runs/2935378198