### PR TITLE
HDDS-7191. Separate prop for s3 admin

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -136,7 +136,7 @@ public final class OzoneConfigKeys {
   public static final String OZONE_S3_ADMINISTRATORS =
           "ozone.s3.administrators";
   public static final String OZONE_S3_ADMINISTRATORS_GROUPS =
-          "ozone.s3.administrators.group";
+          "ozone.s3.administrators.groups";
   /**
    * Used only for testing purpose. Results in making every user an admin.
    * */

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/ozone/OzoneConfigKeys.java
@@ -132,6 +132,11 @@ public final class OzoneConfigKeys {
 
   public static final String OZONE_ADMINISTRATORS_GROUPS =
       "ozone.administrators.groups";
+
+  public static final String OZONE_S3_ADMINISTRATORS =
+          "ozone.s3.administrators";
+  public static final String OZONE_S3_ADMINISTRATORS_GROUPS =
+          "ozone.s3.administrators.group";
   /**
    * Used only for testing purpose. Results in making every user an admin.
    * */

--- a/hadoop-hdds/common/src/main/resources/ozone-default.xml
+++ b/hadoop-hdds/common/src/main/resources/ozone-default.xml
@@ -1612,6 +1612,30 @@
   </property>
 
   <property>
+    <name>ozone.s3.administrators</name>
+    <value/>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      S3 administrator users delimited by a comma.
+      This is the list of users who can access admin only information from s3.
+      If this property is empty then ozone.administrators will be able to access all
+      s3 information regardless of this setting.
+    </description>
+  </property>
+  <property>
+    <name>ozone.s3.administrators.groups</name>
+    <value/>
+    <tag>OZONE, SECURITY</tag>
+    <description>
+      S3 administrator groups delimited by a comma.
+      This is the list of groups who can access admin only information
+      from S3.
+      It is enough to either have the name defined in ozone.s3.administrators
+      or be directly or indirectly in a group defined in this property.
+    </description>
+  </property>
+
+  <property>
     <name>ozone.s3g.volume.name</name>
     <value>s3v</value>
     <tag>OZONE, S3GATEWAY</tag>

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -69,15 +69,19 @@ public final class OzoneConfigUtil {
     return ozAdmins;
   }
 
-  static Collection<String> getOzoneAdminsGroupsFromConfig(OzoneConfiguration conf) {
+  static Collection<String> getOzoneAdminsGroupsFromConfig(
+      OzoneConfiguration conf) {
     return conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
   }
 
-  static Collection<String> getS3AdminsGroupsFromConfig(OzoneConfiguration conf) {
+  static Collection<String> getS3AdminsGroupsFromConfig(
+      OzoneConfiguration conf) {
     Collection<String> s3AdminsGroup =
             conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS_GROUPS);
-    if (s3AdminsGroup.isEmpty() && conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS).isEmpty()) {
-      s3AdminsGroup = conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
+    if (s3AdminsGroup.isEmpty()
+            && conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS).isEmpty()) {
+      s3AdminsGroup = conf
+              .getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
     }
     return s3AdminsGroup;
   }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -28,8 +28,10 @@ import org.apache.hadoop.security.UserGroupInformation;
 import java.io.IOException;
 import java.util.Collection;
 
-import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS;
 import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS;
 
 /**
  * Utility class for ozone configurations.
@@ -78,8 +80,8 @@ public final class OzoneConfigUtil {
       OzoneConfiguration conf) {
     Collection<String> s3AdminsGroup =
             conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS_GROUPS);
-    if (s3AdminsGroup.isEmpty()
-            && conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS).isEmpty()) {
+    if (s3AdminsGroup.isEmpty() && conf
+        .getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS).isEmpty()) {
       s3AdminsGroup = conf
               .getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
     }

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -21,13 +21,65 @@ import org.apache.hadoop.hdds.client.DefaultReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import static org.apache.hadoop.ozone.OzoneConfigKeys.*;
+import static org.apache.hadoop.ozone.OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS;
 
 /**
  * Utility class for ozone configurations.
  */
 public final class OzoneConfigUtil {
   private OzoneConfigUtil() {
+  }
+
+  /**
+   * Return list of OzoneAdministrators from config.
+   */
+  static Collection<String> getOzoneAdminsFromConfig(OzoneConfiguration conf)
+          throws IOException {
+    Collection<String> ozAdmins =
+            conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
+    String omSPN = UserGroupInformation.getCurrentUser().getShortUserName();
+    if (!ozAdmins.contains(omSPN)) {
+      ozAdmins.add(omSPN);
+    }
+    return ozAdmins;
+  }
+
+  /**
+   * Return list of s3 administrators prop from config.
+   */
+  static Collection<String> getS3AdminsFromConfig(OzoneConfiguration conf)
+          throws IOException {
+    Collection<String> ozAdmins =
+            conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS);
+    if (ozAdmins == null || ozAdmins.isEmpty()) {
+      ozAdmins = conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS);
+    }
+    String omSPN = UserGroupInformation.getCurrentUser().getShortUserName();
+    if (!ozAdmins.contains(omSPN)) {
+      ozAdmins.add(omSPN);
+    }
+    return ozAdmins;
+  }
+
+  static Collection<String> getOzoneAdminsGroupsFromConfig(OzoneConfiguration conf) {
+    return conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
+  }
+
+  static Collection<String> getS3AdminsGroupsFromConfig(OzoneConfiguration conf) {
+    Collection<String> s3AdminsGroup =
+            conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS_GROUPS);
+    if (s3AdminsGroup.isEmpty() && conf.getTrimmedStringCollection(OZONE_S3_ADMINISTRATORS).isEmpty()) {
+      s3AdminsGroup = conf.getTrimmedStringCollection(OZONE_ADMINISTRATORS_GROUPS);
+    }
+    return s3AdminsGroup;
   }
 
   public static ReplicationConfig resolveReplicationConfigPreference(

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/OzoneConfigUtil.java
@@ -56,6 +56,9 @@ public final class OzoneConfigUtil {
 
   /**
    * Return list of s3 administrators prop from config.
+   *
+   * If ozone.s3.administrators value is empty string or unset,
+   * defaults to ozone.administrators value.
    */
   static Collection<String> getS3AdminsFromConfig(OzoneConfiguration conf)
           throws IOException {

--- a/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
+++ b/hadoop-ozone/ozone-manager/src/main/java/org/apache/hadoop/ozone/om/request/s3/security/S3SecretRequestHelper.java
@@ -98,7 +98,7 @@ public final class S3SecretRequestHelper {
     // to a tenant), fall back to the old permission check.
     final String fullPrincipal = ugi.getUserName();
     if (!isAccessIdAssignedToTenant &&
-        !fullPrincipal.equals(accessId) && !ozoneManager.isAdmin(ugi)) {
+        !fullPrincipal.equals(accessId) && !ozoneManager.isS3Admin(ugi)) {
 
       throw new OMException("Requested accessId '" + accessId +
           "' doesn't match current user '" + fullPrincipal +

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
@@ -22,9 +22,14 @@ import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.client.ReplicationFactor;
 import org.apache.hadoop.hdds.client.ReplicationType;
+import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
+import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * Tests the server side replication config preference logic.
@@ -102,4 +107,35 @@ public class TestOzoneConfigUtil {
         ReplicationFactor.valueOf(replicationConfig.getRequiredNodes()));
   }
 
+  @Test
+  public void testS3AdminExtraction() throws IOException {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS, "alice,bob");
+
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration).containsAll(Arrays.asList("alice", "bob")));
+  }
+
+  @Test
+  public void testS3AdminExtractionWithFallback() throws IOException {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, "alice,bob");
+
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration).containsAll(Arrays.asList("alice", "bob")));
+  }
+
+  @Test
+  public void testS3AdminGroupExtraction() {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS, "test1, test2");
+
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration).containsAll(Arrays.asList("test1", "test2")));
+  }
+
+  @Test
+  public void testS3AdminGroupExtractionWithFallback() {
+    OzoneConfiguration configuration = new OzoneConfiguration();
+    configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS, "test1, test2");
+
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration).containsAll(Arrays.asList("test1", "test2")));
+  }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/TestOzoneConfigUtil.java
@@ -112,7 +112,8 @@ public class TestOzoneConfigUtil {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS, "alice,bob");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration).containsAll(Arrays.asList("alice", "bob")));
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
+        .containsAll(Arrays.asList("alice", "bob")));
   }
 
   @Test
