### PR TITLE
HDDS-6492. Add metric for failed container moves

### DIFF
--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -538,7 +538,6 @@ public class ContainerBalancer extends StatefulService {
       LOG.warn("{} Container moves are canceled.", timeoutCounts);
       metrics.incrementNumContainerMovesTimeoutInLatestIteration(timeoutCounts);
     } catch (ExecutionException e) {
-      cancelAndCountPendingMoves();
       LOG.error("Got exception while checkIterationMoveResults", e);
     }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -532,7 +532,7 @@ public class ContainerBalancer extends StatefulService {
       LOG.warn("Container balancer is interrupted");
       Thread.currentThread().interrupt();
     } catch (TimeoutException e) {
-      long timeoutCounts = countPendingMoves();
+      long timeoutCounts = cancelAndCountPendingMoves();
       LOG.warn("{} Container moves are canceled.", timeoutCounts);
       metrics.incrementNumContainerMovesTimeoutInLatestIteration(timeoutCounts);
     } catch (ExecutionException e) {
@@ -561,7 +561,7 @@ public class ContainerBalancer extends StatefulService {
         metrics.getNumContainerMovesCompletedInLatestIteration());
   }
 
-  private long countPendingMoves() {
+  private long cancelAndCountPendingMoves() {
     return moveSelectionToFutureMap.entrySet().stream()
         .filter(entry -> !entry.getValue().isDone())
         .peek(entry -> {
@@ -571,6 +571,7 @@ public class ContainerBalancer extends StatefulService {
               containerToSourceMap.get(entry.getKey().getContainerID())
                   .getUuidString(),
               entry.getKey().getTargetNode().getUuidString());
+          entry.getValue().cancel(true);
         }).count();
   }
 

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancer.java
@@ -537,9 +537,8 @@ public class ContainerBalancer extends StatefulService {
       LOG.warn("{} Container moves are canceled.", timeoutCounts);
       metrics.incrementNumContainerMovesTimeoutInLatestIteration(timeoutCounts);
     } catch (ExecutionException e) {
-      long failedCount = performMoveCancelAndFailCount();
+      performTimeMoveCancelAndCount();
       LOG.error("Got exception while checkIterationMoveResults", e);
-      metrics.incrementNumContainerMovesFailed(failedCount);
     }
 
     countDatanodesInvolvedPerIteration =

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -78,6 +78,10 @@ public final class ContainerBalancerMetrics {
       "exceptionally across all iterations of Container Balancer.")
   private MutableCounterLong numContainerMovesFailed;
 
+  @Metric(about = "Total number container for which moves failed " +
+      "exceptionally in latest iteration of Container Balancer.")
+  private MutableCounterLong numContainerMovesFailedInLatestIteration;
+
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
    * for {@link ContainerBalancer}.
@@ -278,5 +282,18 @@ public final class ContainerBalancerMetrics {
 
   public void incrementNumContainerMovesFailed(long valueToAdd) {
     numContainerMovesFailed.incr(valueToAdd);
+  }
+
+  public long getNumContainerMovesFailedInLatestIteration() {
+    return numContainerMovesFailedInLatestIteration.value();
+  }
+
+  public void incrementNumContainerMovesFailedInLatestIteration(
+      long valueToAdd) {
+    numContainerMovesFailedInLatestIteration.incr(valueToAdd);
+  }
+  public void resetNumContainerMovesFailedInLatestIteration() {
+    numContainerMovesFailedInLatestIteration.incr(
+        -getNumContainerMovesFailedInLatestIteration());
   }
 }

--- a/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
+++ b/hadoop-hdds/server-scm/src/main/java/org/apache/hadoop/hdds/scm/container/balancer/ContainerBalancerMetrics.java
@@ -74,6 +74,10 @@ public final class ContainerBalancerMetrics {
       "Container Balancer.")
   private MutableCounterLong dataSizeMovedGB;
 
+  @Metric(about = "Total number container for which moves failed " +
+      "exceptionally across all iterations of Container Balancer.")
+  private MutableCounterLong numContainerMovesFailed;
+
   /**
    * Create and register metrics named {@link ContainerBalancerMetrics#NAME}
    * for {@link ContainerBalancer}.
@@ -266,5 +270,13 @@ public final class ContainerBalancerMetrics {
 
   public void incrementDataSizeMovedGB(long valueToAdd) {
     dataSizeMovedGB.incr(valueToAdd);
+  }
+
+  public long getNumContainerMovesFailed() {
+    return numContainerMovesFailed.value();
+  }
+
+  public void incrementNumContainerMovesFailed(long valueToAdd) {
+    numContainerMovesFailed.incr(valueToAdd);
   }
 }

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -797,7 +797,7 @@ public class TestContainerBalancer {
             new NodeNotFoundException("Test Node not found"))
         .thenReturn(f).thenReturn(CompletableFuture.supplyAsync(() -> {
           try {
-            Thread.sleep(500);
+            Thread.sleep(200);
           } catch (Exception ex) {
           }
           throw new RuntimeException("Throw");
@@ -808,7 +808,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setMaxSizeEnteringTarget(10 * STORAGE_UNIT);
     balancerConfiguration.setMaxSizeToMovePerIteration(100 * STORAGE_UNIT);
     balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(100);
-    balancerConfiguration.setMoveTimeout(Duration.ofMillis(1000));
+    balancerConfiguration.setMoveTimeout(Duration.ofMillis(500));
 
     startBalancer(balancerConfiguration);
     sleepWhileBalancing(1000);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -722,7 +722,7 @@ public class TestContainerBalancer {
     Mockito.when(replicationManager.move(Mockito.any(ContainerID.class),
             Mockito.any(DatanodeDetails.class),
             Mockito.any(DatanodeDetails.class)))
-        .thenReturn(genCompletableFuture(500), genCompletableFuture(2000));
+        .thenReturn(genCompletableFuture(500), genCompletableFuture(3000));
 
     balancerConfiguration.setThreshold(10);
     balancerConfiguration.setIterations(1);

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -797,7 +797,7 @@ public class TestContainerBalancer {
             new NodeNotFoundException("Test Node not found"))
         .thenReturn(f).thenReturn(CompletableFuture.supplyAsync(() -> {
           try {
-            Thread.sleep(1000);
+            Thread.sleep(500);
           } catch (Exception ex) {
           }
           throw new RuntimeException("Throw");
@@ -808,14 +808,11 @@ public class TestContainerBalancer {
     balancerConfiguration.setMaxSizeEnteringTarget(10 * STORAGE_UNIT);
     balancerConfiguration.setMaxSizeToMovePerIteration(100 * STORAGE_UNIT);
     balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(100);
-    balancerConfiguration.setMoveTimeout(Duration.ofMillis(2000));
+    balancerConfiguration.setMoveTimeout(Duration.ofMillis(1000));
 
     startBalancer(balancerConfiguration);
-    sleepWhileBalancing(2000);
+    sleepWhileBalancing(1000);
 
-    /*
-    Immediate failure count is 2 and timeout count is 4 together
-     */
     Assertions.assertEquals(
         ContainerBalancer.IterationResult.ITERATION_COMPLETED,
         containerBalancer.getIterationResult());

--- a/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
+++ b/hadoop-hdds/server-scm/src/test/java/org/apache/hadoop/hdds/scm/container/balancer/TestContainerBalancer.java
@@ -808,7 +808,7 @@ public class TestContainerBalancer {
     balancerConfiguration.setMaxSizeEnteringTarget(10 * STORAGE_UNIT);
     balancerConfiguration.setMaxSizeToMovePerIteration(100 * STORAGE_UNIT);
     balancerConfiguration.setMaxDatanodesPercentageToInvolvePerIteration(100);
-    balancerConfiguration.setMoveTimeout(Duration.ofMillis(1000));
+    balancerConfiguration.setMoveTimeout(Duration.ofMillis(2000));
 
     startBalancer(balancerConfiguration);
     sleepWhileBalancing(2000);


### PR DESCRIPTION
## What changes were proposed in this pull request?

A metric is added for move container failed due to exception occurred in execution - numContainerMovesFailed. This does not include metrics for replication know failure.

## What is the link to the Apache JIRA

https://issues.apache.org/jira/browse/HDDS-6492

## How was this patch tested?

Patch is tested with unit test, here multiple type of exception is thrown using mock of replication manager - checkIterationResultException
