### PR TITLE
HDDS-7201. testContainerIsReplicatedWhenAllNodesGotoMaintenance is failing frequently

### DIFF
--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -433,6 +433,7 @@ public class TestDecommissionAndMaintenance {
     generateData(20, "eckey", ecRepConfig);
     final ContainerInfo ecContainer =
         waitForAndReturnContainer(ecRepConfig, 5);
+    replicas = getContainerReplicas(ecContainer);
     List<DatanodeDetails> ecMaintenance = replicas.stream()
         .map(ContainerReplica::getDatanodeDetails)
         .limit(2)
@@ -444,7 +445,7 @@ public class TestDecommissionAndMaintenance {
       waitForDnToReachPersistedOpState(dn, IN_MAINTENANCE);
     }
     assertTrue(cm.getContainerReplicas(ecContainer.containerID()).size() >= 6);
-    scmClient.recommissionNodes(forMaintenance.stream()
+    scmClient.recommissionNodes(ecMaintenance.stream()
         .map(this::getDNHostAndPort)
         .collect(Collectors.toList()));
     // Ensure the 2 DNs go to IN_SERVICE


### PR DESCRIPTION
## What changes were proposed in this pull request?

Since changes in [HDDS-6975](https://issues.apache.org/jira/browse/HDDS-6975) the test testContainerIsReplicatedWhenAllNodesGotoMaintenance is failing frequently. This PR is to fix the issues with that test.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7201

## How was this patch tested?

Ran test several times locally to ensure it always passes.