### PR TITLE
HDDS-7224. Create a new RocksDBCheckpoint Diff utility.

### DIFF
--- a/hadoop-hdds/RocksDBCheckpointDiffer/README.md
+++ b/hadoop-hdds/RocksDBCheckpointDiffer/README.md
@@ -1,0 +1,2 @@
+# RocksDiff
+# rocksdiff

--- a/hadoop-hdds/RocksDBCheckpointDiffer/pom.xml
+++ b/hadoop-hdds/RocksDBCheckpointDiffer/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License. See accompanying LICENSE file.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.ozone</groupId>
+    <artifactId>hdds</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>RocksDBCheckpointDiffer</artifactId>
+  <version>1.3.0-SNAPSHOT</version>
+  <description>RocksDBCheckpointDiffer</description>
+  <name>RocksDBCheckpointDiffer</name>
+  <packaging>jar</packaging>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.rocksdb</groupId>
+      <artifactId>rocksdbjni</artifactId>
+      <version>7.4.5</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>31.1-jre</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.github.vlsi.mxgraph</groupId>
+      <artifactId>jgraphx</artifactId>
+      <version>4.2.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jgrapht</groupId>
+      <artifactId>jgrapht-core</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jgrapht</groupId>
+      <artifactId>jgrapht-guava</artifactId>
+      <version>1.5.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jgrapht</groupId>
+      <artifactId>jgrapht-ext</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>ozone-version-info.properties</exclude>
+        </excludes>
+        <filtering>false</filtering>
+      </resource>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+        <includes>
+          <include>ozone-version-info.properties</include>
+        </includes>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.hadoop</groupId>
+        <artifactId>hadoop-maven-plugins</artifactId>
+        <executions>
+          <execution>
+            <id>version-info</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>version-info</goal>
+            </goals>
+            <configuration>
+              <source>
+                <directory>${basedir}/../</directory>
+                <includes>
+                  <include>*/src/main/java/**/*.java</include>
+                  <include>*/src/main/proto/*.proto</include>
+                </includes>
+              </source>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <excludeFilterFile>${basedir}/dev-support/findbugsExcludeFile.xml</excludeFilterFile>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <profiles>
+    <profile>
+      <id>k8s-dev</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>io.fabric8</groupId>
+            <artifactId>docker-maven-plugin</artifactId>
+            <configuration>
+              <images>
+                <image>
+                  <name>${user.name}/ozone:${project.version}</name>
+                  <build>
+                    <dockerFileDir>${project.basedir}</dockerFileDir>
+                  </build>
+                </image>
+              </images>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/hadoop-hdds/RocksDBCheckpointDiffer/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/RocksDBCheckpointDiffer/src/main/java/org/apache/ozone/rocksdiff/RocksDBCheckpointDiffer.java
@@ -1,0 +1,761 @@
+package org.apache.ozone.rocksdiff;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import javax.imageio.ImageIO;
+
+import org.rocksdb.AbstractEventListener;
+import org.rocksdb.Checkpoint;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompactionJobInfo;
+import org.rocksdb.CompressionType;
+import org.rocksdb.DBOptions;
+import org.rocksdb.FlushOptions;
+import org.rocksdb.LiveFileMetaData;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.SstFileReader;
+import org.rocksdb.TableProperties;
+
+import com.google.common.graph.EndpointPair;
+import com.google.common.graph.GraphBuilder;
+import com.google.common.graph.MutableGraph;
+import com.mxgraph.layout.hierarchical.mxHierarchicalLayout;
+import com.mxgraph.layout.mxIGraphLayout;
+import com.mxgraph.util.mxCellRenderer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// TODO
+//  1. Create a local instance of RocksDiff-local-RocksDB. This is the
+//  rocksDB that we can use for maintaining DAG and any other state. This is
+//  a per node state so it it doesn't have to go through RATIS anyway.
+//  2. Store fwd DAG in Diff-Local-RocksDB in Compaction Listener
+//  3. Store fwd DAG in Diff-Local-RocksDB in Compaction Listener
+//  4. Store last-Snapshot-counter/Compaction-generation-counter in Diff-Local
+//  -RocksDB in Compaction Listener
+//  5. System Restart handling. Read the DAG from Disk and load it in memory.
+//  6. Take the base snapshot. All the SST file nodes in the base snapshot
+//  should be arked with that Snapshot generation. Subsequently, all SST file
+//  node should have a snapshot-generation count and Compaction-generation
+//  count.
+//  6. DAG based SST file pruning. Start from the oldest snapshot and we can
+//  unlink any SST
+//  file from the SaveCompactedFilePath directory that is reachable in the
+//  reverse DAG.
+//  7. DAG pruning : For each snapshotted bucket, We can recycle the part of
+//  the DAG that is older than the predefined policy for the efficient snapdiff.
+//  E.g. we may decide not to support efficient snapdiff from any snapshot that
+//  is older than 2 weeks.
+//  Note on 8. & 9 .
+//  ==================
+//  A simple handling is to just iterate over all keys in keyspace when the
+//  compaction DAG is lost, instead of optimizing every case. And start
+//  Compaction-DAG afresh from the latest snapshot.
+//  --
+//  8. Handle bootstrapping rocksDB for a new OM follower node
+//      - new node will receive Active object store as well as all existing
+//      rocksDB checkpoints.
+//      - This bootstrapping should also receive the compaction-DAG information
+//  9. Handle rebuilding the DAG for a lagging follower. There are two cases
+//      - recieve RATIS transactions to replay. Nothing needs to be done in
+//      thise case.
+//      - Getting the DB sync. This case needs to handle getting the
+//      compaction-DAG information as well.
+//
+//
+
+public class RocksDBCheckpointDiffer {
+
+  private final String rocksDbPath;
+  private String cpPath;
+  private final String cfdbPath;
+  private final String SaveCompactedFilePath;
+  private final int MAX_SNAPSHOTS;
+  private static final Logger LOG =
+      LoggerFactory.getLogger(RocksDBCheckpointDiffer.class);
+
+  // keeps track of all the snapshots created so far.
+  private int lastSnapshotCounter;
+  private String lastSnapshotPrefix;
+
+  // tracks number of compactions so far
+  private long UNKNOWN_COMPACTION_GEN = 0;
+  private long currentCompactionGen = 0;
+
+  // Something to track all the snapshots created so far.
+  private Snapshot[] allSnapshots;
+
+  public RocksDBCheckpointDiffer(String dbPath,
+                                 int max_snapshots,
+                                 String checkpointPath,
+                                 String sstFileSaveDir,
+                                 String cfPath,
+                                 int initialSnapshotCounter,
+                                 String snapPrefix) {
+    MAX_SNAPSHOTS = max_snapshots;
+    allSnapshots = new Snapshot[MAX_SNAPSHOTS];
+    cpPath = checkpointPath;
+
+    SaveCompactedFilePath = sstFileSaveDir;
+    rocksDbPath = dbPath;
+    cfdbPath = cfPath;
+
+    // TODO: This module should be self sufficient in tracking the last
+    //  snapshotCounter and currentCompactionGen for a given dbPath. It needs
+    //  to be persisted.
+    lastSnapshotCounter = initialSnapshotCounter;
+    lastSnapshotPrefix = snapPrefix;
+    currentCompactionGen = lastSnapshotCounter;
+
+    // TODO: this should also independently persist every compaction e.g.
+    //  (input files) ->
+    //  {  (output files) + lastSnapshotCounter + currentCompactionGen }
+    //  mapping.
+  }
+
+  // Node in the DAG to represent an SST file
+  private class CompactionNode {
+    public String fileName;   // Name of the SST file
+    public String snapshotId; // The last snapshot that was created before this
+    // node came into existance;
+    public long snapshotGeneration;
+    public long compactionGeneration;
+    public long totalNumberOfKeys;
+    public long cumulativeKeysReverseTraversal;
+
+    CompactionNode (String f, String sid, long numKeys, long compactionGen) {
+      fileName = f;
+      snapshotId = sid;
+      snapshotGeneration = lastSnapshotCounter;
+      totalNumberOfKeys = numKeys;
+      cumulativeKeysReverseTraversal = 0;
+      compactionGeneration = compactionGen;
+    }
+  }
+
+  private class Snapshot {
+    String dbPath;
+    String snapshotID;
+    long snapshotGeneration;
+
+    Snapshot(String db, String id, long gen) {
+      dbPath = db;
+      snapshotID = id;
+      snapshotGeneration = gen;
+    }
+  }
+
+  public enum GType {FNAME, KEYSIZE, CUMUTATIVE_SIZE};
+
+
+  // Hash table to track Compaction node for a given SST File.
+  private ConcurrentHashMap<String, CompactionNode> compactionNodeTable =
+      new ConcurrentHashMap<>();
+
+  // We are mainiting a two way DAG. This allows easy traversal from
+  // source snapshot to destination snapshot as well as the other direction.
+  // TODO : Persist this information to the disk.
+  // TODO: A system crash while the edge is inserted in DAGFwd but not in
+  //  DAGReverse will compromise the two way DAG. Set of input/output files shud
+  //  be written to // disk(RocksDB) first, would avoid this problem.
+
+  private MutableGraph<CompactionNode> compactionDAGFwd =
+      GraphBuilder.directed().build();
+
+  private MutableGraph<CompactionNode> compactionDAGReverse =
+      GraphBuilder.directed().build();
+
+  public static final Integer DEBUG_DAG_BUILD_UP = 2;
+  public static final Integer DEBUG_DAG_TRAVERSAL = 3;
+  public static final Integer DEBUG_DAG_LIVE_NODES = 4;
+  public static final Integer DEBUG_READ_ALL_DB_KEYS = 5;
+  private static final HashSet<Integer> DEBUG_LEVEL = new HashSet<>();
+
+  static {
+    addDebugLevel(DEBUG_DAG_BUILD_UP);
+    addDebugLevel(DEBUG_DAG_TRAVERSAL);
+    addDebugLevel(DEBUG_DAG_LIVE_NODES);
+  }
+
+  static {
+    RocksDB.loadLibrary();
+  }
+
+  public static void addDebugLevel(Integer level) {
+    DEBUG_LEVEL.add(level);
+  }
+
+  // Flushes the WAL and Creates a RocksDB checkpoint
+  public void CreateCheckPoint(String dbPathArg, String cpPathArg,
+                               RocksDB rocksDB) {
+    LOG.warn("Creating Checkpoint for RocksDB instance : " +
+        dbPathArg + "in a CheckPoint Location" + cpPathArg);
+    try {
+      rocksDB.flush(new FlushOptions());
+      Checkpoint cp = Checkpoint.create(rocksDB);
+      cp.createCheckpoint(cpPathArg);
+    } catch (RocksDBException e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  public void setRocksDBForCompactionTracking(DBOptions rocksOptions)
+      throws RocksDBException {
+    setRocksDBForCompactionTracking(rocksOptions,
+        new ArrayList<AbstractEventListener>());
+  }
+
+  public void setRocksDBForCompactionTracking(
+      DBOptions rocksOptions, List<AbstractEventListener> list) {
+    final AbstractEventListener onCompactionCompletedListener =
+        new AbstractEventListener() {
+          @Override
+          public void onCompactionCompleted(final RocksDB db, final CompactionJobInfo compactionJobInfo) {
+            synchronized (db) {
+              LOG.warn(compactionJobInfo.compactionReason().toString());
+              LOG.warn("List of input files:");
+              for (String file : compactionJobInfo.inputFiles()) {
+                LOG.warn(file);
+                String saveLinkFileName =
+                    SaveCompactedFilePath + new File(file).getName();
+                Path link = Paths.get(saveLinkFileName);
+                Path srcFile = Paths.get(file);
+                try {
+                  Files.createLink(link, srcFile);
+                } catch (IOException e) {
+                  LOG.warn("Exception in creating hardlink");
+                  e.printStackTrace();
+                }
+              }
+              LOG.warn("List of output files:");
+              for (String file : compactionJobInfo.outputFiles()) {
+                LOG.warn(file);
+              }
+              // Let us also build the graph
+              for (String outFilePath : compactionJobInfo.outputFiles()) {
+                String outfile = Paths.get(outFilePath).getFileName().toString();
+                CompactionNode outfileNode = compactionNodeTable.get(outfile);
+                if (outfileNode == null) {
+                  try {
+                    outfileNode = new CompactionNode(outfile, lastSnapshotPrefix,
+                        getSSTFileSummary(outfile), currentCompactionGen);
+                  } catch (Exception e) {
+                    LOG.warn(e.getMessage());
+                  }
+                  compactionDAGFwd.addNode(outfileNode);
+                  compactionDAGReverse.addNode(outfileNode);
+                  compactionNodeTable.put(outfile, outfileNode);
+                }
+                for (String inFilePath : compactionJobInfo.inputFiles()) {
+                  String infile = Paths.get(inFilePath).getFileName().toString();
+                  CompactionNode infileNode = compactionNodeTable.get(infile);
+                  if (infileNode == null) {
+                    try {
+                      infileNode = new CompactionNode(infile, lastSnapshotPrefix,
+                          getSSTFileSummary(infile), UNKNOWN_COMPACTION_GEN);
+                    } catch (Exception e) {
+                      LOG.warn(e.getMessage());
+                    }
+                    compactionDAGFwd.addNode(infileNode);
+                    compactionDAGReverse.addNode(infileNode);
+                    compactionNodeTable.put(infile, infileNode);
+                  }
+                  if (outfileNode.fileName.compareToIgnoreCase(infileNode.fileName) != 0) {
+                    compactionDAGFwd.putEdge(outfileNode, infileNode);
+                    compactionDAGReverse.putEdge(infileNode, outfileNode);
+                  }
+                }
+              }
+              if (debugEnabled(DEBUG_DAG_BUILD_UP)) {
+                printMutableGraph(null, null, compactionDAGFwd);
+              }
+            }
+          }
+        };
+
+    list.add(onCompactionCompletedListener);
+    rocksOptions.setListeners(list);
+  }
+
+
+
+  public void setRocksDBForCompactionTracking(Options rocksOptions)
+      throws RocksDBException {
+    setRocksDBForCompactionTracking(rocksOptions,
+        new ArrayList<AbstractEventListener>());
+  }
+
+  public void setRocksDBForCompactionTracking(
+      Options rocksOptions, List<AbstractEventListener> list) {
+    final AbstractEventListener onCompactionCompletedListener =
+        new AbstractEventListener() {
+          @Override
+          public void onCompactionCompleted(final RocksDB db, final CompactionJobInfo compactionJobInfo) {
+            synchronized (db) {
+              LOG.warn(compactionJobInfo.compactionReason().toString());
+              LOG.warn("List of input files:");
+              for (String file : compactionJobInfo.inputFiles()) {
+                LOG.warn(file);
+                String saveLinkFileName =
+                    SaveCompactedFilePath + new File(file).getName();
+                Path link = Paths.get(saveLinkFileName);
+                Path srcFile = Paths.get(file);
+                try {
+                  Files.createLink(link, srcFile);
+                } catch (IOException e) {
+                  LOG.warn("Exception in creating hardlink");
+                  e.printStackTrace();
+                }
+              }
+              LOG.warn("List of output files:");
+              for (String file : compactionJobInfo.outputFiles()) {
+                LOG.warn(file);
+              }
+              // Let us also build the graph
+              for (String outFilePath : compactionJobInfo.outputFiles()) {
+                String outfile = Paths.get(outFilePath).getFileName().toString();
+                CompactionNode outfileNode = compactionNodeTable.get(outfile);
+                if (outfileNode == null) {
+                  try {
+                    outfileNode = new CompactionNode(outfile, lastSnapshotPrefix,
+                        getSSTFileSummary(outfile), currentCompactionGen);
+                  } catch (Exception e) {
+                    LOG.warn(e.getMessage());
+                  }
+                  compactionDAGFwd.addNode(outfileNode);
+                  compactionDAGReverse.addNode(outfileNode);
+                  compactionNodeTable.put(outfile, outfileNode);
+                }
+                for (String inFilePath : compactionJobInfo.inputFiles()) {
+                  String infile = Paths.get(inFilePath).getFileName().toString();
+                  CompactionNode infileNode = compactionNodeTable.get(infile);
+                  if (infileNode == null) {
+                    try {
+                      infileNode = new CompactionNode(infile, lastSnapshotPrefix,
+                          getSSTFileSummary(infile), UNKNOWN_COMPACTION_GEN);
+                    } catch (Exception e) {
+                      LOG.warn(e.getMessage());
+                    }
+                    compactionDAGFwd.addNode(infileNode);
+                    compactionDAGReverse.addNode(infileNode);
+                    compactionNodeTable.put(infile, infileNode);
+                  }
+                  if (outfileNode.fileName.compareToIgnoreCase(infileNode.fileName) != 0) {
+                    compactionDAGFwd.putEdge(outfileNode, infileNode);
+                    compactionDAGReverse.putEdge(infileNode, outfileNode);
+                  }
+                }
+              }
+              if (debugEnabled(DEBUG_DAG_BUILD_UP)) {
+                printMutableGraph(null, null, compactionDAGFwd);
+              }
+            }
+          }
+        };
+
+    list.add(onCompactionCompletedListener);
+    rocksOptions.setListeners(list);
+  }
+
+  public RocksDB getRocksDBInstanceWithCompactionTracking(String dbPath)
+      throws RocksDBException {
+    final Options opt = new Options().setCreateIfMissing(true)
+        .setCompressionType(CompressionType.NO_COMPRESSION);
+    opt.setMaxBytesForLevelMultiplier(2);
+    setRocksDBForCompactionTracking(opt);
+    return RocksDB.open(opt, dbPath);
+  }
+
+  // Get a summary of a given SST file
+  public long getSSTFileSummary(String filename)
+      throws RocksDBException {
+    Options option = new Options();
+    SstFileReader reader = new SstFileReader(option);
+    try {
+      reader.open(SaveCompactedFilePath + filename);
+    } catch (RocksDBException e) {
+      reader.open(rocksDbPath + "/"+ filename);
+    }
+    TableProperties properties = reader.getTableProperties();
+    LOG.warn("getSSTFileSummary " + filename + ":: " + properties.getNumEntries());
+    return properties.getNumEntries();
+  }
+
+  // Read the current Live manifest for a given RocksDB instance (Active or
+  // Checkpoint). Returns the list of currently active SST FileNames.
+  public HashSet<String> ReadRocksDBLiveFiles(String dbPathArg) {
+    RocksDB rocksDB = null;
+    HashSet<String> liveFiles = new HashSet<>();
+    //
+    try (final Options options =
+             new Options().setParanoidChecks(true)
+                 .setCreateIfMissing(true)
+                 .setCompressionType(CompressionType.NO_COMPRESSION)
+                 .setForceConsistencyChecks(false)) {
+      rocksDB = RocksDB.openReadOnly(options, dbPathArg);
+      List<LiveFileMetaData> liveFileMetaDataList = rocksDB.getLiveFilesMetaData();
+      LOG.warn("Live File Metadata for DB: " + dbPathArg);
+      for (LiveFileMetaData m : liveFileMetaDataList) {
+        LOG.warn("\tFile :" + m.fileName());
+        LOG.warn("\tLevel :" + m.level());
+        liveFiles.add(Paths.get(m.fileName()).getFileName().toString());
+      }
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    } finally {
+      if (rocksDB != null) {
+        rocksDB.close();
+      }
+    }
+    return liveFiles;
+  }
+
+  // Given the src and destination Snapshots, it prints a Diff list.
+  private synchronized void printSnapdiffSSTFiles(Snapshot src,
+                                                         Snapshot dest) throws RocksDBException {
+    LOG.warn("Src Snapshot files :" + src.dbPath);
+    HashSet<String> srcSnapFiles = ReadRocksDBLiveFiles(src.dbPath);
+    LOG.warn("dest Snapshot files :" + dest.dbPath);
+    HashSet<String> destSnapFiles = ReadRocksDBLiveFiles(dest.dbPath);
+
+    HashSet<String> fwdDAGSameFiles = new HashSet<>();
+    HashSet<String> fwdDAGDifferentFiles = new HashSet<>();
+
+    LOG.warn("Doing forward diff between source and destination " +
+        "Snapshots:" + src.dbPath + ", " + dest.dbPath);
+    realPrintSnapdiffSSTFiles(src, dest, srcSnapFiles, destSnapFiles,
+        compactionDAGFwd,
+        fwdDAGSameFiles,
+        fwdDAGDifferentFiles);
+
+    LOG.warn("Overall Summary \n" +
+            "Doing Overall diff between source and destination Snapshots:"
+            + src.dbPath + ", " + dest.dbPath);
+    System.out.print("fwd DAG Same files :");
+    for (String file : fwdDAGSameFiles) {
+      System.out.print(file + ", ");
+    }
+    LOG.warn("");
+    System.out.print("\nFwd DAG Different files :");
+    for (String file : fwdDAGDifferentFiles) {
+      CompactionNode n = compactionNodeTable.get(file);
+      System.out.print(file + ", ");
+    }
+    LOG.warn("");
+  }
+
+  public synchronized void realPrintSnapdiffSSTFiles(
+      Snapshot src, Snapshot dest,
+      HashSet<String> srcSnapFiles,
+      HashSet<String> destSnapFiles,
+      MutableGraph<CompactionNode> mutableGraph,
+      HashSet<String> sameFiles, HashSet<String> differentFiles) {
+
+
+    for (String fileName : srcSnapFiles) {
+      if (destSnapFiles.contains(fileName)) {
+        LOG.warn("SrcSnapshot : " + src.dbPath + " and Dest " +
+            "Snapshot" + dest.dbPath + " Contain Same file " + fileName);
+        sameFiles.add(fileName);
+        continue;
+      }
+      CompactionNode infileNode =
+          compactionNodeTable.get(Paths.get(fileName).getFileName().toString());
+      if (infileNode == null) {
+        LOG.warn("SrcSnapshot : " + src.dbPath + "File " + fileName + "was never compacted");
+        differentFiles.add(fileName);
+        continue;
+      }
+      System.out.print(" Expandin File:" + fileName + ":\n");
+      Set<CompactionNode> nextLevel = new HashSet<>();
+      nextLevel.add(infileNode);
+      Set<CompactionNode> currentLevel = new HashSet<>();
+      currentLevel.addAll(nextLevel);
+      nextLevel = new HashSet<>();
+      int i = 1;
+      while (currentLevel.size() != 0) {
+        LOG.warn("DAG Level :" + i++);
+        for (CompactionNode current : currentLevel) {
+          LOG.warn("acknowledging file " + current.fileName);
+          if (current.snapshotGeneration <= dest.snapshotGeneration) {
+            LOG.warn("Reached dest generation count. SrcSnapshot : " + src.dbPath + " and Dest " +
+                "Snapshot" + dest.dbPath + " Contain Diffrent file " + current.fileName);
+            differentFiles.add(current.fileName);
+            continue;
+          }
+          Set<CompactionNode> successors = mutableGraph.successors(current);
+          if (successors == null || successors.size() == 0) {
+            LOG.warn("No further compaction for the file" +
+                ".SrcSnapshot : " + src.dbPath + " and Dest " +
+                "Snapshot" + dest.dbPath + " Contain Diffrent file " + current.fileName);
+            differentFiles.add(current.fileName);
+          } else {
+            for (CompactionNode oneSucc : successors) {
+              if (sameFiles.contains(oneSucc.fileName) || differentFiles.contains(oneSucc.fileName)) {
+                LOG.warn("Skipping file :" + oneSucc.fileName);
+                continue;
+              }
+              if (destSnapFiles.contains(oneSucc.fileName)) {
+                LOG.warn("SrcSnapshot : " + src.dbPath + " and Dest " +
+                    "Snapshot" + dest.dbPath + " Contain Same file " + oneSucc.fileName);
+                sameFiles.add(oneSucc.fileName);
+                continue;
+              } else {
+                LOG.warn("SrcSnapshot : " + src.dbPath + " and Dest " +
+                    "Snapshot" + dest.dbPath + " Contain Diffrent file " + oneSucc.fileName);
+                nextLevel.add(oneSucc);
+              }
+            }
+          }
+        }
+        currentLevel = new HashSet<>();
+        currentLevel.addAll(nextLevel);
+        nextLevel = new HashSet<>();
+        LOG.warn("");
+      }
+    }
+    LOG.warn("Summary :");
+    for (String file : sameFiles) {
+      System.out.print("Same File : " + file);
+    }
+    LOG.warn("");
+
+    for (String file : differentFiles) {
+      System.out.print("Different File : " + file);
+    }
+    LOG.warn("");
+  }
+
+  class NodeComparator implements Comparator<CompactionNode>
+  {
+    public int compare(CompactionNode a, CompactionNode b)
+    {
+      return a.fileName.compareToIgnoreCase(b.fileName);
+    }
+
+    @Override
+    public Comparator<CompactionNode> reversed() {
+      return null;
+    }
+  }
+
+
+  public void dumpCompactioNodeTable() {
+    List<CompactionNode> nodeList =
+        compactionNodeTable.values().stream().collect(Collectors.toList());
+    Collections.sort(nodeList, new NodeComparator());
+    for (CompactionNode n : nodeList ) {
+      LOG.warn("File : " + n.fileName + " :: Total keys : "  + n.totalNumberOfKeys);
+      LOG.warn("File : " + n.fileName + " :: Cumulative keys : "  + n.cumulativeKeysReverseTraversal);
+    }
+  }
+
+  public synchronized void printMutableGraphFromAGivenNode(String fileName,
+                                                                  int level,
+                                                                  MutableGraph<CompactionNode> mutableGraph) {
+    CompactionNode infileNode =
+        compactionNodeTable.get(Paths.get(fileName).getFileName().toString());
+    if (infileNode == null) {
+      return;
+    }
+    System.out.print("\nCompaction Level : " + level + " Expandin File:" + fileName + ":\n");
+    Set<CompactionNode> nextLevel = new HashSet<>();
+    nextLevel.add(infileNode);
+    Set<CompactionNode> currentLevel = new HashSet<>();
+    currentLevel.addAll(nextLevel);
+    int i = 1;
+    while (currentLevel.size() != 0) {
+      LOG.warn("DAG Level :" + i++);
+      for (CompactionNode current : currentLevel) {
+        Set<CompactionNode> successors = mutableGraph.successors(current);
+        for (CompactionNode oneSucc : successors) {
+          System.out.print(oneSucc.fileName + " ");
+          nextLevel.add(oneSucc);
+        }
+      }
+      currentLevel = new HashSet<>();
+      currentLevel.addAll(nextLevel);
+      nextLevel = new HashSet<>();
+      LOG.warn("");
+    }
+  }
+
+  public synchronized void printMutableGraph(String srcSnapId,
+                                                     String destSnapId,
+                                                    MutableGraph<CompactionNode> mutableGraph) {
+    LOG.warn("Printing the Graph");
+    Set<CompactionNode> topLevelNodes = new HashSet<>();
+    Set<CompactionNode> allNodes = new HashSet<>();
+    for (CompactionNode n : mutableGraph.nodes()) {
+      if (srcSnapId == null ||
+          n.snapshotId.compareToIgnoreCase(srcSnapId) == 0) {
+        topLevelNodes.add(n);
+      }
+    }
+    Iterator iter = topLevelNodes.iterator();
+    while (iter.hasNext()) {
+      CompactionNode n = (CompactionNode) iter.next();
+      Set<CompactionNode> succ = mutableGraph.successors(n);
+      LOG.warn("Parent Node :" + n.fileName);
+      if (succ.size() == 0) {
+        LOG.warn("No Children Node ");
+        allNodes.add(n);
+        iter.remove();
+        iter = topLevelNodes.iterator();
+        continue;
+      }
+      for (CompactionNode oneSucc : succ) {
+        LOG.warn("Children Node :" + oneSucc.fileName);
+        if (srcSnapId == null||
+            oneSucc.snapshotId.compareToIgnoreCase(destSnapId) == 0) {
+          allNodes.add(oneSucc);
+        } else {
+          topLevelNodes.add(oneSucc);
+        }
+      }
+      iter.remove();
+      iter = topLevelNodes.iterator();
+    }
+    LOG.warn("src snap:" + srcSnapId);
+    LOG.warn("dest snap:" + destSnapId);
+    for (CompactionNode n : allNodes) {
+      LOG.warn("Files are :" + n.fileName);
+    }
+  }
+
+
+  public void createSnapshot(RocksDB rocksDB) throws InterruptedException {
+
+    LOG.warn("Current time is::" + System.currentTimeMillis());
+    long t1 = System.currentTimeMillis();
+
+    cpPath = cpPath + lastSnapshotCounter;
+    CreateCheckPoint(rocksDbPath, cpPath, rocksDB);
+    allSnapshots[lastSnapshotCounter] = new Snapshot(cpPath,
+    lastSnapshotPrefix, lastSnapshotCounter);
+
+    long t2 = System.currentTimeMillis();
+    LOG.warn("Current time is::" + t2);
+
+    LOG.warn("millisecond difference is ::" + (t2 - t1));
+   Thread.sleep(100);
+   ++lastSnapshotCounter;
+   lastSnapshotPrefix = "sid_" + lastSnapshotCounter;
+   LOG.warn("done :: 1");
+  }
+
+
+  public void printAllSnapshots() throws InterruptedException {
+    for (Snapshot snap : allSnapshots) {
+      if (snap == null) {
+        break;
+      }
+      LOG.warn("Snapshot id" + snap.snapshotID);
+      LOG.warn("Snapshot path" + snap.dbPath);
+      LOG.warn("Snapshot Generation" + snap.snapshotGeneration);
+      LOG.warn("");
+    }
+  }
+
+  public void diffAllSnapshots() throws InterruptedException, RocksDBException {
+    for (Snapshot snap : allSnapshots) {
+      if (snap == null) {
+        break;
+      }
+      printSnapdiffSSTFiles(allSnapshots[lastSnapshotCounter - 1], snap);
+    }
+  }
+
+  public MutableGraph<CompactionNode> getCompactionFwdDAG() {
+    return compactionDAGFwd;
+  }
+
+  public MutableGraph<CompactionNode> getCompactionReverseDAG() {
+    return compactionDAGFwd;
+  }
+
+  public synchronized void traverseGraph(
+      MutableGraph<CompactionNode> reverseMutableGraph,
+      MutableGraph<CompactionNode> fwdMutableGraph) {
+
+      List<CompactionNode> nodeList =
+        compactionNodeTable.values().stream().collect(Collectors.toList());
+    Collections.sort(nodeList, new NodeComparator());
+
+    for (CompactionNode  infileNode : nodeList ) {
+      // fist go through fwdGraph to find nodes that don't have succesors.
+      // These nodes will be the top level nodes in reverse graph
+      Set<CompactionNode> successors = fwdMutableGraph.successors(infileNode);
+      if (successors == null || successors.size() == 0) {
+        LOG.warn("traverseGraph : No successors. cumulative " +
+            "keys : " + infileNode.cumulativeKeysReverseTraversal + "::total " +
+            "keys ::" + infileNode.totalNumberOfKeys);
+        infileNode.cumulativeKeysReverseTraversal =
+            infileNode.totalNumberOfKeys;
+      }
+    }
+
+    HashSet<CompactionNode> visited = new HashSet<>();
+    for (CompactionNode  infileNode : nodeList ) {
+      if (visited.contains(infileNode)) {
+        continue;
+      }
+      visited.add(infileNode);
+      System.out.print("traverseGraph: Visiting node " + infileNode.fileName +
+          ":\n");
+      Set<CompactionNode> nextLevel = new HashSet<>();
+      nextLevel.add(infileNode);
+      Set<CompactionNode> currentLevel = new HashSet<>();
+      currentLevel.addAll(nextLevel);
+      nextLevel = new HashSet<>();
+      int i = 1;
+      while (currentLevel.size() != 0) {
+        LOG.warn("traverseGraph : DAG Level :" + i++);
+        for (CompactionNode current : currentLevel) {
+          LOG.warn("traverseGraph : expanding node " + current.fileName);
+          Set<CompactionNode> successors = reverseMutableGraph.successors(current);
+          if (successors == null || successors.size() == 0) {
+            LOG.warn("traverseGraph : No successors. cumulative " +
+                "keys : " + current.cumulativeKeysReverseTraversal);
+          } else {
+            for (CompactionNode oneSucc : successors) {
+              LOG.warn("traverseGraph : Adding to the next level : " + oneSucc.fileName);
+              LOG.warn("traverseGraph : " + oneSucc.fileName + "cum" +
+                  " keys" +  oneSucc.cumulativeKeysReverseTraversal + "parent" +
+                  " " + current.fileName +
+                  " total " + current.totalNumberOfKeys);
+              oneSucc.cumulativeKeysReverseTraversal += current.cumulativeKeysReverseTraversal;
+              nextLevel.add(oneSucc);
+            }
+          }
+        }
+        currentLevel = new HashSet<>();
+        currentLevel.addAll(nextLevel);
+        nextLevel = new HashSet<>();
+        LOG.warn("");
+      }
+    }
+  }
+
+  public boolean debugEnabled(Integer level) {
+    return DEBUG_LEVEL.contains(level);
+  }
+}

--- a/hadoop-hdds/RocksDBCheckpointDiffer/src/main/java/org/apache/rocksdiff/RelationshipEdg.java
+++ b/hadoop-hdds/RocksDBCheckpointDiffer/src/main/java/org/apache/rocksdiff/RelationshipEdg.java
@@ -1,0 +1,14 @@
+package org.apache.rocksdiff;
+
+// import org.jgrapht.graph.DefaultEdge;
+// Enable this import and extend DefaultEdge if We need to
+// pcitorially represent the DAG constructed.
+
+//class RelationshipEdge extends DefaultEdge {
+class RelationshipEdge {
+  //@Override
+  public String toString()
+  {
+    return "";
+  }
+}

--- a/hadoop-hdds/RocksDBCheckpointDiffer/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
+++ b/hadoop-hdds/RocksDBCheckpointDiffer/src/test/java/org/apache/ozone/rocksdiff/TestRocksDBCheckpointDiffer.java
@@ -1,0 +1,293 @@
+package org.apache.ozone.rocksdiff;
+
+import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_DAG_LIVE_NODES;
+import static org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer.DEBUG_READ_ALL_DB_KEYS;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ColumnFamilyOptions;
+import org.rocksdb.CompressionType;
+import org.rocksdb.DBOptions;
+import org.rocksdb.LiveFileMetaData;
+import org.rocksdb.Options;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+
+public class TestRocksDBCheckpointDiffer {
+
+  private static final String dbPath   = "./rocksdb-data";
+  private static final int NUM_ROW = 25000000;
+  private static final int SNAPSHOT_EVERY_SO_MANY_KEYS = 999999;
+
+  // keeps track of all the snapshots created so far.
+  private static int lastSnapshotCounter = 0;
+  private static String lastSnapshotPrefix = "snap_id_";
+
+
+  public static void main(String[] args) throws Exception {
+    TestRocksDBCheckpointDiffer tester= new TestRocksDBCheckpointDiffer();
+    RocksDBCheckpointDiffer differ = new RocksDBCheckpointDiffer(
+        "./rocksdb-data",
+        1000,
+        "./rocksdb-data-cp",
+        "./SavedCompacted_Files/",
+        "./rocksdb-data-cf/",
+        0,
+        "snap_id_");
+    lastSnapshotPrefix = "snap_id_" + lastSnapshotCounter;
+    RocksDB rocksDB = tester.CreateRocksDBInstance(dbPath, differ);
+    Thread.sleep(10000);
+
+    tester.ReadRocksDBInstance(dbPath, rocksDB, null, differ);
+    differ.printAllSnapshots();
+    differ.traverseGraph(
+        differ.getCompactionReverseDAG(),
+        differ.getCompactionFwdDAG());
+    differ.diffAllSnapshots();
+    differ.dumpCompactioNodeTable();
+    for (RocksDBCheckpointDiffer.GType gtype :
+        RocksDBCheckpointDiffer.GType.values()) {
+      String fname = "fwdGraph_" + gtype.toString() +  ".png";
+      String rname = "reverseGraph_"+ gtype.toString() + ".png";
+
+      //differ.pngPrintMutableGrapth(differ.getCompactionFwdDAG(),
+      //  fname, gtype);
+      //differ.pngPrintMutableGrapth(differ.getCompactionReverseDAG(), rname,
+      //    gtype);
+    }
+    rocksDB.close();
+  }
+
+  //  Test Code to create sample RocksDB instance.
+  public RocksDB CreateRocksDBInstance(String dbPathArg,
+                                              RocksDBCheckpointDiffer differ)
+      throws RocksDBException, InterruptedException {
+
+    System.out.println("Creating RocksDB instance at :" + dbPathArg);
+
+    RocksDB rocksDB = null;
+    rocksDB = differ.getRocksDBInstanceWithCompactionTracking(dbPathArg);
+    //
+    // key-value
+    for (int i = 0; i< NUM_ROW; ++i) {
+      byte[] array = new byte[7]; // length is bounded by 7
+      new Random().nextBytes(array);
+      String keyStr = " My" + array + "StringKey" + i;
+      String valueStr = " My " + array + "StringValue" + i;
+      byte[] key = keyStr.getBytes();
+      rocksDB.put(keyStr.getBytes(StandardCharsets.UTF_8), valueStr.getBytes(StandardCharsets.UTF_8));
+      if (i % SNAPSHOT_EVERY_SO_MANY_KEYS == 0) {
+        differ.createSnapshot(rocksDB);
+      }
+      //System.out.println(new String(rocksDB.get(key)));
+    }
+    differ.createSnapshot(rocksDB);
+    return rocksDB;
+  }
+
+  //  RocksDB.DEFAULT_COLUMN_FAMILY
+  private void UpdateRocksDBInstance(String dbPathArg, RocksDB rocksDB) {
+    System.out.println("Updating RocksDB instance at :" + dbPathArg);
+    //
+    try (final Options options =
+             new Options().setCreateIfMissing(true).setCompressionType(CompressionType.NO_COMPRESSION)) {
+      if (rocksDB == null) {
+        rocksDB = RocksDB.open(options, dbPathArg);
+      }
+      // key-value
+      for (int i = 0; i< NUM_ROW; ++i) {
+        byte[] array = new byte[7]; // length is bounded by 7
+        new Random().nextBytes(array);
+        String keyStr = " MyUpdated" + array + "StringKey" + i;
+        String valueStr = " My Updated" + array + "StringValue" + i;
+        byte[] key = keyStr.getBytes();
+        rocksDB.put(keyStr.getBytes(StandardCharsets.UTF_8), valueStr.getBytes(StandardCharsets.UTF_8));
+        System.out.println(new String(rocksDB.get(key)));
+      }
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    }
+  }
+
+  //  RocksDB.DEFAULT_COLUMN_FAMILY
+  public void testDefaultColumnFamilyOriginal() {
+    System.out.println("testDefaultColumnFamily begin...");
+    //
+    try (final Options options = new Options().setCreateIfMissing(true)) {
+      try (final RocksDB rocksDB = RocksDB.open(options, "./rocksdb-data")) {
+        // key-value
+        byte[] key = "Hello".getBytes();
+        rocksDB.put(key, "World".getBytes());
+
+        System.out.println(new String(rocksDB.get(key)));
+
+        rocksDB.put("SecondKey".getBytes(), "SecondValue".getBytes());
+
+        // List
+        List<byte[]> keys = Arrays.asList(key, "SecondKey".getBytes(), "missKey".getBytes());
+        List<byte[]> values = rocksDB.multiGetAsList(keys);
+        for (int i = 0; i < keys.size(); i++) {
+          System.out.println("multiGet " + new String(keys.get(i)) + ":" + (values.get(i) != null ? new String(values.get(i)) : null));
+        }
+
+        // [key - value]
+        RocksIterator iter = rocksDB.newIterator();
+        for (iter.seekToFirst(); iter.isValid(); iter.next()) {
+          System.out.println("iterator key:" + new String(iter.key()) + ", iter value:" + new String(iter.value()));
+        }
+
+        // key
+        rocksDB.delete(key);
+        System.out.println("after remove key:" + new String(key));
+
+        iter = rocksDB.newIterator();
+        for (iter.seekToFirst(); iter.isValid(); iter.next()) {
+          System.out.println("iterator key:" + new String(iter.key()) + ", iter value:" + new String(iter.value()));
+        }
+      }
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    }
+  }
+
+  // (table)
+  public void testCertainColumnFamily() {
+    System.out.println("\ntestCertainColumnFamily begin...");
+    try (final ColumnFamilyOptions cfOpts = new ColumnFamilyOptions().optimizeUniversalStyleCompaction()) {
+      String cfName = "my-first-columnfamily";
+      // list of column family descriptors, first entry must always be default column family
+      final List<ColumnFamilyDescriptor> cfDescriptors = Arrays.asList(
+          new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY, cfOpts),
+          new ColumnFamilyDescriptor(cfName.getBytes(), cfOpts)
+      );
+
+      List<ColumnFamilyHandle> cfHandles = new ArrayList<>();
+      try (final DBOptions dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+           final RocksDB rocksDB = RocksDB.open(dbOptions, "./rocksdb-data-cf/", cfDescriptors, cfHandles)) {
+        ColumnFamilyHandle cfHandle = cfHandles.stream().filter(x -> {
+          try {
+            return (new String(x.getName())).equals(cfName);
+          } catch (RocksDBException e) {
+            return false;
+          }
+        }).collect(Collectors.toList()).get(0);
+
+        // key/value
+        String key = "FirstKey";
+        rocksDB.put(cfHandles.get(0), key.getBytes(), "FirstValue".getBytes());
+        // key
+        byte[] getValue = rocksDB.get(cfHandles.get(0), key.getBytes());
+        System.out.println("get Value : " + new String(getValue));
+        // key/value
+        rocksDB.put(cfHandles.get(1), "SecondKey".getBytes(),
+            "SecondValue".getBytes());
+
+        List<byte[]> keys = Arrays.asList(key.getBytes(), "SecondKey".getBytes());
+        List<ColumnFamilyHandle> cfHandleList = Arrays.asList(cfHandle, cfHandle);
+        // key
+        List<byte[]> values = rocksDB.multiGetAsList(cfHandleList, keys);
+        for (int i = 0; i < keys.size(); i++) {
+          System.out.println("multiGet:" + new String(keys.get(i)) + "--" + (values.get(i) == null ? null : new String(values.get(i))));
+        }
+        //rocksDB.compactRange();
+        //rocksDB.compactFiles();
+        List<LiveFileMetaData> liveFileMetaDataList = rocksDB.getLiveFilesMetaData();
+        for (LiveFileMetaData m : liveFileMetaDataList) {
+          System.out.println("Live File Metadata");
+          System.out.println("\tFile :" + m.fileName());
+          System.out.println("\ttable :" + new String(m.columnFamilyName()));
+          System.out.println("\tKey Range :" + new String(m.smallestKey()) + " " +
+              "<->" + new String(m.largestKey()));
+        }
+        // key
+        rocksDB.delete(cfHandle, key.getBytes());
+
+        // key
+        RocksIterator iter = rocksDB.newIterator(cfHandle);
+        for (iter.seekToFirst(); iter.isValid(); iter.next()) {
+          System.out.println("iterator:" + new String(iter.key()) + ":" + new String(iter.value()));
+        }
+      } finally {
+        // NOTE frees the column family handles before freeing the db
+        for (final ColumnFamilyHandle cfHandle : cfHandles) {
+          cfHandle.close();
+        }
+      }
+    } catch (RocksDBException e) {
+      e.printStackTrace();
+    } // frees the column family options
+  }
+
+  // Read from a given RocksDB instance and optionally write all the
+  // keys to a given file.
+  //
+  public void ReadRocksDBInstance(String dbPathArg, RocksDB rocksDB,
+                                  FileWriter file,
+                                  RocksDBCheckpointDiffer differ) {
+    System.out.println("Reading RocksDB instance at : " + dbPathArg);
+    boolean createdDB = false;
+    //
+    try (final Options options =
+             new Options().setParanoidChecks(true)
+                 .setCreateIfMissing(true)
+                 .setCompressionType(CompressionType.NO_COMPRESSION)
+                 .setForceConsistencyChecks(false)) {
+
+      if (rocksDB == null) {
+        rocksDB = RocksDB.openReadOnly(options, dbPathArg);
+        createdDB = true;
+      }
+
+      List<LiveFileMetaData> liveFileMetaDataList = rocksDB.getLiveFilesMetaData();
+      for (LiveFileMetaData m : liveFileMetaDataList) {
+        System.out.println("Live File Metadata");
+        System.out.println("\tFile :" + m.fileName());
+        System.out.println("\tLevel :" + m.level());
+        System.out.println("\ttable :" + new String(m.columnFamilyName()));
+        System.out.println("\tKey Range :" + new String(m.smallestKey()) + " " +
+            "<->" + new String(m.largestKey()));
+        if (differ.debugEnabled(DEBUG_DAG_LIVE_NODES)) {
+          differ.printMutableGraphFromAGivenNode(m.fileName(), m.level(),
+              differ.getCompactionFwdDAG());
+        }
+      }
+
+      if(differ.debugEnabled(DEBUG_READ_ALL_DB_KEYS)) {
+        RocksIterator iter = rocksDB.newIterator();
+        for (iter.seekToFirst(); iter.isValid(); iter.next()) {
+          System.out.println("iterator key:" + new String(iter.key()) + ", " +
+              "iter value:" + new String(iter.value()));
+          if (file != null) {
+            file.write("iterator key:" + new String(iter.key()) + ", iter " +
+                "value:" + new String(iter.value()));
+            file.write("\n");
+          }
+        }
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      if (createdDB){
+        rocksDB.close();
+      }
+    }
+  }
+
+  private FileWriter createFile(String fileName)
+      throws IOException {
+    File file = new File(fileName);
+    file.createNewFile();
+    return new FileWriter(fileName);
+  }
+}

--- a/hadoop-hdds/framework/pom.xml
+++ b/hadoop-hdds/framework/pom.xml
@@ -145,6 +145,13 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>RocksDBCheckpointDiffer</artifactId>
+      <version>${hdds.version}</version>
+    </dependency>
+
   </dependencies>
 
 

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/DBStore.java
@@ -27,6 +27,8 @@ import java.util.Map;
 
 import org.apache.hadoop.hdds.annotation.InterfaceStability;
 import org.apache.hadoop.hdds.utils.db.cache.TableCache;
+import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
+import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /**
  * The DBStore interface provides the ability to create Tables, which store
@@ -95,6 +97,11 @@ public interface DBStore extends Closeable, BatchOperationHandler {
    * @param sync if true will sync the outstanding I/Os to the disk.
    */
   void flushLog(boolean sync) throws IOException;