@@ -120,22 +121,27 @@ public class TestOzoneConfigUtil {
     OzoneConfiguration configuration = new OzoneConfiguration();
     configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS, "alice,bob");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration).containsAll(Arrays.asList("alice", "bob")));
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsFromConfig(configuration)
+        .containsAll(Arrays.asList("alice", "bob")));
   }
 
   @Test
   public void testS3AdminGroupExtraction() {
     OzoneConfiguration configuration = new OzoneConfiguration();
-    configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS, "test1, test2");
+    configuration.set(OzoneConfigKeys.OZONE_S3_ADMINISTRATORS_GROUPS,
+        "test1, test2");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration).containsAll(Arrays.asList("test1", "test2")));
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration)
+        .containsAll(Arrays.asList("test1", "test2")));
   }
 
   @Test
   public void testS3AdminGroupExtractionWithFallback() {
     OzoneConfiguration configuration = new OzoneConfiguration();
-    configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS, "test1, test2");
+    configuration.set(OzoneConfigKeys.OZONE_ADMINISTRATORS_GROUPS,
+        "test1, test2");
 
-    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration).containsAll(Arrays.asList("test1", "test2")));
+    Assert.assertTrue(OzoneConfigUtil.getS3AdminsGroupsFromConfig(configuration)
+        .containsAll(Arrays.asList("test1", "test2")));
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -200,42 +200,10 @@ public class TestS3GetSecretRequest {
   @Test
   public void testGetSecretOfAnotherUserAsAdmin() throws IOException {
 
-    // This effectively makes alice an admin.
+    // This effectively makes alice an S3 admin.
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
 
-    // 1. Get secret of "bob@EXAMPLE.COM" (as an admin).
-    long txLogIndex = 1;
-
-    // Run preExecute
-    S3GetSecretRequest s3GetSecretRequest =
-        new S3GetSecretRequest(
-            new S3GetSecretRequest(
-                s3GetSecretRequest(ACCESS_ID_BOB)
-            ).preExecute(ozoneManager)
-        );
-
-    // Run validateAndUpdateCache
-    OMClientResponse omClientResponse =
-        s3GetSecretRequest.validateAndUpdateCache(ozoneManager,
-            txLogIndex, ozoneManagerDoubleBufferHelper);
-
-    // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
-    final S3GetSecretResponse s3GetSecretResponse =
-        (S3GetSecretResponse) omClientResponse;
-
-    // Check response
-    final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
-    Assert.assertEquals(ACCESS_ID_BOB, s3SecretValue.getKerberosID());
-    final String awsSecret = s3SecretValue.getAwsSecret();
-    Assert.assertNotNull(awsSecret);
-
-    final GetS3SecretResponse getS3SecretResponse =
-        s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
-    // The secret inside should be the same.
-    final S3Secret s3Secret = getS3SecretResponse.getS3Secret();
-    Assert.assertEquals(ACCESS_ID_BOB, s3Secret.getKerberosID());
-    Assert.assertEquals(awsSecret, s3Secret.getAwsSecret());
+    processSuccessSecretRequest(ACCESS_ID_BOB, 1, true);
   }
 
   @Test
@@ -244,73 +212,13 @@ public class TestS3GetSecretRequest {
     // This effectively makes alice a regular user.
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(false);
 
-    // 1. Get secret of "alice" (as herself).
-    long txLogIndex = 1;
-
-    // Run preExecute
-    S3GetSecretRequest s3GetSecretRequest1 =
-        new S3GetSecretRequest(
-            new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE)
-            ).preExecute(ozoneManager)
-        );
-
-    // Run validateAndUpdateCache
-    OMClientResponse omClientResponse =
-        s3GetSecretRequest1.validateAndUpdateCache(ozoneManager,
-            txLogIndex, ozoneManagerDoubleBufferHelper);
-
-    // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
-    final S3GetSecretResponse s3GetSecretResponse =
-        (S3GetSecretResponse) omClientResponse;
-
-    // Check response
-    final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
-    Assert.assertEquals(USER_ALICE, s3SecretValue.getKerberosID());
-    final String awsSecret1 = s3SecretValue.getAwsSecret();
-    Assert.assertNotNull(awsSecret1);
-
-    final GetS3SecretResponse getS3SecretResponse =
-        s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
-    // The secret inside should be the same.
-    final S3Secret s3Secret1 = getS3SecretResponse.getS3Secret();
-    Assert.assertEquals(USER_ALICE, s3Secret1.getKerberosID());
-    Assert.assertEquals(awsSecret1, s3Secret1.getAwsSecret());
+    final S3Secret s3Secret1 = processSuccessSecretRequest(USER_ALICE, 1, true);
 
 
     // 2. Get secret of "alice" (as herself) again.
