### PR TITLE
HDDS-7209. Bump Jersey2 to 2.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
 
     <!-- jersey version -->
     <jersey.version>1.19</jersey.version>
-    <jersey2.version>2.33</jersey2.version>
+    <jersey2.version>2.34</jersey2.version>
 
     <!-- jackson versions -->
     <jackson2.version>2.13.2</jackson2.version>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade Jersey 2.33 to 2.34 due to CVE-2021-28168.

https://issues.apache.org/jira/browse/HDDS-7209

## How was this patch tested?

Regular CI:
https://github.com/adoroszlai/hadoop-ozone/actions/runs/3024130363