### PR TITLE
HDDS-7206. Change the placement policy interface to allow existing nodes to be specified for Rack Scatter Policy.

### DIFF
--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
@@ -33,8 +33,9 @@ public interface PlacementPolicy {
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes, int nodesRequired,
           long metadataSizeRequired, long dataSizeRequired) throws IOException {
-    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,favoredNodes,
-            nodesRequired, metadataSizeRequired, dataSizeRequired);
+    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,
+            favoredNodes, nodesRequired, metadataSizeRequired,
+            dataSizeRequired);
   }
   /**
    * Given an initial set of datanodes and the size required,

--- a/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
+++ b/hadoop-hdds/common/src/main/java/org/apache/hadoop/hdds/scm/PlacementPolicy.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hdds.scm;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -28,10 +29,18 @@ import java.util.List;
  */
 public interface PlacementPolicy {
 
+  default List<DatanodeDetails> chooseDatanodes(
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequired,
+          long metadataSizeRequired, long dataSizeRequired) throws IOException {
+    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,favoredNodes,
+            nodesRequired, metadataSizeRequired, dataSizeRequired);
+  }
   /**
    * Given an initial set of datanodes and the size required,
    * return set of datanodes that satisfy the nodes and size requirement.
    *
+   * @param usedNodes - List of nodes already chosen for pipeline
    * @param excludedNodes - list of nodes to be excluded.
    * @param favoredNodes - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
@@ -40,9 +49,11 @@ public interface PlacementPolicy {
    * @return list of datanodes chosen.
    * @throws IOException
    */
