### PR TITLE
HDDS-7144. Recon: Make only hostname fixed in Datanodes page.

### DIFF
--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -140,8 +140,7 @@ const COLUMNS = [
     filters: DatanodeStateList.map(state => ({text: state, value: state})),
     onFilter: (value: DatanodeState, record: IDatanode) => record.state === value,
     render: (text: DatanodeState) => renderDatanodeState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state),
-    //fixed: 'left'
+    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state)
   },
   {
     title: 'Operational State',
@@ -153,8 +152,7 @@ const COLUMNS = [
     filters: DatanodeOpStateList.map(state => ({text: state, value: state})),
     onFilter: (value: DatanodeOpState, record: IDatanode) => record.opState === value,
     render: (text: DatanodeOpState) => renderDatanodeOpState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState),
-    //fixed: 'left'
+    sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState)
   },
  
   {

--- a/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
+++ b/hadoop-ozone/recon/src/main/resources/webapps/recon/ozone-recon-web/src/views/datanodes/datanodes.tsx
@@ -121,30 +121,6 @@ const renderDatanodeOpState = (opState: DatanodeOpState) => {
 
 const COLUMNS = [
   {
-    title: 'State',
-    dataIndex: 'state',
-    key: 'state',
-    isVisible: true,
-    filterMultiple: true,
-    filters: DatanodeStateList.map(state => ({text: state, value: state})),
-    onFilter: (value: DatanodeState, record: IDatanode) => record.state === value,
-    render: (text: DatanodeState) => renderDatanodeState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state),
-    fixed: 'left'
-  },
-  {
-    title: 'Operational State',
-    dataIndex: 'opState',
-    key: 'opState',
-    isVisible: true,
-    filterMultiple: true,
-    filters: DatanodeOpStateList.map(state => ({text: state, value: state})),
-    onFilter: (value: DatanodeOpState, record: IDatanode) => record.opState === value,
-    render: (text: DatanodeOpState) => renderDatanodeOpState(text),
-    sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState),
-    fixed: 'left'
-  },
-  {
     title: 'Hostname',
     dataIndex: 'hostname',
     key: 'hostname',
@@ -154,6 +130,33 @@ const COLUMNS = [
     defaultSortOrder: 'ascend' as const,
     fixed: 'left'
   },
+  {
+    title: 'State',
+    dataIndex: 'state',
+    key: 'state',
+    isVisible: true,
+    isSearchable: true,
+    filterMultiple: true,
+    filters: DatanodeStateList.map(state => ({text: state, value: state})),
+    onFilter: (value: DatanodeState, record: IDatanode) => record.state === value,
+    render: (text: DatanodeState) => renderDatanodeState(text),
+    sorter: (a: IDatanode, b: IDatanode) => a.state.localeCompare(b.state),
+    //fixed: 'left'
+  },
+  {
+    title: 'Operational State',
+    dataIndex: 'opState',
+    key: 'opState',
+    isVisible: true,
+    isSearchable: true,
+    filterMultiple: true,
+    filters: DatanodeOpStateList.map(state => ({text: state, value: state})),
+    onFilter: (value: DatanodeOpState, record: IDatanode) => record.opState === value,
+    render: (text: DatanodeOpState) => renderDatanodeOpState(text),
+    sorter: (a: IDatanode, b: IDatanode) => a.opState.localeCompare(b.opState),
+    //fixed: 'left'
+  },
+ 
   {
     title: 'Uuid',
     dataIndex: 'uuid',


### PR DESCRIPTION

## What changes were proposed in this pull request?
I fixed  changes to allow user to filter by HEALTHY or other State; same for Operational State and make only HostName as fixed and float the State and Operational State.


## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7144



## How was this patch tested?
I tested manually  in Localhost 3000 and showed changes to Zita also.