-    ++txLogIndex;
+    final S3Secret s3Secret2 = processSuccessSecretRequest(USER_ALICE, 2, false);
 
-    // Run preExecute
-    S3GetSecretRequest s3GetSecretRequest2 =
-        new S3GetSecretRequest(
-            new S3GetSecretRequest(
-                s3GetSecretRequest(USER_ALICE)
-            ).preExecute(ozoneManager)
-        );
-
-    // Run validateAndUpdateCache
-    OMClientResponse omClientResponse2 =
-        s3GetSecretRequest2.validateAndUpdateCache(ozoneManager,
-            txLogIndex, ozoneManagerDoubleBufferHelper);
-
-    // Check response type and cast
-    Assert.assertTrue(omClientResponse2 instanceof S3GetSecretResponse);
-    final S3GetSecretResponse s3GetSecretResponse2 =
-        (S3GetSecretResponse) omClientResponse2;
-
-    // Check response
-    Assert.assertNull(s3GetSecretResponse2.getS3SecretValue());
-
-    final GetS3SecretResponse getS3SecretResponse2 =
-        s3GetSecretResponse2.getOMResponse().getGetS3SecretResponse();
-    // The secret inside should be the same.
-    final S3Secret s3Secret2 = getS3SecretResponse2.getS3Secret();
-    Assert.assertEquals(USER_ALICE, s3Secret2.getKerberosID());
-
-    // Should get the same secret as the first request's.
-    Assert.assertEquals(awsSecret1, s3Secret2.getAwsSecret());
+    Assert.assertEquals(s3Secret1.getAwsSecret(), s3Secret2.getAwsSecret());
   }
 
   @Test
