### PR TITLE
HDDS-7086. DataNode UI to show failed volumes too

### DIFF
--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/HddsVolume.java
@@ -123,7 +123,7 @@ public class HddsVolume extends StorageVolume {
       // HddsVolume Object.
       this.setState(VolumeState.FAILED);
       volumeIOStats = null;
-      volumeInfoMetrics = null;
+      volumeInfoMetrics = new VolumeInfoMetrics(b.getVolumeRootStr(), this);
       committedBytes = null;
     }
 
@@ -162,9 +162,6 @@ public class HddsVolume extends StorageVolume {
     super.failVolume();
     if (volumeIOStats != null) {
       volumeIOStats.unregister();
-    }
-    if (volumeInfoMetrics != null) {
-      volumeInfoMetrics.unregister();
     }
     closeDbStore();
   }

--- a/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
+++ b/hadoop-hdds/container-service/src/main/java/org/apache/hadoop/ozone/container/common/volume/VolumeInfoMetrics.java
@@ -75,6 +75,11 @@ public class VolumeInfoMetrics {
     return volume.getLayoutVersion();
   }
 
+  @Metric("Returns the Volume State")
+  public String getVolumeState() {
+    return volume.getStorageState().name();
+  }
+
   @Metric("Returns the Volume Type")
   public String getVolumeType() {
     return volume.getType().name();

--- a/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
+++ b/hadoop-hdds/container-service/src/main/resources/webapps/hddsDatanode/dn-overview.html
@@ -33,6 +33,7 @@
         <th>Available Space</th>
         <th>Reserved</th>
         <th>Total Capacity</th>
+        <th>State</th>
     </tr>
     </thead>
     <tbody>
@@ -44,6 +45,7 @@
         <td>{{volumeInfo.Available}}</td>
         <td>{{volumeInfo.Reserved}}</td>
         <td>{{volumeInfo.TotalCapacity}}</td>
+        <td>{{volumeInfo["tag.VolumeState"]}}</td>
     </tr>
     </tbody>
 </table>


### PR DESCRIPTION
## What changes were proposed in this pull request?

In this change I added the volume state to the VolumeInfoMetrics so it will be exposed to the JMX of the datanodes and added a volume state column to the Volume Information's table on the Datanode WebUI. I modified that if a volume fail it will still have a VolumeInfoMetrics with the information added that it is failed.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7086

## How was this patch tested?

Tested locally on a cluster that the volume state have been exposed to the datanode's JMX (`jmx?qry=Hadoop:service=HddsDatanode,name=VolumeInfoMetrics*`) and I can also see it on the WebUI.
```
{
  "beans" : [ {
    "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/hdds",
    "modelerType" : "VolumeInfoMetrics-/data/hdds",
    "tag.Context" : "ozone",
    "tag.VolumeState" : "NORMAL",
    "tag.VolumeType" : "DATA_VOLUME",
    "tag.StorageDirectory" : "/data/hdds/hdds",
    "tag.StorageType" : "DISK",
    "tag.DatanodeUuid" : "70b1bce3-779b-4733-bf2d-fc27cafcb3f1",
    "tag.Hostname" : "6971e80c0c05",
    "TotalCapacity" : 47549485056,
    "Capacity" : 47549485056,
    "Available" : 47549263872,
    "LayoutVersion" : 1,
    "Reserved" : 0,
    "Used" : 221184
  }, {
    "name" : "Hadoop:service=HddsDatanode,name=VolumeInfoMetrics-/data/secondary_volume",
    "modelerType" : "VolumeInfoMetrics-/data/secondary_volume",
    "tag.Context" : "ozone",
    "tag.VolumeState" : "FAILED",
    "tag.VolumeType" : "DATA_VOLUME",
    "tag.StorageDirectory" : "/data/secondary_volume/hdds",
    "tag.StorageType" : "DISK",
    "tag.DatanodeUuid" : "70b1bce3-779b-4733-bf2d-fc27cafcb3f1",
    "tag.Hostname" : "6971e80c0c05",
    "TotalCapacity" : 47549272064,
    "Capacity" : 47549272064,
    "Available" : 47549263872,
    "LayoutVersion" : 1,
    "Reserved" : 0,
    "Used" : 8192
  } ]
}
```
<img width="1718" alt="Screenshot 2022-09-07 at 15 26 30" src="https://user-images.githubusercontent.com/50611074/188919273-9e359bab-bc06-488d-b9b0-b6186fef8b5b.png">

