### PR TITLE
HDDS-7200. Fixed inaccurate get request status code

### DIFF
--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -343,7 +343,6 @@ public class ObjectEndpoint extends EndpointBase {
           }
         };
         responseBuilder = Response
-            .ok(output)
             .status(Status.PARTIAL_CONTENT)
             .entity(output)
             .header(CONTENT_LENGTH, copyLength);

--- a/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
+++ b/hadoop-ozone/s3gateway/src/main/java/org/apache/hadoop/ozone/s3/endpoint/ObjectEndpoint.java
@@ -344,6 +344,8 @@ public class ObjectEndpoint extends EndpointBase {
         };
         responseBuilder = Response
             .ok(output)
+            .status(Status.PARTIAL_CONTENT)
+            .entity(output)
             .header(CONTENT_LENGTH, copyLength);
 
         String contentRangeVal = RANGE_HEADER_SUPPORTED_UNIT + " " +


### PR DESCRIPTION
## What changes were proposed in this pull request?
will get the content in a range( add such as: "Range: bytes=123-" at request header), The backend service needs to return this range of data, and the returned status code should be [206](https://www.rfc-editor.org/rfc/rfc7233#section-4.1)
current Ozone s3 gateway will return 200 instead of 206, this pr will be fixed it.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7200

Please replace this section with the link to the Apache JIRA)

## How was this patch tested?

Send a get request requesting range data, the return status should be 206.
