### PR TITLE
HDDS-7185. Encode asterisk for parsing signature

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/signature/StringToSignProducer.java
@@ -249,6 +249,7 @@ public final class StringToSignProducer {
     try {
       return S3Utils.urlEncode(str)
           .replaceAll("\\+", "%20")
+          .replaceAll("\\*", "%2A")
           .replaceAll("%7E", "~");
     } catch (UnsupportedEncodingException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
## What changes were proposed in this pull request?

The asterisk not encoded when building CanonicalRequest, which will cause the error when validating signatures.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7185

## How was this patch tested?

Test using the following commands:
aws s3api --endpoint http://s3g:9878 list-objects --bucket bucket --prefix "dir1/*"
