### PR TITLE
HDDS-7197. Schema V3 RocksDB instance statitics register as metrics collision

### DIFF
--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStoreBuilder.java
@@ -79,6 +79,7 @@ public final class DBStoreBuilder {
   private ManagedColumnFamilyOptions defaultCfOptions;
   private String dbname;
   private Path dbPath;
+  private String dbJmxBeanNameName;
   // Maps added column family names to the column family options they were
   // added with. Value will be null if the column family was not added with
   // any options. On build, this will be replaced with defaultCfOptions.
@@ -188,7 +189,7 @@ public final class DBStoreBuilder {
       }
 
       return new RDBStore(dbFile, rocksDBOption, writeOptions, tableConfigs,
-          registry, openReadOnly);
+          registry, openReadOnly, dbJmxBeanNameName);
     } finally {
       tableConfigs.forEach(TableConfig::close);
     }
@@ -196,6 +197,11 @@ public final class DBStoreBuilder {
 
   public DBStoreBuilder setName(String name) {
     dbname = name;
+    return this;
+  }
+
+  public DBStoreBuilder setDBJmxBeanNameName(String name) {
+    dbJmxBeanNameName = name;
     return this;
   }
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -92,7 +92,7 @@ public class RDBStore implements DBStore {
         if (statMBeanName == null) {
           LOG.warn("jmx registration failed during RocksDB init, db path :{}",
               dbJmxBeanName);
-         } else {
+        } else {
           LOG.info("jmx registration succeed during RocksDB init, db path :{}",
               dbJmxBeanName);
         }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -93,7 +93,7 @@ public class RDBStore implements DBStore {
           LOG.warn("jmx registration failed during RocksDB init, db path :{}",
               dbJmxBeanName);
         } else {
-          LOG.info("jmx registration succeed during RocksDB init, db path :{}",
+          LOG.debug("jmx registration succeed during RocksDB init, db path :{}",
               dbJmxBeanName);
         }
       }

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -58,23 +58,26 @@ public class RDBStore implements DBStore {
   private final RDBCheckpointManager checkPointManager;
   private final String checkpointsParentDir;
   private final RDBMetrics rdbMetrics;
+  private final String dbJmxBeanName;
 
   @VisibleForTesting
   public RDBStore(File dbFile, ManagedDBOptions options,
                   Set<TableConfig> families) throws IOException {
     this(dbFile, options, new ManagedWriteOptions(), families,
-        new CodecRegistry(), false);
+        new CodecRegistry(), false, null);
   }
 
   public RDBStore(File dbFile, ManagedDBOptions dbOptions,
                   ManagedWriteOptions writeOptions, Set<TableConfig> families,
-                  CodecRegistry registry, boolean readOnly)
-      throws IOException {
+                  CodecRegistry registry, boolean readOnly,
+                  String dbJmxBeanNameName) throws IOException {
     Preconditions.checkNotNull(dbFile, "DB file location cannot be null");
     Preconditions.checkNotNull(families);
     Preconditions.checkArgument(!families.isEmpty());
     codecRegistry = registry;
     dbLocation = dbFile;
+    dbJmxBeanName = dbJmxBeanNameName == null ? dbFile.getName() :
+        dbJmxBeanNameName;
 
     try {
       db = RocksDatabase.open(dbFile, dbOptions, writeOptions,
@@ -82,14 +85,16 @@ public class RDBStore implements DBStore {
 
       if (dbOptions.statistics() != null) {
         Map<String, String> jmxProperties = new HashMap<>();
-        jmxProperties.put("dbName", dbFile.getName());
+        jmxProperties.put("dbName", dbJmxBeanName);
         statMBeanName = HddsUtils.registerWithJmxProperties(
             "Ozone", "RocksDbStore", jmxProperties,
-            RocksDBStoreMBean.create(dbOptions.statistics(),
-                dbFile.getName()));
+            RocksDBStoreMBean.create(dbOptions.statistics(), dbJmxBeanName));
         if (statMBeanName == null) {
           LOG.warn("jmx registration failed during RocksDB init, db path :{}",
-              dbFile.getAbsolutePath());
+              dbJmxBeanName);
+         } else {
+          LOG.info("jmx registration succeed during RocksDB init, db path :{}",
+              dbJmxBeanName);
         }
       }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HDDS-7197

It uses rocksdb directory name as the jmx bean name.   For Schema V2,  every rocksdb directory like this, 

999998-dn-container.db
999999-dn-container.db

While in Schema V3, all rocksdb has the same directory name "container.db".  Collision happens when rocksdb per disk volume come to  register its metrics to jmx with failure "already exists!" metrics exception.  

This patch add the disk storage UUID as prefix of bean name. So now the bean name for each Schema V3 rocksdb instance will be storageUUID-container.db, here is an example,

DS-d26aea2d-cc3b-42e4-b574-b4644227fa8-ccontainer.db 