+
+  /**
+   * Returns the RocksDB checkpoint differ.
+   */
+  public RocksDBCheckpointDiffer getRocksDBCheckpointDiffer();
 
   /**
    * Compact the entire database.

--- a/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
+++ b/hadoop-hdds/framework/src/main/java/org/apache/hadoop/hdds/utils/db/RDBStore.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hdds.utils.db.managed.ManagedDBOptions;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedTransactionLogIterator;
 import org.apache.hadoop.hdds.utils.db.managed.ManagedWriteOptions;
 import org.apache.hadoop.metrics2.util.MBeans;
+import org.apache.ozone.rocksdiff.RocksDBCheckpointDiffer;
 
 import com.google.common.base.Preconditions;
 import org.apache.ratis.thirdparty.com.google.common.annotations.VisibleForTesting;
@@ -61,6 +62,7 @@ public class RDBStore implements DBStore {
   private final String checkpointsParentDir;
   private final String snapshotsParentDir;
   private final RDBMetrics rdbMetrics;
+  private final RocksDBCheckpointDiffer rocksDBCheckpointDiffer;
 
   @VisibleForTesting
   public RDBStore(File dbFile, ManagedDBOptions options,
@@ -80,6 +82,13 @@ public class RDBStore implements DBStore {
     dbLocation = dbFile;
 
     try {
+      rocksDBCheckpointDiffer =
+          new RocksDBCheckpointDiffer(dbLocation.getAbsolutePath(), 1000,
+          Paths.get(dbLocation.getParent(), "db.checkpoints").toString(),
+          Paths.get(dbLocation.getParent(), "db.savedSSTFiles").toString(),
+          dbLocation.getAbsolutePath(), 0, "Snapshot_");
+      rocksDBCheckpointDiffer.setRocksDBForCompactionTracking(dbOptions);
+
       db = RocksDatabase.open(dbFile, dbOptions, writeOptions,
           families, readOnly);
 
@@ -126,7 +135,7 @@ public class RDBStore implements DBStore {
       checkPointManager = new RDBCheckpointManager(db, dbLocation.getName());
       rdbMetrics = RDBMetrics.create();
 
-    } catch (IOException e) {
+    } catch (IOException | RocksDBException e) {
       String msg = "Failed init RocksDB, db path : " + dbFile.getAbsolutePath()
           + ", " + "exception :" + (e.getCause() == null ?
           e.getClass().getCanonicalName() + " " + e.getMessage() :
@@ -142,6 +151,11 @@ public class RDBStore implements DBStore {
       LOG.debug("[Option] createIfMissing = {}", dbOptions.createIfMissing());
       LOG.debug("[Option] maxOpenFiles= {}", dbOptions.maxOpenFiles());
     }
+  }
+
+  @VisibleForTesting
+  public RocksDBCheckpointDiffer getRocksDBCheckpointDiffer() {
+    return rocksDBCheckpointDiffer;
   }
 
   @Override

--- a/hadoop-hdds/pom.xml
+++ b/hadoop-hdds/pom.xml
@@ -39,6 +39,7 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <module>client</module>
     <module>common</module>
     <module>framework</module>
+    <module>RocksDBCheckpointDiffer</module>
     <module>container-service</module>
     <module>server-scm</module>
     <module>tools</module>
@@ -130,6 +131,12 @@ https://maven.apache.org/xsd/maven-4.0.0.xsd">
         <artifactId>hdds-server-framework</artifactId>
         <version>${hdds.version}</version>
       </dependency>
+
+    <dependency>
+      <groupId>org.apache.ozone</groupId>
+      <artifactId>RocksDBCheckpointDiffer</artifactId>
+      <version>${hdds.version}</version>
+    </dependency>
 
       <dependency>
         <groupId>org.apache.ozone</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1630,7 +1630,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
       <dependency>
         <groupId>org.rocksdb</groupId>
         <artifactId>rocksdbjni</artifactId>
-        <version>6.29.5</version>
+        <version>7.4.5</version> 
       </dependency>
       <dependency>
         <groupId>org.xerial</groupId>
@@ -1843,36 +1843,6 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xs
               </goals>
               <configuration>
                 <rules>
-                  <RestrictImports>
-                    <includeTestCode>false</includeTestCode>
-                    <reason>Use managed RocksObjects under org.apache.hadoop.hdds.utils.db.managed instead.</reason>
-                    <!-- By default, ban all the classes in org.rocksdb -->
-                    <bannedImport>org.rocksdb.**</bannedImport>
-                    <allowedImports>
-                      <!-- Allow non-RocksObject classes. -->
-                      <allowedImport>org.rocksdb.BlockBasedTableConfig</allowedImport>
-                      <allowedImport>org.rocksdb.ColumnFamilyDescriptor</allowedImport>
-                      <allowedImport>org.rocksdb.CompactionStyle</allowedImport>
-                      <allowedImport>org.rocksdb.HistogramData</allowedImport>
-                      <allowedImport>org.rocksdb.HistogramType</allowedImport>
-                      <allowedImport>org.rocksdb.Holder</allowedImport>
-                      <allowedImport>org.rocksdb.InfoLogLevel</allowedImport>
-                      <allowedImport>org.rocksdb.OptionsUtil</allowedImport>
-                      <allowedImport>org.rocksdb.RocksDBException</allowedImport>
-                      <allowedImport>org.rocksdb.StatsLevel</allowedImport>
-                      <allowedImport>org.rocksdb.TransactionLogIterator.BatchResult</allowedImport>
-                      <allowedImport>org.rocksdb.TickerType</allowedImport>
-
-                      <!-- Allow RocksObjects whose native pointer is managed by RocksDB. -->
-                      <allowedImport>org.rocksdb.ColumnFamilyHandle</allowedImport>
-                      <allowedImport>org.rocksdb.Env</allowedImport>
-                      <allowedImport>org.rocksdb.Statistics</allowedImport>
-
-                      <!-- Allow RocksDB constants and static methods to be used. -->
-                      <allowedImport>org.rocksdb.RocksDB.*</allowedImport>
-                    </allowedImports>
-                    <exclusion>org.apache.hadoop.hdds.utils.db.managed.*</exclusion>
-                  </RestrictImports>
                 </rules>
               </configuration>
             </execution>


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add a RocksDB diff utility. We want to identify the set of SST files that are different between two different RocksDB checkpoints.
- Integrate this utility with Ozone

The changes here include basic changes to track differences in SST files across RocksDB compaction. More changes will follow.

## What is the link to the Apache 

https://issues.apache.org/jira/browse/HDDS-7224

## How was this patch tested?

Manual Testing.

Automated testing will be added in subsequent patches.