@@ -321,60 +229,32 @@ public class TestS3GetSecretRequest {
 
     // Get secret of "bob@EXAMPLE.COM" (as another regular user).
     // Run preExecute, expect USER_MISMATCH
-    try {
-      new S3GetSecretRequest(
-          s3GetSecretRequest(ACCESS_ID_BOB)
-      ).preExecute(ozoneManager);
-    } catch (OMException omEx) {
-      Assert.assertEquals(ResultCodes.USER_MISMATCH, omEx.getResult());
-      return;
-    }
+    processFailedSecretRequest(ACCESS_ID_BOB);
+  }
 
-    Assert.fail("Should have thrown OMException because alice should not have "
-        + "the permission to get bob's secret in this test case!");
+  @Test
+  public void testGetSecretOfAnotherUserAsS3Admin() throws IOException {
+    // This effectively makes alice an S3 admin.
+    when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
+
+    processSuccessSecretRequest(USER_CAROL, 1, true);
   }
 
   @Test
   public void testGetSecretOfAnotherUserAsOzoneAdmin() throws IOException {
-    // This effectively makes alice an admin.
-    when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
+    // This effectively makes alice an admin but not S3 admin.
+    when(ozoneManager.isAdmin(ugiAlice)).thenReturn(true);
+    when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(false);
 
-
-    int txLogIndex = 1;
-
-    S3GetSecretRequest s3GetSecretRequest = new S3GetSecretRequest(
-        new S3GetSecretRequest(
-            s3GetSecretRequest(USER_CAROL)
-        ).preExecute(ozoneManager));
-
-    // Run validateAndUpdateCache
-    OMClientResponse omClientResponse =
-            s3GetSecretRequest.validateAndUpdateCache(ozoneManager,
-                    txLogIndex, ozoneManagerDoubleBufferHelper);
-
-    // Check response type and cast
-    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
-    final S3GetSecretResponse s3GetSecretResponse =
-        (S3GetSecretResponse) omClientResponse;
-
-    // Check response
-    final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
-    Assert.assertEquals(USER_CAROL, s3SecretValue.getKerberosID());
-    final String awsSecret1 = s3SecretValue.getAwsSecret();
-    Assert.assertNotNull(awsSecret1);
-
-    final GetS3SecretResponse getS3SecretResponse =
-        s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
-    // The secret inside should be the same.
-    final S3Secret s3Secret1 = getS3SecretResponse.getS3Secret();
-    Assert.assertEquals(USER_CAROL, s3Secret1.getKerberosID());
-    Assert.assertEquals(awsSecret1, s3Secret1.getAwsSecret());
+    processSuccessSecretRequest(USER_ALICE, 1, true);
+    processFailedSecretRequest(USER_CAROL);
+    processSuccessSecretRequest(USER_ALICE, 2, false);
   }
 
   @Test
   public void testGetSecretWithTenant() throws IOException {
 
-    // This effectively makes alice an admin.
+    // This effectively makes alice an S3 admin.
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(true);
     // Make alice a non-delegated admin
     when(omMultiTenantManager.isTenantAdmin(ugiAlice, TENANT_ID, false))
@@ -489,5 +369,62 @@ public class TestS3GetSecretRequest {
         s3Secret.getAwsSecret());
     Assert.assertEquals(originalS3Secret.getKerberosID(),
         s3Secret.getKerberosID());
+  }
+
+
+  private S3Secret processSuccessSecretRequest(
+      String userPrincipalId,
+      int txLogIndex,
+      boolean shouldHaveResponse) throws IOException {
+    S3GetSecretRequest s3GetSecretRequest =
+        new S3GetSecretRequest(
+            new S3GetSecretRequest(
+                s3GetSecretRequest(userPrincipalId)
+            ).preExecute(ozoneManager)
+        );
+
+    // Run validateAndUpdateCache
+    OMClientResponse omClientResponse =
+        s3GetSecretRequest.validateAndUpdateCache(ozoneManager,
+            txLogIndex, ozoneManagerDoubleBufferHelper);
+
+    // Check response type and cast
+    Assert.assertTrue(omClientResponse instanceof S3GetSecretResponse);
+    final S3GetSecretResponse s3GetSecretResponse =
+        (S3GetSecretResponse) omClientResponse;
+
+    // Check response
+    if (shouldHaveResponse) {
+      // Check response
+      final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
+      Assert.assertEquals(userPrincipalId, s3SecretValue.getKerberosID());
+      final String awsSecret1 = s3SecretValue.getAwsSecret();
+      Assert.assertNotNull(awsSecret1);
+    } else {
+      Assert.assertNull(s3GetSecretResponse.getS3SecretValue());
+    }
+
+    final GetS3SecretResponse getS3SecretResponse =
+        s3GetSecretResponse.getOMResponse().getGetS3SecretResponse();
+    // The secret inside should be the same.
+    final S3Secret s3Secret = getS3SecretResponse.getS3Secret();
+    Assert.assertEquals(userPrincipalId, s3Secret.getKerberosID());
+
+    return s3Secret;
+  }
+
+
+  private void processFailedSecretRequest(String userPrincipalId) throws IOException {
+    try {
+      new S3GetSecretRequest(
+          s3GetSecretRequest(ACCESS_ID_BOB)
+      ).preExecute(ozoneManager);
+    } catch (OMException omEx) {
+      Assert.assertEquals(ResultCodes.USER_MISMATCH, omEx.getResult());
+      return;
+    }
+
+    Assert.fail("Should have thrown OMException because alice should not have "
+        + "the permission to get bob's secret in this test case!");
   }
 }

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -212,11 +212,13 @@ public class TestS3GetSecretRequest {
     // This effectively makes alice a regular user.
     when(ozoneManager.isS3Admin(ugiAlice)).thenReturn(false);
 
-    final S3Secret s3Secret1 = processSuccessSecretRequest(USER_ALICE, 1, true);
+    final S3Secret s3Secret1 = processSuccessSecretRequest(
+        USER_ALICE, 1, true);
 
 
     // 2. Get secret of "alice" (as herself) again.
-    final S3Secret s3Secret2 = processSuccessSecretRequest(USER_ALICE, 2, false);
+    final S3Secret s3Secret2 = processSuccessSecretRequest(
+        USER_ALICE, 2, false);
 
     Assert.assertEquals(s3Secret1.getAwsSecret(), s3Secret2.getAwsSecret());
   }