-  List<DatanodeDetails> chooseDatanodes(List<DatanodeDetails> excludedNodes,
-      List<DatanodeDetails> favoredNodes, int nodesRequired,
-      long metadataSizeRequired, long dataSizeRequired) throws IOException;
+  List<DatanodeDetails> chooseDatanodes(List<DatanodeDetails> usedNodes,
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes,
+          int nodesRequired, long metadataSizeRequired,
+          long dataSizeRequired) throws IOException;
 
   /**
    * Given a list of datanode and the number of replicas required, return

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -18,10 +18,8 @@
 package org.apache.hadoop.hdds.scm;
 
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
+import java.io.IOException;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -107,6 +105,15 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
     return conf;
   }
 
+  @Override
+  public final List<DatanodeDetails> chooseDatanodes(
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequired,
+          long metadataSizeRequired, long dataSizeRequired) throws SCMException {
+    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,favoredNodes,
+            nodesRequired, metadataSizeRequired, dataSizeRequired);
+  }
+
   /**
    * Given size required, return set of datanodes
    * that satisfy the nodes and size requirement.
@@ -117,8 +124,8 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    * 2. We place containers on nodes with enough space for that container.
    * 3. if a set of containers are requested, we either meet the required
    * number of nodes or we fail that request.
-   *
-   * @param excludedNodes - datanodes with existing replicas
+   * @param usedNodes - datanodes with existing replicas
+   * @param excludedNodes - datanodes with failures
    * @param favoredNodes  - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
    * @param dataSizeRequired - size required for the container.
@@ -128,6 +135,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    */
   @Override
   public final List<DatanodeDetails> chooseDatanodes(
+          List<DatanodeDetails> usedNodes,
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes,
           int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
@@ -146,8 +154,14 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   random node from NetworkTopology should fix this. Check HDDS-7015
  */
     return chooseDatanodesInternal(
+            Objects.isNull(usedNodes) ? Collections.emptyList()
+                    : usedNodes.stream().map(node -> {
+                      DatanodeDetails datanodeDetails =
+                              nodeManager.getNodeByUuid(node.getUuidString());
+                      return datanodeDetails != null ? datanodeDetails : node;
+            }).collect(Collectors.toList()),
             Objects.isNull(excludedNodes)
-                    ? excludedNodes : excludedNodes.stream()
+                    ? Collections.emptyList() : excludedNodes.stream()
                     .map(node -> {
                       DatanodeDetails datanodeDetails =
                               nodeManager.getNodeByUuid(node.getUuidString());
@@ -159,7 +173,8 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
 
   /**
    * Pipeline placement choose datanodes to join the pipeline.
-   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                      pipeline.
    * @param excludedNodes - excluded nodes
    * @param favoredNodes  - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
@@ -169,7 +184,8 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
    * @throws SCMException when chosen nodes are not enough in numbers
    */
   protected List<DatanodeDetails> chooseDatanodesInternal(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+      List<DatanodeDetails> usedNodes, List<DatanodeDetails> excludedNodes,
+      List<DatanodeDetails> favoredNodes,
       int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
       throws SCMException {
     List<DatanodeDetails> healthyNodes =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/SCMCommonPlacementPolicy.java
@@ -18,8 +18,11 @@
 package org.apache.hadoop.hdds.scm;
 
 
-import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
 import java.util.stream.Collectors;
 
 import com.google.common.base.Preconditions;
@@ -109,9 +112,11 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
   public final List<DatanodeDetails> chooseDatanodes(
           List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes, int nodesRequired,
-          long metadataSizeRequired, long dataSizeRequired) throws SCMException {
-    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,favoredNodes,
-            nodesRequired, metadataSizeRequired, dataSizeRequired);
+          long metadataSizeRequired,
+          long dataSizeRequired) throws SCMException {
+    return this.chooseDatanodes(Collections.emptyList(), excludedNodes,
+            favoredNodes, nodesRequired, metadataSizeRequired,
+            dataSizeRequired);
   }
 
   /**
@@ -159,7 +164,7 @@ public abstract class SCMCommonPlacementPolicy implements PlacementPolicy {
                       DatanodeDetails datanodeDetails =
                               nodeManager.getNodeByUuid(node.getUuidString());
                       return datanodeDetails != null ? datanodeDetails : node;
-            }).collect(Collectors.toList()),
+                    }).collect(Collectors.toList()),
             Objects.isNull(excludedNodes)
                     ? Collections.emptyList() : excludedNodes.stream()
                     .map(node -> {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -88,7 +88,8 @@ public final class SCMContainerPlacementCapacity
   /**
    * Called by SCM to choose datanodes.
    *
-   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                    pipeline.
    * @param excludedNodes - list of the datanodes to exclude.
    * @param favoredNodes - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
@@ -99,11 +100,12 @@ public final class SCMContainerPlacementCapacity
    */
   @Override
   protected List<DatanodeDetails> chooseDatanodesInternal(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
-      final int nodesRequired,
-      long metadataSizeRequired, long dataSizeRequired) throws SCMException {
+          List<DatanodeDetails> usedNodes, List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes,
+          final int nodesRequired,
+          long metadataSizeRequired, long dataSizeRequired) throws SCMException {
     List<DatanodeDetails> healthyNodes = super.chooseDatanodesInternal(
-            excludedNodes, favoredNodes, nodesRequired,
+            usedNodes, excludedNodes, favoredNodes, nodesRequired,
             metadataSizeRequired, dataSizeRequired);
     if (healthyNodes.size() == nodesRequired) {
       return healthyNodes;

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementCapacity.java
@@ -102,8 +102,8 @@ public final class SCMContainerPlacementCapacity
   protected List<DatanodeDetails> chooseDatanodesInternal(
           List<DatanodeDetails> usedNodes, List<DatanodeDetails> excludedNodes,
           List<DatanodeDetails> favoredNodes,
-          final int nodesRequired,
-          long metadataSizeRequired, long dataSizeRequired) throws SCMException {
+          final int nodesRequired, long metadataSizeRequired,
+          long dataSizeRequired) throws SCMException {
     List<DatanodeDetails> healthyNodes = super.chooseDatanodesInternal(
             usedNodes, excludedNodes, favoredNodes, nodesRequired,
             metadataSizeRequired, dataSizeRequired);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackAware.java
@@ -84,7 +84,8 @@ public final class SCMContainerPlacementRackAware
    * There are two scenarios, one is choosing all nodes for a new pipeline.
    * Another is choosing node to meet replication requirement.
    *
-   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                      pipeline.
    * @param excludedNodes - list of the datanodes to exclude.
    * @param favoredNodes - list of nodes preferred. This is a hint to the
    *                     allocator, whether the favored nodes will be used
@@ -98,9 +99,11 @@ public final class SCMContainerPlacementRackAware
    */
   @Override
   protected List<DatanodeDetails> chooseDatanodesInternal(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
-      int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
-      throws SCMException {
+          List<DatanodeDetails> usedNodes,
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, int nodesRequired,
+          long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
     Preconditions.checkArgument(nodesRequired > 0);
     metrics.incrDatanodeRequestCount(nodesRequired);
     int datanodeCount = networkTopology.getNumOfLeafNode(NetConstants.ROOT);

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRackScatter.java
@@ -29,14 +29,9 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Container placement policy that scatter datanodes on different racks
@@ -76,85 +71,23 @@ public final class SCMContainerPlacementRackScatter
     this.metrics = metrics;
   }
 
-  /**
-   * Called by SCM to choose datanodes.
-   *
-   *
-   * @param excludedNodes - list of the datanodes to exclude.
-   * @param favoredNodes - list of nodes preferred. This is a hint to the
-   *                     allocator, whether the favored nodes will be used
-   *                     depends on whether the nodes meets the allocator's
-   *                     requirement.
-   * @param nodesRequiredToChoose - number of datanodes required.
-   * @param dataSizeRequired - size required for the container.
-   * @param metadataSizeRequired - size required for Ratis metadata.
-   * @return List of datanodes.
-   * @throws SCMException  SCMException
-   */
-  @Override
-  protected List<DatanodeDetails> chooseDatanodesInternal(
-      final List<DatanodeDetails> excludedNodes,
-      final List<DatanodeDetails> favoredNodes,
-      final int nodesRequiredToChoose, final long metadataSizeRequired,
-      final long dataSizeRequired) throws SCMException {
-    if (nodesRequiredToChoose <= 0) {
-      String errorMsg = "num of nodes required to choose should bigger" +
-          "than 0, but the given num is " + nodesRequiredToChoose;
-      throw new SCMException(errorMsg, null);
+  public Set<DatanodeDetails> chooseNodesFromRacks(List<Node> racks,
+          List<Node> unavailableNodes,
+          List<DatanodeDetails> mutableFavoredNodes,
+          int nodesRequired, final long metadataSizeRequired,
+          final long dataSizeRequired, int maxRetries,
+          int maxOuterLoopIterations) {
+    if (nodesRequired <= 0) {
+      return Collections.emptySet();
     }
-    metrics.incrDatanodeRequestCount(nodesRequiredToChoose);
-    int nodesRequired = nodesRequiredToChoose;
-    int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
-    List<Node> availableNodes = networkTopology.getNodes(
-        networkTopology.getMaxLevel());
-    int totalNodesCount = availableNodes.size();
-    if (excludedNodes != null) {
-      availableNodes.removeAll(excludedNodes);
-    }
-    if (availableNodes.size() < nodesRequired) {
-      throw new SCMException("No enough datanodes to choose. " +
-          "TotalNode = " + totalNodesCount +
-          " AvailableNode = " + availableNodes.size() +
-          " RequiredNode = " + nodesRequired +
-          " ExcludedNode = " + excludedNodesCount,
-          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
-    }
-
-    List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();
-    if (favoredNodes != null) {
-      // Generate mutableFavoredNodes, only stores valid favoredNodes
-      for (DatanodeDetails datanodeDetails : favoredNodes) {
-        if (isValidNode(datanodeDetails, metadataSizeRequired,
-            dataSizeRequired)) {
-          mutableFavoredNodes.add(datanodeDetails);
-        }
-      }
-      Collections.shuffle(mutableFavoredNodes);
-    }
-    if (excludedNodes != null) {
-      mutableFavoredNodes.removeAll(excludedNodes);
-    }
-
-    // For excluded nodes, we sort their racks at rear
-    List<Node> racks = getAllRacks();
-    if (excludedNodes != null && excludedNodes.size() > 0) {
-      racks = sortRackWithExcludedNodes(racks, excludedNodes);
-    }
-
     List<Node> toChooseRacks = new LinkedList<>();
     Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>();
-    List<Node> unavailableNodes = new ArrayList<>();
     Set<Node> skippedRacks = new HashSet<>();
-    if (excludedNodes != null) {
-      unavailableNodes.addAll(excludedNodes);
-    }
-
     // If the result doesn't change after retryCount, we return with exception
     int retryCount = 0;
-    while (nodesRequired > 0) {
-      if (retryCount > OUTER_LOOP_MAX_RETRY) {
-        throw new SCMException("No satisfied datanode to meet the" +
-            " excludedNodes and affinityNode constrains.", null);
+    while (nodesRequired > 0 && maxOuterLoopIterations > 0) {
+      if (retryCount > maxRetries) {
+        return chosenNodes;
       }
       int chosenListSize = chosenNodes.size();
 
@@ -196,7 +129,7 @@ public final class SCMContainerPlacementRackScatter
           continue;
         }
         Node node = chooseNode(rack.getNetworkFullPath(), unavailableNodes,
-            metadataSizeRequired, dataSizeRequired);
+                metadataSizeRequired, dataSizeRequired);
         if (node != null) {
           chosenNodes.add((DatanodeDetails) node);
           mutableFavoredNodes.remove(node);
@@ -220,25 +153,172 @@ public final class SCMContainerPlacementRackScatter
         // If chosenNodes changed, reset the retryCount
         retryCount = 0;
       }
+      maxOuterLoopIterations--;
     }
-    List<DatanodeDetails> result = new ArrayList<>(chosenNodes);
-    ContainerPlacementStatus placementStatus =
-        validateContainerPlacement(result, nodesRequiredToChoose);
-    if (!placementStatus.isPolicySatisfied()) {
-      String errorMsg = "ContainerPlacementPolicy not met, currentRacks is " +
-          placementStatus.actualPlacementCount() + "desired racks is" +
-          placementStatus.expectedPlacementCount();
+    return chosenNodes;
+  }
+
+  /**
+   * Called by SCM to choose datanodes.
+   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                      pipeline.
+   * @param excludedNodes - list of the datanodes to exclude.
+   * @param favoredNodes - list of nodes preferred. This is a hint to the
+   *                     allocator, whether the favored nodes will be used
+   *                     depends on whether the nodes meets the allocator's
+   *                     requirement.
+   * @param nodesRequiredToChoose - number of datanodes required.
+   * @param dataSizeRequired - size required for the container.
+   * @param metadataSizeRequired - size required for Ratis metadata.
+   * @return List of datanodes.
+   * @throws SCMException  SCMException
+   */
+  @Override
+  protected List<DatanodeDetails> chooseDatanodesInternal(
+          List<DatanodeDetails> usedNodes,
+          final List<DatanodeDetails> excludedNodes,
+          final List<DatanodeDetails> favoredNodes,
+          final int nodesRequiredToChoose, final long metadataSizeRequired,
+          final long dataSizeRequired) throws SCMException {
+    if (nodesRequiredToChoose <= 0) {
+      String errorMsg = "num of nodes required to choose should bigger" +
+          "than 0, but the given num is " + nodesRequiredToChoose;
       throw new SCMException(errorMsg, null);
     }
+    metrics.incrDatanodeRequestCount(nodesRequiredToChoose);
+    int nodesRequired = nodesRequiredToChoose;
+    int excludedNodesCount = excludedNodes == null ? 0 : excludedNodes.size();
+    List<Node> availableNodes = networkTopology.getNodes(
+        networkTopology.getMaxLevel());
+    int totalNodesCount = availableNodes.size();
+    if (excludedNodes != null) {
+      availableNodes.removeAll(excludedNodes);
+    }
+    if (availableNodes.size() < nodesRequired) {
+      throw new SCMException("No enough datanodes to choose. " +
+          "TotalNode = " + totalNodesCount +
+          " AvailableNode = " + availableNodes.size() +
+          " RequiredNode = " + nodesRequired +
+          " ExcludedNode = " + excludedNodesCount,
+          SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+
+    List<DatanodeDetails> mutableFavoredNodes = new ArrayList<>();
+    if (favoredNodes != null) {
+      // Generate mutableFavoredNodes, only stores valid favoredNodes
+      for (DatanodeDetails datanodeDetails : favoredNodes) {
+        if (isValidNode(datanodeDetails, metadataSizeRequired,
+            dataSizeRequired)) {
+          mutableFavoredNodes.add(datanodeDetails);
+        }
+      }
+      Collections.shuffle(mutableFavoredNodes);
+    }
+    if (excludedNodes != null) {
+      mutableFavoredNodes.removeAll(excludedNodes);
+    }
+
+    if (usedNodes == null) {
+      usedNodes = Collections.emptyList();
+    }
+    List<Node> racks = getAllRacks();
+    Set<Node> usedRacks = usedNodes.stream()
+            .map(node -> networkTopology.getAncestor(node, RACK_LEVEL))
+            .filter(node -> node != null)
+            .collect(Collectors.toSet());
+    int requiredReplicationFactor = usedNodes.size() + nodesRequired;
+    int numberOfRacksRequired =
+            getRequiredRackCount(requiredReplicationFactor);
+    int additionalRacksRequired = numberOfRacksRequired - usedRacks.size();
+    if (nodesRequired < additionalRacksRequired) {
+      String reason = "Required nodes size: " + nodesRequired
+              + " is less than required number of racks to choose: "
+              + additionalRacksRequired + ".";
+      LOG.warn("Placement policy cannot choose the enough racks. {}"
+                      + "Total number of Required Racks: {} Used Racks Count:" +
+                      " {}, Required Nodes count: {}",
+              reason, numberOfRacksRequired, usedRacks.size(), nodesRequired);
+      throw new SCMException(reason,
+              SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+    // For excluded nodes, we sort their racks at rear
+    racks = sortRackWithExcludedNodes(racks, excludedNodes, usedRacks);
+
+    List<Node> unavailableNodes = new ArrayList<>();
+    if (excludedNodes != null) {
+      unavailableNodes.addAll(excludedNodes);
+    }
+    unavailableNodes.addAll(usedNodes);
+
+    Set<DatanodeDetails> chosenNodes = new LinkedHashSet<>();
+
+    if (racks.size() < additionalRacksRequired ) {
+      String reason = "Number of existing racks: " + racks.size()
+              + "is less than additional required number of racks to choose: "
+              + additionalRacksRequired + " do not match.";
+      LOG.warn("Placement policy cannot choose the enough racks. {}"
+                      + "Total number of Required Racks: {} Used Racks Count:" +
+                      " {}, Required Nodes count: {}",
+              reason, numberOfRacksRequired, usedRacks.size(), nodesRequired);
+      throw new SCMException(reason,
+              SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE);
+    }
+
+    chosenNodes.addAll(chooseNodesFromRacks(racks, unavailableNodes,
+            mutableFavoredNodes, additionalRacksRequired,
+            metadataSizeRequired, dataSizeRequired, OUTER_LOOP_MAX_RETRY, 1));
+
+    if (chosenNodes.size() < additionalRacksRequired) {
+      String reason = "Chosen nodes size from Unique Racks: " + chosenNodes
+              .size() + ", but required nodes to choose from Unique Racks: "
+              + additionalRacksRequired + " do not match.";
+      LOG.warn("Placement policy could not choose the enough nodes from " +
+                      "available racks."
+                      + " {} Available racks count: {}," +
+                      " Excluded nodes count: {}",
+              reason, racks.size(), excludedNodesCount);
+      throw new SCMException(reason,
+              SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
+    }
+
+    if (chosenNodes.size() < nodesRequired) {
+      racks.addAll(usedRacks);
+      usedRacks.addAll(chosenNodes.stream()
+              .map(node -> networkTopology.getAncestor(node, RACK_LEVEL))
+              .filter(node -> node != null)
+              .collect(Collectors.toSet()));
+      sortRackWithExcludedNodes(racks, excludedNodes, usedRacks);
+      racks.addAll(usedRacks);
+      chosenNodes.addAll(chooseNodesFromRacks(racks, unavailableNodes,
+              mutableFavoredNodes, nodesRequired - chosenNodes.size(),
+              metadataSizeRequired, dataSizeRequired, OUTER_LOOP_MAX_RETRY,
+              Integer.MAX_VALUE));
+    }
+
+    List<DatanodeDetails> result = new ArrayList<>(chosenNodes);
+
     if (nodesRequiredToChoose != chosenNodes.size()) {
       String reason = "Chosen nodes size: " + chosenNodes
-          .size() + ", but required nodes to choose: " + nodesRequiredToChoose
-          + " do not match.";
+              .size() + ", but required nodes to choose: " + nodesRequiredToChoose
+              + " do not match.";
       LOG.warn("Placement policy could not choose the enough nodes."
-              + " {} Available nodes count: {}, Excluded nodes count: {}",
-          reason, totalNodesCount, excludedNodesCount);
+                      + " {} Available nodes count: {}, Excluded nodes count: {}",
+              reason, totalNodesCount, excludedNodesCount);
       throw new SCMException(reason,
-          SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
+              SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES);
+    }
+
+    ContainerPlacementStatus placementStatus =
+        validateContainerPlacement(
+                Stream.of(usedNodes, result)
+                      .flatMap(List::stream).collect(Collectors.toList()),
+                requiredReplicationFactor);
+    if (!placementStatus.isPolicySatisfied()) {
+      String errorMsg = "ContainerPlacementPolicy not met, currentRacks is " +
+          placementStatus.actualPlacementCount() + " desired racks is " +
+          placementStatus.expectedPlacementCount();
+      throw new SCMException(errorMsg, null);
     }
     return result;
   }
@@ -328,19 +408,25 @@ public final class SCMContainerPlacementRackScatter
    * racks, so we sort these racks at rear.
    * @param racks
    * @param excludedNodes
+   * @param usedRacks
    * @return
    */
   private List<Node> sortRackWithExcludedNodes(List<Node> racks,
-      List<DatanodeDetails> excludedNodes) {
+          List<DatanodeDetails> excludedNodes, Set<Node> usedRacks) {
+    if ((excludedNodes == null || excludedNodes.isEmpty())
+            && usedRacks.isEmpty()) {
+      return racks;
+    }
     Set<Node> lessPreferredRacks = excludedNodes.stream()
         .map(node -> networkTopology.getAncestor(node, RACK_LEVEL))
         // Dead Nodes have been removed from the topology and so have a
         // null rack. We need to exclude those from the rack list.
         .filter(node -> node != null)
+        .filter(node -> !usedRacks.contains(node))
         .collect(Collectors.toSet());
     List <Node> result = new ArrayList<>();
     for (Node rack : racks) {
-      if (!lessPreferredRacks.contains(rack)) {
+      if (!usedRacks.contains(rack) && !lessPreferredRacks.contains(rack)) {
         result.add(rack);
       }
     }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/SCMContainerPlacementRandom.java
@@ -60,7 +60,8 @@ public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
   /**
    * Choose datanodes called by the SCM to choose the datanode.
    *
-   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                      pipeline.
    * @param excludedNodes - list of the datanodes to exclude.
    * @param favoredNodes - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
@@ -71,11 +72,13 @@ public final class SCMContainerPlacementRandom extends SCMCommonPlacementPolicy
    */
   @Override
   protected List<DatanodeDetails> chooseDatanodesInternal(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
-      final int nodesRequired,
-      long metadataSizeRequired, long dataSizeRequired) throws SCMException {
+          List<DatanodeDetails> usedNodes,
+          List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes, final int nodesRequired,
+          long metadataSizeRequired, long dataSizeRequired)
+          throws SCMException {
     List<DatanodeDetails> healthyNodes =
-        super.chooseDatanodesInternal(excludedNodes, favoredNodes,
+        super.chooseDatanodesInternal(usedNodes, excludedNodes, favoredNodes,
                 nodesRequired, metadataSizeRequired, dataSizeRequired);
 
     if (healthyNodes.size() == nodesRequired) {

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/pipeline/PipelinePlacementPolicy.java
@@ -204,7 +204,8 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
 
   /**
    * Pipeline placement choose datanodes to join the pipeline.
-   *
+   * @param usedNodes - list of the datanodes to already chosen in the
+   *                      pipeline.
    * @param excludedNodes - excluded nodes
    * @param favoredNodes  - list of nodes preferred.
    * @param nodesRequired - number of datanodes required.
@@ -215,8 +216,9 @@ public final class PipelinePlacementPolicy extends SCMCommonPlacementPolicy {
    */
   @Override
   protected List<DatanodeDetails> chooseDatanodesInternal(
-      List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
-      int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
+          List<DatanodeDetails> usedNodes, List<DatanodeDetails> excludedNodes,
+          List<DatanodeDetails> favoredNodes,
+          int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
       throws SCMException {
     // Get a list of viable nodes based on criteria
     // and make sure excludedNodes are excluded from list.

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestContainerPlacementFactory.java
@@ -179,7 +179,9 @@ public class TestContainerPlacementFactory {
   public static class DummyImpl implements PlacementPolicy {
     @Override
     public List<DatanodeDetails> chooseDatanodes(
-        List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+        List<DatanodeDetails> usedNodes,
+        List<DatanodeDetails> excludedNodes,
+        List<DatanodeDetails> favoredNodes,
         int nodesRequired, long metadataSizeRequired, long dataSizeRequired) {
       return null;
     }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -36,6 +36,8 @@ import org.apache.hadoop.hdds.scm.node.DatanodeInfo;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
+import org.assertj.core.util.Lists;
+import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -50,7 +52,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeOperationalState.DECOMMISSIONED;
 import static org.apache.hadoop.hdds.protocol.proto.HddsProtos.NodeState.HEALTHY;
@@ -87,7 +91,20 @@ public class TestSCMContainerPlacementRackScatter {
         IntStream.of(20, 25, 30));
   }
 
+  private void updateStorageInDatanode(int dnIndex, long used, long remaining) {
+    StorageReportProto storage = HddsTestUtils.createStorageReport(
+            dnInfos.get(dnIndex).getUuid(),
+            "/data1-" + dnInfos.get(dnIndex).getUuidString(),
+            STORAGE_CAPACITY, used, remaining, null);
+    dnInfos.get(dnIndex).updateStorageReports(
+            new ArrayList<>(Arrays.asList(storage)));
+  }
+
   private void setup(int datanodeCount) {
+    setup(datanodeCount, NODE_PER_RACK);
+  }
+
+  private void setup(int datanodeCount, int nodesPerRack) {
     //initialize network topology instance
     conf = new OzoneConfiguration();
     // We are using small units here
@@ -105,7 +122,7 @@ public class TestSCMContainerPlacementRackScatter {
       // Totally 6 racks, each has 5 datanodes
       DatanodeDetails datanodeDetails =
           MockDatanodeDetails.createDatanodeDetails(
-          hostname + i, rack + (i / NODE_PER_RACK));
+          hostname + i, rack + (i / nodesPerRack));
 
       datanodes.add(datanodeDetails);
       cluster.add(datanodeDetails);
@@ -495,6 +512,64 @@ public class TestSCMContainerPlacementRackScatter {
     stat = policy.validateContainerPlacement(dns, 1);
     assertTrue(stat.isPolicySatisfied());
     assertEquals(0, stat.misReplicationCount());
+  }
+
+  public List<DatanodeDetails> getDatanodes(List<Integer> dnIndexes) {
+    return dnIndexes.stream().map(datanodes::get).collect(Collectors.toList());
+  }
+
+  private void assertPlacementPolicySatisfied(List<DatanodeDetails> usedDns,
+                                              List<DatanodeDetails> additionalNodes,
+                                              List<DatanodeDetails> excludedNodes,
+                                              int requiredNodes,
+                                              boolean isSatisfied,
+                                              int misReplication) {
+    assertFalse(excludedNodes.stream().anyMatch(additionalNodes::
+    contains));
+    ContainerPlacementStatus stat = policy.validateContainerPlacement(
+            Stream.of(usedDns,additionalNodes)
+                    .flatMap(List::stream).collect(Collectors.toList()),
+            requiredNodes);
+    assertEquals(isSatisfied, stat.isPolicySatisfied());
+    assertEquals(misReplication, stat.misReplicationCount());
+  }
+
+  @Test
+  public void testValidChooseNodesWithUsedNodes() throws SCMException {
+    setup(5, 2);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
+    List<DatanodeDetails> additionalNodes = policy.chooseDatanodes(usedDns,
+            excludedDns, null, 2, 0, 5);
+    assertPlacementPolicySatisfied(usedDns, additionalNodes, excludedDns, 4,
+            true, 0);
+  }
+
+  @Test
+  public void testInValidChooseNodesWithUsedNodesWithInsufficientRequiredNodeCount() {
+    setup(5, 2);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
+    SCMException exception = Assertions.assertThrows(SCMException.class, () ->
+            policy.chooseDatanodes(usedDns, excludedDns,
+                    null, 1, 0, 5));
+    assertEquals("Required nodes size: 1 is less than " +
+            "required number of racks to choose: 2.", exception.getMessage());
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE, exception.getResult());
+  }
+
+  @Test
+  public void testInValidChooseNodesWithUsedNodesWithInsufficientRacks() {
+    setup(6, 2);
+    List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
+    updateStorageInDatanode(4, 99, 1);
+    List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(5));
+    SCMException exception = Assertions.assertThrows(SCMException.class, () ->
+            policy.chooseDatanodes(usedDns, excludedDns,
+                    null, 2, 0, 5));
+    assertEquals("Chosen nodes size from Unique Racks: 1, but required " +
+            "nodes to choose from Unique Racks: 2 do not match.", exception.getMessage());
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES, exception.getResult());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/placement/algorithms/TestSCMContainerPlacementRackScatter.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.ozone.container.upgrade.UpgradeUtils;
 import org.assertj.core.util.Lists;
-import org.junit.Assert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -519,15 +518,12 @@ public class TestSCMContainerPlacementRackScatter {
   }
 
   private void assertPlacementPolicySatisfied(List<DatanodeDetails> usedDns,
-                                              List<DatanodeDetails> additionalNodes,
-                                              List<DatanodeDetails> excludedNodes,
-                                              int requiredNodes,
-                                              boolean isSatisfied,
-                                              int misReplication) {
-    assertFalse(excludedNodes.stream().anyMatch(additionalNodes::
-    contains));
+      List<DatanodeDetails> additionalNodes,
+      List<DatanodeDetails> excludedNodes, int requiredNodes,
+      boolean isSatisfied, int misReplication) {
+    assertFalse(excludedNodes.stream().anyMatch(additionalNodes::contains));
     ContainerPlacementStatus stat = policy.validateContainerPlacement(
-            Stream.of(usedDns,additionalNodes)
+            Stream.of(usedDns, additionalNodes)
                     .flatMap(List::stream).collect(Collectors.toList()),
             requiredNodes);
     assertEquals(isSatisfied, stat.isPolicySatisfied());
@@ -546,7 +542,7 @@ public class TestSCMContainerPlacementRackScatter {
   }
 
   @Test
-  public void testInValidChooseNodesWithUsedNodesWithInsufficientRequiredNodeCount() {
+  public void testChooseNodesWithUsedNodesWithInsufficientRequiredNodeCount() {
     setup(5, 2);
     List<DatanodeDetails> usedDns = getDatanodes(Lists.newArrayList(0, 1));
     List<DatanodeDetails> excludedDns = getDatanodes(Lists.newArrayList(2));
@@ -555,7 +551,8 @@ public class TestSCMContainerPlacementRackScatter {
                     null, 1, 0, 5));
     assertEquals("Required nodes size: 1 is less than " +
             "required number of racks to choose: 2.", exception.getMessage());
-    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE, exception.getResult());
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_SUITABLE_NODE,
+            exception.getResult());
   }
 
   @Test
@@ -568,8 +565,10 @@ public class TestSCMContainerPlacementRackScatter {
             policy.chooseDatanodes(usedDns, excludedDns,
                     null, 2, 0, 5));
     assertEquals("Chosen nodes size from Unique Racks: 1, but required " +
-            "nodes to choose from Unique Racks: 2 do not match.", exception.getMessage());
-    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES, exception.getResult());
+            "nodes to choose from Unique Racks: 2 do not match.",
+            exception.getMessage());
+    assertEquals(SCMException.ResultCodes.FAILED_TO_FIND_HEALTHY_NODES,
+            exception.getResult());
   }
 
   @Test

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationTestUtil.java
@@ -149,9 +149,10 @@ public final class ReplicationTestUtil {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {
       @Override
       protected List<DatanodeDetails> chooseDatanodesInternal(
-          List<DatanodeDetails> excludedNodes,
-          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
-          long metadataSizeRequired, long dataSizeRequired) {
+              List<DatanodeDetails> usedNodes,
+              List<DatanodeDetails> excludedNodes,
+              List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+              long metadataSizeRequired, long dataSizeRequired) {
         List<DatanodeDetails> dns = new ArrayList<>();
         for (int i = 0; i < nodesRequiredToChoose; i++) {
           dns.add(MockDatanodeDetails.randomDatanodeDetails());
@@ -172,10 +173,11 @@ public final class ReplicationTestUtil {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {
       @Override
       protected List<DatanodeDetails> chooseDatanodesInternal(
-          List<DatanodeDetails> excludedNodes,
-          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
-          long metadataSizeRequired, long dataSizeRequired)
-          throws SCMException {
+              List<DatanodeDetails> usedNodes,
+              List<DatanodeDetails> excludedNodes,
+              List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+              long metadataSizeRequired, long dataSizeRequired)
+              throws SCMException {
         if (nodesRequiredToChoose > 1) {
           throw new IllegalArgumentException("Only one node is allowed");
         }
@@ -200,12 +202,13 @@ public final class ReplicationTestUtil {
     return new SCMCommonPlacementPolicy(nodeManager, conf) {
       @Override
       protected List<DatanodeDetails> chooseDatanodesInternal(
-          List<DatanodeDetails> excludedNodes,
-          List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
-          long metadataSizeRequired, long dataSizeRequired)
-          throws SCMException {
+              List<DatanodeDetails> usedNodes,
+              List<DatanodeDetails> excludedNodes,
+              List<DatanodeDetails> favoredNodes, int nodesRequiredToChoose,
+              long metadataSizeRequired, long dataSizeRequired)
+              throws SCMException {
         throw new SCMException("No nodes available",
-            FAILED_TO_FIND_SUITABLE_NODE);
+                FAILED_TO_FIND_SUITABLE_NODE);
       }
 
       @Override

--- a/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
+++ b/hadoop-ozone/recon/src/test/java/org/apache/hadoop/ozone/recon/fsck/TestContainerHealthTask.java
@@ -353,7 +353,8 @@ public class TestContainerHealthTask extends AbstractReconSqlDBTest {
 
     @Override
     public List<DatanodeDetails> chooseDatanodes(
-        List<DatanodeDetails> excludedNodes, List<DatanodeDetails> favoredNodes,
+        List<DatanodeDetails> usedNodes, List<DatanodeDetails> excludedNodes,
+        List<DatanodeDetails> favoredNodes,
         int nodesRequired, long metadataSizeRequired, long dataSizeRequired)
         throws IOException {
       return null;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The existing interface only allows for excluded nodes to be passed, which we use to exclude nodes already used in a pipeline. However when we go to add a new node to a pipeline (eg EC Reconstruction, or replication) the excluded node list cannot be used to indicate the existing racks used. This means the placement policies are not "rack aware" when used to select additional nodes. We will pick new nodes, and it may cause the container to become mis-replicated (ie not on enough racks).

Ideally we should pass in the existing nodes separately from excluded nodes. That would allow the policies to lookup the racks of those nodes and hence correctly select new nodes that meet the placement policy.
Changing the interface to segregate usedNodes & excludedNodes(Nodes with Failure)

## What is the link to the Apache JIRA
https://issues.apache.org/jira/browse/HDDS-7206

## How was this patch tested?

Unit Test Cases
