### PR TITLE
HDDS-7213. extract ReplicationManagerConfiguration to a separate class

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManagerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/LegacyReplicationManagerConfiguration.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigType;
+
+import java.time.Duration;
+
+import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
+import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
+
+/**
+ * Configuration used by the {@link LegacyReplicationManager}.
+ */
+@ConfigGroup(prefix = "hdds.scm.replication")
+public class LegacyReplicationManagerConfiguration {
+    /**
+     * The frequency in which ReplicationMonitor thread should run.
+     */
+    @Config(key = "thread.interval",
+            type = ConfigType.TIME,
+            defaultValue = "300s",
+            tags = {SCM, OZONE},
+            description = "There is a replication monitor thread running inside " +
+                    "SCM which takes care of replicating the containers in the " +
+                    "cluster. This property is used to configure the interval in " +
+                    "which that thread runs."
+    )
+    private long interval = Duration.ofSeconds(300).toMillis();
+
+    /**
+     * Timeout for container replication & deletion command issued by
+     * ReplicationManager.
+     */
+    @Config(key = "event.timeout",
+            type = ConfigType.TIME,
+            defaultValue = "30m",
+            tags = {SCM, OZONE},
+            description = "Timeout for the container replication/deletion commands "
+                    + "sent  to datanodes. After this timeout the command will be "
+                    + "retried.")
+    private long eventTimeout = Duration.ofMinutes(30).toMillis();
+
+    public void setInterval(Duration interval) {
+        this.interval = interval.toMillis();
+    }
+
+    public void setEventTimeout(Duration timeout) {
+        this.eventTimeout = timeout.toMillis();
+    }
+
+    /**
+     * The number of container replica which must be available for a node to
+     * enter maintenance.
+     */
+    @Config(key = "maintenance.replica.minimum",
+            type = ConfigType.INT,
+            defaultValue = "2",
+            tags = {SCM, OZONE},
+            description = "The minimum number of container replicas which must " +
+                    " be available for a node to enter maintenance. If putting a " +
+                    " node into maintenance reduces the available replicas for any " +
+                    " container below this level, the node will remain in the " +
+                    " entering maintenance state until a new replica is created.")
+    private int maintenanceReplicaMinimum = 2;
+
+    @Config(key = "container.inflight.replication.limit",
+            type = ConfigType.INT,
+            defaultValue = "0", // 0 means unlimited.
+            tags = {SCM, OZONE},
+            description = "This property is used to limit" +
+                    " the maximum number of inflight replication."
+    )
+    private int containerInflightReplicationLimit = 0;
+
+    @Config(key = "container.inflight.deletion.limit",
+            type = ConfigType.INT,
+            defaultValue = "0", // 0 means unlimited.
+            tags = {SCM, OZONE},
+            description = "This property is used to limit" +
+                    " the maximum number of inflight deletion."
+    )
+    private int containerInflightDeletionLimit = 0;
+
+    public void setContainerInflightReplicationLimit(int replicationLimit) {
+        this.containerInflightReplicationLimit = replicationLimit;
+    }
+
+    public void setContainerInflightDeletionLimit(int deletionLimit) {
+        this.containerInflightDeletionLimit = deletionLimit;
+    }
+
+    public void setMaintenanceReplicaMinimum(int replicaCount) {
+        this.maintenanceReplicaMinimum = replicaCount;
+    }
+
+    public int getContainerInflightReplicationLimit() {
+        return containerInflightReplicationLimit;
+    }
+
+    public int getContainerInflightDeletionLimit() {
+        return containerInflightDeletionLimit;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public long getEventTimeout() {
+        return eventTimeout;
+    }
+
+    public int getMaintenanceReplicaMinimum() {
+        return maintenanceReplicaMinimum;
+    }
+}

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerConfiguration.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/replication/ReplicationManagerConfiguration.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hdds.scm.container.replication;
+
+import org.apache.hadoop.hdds.conf.Config;
+import org.apache.hadoop.hdds.conf.ConfigGroup;
+import org.apache.hadoop.hdds.conf.ConfigType;
+
+import java.time.Duration;
+
+import static org.apache.hadoop.hdds.conf.ConfigTag.OZONE;
+import static org.apache.hadoop.hdds.conf.ConfigTag.SCM;
+
+/**
+ * Configuration used by the {@link ReplicationManager}.
+ */
+@ConfigGroup(prefix = "hdds.scm.replication")
+public class ReplicationManagerConfiguration {
+    /**
+     * The frequency in which ReplicationMonitor thread should run.
+     */
+    @Config(key = "thread.interval",
+            type = ConfigType.TIME,
+            defaultValue = "300s",
+            tags = {SCM, OZONE},
+            description = "There is a replication monitor thread running inside " +
+                    "SCM which takes care of replicating the containers in the " +
+                    "cluster. This property is used to configure the interval in " +
+                    "which that thread runs."
+    )
+    private long interval = Duration.ofSeconds(300).toMillis();
+
+    /**
+     * The frequency in which the Under Replicated queue is processed.
+     */
+    @Config(key = "under.replicated.interval",
+            type = ConfigType.TIME,
+            defaultValue = "30s",
+            tags = {SCM, OZONE},
+            description = "How frequently to check if there are work to process " +
+                    " on the under replicated queue"
+    )
+    private long underReplicatedInterval = Duration.ofSeconds(30).toMillis();
+
+    /**
+     * The frequency in which the Over Replicated queue is processed.
+     */
+    @Config(key = "over.replicated.interval",
+            type = ConfigType.TIME,
+            defaultValue = "30s",
+            tags = {SCM, OZONE},
+            description = "How frequently to check if there are work to process " +
+                    " on the over replicated queue"
+    )
+    private long overReplicatedInterval = Duration.ofSeconds(30).toMillis();
+
+    /**
+     * Timeout for container replication & deletion command issued by
+     * ReplicationManager.
+     */
+    @Config(key = "event.timeout",
+            type = ConfigType.TIME,
+            defaultValue = "30m",
+            tags = {SCM, OZONE},
+            description = "Timeout for the container replication/deletion commands "
+                    + "sent  to datanodes. After this timeout the command will be "
+                    + "retried.")
+    private long eventTimeout = Duration.ofMinutes(30).toMillis();
+
+    public void setInterval(Duration interval) {
+        this.interval = interval.toMillis();
+    }
+
+    public void setEventTimeout(Duration timeout) {
+        this.eventTimeout = timeout.toMillis();
+    }
+
+    /**
+     * The number of container replica which must be available for a node to
+     * enter maintenance.
+     */
+    @Config(key = "maintenance.replica.minimum",
+            type = ConfigType.INT,
+            defaultValue = "2",
+            tags = {SCM, OZONE},
+            description = "The minimum number of container replicas which must " +
+                    " be available for a node to enter maintenance. If putting a " +
+                    " node into maintenance reduces the available replicas for any " +
+                    " container below this level, the node will remain in the " +
+                    " entering maintenance state until a new replica is created.")
+    private int maintenanceReplicaMinimum = 2;
+
+    public void setMaintenanceReplicaMinimum(int replicaCount) {
+        this.maintenanceReplicaMinimum = replicaCount;
+    }
+
+    /**
+     * Defines how many redundant replicas of a container must be online for a
+     * node to enter maintenance. Currently, only used for EC containers. We
+     * need to consider removing the "maintenance.replica.minimum" setting
+     * and having both Ratis and EC use this new one.
+     */
+    @Config(key = "maintenance.remaining.redundancy",
+            type = ConfigType.INT,
+            defaultValue = "1",
+            tags = {SCM, OZONE},
+            description = "The number of redundant containers in a group which" +
+                    " must be available for a node to enter maintenance. If putting" +
+                    " a node into maintenance reduces the redundancy below this value" +
+                    " , the node will remain in the ENTERING_MAINTENANCE state until" +
+                    " a new replica is created. For Ratis containers, the default" +
+                    " value of 1 ensures at least two replicas are online, meaning 1" +
+                    " more can be lost without data becoming unavailable. For any EC" +
+                    " container it will have at least dataNum + 1 online, allowing" +
+                    " the loss of 1 more replica before data becomes unavailable." +
+                    " Currently only EC containers use this setting. Ratis containers" +
+                    " use hdds.scm.replication.maintenance.replica.minimum. For EC," +
+                    " if nodes are in maintenance, it is likely reconstruction reads" +
+                    " will be required if some of the data replicas are offline. This" +
+                    " is seamless to the client, but will affect read performance."
+    )
+    private int maintenanceRemainingRedundancy = 1;
+
+    public void setMaintenanceRemainingRedundancy(int redundancy) {
+        this.maintenanceRemainingRedundancy = redundancy;
+    }
+
+    public int getMaintenanceRemainingRedundancy() {
+        return maintenanceRemainingRedundancy;
+    }
+
+    public long getInterval() {
+        return interval;
+    }
+
+    public long getUnderReplicatedInterval() {
+        return underReplicatedInterval;
+    }
+
+    public void setUnderReplicatedInterval(Duration duration) {
+        this.underReplicatedInterval = duration.toMillis();
+    }
+
+    public void setOverReplicatedInterval(Duration duration) {
+        this.overReplicatedInterval = duration.toMillis();
+    }
+
+    public long getOverReplicatedInterval() {
+        return overReplicatedInterval;
+    }
+
+    public long getEventTimeout() {
+        return eventTimeout;
+    }
+
+    public int getMaintenanceReplicaMinimum() {
+        return maintenanceReplicaMinimum;
+    }
+}

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestLegacyReplicationManager.java
@@ -42,8 +42,6 @@ import org.apache.hadoop.hdds.scm.container.ContainerStateManagerImpl;
 import org.apache.hadoop.hdds.scm.container.ReplicationManagerReport;
 import org.apache.hadoop.hdds.scm.container.SimpleMockNodeManager;
 import org.apache.hadoop.hdds.scm.container.TestContainerManagerImpl;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager
-    .ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.PlacementPolicy;
 import org.apache.hadoop.hdds.scm.container.common.helpers.MoveDataNodePair;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.ContainerPlacementStatusDefault;
@@ -219,15 +217,15 @@ public class TestLegacyReplicationManager {
       throws Exception {
     replicationManager.stop();
     dbStore.close();
-    final LegacyReplicationManager.ReplicationManagerConfiguration conf
-        = new LegacyReplicationManager.ReplicationManagerConfiguration();
+    final LegacyReplicationManagerConfiguration conf
+        = new LegacyReplicationManagerConfiguration();
     conf.setContainerInflightReplicationLimit(replicationLimit);
     conf.setContainerInflightDeletionLimit(deletionLimit);
     createReplicationManager(conf);
   }
 
   void createReplicationManager(
-      LegacyReplicationManager.ReplicationManagerConfiguration conf)
+      LegacyReplicationManagerConfiguration conf)
       throws Exception {
     createReplicationManager(null, conf);
   }
@@ -238,7 +236,7 @@ public class TestLegacyReplicationManager {
   }
 
   void createReplicationManager(ReplicationManagerConfiguration rmConf,
-      LegacyReplicationManager.ReplicationManagerConfiguration lrmConf)
+      LegacyReplicationManagerConfiguration lrmConf)
       throws InterruptedException, IOException {
     OzoneConfiguration config = new OzoneConfiguration();
     testDir = GenericTestUtils

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestOverReplicatedProcessor.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.DeleteContainerCommand;

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/replication/TestUnderReplicatedProcessor.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.protocol.MockDatanodeDetails;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.events.SCMEvents;
 import org.apache.hadoop.hdds.server.events.EventPublisher;
 import org.apache.hadoop.ozone.protocol.commands.ReconstructECContainersCommand;

--- a/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
+++ b/hadoop-ozone/fault-injection-test/mini-chaos-tests/src/test/java/org/apache/hadoop/ozone/MiniOzoneChaosCluster.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.DatanodeDetails;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.server.SCMConfigurator;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;

--- a/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ReplicaManagerInsight.java
+++ b/hadoop-ozone/insight/src/main/java/org/apache/hadoop/ozone/insight/scm/ReplicaManagerInsight.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.ozone.insight.BaseInsightPoint;
 import org.apache.hadoop.ozone.insight.Component.Type;
 import org.apache.hadoop.ozone.insight.LoggerSource;
@@ -50,7 +51,7 @@ public class ReplicaManagerInsight extends BaseInsightPoint {
   @Override
   public List<Class> getConfigurationClasses() {
     List<Class> result = new ArrayList<>();
-    result.add(ReplicationManager.ReplicationManagerConfiguration.class);
+    result.add(ReplicationManagerConfiguration.class);
     return result;
   }
 

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/TestContainerReplicationEndToEnd.java
@@ -27,7 +27,7 @@ import org.apache.hadoop.hdds.scm.ScmConfigKeys;
 import org.apache.hadoop.hdds.scm.XceiverClientManager;
 import org.apache.hadoop.hdds.scm.XceiverClientSpi;
 import org.apache.hadoop.hdds.scm.container.ContainerID;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.pipeline.PipelineID;
 import org.apache.hadoop.ozone.HddsDatanodeService;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/client/rpc/read/TestInputStreamBase.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hdds.client.ReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.scm.OzoneClientConfig;
 import org.apache.hadoop.hdds.scm.ScmConfigKeys;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.ozone.MiniOzoneCluster;
 import org.apache.hadoop.ozone.OzoneConfigKeys;
 import org.apache.hadoop.ozone.client.ObjectStore;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/container/TestContainerReplication.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hdds.client.RatisReplicationConfig;
 import org.apache.hadoop.hdds.conf.OzoneConfiguration;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementCapacity;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRackAware;
 import org.apache.hadoop.hdds.scm.container.placement.algorithms.SCMContainerPlacementRandom;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/TestCloseContainer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hdds.conf.OzoneConfiguration;
 import org.apache.hadoop.hdds.protocol.proto.HddsProtos;
 import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;
 import org.apache.hadoop.hdds.scm.server.StorageContainerManager;
 import org.apache.hadoop.ozone.MiniOzoneCluster;

--- a/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
+++ b/hadoop-ozone/integration-test/src/test/java/org/apache/hadoop/ozone/scm/node/TestDecommissionAndMaintenance.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.hdds.scm.container.ContainerInfo;
 import org.apache.hadoop.hdds.scm.container.ContainerManager;
 import org.apache.hadoop.hdds.scm.container.ContainerReplica;
 import org.apache.hadoop.hdds.scm.container.replication.ContainerReplicaCount;
-import org.apache.hadoop.hdds.scm.container.replication.ReplicationManager.ReplicationManagerConfiguration;
+import org.apache.hadoop.hdds.scm.container.replication.ReplicationManagerConfiguration;
 import org.apache.hadoop.hdds.scm.node.NodeManager;
 import org.apache.hadoop.hdds.scm.node.NodeStatus;
 import org.apache.hadoop.hdds.scm.pipeline.Pipeline;


### PR DESCRIPTION
## What changes were proposed in this pull request?

There are 2 similar classes:

- ReplicationManager.ReplicationManagerConfiguration
- LegacyReplicationManager.ReplicationManagerConfiguration
 
ReplicationManager and LegacyReplicationManager are coupled (ReplicationManager does proxy calls to LegacyReplicationManager), and both classes are enormous, so extracting ReplicationManagerConfiguration to a separate class looks reasonable for improving maintainability.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-7213

## How was this patch tested?

unit tests