@@ -413,11 +415,10 @@ public class TestS3GetSecretRequest {
     return s3Secret;
   }
 
-
   private void processFailedSecretRequest(String userPrincipalId) throws IOException {
     try {
       new S3GetSecretRequest(
-          s3GetSecretRequest(ACCESS_ID_BOB)
+          s3GetSecretRequest(userPrincipalId)
       ).preExecute(ozoneManager);
     } catch (OMException omEx) {
       Assert.assertEquals(ResultCodes.USER_MISMATCH, omEx.getResult());

--- a/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
+++ b/hadoop-ozone/ozone-manager/src/test/java/org/apache/hadoop/ozone/om/request/s3/security/TestS3GetSecretRequest.java
@@ -398,7 +398,8 @@ public class TestS3GetSecretRequest {
     // Check response
     if (shouldHaveResponse) {
       // Check response
-      final S3SecretValue s3SecretValue = s3GetSecretResponse.getS3SecretValue();
+      final S3SecretValue s3SecretValue =
+          s3GetSecretResponse.getS3SecretValue();
       Assert.assertEquals(userPrincipalId, s3SecretValue.getKerberosID());
       final String awsSecret1 = s3SecretValue.getAwsSecret();
       Assert.assertNotNull(awsSecret1);
@@ -415,7 +416,8 @@ public class TestS3GetSecretRequest {
     return s3Secret;
   }
 
-  private void processFailedSecretRequest(String userPrincipalId) throws IOException {
+  private void processFailedSecretRequest(String userPrincipalId)
+      throws IOException {
     try {
       new S3GetSecretRequest(
           s3GetSecretRequest(userPrincipalId)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Created new props `ozone.s3.administrators` and `ozone.s3.administrators.groups`
2. In case when at least one of these props is defined all s3 shell operation can be executed only by one of defined user as admin. Each user still should have permission to generate keys for itself.
3. In case when these properties are empty admins should be taken from `ozone.administrators` or `ozone.administrators.groups`

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7191

## How was this patch tested?

Manual testing and new unit tests
